### PR TITLE
NEBDUTY-504: save dmesg -T on the tear_down of blockstore loadtest (#309)

### DIFF
--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -15,6 +15,7 @@ import yatest.common as yatest_common
 
 import logging
 import os
+import subprocess
 
 
 logger = logging.getLogger(__name__)
@@ -129,12 +130,26 @@ class LocalLoadTest:
         wait_for_nbs_server(self.nbs.nbs_port)
 
     def tear_down(self):
-        self.nbs.stop()
-        self.kikimr_cluster.stop()
+        try:
+            self.nbs.stop()
+            self.kikimr_cluster.stop()
 
-        for d in self.__devices:
-            d.handle.close()
-            os.unlink(d.path)
+            for d in self.__devices:
+                d.handle.close()
+                os.unlink(d.path)
+        finally:
+            # It may be beneficial to save dmesg output for debugging purposes.
+            try:
+                with open(yatest_common.output_path() + "/dmesg.txt", "w") as dmesg_output:
+                    subprocess.run(
+                        ["sudo", "dmesg", "-T"],
+                        stdout=dmesg_output,
+                        stderr=dmesg_output,
+                        timeout=10
+                    )
+            except Exception as dmesg_error:
+                logging.info(f"Failed to save dmesg output: {dmesg_error}")
+                pass
 
     @property
     def endpoint(self):


### PR DESCRIPTION
save dmesg -T on the tear_down of blockstore loadtest