### PR TITLE
NEBDUTY-504: save dmesg -T on the tear_down of blockstore loadtest

### DIFF
--- a/cloud/blockstore/tests/loadtest/local-encryption/test.py
+++ b/cloud/blockstore/tests/loadtest/local-encryption/test.py
@@ -131,6 +131,9 @@ def __run_test(test_case):
             client_config=client,
             env_processes=[env.nbs],
         )
+
+        raise RuntimeError("Imitation of failure, expecting to find dmesg in logs")
+
     finally:
         env.tear_down()
 

--- a/cloud/blockstore/tests/loadtest/local-encryption/test.py
+++ b/cloud/blockstore/tests/loadtest/local-encryption/test.py
@@ -131,9 +131,6 @@ def __run_test(test_case):
             client_config=client,
             env_processes=[env.nbs],
         )
-
-        raise RuntimeError("Imitation of failure, expecting to find dmesg in logs")
-
     finally:
         env.tear_down()
 

--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -15,6 +15,7 @@ import yatest.common as yatest_common
 
 import logging
 import os
+import subprocess
 
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,21 @@ class LocalLoadTest:
         for d in self.__devices:
             d.handle.close()
             os.unlink(d.path)
+
+        
+        # It may be beneficial to save dmesg output for debugging purposes.
+        try:
+            dmesg_output = open("dmesg.txt", "w")
+            subprocess.run(
+                ["sudo", "dmesg", "-T"],
+                stdout=dmesg_output,
+                stderr=dmesg_output,
+                timeout=10
+            )
+        except Exception as dmesg_error:
+            logging.info(f"Failed to save dmesg output: {dmesg_error}")
+            pass
+
 
     @property
     def endpoint(self):

--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -140,7 +140,7 @@ class LocalLoadTest:
         
         # It may be beneficial to save dmesg output for debugging purposes.
         try:
-            with open("dmesg.txt", "w") as dmesg_output:
+            with open(yatest_common.output_path() + "/dmesg.txt", "w") as dmesg_output:
                 subprocess.run(
                     ["sudo", "dmesg", "-T"],
                     stdout=dmesg_output,

--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -140,13 +140,13 @@ class LocalLoadTest:
         
         # It may be beneficial to save dmesg output for debugging purposes.
         try:
-            dmesg_output = open("dmesg.txt", "w")
-            subprocess.run(
-                ["sudo", "dmesg", "-T"],
-                stdout=dmesg_output,
-                stderr=dmesg_output,
-                timeout=10
-            )
+            with open("dmesg.txt", "w") as dmesg_output:
+                subprocess.run(
+                    ["sudo", "dmesg", "-T"],
+                    stdout=dmesg_output,
+                    stderr=dmesg_output,
+                    timeout=10
+                )
         except Exception as dmesg_error:
             logging.info(f"Failed to save dmesg output: {dmesg_error}")
             pass


### PR DESCRIPTION
Our nightly builds have some flaky tests, including [loadtests](https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/7720050558/1/nebius-x86-64/summary/ya-test.html#FAIL). It may be reasonable to save `dmesg` output on the loadtests termination to the `testing_out_stuff` directory. See example: [link](https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Build-and-test-NBS-on-demand/7730964402/1/nebius-x86-64/test_data/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-encryption/test-results/py3test/chunk0/testing_out_stuff/dmesg.txt).

the whole dmesg command is wrapped in a try-except block, so it is not supposed to affect execution on platforms, where one does not have access to sudo or dmesg.