### PR TITLE
NBS-3864: introduce fast data path external endpoint

### DIFF
--- a/cloud/blockstore/libs/common/device_path.cpp
+++ b/cloud/blockstore/libs/common/device_path.cpp
@@ -1,0 +1,55 @@
+#include "device_path.h"
+
+#include <library/cpp/uri/uri.h>
+
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore {
+
+NProto::TError DevicePath::Parse(const TString& devicePath)
+{
+    // rdma://myt1-ct5-13.cloud.yandex.net:10020/62ccf40f2743308191205ad6391bfa06
+
+    NUri::TUri uri;
+    auto res = uri.Parse(
+        devicePath,
+        NUri::TFeature::FeaturesDefault |
+            NUri::TFeature::FeatureSchemeFlexible);
+    if (res != NUri::TState::ParsedOK) {
+        return MakeError(
+            E_FAIL,
+            TStringBuilder() << "invalid device path " << devicePath);
+    }
+
+    if (uri.GetField(NUri::TField::FieldScheme) != Protocol) {
+        return MakeError(
+            E_FAIL,
+            TStringBuilder()
+            << "device path doesn't start with "
+            << Protocol << "://, " << devicePath);
+    }
+
+    auto path = uri.GetField(NUri::TField::FieldPath);
+    if (path.size() < 2 || path[0] != '/') {
+        return MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "invalid uuid inside device path " << devicePath);
+    }
+
+    Host = uri.GetHost();
+    Port = uri.GetPort();
+    Uuid = path.substr(1);
+
+    return {};
+}
+
+TString DevicePath::Serialize() const
+{
+    return TStringBuilder()
+        << Protocol << "://"
+        << Host << ":" << Port
+        << "/" << Uuid;
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/device_path.h
+++ b/cloud/blockstore/libs/common/device_path.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct DevicePath
+{
+    TString Protocol;
+    TString Host;
+    ui16 Port;
+    TString Uuid;
+
+    DevicePath(
+            const TString protocol,
+            const TString& host = {},
+            ui16 port = 0,
+            const TString& uuid = {})
+        : Protocol(protocol)
+        , Host(host)
+        , Port(port)
+        , Uuid(uuid)
+    {}
+    NProto::TError Parse(const TString& devicePath);
+    TString Serialize() const;
+};
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/device_path_ut.cpp
+++ b/cloud/blockstore/libs/common/device_path_ut.cpp
@@ -1,0 +1,50 @@
+#include "device_path.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDevicePathTest)
+{
+    Y_UNIT_TEST(TestParseValidDevicePath)
+    {
+        DevicePath devPath("rdma");
+        auto error = devPath.Parse("rdma://a.b.c.d:10020/11223344");
+        UNIT_ASSERT_C(!HasError(error), error);
+
+        UNIT_ASSERT_EQUAL(devPath.Protocol, "rdma");
+        UNIT_ASSERT_EQUAL(devPath.Host, "a.b.c.d");
+        UNIT_ASSERT_EQUAL(devPath.Port, 10020);
+        UNIT_ASSERT_EQUAL(devPath.Uuid, "11223344");
+    }
+
+    Y_UNIT_TEST(TestParseInvalidProtocol)
+    {
+        DevicePath devPath("unknown");
+        auto error = devPath.Parse("rdma://a.b.c.d:10020/11223344");
+        UNIT_ASSERT(HasError(error));
+    }
+
+    Y_UNIT_TEST(TestParseNoUuid)
+    {
+        DevicePath devPath("rdma");
+        auto error = devPath.Parse("rdma://a.b.c.d:10020");
+        UNIT_ASSERT(HasError(error));
+    }
+
+    Y_UNIT_TEST(TestSerialize)
+    {
+        auto expectedPath = "rdma://a.b.c.d:10020/11223344";
+        DevicePath devPath("rdma", "a.b.c.d", 10020, "11223344");
+        UNIT_ASSERT_EQUAL(devPath.Serialize(), expectedPath);
+
+        DevicePath devPath2("rdma");
+        auto error = devPath2.Parse(expectedPath);
+        UNIT_ASSERT_C(!HasError(error), error);
+        UNIT_ASSERT_EQUAL(expectedPath, devPath2.Serialize());
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/ut/ya.make
+++ b/cloud/blockstore/libs/common/ut/ya.make
@@ -10,7 +10,12 @@ SRCS(
     caching_allocator_ut.cpp
     block_checksum_ut.cpp
     block_range_ut.cpp
+    device_path_ut.cpp
     iovector_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/uri
 )
 
 END()

--- a/cloud/blockstore/libs/common/ya.make
+++ b/cloud/blockstore/libs/common/ya.make
@@ -4,13 +4,14 @@ SRCS(
     block_checksum.cpp
     block_range.cpp
     caching_allocator.cpp
+    device_path.cpp
     iovector.cpp
     typeinfo.cpp
 )
 
 PEERDIR(
     cloud/blockstore/public/api/protos
-    
+
     cloud/storage/core/libs/common
 
     library/cpp/digest/crc32c

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -28,6 +28,7 @@
 #include <cloud/blockstore/libs/encryption/encryption_client.h>
 #include <cloud/blockstore/libs/encryption/encryption_key.h>
 #include <cloud/blockstore/libs/encryption/encryption_service.h>
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_manager.h>
 #include <cloud/blockstore/libs/endpoints/service_endpoint.h>
@@ -210,6 +211,7 @@ void TBootstrapBase::Init()
     Executor = TExecutor::Create("SVC");
 
     VolumeBalancerSwitch = CreateVolumeBalancerSwitch();
+    EndpointEventHandler = CreateEndpointEventProxy();
 
     switch (Configs->Options->ServiceKind) {
         case TOptionsCommon::EServiceKind::Ydb:
@@ -479,6 +481,7 @@ void TBootstrapBase::Init()
         Logging,
         ServerStats,
         Executor,
+        EndpointEventHandler,
         std::move(sessionManager),
         std::move(endpointListeners),
         Configs->ServerConfig->GetNbdSocketSuffix());

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -69,6 +69,7 @@ protected:
     ICachingAllocatorPtr Allocator;
     IStorageProviderPtr AioStorageProvider;
     IEndpointServicePtr EndpointService;
+    IEndpointEventProxyPtr EndpointEventHandler;
     NRdma::IServerPtr RdmaServer;
     NRdma::IClientPtr RdmaClient;
     ITaskQueuePtr RdmaThreadPool;

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -15,6 +15,7 @@
 #include <cloud/blockstore/libs/discovery/fetch.h>
 #include <cloud/blockstore/libs/discovery/healthcheck.h>
 #include <cloud/blockstore/libs/discovery/ping.h>
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/kms/iface/compute_client.h>
 #include <cloud/blockstore/libs/kms/iface/key_provider.h>
 #include <cloud/blockstore/libs/kms/iface/kms_client.h>
@@ -528,6 +529,7 @@ void TBootstrapYdb::InitKikimrService()
             return FindPtr(nodes, fqdn) || CityHash64(fqdn) % 100 < p;
         }();
     args.VolumeBalancerSwitch = VolumeBalancerSwitch;
+    args.EndpointEventHandler = EndpointEventHandler;
 
     ActorSystem = NStorage::CreateActorSystem(args);
 

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -50,6 +50,7 @@ namespace NCloud::NBlockStore {
     xxx(DiskAgentConfigMismatch)                                               \
     xxx(DiskRegistryDeviceNotFoundSoft)                                        \
     xxx(DiskRegistrySourceDiskNotFound)                                        \
+    xxx(EndpointSwitchFailure)                                                 \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/endpoints/endpoint_events.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_events.cpp
@@ -1,0 +1,42 @@
+#include "endpoint_events.h"
+
+namespace NCloud::NBlockStore::NServer {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TEndpointEventProxy: public IEndpointEventProxy
+{
+private:
+    IEndpointEventHandlerPtr Handler;
+
+public:
+    void OnVolumeConnectionEstablished(const TString& diskId) override;
+    void Register(IEndpointEventHandlerPtr listener) override;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TEndpointEventProxy::OnVolumeConnectionEstablished(const TString& diskId)
+{
+    if (Handler) {
+        Handler->OnVolumeConnectionEstablished(diskId);
+    }
+}
+
+void TEndpointEventProxy::Register(IEndpointEventHandlerPtr listener)
+{
+    Handler = std::move(listener);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IEndpointEventProxyPtr CreateEndpointEventProxy()
+{
+    return std::make_shared<TEndpointEventProxy>();
+}
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/endpoint_events.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_events.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/public/api/protos/volume.pb.h>
+
+namespace NCloud::NBlockStore::NServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IEndpointEventHandler
+{
+    virtual ~IEndpointEventHandler() = default;
+
+    virtual void OnVolumeConnectionEstablished(const TString& diskId) = 0;
+};
+
+struct IEndpointEventProxy: public IEndpointEventHandler
+{
+    virtual ~IEndpointEventProxy() = default;
+
+    virtual void Register(IEndpointEventHandlerPtr eventHandler) = 0;
+};
+
+IEndpointEventProxyPtr CreateEndpointEventProxy();
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/endpoint_listener.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_listener.h
@@ -36,6 +36,11 @@ struct IEndpointListener
     virtual NProto::TError RefreshEndpoint(
         const TString& socketPath,
         const NProto::TVolume& volume) = 0;
+
+    virtual NThreading::TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.h
@@ -46,6 +46,7 @@ IEndpointManagerPtr CreateEndpointManager(
     ILoggingServicePtr logging,
     IServerStatsPtr serverStats,
     TExecutorPtr executor,
+    IEndpointEventProxyPtr eventProxy,
     ISessionManagerPtr sessionManager,
     THashMap<NProto::EClientIpcType, IEndpointListenerPtr> listeners,
     TString nbdSocketSuffix);

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -1,5 +1,6 @@
 #include "endpoint_manager.h"
 
+#include "endpoint_events.h"
 #include "endpoint_listener.h"
 #include "session_manager.h"
 
@@ -194,6 +195,18 @@ public:
         return {};
     }
 
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+
+        return MakeFuture<NProto::TError>();
+    }
+
     TMap<TString, TTestEndpoint> GetEndpoints() const
     {
         return Endpoints;
@@ -377,10 +390,13 @@ IEndpointManagerPtr CreateEndpointManager(
         bootstrap.Executor,
         sessionManagerOptions);
 
+    auto eventProxy = CreateEndpointEventProxy();
+
     return NServer::CreateEndpointManager(
         bootstrap.Logging,
         serverStats,
         bootstrap.Executor,
+        CreateEndpointEventProxy(),
         std::move(sessionManager),
         std::move(endpointListeners),
         std::move(nbdSocketSuffix));
@@ -1012,6 +1028,7 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
             bootstrap.Logging,
             CreateServerStatsStub(),
             bootstrap.Executor,
+            CreateEndpointEventProxy(),
             sessionManager,
             {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
             ""  // NbdSocketSuffix

--- a/cloud/blockstore/libs/endpoints/public.h
+++ b/cloud/blockstore/libs/endpoints/public.h
@@ -25,4 +25,10 @@ using IEndpointListenerPtr = std::shared_ptr<IEndpointListener>;
 struct IEndpointService;
 using IEndpointServicePtr = std::shared_ptr<IEndpointService>;
 
+struct IEndpointEventHandler;
+using IEndpointEventHandlerPtr = std::shared_ptr<IEndpointEventHandler>;
+
+struct IEndpointEventProxy;
+using IEndpointEventProxyPtr = std::shared_ptr<IEndpointEventProxy>;
+
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/ya.make
+++ b/cloud/blockstore/libs/endpoints/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    endpoint_events.cpp
     endpoint_listener.cpp
     endpoint_manager.cpp
     service_endpoint.cpp

--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
@@ -293,6 +293,18 @@ public:
         Y_UNUSED(volume);
         return {};
     }
+
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture<NProto::TError>();
+    }
+
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -86,6 +86,18 @@ public:
         Y_UNUSED(volume);
         return {};
     }
+
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
+    }
+
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -356,6 +356,18 @@ public:
         return {};
     }
 
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
+    }
+
+
 private:
     NProto::TError DoStartEndpoint(
         const NProto::TStartEndpointRequest& request,

--- a/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
+++ b/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
@@ -315,6 +315,17 @@ public:
         return {};
     }
 
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
+    }
+
 private:
     NProto::TError DoStartEndpoint(
         const NProto::TStartEndpointRequest& request,
@@ -479,6 +490,17 @@ public:
         Y_UNUSED(socketPath);
         Y_UNUSED(volume);
         return {};
+    }
+
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
     }
 
 private:

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -118,6 +118,17 @@ struct TTestEndpointListener
 
         return {};
     }
