### PR TITLE
NBS-4759: [Disk Manager] optimize relocation of overlay disks without alive pool

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
@@ -191,7 +191,7 @@ func setupMigrateEmptyOverlayDiskTest(
 	imageID := t.Name()
 	diskSize := migrationTestsDiskSize
 	imageSize := diskSize / 2
-	_, storageSize := testcommon.CreateImage(
+	testcommon.CreateImage(
 		t,
 		ctx,
 		imageID,
@@ -241,12 +241,8 @@ func setupMigrateEmptyOverlayDiskTest(
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), changedBytes)
 
-	if withAliveSrcImage {
-		// storageSize is 0 because we should not copy base disk data.
-		return 0
-	}
-
-	return storageSize
+	// storageSize is 0 because we should not copy base disk data.
+	return 0
 }
 
 func successfullyMigrateEmptyOverlayDisk(

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -1280,6 +1280,16 @@ func TestStorageYDBRelocateOverlayDiskWithoutPool(t *testing.T) {
 	err = storage.BaseDisksScheduled(ctx, baseDisks)
 	require.NoError(t, err)
 
+	_, err = relocateOverlayDisk(
+		ctx,
+		db,
+		storage,
+		slot.OverlayDisk,
+		"other",
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.NewInterruptExecutionError()))
+
 	for _, baseDisk := range baseDisks {
 		err = storage.BaseDiskCreated(ctx, baseDisk)
 		require.NoError(t, err)

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -1211,6 +1211,70 @@ func TestStorageYDBRelocateOverlayDisk(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestStorageYDBRelocateOverlayDiskWithoutPool(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	err = storage.ConfigurePool(
+		ctx,
+		"image",
+		"zone",
+		makeDefaultConfig().GetMaxActiveSlots()+1,
+		0,
+	)
+	require.NoError(t, err)
+
+	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(baseDisks))
+
+	for i := 0; i < len(baseDisks); i++ {
+		baseDisks[i].CreateTaskID = "create"
+	}
+	err = storage.BaseDisksScheduled(ctx, baseDisks)
+	require.NoError(t, err)
+
+	slot := Slot{
+		OverlayDisk: &types.Disk{
+			ZoneId: "zone",
+			DiskId: "overlay",
+		},
+	}
+
+	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
+	require.NoError(t, err)
+	require.Contains(t, baseDisks, source)
+
+	for _, baseDisk := range baseDisks {
+		err = storage.BaseDiskCreated(ctx, baseDisk)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < len(baseDisks); i++ {
+		baseDisks[i].Ready = true
+	}
+
+	_, err = relocateOverlayDisk(
+		ctx,
+		db,
+		storage,
+		slot.OverlayDisk,
+		"other",
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.NewInterruptExecutionError()))
+
+	baseDisks, err = storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(baseDisks))
+}
+
 func TestStorageYDBRebaseOverlayDiskDuringRelocating(t *testing.T) {
 	ctx, cancel := context.WithCancel(newContext())
 	defer cancel()


### PR DESCRIPTION
При релокации оверлейных дисков не хочется копировать данные еще и базовых дисков 

Оптимизация работает так:
1) создаем базовые диски в DST зоне 
2) при релокации не копируем информацию с базового диска в SRC зоне, а просто создаем оверлейные, которые ссылаются на базовые диски в DST зоне (то есть экономим наливку базовых дисков)

Это работало только для живых пулов (которые не удалили) - потому что для таких пулов eventually наливаются базовые диски 

Это изменение делает так, что если мы хотим релоцировать оверлейный диск и даже если пул удален - то мы создадим такие же базовые диски в DST зоне и тоже используем оптимизацию в этом месте 