### PR TITLE
NBS-179: use backward compatible arguments to run vhost-server for local disks (#199)

### DIFF
--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -837,18 +837,24 @@ private:
             : request.GetInstanceId();
 
         TVector<TString> args {
-            "--client-id", clientId,
-            "--disk-id", request.GetDiskId(),
             "--serial", deviceName,
             "--socket-path", socketPath,
             "-q", ToString(request.GetVhostQueuesCount())
         };
 
-        args.emplace_back("--device-backend");
-        args.emplace_back(GetDeviceBackend(epType));
+        if (epType == EEndpointType::Rdma) {
+            args.emplace_back("--client-id");
+            args.emplace_back(clientId);
 
-        args.emplace_back("--block-size");
-        args.emplace_back(ToString(volume.GetBlockSize()));
+            args.emplace_back("--disk-id");
+            args.emplace_back(request.GetDiskId());
+
+            args.emplace_back("--device-backend");
+            args.emplace_back(GetDeviceBackend(epType));
+
+            args.emplace_back("--block-size");
+            args.emplace_back(ToString(volume.GetBlockSize()));
+        }
 
         for (const auto& device: volume.GetDevices()) {
             const ui64 size = device.GetBlockCount() * volume.GetBlockSize();


### PR DESCRIPTION
We are extending the command-line arguments of blockstore-vhost-server to
support the RDMA backend but to ensure compatibility during version upgrades we
will use old local disk arguments for aio backend.

For aio backend vhost-server will be started with:

```
blockstore-vhost-server --serial nvme-disk-0 --socket-path /tmp/1.sock -q 2 --device /dev/nvme3n1:394062200832:5518414315520
```

For rdma backend vhost-server will be started with  additional arguments:

```
blockstore-vhost-server ... --client-id aaa --disk-id bbb --device-backend rdma --block-size 4096
```