### PR TITLE
[Disk Manager]: Fix s3 url in disk manager acceptance tests

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
@@ -17,9 +17,12 @@ class AcceptanceTestBinaryExecutor(BaseTestBinaryExecutor):
 
     def __init__(self, args, *arguments, **kwargs):
         super(AcceptanceTestBinaryExecutor, self).__init__(args, *arguments, **kwargs)
+        location = args.cluster
+        if args.profile_name is not None:
+            location = args.profile_name
         self._acceptance_test_cmd.extend([
             '--url-for-create-image-from-url-test',
-            f"https://{self._s3_host}/{args.cluster}.disk-manager/acceptance-tests/ubuntu-1604-ci-stable"])
+            f"https://{self._s3_host}/{location}.disk-manager/acceptance-tests/ubuntu-1604-ci-stable"])
 
 
 class AcceptanceTestRunner(BaseAcceptanceTestRunner):


### PR DESCRIPTION
We should use profile-name parameter in the s3 url if available.