### PR TITLE
[CI]: Add ya cache garbage collection before scripts

### DIFF
--- a/cloud/storage/core/tools/ci/runner/run_all.sh
+++ b/cloud/storage/core/tools/ci/runner/run_all.sh
@@ -17,6 +17,8 @@ fi
 cd $nbspath &&
 git pull
 
+"${nbspath}/ya" gc cache
+
 logs_dir="/var/www/build/logs/run_$(date +%y_%m_%d__%H)" &&
 rm -rf "$logs_dir" &&
 mkdir -p "$logs_dir"


### PR DESCRIPTION
Ya cache grows uncontrollably, consuming all the disk space.