### PR TITLE
fix: log handling in chunk tests, added more logs to summary, append summary instead of add or modify, add flag to disable all info sync

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -94,8 +94,6 @@ runs:
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
           "${extra_params[@]}"
 
-        
-
     - name: Sync logs to S3
       if: always()
       shell: bash

--- a/.github/actions/s3cmd/action.yaml
+++ b/.github/actions/s3cmd/action.yaml
@@ -66,9 +66,9 @@ runs:
             ;;
         esac
 
-        echo "S3_BUCKET_PATH=s3://${{ inputs.s3_bucket }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
-        echo "S3_URL_PREFIX=${{ inputs.s3_endpoint }}/${{ inputs.s3_bucket }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
-        echo "S3_WEBSITE_PREFIX=https://${{ inputs.s3_bucket }}.${{ inputs.s3_website_suffix }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
+        echo "S3_BUCKET_PATH=s3://${{ inputs.s3_bucket }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
+        echo "S3_URL_PREFIX=${{ inputs.s3_endpoint }}/${{ inputs.s3_bucket }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
+        echo "S3_WEBSITE_PREFIX=https://${{ inputs.s3_bucket }}.${{ inputs.s3_website_suffix }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
       env:
         s3_key_id: ${{ inputs.s3_key_id }}
         s3_secret_access_key: ${{ inputs.s3_key_secret }}

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -30,6 +30,10 @@ inputs:
   cache_update:
     required: false
     description: "Use cache for tests"
+  sync_to_s3:
+    required: false
+    default: 'false'
+    description: 'Sync failed tests folders to s3'
 runs:
   using: composite
   steps:
@@ -107,6 +111,7 @@ runs:
         readarray -d ',' -t test_size < <(printf "%s" "${{ inputs.test_size }}")
         readarray -d ',' -t test_type < <(printf "%s" "${{ inputs.test_type }}")
 
+        echo "::group::ya-make-test"
         sudo -E -H -u github ./ya test -k --build "${build_type}" -D'BUILD_LANGUAGES=CPP PY3 PY2 GO' \
           ${test_size[@]/#/--test-size=} ${test_type[@]/#/--test-type=} \
           --test-threads "${{ inputs.test_threads }}" --link-threads "${{ inputs.link_threads }}" \
@@ -127,6 +132,7 @@ runs:
               fi
             fi
         )
+        echo "::endgroup::"
 
     - name: archive unitest reports (orig)
       shell: bash
@@ -185,12 +191,22 @@ runs:
             echo $path
             find "${GITHUB_WORKSPACE}/${path}" -print0 | xargs -0 xargs -0 cp -L -r --parents -t "$TESTS_DATA_DIR"
           done
+          chown -R github:github "$TESTS_DATA_DIR"
+          echo "::endgroup::"
+          echo "::group::remove-binaries-from-tests-data-dir"
+          find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}'
+          find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
           echo "::endgroup::"
           echo "::group::s3-sync"
-          #sudo -E -H -u github s3cmd sync --follow-symlinks --acl-private --no-progress --stats --no-check-md5 "$TESTS_DATA_DIR/" "$S3_BUCKET_PATH/test_data/"
+          if [ "$SYNC_TO_S3" = "true" ];
+          then
+            sudo -E -H -u github s3cmd sync --follow-symlinks --acl-private --no-progress --stats --no-check-md5 "$TESTS_DATA_DIR/" "$S3_BUCKET_PATH/test_data/"
+          fi
           echo "::endgroup::"
           exit $RC
         }
+      env:
+        SYNC_TO_S3: ${{ inputs.sync_to_s3 || 'false' }}
 
     - name: Sync test results to S3
       if: always()
@@ -224,11 +240,7 @@ runs:
         echo ${S3_WEBSITE_PREFIX}/summary/ya-test.html
         echo "::endgroup::"
 
-
-
     - name: show free space
       if: always()
       shell: bash
       run: df -h
-
-     

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -4,7 +4,7 @@
         th {
             text-transform: uppercase;
         }
-        
+
         th, td {
             padding: 5px;
         }
@@ -55,7 +55,7 @@
         <td>{{ t.full_name }}</td>
         <td><span title="{{ t.elapsed }}s">{{ t.elapsed_display }}</span></td>
         <td>
-            <span class="test_status test_{{ t.status_display }}">{{ t.status_display }}</span>
+            <span class="test_status test_{{ t.status_display }}">{{ t.status_display }}{% if t.is_timed_out %}(TIMEOUT){% endif %}</span>
         </td>
         {% if status in has_any_log %}
         <td>
@@ -65,7 +65,7 @@
 
                 {% endfor %}
             {% else %}
-                &nbsp;
+                LOGS ARE EMPTY
             {% endif %}
         </td>
         {% endif %}

