### PR TITLE
NBSNEBIUS-86: impld garbage FreshDeviceIds filtration in TVolumeState

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -35,14 +35,10 @@ TMirrorPartitionState::TMirrorPartitionState(
     }
 
     if (freshDeviceCount != partConfig->GetFreshDeviceIds().size()) {
-        // XXX needed to mute crit events for old disks after NBS-4383
-        const TInstant oldDate = TInstant::ParseIso8601("2023-08-30");
-        if (partConfig->GetVolumeInfo().CreationTs > oldDate) {
-            ReportFreshDeviceNotFoundInConfig(TStringBuilder()
-                << "Fresh device count mismatch: " << freshDeviceCount
-                << " != " << partConfig->GetFreshDeviceIds().size()
-                << " for disk " << partConfig->GetName());
-        }
+        ReportFreshDeviceNotFoundInConfig(TStringBuilder()
+            << "Fresh device count mismatch: " << freshDeviceCount
+            << " != " << partConfig->GetFreshDeviceIds().size()
+            << " for disk " << partConfig->GetName());
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
@@ -563,37 +563,6 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         UNIT_ASSERT_VALUES_EQUAL(1, freshDeviceNotFoundInConfig->Val());
     }
 
-    Y_UNIT_TEST(ShouldNotReportFreshDeviceNotFoundInConfigForOldDisks)
-    {
-        // testing that we do not report this problem for the disks that were
-        // created before NBS-4383 got fixed - roughly the end of August 2023
-        using namespace NMonitoring;
-
-        TEnv env;
-        env.FreshDeviceIds = {"nonexistent_device", "2_1", "3_1"};
-        const TInstant oldDate = TInstant::ParseIso8601("2023-08-30");
-        // only SSD/HDD distinction matters
-        env.Init({oldDate, NProto::STORAGE_MEDIA_SSD_MIRROR3});
-
-        TDynamicCountersPtr counters = new TDynamicCounters();
-        InitCriticalEventsCounter(counters);
-        auto freshDeviceNotFoundInConfig = counters->GetCounter(
-            "AppCriticalEvents/FreshDeviceNotFoundInConfig",
-            true);
-
-        TMirrorPartitionState state(
-            std::make_shared<TStorageConfig>(
-                NProto::TStorageServiceConfig(),
-                nullptr),
-            "xxx",      // rwClientId
-            env.Config,
-            env.Migrations,
-            {env.ReplicaDevices}
-        );
-
-        UNIT_ASSERT_VALUES_EQUAL(0, freshDeviceNotFoundInConfig->Val());
-    }
-
     // TODO: test config validation
 
 #undef TEST_READ_REPLICA

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -1278,10 +1278,40 @@ void TVolumeActor::RenderStatus(IOutputStream& out) const
 void TVolumeActor::RenderMigrationStatus(IOutputStream& out) const
 {
     HTML(out) {
+        const auto& freshDeviceIds = State->GetMeta().GetFreshDeviceIds();
+
+        // this check is needed due to a bug that caused some disks to have
+        // garbage in FreshDeviceIds list
+        // this garbage causes no real issues - just requires us to filter
+        // FreshDeviceIds on monpages and in similar places
+        auto hasFreshDevices = [&] (const auto& devices) {
+            for (const auto& device: devices) {
+                const bool found = Find(
+                    freshDeviceIds.begin(),
+                    freshDeviceIds.end(),
+                    device.GetDeviceUUID()) != freshDeviceIds.end();
+
+                if (found) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        bool replicationInProgress =
+            hasFreshDevices(State->GetMeta().GetDevices());
+        for (auto& r: State->GetMeta().GetReplicas()) {
+            if (replicationInProgress) {
+                break;
+            }
+
+            replicationInProgress = hasFreshDevices(r.GetDevices());
+        }
+
         bool active = State->GetMeta().GetMigrations().size()
-            || State->GetMeta().GetFreshDeviceIds().size();
-        TStringBuf label = State->GetMeta().GetFreshDeviceIds().empty()
-            ? "Migration" : "Replication";
+            || replicationInProgress;
+        TStringBuf label = replicationInProgress ? "Replication" : "Migration";
 
         TAG(TH3) {
             TString statusText = "inactive";

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -169,14 +169,12 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
         State->GetDiskId(),
         State->GetMeta().GetConfig().GetBlockSize(),
         TNonreplicatedPartitionConfig::TVolumeInfo{
-            TInstant::MicroSeconds(volumeConfig.GetCreationTs()),
+            State->GetCreationTs(),
             mediaKind},
         SelfId(),
         State->GetMeta().GetMuteIOErrors(),
         State->GetTrackUsedBlocks(),
-        THashSet<TString>(
-            State->GetMeta().GetFreshDeviceIds().begin(),
-            State->GetMeta().GetFreshDeviceIds().end()),
+        State->GetFilteredFreshDevices(),
         maxTimedOutDeviceStateDuration,
         maxTimedOutDeviceStateDurationOverridden,
         useSimpleMigrationBandwidthLimiter);

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -107,6 +107,8 @@ private:
     const NProto::TPartitionConfig* Config;
     TRuntimeVolumeParams VolumeParams;
     ui64 BlockCount = 0;
+    // only for mirrored disks
+    THashSet<TString> FilteredFreshDeviceIds;
 
     TPartitionInfoList Partitions;
     TPartitionInfo::EState PartitionsState = TPartitionInfo::UNKNOWN;
@@ -172,6 +174,16 @@ public:
     const TVector<TVolumeMetaHistoryItem>& GetMetaHistory() const
     {
         return MetaHistory;
+    }
+
+    const THashSet<TString>& GetFilteredFreshDevices() const
+    {
+        return FilteredFreshDeviceIds;
+    }
+
+    TInstant GetCreationTs() const
+    {
+        return TInstant::MicroSeconds(Meta.GetVolumeConfig().GetCreationTs());
     }
 
     const TRuntimeVolumeParams& GetVolumeParams() const;

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/kikimr/events.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/config.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -1625,6 +1626,37 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
 
         volumeState.Reset();
         UNIT_ASSERT(volumeState.GetShouldStartPartitionsForGc(TInstant::Now()));
+    }
+
+    Y_UNIT_TEST(ShouldFilterFreshDeviceIdsForOldDisks)
+    {
+        // testing that we filter out garbage fresh device ids for the disks
+        // created before NBS-4383 got fixed - roughly the end of August 2023
+        auto volumeState = CreateVolumeState();
+        auto meta = volumeState.GetMeta();
+        const TInstant oldDate = TInstant::ParseIso8601("2023-08-30");
+        meta.MutableVolumeConfig()->SetCreationTs(oldDate.MicroSeconds());
+        meta.AddDevices()->SetDeviceUUID("d1");
+        meta.AddDevices()->SetDeviceUUID("d2");
+        auto& r1 = *meta.AddReplicas();
+        r1.AddDevices()->SetDeviceUUID("d3");
+        r1.AddDevices()->SetDeviceUUID("d4");
+        auto& r2 = *meta.AddReplicas();
+        r2.AddDevices()->SetDeviceUUID("d5");
+        r2.AddDevices()->SetDeviceUUID("d6");
+        meta.AddFreshDeviceIds("d2");
+        meta.AddFreshDeviceIds("d3");
+        meta.AddFreshDeviceIds("d5");
+        meta.AddFreshDeviceIds("garbage1");
+        meta.AddFreshDeviceIds("garbage2");
+        meta.AddFreshDeviceIds("garbage3");
+        volumeState.ResetMeta(meta);
+
+        ASSERT_VECTOR_CONTENTS_EQUAL(
+            TVector<TString>({"d2", "d3", "d5"}),
+            TVector<TString>(
+                volumeState.GetFilteredFreshDevices().begin(),
+                volumeState.GetFilteredFreshDevices().end()));
     }
 }
 


### PR DESCRIPTION
There used to be a bug (fixed a couple months ago) because of which some garbage device ids were added to the configs of some volumes. Even though the bug is fixed, some old volumes still contain garbage in their FreshDeviceIds lists and show "ReplicationStatus:in progress" on their monpages. This PR fixes the monpages for those volumes.