### PR TITLE
[BB->arc sync] Libvhost support for MEM_SLOTS/VRING_ENABLE

### DIFF
--- a/cloud/contrib/vhost/memmap.h
+++ b/cloud/contrib/vhost/memmap.h
@@ -12,6 +12,9 @@ struct vhd_memory_map;
 
 struct vhd_memory_map *vhd_memmap_new(int (*map_cb)(void *, size_t),
                                       int (*unmap_cb)(void *, size_t));
+struct vhd_memory_map *vhd_memmap_dup(struct vhd_memory_map *mm);
+
+size_t vhd_memmap_max_memslots(void);
 
 int vhd_memmap_add_slot(struct vhd_memory_map *mm, uint64_t gpa, uint64_t uva,
                         size_t size, int fd, off_t offset);

--- a/cloud/contrib/vhost/vdev.h
+++ b/cloud/contrib/vhost/vdev.h
@@ -193,6 +193,7 @@ struct vhd_vring {
         void *avail;
         struct vhd_memory_map *mm;
         struct vhd_memory_log *log;
+        bool enabled;
     } shadow_vq;
 
     /*

--- a/cloud/contrib/vhost/vhost_spec.h
+++ b/cloud/contrib/vhost/vhost_spec.h
@@ -38,6 +38,7 @@ extern "C" {
 #define VHOST_USER_PROTOCOL_F_PAGEFAULT      8
 #define VHOST_USER_PROTOCOL_F_CONFIG         9
 #define VHOST_USER_PROTOCOL_F_INFLIGHT_SHMFD 12
+#define VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS 15
 
 /* Vhost user features (GET_FEATURES and SET_FEATURES commands). */
 #define VHOST_F_LOG_ALL                     26
@@ -101,6 +102,9 @@ enum {
     VHOST_USER_POSTCOPY_END = 30,
     VHOST_USER_GET_INFLIGHT_FD = 31,
     VHOST_USER_SET_INFLIGHT_FD = 32,
+    VHOST_USER_GET_MAX_MEM_SLOTS = 36,
+    VHOST_USER_ADD_MEM_REG = 37,
+    VHOST_USER_REM_MEM_REG = 38,
 };
 
 struct vhost_user_mem_region {
@@ -108,6 +112,11 @@ struct vhost_user_mem_region {
     uint64_t size;
     uint64_t user_addr;
     uint64_t mmap_offset;
+};
+
+struct vhost_user_mem_single_mem_desc {
+    uint64_t _padding;
+    struct vhost_user_mem_region region;
 };
 
 struct vhost_user_mem_desc {

--- a/cloud/contrib/vhost/virtio/virt_queue.h
+++ b/cloud/contrib/vhost/virtio/virt_queue.h
@@ -73,6 +73,12 @@ struct virtio_virtq {
      */
     int notify_fd;
 
+    /*
+     * Whether the processing of this virtq is enabled.
+     * Can be toggled after virtq is started.
+     */
+    bool enabled;
+
     /* inflight information */
     uint64_t req_cnt;
     struct inflight_split_region *inflight_region;


### PR DESCRIPTION
scripts/sync_with_arc: change the default sync branch NBS no longer uses trunk to synchronize their changes to GitHub, so switch the branch to the one they use now.

Add support for VHOST_USER_SET_VRING_ENABLE

aio_server: don't forget to free config strings on disk stop

vdev: advertise support for CONFIGURE_MEM_SLOTS
Now that we have all calls implemented we can finally advertise support for this feature.

vhost_spec: add definition for VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS

Implement VHOST_REM_MEM_REG
This reuses existing logic from set_mem_table, with the only difference being that instead of replacing the old mem table entirely we create a copy of the old mem table with one memory region removed and then pretend it's a SET_MEM_TABLE call.

Implement VHOST_USER_ADD_MEM_REG

memmap: add a vhd_memmap_dup helper
This will be used to implement region removal in the future commits.

Implement VHOST_GET_MAX_MEM_SLOTS
This simply uses the memmap API we added earlier.

memmap: add a vhd_memmap_max_memslots getter
This will be used to implemenet the GET_MAX_MEM_SLOTS vhost call.

pytest/test_disk: add missing disk proc attribute checking Last patch missed a few extra places where this was used.

test: run multidisk tests when doing pytest-full as well

pytest/test_disk: don't start/stop backends without a proc Not all backends have a proc attribute, e.g. the VirtioBlk backend only has a raw file backing without an associated process.