### PR TITLE
NBS-4684: [Disk Manager] use proxy overlay disks in relocation if possible

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/common/util.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/common/util.go
@@ -1,0 +1,9 @@
+package common
+
+import "fmt"
+
+////////////////////////////////////////////////////////////////////////////////
+
+func GetProxyOverlayDiskID(diskID string, ID string) string {
+	return fmt.Sprintf("proxy_%v_%v", diskID, ID)
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/common/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/common/ya.make
@@ -3,6 +3,7 @@ GO_LIBRARY()
 SRCS(
     chunk.go
     transfer.go
+    util.go
 )
 
 GO_TEST_SRCS(

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
@@ -2,7 +2,6 @@ package dataplane
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	nbs_client "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
@@ -272,14 +271,6 @@ func (t *createSnapshotFromDiskTask) run(
 	)
 }
 
-func (t *createSnapshotFromDiskTask) getProxyOverlayDiskID(
-	diskID string,
-	snapshotID string,
-) string {
-
-	return fmt.Sprintf("proxy_%v_%v", diskID, snapshotID)
-}
-
 func (t *createSnapshotFromDiskTask) createProxyOverlayDiskIfNeeded(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
@@ -291,7 +282,7 @@ func (t *createSnapshotFromDiskTask) createProxyOverlayDiskIfNeeded(
 	}
 
 	diskID := t.request.SrcDisk.DiskId
-	proxyOverlayDiskID := t.getProxyOverlayDiskID(
+	proxyOverlayDiskID := common.GetProxyOverlayDiskID(
 		diskID,
 		t.request.DstSnapshotId,
 	)
@@ -341,7 +332,7 @@ func (t *createSnapshotFromDiskTask) deleteProxyOverlayDiskIfNeeded(
 		return err
 	}
 
-	proxyOverlayDiskID := t.getProxyOverlayDiskID(
+	proxyOverlayDiskID := common.GetProxyOverlayDiskID(
 		t.request.SrcDisk.DiskId,
 		t.request.DstSnapshotId,
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
@@ -17,12 +17,6 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func getProxyOverlayDiskID(diskID string, snapshotID string) string {
-	return fmt.Sprintf("proxy_%v_%v", diskID, snapshotID)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 type createSnapshotFromDiskTask struct {
 	nbsFactory nbs_client.Factory
 	storage    storage.Storage
@@ -278,6 +272,14 @@ func (t *createSnapshotFromDiskTask) run(
 	)
 }
 
+func (t *createSnapshotFromDiskTask) getProxyOverlayDiskID(
+	diskID string,
+	snapshotID string,
+) string {
+
+	return fmt.Sprintf("proxy_%v_%v", diskID, snapshotID)
+}
+
 func (t *createSnapshotFromDiskTask) createProxyOverlayDiskIfNeeded(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
@@ -289,7 +291,10 @@ func (t *createSnapshotFromDiskTask) createProxyOverlayDiskIfNeeded(
 	}
 
 	diskID := t.request.SrcDisk.DiskId
-	proxyOverlayDiskID := getProxyOverlayDiskID(diskID, t.request.DstSnapshotId)
+	proxyOverlayDiskID := t.getProxyOverlayDiskID(
+		diskID,
+		t.request.DstSnapshotId,
+	)
 
 	if t.state.ProxyOverlayDiskCreated != nil {
 		if *t.state.ProxyOverlayDiskCreated {
@@ -336,7 +341,7 @@ func (t *createSnapshotFromDiskTask) deleteProxyOverlayDiskIfNeeded(
 		return err
 	}
 
-	proxyOverlayDiskID := getProxyOverlayDiskID(
+	proxyOverlayDiskID := t.getProxyOverlayDiskID(
 		t.request.SrcDisk.DiskId,
 		t.request.DstSnapshotId,
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/protos/replicate_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/protos/replicate_disk_task.proto
@@ -39,8 +39,6 @@ message ReplicateDiskTaskState {
     // Store SecondsRemaining each UselessReplicationIterationsBeforeAbort.
     // If SecondsRemaining degrades, abort replication.
     int64 MeasuredSecondsRemaining = 9;
-
-    string ProxyOverlayDiskId = 10;
 }
 
 message ReplicateDiskTaskMetadata {

--- a/cloud/disk_manager/internal/pkg/dataplane/protos/replicate_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/protos/replicate_disk_task.proto
@@ -39,6 +39,8 @@ message ReplicateDiskTaskState {
     // Store SecondsRemaining each UselessReplicationIterationsBeforeAbort.
     // If SecondsRemaining degrades, abort replication.
     int64 MeasuredSecondsRemaining = 9;
+
+    string ProxyOverlayDiskId = 10;
 }
 
 message ReplicateDiskTaskMetadata {

--- a/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
@@ -173,7 +173,6 @@ func (t *replicateDiskTask) deleteProxyOverlayDiskIfNeeded(
 		diskID,
 		currentCheckpointID,
 	)
-
 	return client.Delete(ctx, proxyOverlayDiskID)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
@@ -174,9 +174,6 @@ func (t *replicateDiskTask) deleteProxyOverlayDiskIfNeeded(
 		currentCheckpointID,
 	)
 
-	if len(proxyOverlayDiskID) == 0 {
-		return nil
-	}
 	return client.Delete(ctx, proxyOverlayDiskID)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
@@ -119,14 +119,6 @@ func (t *replicateDiskTask) GetResponse() proto.Message {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func (t *replicateDiskTask) getProxyOverlayDiskID(
-	diskID string,
-	checkpointID string,
-) string {
-
-	return fmt.Sprintf("proxy_%v_%v", diskID, checkpointID)
-}
-
 func (t *replicateDiskTask) createProxyOverlayDisk(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
@@ -135,12 +127,15 @@ func (t *replicateDiskTask) createProxyOverlayDisk(
 ) (string, error) {
 
 	diskID := t.request.SrcDisk.DiskId
-	proxyOverlayDiskID := t.getProxyOverlayDiskID(diskID, currentCheckpointID)
+	proxyOverlayDiskID := common.GetProxyOverlayDiskID(
+		diskID,
+		currentCheckpointID,
+	)
 
 	created, err := client.CreateProxyOverlayDisk(
 		ctx,
 		proxyOverlayDiskID,
-		diskID, // baseDiskID
+		diskID,
 		currentCheckpointID,
 	)
 	if err != nil {
@@ -170,6 +165,8 @@ func (t *replicateDiskTask) deleteProxyOverlayDisk(
 	}
 	return client.Delete(ctx, proxyOverlayDiskID)
 }
+
+////////////////////////////////////////////////////////////////////////////////
 
 func (t *replicateDiskTask) saveProgress(
 	ctx context.Context,

--- a/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
@@ -52,7 +52,7 @@ func (t *replicateDiskTask) Run(
 ) error {
 
 	for {
-		err := t.deleteProxyOverlayDiskIfNeeded(
+		err := t.deleteProxyOverlayDisk(
 			ctx,
 			execCtx,
 		)
@@ -99,7 +99,7 @@ func (t *replicateDiskTask) Cancel(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	return t.deleteProxyOverlayDiskIfNeeded(ctx, execCtx)
+	return t.deleteProxyOverlayDisk(ctx, execCtx)
 }
 
 func (t *replicateDiskTask) GetMetadata(
@@ -157,7 +157,7 @@ func (t *replicateDiskTask) createProxyOverlayDisk(
 	return "", nil
 }
 
-func (t *replicateDiskTask) deleteProxyOverlayDiskIfNeeded(
+func (t *replicateDiskTask) deleteProxyOverlayDisk(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
 ) error {


### PR DESCRIPTION
need to use proxy overlay disk in relocation 

now data path looks like
snapshot -> nbs control -> host with volume tablet -> nbs control -> snapshot 

after this optimization it will be
snapshot -> nbs control -> snapshot