### PR TITLE
[Disk Manager]: Tests: Use YDB binary from S3 instead of building it …

### DIFF
--- a/cloud/disk_manager/test/recipe/__main__.py
+++ b/cloud/disk_manager/test/recipe/__main__.py
@@ -59,7 +59,7 @@ def start(argv):
     s3.start()
     set_env("DISK_MANAGER_RECIPE_S3_PORT", str(s3.port))
 
-    ydb_binary_path = yatest_common.binary_path("contrib/ydb/apps/ydbd/ydbd")
+    ydb_binary_path = yatest_common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
     nbs_binary_path = yatest_common.binary_path("cloud/blockstore/apps/server/nbsd")
     nfs_binary_path = yatest_common.binary_path("cloud/filestore/apps/server/filestore-server")
     disk_manager_binary_path = yatest_common.binary_path(args.disk_manager_binary_path)

--- a/cloud/disk_manager/test/recipe/recipe.inc
+++ b/cloud/disk_manager/test/recipe/recipe.inc
@@ -11,10 +11,9 @@ DEPENDS(
     cloud/disk_manager/test/mocks/kms
     cloud/disk_manager/test/mocks/metadata
     cloud/disk_manager/test/recipe
+    cloud/storage/core/tools/testing/ydb/bin
     cloud/tasks/test/nemesis
-
     contrib/python/moto/bin
-    contrib/ydb/apps/ydbd
 )
 
 DATA(


### PR DESCRIPTION
…locally

We were using an old YDB version which led to hangs in disk manager tests after the context cancellation.For problem details, see: https://github.com/ydb-platform/ydb-go-sdk/issues/1025