### PR TITLE
NBSNEBIUS-82: not counting broken placement group partitions for non-HDD disks; slightly improved ShouldHandleCmsRequestsForHostsWithDependentHddDisks ut

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1,6 +1,5 @@
 #include "disk_registry_state.h"
 
-#include "cloud/storage/core/protos/media.pb.h"
 #include "disk_registry_schema.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1,5 +1,6 @@
 #include "disk_registry_state.h"
 
+#include "cloud/storage/core/protos/media.pb.h"
 #include "disk_registry_schema.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
@@ -4672,17 +4673,17 @@ bool TDiskRegistryState::HasDependentSsdDisks(
     return false;
 }
 
-ui32 TDiskRegistryState::CountBrokenPlacementGroupPartitionsAfterAgentRemoval(
+ui32 TDiskRegistryState::CountBrokenHddPlacementGroupPartitionsAfterAgentRemoval(
     const NProto::TAgentConfig& agent) const
 {
     THashSet<TString> deviceIds;
     for (const auto& d: agent.GetDevices()) {
         deviceIds.insert(d.GetDeviceUUID());
     }
-    return CountBrokenPlacementGroupPartitionsAfterDeviceRemoval(deviceIds);
+    return CountBrokenHddPlacementGroupPartitionsAfterDeviceRemoval(deviceIds);
 }
 
-ui32 TDiskRegistryState::CountBrokenPlacementGroupPartitionsAfterDeviceRemoval(
+ui32 TDiskRegistryState::CountBrokenHddPlacementGroupPartitionsAfterDeviceRemoval(
     const THashSet<TString>& deviceIds) const
 {
     ui32 maxBrokenCount = 0;
@@ -4701,6 +4702,10 @@ ui32 TDiskRegistryState::CountBrokenPlacementGroupPartitionsAfterDeviceRemoval(
             auto* disk = Disks.FindPtr(diskInfo.GetDiskId());
             Y_DEBUG_ABORT_UNLESS(disk);
             if (!disk) {
+                continue;
+            }
+
+            if (disk->MediaKind != NProto::STORAGE_MEDIA_HDD_NONREPLICATED) {
                 continue;
             }
 
@@ -4794,11 +4799,11 @@ NProto::TError TDiskRegistryState::UpdateCmsHostState(
 
     const bool hasDependentDisks = HasDependentSsdDisks(*agent);
     const ui32 brokenPlacementGroupPartitions =
-        CountBrokenPlacementGroupPartitionsAfterAgentRemoval(*agent);
-    const ui32 maxBrokenPartitions =
+        CountBrokenHddPlacementGroupPartitionsAfterAgentRemoval(*agent);
+    const ui32 maxBrokenHddPartitions =
         StorageConfig->GetMaxBrokenHddPlacementGroupPartitionsAfterDeviceRemoval();
     if (!hasDependentDisks
-            && brokenPlacementGroupPartitions <= maxBrokenPartitions)
+            && brokenPlacementGroupPartitions <= maxBrokenHddPartitions)
     {
         // no dependent disks => we can return this host immediately
         timeout = TDuration::Zero();
@@ -5013,7 +5018,7 @@ NProto::TError TDiskRegistryState::UpdateDeviceState(
     }
 
     auto error = CheckDeviceStateTransition(*devicePtr, newState, now);
-    if (FAILED(error.GetCode())) {
+    if (HasError(error)) {
         return error;
     }
 
@@ -5226,11 +5231,11 @@ NProto::TError TDiskRegistryState::CmsRemoveDevice(
     }
 
     const ui32 brokenPlacementGroupPartitions =
-        CountBrokenPlacementGroupPartitionsAfterDeviceRemoval({deviceId});
-    const ui32 maxBrokenPartitions =
+        CountBrokenHddPlacementGroupPartitionsAfterDeviceRemoval({deviceId});
+    const ui32 maxBrokenHddPartitions =
         StorageConfig->GetMaxBrokenHddPlacementGroupPartitionsAfterDeviceRemoval();
 
-    if (brokenPlacementGroupPartitions > maxBrokenPartitions) {
+    if (brokenPlacementGroupPartitions > maxBrokenHddPartitions) {
         error = MakeError(
             E_TRY_AGAIN,
             TStringBuilder() << "will break too many partitions: "

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -924,9 +924,9 @@ private:
         TVector<TDiskId>& affectedDisks);
 
     bool HasDependentSsdDisks(const NProto::TAgentConfig& agent) const;
-    ui32 CountBrokenPlacementGroupPartitionsAfterAgentRemoval(
+    ui32 CountBrokenHddPlacementGroupPartitionsAfterAgentRemoval(
         const NProto::TAgentConfig& agent) const;
-    ui32 CountBrokenPlacementGroupPartitionsAfterDeviceRemoval(
+    ui32 CountBrokenHddPlacementGroupPartitionsAfterDeviceRemoval(
         const THashSet<TString>& deviceIds) const;
 
     NProto::TError CheckAgentStateTransition(


### PR DESCRIPTION
We should not allow maintenance if it affects a placement group which may have 2+ partitions with broken STORAGE_MEDIA_HDD_NONREPLICATED disks. But in reality we don't check disk media kind and may block maintenance for placement groups with STORAGE_MEDIA_SSD_NONREPLICATED disks. This PR adds the missing MediaKind check.