### PR TITLE
fix: vhost-server aio backend was incorrectly batching ios (#248)

### DIFF
--- a/cloud/blockstore/vhost-server/backend.h
+++ b/cloud/blockstore/vhost-server/backend.h
@@ -16,6 +16,7 @@ struct IBackend: public IStartable
 
     virtual vhd_bdev_info Init(const TOptions& options) = 0;
     virtual void ProcessQueue(
+        ui32 queueIndex,
         vhd_request_queue* queue,
         TSimpleStats& queueStats) = 0;
     virtual std::optional<TSimpleStats> GetCompletionStats(

--- a/cloud/blockstore/vhost-server/backend_null.cpp
+++ b/cloud/blockstore/vhost-server/backend_null.cpp
@@ -23,7 +23,10 @@ public:
     vhd_bdev_info Init(const TOptions& options) override;
     void Start() override;
     void Stop() override;
-    void ProcessQueue(vhd_request_queue* queue, TSimpleStats& queueStats) override;
+    void ProcessQueue(
+        ui32 queueIndex,
+        vhd_request_queue* queue,
+        TSimpleStats& queueStats) override;
     std::optional<TSimpleStats> GetCompletionStats(TDuration timeout) override;
 };
 
@@ -60,8 +63,12 @@ void TNullBackend::Start()
 void TNullBackend::Stop()
 {}
 
-void TNullBackend::ProcessQueue(vhd_request_queue* queue, TSimpleStats& queueStats)
+void TNullBackend::ProcessQueue(
+    ui32 queueIndex,
+    vhd_request_queue* queue,
+    TSimpleStats& queueStats)
 {
+    Y_UNUSED(queueIndex);
     Y_UNUSED(queueStats);
 
     vhd_request req;

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -49,8 +49,10 @@ public:
     vhd_bdev_info Init(const TOptions& options) override;
     void Start() override;
     void Stop() override;
-    void ProcessQueue(vhd_request_queue* queue, TSimpleStats& queueStats)
-        override;
+    void ProcessQueue(
+        ui32 queueIndex,
+        vhd_request_queue* queue,
+        TSimpleStats& queueStats) override;
     std::optional<TSimpleStats> GetCompletionStats(TDuration timeout) override;
 
 private:
@@ -179,9 +181,12 @@ void TRdmaBackend::Stop()
 }
 
 void TRdmaBackend::ProcessQueue(
+    ui32 queueIndex,
     vhd_request_queue* queue,
     TSimpleStats& queueStats)
 {
+    Y_UNUSED(queueIndex);
+
     vhd_request req;
     while (vhd_dequeue_request(queue, &req)) {
         ++queueStats.Dequeued;

--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -251,7 +251,7 @@ void TServer::QueueThreadFunc(ui32 queueIndex)
             break;
         }
 
-        Backend->ProcessQueue(queue, queueStats);
+        Backend->ProcessQueue(queueIndex, queue, queueStats);
 
         SyncQueueStats(queueIndex, queueStats);
     }


### PR DESCRIPTION
After refactoring the `Batch` array of iocb was incorrectly shared between
different vhost queues. This lead to memory corruption which was not detected
since tests were running with only 1 vhost queue configured.

```
qemu ... -device vhost-user-blk-pci,chardev=vhost0,id=vhost-user-blk0,num-queues=1
```