### PR TITLE
NBSNEBIUS-86: rendering raw volume config (pretty-printed proto) on volume monpage

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -408,6 +408,7 @@ private:
     void RenderCheckpoints(IOutputStream& out) const;
     void RenderTraces(IOutputStream& out) const;
     void RenderStorageConfig(IOutputStream& out) const;
+    void RenderRawVolumeConfig(IOutputStream& out) const;
     void RenderCommonButtons(IOutputStream& out) const;
 
     void OnDetach(const NActors::TActorContext& ctx) override;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -470,7 +470,7 @@ void TVolumeActor::HandleHttpInfo_Default(
         tracesTab = activeTab;
     } else if (tabName == storageConfigTabName) {
         storageConfigTab = activeTab;
-    } else if (tabName == rawVolumeConfigTab) {
+    } else if (tabName == rawVolumeConfigTabName) {
         rawVolumeConfigTab = activeTab;
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -448,6 +448,7 @@ void TVolumeActor::HandleHttpInfo_Default(
     const char* checkpointsTabName = "Checkpoints";
     const char* tracesTabName = "Traces";
     const char* storageConfigTabName = "StorageConfig";
+    const char* rawVolumeConfigTabName = "RawVolumeConfig";
 
     const char* activeTab = "tab-pane active";
     const char* inactiveTab = "tab-pane";
@@ -457,6 +458,7 @@ void TVolumeActor::HandleHttpInfo_Default(
     const char* checkpointsTab = inactiveTab;
     const char* tracesTab = inactiveTab;
     const char* storageConfigTab = inactiveTab;
+    const char* rawVolumeConfigTab = inactiveTab;
 
     if (tabName.Empty() || tabName == overviewTabName) {
         overviewTab = activeTab;
@@ -468,6 +470,8 @@ void TVolumeActor::HandleHttpInfo_Default(
         tracesTab = activeTab;
     } else if (tabName == storageConfigTabName) {
         storageConfigTab = activeTab;
+    } else if (tabName == rawVolumeConfigTab) {
+        rawVolumeConfigTab = activeTab;
     }
 
     TStringStream out;
@@ -496,6 +500,10 @@ void TVolumeActor::HandleHttpInfo_Default(
 
                 DIV_CLASS_ID(storageConfigTab, storageConfigTabName) {
                     RenderStorageConfig(out);
+                }
+
+                DIV_CLASS_ID(rawVolumeConfigTab, rawVolumeConfigTabName) {
+                    RenderRawVolumeConfig(out);
                 }
             }
         }
@@ -772,6 +780,27 @@ void TVolumeActor::RenderStorageConfig(IOutputStream& out) const
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+void TVolumeActor::RenderRawVolumeConfig(IOutputStream& out) const
+{
+    if (!State) {
+        return;
+    }
+
+    const auto& volumeConfig = State->GetMeta().GetVolumeConfig();
+
+    HTML(out) {
+        DIV_CLASS("row") {
+            TAG(TH3) {
+                out << "RawVolumeConfig";
+            }
+
+            PRE() {
+                SerializeToTextFormatPretty(volumeConfig, out);
             }
         }
     }


### PR DESCRIPTION
To be able to see all volume config fields (right now some fields cannot be seen in UI - e.g. CreationTs)