### PR TITLE
[CI]: Add missing temporary directory creation for the ssh client

### DIFF
--- a/cloud/blockstore/pylibs/common/ssh_client.py
+++ b/cloud/blockstore/pylibs/common/ssh_client.py
@@ -287,6 +287,7 @@ class SftpClient:
 
     def __init__(self, client: SshClient) -> None:
         self._client = client
+        self._tmp_dir.mkdir(exist_ok=True)
 
     def put(self, src, dst) -> None:
         self._client.upload_file(src, dst)


### PR DESCRIPTION
In python tests sftp client the temporary directory for file transfer was not properly created.