### PR TITLE
NBSNEBIUS-83: device config validation should not fail if Serial or PhysicalOffset changed from 0 to non-0

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1013,7 +1013,6 @@ NProto::TError TDiskRegistryState::CheckDestructiveConfigurationChange(
             d.GetBlockSize(),
             d.GetBlocksCount(),
             d.GetUnadjustedBlockCount(),
-            d.GetPhysicalOffset(),
             TStringBuf {d.GetDeviceName()}
         );
     };
@@ -1022,7 +1021,9 @@ NProto::TError TDiskRegistryState::CheckDestructiveConfigurationChange(
     const auto newKey = key(device);
 
     if (oldKey == newKey && (oldConfig->GetSerialNumber().empty()
-            || oldConfig->GetSerialNumber() == device.GetSerialNumber()))
+            || oldConfig->GetSerialNumber() == device.GetSerialNumber())
+            && (oldConfig->GetPhysicalOffset() == 0
+                || oldConfig->GetPhysicalOffset() == device.GetPhysicalOffset()))
     {
         return {};
     }


### PR DESCRIPTION
[NBS] Не фейлить валидацию конфига девайса, если Serial или PhysicalOffset поменялись из 0 в не-0

Иначе релиз выкатить невозможно - после рестарта DiskRegistry отстреливает все девайсы, для которых появились PhysicalOffset или Serial. Этих полей раньше не было, поэтому тут на уровне логики валидации ломается совместимость.