### PR TITLE
merge to stable-23-3: NBSNEBIUS-76: RejectAgentTimeout dynamic calculation should deduplica…

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -424,7 +424,7 @@ void TDiskRegistryActor::HandleServerDisconnected(
             << " disconnected, SeqNo=" << info.SeqNo);
 
         ScheduleRejectAgent(ctx, agentId, info.SeqNo);
-        State->OnAgentDisconnected(ctx.Now());
+        State->OnAgentDisconnected(ctx.Now(), agentId);
     }
 
     ServerToAgentId.erase(it);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -738,9 +738,9 @@ public:
         return AgentList.GetRejectAgentTimeout(now, agentId);
     }
 
-    void OnAgentDisconnected(TInstant now)
+    void OnAgentDisconnected(TInstant now, const TString& agentId)
     {
-        AgentList.OnAgentDisconnected(now);
+        AgentList.OnAgentDisconnected(now, agentId);
     }
 
     void SetDiskRegistryAgentListParams(

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
@@ -48,7 +48,8 @@ private:
     const NMonitoring::TDynamicCountersPtr ComponentGroup;
 
     double RejectTimeoutMultiplier = 1;
-    TInstant LastAgentEventTs;
+    TInstant LastAgentDisconnectTs;
+    THashMap<TString, TInstant> Rack2LastDisconnectTs;
 
     TVector<NProto::TAgentConfig> Agents;
     TVector<TAgentCounters> AgentCounters;
@@ -107,7 +108,7 @@ public:
         const NProto::TMeanTimeBetweenFailures& mtbf);
 
     TDuration GetRejectAgentTimeout(TInstant now, const TString& agentId) const;
-    void OnAgentDisconnected(TInstant now);
+    void OnAgentDisconnected(TInstant now, const TString& agentId);
 
     const THashMap<TString, NProto::TDiskRegistryAgentParams>& GetDiskRegistryAgentListParams() const
     {
@@ -161,6 +162,8 @@ private:
         const TKnownAgent& knownAgent,
         TInstant timestamp,
         NProto::TDeviceConfig device);
+
+    TString FindAgentRack(const TString& agentId) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
…te agent disconnects by rack - problems in a single rack should not make RejectAgentTimeout reach max values (#159)

* NBSNEBIUS-76: RejectAgentTimeout dynamic calculation should deduplicate agent disconnects by rack - problems in a single rack should not make RejectAgentTimeout reach max values

* NBSNEBIUS-76: RejectAgentTimeout dynamic calculation should deduplicate agent disconnects by rack - problems in a single rack should not make RejectAgentTimeout reach max values - fixed lifecycle ut