### PR TITLE
fix test artifact permissions

### DIFF
--- a/cloud/storage/core/tools/ci/runner/run_test.sh
+++ b/cloud/storage/core/tools/ci/runner/run_test.sh
@@ -12,3 +12,4 @@ mkdir -p "$logs_root"
 "${nbs_path}/ya" make -A -j10 --keep-going --output "$logs_root" --junit "${logs_dir}/${result_xml}" "$test_path"
 
 find "${logs_dir}" -maxdepth 1 -mindepth 1 -type f -not -name "${result_xml}" -exec rm {} \;
+find "${logs_dir}" -type f -exec chmod 644 {} \;

--- a/cloud/storage/core/tools/ci/runner/run_test.sh
+++ b/cloud/storage/core/tools/ci/runner/run_test.sh
@@ -12,4 +12,4 @@ mkdir -p "$logs_root"
 "${nbs_path}/ya" make -A -j10 --keep-going --output "$logs_root" --junit "${logs_dir}/${result_xml}" "$test_path"
 
 find "${logs_dir}" -maxdepth 1 -mindepth 1 -type f -not -name "${result_xml}" -exec rm {} \;
-find "${logs_dir}" -type f -exec chmod 644 {} \;
+find "${logs_dir}" -type f -exec chmod +r {} \;


### PR DESCRIPTION
some files generated by ya-make (e.g. stdout_*) have 600 permissions, which results in 403 error when trying to access artifacts via web interface