### PR TITLE
[Disk Manager]: Fix eternal tests race condition

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
@@ -306,7 +306,7 @@ class BaseAcceptanceTestRunner(ABC):
         disk_bs: int,
         extra_params: dict,
         test_case_name: str,
-    ) -> None:
+    ) -> contextlib.AbstractContextManager[None]:
         error = None
         try:
             yield

--- a/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
@@ -7,6 +7,7 @@ from .base_acceptance_test_runner import BaseAcceptanceTestRunner, \
 
 from .lib import (
     check_ssh_connection,
+    file_lock,
     size_prettifier,
     Error,
 )
@@ -51,6 +52,7 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
         )
 
         with contextlib.ExitStack() as stack:
+            stack.enter_context(file_lock(self._get_test_suite()))
             instance = stack.enter_context(self._instance_policy.obtain())
             stack.enter_context(
                 self._recording_result(
@@ -60,12 +62,8 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
                     self._args.disk_type,
                     self._args.disk_blocksize,
                     {},
-                    (
-                        f'{self._args.zone_id}_eternal_'
-                        f'{size_prettifier(self._args.disk_size * (1024 ** 3))}_'
-                        f'{size_prettifier(self._args.disk_blocksize)}'.lower()
-                    ),
-                    )
+                    self._get_test_suite(),
+                )
             )
             # Copy cmp binary to instance
             _logger.info(f'Copying <path={self._args.cmp_util}> to'

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -1,8 +1,11 @@
+import contextlib
+import fcntl
 import logging
 import os
 
 import random
 import socket
+from pathlib import Path
 
 from typing import Callable, Protocol
 
@@ -82,3 +85,12 @@ def size_prettifier(size_bytes: int) -> str:
         return '%sKiB' % (size_bytes // 1024)
     else:
         return '%sB' % size_bytes
+
+
+@contextlib.contextmanager
+def file_lock(name: str):
+    lock_path = Path(f'/tmp/disk_manager_acceptance_lock/{name}.lock')
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open('w') as f:
+        fcntl.lockf(f, fcntl.LOCK_EX)
+        yield


### PR DESCRIPTION
Implement file-locking mechanism for disk manager eternal tests. Disk manager eternal tests for 8TiB disks take more than 24hours to complete. Since they are started with cron, next test run starts before the previous run is finished. Since those tests use the same disk per suite but not per run, the same disk is detached from the previous machine, crashing tests for the previous run.