### PR TITLE
Fix execution of json requests in /example

### DIFF
--- a/example/prepare_binaries.sh
+++ b/example/prepare_binaries.sh
@@ -14,26 +14,26 @@ do
 done
 
 function ydbd {
-  LD_LIBRARY_PATH=$(dirname $YDBD_BIN) $YDBD_BIN $@
+  LD_LIBRARY_PATH=$(dirname $YDBD_BIN) $YDBD_BIN "$@"
 }
 
 function nbsd {
-  LD_LIBRARY_PATH=$(dirname $NBSD_BIN) $NBSD_BIN $@
+  LD_LIBRARY_PATH=$(dirname $NBSD_BIN) $NBSD_BIN "$@"
 }
 
 function blockstore-client {
-  LD_LIBRARY_PATH=$(dirname $BLOCKSTORE_CLIENT_BIN) $BLOCKSTORE_CLIENT_BIN $@
+  LD_LIBRARY_PATH=$(dirname $BLOCKSTORE_CLIENT_BIN) $BLOCKSTORE_CLIENT_BIN "$@"
 }
 
 function diskagentd {
-  LD_LIBRARY_PATH=$(dirname $DISK_AGENT_BIN) $DISK_AGENT_BIN $@
+  LD_LIBRARY_PATH=$(dirname $DISK_AGENT_BIN) $DISK_AGENT_BIN "$@"
 }
 
 function blockstore-nbd {
-  LD_LIBRARY_PATH=$(dirname $BLOCKSTORE_NBD_BIN) $BLOCKSTORE_NBD_BIN $@
+  LD_LIBRARY_PATH=$(dirname $BLOCKSTORE_NBD_BIN) $BLOCKSTORE_NBD_BIN "$@"
 }
 
 function sudo-blockstore-nbd {
   LD_LIBRARY_PATH=$(dirname $BLOCKSTORE_NBD_BIN)
-  sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH $BLOCKSTORE_NBD_BIN $@
+  sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH $BLOCKSTORE_NBD_BIN "$@"
 }


### PR DESCRIPTION
There is an issue with passing parameters In /example. The following request from console won't work:
```
REQUEST='{"Host": "eu-north1-a-2ct3-2.infra.dev-stands-lab.nebiuscloud.net"}'
blockstore-client executeaction --action GetDependentDisks --input-bytes "$REQUEST" --host localhost --port 9766 --secure-port 0 --verbose error
```
since bash `$@` statement will split "$REQUEST" argument into pieces producing following command:
```
../cloud/blockstore/buildall/cloud/blockstore/apps/client/blockstore-client executeaction --action GetDependentDisks --input-bytes '{"Host":' '"eu-north1-a-2ct3-2.infra.dev-stands-lab.nebiuscloud.net"}' --host localhost --port 9766 --secure-port 0 --verbose error
(NLastGetopt::TUsageException) required exactly 0 free args
```