### PR TITLE
fix: trying to lower test_threads to limit concurrency and free up resources for large tests

### DIFF
--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -172,7 +172,7 @@ jobs:
       test_size: ${{ inputs.test_size }}
       test_type: ${{ inputs.test_type }}
       link_threads: 24
-      test_threads: 24
+      test_threads: 12
       sleep_after_tests: ${{ inputs.sleep_after_tests }}
       cache_update_build: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('{0}', inputs.cache_update) || format('{0}', inputs.cache_update_build)) }}
       cache_update_tests: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('{0}', inputs.cache_update) || format('{0}', inputs.cache_update_tests)) }}


### PR DESCRIPTION
There is and ongoing problem with large (in terms of concurrency) tests that results in more or less random test failures. So to try and resolve this issue we want to limit amount of tests in parallel, so that those tests will have more resources.