### PR TITLE
[Filestore] NBSNEBIUS-91: Add ForcedCleanup handle for fs

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -222,7 +222,7 @@ private:
     void EnqueueBlobIndexOpIfNeeded(const NActors::TActorContext& ctx);
     void EnqueueCollectGarbageIfNeeded(const NActors::TActorContext& ctx);
     void EnqueueTruncateIfNeeded(const NActors::TActorContext& ctx);
-    void EnqueueForcedCompactionIfNeeded(const NActors::TActorContext& ctx);
+    void EnqueueForcedRangeOperationIfNeeded(const NActors::TActorContext& ctx);
     void LoadNextCompactionMapChunkIfNeeded(const NActors::TActorContext& ctx);
 
     void NotifySessionEvent(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -294,7 +294,7 @@ private:
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
-    void HandleHttpInfo_Compaction(
+    void HandleHttpInfo_ForceOperation(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -58,7 +58,7 @@ public:
 private:
     STFUNC(StateWork);
 
-    void SendCompactionRequest(const TActorContext& ctx);
+    void SendRangeOperationRequest(const TActorContext& ctx);
 
     void HandleRangeOperationResponse(
         const TResponseType::TPtr& ev,
@@ -107,12 +107,12 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::Bootstrap(
         RequestInfo->CallContext,
         "ForcedRangeOperation");
 
-    SendCompactionRequest(ctx);
+    SendRangeOperationRequest(ctx);
 }
 
 template <typename TResponseType, typename TRequestConstructor>
 void TForcedOperationActor<TResponseType, TRequestConstructor>::
-    SendCompactionRequest(const TActorContext& ctx)
+    SendRangeOperationRequest(const TActorContext& ctx)
 {
     auto request = TRequestConstructor()(State->GetCurrentRange());
 
@@ -156,7 +156,7 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::
         return ReplyAndDie(ctx, {});
     }
 
-    SendCompactionRequest(ctx);
+    SendRangeOperationRequest(ctx);
 }
 
 template <typename TResponseType, typename TRequestConstructor>
@@ -164,7 +164,7 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::
     HandleWakeUp(const TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    SendCompactionRequest(ctx);
+    SendRangeOperationRequest(ctx);
 }
 
 template <typename TResponseType, typename TRequestConstructor>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -306,7 +306,7 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 ctx.SelfID,
                 LogTag,
                 Config->GetCompactionRetryTimeout(),
-                GeTForcedRangeOperationState(),
+                GetForcedRangeOperationState(),
                 std::move(requestInfo));
             break;
 
@@ -315,7 +315,7 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 ctx.SelfID,
                 LogTag,
                 Config->GetCompactionRetryTimeout(),
-                GeTForcedRangeOperationState(),
+                GetForcedRangeOperationState(),
                 std::move(requestInfo));
             break;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -263,14 +263,13 @@ void TIndexTabletActor::HandleForcedRangeOperation(
 {
     auto* msg = ev->Get();
 
-    LOG_DEBUG(
-        ctx,
-        TFileStoreComponents::TABLET,
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
         "%s ForcedRangeOperation request for %lu ranges",
         LogTag.c_str(),
         msg->Ranges.size());
 
-    auto replyError = [&](const NProto::TError& error)
+    auto replyError = [&] (
+        const NProto::TError& error)
     {
         if (ev->Sender == ctx.SelfID) {
             return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -950,7 +950,7 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         }
 
         if (IsForcedRangeOperationRunning()) {
-            DumpCompactionInfo(out, *GeTForcedRangeOperationState());
+            DumpCompactionInfo(out, *GetForcedRangeOperationState());
         } else {
             out << "<div class='collapse form-group' id='compact-all'>";
             BuildForceCompactionButton(out, TabletID());

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -28,7 +28,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(DumpCompactionRange,                    __VA_ARGS__)                   \
     xxx(Flush,                                  __VA_ARGS__)                   \
     xxx(FlushBytes,                             __VA_ARGS__)                   \
-    xxx(ForcedCompaction,                       __VA_ARGS__)                   \
+    xxx(ForcedRangeOperation,                   __VA_ARGS__)                   \
     xxx(Truncate,                               __VA_ARGS__)                   \
     xxx(ReadBlob,                               __VA_ARGS__)                   \
     xxx(WriteBlob,                              __VA_ARGS__)                   \
@@ -372,33 +372,33 @@ struct TEvIndexTabletPrivate
     };
 
     //
-    // ForcedCompaction
+    // ForcedRangeOperation
     //
 
-    enum EForcedCompactionMode
+    enum EForcedRangeOperationMode
     {
         Compaction = 0,
         Cleanup = 1,
     };
 
-    struct TForcedCompactionRequest
+    struct TForcedRangeOperationRequest
     {
         TVector<ui32> Ranges;
-        EForcedCompactionMode Mode;
+        EForcedRangeOperationMode Mode;
 
-        TForcedCompactionRequest(
+        TForcedRangeOperationRequest(
             TVector<ui32> ranges,
-            EForcedCompactionMode mode)
+            EForcedRangeOperationMode mode)
             : Ranges(std::move(ranges))
             , Mode(mode)
         {}
     };
 
-    struct TForcedCompactionResponse
+    struct TForcedRangeOperationResponse
     {
     };
 
-    using TForcedCompactionCompleted = TEmpty;
+    using TForcedRangeOperationCompleted = TEmpty;
 
     //
     // DumpCompactionRange

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -375,12 +375,22 @@ struct TEvIndexTabletPrivate
     // ForcedCompaction
     //
 
+    enum EForcedCompactionMode
+    {
+        Compaction = 0,
+        Cleanup = 1,
+    };
+
     struct TForcedCompactionRequest
     {
         TVector<ui32> Ranges;
+        EForcedCompactionMode Mode;
 
-        TForcedCompactionRequest(TVector<ui32> ranges)
+        TForcedCompactionRequest(
+            TVector<ui32> ranges,
+            EForcedCompactionMode mode)
             : Ranges(std::move(ranges))
+            , Mode(mode)
         {}
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -885,12 +885,20 @@ public:
     using TForcedCompactionStatePtr = std::shared_ptr<TForcedCompactionState>;
 
 private:
-    TVector<TVector<ui32>> PendingForcedCompactions;
+    struct TPendingForcedCompaction
+    {
+        TVector<ui32> Ranges;
+        TEvIndexTabletPrivate::EForcedCompactionMode Mode;
+    };
+
+    TVector<TPendingForcedCompaction> PendingForcedCompactions;
     TForcedCompactionStatePtr ForcedCompactionState;
 
 public:
-    void EnqueueForcedCompaction(TVector<ui32> ranges);
-    TVector<ui32> DequeueForcedCompaction();
+    void EnqueueForcedCompaction(
+        TVector<ui32> ranges,
+        TEvIndexTabletPrivate::EForcedCompactionMode mode);
+    TPendingForcedCompaction DequeueForcedCompaction();
 
     void StartForcedCompaction(TVector<ui32> ranges);
     void CompleteForcedCompaction();

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -860,14 +860,14 @@ public:
     //
 
 public:
-    struct TForcedCompactionState
+    struct TForcedRangeOperationState
     {
         const TVector<ui32> RangesToCompact;
 
         TInstant StartTime = TInstant::Now();
         std::atomic<ui32> Current = 0;
 
-        TForcedCompactionState(TVector<ui32> ranges)
+        TForcedRangeOperationState(TVector<ui32> ranges)
             : RangesToCompact(std::move(ranges))
         {}
 
@@ -882,35 +882,36 @@ public:
         }
     };
 
-    using TForcedCompactionStatePtr = std::shared_ptr<TForcedCompactionState>;
+    using TForcedRangeOperationStatePtr =
+        std::shared_ptr<TForcedRangeOperationState>;
 
 private:
-    struct TPendingForcedCompaction
+    struct TPendingForcedRangeOperation
     {
         TVector<ui32> Ranges;
-        TEvIndexTabletPrivate::EForcedCompactionMode Mode;
+        TEvIndexTabletPrivate::EForcedRangeOperationMode Mode;
     };
 
-    TVector<TPendingForcedCompaction> PendingForcedCompactions;
-    TForcedCompactionStatePtr ForcedCompactionState;
+    TVector<TPendingForcedRangeOperation> PendingForcedRangeOperations;
+    TForcedRangeOperationStatePtr ForcedRangeOperationState;
 
 public:
-    void EnqueueForcedCompaction(
+    void EnqueueForcedRangeOperation(
         TVector<ui32> ranges,
-        TEvIndexTabletPrivate::EForcedCompactionMode mode);
-    TPendingForcedCompaction DequeueForcedCompaction();
+        TEvIndexTabletPrivate::EForcedRangeOperationMode mode);
+    TPendingForcedRangeOperation DequeueForcedRangeOperation();
 
-    void StartForcedCompaction(TVector<ui32> ranges);
-    void CompleteForcedCompaction();
+    void StartForcedRangeOperation(TVector<ui32> ranges);
+    void CompleteForcedRangeOperation();
 
-    const TForcedCompactionStatePtr& GetForcedCompactionState() const
+    const TForcedRangeOperationStatePtr& GeTForcedRangeOperationState() const
     {
-        return ForcedCompactionState;
+        return ForcedRangeOperationState;
     }
 
-    bool IsForcedCompactionRunning() const
+    bool IsForcedRangeOperationRunning() const
     {
-        return (bool)ForcedCompactionState;
+        return (bool)ForcedRangeOperationState;
     }
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -904,7 +904,7 @@ public:
     void StartForcedRangeOperation(TVector<ui32> ranges);
     void CompleteForcedRangeOperation();
 
-    const TForcedRangeOperationStatePtr& GeTForcedRangeOperationState() const
+    const TForcedRangeOperationStatePtr& GetForcedRangeOperationState() const
     {
         return ForcedRangeOperationState;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1058,35 +1058,36 @@ void TIndexTabletState::LoadCompactionMap(
     }
 }
 
-void TIndexTabletState::EnqueueForcedCompaction(
+void TIndexTabletState::EnqueueForcedRangeOperation(
     TVector<ui32> ranges,
-    TEvIndexTabletPrivate::EForcedCompactionMode mode)
+    TEvIndexTabletPrivate::EForcedRangeOperationMode mode)
 {
-    PendingForcedCompactions.emplace_back(std::move(ranges), mode);
+    PendingForcedRangeOperations.emplace_back(std::move(ranges), mode);
 }
 
-TIndexTabletState::TPendingForcedCompaction TIndexTabletState::
-    DequeueForcedCompaction()
+TIndexTabletState::TPendingForcedRangeOperation TIndexTabletState::
+    DequeueForcedRangeOperation()
 {
-    if (PendingForcedCompactions.empty()) {
+    if (PendingForcedRangeOperations.empty()) {
         return {};
     }
 
-    auto ranges = std::move(PendingForcedCompactions.back());
-    PendingForcedCompactions.pop_back();
+    auto ranges = std::move(PendingForcedRangeOperations.back());
+    PendingForcedRangeOperations.pop_back();
 
     return ranges;
 }
 
-void TIndexTabletState::StartForcedCompaction(TVector<ui32> ranges)
+void TIndexTabletState::StartForcedRangeOperation(TVector<ui32> ranges)
 {
-    TABLET_VERIFY(!ForcedCompactionState);
-    ForcedCompactionState = std::make_shared<TForcedCompactionState>(std::move(ranges));
+    TABLET_VERIFY(!ForcedRangeOperationState);
+    ForcedRangeOperationState =
+        std::make_shared<TForcedRangeOperationState>(std::move(ranges));
 }
 
-void TIndexTabletState::CompleteForcedCompaction()
+void TIndexTabletState::CompleteForcedRangeOperation()
 {
-    ForcedCompactionState.reset();
+    ForcedRangeOperationState.reset();
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1058,12 +1058,15 @@ void TIndexTabletState::LoadCompactionMap(
     }
 }
 
-void TIndexTabletState::EnqueueForcedCompaction(TVector<ui32> ranges)
+void TIndexTabletState::EnqueueForcedCompaction(
+    TVector<ui32> ranges,
+    TEvIndexTabletPrivate::EForcedCompactionMode mode)
 {
-    PendingForcedCompactions.emplace_back(std::move(ranges));
+    PendingForcedCompactions.emplace_back(std::move(ranges), mode);
 }
 
-TVector<ui32> TIndexTabletState::DequeueForcedCompaction()
+TIndexTabletState::TPendingForcedCompaction TIndexTabletState::
+    DequeueForcedCompaction()
 {
     if (PendingForcedCompactions.empty()) {
         return {};

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2562,7 +2562,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(ranges[2], 1);
     }
 
-    TABLET_TEST(ShouldEnqueuePendingForcedRangeOperation)
+    TABLET_TEST(ShouldEnqueuePendingForcedCompaction)
     {
         TTestEnv env;
         env.CreateSubDomain("nfs");

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2495,16 +2495,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             ::xrange(0, 10, 1),
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 10);
         UNIT_ASSERT_VALUES_EQUAL(ranges.front(), 0);
         UNIT_ASSERT_VALUES_EQUAL(ranges.back(), 9);
 
-        tablet.AssertForcedCompactionFailed(
+        tablet.AssertForcedRangeOperationFailed(
             TVector<ui32>{},
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
     }
 
     TABLET_TEST(ShouldRetryForcedCompaction)
@@ -2553,16 +2553,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             ::xrange(0, 2, 1),
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 3);
         UNIT_ASSERT_VALUES_EQUAL(ranges[0], 0);
         UNIT_ASSERT_VALUES_EQUAL(ranges[1], 0);
         UNIT_ASSERT_VALUES_EQUAL(ranges[2], 1);
     }
 
-    TABLET_TEST(ShouldEnqueuePendingForcedCompaction)
+    TABLET_TEST(ShouldEnqueuePendingForcedRangeOperation)
     {
         TTestEnv env;
         env.CreateSubDomain("nfs");
@@ -2598,15 +2598,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.SendForcedCompactionRequest(
+        tablet.SendForcedRangeOperationRequest(
             ::xrange(0, 1, 1),
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT(request);
 
-        tablet.SendForcedCompactionRequest(
+        tablet.SendForcedRangeOperationRequest(
             ::xrange(1, 2, 1),
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         env.GetRuntime().Send(request.Release(), 1 /* node index */);
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
 
@@ -2651,16 +2651,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             ::xrange(0, 10, 1),
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         UNIT_ASSERT_VALUES_EQUAL(compactionRanges.size(), 10);
         UNIT_ASSERT_VALUES_EQUAL(compactionRanges.front(), 0);
         UNIT_ASSERT_VALUES_EQUAL(compactionRanges.back(), 9);
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             ::xrange(5, 15, 1),
-            TEvIndexTabletPrivate::EForcedCompactionMode::Cleanup);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Cleanup);
         UNIT_ASSERT_VALUES_EQUAL(cleanupRanges.size(), 10);
         UNIT_ASSERT_VALUES_EQUAL(cleanupRanges.front(), 5);
         UNIT_ASSERT_VALUES_EQUAL(cleanupRanges.back(), 14);
@@ -2755,9 +2755,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 rangesCount * 2 * BlockGroupSize);
         }
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             rangesSubjectToCleanup,
-            TEvIndexTabletPrivate::EForcedCompactionMode::Cleanup);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Cleanup);
 
         UNIT_ASSERT_VALUES_EQUAL(cleanupCount, rangesCount * BlockGroupSize);
 
@@ -2831,9 +2831,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 1);
         }
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             TVector<ui32>{rangeId},
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
@@ -2860,9 +2860,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 1);
         }
 