+
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture<NProto::TError>();
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -345,15 +356,21 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
             UNIT_ASSERT_VALUES_EQUAL(Volume.GetDiskId(), create->DiskId);
 
             /*
-                --device ...                        2
-                --device ...                        2
+                --client-id ...                     2
+                --disk-id ...                       2
                 --serial local0                     2
                 --socket-path /tmp/socket.vhost     2
                 -q 2                                2
+                --device-backend ...                2
+                --device ...                        2
+                --device ...                        2
                 --read-only                         1
-                                                   11
+                                                   17
             */
-            UNIT_ASSERT_VALUES_EQUAL(11, create->CmdArgs.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(17, create->CmdArgs.size());
+            UNIT_ASSERT_VALUES_EQUAL("client", GetArg(create->CmdArgs, "--client-id"));
+            UNIT_ASSERT_VALUES_EQUAL("vol0", GetArg(create->CmdArgs, "--disk-id"));
             UNIT_ASSERT_VALUES_EQUAL("local0", GetArg(create->CmdArgs, "--serial"));
 
             UNIT_ASSERT_VALUES_EQUAL(
@@ -361,6 +378,7 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
                 GetArg(create->CmdArgs, "--socket-path"));
 
             UNIT_ASSERT_VALUES_EQUAL("2", GetArg(create->CmdArgs, "-q"));
+            UNIT_ASSERT_VALUES_EQUAL("aio", GetArg(create->CmdArgs, "--device-backend"));
             UNIT_ASSERT(FindPtr(create->CmdArgs, "--read-only"));
 
             auto devices = GetArgN(create->CmdArgs, "--device");

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -65,6 +65,17 @@ public:
     {
         return Server->UpdateEndpoint(socketPath, volume.GetBlocksCount());
     }
+
+    TFuture<NProto::TError> SwitchEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return MakeFuture<NProto::TError>();
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -184,6 +184,15 @@ void VolumeConfigToVolume(
     volume.SetBaseDiskCheckpointId(volumeConfig.GetBaseDiskCheckpointId());
     volume.SetIsSystem(volumeConfig.GetIsSystem());
     volume.SetIsFillFinished(volumeConfig.GetIsFillFinished());
+
+    TStringBuf sit(volumeConfig.GetTagsStr());
+    TStringBuf tag;
+    while (sit.NextTok(',', tag)) {
+        if (tag == "use-fastpath") {
+            volume.SetIsFastPathEnabled(true);
+        }
+    }
+
 }
 
 void VolumeConfigToVolumeModel(

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -210,6 +210,7 @@ public:
             Args.BlockDigestGenerator,
             Args.DiscoveryService,
             Args.TraceSerializer,
+            Args.EndpointEventHandler,
             Args.RdmaClient,
             Args.VolumeStats,
             Args.PreemptedVolumes);
@@ -342,6 +343,7 @@ private:
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ITraceSerializerPtr TraceSerializer;
+    const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const NLogbroker::IServicePtr LogbrokerService;
     const NNotify::IServicePtr NotifyService;
     const NRdma::IClientPtr RdmaClient;

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/common/public.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/discovery/public.h>
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/nvme/public.h>
 #include <cloud/blockstore/libs/logbroker/iface/public.h>
@@ -63,6 +64,7 @@ struct TServerActorSystemArgs
     TManuallyPreemptedVolumesPtr PreemptedVolumes;
     NNvme::INvmeManagerPtr NvmeManager;
     IVolumeBalancerSwitchPtr VolumeBalancerSwitch;
+    NServer::IEndpointEventHandlerPtr EndpointEventHandler;
 
     TVector<NCloud::NStorage::IUserMetricsSupplierPtr> UserCounterProviders;
 

--- a/cloud/blockstore/libs/storage/service/service.cpp
+++ b/cloud/blockstore/libs/storage/service/service.cpp
@@ -15,6 +15,7 @@ IActorPtr CreateStorageService(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     NDiscovery::IDiscoveryServicePtr discoveryService,
     ITraceSerializerPtr traceSerializer,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     IVolumeStatsPtr volumeStats,
     TManuallyPreemptedVolumesPtr preemptedVolumes)
@@ -26,6 +27,7 @@ IActorPtr CreateStorageService(
         std::move(blockDigestGenerator),
         std::move(discoveryService),
         std::move(traceSerializer),
+        std::move(endpointEventHandler),
         std::move(rdmaClient),
         std::move(volumeStats),
         std::move(preemptedVolumes));

--- a/cloud/blockstore/libs/storage/service/service.h
+++ b/cloud/blockstore/libs/storage/service/service.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/discovery/public.h>
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
@@ -19,6 +20,7 @@ NActors::IActorPtr CreateStorageService(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     NDiscovery::IDiscoveryServicePtr discoveryService,
     ITraceSerializerPtr traceSerializer,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     IVolumeStatsPtr volumeStats,
     TManuallyPreemptedVolumesPtr preemptedVolumes);

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -24,6 +24,7 @@ TServiceActor::TServiceActor(
         IBlockDigestGeneratorPtr blockDigestGenerator,
         NDiscovery::IDiscoveryServicePtr discoveryService,
         ITraceSerializerPtr traceSerializer,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         IVolumeStatsPtr volumeStats,
         TManuallyPreemptedVolumesPtr preemptedVolumes)
@@ -33,6 +34,7 @@ TServiceActor::TServiceActor(
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , DiscoveryService(std::move(discoveryService))
     , TraceSerializer(std::move(traceSerializer))
+    , EndpointEventHandler(std::move(endpointEventHandler))
     , RdmaClient(std::move(rdmaClient))
     , VolumeStats(std::move(volumeStats))
     , SharedCounters(MakeIntrusive<TSharedServiceCounters>(Config))

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/discovery/discovery.h>
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
@@ -43,6 +44,7 @@ private:
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const NDiscovery::IDiscoveryServicePtr DiscoveryService;
     const ITraceSerializerPtr TraceSerializer;
+    const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const NRdma::IClientPtr RdmaClient;
     const IVolumeStatsPtr VolumeStats;
 
@@ -65,6 +67,7 @@ public:
         IBlockDigestGeneratorPtr blockDigestGenerator,
         NDiscovery::IDiscoveryServicePtr discoveryService,
         ITraceSerializerPtr traceSerializer,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         IVolumeStatsPtr volumeStats,
         TManuallyPreemptedVolumesPtr preemptedVolumes);
@@ -381,6 +384,7 @@ NActors::IActorPtr CreateVolumeSessionActor(
     IProfileLogPtr profileLog,
     IBlockDigestGeneratorPtr blockDigestGenerator,
     ITraceSerializerPtr traceSerializer,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     std::shared_ptr<NKikimr::TTabletCountersBase> counters,
     TSharedServiceCountersPtr sharedCounters);

--- a/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
@@ -136,6 +136,7 @@ void TServiceActor::HandleMountVolume(
                 ProfileLog,
                 BlockDigestGenerator,
                 TraceSerializer,
+                EndpointEventHandler,
                 RdmaClient,
                 Counters,
                 SharedCounters

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 
@@ -14,6 +15,7 @@ namespace NCloud::NBlockStore::NStorage {
 NActors::IActorPtr CreateVolumeClient(
     TStorageConfigPtr config,
     ITraceSerializerPtr traceSerializer,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     const NActors::TActorId& sessionActorId,
     TString diskId,
     ui64 tabletId);

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -66,6 +66,7 @@ void TVolumeSessionActor::HandleDescribeVolumeResponse(
             CreateVolumeClient(
                 Config,
                 TraceSerializer,
+                EndpointEventHandler,
                 SelfId(),
                 VolumeInfo->DiskId,
                 TabletId
@@ -337,6 +338,7 @@ IActorPtr CreateVolumeSessionActor(
     IProfileLogPtr profileLog,
     IBlockDigestGeneratorPtr blockDigestGenerator,
     ITraceSerializerPtr traceSerializer,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     std::shared_ptr<NKikimr::TTabletCountersBase> counters,
     TSharedServiceCountersPtr sharedCounters)
@@ -348,6 +350,7 @@ IActorPtr CreateVolumeSessionActor(
         std::move(profileLog),
         std::move(blockDigestGenerator),
         std::move(traceSerializer),
+        std::move(endpointEventHandler),
         std::move(rdmaClient),
         std::move(counters),
         std::move(sharedCounters));

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -7,6 +7,7 @@
 #include "service_state.h"
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
@@ -47,6 +48,7 @@ private:
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ITraceSerializerPtr TraceSerializer;
+    const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const NRdma::IClientPtr RdmaClient;
     const std::shared_ptr<NKikimr::TTabletCountersBase> Counters;
     const TSharedServiceCountersPtr SharedCounters;
@@ -77,6 +79,7 @@ public:
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ITraceSerializerPtr traceSerializer,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         std::shared_ptr<NKikimr::TTabletCountersBase> counters,
         TSharedServiceCountersPtr sharedCounters)
@@ -86,6 +89,7 @@ public:
         , ProfileLog(std::move(profileLog))
         , BlockDigestGenerator(std::move(blockDigestGenerator))
         , TraceSerializer(std::move(traceSerializer))
+        , EndpointEventHandler(std::move(endpointEventHandler))
         , RdmaClient(std::move(rdmaClient))
         , Counters(std::move(counters))
         , SharedCounters(std::move(sharedCounters))

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -51,6 +51,7 @@ private:
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ITraceSerializerPtr TraceSerializer;
+    const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const NRdma::IClientPtr RdmaClient;
     const TString DiskId;
     const ui64 VolumeTabletId;
@@ -83,6 +84,7 @@ public:
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ITraceSerializerPtr traceSerializer,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         TString diskId,
         ui64 volumeTabletId = 0);
@@ -159,6 +161,7 @@ TStartVolumeActor::TStartVolumeActor(
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ITraceSerializerPtr traceSerializer,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         TString diskId,
         ui64 volumeTabletId)
@@ -168,6 +171,7 @@ TStartVolumeActor::TStartVolumeActor(
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , TraceSerializer(std::move(traceSerializer))
+    , EndpointEventHandler(std::move(endpointEventHandler))
     , RdmaClient(std::move(rdmaClient))
     , DiskId(std::move(diskId))
     , VolumeTabletId(volumeTabletId)
@@ -435,6 +439,7 @@ void TStartVolumeActor::StartTablet(const TActorContext& ctx)
     auto profileLog = ProfileLog;
     auto blockDigestGenerator = BlockDigestGenerator;
     auto traceSerializer = TraceSerializer;
+    auto endpointEventHandler = EndpointEventHandler;
     auto rdmaClient = RdmaClient;
 
     auto factory = [=] (const TActorId& owner, TTabletStorageInfo* storage) {
@@ -858,6 +863,7 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
             ProfileLog,
             BlockDigestGenerator,
             TraceSerializer,
+            EndpointEventHandler,
             RdmaClient,
             diskId,
             TabletId);

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
@@ -401,6 +401,7 @@ void TVolumeSessionActor::HandleUnmountRequestProcessed(
                 CreateVolumeClient(
                     Config,
                     TraceSerializer,
+                    EndpointEventHandler,
                     SelfId(),
                     VolumeInfo->DiskId,
                     TabletId

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/discovery/discovery.h>
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
@@ -371,6 +372,7 @@ ui32 TTestEnv::CreateBlockStoreNode(
         CreateBlockDigestGeneratorStub(),
         NDiscovery::CreateDiscoveryServiceStub(),
         TraceSerializer,
+        NServer::CreateEndpointEventProxy(),
         nullptr, // rdmaClient
         CreateVolumeStatsStub(),
         std::move(manuallyPreemptedVolumes));

--- a/cloud/blockstore/libs/storage/testlib/ya.make
+++ b/cloud/blockstore/libs/storage/testlib/ya.make
@@ -17,6 +17,7 @@ SRCS(
 PEERDIR(
     cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/discovery
+    cloud/blockstore/libs/endpoints
     cloud/blockstore/libs/kikimr
     cloud/blockstore/libs/service
     cloud/blockstore/libs/storage/api

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -276,6 +276,10 @@ message TVolume
 
     // Represents whether disk filling finished or not.
     bool IsFillFinished = 35;
+
+    // Whether volume can use fast data path (external endpoint with direct
+    // rdma connection to engine)
+    bool IsFastPathEnabled = 36;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
volumes with "use-fastpath" tag can connect directly to disk-agent without passing the actor system. When migration needed the endpoint will switch back to actor system based data path