### PR TITLE
issue #95 NBSNEBIUS-70: if Flush/Compaction/Cleanup/FlushBytes ops are enqueued before CompactionMap is completely loaded, their EOperationStates should not get stuck in the Enqueued state

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -41,6 +41,10 @@ void TIndexTabletActor::HandleCleanup(
     };
 
     if (!CompactionStateLoadStatus.Finished) {
+        if (BlobIndexOpState.GetOperationState() == EOperationState::Enqueued) {
+            BlobIndexOpState.Complete();
+        }
+
         replyError(MakeError(E_TRY_AGAIN, "compaction state not loaded yet"));
         return;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -411,6 +411,10 @@ void TIndexTabletActor::HandleCompaction(
     };
 
     if (!CompactionStateLoadStatus.Finished) {
+        if (BlobIndexOpState.GetOperationState() == EOperationState::Enqueued) {
+            BlobIndexOpState.Complete();
+        }
+
         replyError(MakeError(E_TRY_AGAIN, "compaction state not loaded yet"));
         return;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -352,6 +352,12 @@ void TIndexTabletActor::HandleGetStorageStats(
         }
     }
 
+    stats->SetFlushState(static_cast<ui32>(FlushState.GetOperationState()));
+    stats->SetBlobIndexOpState(static_cast<ui32>(
+        BlobIndexOpState.GetOperationState()));
+    stats->SetCollectGarbageState(static_cast<ui32>(
+        CollectGarbageState.GetOperationState()));
+
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -271,6 +271,10 @@ void TIndexTabletActor::HandleFlush(
     };
 
     if (!CompactionStateLoadStatus.Finished) {
+        if (FlushState.GetOperationState() == EOperationState::Enqueued) {
+            FlushState.Complete();
+        }
+
         replyError(
             ctx,
             *ev,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -490,6 +490,10 @@ void TIndexTabletActor::HandleFlushBytes(
     };
 
     if (!CompactionStateLoadStatus.Finished) {
+        if (BlobIndexOpState.GetOperationState() == EOperationState::Enqueued) {
+            BlobIndexOpState.Complete();
+        }
+
         replyError(
             ctx,
             *ev,

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -125,6 +125,11 @@ message TStorageStats
 
     // compaction map range stats
     repeated TCompactionRangeStats CompactionRangeStats = 3000;
+
+    // background operation states
+    uint32 FlushState = 4001;
+    uint32 BlobIndexOpState = 4002;
+    uint32 CollectGarbageState = 4003;
 }
 
 message TGetStorageStatsRequest


### PR DESCRIPTION
Right now write operation succeeds if the compaction range that is targeted by this operation is completely loaded. After this write operation completes Flush/Compaction/Cleanup/FlushBytes may be enqueued. If they are, TIndexTabletActor will send the corresponding request to itself and will handle it with a E_TRY_AGAIN error leaving the operation state in the EOperationState::Enqueued state which will block any new background operations. This PR fixes this bug.