### PR TITLE
loadtest env tear_down should happen inside finally blocks because otherwise we may get an exception because blockstore-loadtest run failed and will never know that kikimr daemon crashed

### DIFF
--- a/cloud/blockstore/tests/loadtest/local-auth/test.py
+++ b/cloud/blockstore/tests/loadtest/local-auth/test.py
@@ -43,17 +43,18 @@ def test_load():
         "cloud/blockstore/tests/certs/server.crt")
     client.AuthToken = "test_auth_token"
 
-    ret = run_test(
-        "load",
-        common.source_path(
-            "cloud/blockstore/tests/loadtest/local-auth/local.txt"),
-        env.nbs_secure_port,
-        env.mon_port,
-        client_config=client,
-        enable_tls=True,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            "load",
+            common.source_path(
+                "cloud/blockstore/tests/loadtest/local-auth/local.txt"),
+            env.nbs_secure_port,
+            env.mon_port,
+            client_config=client,
+            enable_tls=True,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret

--- a/cloud/blockstore/tests/loadtest/local-checkpoint/test.py
+++ b/cloud/blockstore/tests/loadtest/local-checkpoint/test.py
@@ -123,16 +123,17 @@ def __run_test(test_case):
         use_in_memory_pdisks=True,
     )
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-discovery/test.py
+++ b/cloud/blockstore/tests/loadtest/local-discovery/test.py
@@ -115,27 +115,28 @@ def test_load():
         use_in_memory_pdisks=True,
     )
 
-    ret = run_test(
-        "load",
-        common.source_path(
-            "cloud/blockstore/tests/loadtest/local-discovery/local.txt"),
-        env.nbs_port,
-        env.mon_port,
-        env_processes=[env.nbs],
-    )
+    try:
+        ret = run_test(
+            "load",
+            common.source_path(
+                "cloud/blockstore/tests/loadtest/local-discovery/local.txt"),
+            env.nbs_port,
+            env.mon_port,
+            env_processes=[env.nbs],
+        )
 
-    results_path = os.path.join(common.output_path(), "results.txt")
+        results_path = os.path.join(common.output_path(), "results.txt")
 
-    def is_good(port):
-        return port in good_ports
+        def is_good(port):
+            return port in good_ports
 
-    with open(results_path, "r") as f:
-        for line in f:
-            data = json.loads(line)
-            ports = [x['Port'] for x in data['Instances']]
-            for port in ports:
-                assert is_good(port)
-
-    env.tear_down()
+        with open(results_path, "r") as f:
+            for line in f:
+                data = json.loads(line)
+                ports = [x['Port'] for x in data['Instances']]
+                for port in ports:
+                    assert is_good(port)
+    finally:
+        env.tear_down()
 
     return ret

--- a/cloud/blockstore/tests/loadtest/local-edgecase/test.py
+++ b/cloud/blockstore/tests/loadtest/local-edgecase/test.py
@@ -131,15 +131,16 @@ def __run_test(test_case):
         use_in_memory_pdisks=True,
     )
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -99,15 +99,16 @@ def __run_test(test_case):
     env.kikimr_cluster.restart_nodes()
     env.nbs.restart()
 
