### PR TITLE
NBSNEBIUS-71: get rid of lock-free stack in eternal-load

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -176,7 +176,6 @@ bool TTestExecutor::Run()
     STORAGE_INFO("Running load");
 
     AsyncIO.Start();
-    TVector<ui16> buf;
     for (ui16 rangeIdx = 0; rangeIdx < ConfigHolder->GetConfig().IoDepth(); ++rangeIdx) {
         DoRandomRequest(rangeIdx);
     }
@@ -333,7 +332,6 @@ void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
     });
 }
 
-// Enques a random read or write request with probabil
 void TTestExecutor::DoRandomRequest(ui16 rangeIdx) {
     if (!AtomicGet(ShouldStop)) {
         if (RandomNumber(100U) >= ConfigHolder->GetConfig().WriteRate()) {

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -184,7 +184,7 @@ bool TTestExecutor::Run()
         Sleep(TDuration::Seconds(1));
     }
 
-    for (const auto& future: Futures) {
+    for (auto future: Futures) {
         future.GetValueSync();
     }
     AsyncIO.Stop();
@@ -327,7 +327,7 @@ void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
     }
 
     Futures[rangeIdx] = WaitAll(futures);
-    Futures[rangeIdx].Subscribe([rangeIdx, this] (auto) {
+    Futures[rangeIdx].Subscribe([=] (auto) {
         DoRandomRequest(rangeIdx);
     });
 }


### PR DESCRIPTION
There seems to be an issue with eternal test, as the latency of a lock-free stack was comparable with the latency of r/w requests (when iodepth exceeds 4).

Thus, using a lock-free stack may impose limitations on a number of in-flight requests.