### PR TITLE
[Tests]: Do not allocate pseudo-terminal

### DIFF
--- a/cloud/blockstore/pylibs/common/ssh_client.py
+++ b/cloud/blockstore/pylibs/common/ssh_client.py
@@ -228,7 +228,7 @@ class SshClient:
             '-o',  'ServerAliveInterval=60',
             '-o', 'StrictHostKeyChecking no',
             *self._key_path_cmd_argument,
-            '-tt',
+            '-T',  # Disable pseudo-terminal allocation.
             self._authorization_string,
             command_line,
         ]


### PR DESCRIPTION
Pseudo terminal allocation was not previously supported in tests, the -t option caused significant divergence in test results with proprietary tests.