### PR TITLE
NBS-4789: [Disk Manager] refactor sre tools

### DIFF
--- a/cloud/disk_manager/pkg/admin/tasks.go
+++ b/cloud/disk_manager/pkg/admin/tasks.go
@@ -272,7 +272,7 @@ func newListRunningCmd(
 		clientConfig,
 		serverConfig,
 		"running",
-		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
+		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]TaskInfo, error) {
 			return storage.ListTasksRunning(ctx, limit)
 		},
 	)
@@ -287,7 +287,7 @@ func newListCancellingCmd(
 		clientConfig,
 		serverConfig,
 		"cancelling",
-		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
+		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]TaskInfo, error) {
 			return storage.ListTasksCancelling(ctx, limit)
 		},
 	)

--- a/cloud/disk_manager/pkg/admin/tasks.go
+++ b/cloud/disk_manager/pkg/admin/tasks.go
@@ -272,8 +272,13 @@ func newListRunningCmd(
 		clientConfig,
 		serverConfig,
 		"running",
-		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]TaskInfo, error) {
-			return storage.ListTasksRunning(ctx, limit)
+		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
+			taskInfos, err := storage.ListTasksRunning(ctx, limit)
+			if err != nil {
+				return []string{}, err
+			}
+
+			return getTaskIDs(taskInfos), nil
 		},
 	)
 }
@@ -287,8 +292,13 @@ func newListCancellingCmd(
 		clientConfig,
 		serverConfig,
 		"cancelling",
-		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]TaskInfo, error) {
-			return storage.ListTasksCancelling(ctx, limit)
+		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
+			taskInfos, err := storage.ListTasksCancelling(ctx, limit)
+			if err != nil {
+				return []string{}, err
+			}
+
+			return getTaskIDs(taskInfos), nil
 		},
 	)
 }

--- a/cloud/disk_manager/pkg/admin/tasks.go
+++ b/cloud/disk_manager/pkg/admin/tasks.go
@@ -225,7 +225,7 @@ func newListReadyToRunCmd(
 		serverConfig,
 		"ready_to_run",
 		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
-			taskInfos, err := storage.ListTasksReadyToRun(
+			tasks, err := storage.ListTasksReadyToRun(
 				ctx,
 				limit,
 				nil, // taskTypeWhitelist
@@ -234,7 +234,7 @@ func newListReadyToRunCmd(
 				return []string{}, err
 			}
 
-			return getTaskIDs(taskInfos), nil
+			return getTaskIDs(tasks), nil
 		},
 	)
 }
@@ -249,7 +249,7 @@ func newListReadyToCancelCmd(
 		serverConfig,
 		"ready_to_cancel",
 		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
-			taskInfos, err := storage.ListTasksReadyToCancel(
+			tasks, err := storage.ListTasksReadyToCancel(
 				ctx,
 				limit,
 				nil, // taskTypeWhitelist
@@ -258,7 +258,7 @@ func newListReadyToCancelCmd(
 				return []string{}, err
 			}
 
-			return getTaskIDs(taskInfos), nil
+			return getTaskIDs(tasks), nil
 		},
 	)
 }
@@ -273,12 +273,12 @@ func newListRunningCmd(
 		serverConfig,
 		"running",
 		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
-			taskInfos, err := storage.ListTasksRunning(ctx, limit)
+			tasks, err := storage.ListTasksRunning(ctx, limit)
 			if err != nil {
 				return []string{}, err
 			}
 
-			return getTaskIDs(taskInfos), nil
+			return getTaskIDs(tasks), nil
 		},
 	)
 }
@@ -293,12 +293,12 @@ func newListCancellingCmd(
 		serverConfig,
 		"cancelling",
 		func(ctx context.Context, storage tasks_storage.Storage, limit uint64) ([]string, error) {
-			taskInfos, err := storage.ListTasksCancelling(ctx, limit)
+			tasks, err := storage.ListTasksCancelling(ctx, limit)
 			if err != nil {
 				return []string{}, err
 			}
 
-			return getTaskIDs(taskInfos), nil
+			return getTaskIDs(tasks), nil
 		},
 	)
 }