-    ret = run_test(
-        "emergency-%s" % test_case.name,
-        common.source_path(test_case.config_path),
-        env.nbs_port,
-        env.mon_port,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            "emergency-%s" % test_case.name,
+            common.source_path(test_case.config_path),
+            env.nbs_port,
+            env.mon_port,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-encryption/test.py
+++ b/cloud/blockstore/tests/loadtest/local-encryption/test.py
@@ -121,17 +121,18 @@ def __run_test(test_case):
     client = TClientConfig()
     client.NbdSocketSuffix = nbd_socket_suffix
 
-    ret = run_test(
-        test_case.name,
-        config_path,
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        client_config=client,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            config_path,
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            client_config=client,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-endpoints/test.py
+++ b/cloud/blockstore/tests/loadtest/local-endpoints/test.py
@@ -118,17 +118,18 @@ def __run_test(test_case):
     client_config.NbdSocketSuffix = nbd_socket_suffix
     client_config.NbdStructuredReply = test_case.nbd_structured_reply
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        client_config=client_config,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            client_config=client_config,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-mirror/test.py
+++ b/cloud/blockstore/tests/loadtest/local-mirror/test.py
@@ -259,21 +259,22 @@ def __run_test(test_case):
 
         config_path = __process_config(test_case.config_path, devices_per_agent)
 
-        ret = run_test(
-            test_case.name,
-            config_path,
-            nbs.nbs_port,
-            nbs.mon_port,
-            nbs_log_path=nbs.stderr_file_name,
-            client_config=client,
-            env_processes=disk_agents + [nbs],
-        )
+        try:
+            ret = run_test(
+                test_case.name,
+                config_path,
+                nbs.nbs_port,
+                nbs.mon_port,
+                nbs_log_path=nbs.stderr_file_name,
+                client_config=client,
+                env_processes=disk_agents + [nbs],
+            )
+        finally:
+            for disk_agent in disk_agents:
+                disk_agent.stop()
 
-        for disk_agent in disk_agents:
-            disk_agent.stop()
-
-        nbs.stop()
-        kikimr_cluster.stop()
+            nbs.stop()
+            kikimr_cluster.stop()
     finally:
         __cleanup_file_devices(devices)
 

--- a/cloud/blockstore/tests/loadtest/local-nemesis/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nemesis/test.py
@@ -107,18 +107,19 @@ def __run_test(test_case):
     client.NbdSocketSuffix = nbd_socket_suffix
     client.NbdStructuredReply = test_case.nbd_structured_reply
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        client_config=client,
-        endpoint_storage_dir=endpoint_storage_dir,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            client_config=client,
+            endpoint_storage_dir=endpoint_storage_dir,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -280,17 +280,18 @@ def __run_test(test_case):
     client = TClientConfig()
     client.NbdSocketSuffix = nbd_socket_suffix
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        client_config=client,
-        endpoint_storage_dir=endpoint_storage_dir,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            client_config=client,
+            endpoint_storage_dir=endpoint_storage_dir,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -318,20 +318,21 @@ def __run_test(test_case):
         client = TClientConfig()
         client.NbdSocketSuffix = nbd_socket_suffix
 
-        ret = run_test(
-            test_case.name,
-            config_path,
-            nbs.nbs_port,
-            nbs.mon_port,
-            nbs_log_path=nbs.stderr_file_name,
-            client_config=client,
-            env_processes=disk_agents + [nbs])
+        try:
+            ret = run_test(
+                test_case.name,
+                config_path,
+                nbs.nbs_port,
+                nbs.mon_port,
+                nbs_log_path=nbs.stderr_file_name,
+                client_config=client,
+                env_processes=disk_agents + [nbs])
+        finally:
+            for disk_agent in disk_agents:
+                disk_agent.stop()
 
-        for disk_agent in disk_agents:
-            disk_agent.stop()
-
-        nbs.stop()
-        kikimr_cluster.stop()
+            nbs.stop()
+            kikimr_cluster.stop()
     finally:
         if not test_case.use_memory_devices:
             cleanup_file_devices(devices)

--- a/cloud/blockstore/tests/loadtest/local-overflow/test.py
+++ b/cloud/blockstore/tests/loadtest/local-overflow/test.py
@@ -72,16 +72,17 @@ def __run_test(test_case):
         ],
     )
 
-    ret = run_test(
-        "overflow-%s" % test_case.name,
-        common.source_path(test_case.config_path),
-        env.nbs_port,
-        env.mon_port,
-        stat_filter=test_case.stat_filter,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            "overflow-%s" % test_case.name,
+            common.source_path(test_case.config_path),
+            env.nbs_port,
+            env.mon_port,
+            stat_filter=test_case.stat_filter,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-overlay/test.py
+++ b/cloud/blockstore/tests/loadtest/local-overlay/test.py
@@ -140,16 +140,17 @@ def __run_test(test_case):
         use_in_memory_pdisks=True,
     )
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-throttling/test.py
+++ b/cloud/blockstore/tests/loadtest/local-throttling/test.py
@@ -73,17 +73,18 @@ def __run_test(test_case):
         use_in_memory_pdisks=True,
     )
 
-    ret = run_test(
-        "throttling-%s" % test_case.name,
-        common.source_path(test_case.config_path),
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        track_filter=test_case.track_filter,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            "throttling-%s" % test_case.name,
+            common.source_path(test_case.config_path),
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            track_filter=test_case.track_filter,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local-v2/test.py
+++ b/cloud/blockstore/tests/loadtest/local-v2/test.py
@@ -84,16 +84,17 @@ def __run_test(test_case):
         use_in_memory_pdisks=True,
     )
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        nbs_log_path=env.nbs_log_path,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            nbs_log_path=env.nbs_log_path,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 

--- a/cloud/blockstore/tests/loadtest/local/test.py
+++ b/cloud/blockstore/tests/loadtest/local/test.py
@@ -182,18 +182,19 @@ def __run_test(test_case):
         bs_cache_file_path=cache_folder + "/bs_cache.txt",
     )
 
-    ret = run_test(
-        test_case.name,
-        test_case.config_path,
-        env.nbs_port,
-        env.mon_port,
-        stat_filter=test_case.stat_filter,
-        nbs_log_path=env.nbs_log_path,
-        track_filter=test_case.track_filter,
-        env_processes=[env.nbs],
-    )
-
-    env.tear_down()
+    try:
+        ret = run_test(
+            test_case.name,
+            test_case.config_path,
+            env.nbs_port,
+            env.mon_port,
+            stat_filter=test_case.stat_filter,
+            nbs_log_path=env.nbs_log_path,
+            track_filter=test_case.track_filter,
+            env_processes=[env.nbs],
+        )
+    finally:
+        env.tear_down()
 
     return ret
 


### PR DESCRIPTION
fixing the following problem: kikimr crashes => operations hang in blockstore-server => blockstore-loadtest fails because of a timeout => we only see that blockstore-loadtest failed