### PR TITLE
Fix tests in cmake

### DIFF
--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener_ut.cpp
@@ -225,7 +225,7 @@ public:
 
 struct TOptions
 {
-    TString UnixSocketPath = "./testSocket";
+    TString UnixSocketPath = CreateGuidAsString() + ".sock";
     TString ClientId = "testClientId";
     TString DiskId = "testDiskId";
     ui32 UnixSocketBacklog = 16;
@@ -329,7 +329,7 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
     Y_UNIT_TEST(ShouldHandleStartStopEndpoint)
     {
         auto logging = CreateLoggingService("console");
-        TFsPath unixSocket("./testSocket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto clientAcceptor = std::make_shared<TTestClientAcceptor>();
         auto listener = CreateSocketEndpointListener(logging, 16);
@@ -374,7 +374,7 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
     Y_UNIT_TEST(ShouldHandleClientDisconnection)
     {
         auto logging = CreateLoggingService("console");
-        TFsPath unixSocket("./testSocket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto clientAcceptor = std::make_shared<TTestClientAcceptor>();
         auto listener = CreateSocketEndpointListener(logging, 16);
@@ -415,7 +415,7 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
         TString diskId = "testDiskId";
         ui32 unixSocketBacklog = 16;
         auto blocksCount = 42;
-        TFsPath unixSocket("./testSocket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         TPortManager portManager;
         ui16 dataPort = portManager.GetPort(9001);
@@ -914,14 +914,14 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
 
     Y_UNIT_TEST(ShouldStartEndpointIfSocketAlreadyExists)
     {
-        TOptions options;
-        options.UnixSocketPath = "./TestUnixSocket";
-
-        TFsPath unixSocket(options.UnixSocketPath);
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
         unixSocket.Touch();
         Y_DEFER {
             unixSocket.DeleteIfExists();
         };
+
+        TOptions options;
+        options.UnixSocketPath = unixSocket.GetPath();
 
         auto bootstrap = CreateBootstrap(options);
         bootstrap.Start();

--- a/cloud/blockstore/libs/nbd/server_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_ut.cpp
@@ -25,6 +25,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/testing/unittest/tests_data.h>
 
+#include <util/generic/guid.h>
 #include <util/generic/scope.h>
 
 namespace NCloud::NBlockStore::NBD {
@@ -588,7 +589,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
     Y_UNIT_TEST(ShouldRemoveUnixSocketAfterStopEndpoint)
     {
-        TFsPath unixSocket("./TestUnixSocket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
         TNetworkAddress connectAddress(TUnixSocketPath(unixSocket.GetPath()));
 
         auto storage = std::make_shared<TTestStorage>();
@@ -627,7 +628,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         auto serverCode1 = E_FAIL;
         auto serverCode2 = E_ARGUMENT;
 
-        TFsPath unixSocket("./TestUnixSocket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
         TNetworkAddress connectAddress(TUnixSocketPath(unixSocket.GetPath()));
 
         auto storage1 = std::make_shared<TTestStorage>();
@@ -712,7 +713,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
     Y_UNIT_TEST(ShouldStartEndpointIfSocketAlreadyExists)
     {
-        TFsPath unixSocket("./TestUnixSocket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
         unixSocket.Touch();
         Y_DEFER {
             unixSocket.DeleteIfExists();

--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -12,6 +12,7 @@
 #include <library/cpp/testing/unittest/tests_data.h>
 
 #include <util/folder/path.h>
+#include <util/generic/guid.h>
 #include <util/generic/scope.h>
 
 namespace NCloud::NBlockStore::NServer {
@@ -815,7 +816,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
     Y_UNIT_TEST(ShouldIdentifyFdControlChannelSource)
     {
-        TFsPath unixSocket("./test_socket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -866,7 +867,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         TPortManager portManager;
         ui16 serverPort = portManager.GetPort(9001);
         ui16 clientPort = portManager.GetPort(9002);
-        TFsPath unixSocket("./test_socket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -1087,7 +1088,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         TPortManager portManager;
         ui16 serverPort = portManager.GetPort(9001);
         ui16 clientPort = portManager.GetPort(9002);
-        TFsPath unixSocket("./test_socket");
+        TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -15,6 +15,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/folder/path.h>
+#include <util/generic/guid.h>
 #include <util/generic/scope.h>
 #include <util/thread/factory.h>
 #include <util/thread/lfqueue.h>
@@ -44,7 +45,7 @@ class TTestEnvironment
 private:
     const size_t ThreadsCount = 2;
 
-    const TFsPath SocketPath = TFsPath("./testSocketPath");
+    const TFsPath SocketPath = TFsPath(CreateGuidAsString() + ".sock");
     const ui32 VhostQueuesCount = 1;
     const ui32 BlockSize;
     const ui64 BlocksCount = 256;
@@ -244,7 +245,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         vhostServer->Start();
 
-        const TFsPath socket("./testSocketPath");
+        const TFsPath socket(CreateGuidAsString() + ".sock");
 
         {
             TStorageOptions options;
@@ -297,14 +298,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
         options.VhostQueuesCount = 1;
         options.UnalignedRequestsDisabled = false;
 
-        TString socketPath = "./testSocketPath";
-
         const size_t endpointCount = 8;
         TString sockets[endpointCount];
 
         for (size_t i = 0; i < endpointCount; ++i) {
             char ch = '0' + i;
-            sockets[i] = socketPath + ch;
+            sockets[i] = CreateGuidAsString() + ch + ".sock";
 
             auto future = vhostServer->StartEndpoint(
                 sockets[i],
@@ -452,7 +451,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         vhostServer->Start();
 
-        const TFsPath socket("./testSocketPath");
+        const TFsPath socket(CreateGuidAsString() + ".sock");
         socket.Touch();
         Y_DEFER {
             socket.DeleteIfExists();
@@ -494,7 +493,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         vhostServer->Start();
 
-        const TFsPath socket("./testSocketPath");
+        const TFsPath socket(CreateGuidAsString() + ".sock");
 
         {
             TStorageOptions options;
@@ -537,7 +536,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         vhostServer->Start();
 
-        const TFsPath socket("./testSocketPath");
+        const TFsPath socket(CreateGuidAsString() + ".sock");
 
         {
             TStorageOptions options;
@@ -561,7 +560,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
     Y_UNIT_TEST(ShouldCancelRequestsInFlightWhenStopEndpointOrStopServer)
     {
-        TString unixSocketPath = "./testSocketPath";
+        TString unixSocketPath = CreateGuidAsString() + ".sock";
         const ui32 blockSize = 4096;
         const ui64 startIndex = 3;
         const ui64 blocksCount = 41;
@@ -853,7 +852,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
             options.UnalignedRequestsDisabled = false;
 
             auto future = server->StartEndpoint(
-                "./testSocketPath",
+                CreateGuidAsString() + ".sock",
                 testStorage,
                 options);
             const auto& error = future.GetValue(TDuration::Seconds(5));
@@ -923,7 +922,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
     Y_UNIT_TEST(ShouldNotBeRaceOnStopEndpoint)
     {
-        TString unixSocketPath = "./testSocketPath";
+        TString unixSocketPath = CreateGuidAsString() + ".sock";
         const ui32 blockSize = 4096;
         const ui64 startIndex = 3;
         const ui64 blocksCount = 2;


### PR DESCRIPTION
cmake doesn't provide a unique tmpdir for each test chunk (unlike ya) that is why we should use unique paths (for unix sockets) in our tests.