### PR TITLE
issue #196: implemented block checksum calculation and verification for the blobs stored in blobstorage

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -902,7 +902,10 @@ message TStorageServiceConfig
     // Affects only blobstorage-based disks.
     optional uint64 DiskPrefixLengthWithBlockChecksumsInBlobs = 345;
 
-    // Read BlobMeta upon ReadBlob, calculate crc32c checksums for the fetched
+    // Read BlobMeta upon ReadBlocks, calculate crc32c checksums for the fetched
     // blocks and compare these checksums to the checksums from BlobMeta.
+    //
+    // IMPORTANT: Compaction verifies block checksums for the blocks affected by
+    // it regardless of this flag!
     optional bool CheckBlockChecksumsInBlobsUponRead = 346;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -896,4 +896,13 @@ message TStorageServiceConfig
 
     // Create shadow disks for checkpoints for DiskRegistry-based disks.
     optional bool UseShadowDisksForNonreplDiskCheckpoints = 344;
+
+    // Calculate crc32c checksums for blocks in the half-interval [0, X) upon
+    // write and store these checksums in local db.
+    // Affects only blobstorage-based disks.
+    optional uint64 DiskPrefixLengthWithBlockChecksumsInBlobs = 345;
+
+    // Read BlobMeta upon ReadBlob, calculate crc32c checksums for the fetched
+    // blocks and compare these checksums to the checksums from BlobMeta.
+    optional bool CheckBlockChecksumsInBlobsUponRead = 346;
 }

