### PR TITLE
[Disk Manager]: Fix eternal and sync tests reporting

### DIFF
--- a/cloud/storage/core/tools/ci/runner/disk_manager_acceptance_common.sh
+++ b/cloud/storage/core/tools/ci/runner/disk_manager_acceptance_common.sh
@@ -7,9 +7,6 @@ export dm="${d}/disk_manager_acceptance_test/disk_manager_acceptance_tests"
 export cluster="nemax"
 
 export results_dir="/var/www/build/results"
-export result_case_directory="${results_dir}/disk_manager_${test_name:=acceptance}/${cluster}/disk-manager/"
-results_path="${result_case_directory}${test_suite:?"test_suite parameter undefined"}/$(date +%Y-%m-%d)"
-export results_path
 
 function create_results_directory () {
     rm -rf "$results_path"
@@ -41,6 +38,9 @@ function report_results () {
 }
 
 function execute_tests () {
+    export result_case_directory="${results_dir}/disk_manager_${test_name:=acceptance}/${cluster}/disk-manager/"
+    results_path="${result_case_directory}${test_suite:?"test_suite parameter undefined"}/$(date +%Y-%m-%d)"
+    export results_path
     create_results_directory
     # shellcheck disable=SC2068
     # shellcheck disable=SC2046

--- a/cloud/storage/core/tools/ci/runner/generate_index.py
+++ b/cloud/storage/core/tools/ci/runner/generate_index.py
@@ -87,7 +87,9 @@ def generate_nfs_section(index, results_xml_path):
 
 
 def generate_dm_section(index, results_xml_path):
-    for tests_type in ["disk_manager_acceptance"]:
+    for tests_type in [
+        "disk_manager_acceptance", "disk_manager_eternal", "disk_manager_sync"
+    ]:
         generate_generic_tests_section(index, tests_type, results_xml_path)
 
 

--- a/cloud/storage/core/tools/ci/runner/index.xsl
+++ b/cloud/storage/core/tools/ci/runner/index.xsl
@@ -170,6 +170,17 @@
     </xsl:call-template>
 </xsl:template>
 
+<xsl:template match="disk_manager_eternal" mode="detailed">
+    <xsl:call-template name="detailed">
+        <xsl:with-param name="suite-kind">disk_manager_eternal</xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="disk_manager_sync" mode="detailed">
+    <xsl:call-template name="detailed">
+        <xsl:with-param name="suite-kind">disk_manager_sync</xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
 <!-- boilerplate wrappers for brief suite reports -->
 
 <xsl:template match="fio" mode="brief">
@@ -214,6 +225,17 @@
     </xsl:call-template>
 </xsl:template>
 
+<xsl:template match="disk_manager_eternal" mode="brief">
+    <xsl:call-template name="brief">
+        <xsl:with-param name="suite-kind">disk_manager_eternal</xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="disk_manager_sync" mode="brief">
+    <xsl:call-template name="brief">
+        <xsl:with-param name="suite-kind">disk_manager_sync</xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
 <!-- main template -->
 
 <xsl:template match="index">
@@ -242,6 +264,8 @@
                 <div style="border: 1px solid black; margin-bottom: 20px; padding: 10px">
                     <h3>DM</h3>
                     <xsl:apply-templates select="disk_manager_acceptance" mode="brief"/>
+                    <xsl:apply-templates select="disk_manager_eternal" mode="brief"/>
+                    <xsl:apply-templates select="disk_manager_sync" mode="brief"/>
                 </div>
             </div>
             <div style="border-top: 1px dashed black; margin-bottom: 20px">
@@ -262,6 +286,8 @@
                 <div style="border: 1px solid black; margin-bottom: 20px; padding: 10px">
                     <h3>DM</h3>
                     <xsl:apply-templates select="disk_manager_acceptance" mode="detailed"/>
+                    <xsl:apply-templates select="disk_manager_eternal" mode="detailed"/>
+                    <xsl:apply-templates select="disk_manager_sync" mode="detailed"/>
                 </div>
             </div>
         </body>


### PR DESCRIPTION
The eternal and sync tests were not reported, due to incorrect path in
 disk_manager_acceptance_common.sh.