--- a/cloud/tasks/storage/compound_storage.go
+++ b/cloud/tasks/storage/compound_storage.go
@@ -226,9 +226,9 @@ func (s *compoundStorage) ListTasksStallingWhileCancelling(
 func (s *compoundStorage) ListTasksRunning(
 	ctx context.Context,
 	limit uint64,
-) ([]string, error) {
+) ([]TaskInfo, error) {
 
-	tasks := []string{}
+	tasks := []TaskInfo{}
 	err := s.visit(ctx, func(storage Storage) error {
 		values, err := storage.ListTasksRunning(ctx, limit)
 		tasks = append(tasks, values...)
@@ -240,9 +240,9 @@ func (s *compoundStorage) ListTasksRunning(
 func (s *compoundStorage) ListTasksCancelling(
 	ctx context.Context,
 	limit uint64,
-) ([]string, error) {
+) ([]TaskInfo, error) {
 
-	tasks := []string{}
+	tasks := []TaskInfo{}
 	err := s.visit(ctx, func(storage Storage) error {
 		values, err := storage.ListTasksCancelling(ctx, limit)
 		tasks = append(tasks, values...)

--- a/cloud/tasks/storage/mocks/storage_mock.go
+++ b/cloud/tasks/storage/mocks/storage_mock.go
@@ -103,19 +103,19 @@ func (s *StorageMock) ListTasksStallingWhileCancelling(
 func (s *StorageMock) ListTasksRunning(
 	ctx context.Context,
 	limit uint64,
-) ([]string, error) {
+) ([]tasks_storage.TaskInfo, error) {
 
 	args := s.Called(ctx, limit)
-	res, _ := args.Get(0).([]string)
+	res, _ := args.Get(0).([]tasks_storage.TaskInfo)
 	return res, args.Error(1)
 }
 func (s *StorageMock) ListTasksCancelling(
 	ctx context.Context,
 	limit uint64,
-) ([]string, error) {
+) ([]tasks_storage.TaskInfo, error) {
 
 	args := s.Called(ctx, limit)
-	res, _ := args.Get(0).([]string)
+	res, _ := args.Get(0).([]tasks_storage.TaskInfo)
 	return res, args.Error(1)
 }
 

--- a/cloud/tasks/storage/storage.go
+++ b/cloud/tasks/storage/storage.go
@@ -313,8 +313,8 @@ type Storage interface {
 	) ([]TaskInfo, error)
 
 	// Used for SRE tools.
-	ListTasksRunning(ctx context.Context, limit uint64) ([]string, error)
-	ListTasksCancelling(ctx context.Context, limit uint64) ([]string, error)
+	ListTasksRunning(ctx context.Context, limit uint64) ([]TaskInfo, error)
+	ListTasksCancelling(ctx context.Context, limit uint64) ([]TaskInfo, error)
 	ListFailedTasks(ctx context.Context, since time.Time) ([]string, error)
 	ListSlowTasks(ctx context.Context, since time.Time, estimateMiss time.Duration) ([]string, error)
 

--- a/cloud/tasks/storage/storage_ydb.go
+++ b/cloud/tasks/storage/storage_ydb.go
@@ -208,15 +208,15 @@ func (s *storageYDB) ListTasksStallingWhileCancelling(
 func (s *storageYDB) ListTasksRunning(
 	ctx context.Context,
 	limit uint64,
-) ([]string, error) {
+) ([]TaskInfo, error) {
 
-	var tasks []string
+	var tasks []TaskInfo
 
 	err := s.db.Execute(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
 			var err error
-			tasks, err = s.listTaskIDs(
+			tasks, err = s.listTasks(
 				ctx,
 				session,
 				"running",
@@ -232,15 +232,15 @@ func (s *storageYDB) ListTasksRunning(
 func (s *storageYDB) ListTasksCancelling(
 	ctx context.Context,
 	limit uint64,
-) ([]string, error) {
+) ([]TaskInfo, error) {
 
-	var tasks []string
+	var tasks []TaskInfo
 
 	err := s.db.Execute(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
 			var err error
-			tasks, err = s.listTaskIDs(
+			tasks, err = s.listTasks(
 				ctx,
 				session,
 				"cancelling",

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -1114,7 +1114,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	expectedTaskInfos := []TaskInfo{
+	expectedTasks := []TaskInfo{
 		TaskInfo{
 			ID:           taskIDRunning,
 			GenerationID: generationID,
@@ -1127,9 +1127,9 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		},
 	}
 
-	taskInfos, err := storage.ListTasksRunning(ctx, 100500)
+	tasks, err := storage.ListTasksRunning(ctx, 100500)
 	require.NoError(t, err)
-	require.ElementsMatch(t, expectedTaskInfos, taskInfos)
+	require.ElementsMatch(t, expectedTasks, tasks)
 }
 
 func TestStorageYDBListTasksCancelling(t *testing.T) {
@@ -1292,7 +1292,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	expectedTaskInfos := []TaskInfo{
+	expectedTasks := []TaskInfo{
 		TaskInfo{
 			ID:           taskIDCancelling,
 			GenerationID: generationID,
@@ -1305,9 +1305,9 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		},
 	}
 
-	taskInfos, err := storage.ListTasksCancelling(ctx, 100500)
+	tasks, err := storage.ListTasksCancelling(ctx, 100500)
 	require.NoError(t, err)
-	require.ElementsMatch(t, expectedTaskInfos, taskInfos)
+	require.ElementsMatch(t, expectedTasks, tasks)
 }
 
 func TestStorageYDBListFailedTasks(t *testing.T) {

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -1114,14 +1114,22 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	expectedTasks := []string{
-		taskIDRunning,
-		taskIDStallingWhileRunning,
+	expectedTaskInfos := []TaskInfo{
+		TaskInfo{
+			ID:           taskIDRunning,
+			GenerationID: generationID,
+			TaskType:     "task1",
+		},
+		TaskInfo{
+			ID:           taskIDStallingWhileRunning,
+			GenerationID: generationID,
+			TaskType:     "task1",
+		},
 	}
 
-	taskIDs, err := storage.ListTasksRunning(ctx, 100500)
+	taskInfos, err := storage.ListTasksRunning(ctx, 100500)
 	require.NoError(t, err)
-	require.ElementsMatch(t, expectedTasks, taskIDs)
+	require.ElementsMatch(t, expectedTaskInfos, taskInfos)
 }
 
 func TestStorageYDBListTasksCancelling(t *testing.T) {
@@ -1284,14 +1292,22 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	expectedTasks := []string{
-		taskIDCancelling,
-		taskIDStallingWhileCancelling,
+	expectedTaskInfos := []TaskInfo{
+		TaskInfo{
+			ID:           taskIDCancelling,
+			GenerationID: generationID,
+			TaskType:     "task1",
+		},
+		TaskInfo{
+			ID:           taskIDStallingWhileCancelling,
+			GenerationID: generationID,
+			TaskType:     "task1",
+		},
 	}
 
-	taskIDs, err := storage.ListTasksCancelling(ctx, 100500)
+	taskInfos, err := storage.ListTasksCancelling(ctx, 100500)
 	require.NoError(t, err)
-	require.ElementsMatch(t, expectedTasks, taskIDs)
+	require.ElementsMatch(t, expectedTaskInfos, taskInfos)
 }
 
 func TestStorageYDBListFailedTasks(t *testing.T) {

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -696,12 +696,7 @@ func TestTasksRunningLimit(t *testing.T) {
 					runningLongTaskCount++
 				}
 			}
-
-			require.LessOrEqual(
-				t,
-				runningLongTaskCount,
-				inflightLongTaskPerNodeLimit,
-			)
+			require.LessOrEqual(t, runningLongTaskCount, inflightLongTaskPerNodeLimit)
 		case err := <-errs:
 			require.NoError(t, err)
 			endedLongTaskCount++

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -689,14 +689,19 @@ func TestTasksRunningLimit(t *testing.T) {
 
 			runningLongTaskCount := 0
 			for _, task := range runningTasks {
-				taskState, err := s.storage.GetTask(ctx, task)
+				taskState, err := s.storage.GetTask(ctx, task.ID)
 				require.NoError(t, err)
 
 				if taskState.TaskType == "long" {
 					runningLongTaskCount++
 				}
 			}
-			require.LessOrEqual(t, runningLongTaskCount, inflightLongTaskPerNodeLimit)
+
+			require.LessOrEqual(
+				t,
+				runningLongTaskCount,
+				inflightLongTaskPerNodeLimit,
+			)
 		case err := <-errs:
 			require.NoError(t, err)
 			endedLongTaskCount++


### PR DESCRIPTION
need to return []TaskInfo not []string from ListTasksRunning/ListTasksCancelling methods because I want to use them in collect_lister_metrics_task

https://github.com/ydb-platform/nbs/blob/fc1dd1fa9accb81ec0f7c2a5df231817bc56fb90/cloud/tasks/collect_lister_metrics_task.go#L107

