### PR TITLE
Fixed idle session logic in TCreateSessionActor + added a ut for this logic

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -67,7 +67,7 @@ private:
     TActorId EventListener;
 
     bool Shutdown = false;
-    bool WakeupScheduled = false;
+    bool FirstWakeupScheduled = false;
 
     TActorId Owner;
 
@@ -269,7 +269,10 @@ void TCreateSessionActor::HandleConnect(
     LastPing = ctx.Now();
 
     CreateSession(ctx);
-    ScheduleWakeup(ctx);
+    if (!FirstWakeupScheduled) {
+        ScheduleWakeup(ctx);
+        FirstWakeupScheduled = true;
+    }
 }
 
 void TCreateSessionActor::HandleDisconnect(
@@ -457,12 +460,7 @@ void TCreateSessionActor::HandleGetSessionEventsResponse(
 
 void TCreateSessionActor::ScheduleWakeup(const TActorContext& ctx)
 {
-    if (WakeupScheduled) {
-        return;
-    }
-
     ctx.Schedule(TDuration::Seconds(1), new TEvents::TEvWakeup());
-    WakeupScheduled = true;
 }
 
 void TCreateSessionActor::HandleWakeup(

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -220,7 +220,6 @@ void TCreateSessionActor::HandleDescribeFileStoreResponse(
     TabletId = fsDescr.GetIndexTabletId();
 
     CreatePipe(ctx);
-    ScheduleWakeUp(ctx);
 
     Become(&TThis::StateWork);
 }
@@ -269,6 +268,7 @@ void TCreateSessionActor::HandleConnect(
     LastPing = ctx.Now();
 
     CreateSession(ctx);
+    ScheduleWakeUp(ctx);
 }
 
 void TCreateSessionActor::HandleDisconnect(
@@ -833,7 +833,7 @@ void TStorageServiceActor::HandleSessionCreated(
     }
 
     if (msg->RequestInfo) {
-        auto inflight = FindInFlightRequest(msg->RequestInfo->Cookie);
+        auto* inflight = FindInFlightRequest(msg->RequestInfo->Cookie);
         if (!inflight) {
             LOG_CRIT(ctx, TFileStoreComponents::SERVICE,
                 "%s failed complete CreateSession: invalid cookie (%lu)",

--- a/cloud/filestore/libs/storage/service/ut/ya.make
+++ b/cloud/filestore/libs/storage/service/ut/ya.make
@@ -1,10 +1,6 @@
 UNITTEST_FOR(cloud/filestore/libs/storage/service)
 
-IF (SANITIZER_TYPE)
-    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
-ELSE()
-    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
-ENDIF()
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
 
 SRCS(
     helpers_ut.cpp


### PR DESCRIPTION
NBSNEBIUS-46:
1. TCreateSessionActor should schedule EvWakeup only after TEvTabletPipe::EvClientConnected because otherwise it can decide that the session is idle before it could be physically pinged
2. added a ut that tests pipe restoration logic in TCreateSessionActor