### PR TITLE
Make forbidden dependency check for model dirs

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/model/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     compare_configs.cpp
     config.cpp

--- a/cloud/blockstore/libs/storage/disk_registry/model/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+#INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     agent_counters.cpp
     agent_list.cpp

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/model/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     config.cpp
 )

--- a/cloud/blockstore/libs/storage/model/ya.make
+++ b/cloud/blockstore/libs/storage/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 GENERATE_ENUM_SERIALIZATION(channel_data_kind.h)
 
 PEERDIR(

--- a/cloud/blockstore/libs/storage/partition/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+#INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 GENERATE_ENUM_SERIALIZATION(mixed_index_cache.h)
 GENERATE_ENUM_SERIALIZATION(operation_status.h)
 

--- a/cloud/blockstore/libs/storage/partition2/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition2/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 GENERATE_ENUM_SERIALIZATION(alloc.h)
 GENERATE_ENUM_SERIALIZATION(operation_status.h)
 

--- a/cloud/blockstore/libs/storage/partition_common/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition_common/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     blob_markers.cpp
     fresh_blob.cpp

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     processing_blocks.cpp
 )

--- a/cloud/blockstore/libs/storage/service/model/ya.make
+++ b/cloud/blockstore/libs/storage/service/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     ping_metrics.cpp
 )

--- a/cloud/blockstore/libs/storage/volume/model/ya.make
+++ b/cloud/blockstore/libs/storage/volume/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+#INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 GENERATE_ENUM_SERIALIZATION(checkpoint.h)
 
 SRCS(

--- a/cloud/deny_ydb_dependency.inc
+++ b/cloud/deny_ydb_dependency.inc
@@ -1,0 +1,14 @@
+CHECK_DEPENDENT_DIRS(
+    DENY ALL
+        contrib/ydb
+
+    EXCEPT contrib/ydb/library/actors
+    EXCEPT contrib/ydb/library/services
+    EXCEPT contrib/ydb/library/yql/providers/generic/connector/api/common
+    EXCEPT contrib/ydb/library/yql/public/types
+    EXCEPT contrib/ydb/public/lib/validation/
+
+    EXCEPT GLOB contrib/ydb/**/proto
+    EXCEPT GLOB contrib/ydb/**/protos
+    EXCEPT GLOB contrib/ydb/**/protos/annotations
+)

--- a/cloud/filestore/libs/storage/model/ya.make
+++ b/cloud/filestore/libs/storage/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY(filestore-libs-storage-model)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 GENERATE_ENUM_SERIALIZATION(
     channel_data_kind.h
 )

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+#INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 GENERATE_ENUM_SERIALIZATION(alloc.h)
 
 SRCS(

--- a/cloud/storage/core/libs/tablet/model/ya.make
+++ b/cloud/storage/core/libs/tablet/model/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/deny_ydb_dependency.inc)
+
 SRCS(
     commit.cpp
     partial_blob_id.cpp


### PR DESCRIPTION
Добавил проверки в каталогах model что они не зависят от contrib/ydb
теперь если попытаться заинклюить чтонить лишнего - будет ошибка сборки примерно такого содержания:
```
Error[-WBadDep]: in $B/cloud/blockstore/libs/storage/volume/model/libstorage-volume-model.a: forbids direct or indirect dependency to module $B/contrib/ydb/library/yql/core/expr_nodes_gen/gen/libpy3core-expr_nodes_gen-gen.a via CHECK_DEPENDENT_DIRS
    $B/cloud/blockstore/libs/storage/volume/model/libstorage-volume-model.a -> $B/cloud/blockstore/libs/kikimr/libblockstore-libs-kikimr.a
    $B/cloud/blockstore/libs/kikimr/libblockstore-libs-kikimr.a -> $B/cloud/storage/core/libs/kikimr/libcore-libs-kikimr.a
    $B/cloud/storage/core/libs/kikimr/libcore-libs-kikimr.a -> $B/contrib/ydb/core/mind/libydb-core-mind.a
    $B/contrib/ydb/core/mind/libydb-core-mind.a -> $B/contrib/ydb/core/engine/minikql/libcore-engine-minikql.a
    $B/contrib/ydb/core/engine/minikql/libcore-engine-minikql.a -> $B/contrib/ydb/core/client/minikql_compile/libcore-client-minikql_compile.a
    $B/contrib/ydb/core/client/minikql_compile/libcore-client-minikql_compile.a -> $B/contrib/ydb/core/engine/libydb-core-engine.a
    $B/contrib/ydb/core/engine/libydb-core-engine.a -> $B/contrib/ydb/library/mkql_proto/libydb-library-mkql_proto.a
    $B/contrib/ydb/library/mkql_proto/libydb-library-mkql_proto.a -> $B/contrib/ydb/library/yql/providers/common/codec/libproviders-common-codec.a
    $B/contrib/ydb/library/yql/providers/common/codec/libproviders-common-codec.a -> $B/contrib/ydb/library/yql/providers/common/mkql/libproviders-common-mkql.a
    $B/contrib/ydb/library/yql/providers/common/mkql/libproviders-common-mkql.a -> $B/contrib/ydb/library/yql/core/liblibrary-yql-core.a
    $B/contrib/ydb/library/yql/core/liblibrary-yql-core.a -> $B/contrib/ydb/library/yql/core/expr_nodes/libyql-core-expr_nodes.a
    $B/contrib/ydb/library/yql/core/expr_nodes/libyql-core-expr_nodes.a -> $B/contrib/ydb/library/yql/core/expr_nodes_gen/gen/gen
    $B/contrib/ydb/library/yql/core/expr_nodes_gen/gen/gen -> $B/contrib/ydb/library/yql/core/expr_nodes_gen/gen/libpy3core-expr_nodes_gen-gen.a```
