### PR TITLE
tablet history entries should contain fqdn

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -14,6 +14,7 @@
 #include <util/generic/deque.h>
 #include <util/generic/guid.h>
 #include <util/generic/string.h>
+#include <util/system/hostname.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -615,7 +616,7 @@ void TStorageServiceActor::HandleCreateSession(
     const auto& clientId = GetClientId(msg->Record);
     const auto& fileSystemId = msg->Record.GetFileSystemId();
     const auto& checkpointId = msg->Record.GetCheckpointId();
-    const auto& originFqdn = GetOriginFqdn(msg->Record);
+    auto originFqdn = GetOriginFqdn(msg->Record);
 
     ui64 cookie;
     TInFlightRequest* inflight;
@@ -692,6 +693,10 @@ void TStorageServiceActor::HandleCreateSession(
         sessionId = CreateGuidAsString();
     }
 
+    if (!originFqdn) {
+        originFqdn = GetFQDNHostName();
+    }
+
     auto requestInfo = CreateRequestInfo(
         SelfId(),
         cookie,
@@ -704,7 +709,7 @@ void TStorageServiceActor::HandleCreateSession(
         fileSystemId,
         sessionId,
         checkpointId,
-        originFqdn,
+        std::move(originFqdn),
         msg->Record.GetMountSeqNumber(),
         msg->Record.GetReadOnly(),
         msg->Record.GetRestoreClientSession(),


### PR DESCRIPTION
Some createsession requests do not contain fqdn of the origin. This makes it difficult to figure out source host for session requests in tablet history