-        tablet.ForcedCompaction(
+        tablet.ForcedRangeOperation(
             TVector<ui32>{rangeId},
-            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1,4 +1,3 @@
-#include "tablet.h"
 #include "tablet_schema.h"
 
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
@@ -2496,12 +2495,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.ForcedCompaction(::xrange(0, 10, 1));
+        tablet.ForcedCompaction(
+            ::xrange(0, 10, 1),
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
         UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 10);
         UNIT_ASSERT_VALUES_EQUAL(ranges.front(), 0);
         UNIT_ASSERT_VALUES_EQUAL(ranges.back(), 9);
 
-        tablet.AssertForcedCompactionFailed(TVector<ui32>{});
+        tablet.AssertForcedCompactionFailed(
+            TVector<ui32>{},
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
     }
 
     TABLET_TEST(ShouldRetryForcedCompaction)
@@ -2550,7 +2553,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.ForcedCompaction(::xrange(0, 2, 1));
+        tablet.ForcedCompaction(
+            ::xrange(0, 2, 1),
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
         UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 3);
         UNIT_ASSERT_VALUES_EQUAL(ranges[0], 0);
         UNIT_ASSERT_VALUES_EQUAL(ranges[1], 0);
@@ -2593,15 +2598,177 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.SendForcedCompactionRequest(::xrange(0, 1, 1));
+        tablet.SendForcedCompactionRequest(
+            ::xrange(0, 1, 1),
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT(request);
 
-        tablet.SendForcedCompactionRequest(::xrange(1, 2, 1));
+        tablet.SendForcedCompactionRequest(
+            ::xrange(1, 2, 1),
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
         env.GetRuntime().Send(request.Release(), 1 /* node index */);
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
 
         UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 2);
+    }
+
+    TABLET_TEST(ShouldForceCompactAndCleanup)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        TVector<ui32> compactionRanges;
+        TVector<ui32> cleanupRanges;
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTabletPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvIndexTabletPrivate::TEvCompactionRequest>();
+                        compactionRanges.push_back(msg->RangeId);
+                        break;
+                    }
+                    case TEvIndexTabletPrivate::EvCleanupRequest: {
+                        auto* msg = event->Get<
+                            TEvIndexTabletPrivate::TEvCleanupRequest>();
+                        cleanupRanges.push_back(msg->RangeId);
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        tablet.ForcedCompaction(
+            ::xrange(0, 10, 1),
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
+        UNIT_ASSERT_VALUES_EQUAL(compactionRanges.size(), 10);
+        UNIT_ASSERT_VALUES_EQUAL(compactionRanges.front(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(compactionRanges.back(), 9);
+
+        tablet.ForcedCompaction(
+            ::xrange(5, 15, 1),
+            TEvIndexTabletPrivate::EForcedCompactionMode::Cleanup);
+        UNIT_ASSERT_VALUES_EQUAL(cleanupRanges.size(), 10);
+        UNIT_ASSERT_VALUES_EQUAL(cleanupRanges.front(), 5);
+        UNIT_ASSERT_VALUES_EQUAL(cleanupRanges.back(), 14);
+    }
+
+    TABLET_TEST(ForcedCleanupShouldRemoveStaleData)
+    {
+        const auto block = tabletConfig.BlockSize;
+        const auto rangesCount = 13;
+        const auto dataSize = BlockGroupSize * block * rangesCount;
+
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        ui32 cleanupCount = 0;
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTabletPrivate::EvCleanupRequest: {
+                        ++cleanupCount;
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+
+        TVector<ui32> rangesSubjectToCleanup;
+        for (ui32 i = 0; i < rangesCount * BlockGroupSize; ++i) {
+            rangesSubjectToCleanup.push_back(GetMixedRangeIndex(id, i));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(
+            THashSet<ui32>(
+                rangesSubjectToCleanup.begin(),
+                rangesSubjectToCleanup.end())
+                .size(),
+            rangesCount);
+
+        ui64 handle = CreateHandle(tablet, id);
+        tablet.WriteData(handle, 0, dataSize, 'a');
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), rangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMixedBlocksCount(),
+                rangesCount * BlockGroupSize);
+        }
+
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        tablet.DestroyHandle(handle);
+
+        ui32 id2 =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test2"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetMixedRangeIndex(id, 0),
+            GetMixedRangeIndex(id2, 0));
+
+        handle = CreateHandle(tablet, id2);
+        tablet.WriteData(handle, 0, dataSize, 'a');
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMixedBlobsCount(),
+                rangesCount * 2);
+        }
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMixedBlobsCount(),
+                rangesCount * 2);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMixedBlocksCount(),
+                rangesCount * 2 * BlockGroupSize);
+        }
+
+        tablet.ForcedCompaction(
+            rangesSubjectToCleanup,
+            TEvIndexTabletPrivate::EForcedCompactionMode::Cleanup);
+
+        UNIT_ASSERT_VALUES_EQUAL(cleanupCount, rangesCount * BlockGroupSize);
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), rangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMixedBlocksCount(),
+                rangesCount * BlockGroupSize);
+        }
     }
 
     TABLET_TEST(ShouldForceCompactRangeAndRemoveStaleNodesData)
