### PR TITLE
[Disk Manager]: Fix stdout and stderr paths naming in acceptance tests

### DIFF
--- a/cloud/storage/core/tools/ci/runner/disk_manager_acceptance_common.sh
+++ b/cloud/storage/core/tools/ci/runner/disk_manager_acceptance_common.sh
@@ -45,8 +45,8 @@ function execute_tests () {
     # shellcheck disable=SC2068
     # shellcheck disable=SC2046
     $dm/disk-manager-ci-acceptance-test-suite $(base_shell_args) $@ \
-    2>> "$results_path/disk_manager_${test_name:=acceptance}.err" \
-    >> "$results_path/disk_manager_${test_name:=acceptance}.out"
+    2>> "$results_path/stdout.txt" \
+    >> "$results_path/stderr.txt"
     report_results
 }
 


### PR DESCRIPTION
In all the other tests the results path is either `stderr.txt` or `stdout.txt`