### PR TITLE
NEBDUTY-500: use unique temp directories for unit tests data

### DIFF
--- a/build/scripts/split_unittest.py
+++ b/build/scripts/split_unittest.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import tempfile
 import shlex
 import subprocess
@@ -70,10 +71,12 @@ def main():
     else:
         cmd = args.command
 
-    rc = subprocess.call(cmd)
-    if rc:
-        print("Some tests failed. To reproduce run: {}".format(shlex.join(cmd)))
-    return rc
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["TMPDIR"] = tmpdir
+        rc = subprocess.call(cmd, cwd=tmpdir)
+        if rc:
+            print("Some tests failed. To reproduce run: {}".format(shlex.join(cmd)))
+        return rc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
when running tests using ya make we have TMPDIR set to unique name for each
chunk of unit tests.

In stable branch we still using cmake which doesn't pass unique TMPDIR and
therefore when running in parallel execution of different tests can overwrite
each other data and fail.

This commit fixes this by passing unique TMPDIR before calling cpp unit test.