--- a/cloud/blockstore/libs/diagnostics/block_digest.cpp
+++ b/cloud/blockstore/libs/diagnostics/block_digest.cpp
@@ -13,6 +13,19 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ui32 ComputeDefaultDigest(TBlockDataRef blockContent)
+{
+    Y_DEBUG_ABORT_UNLESS(blockContent.Data() != nullptr);
+
+    if (blockContent.Data() != nullptr) {
+        return Crc32c(blockContent.Data(), blockContent.Size());
+    }
+
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TExt4BlockDigestGenerator final
     : IBlockDigestGenerator
 {
@@ -38,7 +51,7 @@ struct TExt4BlockDigestGenerator final
         }
 
         if (blockContent.Data() != nullptr) {
-            return Crc32c(blockContent.Data(), blockContent.Size());
+            return ComputeDefaultDigest(blockContent);
         }
 
         double idx = log2(static_cast<double>(blockContent.Size()) / DefaultBlockSize);

--- a/cloud/blockstore/libs/diagnostics/block_digest.h
+++ b/cloud/blockstore/libs/diagnostics/block_digest.h
@@ -30,4 +30,8 @@ IBlockDigestGeneratorPtr CreateExt4BlockDigestGenerator(
 IBlockDigestGeneratorPtr CreateTestBlockDigestGenerator();
 IBlockDigestGeneratorPtr CreateBlockDigestGeneratorStub();
 
+////////////////////////////////////////////////////////////////////////////////
+
+ui32 ComputeDefaultDigest(TBlockDataRef blockContent);
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/block_digest_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/block_digest_ut.cpp
@@ -94,6 +94,11 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
         UNIT_ASSERT(!gen->ShouldProcess(0, 10, 4_KB));
         UNIT_ASSERT(!gen->ShouldProcess(100500, 10, 4_KB));
     }
+
+    Y_UNIT_TEST(TestComputeDefaultDigest)
+    {
+        UNIT_ASSERT_VALUES_EQUAL(3387363646, ComputeDefaultDigest({"vasya", 5}));
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -53,6 +53,7 @@ namespace NCloud::NBlockStore {
     xxx(EndpointSwitchFailure)                                                 \
     xxx(DiskAgentSessionCacheUpdateError)                                      \
     xxx(DiskAgentSessionCacheRestoreError)                                     \
+    xxx(BlockDigestMismatchInBlob)                                             \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/block_handler.cpp
+++ b/cloud/blockstore/libs/storage/core/block_handler.cpp
@@ -132,6 +132,7 @@ public:
             Y_ABORT_UNLESS(ReadRange.Contains(blockIndex));
 
             size_t index = blockIndex - ReadRange.Start;
+            Y_ABORT_UNLESS(index < Blocks.BuffersSize());
             const auto& block = Blocks.GetBuffers(index);
             sglist.emplace_back(block.data(), BlockSize);
         }

--- a/cloud/blockstore/libs/storage/core/block_handler.h
+++ b/cloud/blockstore/libs/storage/core/block_handler.h
@@ -24,9 +24,15 @@ struct IReadBlocksHandler
 {
     virtual ~IReadBlocksHandler() = default;
 
+    // TODO: split into multiple funcs:
+    // * void SetUnencryptedBlockMaskBits(const TVector<ui64>& blockIndices, bool value)
+    // * TGuardedSgList InitializeBuffers(const TVector<ui64>& blockIndices)
     virtual TGuardedSgList GetGuardedSgList(
         const TVector<ui64>& blockIndices,
         bool baseDisk) = 0;
+
+    virtual TGuardedSgList GetGuardedSgList(
+        const TVector<ui64>& blockIndices) const = 0;
 
     virtual bool SetBlock(
         ui64 blockIndex,

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -459,6 +459,9 @@ TDuration MSeconds(ui32 value)
     xxx(AgentListExpiredParamsCleanupInterval,     TDuration, Seconds(1)      )\
                                                                                \
     xxx(UseShadowDisksForNonreplDiskCheckpoints,   bool,      false           )\
+                                                                               \
+    xxx(DiskPrefixLengthWithBlockChecksumsInBlobs, ui64,      0               )\
+    xxx(CheckBlockChecksumsInBlobsUponRead,        bool,      false           )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -519,6 +519,9 @@ public:
     ui64 GetTenantHiveTabletId() const;
 
     bool GetUseShadowDisksForNonreplDiskCheckpoints() const;
+
+    ui64 GetDiskPrefixLengthWithBlockChecksumsInBlobs() const;
+    bool GetCheckBlockChecksumsInBlobsUponRead() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -27,6 +27,7 @@
 #include <cloud/blockstore/libs/storage/partition_common/long_running_operation_companion.h>
 
 #include <cloud/storage/core/libs/api/hive_proxy.h>
+#include <cloud/storage/core/libs/tablet/blob_id.h>
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 
 #include <contrib/ydb/library/actors/core/actor.h>
@@ -643,5 +644,14 @@ void SetCounters(
     const TDuration execTime,
     const TDuration waitTime,
     ui64 blocksCount);
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError VerifyBlockChecksum(
+    const TBlockDataRef& block,
+    const NKikimr::TLogoBlobID& blobID,
+    const ui64 blockIndex,
+    const ui16 blobOffset,
+    const ui32 expectedChecksum);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -169,6 +169,10 @@ private:
             mixedBlocks.AddBlocks(blockIndex);
         }
 
+        for (ui32 checksum: blob.Checksums) {
+            blobMeta.AddBlockChecksums(checksum);
+        }
+
         db.WriteBlobMeta(blob.BlobId, blobMeta);
 
         if (!IsDeletionMarker(blob.BlobId)) {
@@ -225,6 +229,10 @@ private:
         mergedBlocks.SetStart(blob.BlockRange.Start);
         mergedBlocks.SetEnd(blob.BlockRange.End);
         mergedBlocks.SetSkipped(skipped);
+
+        for (ui32 checksum: blob.Checksums) {
+            blobMeta.AddBlockChecksums(checksum);
+        }
 
         db.WriteBlobMeta(blob.BlobId, blobMeta);
 
@@ -287,6 +295,10 @@ private:
         for (const auto& block: blob.Blocks) {
             mixedBlocks.AddBlocks(block.BlockIndex);
             mixedBlocks.AddCommitIds(block.CommitId);
+        }
+
+        for (ui32 checksum: blob.Checksums) {
+            blobMeta.AddBlockChecksums(checksum);
         }
 
         db.WriteBlobMeta(blob.BlobId, blobMeta);

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -287,7 +287,8 @@ void TPartitionActor::HandleAddConfirmedBlobs(
             mergedBlobs.emplace_back(
                 MakePartialBlobId(commitId, blob.UniqueId),
                 blob.BlockRange,
-                TBlockMask());
+                TBlockMask(), // skipMask
+                TVector<ui32>() /* TODO: checksums */);
         }
 
         auto request = std::make_unique<TRequest>(

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -784,9 +784,9 @@ void TCompactionActor::HandleReadBlobResponse(
     const auto& rc = *batch.RangeCompactionInfo;
 
     if (rc.BlockChecksums) {
+        const auto& buffer = rc.BlobContent.Get();
         for (const auto* r: batch.Requests) {
-            const auto block =
-                rc.BlobContent.Get().GetBlock(r->IndexInBlobContent);
+            const auto block = buffer.GetBlock(r->IndexInBlobContent);
             const auto expectedChecksum =
                 rc.BlockChecksums[r->IndexInBlobContent];
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -1033,14 +1033,14 @@ bool TPartitionActor::PrepareReadBlocks(
     args.ChecksumsEnabled = args.ReadRange.Start < checksumBoundary
         && Config->GetCheckBlockChecksumsInBlobsUponRead();
 
-    for (auto& mark: args.BlockMarks) {
-        if (!std::holds_alternative<TBlobMark>(mark)) {
-            continue;
-        }
+    if (args.ChecksumsEnabled) {
+        for (auto& mark: args.BlockMarks) {
+            if (!std::holds_alternative<TBlobMark>(mark)) {
+                continue;
+            }
 
-        const auto& value = std::get<TBlobMark>(mark);
+            const auto& value = std::get<TBlobMark>(mark);
 
-        if (args.ChecksumsEnabled) {
             TMaybe<NProto::TBlobMeta> meta;
             auto blobId = MakePartialBlobId(value.BlobId);
             if (db.ReadBlobMeta(blobId, meta)) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -436,7 +436,7 @@ void TReadBlocksActor::ReadBlocks(
         auto request = std::make_unique<TEvPartitionCommonPrivate::TEvReadBlobRequest>(
             batch.BlobId,
             batch.Proxy,
-            std::move(batch.BlobOffsets),
+            batch.BlobOffsets,
             ReadHandler->GetGuardedSgList(batch.Requests, baseDisk),
             batch.GroupId);
 
@@ -516,7 +516,8 @@ bool TReadBlocksActor::VerifyChecksums(
         return true;
     }
 
-    const auto guard = ReadHandler->GetGuardedSgList(batch.Requests).Acquire();
+    const auto sublist = ReadHandler->GetGuardedSgList(batch.Requests);
+    const auto guard = sublist.Acquire();
     if (!guard) {
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -516,18 +516,20 @@ bool TReadBlocksActor::VerifyChecksums(
         return true;
     }
 
-    const auto sgList = ReadHandler->GetGuardedSgList(batch.Requests).Acquire();
-    if (!sgList) {
+    const auto guard = ReadHandler->GetGuardedSgList(batch.Requests).Acquire();
+    if (!guard) {
         return true;
     }
 
-    Y_DEBUG_ABORT_UNLESS(batch.Requests.size() == sgList.Get().size());
-    if (batch.Requests.size() != sgList.Get().size()) {
+    const auto& sgList = guard.Get();
+
+    Y_DEBUG_ABORT_UNLESS(batch.Requests.size() == sgList.size());
+    if (batch.Requests.size() != sgList.size()) {
         return true;
     }
 
     for (ui32 i = 0; i < batch.Requests.size(); ++i) {
-        const auto block = sgList.Get()[i];
+        const auto block = sgList[i];
 
         auto error = VerifyBlockChecksum(
             block,

--- a/cloud/blockstore/libs/storage/partition/part_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_zeroblocks.cpp
@@ -320,7 +320,11 @@ void TPartitionActor::HandleZeroBlocks(
                 0,  // deletion marker
                 blobIndex++);
 
-            requests.emplace_back(blobId, range, TBlockMask());
+            requests.emplace_back(
+                blobId,
+                range,
+                TBlockMask(), // skipMask
+                TVector<ui32>() /* checksums */);
         }
 
         Y_ABORT_UNLESS(requests);

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -47,12 +47,15 @@ struct TAddMixedBlob
 {
     const TPartialBlobId BlobId;
     const TVector<ui32> Blocks;
+    const TVector<ui32> Checksums;
 
     TAddMixedBlob(
             const TPartialBlobId& blobId,
-            TVector<ui32> blocks)
+            TVector<ui32> blocks,
+            TVector<ui32> checksums)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
+        , Checksums(std::move(checksums))
     {}
 };
 
@@ -63,14 +66,17 @@ struct TAddMergedBlob
     const TPartialBlobId BlobId;
     const TBlockRange32 BlockRange;
     const TBlockMask SkipMask;
+    const TVector<ui32> Checksums;
 
     TAddMergedBlob(
             const TPartialBlobId& blobId,
             const TBlockRange32& blockRange,
-            const TBlockMask& skipMask)
+            const TBlockMask& skipMask,
+            TVector<ui32> checksums)
         : BlobId(blobId)
         , BlockRange(blockRange)
         , SkipMask(skipMask)
+        , Checksums(std::move(checksums))
     {}
 };
 
@@ -80,12 +86,15 @@ struct TAddFreshBlob
 {
     const TPartialBlobId BlobId;
     const TVector<TBlock> Blocks;
+    const TVector<ui32> Checksums;
 
     TAddFreshBlob(
             const TPartialBlobId& blobId,
-            TVector<TBlock> blocks)
+            TVector<TBlock> blocks,
+            TVector<ui32> checksums)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
+        , Checksums(std::move(checksums))
     {}
 };
 
@@ -109,6 +118,10 @@ struct TAffectedBlob
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;
+
+    // Filled only if a flag is set. BlobMeta is needed only to do some extra
+    // consistency checks.
+    TMaybe<NProto::TBlobMeta> BlobMeta;
 };
 
 using TAffectedBlobs = THashMap<TPartialBlobId, TAffectedBlob, TPartialBlobIdHash>;
@@ -175,18 +188,21 @@ struct TReadBlocksRequest
     ui16 BlobOffset;
     ui32 BlockIndex;
     ui32 GroupId;
+    ui32 BlockChecksum;
 
     TReadBlocksRequest(
             const NKikimr::TLogoBlobID& blobId,
             NActors::TActorId proxy,
             ui16 blobOffset,
             ui32 blockIndex,
-            ui32 groupId)
+            ui32 groupId,
+            ui32 blockChecksum)
         : BlobId(blobId)
         , BSProxy(proxy)
         , BlobOffset(blobOffset)
         , BlockIndex(blockIndex)
         , GroupId(groupId)
+        , BlockChecksum(blockChecksum)
     {}
 };
 

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -230,10 +230,12 @@ struct TTxPartition
         const TBlockRange32 ReadRange;
         const IReadBlocksHandlerPtr ReadHandler;
         const bool ReplyLocal;
+        bool ChecksumsEnabled = false;
         bool Interrupted = false;
 
         TBlockMarks BlockMarks;
         TVector<ui64> BlockMarkCommitIds;
+        THashMap<TPartialBlobId, NProto::TBlobMeta, TPartialBlobIdHash> BlobId2Meta;
 
         TVector<IProfileLog::TBlockInfo> BlockInfos;
 
@@ -255,8 +257,10 @@ struct TTxPartition
         void Clear()
         {
             ReadHandler->Clear();
+            ChecksumsEnabled = false;
             std::fill(BlockMarks.begin(), BlockMarks.end(), NBlobMarkers::TEmptyMark());
             std::fill(BlockMarkCommitIds.begin(), BlockMarkCommitIds.end(), 0);
+            BlobId2Meta.clear();
             BlockInfos.clear();
         }
 
@@ -358,6 +362,7 @@ struct TTxPartition
         ui32 BlobsSkipped = 0;
         ui32 BlocksSkipped = 0;
         bool Discarded = false;
+        bool ChecksumsEnabled = false;
 
         TRangeCompaction(ui32 rangeIdx, const TBlockRange32& blockRange)
             : RangeIdx(rangeIdx)
@@ -373,6 +378,7 @@ struct TTxPartition
             BlobsSkipped = 0;
             BlocksSkipped = 0;
             Discarded = false;
+            ChecksumsEnabled = false;
         }
 
         TBlockMark& GetBlockMark(ui32 blockIndex)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -111,6 +111,7 @@ NProto::TStorageServiceConfig DefaultConfig(ui32 flushBlobSizeThreshold = 4_KB)
     config.SetFreshByteCountLimitForBackpressure(1200_KB);
     config.SetFreshByteCountFeatureMaxValue(6);
     config.SetCollectGarbageThreshold(10);
+    config.SetDiskPrefixLengthWithBlockChecksumsInBlobs(1_GB);
 
     return config;
 }

--- a/cloud/blockstore/libs/storage/protos/part.proto
+++ b/cloud/blockstore/libs/storage/protos/part.proto
@@ -165,6 +165,12 @@ message TBlobMeta
         TMixedBlocks MixedBlocks = 1;
         TMergedBlocks MergedBlocks = 2;
     }
+
+    // May be empty. Checksums are calculated and stored only if the
+    // corresponding flag in TStorageServiceConfig is set.
+    // May contain zeroes. Zeroes are treated as "no checksum" and thus
+    // verification doesn't work for actual zero checksums.
+    repeated uint32 BlockChecksums = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tests/loadtest/local/test.py
+++ b/cloud/blockstore/tests/loadtest/local/test.py
@@ -46,6 +46,7 @@ def default_storage_config(tablet_version, cache_folder):
 
     storage.InactiveClientsTimeout = 10000
     storage.DiskPrefixLengthWithBlockChecksumsInBlobs = 1 << 30  # 1 GiB
+    storage.CheckBlockChecksumsInBlobsUponRead = True
 
     if tablet_version == 2:
         storage.BlockDigestsEnabled = True

--- a/cloud/blockstore/tests/loadtest/local/test.py
+++ b/cloud/blockstore/tests/loadtest/local/test.py
@@ -20,8 +20,8 @@ def parse_storage_config(param):
 
 
 def default_storage_config(tablet_version, cache_folder):
-    bw = 1 << 6     # 64 MB/s
-    iops = 1 << 12  # 4096 iops
+    bw = 1 << 6     # 64 MiB/s
+    iops = 1 << 12  # 4096 IOPS
 
     storage = TStorageServiceConfig()
     storage.ThrottlingEnabled = True
@@ -45,6 +45,7 @@ def default_storage_config(tablet_version, cache_folder):
     storage.HDDMaxWriteIops = iops
 
     storage.InactiveClientsTimeout = 10000
+    storage.DiskPrefixLengthWithBlockChecksumsInBlobs = 1 << 30  # 1 GiB
 
     if tablet_version == 2:
         storage.BlockDigestsEnabled = True


### PR DESCRIPTION
implemented calculation of block checksums in the blobs stored in blobstorage
implemented checksum checking for those blobs upon read
enabled this logic for the first 1GiB of the disk space in most of the uts in part_ut and in tests/loadtest/local large test suite

checksum calculation and verification for patched blobs and unconfirmed blobs is a TODO