--- a/.github/scripts/tests/transform-ya-junit.py
+++ b/.github/scripts/tests/transform-ya-junit.py
@@ -4,6 +4,7 @@ import re
 import json
 import os
 import sys
+import shutil
 import urllib.parse
 from xml.etree import ElementTree as ET
 from mute_utils import mute_target, pattern_to_re
@@ -74,16 +75,41 @@ class YTestReportTrace:
                     event = json.loads(line.strip())
                     if event["name"] == "subtest-finished":
                         event = event["value"]
-                        cls = event["class"]
+                        class_event = event["class"]
                         subtest = event["subtest"]
-                        cls = cls.replace("::", ".")
-                        self.traces[(cls, subtest)] = event
+                        class_event = class_event.replace("::", ".")
+                        log_print(f"loaded ({class_event}, {subtest})")
+                        self.traces[(class_event, subtest)] = event
+                    elif event["name"] == "chunk-event":
+                        event = event["value"]
+                        chunk_idx = event["chunk_index"]
+                        chunk_total = event["nchunks"]
+                        test_name = subdir
+                        log_print(f"loaded ({test_name}, {chunk_idx}, {chunk_total})")
+                        self.traces[(test_name, chunk_idx, chunk_total)] = event
 
-    def has(self, cls, name):
-        return (cls, name) in self.traces
+    def has(self, class_event, name):
+        return (class_event, name) in self.traces
 
-    def get_logs(self, cls, name):
-        trace = self.traces.get((cls, name))
+    def get_logs(self, class_event, name):
+        trace = self.traces.get((class_event, name))
+
+        if not trace:
+            return {}
+
+        logs = trace["logs"]
+
+        result = {}
+        for k, path in logs.items():
+            if k == "logsdir":
+                continue
+
+            result[k] = path.replace("$(BUILD_ROOT)", self.out_root)
+
+        return result
+
+    def get_logs_chunks(self, suite, idx, total):
+        trace = self.traces.get((suite, idx, total))
 
         if not trace:
             return {}
@@ -104,6 +130,7 @@ def filter_empty_logs(logs):
     result = {}
     for k, v in logs.items():
         if not os.path.isfile(v) or os.stat(v).st_size == 0:
+            log_print(f"skipping log file {v} as empty or missing")
             continue
         result[k] = v
     return result
@@ -132,7 +159,8 @@ def save_log(build_root, fn, out_dir, log_url_prefix, trunc_size):
                             break
                         out_fp.write(buf)
         else:
-            os.symlink(fn, out_fn)
+            if fn != out_fn:
+                shutil.copy(fn, out_fn)
     quoted_fpath = urllib.parse.quote(fpath)
     return f"{log_url_prefix}{quoted_fpath}"
 
@@ -164,13 +192,29 @@ def transform(
                 log_print("mute", suite_name, test_name)
                 mute_target(case)
 
-            if is_fail and "." in test_name:
-                test_cls, test_method = test_name.rsplit(".", maxsplit=1)
-                logs = filter_empty_logs(traces.get_logs(test_cls, test_method))
+            if is_fail:
+                if "." in test_name:
+                    test_cls, test_method = test_name.rsplit(".", maxsplit=1)
+                    logs = filter_empty_logs(traces.get_logs(test_cls, test_method))
+
+                elif "chunk" in test_name:
+                    if "sole" in test_name:
+                        chunk_idx = 0
+                        chunks_total = 1
+                    else:
+                        pattern = r"\[(\d+)/(\d+)\]"
+                        match = re.search(pattern, test_name)
+                        chunk_idx = int(match.group(1))
+                        chunks_total = int(match.group(2))
+                    logs = filter_empty_logs(
+                        traces.get_logs_chunks(suite_name, chunk_idx, chunks_total)
+                    )
+                else:
+                    continue
 
                 if logs:
                     log_print(
-                        f"add {list(logs.keys())!r} properties for {test_cls}.{test_method}"
+                        f"add {list(logs.keys())!r} properties for {suite_name}/{test_name}"
                     )
                     for name, fn in logs.items():
                         url = save_log(

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -123,6 +123,7 @@ jobs:
         bazel_remote_uri: ${{ vars.REMOTE_CACHE_URL_YA || '' }}
         link_threads: ${{ inputs.link_threads }}
         test_threads: ${{ inputs.test_threads }}
+        sync_to_s3: ${{ vars.SYNC_TO_S3 }}
 
     - id: failure
       name: set sleep_after_tests in case of failure


### PR DESCRIPTION
1. Added logs for "chunk-event" internal test type (used in FORK_TESTS()/FORK_SUBTESTS() in ya make) in future we need to somehow merge them in human readable test
2. Summary, now, distinguishes between failed and timeouted test
3. Summary now is not editing comment but adding new comments 
4. Added special flag to disable upload of test results in s3 in case of emergency
