### PR TITLE
issue #324: introduced TwoStageReadEnabled flag, returning this flag to filestore-vhost via TCreateSessionResponse::FileStore::Features; outputting StorageConfig overrides on monpage; minor cleanup

### DIFF
--- a/cloud/filestore/apps/client/lib/execute_action.cpp
+++ b/cloud/filestore/apps/client/lib/execute_action.cpp
@@ -15,7 +15,7 @@ TString ReadFile(const TString& path)
 }
 
 class TExecuteActionCommand final
-    : public TFileStoreCommand
+    : public TFileStoreServiceCommand
 {
 private:
     TString Action;
@@ -51,10 +51,6 @@ public:
 
         auto& input = Input.Empty() ? Cin : inputBytes;
         auto inputJsonStr = input.ReadAll();
-        if (NJson::ValidateJson(inputJsonStr)) {
-            Cout << "Invalid input-json" << Endl;
-            return false;
-        }
 
         STORAGE_DEBUG("Reading ExecuteAction request");
         auto request = std::make_shared<NProto::TExecuteActionRequest>();
@@ -71,7 +67,7 @@ public:
 
         if (HasError(result)) {
             Cout << FormatError(result.GetError()) << Endl;
-            return false;
+            return true;
         }
 
         Cout << result.GetOutput() << Endl;

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -42,7 +42,7 @@ message TStorageConfig
     // flushing.
     optional uint32 FlushThreshold = 10;
 
-    // Backpressure thresholds.
+    // Thresholds for background ops.
     optional uint32 CleanupThreshold = 11;
     optional uint32 CompactionThreshold = 12;
     optional uint32 CollectGarbageThreshold = 13;

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -196,4 +196,7 @@ message TStorageConfig
     // Max number of compaction ranges loaded per 1 compaction state load
     // iteration.
     optional uint32 LoadedCompactionRangesPerTx = 330;
+
+    // Enables DescribeData + ReadBlob instead of ReadData for reading.
+    optional bool TwoStageReadEnabled = 331;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -224,8 +224,7 @@ void TStorageConfig::DumpHtml(IOutputStream& out) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TStorageConfig::Merge(
-    const NProto::TStorageConfig& storageConfig)
+void TStorageConfig::Merge(const NProto::TStorageConfig& storageConfig)
 {
     ProtoConfig.MergeFrom(storageConfig);
 }
@@ -233,8 +232,8 @@ void TStorageConfig::Merge(
 TStorageConfig::TValueByName TStorageConfig::GetValueByName(
     const TString& name) const
 {
-    auto descriptor =
-        ProtoConfig.GetDescriptor()->FindFieldByName(name);
+    const auto* descriptor =
+        NProto::TStorageConfig::GetDescriptor()->FindFieldByName(name);
     using TStatus = TValueByName::ENameStatus;
 
     if (descriptor == nullptr) {

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -130,6 +130,8 @@ namespace {
     xxx(AuthorizationMode,                                                     \
             NCloud::NProto::EAuthorizationMode,                                \
             NCloud::NProto::AUTHORIZATION_IGNORE                              )\
+                                                                               \
+    xxx(TwoStageReadEnabled,             bool,      false                     )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_DECLARE_CONFIG(name, type, value)                            \
@@ -209,6 +211,30 @@ void TStorageConfig::DumpHtml(IOutputStream& out) const
         TABLED() { out << #name; }                                             \
         TABLED() { DumpImpl(Get##name(), out); }                               \
     }                                                                          \
+// FILESTORE_DUMP_CONFIG
+
+    HTML(out) {
+        TABLE_CLASS("table table-condensed") {
+            TABLEBODY() {
+                FILESTORE_STORAGE_CONFIG(FILESTORE_DUMP_CONFIG);
+            }
+        }
+    }
+
+#undef FILESTORE_DUMP_CONFIG
+}
+
+void TStorageConfig::DumpOverridesHtml(IOutputStream& out) const
+{
+#define FILESTORE_DUMP_CONFIG(name, type, ...) {                               \
+    const auto value = ProtoConfig.Get##name();                                \
+    if (!IsEmpty(value)) {                                                     \
+        TABLER() {                                                             \
+            TABLED() { out << #name; }                                         \
+            TABLED() { DumpImpl(ConvertValue<type>(value), out); }             \
+        }                                                                      \
+    }                                                                          \
+}                                                                              \
 // FILESTORE_DUMP_CONFIG
 
     HTML(out) {

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -45,7 +45,7 @@ public:
 
     TStorageConfig(const TStorageConfig&) = default;
 
-    void Merge(const NProto::TStorageConfig& storageServiceConfig);
+    void Merge(const NProto::TStorageConfig& storageConfig);
 
     TValueByName GetValueByName(const TString& name) const;
 

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -174,8 +174,11 @@ public:
     TString GetFolderId() const;
     NCloud::NProto::EAuthorizationMode GetAuthorizationMode() const;
 
+    bool GetTwoStageReadEnabled() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
+    void DumpOverridesHtml(IOutputStream& out) const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -35,6 +35,7 @@
 #include <contrib/ydb/library/actors/core/log.h>
 #include <contrib/ydb/library/actors/core/mon.h>
 
+#include <util/generic/size_literals.h>
 #include <util/generic/string.h>
 
 #include <atomic>
@@ -48,7 +49,7 @@ class TIndexTabletActor final
     , public TTabletBase<TIndexTabletActor>
     , public TIndexTabletState
 {
-    static constexpr size_t MaxBlobStorageBlobSize = 40 * 1024 * 1024;
+    static constexpr size_t MaxBlobStorageBlobSize = 40_MB;
 
     enum EState
     {
@@ -166,6 +167,9 @@ private:
         bool Finished = false;
     } CompactionStateLoadStatus;
 
+    // used on monpages
+    NProto::TStorageConfig StorageConfigOverride;
+
 public:
     TIndexTabletActor(
         const NActors::TActorId& owner,
@@ -174,7 +178,7 @@ public:
         IProfileLogPtr profileLog,
         ITraceSerializerPtr traceSerializer,
         NMetrics::IMetricsRegistryPtr metricsRegistry);
-    ~TIndexTabletActor();
+    ~TIndexTabletActor() override;
 
     static constexpr ui32 LogComponent = TFileStoreComponents::TABLET;
     using TCounters = TIndexTabletCounters;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
@@ -29,7 +29,7 @@ void TIndexTabletActor::ExecuteTx_ChangeStorageConfig(
 {
     TIndexTabletDatabase db(tx.DB);
     if (args.StorageConfigFromDB.Defined()) {
-        auto config = args.StorageConfigFromDB.Get();
+        auto* config = args.StorageConfigFromDB.Get();
         config->MergeFrom(args.StorageConfigNew);
         db.WriteStorageConfig(*config);
         args.ResultStorageConfig = std::move(*config);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -184,6 +184,7 @@ void TIndexTabletActor::CompleteTx_LoadState(
     TTxIndexTablet::TLoadState& args)
 {
     if (args.StorageConfig.Defined()) {
+        StorageConfigOverride = *args.StorageConfig;
         Config = std::make_shared<TStorageConfig>(*Config);
         Config->Merge(*args.StorageConfig.Get());
         LOG_INFO_S(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -961,7 +961,6 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         DumpProfillingAllocatorStats(GetFileStoreProfilingRegistry(), out);
 
         TAG(TH3) { out << "Blob index stats"; }
-        ;
 
         const auto storageThrottlingEnabled = Config->GetThrottlingEnabled();
 
@@ -970,8 +969,7 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         DumpPerformanceProfile(storageThrottlingEnabled, fsPerfProfile, out);
 
         const auto& usedPerfProfile = GetPerformanceProfile();
-        if (!NProtoBuf::IsEqual(fsPerfProfile, usedPerfProfile))
-        {
+        if (!NProtoBuf::IsEqual(fsPerfProfile, usedPerfProfile)) {
             TAG(TH3) { out << "Used performance profile"; }
             DumpPerformanceProfile(
                 storageThrottlingEnabled,
@@ -982,6 +980,12 @@ void TIndexTabletActor::HandleHttpInfo_Default(
 
         TAG(TH3) { out << "Throttler state"; }
         DumpThrottlingState(Throttler.get(), GetThrottlingPolicy(), out);
+
+        if (StorageConfigOverride.ByteSize()) {
+            TAG(TH3) { out << "StorageConfig overrides"; }
+            TStorageConfig config(StorageConfigOverride);
+            config.DumpOverridesHtml(out);
+        }
 
         TAG(TH3)
         {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -802,6 +802,34 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             UNIT_ASSERT_VALUES_EQUAL(expected, buffer);
         }
     }
+
+    void DoTestShouldReturnFeaturesInCreateSessionResponse(
+        const NProto::TStorageConfig& config,
+        const NProto::TFileStoreFeatures& expected)
+    {
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        auto response = tablet.CreateSession("client", "session");
+        const auto& features = response->Record.GetFileStore().GetFeatures();
+        UNIT_ASSERT_VALUES_EQUAL(features.DebugString(), expected.DebugString());
+    }
+
+    Y_UNIT_TEST(ShouldReturnFeaturesInCreateSessionResponse)
+    {
+        NProto::TStorageConfig config;
+        NProto::TFileStoreFeatures features;
+        DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
+
+        config.SetTwoStageReadEnabled(true);
+        features.SetTwoStageReadEnabled(true);
+        DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/private/api/protos/actions.proto
+++ b/cloud/filestore/private/api/protos/actions.proto
@@ -5,7 +5,7 @@ package NCloud.NFileStore.NProtoPrivate;
 option go_package = "github.com/ydb-platform/nbs/cloud/filestore/private/api/protos";
 
 ////////////////////////////////////////////////////////////////////////////////
-// Actiions
+// Actions
 
 message TDrainNodeRequest
 {

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -11,6 +11,11 @@ option go_package = "github.com/ydb-platform/nbs/cloud/filestore/public/api/prot
 ////////////////////////////////////////////////////////////////////////////////
 // FileStore information
 
+message TFileStoreFeatures
+{
+    bool TwoStageReadEnabled = 1;
+}
+
 message TFileStore
 {
     string FileSystemId = 1;
@@ -29,6 +34,9 @@ message TFileStore
 
     // Performance profile, used for throttling.
     TFileStorePerformanceProfile PerformanceProfile = 10;
+
+    // The list of features that are enabled for this fs.
+    TFileStoreFeatures Features = 11;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
TFileStore now contains a TFileStoreFeatures field which will contain the feature flags enabling various features for this TFileStore. Right now there is only one feature - TwoStageReadEnabled (the one that's implemented in issue #324). The value for this feature is taken from TStorageConfig - the global one or the overridden one. Outputting overridden TStorageConfig fields on fs monpage.