### PR TITLE
NBSNEBIUS-86: TDiskConfigs in DiskRegistry now store event history, history is displayed on DiskRegistry monpage, currently only ReplaceDevice events are added to history - will add other stuff in the next PRs

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -710,6 +710,33 @@ void TDiskRegistryActor::RenderDiskHtmlInfo(
         }
 
         GenerateVolumeActionsJS(out);
+
+        TAG(TH3) {
+            out << "History";
+        }
+
+        TABLE_SORTABLE_CLASS("table table-bordered") {
+            TABLEHEAD() {
+                TABLER() {
+                    TABLEH() { out << "Timestamp"; }
+                    TABLEH() { out << "Message"; }
+                }
+
+                for (const auto& hi: info.History) {
+                    TABLER() {
+                        TABLED() {
+                            out << TInstant::MicroSeconds(hi.GetTimestamp())
+                                << " (" << hi.GetTimestamp() << ")";
+                        }
+                        TABLED() {
+                            PRE() {
+                                out << hi.GetMessage();
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -53,10 +53,13 @@ struct TDiskInfo
     TString CheckpointId;
     TString SourceDiskId;
     TInstant MigrationStartTs;
+    TVector<NProto::TDiskHistoryItem> History;
 
     ui64 GetBlocksCount() const;
     TString GetPoolName() const;
 };
+
+////////////////////////////////////////////////////////////////////////////////
 
 struct TRackInfo
 {
@@ -99,6 +102,8 @@ struct TRackInfo
     }
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
 class TBrokenCounter
 {
 public:
@@ -136,6 +141,8 @@ private:
     THashSet<ui32> BrokenPartitions;
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
 struct TBrokenGroupInfo
 {
     explicit TBrokenGroupInfo(NProto::EPlacementStrategy strategy)
@@ -146,6 +153,8 @@ struct TBrokenGroupInfo
     TBrokenCounter Total;
     TBrokenCounter Recently;
 };
+
+////////////////////////////////////////////////////////////////////////////////
 
 struct TCheckpointInfo
 {
@@ -175,6 +184,8 @@ struct TCheckpointInfo
     TString UniqueId() const;
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
 struct TPlacementGroupInfo
 {
     NProto::TPlacementGroupConfig Config;
@@ -191,6 +202,8 @@ struct TPlacementGroupInfo
     {
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
 
 class TDiskRegistryState
 {
@@ -250,6 +263,8 @@ class TDiskRegistryState
 
         NProto::EStorageMediaKind MediaKind =
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED;
+
+        TVector<NProto::TDiskHistoryItem> History;
     };
 
     struct TVolumeDeviceOverrides

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -1041,6 +1041,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             TVector<TString>{},
             diskInfo.DeviceReplacementIds);
 
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.History.size());
+
+        replicaInfo = {};
+        error = state.GetDiskInfo("disk-1/0", replicaInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(1, replicaInfo.History.size());
+
+        replicaInfo = {};
+        error = state.GetDiskInfo("disk-1/1", replicaInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(0, replicaInfo.History.size());
+
+        replicaInfo = {};
+        error = state.GetDiskInfo("disk-1/2", replicaInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(0, replicaInfo.History.size());
+
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
             TVector<TVector<TDeviceConfig>> replicas;

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -214,6 +214,14 @@ message TCheckpointReplica
 
 ////////////////////////////////////////////////////////////////////////////////
 
+message TDiskHistoryItem
+{
+    uint64 Timestamp = 1;
+    string Message = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 message TDiskConfig
 {
     // Label of volume.
@@ -263,6 +271,9 @@ message TDiskConfig
 
     // The timestamp of the start of migration (in microseconds).
     uint64 MigrationStartTs = 16;
+
+    // A log of important events in the life of this disk.
+    repeated TDiskHistoryItem History = 17;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When there is a problem with a mirrored disk / nonreplicated disk we often want to see recent config changes that happened to that disk. Right now we need to look for these events in logs - not very convenient. This PR introduces a mechanism which will let us see these events on DiskRegistry monpage - individually for every disk.