### PR TITLE
[Disk Manager]: Ensure disk manager eternal tests are ran one at a time

### DIFF
--- a/cloud/storage/core/tools/ci/runner/disk_manager_acceptance_common.sh
+++ b/cloud/storage/core/tools/ci/runner/disk_manager_acceptance_common.sh
@@ -41,11 +41,15 @@ function execute_tests () {
     results_path="${result_case_directory}${test_suite:?"test_suite parameter undefined"}/$(date +%Y-%m-%d)"
     export results_path
     create_results_directory
+    export lockfile="/tmp/disk_manager_${test_name:=acceptance}_${test_suite:?"test_suite parameter undefined"}.lock"
     # shellcheck disable=SC2068
     # shellcheck disable=SC2046
-    $dm/disk-manager-ci-acceptance-test-suite $(base_shell_args) $@ \
-    2>> "$results_path/stderr.txt" \
-    >> "$results_path/stdout.txt"
+    (
+      flock 200
+      $dm/disk-manager-ci-acceptance-test-suite $(base_shell_args) $@ \
+          2>> "$results_path/stderr.txt" \
+          >> "$results_path/stdout.txt"
+    ) 200>"$lockfile"
     report_results
 }
 


### PR DESCRIPTION
Disk manager eternal tests for 8TiB disks take more than 24hours to complete. Since they are started with cron, next test run starts before the previous run is finished. Since those tests use the same disk per suite but not per run, the same disk is detached from the previous machine, crashing tests for the previous run.