### PR TITLE
Show overridden AgentParams on monitoring page

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -1635,7 +1635,7 @@ void TDiskRegistryActor::RenderAgentList(
             TABLEHEAD() {
                 TABLER() {
                     TABLEH() { out << "Agent"; }
-                    TABLEH() { out << "RejectAgentTimeout(" << now << ")"; }
+                    TABLEH() { out << "RejectAgentTimeout (" << now << ")"; }
                 }
 
                 TABLER() {
@@ -1646,7 +1646,7 @@ void TDiskRegistryActor::RenderAgentList(
                         out << State->GetRejectAgentTimeout(now, "");
                     }
                 }
-                for (const auto& agentId : State->GetAgentIdsWithOverridedListParams()) {
+                for (const auto& agentId: State->GetAgentIdsWithOverriddenListParams()) {
                     TABLER() {
                         TABLED() {
                             out << agentId << " (overridden)";

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -1634,16 +1634,26 @@ void TDiskRegistryActor::RenderAgentList(
         TABLE_SORTABLE_CLASS("table table-bordered") {
             TABLEHEAD() {
                 TABLER() {
-                    TABLEH() { out << "Name"; }
-                    TABLEH() { out << "Value"; }
+                    TABLEH() { out << "Agent"; }
+                    TABLEH() { out << "RejectAgentTimeout(" << now << ")"; }
                 }
 
                 TABLER() {
                     TABLED() {
-                        out << "RejectAgentTimeout(" << now << ")";
+                        out << "default";
                     }
                     TABLED() {
                         out << State->GetRejectAgentTimeout(now, "");
+                    }
+                }
+                for (const auto& agentId : State->GetAgentIdsWithOverridedListParams()) {
+                    TABLER() {
+                        TABLED() {
+                            out << agentId << " (overridden)";
+                        }
+                        TABLED() {
+                            out << State->GetRejectAgentTimeout(now, agentId);
+                        }
                     }
                 }
             }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -784,9 +784,9 @@ public:
         AgentList.OnAgentDisconnected(now, agentId);
     }
 
-    TVector<TAgentId> GetAgentIdsWithOverridedListParams() const
+    TVector<TAgentId> GetAgentIdsWithOverriddenListParams() const
     {
-        return AgentList.GetAgentIdsWithOverridedListParams();
+        return AgentList.GetAgentIdsWithOverriddenListParams();
     }
 
     void SetDiskRegistryAgentListParams(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -784,6 +784,11 @@ public:
         AgentList.OnAgentDisconnected(now, agentId);
     }
 
+    TVector<TAgentId> GetAgentIdsWithOverridedListParams() const
+    {
+        return AgentList.GetAgentIdsWithOverridedListParams();
+    }
+
     void SetDiskRegistryAgentListParams(
         TDiskRegistryDatabase& db,
         const TString& agentId,

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.cpp
@@ -604,10 +604,10 @@ void TAgentList::SetDiskRegistryAgentListParams(
     DiskRegistryAgentListParams[agentId] = params;
 }
 
-TVector<TString> TAgentList::GetAgentIdsWithOverridedListParams() const
+TVector<TString> TAgentList::GetAgentIdsWithOverriddenListParams() const
 {
     TVector<TAgentId> agentIds(Reserve(DiskRegistryAgentListParams.size()));
-    for (const auto& [agentId, _] : DiskRegistryAgentListParams) {
+    for (const auto& [agentId, _]: DiskRegistryAgentListParams) {
         agentIds.push_back(agentId);
     }
     return agentIds;

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.cpp
@@ -604,4 +604,13 @@ void TAgentList::SetDiskRegistryAgentListParams(
     DiskRegistryAgentListParams[agentId] = params;
 }
 
+TVector<TString> TAgentList::GetAgentIdsWithOverridedListParams() const
+{
+    TVector<TAgentId> agentIds(Reserve(DiskRegistryAgentListParams.size()));
+    for (const auto& [agentId, _] : DiskRegistryAgentListParams) {
+        agentIds.push_back(agentId);
+    }
+    return agentIds;
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
@@ -119,7 +119,7 @@ public:
     void SetDiskRegistryAgentListParams(
         const TString& agentId, const NProto::TDiskRegistryAgentParams& params);
     TVector<TString> CleanupExpiredAgentListParams(TInstant now);
-    TVector<TString> GetAgentIdsWithOverridedListParams() const;
+    TVector<TString> GetAgentIdsWithOverriddenListParams() const;
 
 private:
     NProto::TAgentConfig& AddAgent(NProto::TAgentConfig config);

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
@@ -119,6 +119,7 @@ public:
     void SetDiskRegistryAgentListParams(
         const TString& agentId, const NProto::TDiskRegistryAgentParams& params);
     TVector<TString> CleanupExpiredAgentListParams(TInstant now);
+    TVector<TString> GetAgentIdsWithOverridedListParams() const;
 
 private:
     NProto::TAgentConfig& AddAgent(NProto::TAgentConfig config);


### PR DESCRIPTION
This PR modifies the `AgentList Parameters` section in monitoring page in order to display agents with overridden values.
New layout looks as following:
 
![image](https://github.com/ydb-platform/nbs/assets/153231895/1e695c94-39db-4f21-bd2c-88adaa4ed727)
