### PR TITLE
NBS-4759: [Disk Manager] remove unnecessary logic from generateBaseDisk

### DIFF
--- a/cloud/disk_manager/internal/api/private_service.proto
+++ b/cloud/disk_manager/internal/api/private_service.proto
@@ -58,9 +58,10 @@ message RebaseOverlayDiskRequest {
 }
 
 message RetireBaseDiskRequest {
+    reserved 3;
+    
     string base_disk_id = 1;
     yandex.cloud.priv.disk_manager.v1.DiskId src_disk_id = 2;
-    string src_disk_checkpoint_id = 3;
 }
 
 message RetireBaseDisksRequest {

--- a/cloud/disk_manager/internal/pkg/facade/private_service.go
+++ b/cloud/disk_manager/internal/pkg/facade/private_service.go
@@ -79,7 +79,6 @@ func (s *privateService) RetireBaseDisk(
 				ZoneId: req.SrcDiskId.ZoneId,
 				DiskId: req.SrcDiskId.DiskId,
 			},
-			SrcDiskCheckpointId: req.SrcDiskCheckpointId,
 		},
 	)
 	if err != nil {

--- a/cloud/disk_manager/internal/pkg/services/pools/protos/retire_base_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/protos/retire_base_disk_task.proto
@@ -15,8 +15,5 @@ message RetireBaseDiskRequest {
 }
 
 message RetireBaseDiskTaskState {
-    // Used to save GetCheckpointSize execution state.
-    uint64 SrcDiskMilestoneBlockIndex = 2;
-    // Used to save GetCheckpointSize execution state.
-    uint64 SrcDiskMilestoneCheckpointSize = 3;
+    reserved 2 to 3;
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/protos/retire_base_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/protos/retire_base_disk_task.proto
@@ -9,9 +9,10 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message RetireBaseDiskRequest {
+    reserved 3;
+    
     string BaseDiskId = 1;
     types.Disk SrcDisk = 2;
-    string SrcDiskCheckpointId = 3;
 }
 
 message RetireBaseDiskTaskState {

--- a/cloud/disk_manager/internal/pkg/services/pools/retire_base_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/retire_base_disk_task.go
@@ -47,40 +47,10 @@ func (t *retireBaseDiskTask) Run(
 	baseDiskID := t.request.BaseDiskId
 	selfTaskID := execCtx.GetTaskID()
 
-	if t.request.SrcDisk != nil {
-		client, err := t.nbsFactory.GetClient(ctx, t.request.SrcDisk.ZoneId)
-		if err != nil {
-			return err
-		}
-
-		err = client.GetCheckpointSize(
-			ctx,
-			func(blockIndex uint64, checkpointSize uint64) error {
-				t.state.SrcDiskMilestoneBlockIndex = blockIndex
-				t.state.SrcDiskMilestoneCheckpointSize = checkpointSize
-				return execCtx.SaveState(ctx)
-			},
-			t.request.SrcDisk.DiskId,
-			t.request.SrcDiskCheckpointId,
-			t.state.SrcDiskMilestoneBlockIndex,
-			t.state.SrcDiskMilestoneCheckpointSize,
-		)
-		if err != nil {
-			if nbs.IsDiskNotFoundError(err) {
-				// Should be idempotent.
-				return nil
-			}
-
-			return err
-		}
-	}
-
 	rebaseInfos, err := t.storage.RetireBaseDisk(
 		ctx,
 		baseDiskID,
 		t.request.SrcDisk,
-		t.request.SrcDiskCheckpointId,
-		t.state.SrcDiskMilestoneCheckpointSize,
 	)
 	if err != nil {
 		return err

--- a/cloud/disk_manager/internal/pkg/services/pools/retire_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/retire_base_disks_task.go
@@ -98,14 +98,11 @@ func (t *retireBaseDisksTask) Run(
 		idempotencyKey := fmt.Sprintf("%v_%v", execCtx.GetTaskID(), baseDiskID)
 
 		var srcDisk *types.Disk
-		var srcDiskCheckpointID string
 		if t.request.UseBaseDiskAsSrc {
 			srcDisk = &types.Disk{
 				ZoneId: zoneID,
 				DiskId: baseDiskID,
 			}
-			// Note: we use image id as checkpoint id.
-			srcDiskCheckpointID = imageID
 		}
 
 		taskID, err := t.scheduler.ScheduleTask(

--- a/cloud/disk_manager/internal/pkg/services/pools/retire_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/retire_base_disks_task.go
@@ -117,9 +117,8 @@ func (t *retireBaseDisksTask) Run(
 				zoneID,
 			),
 			&protos.RetireBaseDiskRequest{
-				BaseDiskId:          baseDiskID,
-				SrcDisk:             srcDisk,
-				SrcDiskCheckpointId: srcDiskCheckpointID,
+				BaseDiskId: baseDiskID,
+				SrcDisk:    srcDisk,
 			},
 			"",
 			"",

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -650,28 +650,18 @@ func (s *storageYDB) generateBaseDisk(
 	zoneID string,
 	imageSize uint64,
 	srcDisk *types.Disk,
-	srcDiskCheckpointID string,
-	srcDiskCheckpointSize uint64,
 ) baseDisk {
-
-	var requiredSize uint64
-	if srcDisk != nil {
-		// Base disk will be copied from 'src disk'.
-		requiredSize = srcDiskCheckpointSize
-	} else {
-		requiredSize = imageSize
-	}
 
 	var size, maxActiveSlots, units uint64
 
-	if requiredSize == 0 {
+	if imageSize == 0 {
 		// Default case.
 		units = s.maxBaseDiskUnits
 		maxActiveSlots = s.maxActiveSlots
 	} else {
 		// Base disks are using SSD.
 		ssdUnits := divideWithRoundingUp(
-			requiredSize,
+			imageSize,
 			baseDiskUnitSize,
 		)
 		size = ssdUnits * baseDiskUnitSize
@@ -701,7 +691,7 @@ func (s *storageYDB) generateBaseDisk(
 		size:                size,
 		srcDiskZoneID:       srcDiskZoneID,
 		srcDiskID:           srcDiskID,
-		srcDiskCheckpointID: srcDiskCheckpointID,
+		srcDiskCheckpointID: imageID, // Note: we use image id as checkpoint id.
 
 		maxActiveSlots: maxActiveSlots,
 		units:          units,

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
@@ -16,7 +16,7 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 	check := func(
 		actual baseDisk,
 		imageSize uint64,
-		srcDiskCheckpointSize uint64,
+		srcDisk *types.Disk,
 	) {
 
 		require.NotEmpty(t, actual.id)
@@ -29,10 +29,10 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 		require.True(t, actual.fromPool)
 		require.Equal(t, baseDiskStatusScheduling, actual.status)
 
-		if srcDiskCheckpointSize != 0 {
+		if imageSize != 0 && srcDisk != nil {
 			require.Equal(t, "src_disk_zone", actual.srcDiskZoneID)
 			require.Equal(t, "src_disk", actual.srcDiskID)
-			require.Equal(t, "src_disk_checkpoint", actual.srcDiskCheckpointID)
+			require.Equal(t, "image", actual.srcDiskCheckpointID)
 		}
 	}
 
@@ -43,28 +43,24 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 		}
 
 		imageSize := requiredSize
-		var srcDiskCheckpointSize uint64
+		var srcDisk *types.Disk
 
 		baseDisk := storage.generateBaseDisk(
 			"image",
 			"zone",
 			imageSize,
-			nil,
-			"",
-			srcDiskCheckpointSize,
+			srcDisk,
 		)
-		check(baseDisk, imageSize, srcDiskCheckpointSize)
+		check(baseDisk, imageSize, srcDisk)
 
-		srcDiskCheckpointSize = requiredSize
+		srcDisk = &types.Disk{ZoneId: "src_disk_zone", DiskId: "src_disk"}
 		baseDisk = storage.generateBaseDisk(
 			"image",
 			"zone",
 			imageSize,
-			&types.Disk{ZoneId: "src_disk_zone", DiskId: "src_disk"},
-			"src_disk_checkpoint",
-			srcDiskCheckpointSize,
+			srcDisk,
 		)
-		check(baseDisk, imageSize, srcDiskCheckpointSize)
+		check(baseDisk, imageSize, srcDisk)
 		return baseDisk
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/mocks/storage_mock.go
@@ -182,16 +182,12 @@ func (s *StorageMock) RetireBaseDisk(
 	ctx context.Context,
 	baseDiskID string,
 	srcDisk *types.Disk,
-	srcDiskCheckpointID string,
-	srcDiskCheckpointSize uint64,
 ) ([]storage.RebaseInfo, error) {
 
 	args := s.Called(
 		ctx,
 		baseDiskID,
 		srcDisk,
-		srcDiskCheckpointID,
-		srcDiskCheckpointSize,
 	)
 	return args.Get(0).([]storage.RebaseInfo), args.Error(1)
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
@@ -129,8 +129,6 @@ type Storage interface {
 		ctx context.Context,
 		baseDiskID string,
 		srcDisk *types.Disk,
-		srcDiskCheckpointID string,
-		srcDiskCheckpointSize uint64,
 	) ([]RebaseInfo, error)
 
 	IsBaseDiskRetired(ctx context.Context, baseDiskID string) (bool, error)

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
@@ -317,8 +317,6 @@ func (s *storageYDB) RetireBaseDisk(
 	ctx context.Context,
 	baseDiskID string,
 	srcDisk *types.Disk,
-	srcDiskCheckpointID string,
-	srcDiskCheckpointSize uint64,
 ) ([]RebaseInfo, error) {
 
 	var rebaseInfos []RebaseInfo
@@ -332,8 +330,6 @@ func (s *storageYDB) RetireBaseDisk(
 				session,
 				baseDiskID,
 				srcDisk,
-				srcDiskCheckpointID,
-				srcDiskCheckpointSize,
 			)
 			return err
 		},

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
@@ -2029,8 +2029,6 @@ func (s *storageYDB) takeBaseDisksToScheduleForPool(
 		config.zoneID,
 		config.imageSize,
 		nil, // srcDisk
-		"",  // srcDiskCheckpointID
-		0,   // srcDiskCheckpointSize
 	)
 
 	// size and capacity are measured in slots, not base disks.
@@ -3146,8 +3144,6 @@ func (s *storageYDB) retireBaseDisk(
 				zoneID,
 				imageSize,
 				srcDisk,
-				srcDiskCheckpointID,
-				srcDiskCheckpointSize,
 			)
 			logging.Info(
 				ctx,

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
@@ -3027,8 +3027,6 @@ func (s *storageYDB) retireBaseDisk(
 	session *persistence.Session,
 	baseDiskID string,
 	srcDisk *types.Disk,
-	srcDiskCheckpointID string,
-	srcDiskCheckpointSize uint64,
 ) ([]RebaseInfo, error) {
 
 	tx, err := session.BeginRWTransaction(ctx)

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -1583,7 +1583,7 @@ func TestStorageYDBRetireBaseDisks(t *testing.T) {
 		})
 	}
 
-	rebaseInfos, err := storage.RetireBaseDisk(ctx, "unexisting", nil, "", 0)
+	rebaseInfos, err := storage.RetireBaseDisk(ctx, "unexisting", nil)
 	require.NoError(t, err)
 	require.Empty(t, rebaseInfos)
 
@@ -1637,7 +1637,7 @@ func TestStorageYDBRetireBaseDisks(t *testing.T) {
 	newBaseDisks := make([]BaseDisk, 0)
 
 	for _, baseDisk := range oldBaseDisks {
-		rebaseInfos, err := storage.RetireBaseDisk(ctx, baseDisk.ID, nil, "", 0)
+		rebaseInfos, err := storage.RetireBaseDisk(ctx, baseDisk.ID, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, rebaseInfos)
 
@@ -1650,7 +1650,7 @@ func TestStorageYDBRetireBaseDisks(t *testing.T) {
 		}
 
 		// Check idempotency.
-		actual, err := storage.RetireBaseDisk(ctx, baseDisk.ID, nil, "", 0)
+		actual, err := storage.RetireBaseDisk(ctx, baseDisk.ID, nil)
 		require.NoError(t, err)
 		require.ElementsMatch(t, rebaseInfos, actual)
 
@@ -1776,7 +1776,7 @@ func TestStorageYDBBaseDiskShouldNotBeFreeAfterRetireStarted(t *testing.T) {
 	_, err = storage.AcquireBaseDiskSlot(ctx, "image", slot2)
 	require.NoError(t, err)
 
-	_, err = storage.RetireBaseDisk(ctx, baseDisks[0].ID, nil, "", 0)
+	_, err = storage.RetireBaseDisk(ctx, baseDisks[0].ID, nil)
 	require.NoError(t, err)
 
 	_, err = storage.AcquireBaseDiskSlot(ctx, "image", slot3)
@@ -1938,7 +1938,7 @@ func TestStorageYDBRetireBaseDiskForPoolWithImageSize(t *testing.T) {
 	err = storage.ConfigurePool(ctx, "image", "zone", 1, imageSize)
 	require.NoError(t, err)
 
-	_, err = storage.RetireBaseDisk(ctx, baseDisks[0].ID, nil, "", 0)
+	_, err = storage.RetireBaseDisk(ctx, baseDisks[0].ID, nil)
 	require.NoError(t, err)
 
 	baseDisks, err = storage.TakeBaseDisksToSchedule(ctx)
@@ -1998,8 +1998,6 @@ func TestStorageYDBRetireBaseDiskForDeletedPool(t *testing.T) {
 			ZoneId: baseDisks[0].ZoneID,
 			DiskId: baseDisks[0].ID,
 		},
-		baseDisks[0].CheckpointID,
-		baseDiskUnitSize,
 	)
 	require.NoError(t, err)
 
@@ -2237,8 +2235,6 @@ func TestStorageYDBDeletePoolWhenRetiringIsInFlight(t *testing.T) {
 			ZoneId: baseDisks[0].ZoneID,
 			DiskId: baseDisks[0].ID,
 		},
-		baseDisks[0].CheckpointID,
-		baseDiskUnitSize,
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rebaseInfos))

--- a/cloud/disk_manager/pkg/admin/private.go
+++ b/cloud/disk_manager/pkg/admin/private.go
@@ -91,11 +91,10 @@ func newRebaseOverlayDiskCmd(config *client_config.ClientConfig) *cobra.Command 
 ////////////////////////////////////////////////////////////////////////////////
 
 type retireBaseDisk struct {
-	config              *client_config.ClientConfig
-	baseDiskID          string
-	srcDiskZoneID       string
-	srcDiskID           string
-	srcDiskCheckpointID string
+	config        *client_config.ClientConfig
+	baseDiskID    string
+	srcDiskZoneID string
+	srcDiskID     string
 }
 
 func (c *retireBaseDisk) run() error {
@@ -113,7 +112,6 @@ func (c *retireBaseDisk) run() error {
 			ZoneId: c.srcDiskZoneID,
 			DiskId: c.srcDiskID,
 		},
-		SrcDiskCheckpointId: c.srcDiskCheckpointID,
 	}
 
 	resp, err := client.RetireBaseDisk(getRequestContext(ctx), req)
@@ -155,12 +153,6 @@ func newRetireBaseDiskCmd(config *client_config.ClientConfig) *cobra.Command {
 		"zone ID where source disk is located",
 	)
 	cmd.Flags().StringVar(&c.srcDiskID, "src-disk-id", "", "id of source disk")
-	cmd.Flags().StringVar(
-		&c.srcDiskCheckpointID,
-		"src-disk-checkpoint-id",
-		"",
-		"id of source disk checkpoint",
-	)
 
 	return cmd
 }


### PR DESCRIPTION
исправление логики в generateBaseDisk 

заходим туда только если 
1) пул был удален в процессе retire
2) пул есть, но базовые диски еще не успели налиться 

в обоих случаях из дефолтных (больших) базовых дисков нужно создавать дефолтные (такие же)

иначе: из базовых дисков размером с образ можно создавать такие же диски размером с образ а не с чекпоинт, так как разница между этими двумя показателями незначительна (она не может быть больше чем disk_size - image_size, при этом порядок этой метрики очень мал. по подсчетам там максимум не больше примерно 30 гб)

после этих исправлений больше нет необходимости в полях checkpoint_id, checkpoint_size - поэтому удаляю их тоже

