### PR TITLE
issue #324: DescribeData API and implementation stub

### DIFF
--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -22,6 +22,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(GetFileSystemConfig,        __VA_ARGS__)                               \
     xxx(GetStorageConfigFields,     __VA_ARGS__)                               \
     xxx(ChangeStorageConfig,        __VA_ARGS__)                               \
+    xxx(DescribeData,               __VA_ARGS__)                               \
 // FILESTORE_TABLET_REQUESTS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -56,6 +57,9 @@ struct TEvIndexTablet
 
         EvChangeStorageConfigRequest = EvBegin + 13,
         EvChangeStorageConfigResponse,
+
+        EvDescribeDataRequest = EvBegin + 15,
+        EvDescribeDataResponse,
 
         EvEnd
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -112,6 +112,7 @@ template void TIndexTabletActor::CompleteResponse<ns::T##name##Method>(         
 // FILESTORE_IMPL_VALIDATE
 
 FILESTORE_SERVICE(FILESTORE_GENERATE_IMPL, TEvService)
+FILESTORE_GENERATE_IMPL(DescribeData, TEvIndexTablet)
 
 #undef FILESTORE_GENERATE_IMPL
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1123,6 +1123,7 @@ struct TTxIndexTablet
         const TByteRange OriginByteRange;
         const TByteRange AlignedByteRange;
         /*const*/ IBlockBufferPtr Buffer;
+        const bool DescribeOnly;
 
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
@@ -1133,18 +1134,21 @@ struct TTxIndexTablet
         // NOTE: should persist state across tx restarts
         TSet<ui32> MixedBlocksRanges;
 
+        template <typename TReadRequest>
         TReadData(
                 TRequestInfoPtr requestInfo,
-                const NProto::TReadDataRequest& request,
+                const TReadRequest& request,
                 TByteRange originByteRange,
                 TByteRange alignedByteRange,
-                IBlockBufferPtr buffer)
+                IBlockBufferPtr buffer,
+                bool describeOnly)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , Handle(request.GetHandle())
             , OriginByteRange(originByteRange)
             , AlignedByteRange(alignedByteRange)
             , Buffer(std::move(buffer))
+            , DescribeOnly(describeOnly)
             , Blocks(AlignedByteRange.BlockCount())
             , Bytes(AlignedByteRange.BlockCount())
         {

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -6,6 +6,8 @@ import "cloud/filestore/public/api/protos/fs.proto";
 import "cloud/filestore/public/api/protos/headers.proto";
 import "cloud/filestore/config/storage.proto";
 
+import "contrib/ydb/core/protos/base.proto";
+
 package NCloud.NFileStore.NProtoPrivate;
 
 option go_package = "github.com/ydb-platform/nbs/cloud/filestore/private/api/protos";
@@ -214,7 +216,7 @@ message TGetFileSystemConfigResponse
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// GetStorageConfig fields request/response.
+// GetStorageConfigFields request/response.
 
 message TGetStorageConfigFieldsRequest
 {
@@ -238,7 +240,7 @@ message TGetStorageConfigFieldsResponse
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Change StorageConfig request/response
+// ChangeStorageConfig request/response
 
 message TChangeStorageConfigRequest
 {
@@ -262,4 +264,73 @@ message TChangeStorageConfigResponse
 
     // Result Storage config.
     NProto.TStorageConfig StorageConfig = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DescribeData request/response.
+
+message TDescribeDataRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+
+    // Node.
+    uint64 NodeId = 3;
+
+    // IO handle.
+    uint64 Handle = 4;
+
+    // Starting offset for read.
+    uint64 Offset = 5;
+
+    // Number of bytes to read.
+    uint64 Length = 6;
+}
+
+// Represents actual data - for the data that is not stored in data channels as
+// blobs yet.
+message TFreshDataRange
+{
+    // This offset is relative to the beginning of the inode.
+    uint64 Offset = 1;
+    // Data bytes.
+    bytes Content = 2;
+}
+
+// Represents a range of consecutive bytes inside some blob.
+message TRangeInBlob
+{
+    // This offset is relative to the beginning of the inode.
+    uint64 Offset = 1;
+    // This offset is relative to the beginning of the blob. Measured in bytes.
+    uint32 BlobOffset = 2;
+    uint32 Length = 3;
+}
+
+// Represents the ranges that need to be read from a single blob.
+message TBlobPiece
+{
+    // Blob id.
+    NKikimrProto.TLogoBlobID BlobId = 1;
+
+    // Group id.
+    uint32 BSGroupId = 2;
+
+    // Data ranges.
+    repeated TRangeInBlob Ranges = 3;
+}
+
+message TDescribeDataResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    repeated TFreshDataRange FreshDataRanges = 2;
+    repeated TBlobPiece BlobPieces = 3;
+
+    // Optional response headers.
+    NProto.TResponseHeaders Headers = 1000;
 }

--- a/cloud/filestore/private/api/protos/ya.make
+++ b/cloud/filestore/private/api/protos/ya.make
@@ -1,12 +1,14 @@
 PROTO_LIBRARY(filestore-private-api-protos)
 
-INCLUDE_TAGS(GO_PROTO)
+EXCLUDE_TAGS(GO_PROTO)
 EXCLUDE_TAGS(JAVA_PROTO)
 
 PEERDIR(
     cloud/filestore/config
     cloud/filestore/public/api/protos
     cloud/storage/core/protos
+
+    contrib/ydb/core/protos
 )
 
 SRCS(


### PR DESCRIPTION
See https://github.com/ydb-platform/nbs/issues/324

This API will be used by filestore-vhost to look up blob ids where the data is stored to read those blobs by itself.