### PR TITLE
fix config.proto in eternal-load to make compatible with previous config.sc

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
@@ -5,14 +5,14 @@ package NCloud.NBlockStore;
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config";
 
 message TRangeConfig {
-  required uint64 StartOffset = 1;
-  required uint64 RequestBlockCount = 2;
-  required uint64 RequestCount = 3;
-  required uint64 Step = 4;
-  required uint64 StartBlockIdx = 5;
-  required uint64 LastBlockIdx = 6;
-  required uint64 NumberToWrite = 7;
-  required uint64 WriteParts = 8;
+  uint64 StartOffset = 1;
+  uint64 RequestBlockCount = 2;
+  uint64 RequestCount = 3;
+  uint64 Step = 4;
+  uint64 StartBlockIdx = 5;
+  uint64 LastBlockIdx = 6;
+  uint64 NumberToWrite = 7;
+  uint64 WriteParts = 8;
 }
 
 message TTestConfig {
@@ -22,7 +22,7 @@ message TTestConfig {
   required uint64 FileSize = 4;
   required uint64 BlockSize = 5;
   required uint32 WriteRate = 6;
-  required uint64 RangeBlockCount = 7;
+  uint64 RangeBlockCount = 7;
   repeated TRangeConfig Ranges = 8;
   required string SlowRequestThreshold = 9 [default = "10s"];
   // Used for a testcases, where write rate is periodically replaced

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
@@ -5,14 +5,14 @@ package NCloud.NBlockStore;
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config";
 
 message TRangeConfig {
-  uint64 StartOffset = 1;
-  uint64 RequestBlockCount = 2;
-  uint64 RequestCount = 3;
-  uint64 Step = 4;
-  uint64 StartBlockIdx = 5;
-  uint64 LastBlockIdx = 6;
-  uint64 NumberToWrite = 7;
-  uint64 WriteParts = 8;
+  optional uint64 StartOffset = 1;
+  optional uint64 RequestBlockCount = 2;
+  optional uint64 RequestCount = 3;
+  optional uint64 Step = 4;
+  optional uint64 StartBlockIdx = 5;
+  optional uint64 LastBlockIdx = 6;
+  optional uint64 NumberToWrite = 7;
+  optional uint64 WriteParts = 8;
 }
 
 message TTestConfig {
@@ -22,7 +22,7 @@ message TTestConfig {
   required uint64 FileSize = 4;
   required uint64 BlockSize = 5;
   required uint32 WriteRate = 6;
-  uint64 RangeBlockCount = 7;
+  optional uint64 RangeBlockCount = 7;
   repeated TRangeConfig Ranges = 8;
   required string SlowRequestThreshold = 9 [default = "10s"];
   // Used for a testcases, where write rate is periodically replaced


### PR DESCRIPTION
Field `RangeBlockCount` in prefious config specification for eternal_tests (https://github.com/ydb-platform/nbs/blob/ac799e1fe11eaa3e3b31dc8bacad6d7010731037/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.sc) used to be optional. In the PR #202 it has been mistakenly marked as required.