@@ -2664,7 +2831,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 1);
         }
 
-        tablet.ForcedCompaction(TVector<ui32>{rangeId});
+        tablet.ForcedCompaction(
+            TVector<ui32>{rangeId},
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
@@ -2691,7 +2860,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 1);
         }
 
-        tablet.ForcedCompaction(TVector<ui32>{rangeId});
+        tablet.ForcedCompaction(
+            TVector<ui32>{rangeId},
+            TEvIndexTabletPrivate::EForcedCompactionMode::Compaction);
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -299,12 +299,12 @@ public:
         return std::make_unique<TEvIndexTabletPrivate::TEvCompactionRequest>(rangeId, filter);
     }
 
-    auto CreateForcedCompactionRequest(
+    auto CreateForcedRangeOperationRequest(
         TVector<ui32> ranges,
-        TEvIndexTabletPrivate::EForcedCompactionMode mode)
+        TEvIndexTabletPrivate::EForcedRangeOperationMode mode)
     {
         return std::make_unique<
-            TEvIndexTabletPrivate::TEvForcedCompactionRequest>(
+            TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
             std::move(ranges),
             mode);
     }

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -299,10 +299,14 @@ public:
         return std::make_unique<TEvIndexTabletPrivate::TEvCompactionRequest>(rangeId, filter);
     }
 
-    auto CreateForcedCompactionRequest(TVector<ui32> ranges)
+    auto CreateForcedCompactionRequest(
+        TVector<ui32> ranges,
+        TEvIndexTabletPrivate::EForcedCompactionMode mode)
     {
-        return std::make_unique<TEvIndexTabletPrivate::TEvForcedCompactionRequest>(
-            std::move(ranges));
+        return std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedCompactionRequest>(
+            std::move(ranges),
+            mode);
     }
 
     auto CreateCollectGarbageRequest()


### PR DESCRIPTION
Currently there is a mechanism that forcefully compacts all ranges present in the fs. In this PR a forced cleanup is introduced, which similarly forcefully runs cleanup operation on all ranges. No new transactions are introduced – ForcedCompaction request is extended with a enum that specifies if compaction or a cleanup is to be performed on the range.