### PR TITLE
[Disk Manager]: Snapshot: Fix inflight queue not closing in ShallowCopySnapshot()

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_impl.go
@@ -527,6 +527,7 @@ func (s *storageYDB) shallowCopySnapshot(
 		common.ChannelWithCancellation{}, // holeValues
 		s.shallowCopyInflightLimit,
 	)
+	defer inflightQueue.Close()
 
 	waitSaver := func() error { return nil }
 	var saverError <-chan error


### PR DESCRIPTION
InflightQueue was not closed after the shallowCopySnapshot was finished, which was causing a goroutine leak.