### PR TITLE
NBSNEBIUS-71: make .proto config more compatible with previous .sc config

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
@@ -108,6 +108,9 @@ void TConfigHolder::GenerateMissingFields()
     }
 
     for (ui16 i = 0; i < Config.GetIoDepth(); ++i) {
+        if (i >= Config.GetRanges().size()) {
+            Config.MutableRanges()->Add();
+        }
         auto& range = *Config.MutableRanges(i);
         if (!range.HasRequestBlockCount()) {
             range.SetRequestBlockCount(1);


### PR DESCRIPTION
In prefious config specification for eternal_tests (https://github.com/ydb-platform/nbs/blob/ac799e1fe11eaa3e3b31dc8bacad6d7010731037/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.sc) in the situations, where `IoDepth` was less than the number of specified ranges, the config generator was supposed to generate missing ranges. This was the default behavior of the config generator when using the .sc specification and should stay this way after the switch to .proto specification.