### PR TITLE
[Filestore] NBSNEBIUS-91: Add ForcedCleanup handle for fs (#268)

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -222,7 +222,7 @@ private:
     void EnqueueBlobIndexOpIfNeeded(const NActors::TActorContext& ctx);
     void EnqueueCollectGarbageIfNeeded(const NActors::TActorContext& ctx);
     void EnqueueTruncateIfNeeded(const NActors::TActorContext& ctx);
-    void EnqueueForcedCompactionIfNeeded(const NActors::TActorContext& ctx);
+    void EnqueueForcedRangeOperationIfNeeded(const NActors::TActorContext& ctx);
     void LoadNextCompactionMapChunkIfNeeded(const NActors::TActorContext& ctx);
 
     void NotifySessionEvent(
@@ -294,7 +294,7 @@ private:
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
-    void HandleHttpInfo_Compaction(
+    void HandleHttpInfo_ForceOperation(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -61,7 +61,7 @@ private:
     void SendRangeOperationRequest(const TActorContext& ctx);
 
     void HandleRangeOperationResponse(
-        const TResponseType::TPtr& ev,
+        const typename TResponseType::TPtr& ev,
         const TActorContext& ctx);
 
     void HandleWakeUp(
@@ -138,7 +138,7 @@ STFUNC(
 template <typename TResponseType, typename TRequestConstructor>
 void TForcedOperationActor<TResponseType, TRequestConstructor>::
     HandleRangeOperationResponse(
-        const TResponseType::TPtr& ev,
+        const typename TResponseType::TPtr& ev,
         const TActorContext& ctx)
 {
     auto* msg = ev->Get();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -22,23 +22,35 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TForcedCompactionActor final
-    : public TActorBootstrapped<TForcedCompactionActor>
+/**
+ * @brief An actor that performs forced compaction or forced cleanup. It is
+ * implemented as a template class to avoid code duplication.
+ *
+ * @tparam TRequestConstructor A functor that constructs a unique_ptr to a
+ * request that is necessary to be performed to passed range.
+ */
+template <typename TResponseType, typename TRequestConstructor>
+class TForcedOperationActor final
+    : public TActorBootstrapped<
+          TForcedOperationActor<TResponseType, TRequestConstructor>>
 {
 private:
+    using TBase = NActors::TActorBootstrapped<
+        TForcedOperationActor<TResponseType, TRequestConstructor>>;
+
     const TActorId Tablet;
     const TString LogTag;
     const TDuration RetryTimeout;
 
-    const TIndexTabletState::TForcedCompactionStatePtr State;
+    const TIndexTabletState::TForcedRangeOperationStatePtr State;
     const TRequestInfoPtr RequestInfo;
 
 public:
-    TForcedCompactionActor(
+    TForcedOperationActor(
         TActorId tablet,
         TString logTag,
         TDuration retry,
-        TIndexTabletState::TForcedCompactionStatePtr state,
+        TIndexTabletState::TForcedRangeOperationStatePtr state,
         TRequestInfoPtr requestInfo);
 
     void Bootstrap(const TActorContext& ctx);
@@ -46,10 +58,10 @@ public:
 private:
     STFUNC(StateWork);
 
-    void SendCompactionRequest(const TActorContext& ctx);
+    void SendRangeOperationRequest(const TActorContext& ctx);
 
-    void HandleCompactionResponse(
-        const TEvIndexTabletPrivate::TEvCompactionResponse::TPtr& ev,
+    void HandleRangeOperationResponse(
+        const TResponseType::TPtr& ev,
         const TActorContext& ctx);
 
     void HandleWakeUp(
@@ -67,11 +79,13 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TForcedCompactionActor::TForcedCompactionActor(
+template <typename TResponseType, typename TRequestConstructor>
+TForcedOperationActor<TResponseType, TRequestConstructor>::
+    TForcedOperationActor(
         TActorId tablet,
         TString logTag,
         TDuration retry,
-        TIndexTabletState::TForcedCompactionStatePtr state,
+        TIndexTabletState::TForcedRangeOperationStatePtr state,
         TRequestInfoPtr requestInfo)
     : Tablet(tablet)
     , LogTag(std::move(logTag))
@@ -79,36 +93,41 @@ TForcedCompactionActor::TForcedCompactionActor(
     , State(std::move(state))
     , RequestInfo(std::move(requestInfo))
 {
-    ActivityType = TFileStoreActivities::TABLET_WORKER;
+    TBase::ActivityType = TFileStoreActivities::TABLET_WORKER;
 }
 
-void TForcedCompactionActor::Bootstrap(const TActorContext& ctx)
+template <typename TResponseType, typename TRequestConstructor>
+void TForcedOperationActor<TResponseType, TRequestConstructor>::Bootstrap(
+    const TActorContext& ctx)
 {
-    Become(&TThis::StateWork);
+    TBase::Become(&TBase::TThis::StateWork);
 
     FILESTORE_TRACK(
         RequestReceived_TabletWorker,
         RequestInfo->CallContext,
-        "ForcedCompaction");
+        "ForcedRangeOperation");
 
-    SendCompactionRequest(ctx);
+    SendRangeOperationRequest(ctx);
 }
 
-void TForcedCompactionActor::SendCompactionRequest(const TActorContext& ctx)
+template <typename TResponseType, typename TRequestConstructor>
+void TForcedOperationActor<TResponseType, TRequestConstructor>::
+    SendRangeOperationRequest(const TActorContext& ctx)
 {
-    auto request = std::make_unique<TEvIndexTabletPrivate::TEvCompactionRequest>(
-        State->GetCurrentRange(), true);
+    auto request = TRequestConstructor()(State->GetCurrentRange());
 
     ctx.Send(Tablet, request.release());
 }
 
-STFUNC(TForcedCompactionActor::StateWork)
+template <typename TResponseType, typename TRequestConstructor>
+STFUNC(
+    (TForcedOperationActor<TResponseType, TRequestConstructor>::StateWork))
 {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvents::TEvWakeup, HandleWakeUp);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
-        HFunc(TEvIndexTabletPrivate::TEvCompactionResponse, HandleCompactionResponse);
+        HFunc(TResponseType, HandleRangeOperationResponse);
 
         default:
             HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
@@ -116,9 +135,11 @@ STFUNC(TForcedCompactionActor::StateWork)
     }
 }
 
-void TForcedCompactionActor::HandleCompactionResponse(
-    const TEvIndexTabletPrivate::TEvCompactionResponse::TPtr& ev,
-    const TActorContext& ctx)
+template <typename TResponseType, typename TRequestConstructor>
+void TForcedOperationActor<TResponseType, TRequestConstructor>::
+    HandleRangeOperationResponse(
+        const TResponseType::TPtr& ev,
+        const TActorContext& ctx)
 {
     auto* msg = ev->Get();
 
@@ -135,79 +156,115 @@ void TForcedCompactionActor::HandleCompactionResponse(
         return ReplyAndDie(ctx, {});
     }
 
-    SendCompactionRequest(ctx);
+    SendRangeOperationRequest(ctx);
 }
 
-void TForcedCompactionActor::HandleWakeUp(
-    const TEvents::TEvWakeup::TPtr& ev,
-    const TActorContext& ctx)
+template <typename TResponseType, typename TRequestConstructor>
+void TForcedOperationActor<TResponseType, TRequestConstructor>::
+    HandleWakeUp(const TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    SendCompactionRequest(ctx);
+    SendRangeOperationRequest(ctx);
 }
 
-void TForcedCompactionActor::HandlePoisonPill(
-    const TEvents::TEvPoison::TPtr& ev,
-    const TActorContext& ctx)
+template <typename TResponseType, typename TRequestConstructor>
+void TForcedOperationActor<TResponseType, TRequestConstructor>::
+    HandlePoisonPill(
+        const TEvents::TEvPoison::TPtr& ev,
+        const TActorContext& ctx)
 {
     Y_UNUSED(ev);
     ReplyAndDie(ctx, MakeError(E_FAIL, "actor killed"));
 }
 
-void TForcedCompactionActor::ReplyAndDie(
-    const TActorContext& ctx,
-    const NProto::TError& error)
+template <typename TResponseType, typename TRequestConstructor>
+void TForcedOperationActor<TResponseType, TRequestConstructor>::
+    ReplyAndDie(const TActorContext& ctx, const NProto::TError& error)
 {
     {
         // notify tablet
-        auto response = std::make_unique<TEvIndexTabletPrivate::TEvForcedCompactionCompleted>(
-            error);
+        auto response = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationCompleted>(error);
         NCloud::Send(ctx, Tablet, std::move(response));
     }
 
     FILESTORE_TRACK(
         ResponseSent_TabletWorker,
         RequestInfo->CallContext,
-        "ForcedCompaction");
+        "ForcedRangeOperation");
 
     if (RequestInfo->Sender != Tablet) {
         // reply to caller
-        auto response = std::make_unique<TEvIndexTabletPrivate::TEvForcedCompactionResponse>(
-            error);
+        auto response = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationResponse>(error);
         NCloud::Reply(ctx, *RequestInfo, std::move(response));
     }
 
-    Die(ctx);
+    TBase::Die(ctx);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCompactionRequestConstructor
+{
+    std::unique_ptr<TEvIndexTabletPrivate::TEvCompactionRequest> operator()(
+        const ui32 rangeId) const
+    {
+        return std::make_unique<TEvIndexTabletPrivate::TEvCompactionRequest>(
+            rangeId,
+            true);
+    }
+};
+
+struct TCleanupRequestConstructor
+{
+    std::unique_ptr<TEvIndexTabletPrivate::TEvCleanupRequest> operator()(
+        const ui32 range) const
+    {
+        return std::make_unique<TEvIndexTabletPrivate::TEvCleanupRequest>(
+            range);
+    }
+};
+
+using TForcedCompactionActor = TForcedOperationActor<
+    TEvIndexTabletPrivate::TEvCompactionResponse,
+    TCompactionRequestConstructor>;
+
+using TForcedCleanupActor = TForcedOperationActor<
+    TEvIndexTabletPrivate::TEvCleanupResponse,
+    TCleanupRequestConstructor>;
 
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TIndexTabletActor::EnqueueForcedCompactionIfNeeded(const TActorContext& ctx)
+void TIndexTabletActor::EnqueueForcedRangeOperationIfNeeded(
+    const TActorContext& ctx)
 {
-    if (IsForcedCompactionRunning()) {
+    if (IsForcedRangeOperationRunning()) {
         return;
     }
 
-    auto ranges = DequeueForcedCompaction();
-    if (ranges.empty()) {
+    auto pendingRequest = DequeueForcedRangeOperation();
+    if (pendingRequest.Ranges.empty()) {
         return;
     }
 
     auto request =
-        std::make_unique<TEvIndexTabletPrivate::TEvForcedCompactionRequest>(std::move(ranges));
+        std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
+            std::move(pendingRequest.Ranges),
+            pendingRequest.Mode);
     ctx.Send(ctx.SelfID, request.release());
 }
 
-void TIndexTabletActor::HandleForcedCompaction(
-    const TEvIndexTabletPrivate::TEvForcedCompactionRequest::TPtr& ev,
+void TIndexTabletActor::HandleForcedRangeOperation(
+    const TEvIndexTabletPrivate::TEvForcedRangeOperationRequest::TPtr& ev,
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedCompaction request for %lu ranges",
+        "%s ForcedRangeOperation request for %lu ranges",
         LogTag.c_str(),
         msg->Ranges.size());
 
@@ -218,8 +275,8 @@ void TIndexTabletActor::HandleForcedCompaction(
             return;
         }
 
-        auto response =
-            std::make_unique<TEvIndexTabletPrivate::TEvForcedCompactionResponse>(error);
+        auto response = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationResponse>(error);
         NCloud::Reply(ctx, *ev, std::move(response));
     };
 
@@ -234,39 +291,57 @@ void TIndexTabletActor::HandleForcedCompaction(
         msg->CallContext);
 
     // will loose original request info in case of enqueueing external request
-    if (IsForcedCompactionRunning()) {
-        EnqueueForcedCompaction(std::move(msg->Ranges));
+    if (IsForcedRangeOperationRunning()) {
+        EnqueueForcedRangeOperation(std::move(msg->Ranges), msg->Mode);
         return;
     }
 
-    StartForcedCompaction(std::move(msg->Ranges));
+    StartForcedRangeOperation(std::move(msg->Ranges));
 
-    auto actor = std::make_unique<TForcedCompactionActor>(
-        ctx.SelfID,
-        LogTag,
-        Config->GetCompactionRetryTimeout(),
-        GetForcedCompactionState(),
-        std::move(requestInfo));
+    std::unique_ptr<IActor> actor;
+
+    switch (msg->Mode) {
+        case TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction:
+            actor = std::make_unique<TForcedCompactionActor>(
+                ctx.SelfID,
+                LogTag,
+                Config->GetCompactionRetryTimeout(),
+                GetForcedRangeOperationState(),
+                std::move(requestInfo));
+            break;
+
+        case TEvIndexTabletPrivate::EForcedRangeOperationMode::Cleanup:
+            actor = std::make_unique<TForcedCleanupActor>(
+                ctx.SelfID,
+                LogTag,
+                Config->GetCompactionRetryTimeout(),
+                GetForcedRangeOperationState(),
+                std::move(requestInfo));
+            break;
+
+        default:
+            TABLET_VERIFY_C(false, "unexpected forced compaction mode");
+    }
 
     auto actorId = ctx.Register(actor.release());
     WorkerActors.insert(actorId);
 }
 
-void TIndexTabletActor::HandleForcedCompactionCompleted(
-    const TEvIndexTabletPrivate::TEvForcedCompactionCompleted::TPtr& ev,
+void TIndexTabletActor::HandleForcedRangeOperationCompleted(
+    const TEvIndexTabletPrivate::TEvForcedRangeOperationCompleted::TPtr& ev,
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedCompaction completed (%s)",
+        "%s ForcedRangeOperation completed (%s)",
         LogTag.c_str(),
         FormatError(msg->GetError()).c_str());
 
-    TABLET_VERIFY(IsForcedCompactionRunning());
+    TABLET_VERIFY(IsForcedRangeOperationRunning());
     WorkerActors.erase(ev->Sender);
 
-    CompleteForcedCompaction();
-    EnqueueForcedCompactionIfNeeded(ctx);
+    CompleteForcedRangeOperation();
+    EnqueueForcedRangeOperationIfNeeded(ctx);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -28,7 +28,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(DumpCompactionRange,                    __VA_ARGS__)                   \
     xxx(Flush,                                  __VA_ARGS__)                   \
     xxx(FlushBytes,                             __VA_ARGS__)                   \
-    xxx(ForcedCompaction,                       __VA_ARGS__)                   \
+    xxx(ForcedRangeOperation,                   __VA_ARGS__)                   \
     xxx(Truncate,                               __VA_ARGS__)                   \
     xxx(ReadBlob,                               __VA_ARGS__)                   \
     xxx(WriteBlob,                              __VA_ARGS__)                   \
@@ -372,23 +372,33 @@ struct TEvIndexTabletPrivate
     };
 
     //
-    // ForcedCompaction
+    // ForcedRangeOperation
     //
 
-    struct TForcedCompactionRequest
+    enum EForcedRangeOperationMode
+    {
+        Compaction = 0,
+        Cleanup = 1,
+    };
+
+    struct TForcedRangeOperationRequest
     {
         TVector<ui32> Ranges;
+        EForcedRangeOperationMode Mode;
 
-        TForcedCompactionRequest(TVector<ui32> ranges)
+        TForcedRangeOperationRequest(
+            TVector<ui32> ranges,
+            EForcedRangeOperationMode mode)
             : Ranges(std::move(ranges))
+            , Mode(mode)
         {}
     };
 
-    struct TForcedCompactionResponse
+    struct TForcedRangeOperationResponse
     {
     };
 
-    using TForcedCompactionCompleted = TEmpty;
+    using TForcedRangeOperationCompleted = TEmpty;
 
     //
     // DumpCompactionRange

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -891,6 +891,8 @@ private:
         TVector<ui32> Ranges;
         TEvIndexTabletPrivate::EForcedRangeOperationMode Mode;
 
+        TPendingForcedRangeOperation() = default;
+
         TPendingForcedRangeOperation(
             TVector<ui32> ranges,
             TEvIndexTabletPrivate::EForcedRangeOperationMode mode)

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -860,14 +860,14 @@ public:
     //
 
 public:
-    struct TForcedCompactionState
+    struct TForcedRangeOperationState
     {
         const TVector<ui32> RangesToCompact;
 
         TInstant StartTime = TInstant::Now();
         std::atomic<ui32> Current = 0;
 
-        TForcedCompactionState(TVector<ui32> ranges)
+        TForcedRangeOperationState(TVector<ui32> ranges)
             : RangesToCompact(std::move(ranges))
         {}
 
@@ -882,27 +882,36 @@ public:
         }
     };
 
-    using TForcedCompactionStatePtr = std::shared_ptr<TForcedCompactionState>;
+    using TForcedRangeOperationStatePtr =
+        std::shared_ptr<TForcedRangeOperationState>;
 
 private:
-    TVector<TVector<ui32>> PendingForcedCompactions;
-    TForcedCompactionStatePtr ForcedCompactionState;
+    struct TPendingForcedRangeOperation
+    {
+        TVector<ui32> Ranges;
+        TEvIndexTabletPrivate::EForcedRangeOperationMode Mode;
+    };
+
+    TVector<TPendingForcedRangeOperation> PendingForcedRangeOperations;
+    TForcedRangeOperationStatePtr ForcedRangeOperationState;
 
 public:
-    void EnqueueForcedCompaction(TVector<ui32> ranges);
-    TVector<ui32> DequeueForcedCompaction();
+    void EnqueueForcedRangeOperation(
+        TVector<ui32> ranges,
+        TEvIndexTabletPrivate::EForcedRangeOperationMode mode);
+    TPendingForcedRangeOperation DequeueForcedRangeOperation();
 
-    void StartForcedCompaction(TVector<ui32> ranges);
-    void CompleteForcedCompaction();
+    void StartForcedRangeOperation(TVector<ui32> ranges);
+    void CompleteForcedRangeOperation();
 
-    const TForcedCompactionStatePtr& GetForcedCompactionState() const
+    const TForcedRangeOperationStatePtr& GetForcedRangeOperationState() const
     {
-        return ForcedCompactionState;
+        return ForcedRangeOperationState;
     }
 
-    bool IsForcedCompactionRunning() const
+    bool IsForcedRangeOperationRunning() const
     {
-        return (bool)ForcedCompactionState;
+        return (bool)ForcedRangeOperationState;
     }
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -890,6 +890,11 @@ private:
     {
         TVector<ui32> Ranges;
         TEvIndexTabletPrivate::EForcedRangeOperationMode Mode;
+
+        TPendingForcedRangeOperation(
+            TVector<ui32> ranges,
+            TEvIndexTabletPrivate::EForcedRangeOperationMode mode)
+            : Ranges(std::move(ranges)), Mode(mode) {}
     };
 
     TVector<TPendingForcedRangeOperation> PendingForcedRangeOperations;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1058,32 +1058,36 @@ void TIndexTabletState::LoadCompactionMap(
     }
 }
 
-void TIndexTabletState::EnqueueForcedCompaction(TVector<ui32> ranges)
+void TIndexTabletState::EnqueueForcedRangeOperation(
+    TVector<ui32> ranges,
+    TEvIndexTabletPrivate::EForcedRangeOperationMode mode)
 {
-    PendingForcedCompactions.emplace_back(std::move(ranges));
+    PendingForcedRangeOperations.emplace_back(std::move(ranges), mode);
 }
 
-TVector<ui32> TIndexTabletState::DequeueForcedCompaction()
+TIndexTabletState::TPendingForcedRangeOperation TIndexTabletState::
+    DequeueForcedRangeOperation()
 {
-    if (PendingForcedCompactions.empty()) {
+    if (PendingForcedRangeOperations.empty()) {
         return {};
     }
 
-    auto ranges = std::move(PendingForcedCompactions.back());
-    PendingForcedCompactions.pop_back();
+    auto ranges = std::move(PendingForcedRangeOperations.back());
+    PendingForcedRangeOperations.pop_back();
 
     return ranges;
 }
 
-void TIndexTabletState::StartForcedCompaction(TVector<ui32> ranges)
+void TIndexTabletState::StartForcedRangeOperation(TVector<ui32> ranges)
 {
-    TABLET_VERIFY(!ForcedCompactionState);
-    ForcedCompactionState = std::make_shared<TForcedCompactionState>(std::move(ranges));
+    TABLET_VERIFY(!ForcedRangeOperationState);
+    ForcedRangeOperationState =
+        std::make_shared<TForcedRangeOperationState>(std::move(ranges));
 }
 
-void TIndexTabletState::CompleteForcedCompaction()
+void TIndexTabletState::CompleteForcedRangeOperation()
 {
-    ForcedCompactionState.reset();
+    ForcedRangeOperationState.reset();
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2632,7 +2632,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         TVector<ui32> compactionRanges;
         TVector<ui32> cleanupRanges;
         env.GetRuntime().SetObserverFunc(
-            [&](TAutoPtr<IEventHandle>& event)
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
                     case TEvIndexTabletPrivate::EvCompactionRequest: {
@@ -2649,7 +2649,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                     }
                 }
 
-                return TTestActorRuntime::DefaultObserverFunc(event);
+                return TTestActorRuntime::DefaultObserverFunc(runtime, event);
             });
 
         tablet.ForcedRangeOperation(
@@ -2688,7 +2688,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         ui32 cleanupCount = 0;
         env.GetRuntime().SetObserverFunc(
-            [&](TAutoPtr<IEventHandle>& event)
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
                     case TEvIndexTabletPrivate::EvCleanupRequest: {
@@ -2697,7 +2697,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                     }
                 }
 
-                return TTestActorRuntime::DefaultObserverFunc(event);
+                return TTestActorRuntime::DefaultObserverFunc(runtime, event);
             });
 
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -299,10 +299,14 @@ public:
         return std::make_unique<TEvIndexTabletPrivate::TEvCompactionRequest>(rangeId, filter);
     }
 
-    auto CreateForcedCompactionRequest(TVector<ui32> ranges)
+    auto CreateForcedRangeOperationRequest(
+        TVector<ui32> ranges,
+        TEvIndexTabletPrivate::EForcedRangeOperationMode mode)
     {
-        return std::make_unique<TEvIndexTabletPrivate::TEvForcedCompactionRequest>(
-            std::move(ranges));
+        return std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
+            std::move(ranges),
+            mode);
     }
 
     auto CreateCollectGarbageRequest()


### PR DESCRIPTION
Currently there is a mechanism that forcefully compacts all ranges present in the fs. In this PR a forced cleanup is introduced, which similarly forcefully runs cleanup operation on all ranges. No new transactions are introduced – ForcedCompaction request is extended with a enum that specifies if compaction or a cleanup is to be performed on the range.