### PR TITLE
NEBDUTY-500: use unique temp directories for unit tests data

### DIFF
--- a/cloud/blockstore/libs/service_local/storage_aio_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_aio_ut.cpp
@@ -94,14 +94,6 @@ TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
 
 }
 
-TFsPath TryGetRamDrivePath()
-{
-    auto p = GetRamDrivePath();
-    return !p
-        ? GetSystemTempDir()
-        : p;
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -114,7 +106,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui64 blockCount = 1024;
         const ui64 startIndex = 10;
-        const auto filePath = TryGetRamDrivePath() / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(blockSize * (blockCount + startIndex));
@@ -223,7 +216,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui32 blockSize = 4096;
         const ui64 blockCount = 32_MB / blockSize;
-        const auto filePath = TryGetRamDrivePath() / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
 
@@ -332,7 +326,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui32 blockSize = 4_KB;
         const ui64 blockCount = 8_GB / blockSize;
-        const auto filePath = TryGetRamDrivePath() / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(blockSize * blockCount);
@@ -466,7 +461,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui32 blockSize = 4_KB;
         const ui64 blockCount = 32_MB / blockSize;
-        const auto filePath = TryGetRamDrivePath() / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(blockSize * blockCount);
@@ -531,7 +527,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui32 blockSize = 4_KB;
         const ui64 blockCount = 32_MB / blockSize;
-        const auto filePath = TryGetRamDrivePath() / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(blockSize * blockCount);
@@ -594,7 +591,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui32 blockSize = 4_KB;
         const ui64 blockCount = 32_MB / blockSize;
-        const auto filePath = TryGetRamDrivePath() / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(blockSize * blockCount);

--- a/cloud/blockstore/libs/service_local/storage_aio_ut_large.cpp
+++ b/cloud/blockstore/libs/service_local/storage_aio_ut_large.cpp
@@ -39,7 +39,8 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
     {
         const ui32 blockSize = 4_KB;
         const ui64 totalBlockCount = 5_GB / blockSize;
-        const auto filePath = TFsPath(GetSystemTempDir()) / "test";
+        TTempDir dir;
+        const auto filePath = dir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(blockSize * totalBlockCount);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -41,14 +41,6 @@ NLWTrace::TQuery QueryFromString(const TString& text)
     return query;
 }
 
-TFsPath TryGetRamDrivePath()
-{
-    auto p = GetRamDrivePath();
-    return !p
-        ? GetSystemTempDir()
-        : p;
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1333,7 +1325,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
 
     Y_UNIT_TEST(ShouldUpdateStats)
     {
-        auto const workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        auto const workingDir = tempDir.Path();
 
         TTestBasicRuntime runtime;
 
@@ -1600,7 +1593,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         agentConfig.SetAcquireRequired(true);
         agentConfig.SetEnabled(true);
 
-        auto const workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        auto const workingDir = tempDir.Path();
 
         *agentConfig.AddFileDevices() = PrepareFileDevice(
             workingDir / "test",
@@ -1781,7 +1775,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         agentConfig.SetAcquireRequired(true);
         agentConfig.SetEnabled(true);
 
-        const auto workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        const auto workingDir = tempDir.Path();
         const auto filePath = workingDir / "test";
 
         {
@@ -2044,7 +2039,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         agentConfig.SetAgentId("agent-id");
         agentConfig.SetEnabled(true);
 
-        auto const workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        auto const workingDir = tempDir.Path();
 
         *agentConfig.AddFileDevices() = PrepareFileDevice(
             workingDir / "test-1",
@@ -2211,7 +2207,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         agentConfig.SetAgentId("agent-id");
         agentConfig.SetEnabled(true);
 
-        auto const workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        auto const workingDir = tempDir.Path();
 
         *agentConfig.AddFileDevices() = PrepareFileDevice(
             workingDir / "test-1",
@@ -2237,7 +2234,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         agentConfig.SetEnabled(true);
         agentConfig.SetAcquireRequired(true);
 
-        auto const workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        auto const workingDir = tempDir.Path();
 
         *agentConfig.AddFileDevices() = PrepareFileDevice(
             workingDir / "test-1",
@@ -3221,7 +3219,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             }
         };
 
-        const auto workingDir = TryGetRamDrivePath();
+        TTempDir tempDir;
+        const auto workingDir = tempDir.Path();
         TTestBasicRuntime runtime;
         auto mockSp = new TMockStorageProvider();
         std::shared_ptr<IStorageProvider> sp(mockSp);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_ut_large.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_ut_large.cpp
@@ -22,7 +22,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
         const ui32 blockSize = 4_KB;
         const ui64 totalBlockCount = totalSize / blockSize;
         const TString uuid = "FileDevice-1";
-        const auto filePath = TFsPath(GetSystemTempDir()) / "test";
+        TTempDir tempDir;
+        const auto filePath = tempDir.Path() / "test";
 
         TFile fileData(filePath, EOpenModeFlag::CreateAlways);
         fileData.Resize(totalSize);

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -11,6 +11,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/subscription/wait_all.h>
 
+#include <util/folder/tempdir.h>
 #include <util/generic/size_literals.h>
 #include <util/system/file.h>
 
@@ -43,6 +44,7 @@ struct TFixture
     NCloud::ILoggingServicePtr Logging;
     std::shared_ptr<IServer> Server;
     TVector<TFile> Files;
+    TTempDir TempDir;
 
     TOptions Options {
         .SocketPath = SocketPath,
@@ -65,7 +67,7 @@ public:
         Files.reserve(ChunkCount);
         for (ui32 i = 0; i != ChunkCount; ++i) {
             auto& file = Files.emplace_back(
-                "nrd_" + ToString(i),
+                TempDir.Path() / ("nrd_" + ToString(i)),
                 EOpenModeFlag::CreateAlways);
 
             Options.Layout.push_back({


### PR DESCRIPTION
when running tests using `ya make` we have TMPDIR set to unique for each chunk of
unit tests.

In stable branch we still using `cmake` which doesn't pass unique TMPDIR and
therefore when running in parallel execution different tests can overwrite each
other data and fail.

This commit fixes this by using system unique tmpdir for each test.
