### PR TITLE
#353: move checks of processing sockets to EndpointManager

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.h
@@ -51,7 +51,7 @@ IEndpointManagerPtr CreateEndpointManager(
     THashMap<NProto::EClientIpcType, IEndpointListenerPtr> listeners,
     TString nbdSocketSuffix);
 
-bool IsSameStartEndpointRequests(
+bool AreSameStartEndpointRequests(
     const NProto::TStartEndpointRequest& left,
     const NProto::TStartEndpointRequest& right);
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -390,8 +390,6 @@ IEndpointManagerPtr CreateEndpointManager(
         bootstrap.Executor,
         sessionManagerOptions);
 
-    auto eventProxy = CreateEndpointEventProxy();
-
     return NServer::CreateEndpointManager(
         bootstrap.Logging,
         serverStats,
@@ -1137,7 +1135,7 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         google::protobuf::util::MessageDifferencer comparator;
         UNIT_ASSERT(!comparator.Equals(request1, request2));
 
-        UNIT_ASSERT(IsSameStartEndpointRequests(request1, request2));
+        UNIT_ASSERT(AreSameStartEndpointRequests(request1, request2));
     }
 
     // NBS-3018, CLOUD-98154

--- a/cloud/storage/core/libs/coroutine/executor.h
+++ b/cloud/storage/core/libs/coroutine/executor.h
@@ -56,6 +56,13 @@ public:
         return future.GetValue();
     }
 
+    void WaitFor(NThreading::TFuture<void> future)
+    {
+        if (!future.HasValue()) {
+            WaitForI(future);
+        }
+    }
+
     template <typename T>
     T ExtractResponse(NThreading::TFuture<T> future)
     {


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/353

- move checks of processing sockets to EndpointManager (reject control requests if the corresponding socket is processing)
- add checks of restoring sockets to EndpointService (reject control requests if the corresponding socket is restoring)
- move control request timeout to EndpointService