### PR TITLE
NBSNEBIUS-76: RejectAgentTimeout dynamic calculation should deduplicate agent disconnects by rack - problems in a single rack should not make RejectAgentTimeout reach max values

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -424,7 +424,7 @@ void TDiskRegistryActor::HandleServerDisconnected(
             << " disconnected, SeqNo=" << info.SeqNo);
 
         ScheduleRejectAgent(ctx, agentId, info.SeqNo);
-        State->OnAgentDisconnected(ctx.Now());
+        State->OnAgentDisconnected(ctx.Now(), agentId);
     }
 
     ServerToAgentId.erase(it);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -776,9 +776,9 @@ public:
         return AgentList.GetRejectAgentTimeout(now, agentId);
     }
 
-    void OnAgentDisconnected(TInstant now)
+    void OnAgentDisconnected(TInstant now, const TString& agentId)
     {
-        AgentList.OnAgentDisconnected(now);
+        AgentList.OnAgentDisconnected(now, agentId);
     }
 
     void SetDiskRegistryAgentListParams(

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
@@ -48,7 +48,8 @@ private:
     const NMonitoring::TDynamicCountersPtr ComponentGroup;
 
     double RejectTimeoutMultiplier = 1;
-    TInstant LastAgentEventTs;
+    TInstant LastAgentDisconnectTs;
+    THashMap<TString, TInstant> Rack2LastDisconnectTs;
 
     TVector<NProto::TAgentConfig> Agents;
     TVector<TAgentCounters> AgentCounters;
@@ -107,7 +108,7 @@ public:
         const NProto::TMeanTimeBetweenFailures& mtbf);
 
     TDuration GetRejectAgentTimeout(TInstant now, const TString& agentId) const;
-    void OnAgentDisconnected(TInstant now);
+    void OnAgentDisconnected(TInstant now, const TString& agentId);
 
     const THashMap<TString, NProto::TDiskRegistryAgentParams>& GetDiskRegistryAgentListParams() const
     {
@@ -161,6 +162,8 @@ private:
         const TKnownAgent& knownAgent,
         TInstant timestamp,
         NProto::TDeviceConfig device);
+
+    TString FindAgentRack(const TString& agentId) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
У нас в DiskRegistry есть таймауты на признание агента недоступным (и выполнение следующих из этого действий - например, замен реплик в mirrored-дисках). Таймаут динамический - от 30s до 5m. Если агенты ломаются редко, таймаут 30s. Если вдруг в течение короткого времени ломается много агентов, мы консервативно повышаем таймаут, чтоб на случай масштабного сетевого флапа не поотстреливать сразу много агентов. Но эта логика ведет себя не очень хорошо при потере стойки (а это иногда случается) - таймаут быстро возрастает до 5 минут и многие из тех mirrored-дисков, которые зависели от этой стойки, таким образом ждут замен пострадавших реплик по 5 минут. Надо сделать так, чтобы логика увеличения таймаута учитывала кол-во потерянных за короткое время стоек, а не отдельных агентов.