### PR TITLE
fix deletion of rdma server session

### DIFF
--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -1323,15 +1323,6 @@ public:
         Endpoints.Add(std::move(endpoint));
     }
 
-    void Delete(TClientEndpoint* endpoint)
-    {
-        endpoint->Poller = nullptr;
-
-        Endpoints.Delete([=](auto other) {
-            return endpoint == other.get();
-        });
-    }
-
     void Attach(TClientEndpoint* endpoint)
     {
         if (Config->WaitMode == EWaitMode::Poll) {

--- a/cloud/blockstore/libs/rdma/impl/rcu.h
+++ b/cloud/blockstore/libs/rdma/impl/rcu.h
@@ -38,7 +38,7 @@ public:
 
         with_lock (Lock) {
             for (const T& item: *List) {
-                if (predicate(item)) {
+                if (!predicate(item)) {
                     list->push_back(item);
                 }
             }

--- a/cloud/blockstore/libs/rdma/impl/rcu_ut.cpp
+++ b/cloud/blockstore/libs/rdma/impl/rcu_ut.cpp
@@ -1,0 +1,72 @@
+#include "rcu.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NRdma {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TRcuListTest)
+{
+    Y_UNIT_TEST(ShouldAddItems)
+    {
+        TRCUList<int> rcuList;
+        for (int i = 0; i < 10; ++i) {
+            rcuList.Add(i);
+        }
+
+        auto list = rcuList.Get();
+        UNIT_ASSERT_EQUAL(list->size(), 10);
+
+        for (int i = 0; i < 10; ++i) {
+            UNIT_ASSERT_EQUAL(list->at(i), i);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldDeleteItems)
+    {
+        TRCUList<int> rcuList;
+        for (int i = 0; i < 10; ++i) {
+            rcuList.Add(i);
+        }
+
+        rcuList.Delete([](auto other) {
+            return other % 2 == 0;
+        });
+
+        auto list = rcuList.Get();
+        UNIT_ASSERT_EQUAL(list->size(), 5);
+
+        for (int i = 0; i < 5; ++i) {
+            UNIT_ASSERT_EQUAL(list->at(i), i*2 + 1);
+        }
+
+        rcuList.Delete([](auto) {
+            return true;
+        });
+
+        UNIT_ASSERT_EQUAL(rcuList.Get()->size(), 0);
+
+    }
+
+    Y_UNIT_TEST(ShouldNotModifyAccessedList)
+    {
+        TRCUList<int> rcuList;
+        for (int i = 0; i < 10; ++i) {
+            rcuList.Add(i);
+        }
+
+        auto list = rcuList.Get();
+        rcuList.Delete([](auto) {
+            return true;
+        });
+
+        UNIT_ASSERT_EQUAL(list->size(), 10);
+
+        for (int i = 0; i < 10; ++i) {
+            UNIT_ASSERT_EQUAL(list->at(i), i);
+        }
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -292,6 +292,7 @@ private:
     TLockFreeList<TRequest> InputRequests;
     TSimpleList<TRequest> QueuedRequests;
     TEventHandle RequestEvent;
+    bool FlushStarted = false;
 
 public:
     static TServerSession* FromEvent(rdma_cm_event* event)
@@ -314,6 +315,7 @@ public:
     // called from CM thread
     void Start();
     void Stop() noexcept;
+    void Flush();
 
     // called from external thread
     void EnqueueRequest(TRequestPtr req) noexcept;
@@ -321,6 +323,7 @@ public:
     // called from CQ thread
     bool HandleInputRequests();
     bool HandleCompletionEvents();
+    bool IsFlushed();
 
 private:
     // called inderectly from CQ by 2 previous functions
@@ -338,6 +341,7 @@ private:
     void SendResponseCompleted(TSendWr* send, ibv_wc_status status);
     void FreeRequest(TRequestPtr req, TSendWr* send) noexcept;
     void RejectRequest(TRequestPtr req, ui32 status, TStringBuf message);
+    void HandleFlush(const TWorkRequestId& id) noexcept;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -447,8 +451,10 @@ TServerSession::TServerSession(
 
 TServerSession::~TServerSession()
 {
-    STORAGE_INFO("close session to "
-        << NVerbs::PrintAddress(rdma_get_peer_addr(Connection.get())));
+    STORAGE_INFO("close session [send_magic=%X recv_magic=%X] to %s",
+        SendMagic,
+        RecvMagic,
+        NVerbs::PrintAddress(rdma_get_peer_addr(Connection.get())).c_str());
 
     Verbs->DestroyQP(Connection.get());
 
@@ -563,6 +569,36 @@ bool TServerSession::HandleCompletionEvents()
     return hasWork;
 }
 
+void TServerSession::Flush()
+{
+    STORAGE_INFO("flush session [send_magic=%X recv_magic=%X]",
+        SendMagic, RecvMagic);
+
+    struct ibv_qp_attr attr = {.qp_state = IBV_QPS_ERR};
+    Verbs->ModifyQP(Connection->qp, &attr, IBV_QP_STATE);
+    FlushStarted = true;
+}
+
+bool TServerSession::IsFlushed()
+{
+    return FlushStarted
+        && SendQueue.Size() == Config->QueueSize
+        && RecvQueue.Size() == Config->QueueSize;
+}
+
+void TServerSession::HandleFlush(const TWorkRequestId& id) noexcept
+{
+    // flush WRs have opcode=0
+    if (id.Magic == SendMagic && id.Index < SendWrs.size()) {
+        SendQueue.Push(&SendWrs[id.Index]);
+        return;
+    }
+    if (id.Magic == RecvMagic && id.Index < RecvWrs.size()) {
+        RecvQueue.Push(&RecvWrs[id.Index]);
+        return;
+    }
+}
+
 bool TServerSession::IsWorkRequestValid(const TWorkRequestId& id) const
 {
     if (id.Magic == SendMagic && id.Index < SendWrs.size()) {
@@ -591,6 +627,7 @@ void TServerSession::HandleCompletionEvent(ibv_wc* wc)
 
     // session is closing
     if (wc->status == IBV_WC_WR_FLUSH_ERR) {
+        HandleFlush(id);
         return;
     }
 
@@ -640,11 +677,6 @@ void TServerSession::FreeRequest(TRequestPtr req, TSendWr* send) noexcept
 
 void TServerSession::RecvRequestCompleted(TRecvWr* recv, ibv_wc_status status)
 {
-    if (status == IBV_WC_WR_FLUSH_ERR) {
-        RecvQueue.Push(recv);;
-        return;
-    }
-
     if (status != IBV_WC_SUCCESS) {
         STORAGE_ERROR("RECV " << TWorkRequestId(recv->wr.wr_id) << ": "
             << NVerbs::GetStatusString(status));
@@ -945,11 +977,6 @@ void TServerSession::SendResponse(TRequestPtr req, TSendWr* send)
 
 void TServerSession::SendResponseCompleted(TSendWr* send, ibv_wc_status status)
 {
-    if (status == IBV_WC_WR_FLUSH_ERR) {
-        SendQueue.Push(send);
-        return;
-    }
-
     auto req = ExtractRequest(send);
 
     if (req == nullptr) {
@@ -1327,6 +1354,17 @@ private:
         return hasWork;
     }
 
+    void DisconnectFlushed()
+    {
+        auto sessions = Sessions.Get();
+
+        for (const auto& session: *sessions) {
+            if (session->IsFlushed()) {
+                session->CompletionPoller->Release(session.get());
+            }
+        }
+    }
+
     template <EWaitMode WaitMode>
     void Execute()
     {
@@ -1351,6 +1389,8 @@ private:
                         aw.Sleep();
                     }
             }
+
+            DisconnectFlushed();
         }
     }
 };
@@ -1658,7 +1698,7 @@ void TServer::HandleConnected(TServerSession* session) noexcept
 
 void TServer::HandleDisconnected(TServerSession* session) noexcept
 {
-    session->CompletionPoller->Release(session);
+    session->Flush();
 }
 
 void TServer::Reject(rdma_cm_id* id, int status) noexcept

--- a/cloud/blockstore/libs/rdma/impl/ut/ya.make
+++ b/cloud/blockstore/libs/rdma/impl/ut/ya.make
@@ -5,9 +5,10 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 SRCS(
     buffer_ut.cpp
     client_ut.cpp
-    server_ut.cpp
-    poll_ut.cpp
     list_ut.cpp
+    poll_ut.cpp
+    rcu_ut.cpp
+    server_ut.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
Disconnected session was not deleted and all other sessions were deleted
instead due to problem in rcu list predicate implementation.

Just deleting the server session and calling DestroyQP is not enough and will
lead to deadlock. We need to wait for all WR's to flush and only then it's safe
to delete Connection object (calling rdma_destroy_id)
