### PR TITLE
NBS-4665: [disk-manager] fix test on delete checkpoint data

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/tests/client_test.go
@@ -285,10 +285,20 @@ func TestDeleteCheckpointData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	err = client.CreateCheckpoint(
+		ctx,
+		nbs.CheckpointParams{
+			DiskID:       diskID,
+			CheckpointID: "checkpointID",
+		},
+	)
+	require.NoError(t, err)
+
 	err = client.DeleteCheckpointData(ctx, diskID, "checkpointID")
 	require.NoError(t, err)
 
 	// TODO: NBS-4665: check that CreateCheckpoint request returns error if checkpoint data was deleted.
+	// TODO: NBS-4665: check that CreateCheckpointWithoutData request returns error if checkpoint data was deleted.
 }
 
 func TestResizeDisk(t *testing.T) {


### PR DESCRIPTION
Правка в тест TestDeleteCheckpointData. В этом тесте присылается запрос на удаление данных чекпоинта в момент, когда чекпоинта не существует. Я хочу сделать коммит, в котором такой запрос завершается ошибкой. Соответственно, с этим коммитом этот тест падает.

Временно правлю тест, чтобы он не падал. Уже правил этот тест здесь https://arcanum.yandex-team.ru/review/4845454/details, но там я поправил криво :( Поэтому исправляюсь.