### PR TITLE
disk agent should reject secure erase if there are inflight write or zero requests

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -54,6 +54,8 @@ namespace NCloud::NBlockStore {
     xxx(ExternalEndpointUnexpectedExit)                                        \
     xxx(DiskAgentSessionCacheUpdateError)                                      \
     xxx(DiskAgentSessionCacheRestoreError)                                     \
+    xxx(DiskAgentSecureEraseDuringIo)                                          \
+    xxx(DiskAgentIoDuringSecureErase)                                          \
     xxx(BlockDigestMismatchInBlob)                                             \
 // BLOCKSTORE_CRITICAL_EVENTS
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -1,5 +1,6 @@
 #include "disk_agent_actor.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
@@ -182,6 +183,7 @@ void TDiskAgentActor::PerformIO(
         clientId.c_str());
 
     if (SecureErasePendingRequests.contains(deviceUUID)) {
+        ReportDiskAgentIoDuringSecureErase();
         replyError(E_REJECTED, "Secure erase in progress");
         return;
     }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -771,6 +771,97 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldRejectSecureEraseWhenInflightIosPresent)
+    {
+        TTestBasicRuntime runtime;
+
+        const TVector<TString> uuids = {"MemoryDevice1"};
+
+        auto env = TTestEnvBuilder(runtime)
+                       .With(DiskAgentConfig(uuids))
+                       .With([] {
+                           NProto::TStorageServiceConfig config;
+                           config.SetRejectLateRequestsAtDiskAgentEnabled(true);
+                           return config;
+                       }())
+                       .Build();
+
+        auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        InitCriticalEventsCounter(counters);
+
+        TDiskAgentClient diskAgent(runtime);
+        diskAgent.WaitReady();
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        const TString clientId = "client-1";
+
+        diskAgent.AcquireDevices(
+            uuids,
+            clientId,
+            NProto::VOLUME_ACCESS_READ_WRITE);
+
+        // Steal TEvWriteOrZeroCompleted message.
+        std::vector<std::unique_ptr<IEventHandle>> stolenWriteCompletedRequests;
+        auto stealFirstDeviceRequest = [&](TAutoPtr<IEventHandle>& event) {
+            if (event->GetTypeRewrite() ==
+                TEvDiskAgentPrivate::EvWriteOrZeroCompleted)
+            {
+                stolenWriteCompletedRequests.push_back(
+                    std::unique_ptr<IEventHandle>{event.Release()});
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+        auto oldObserverFunc = runtime.SetObserverFunc(stealFirstDeviceRequest);
+
+        auto sendWriteRequest = [&](ui64 volumeRequestId,
+                                    ui64 blockStart,
+                                    ui32 blockCount) {
+            auto request =
+                std::make_unique<TEvDiskAgent::TEvWriteDeviceBlocksRequest>();
+            request->Record.MutableHeaders()->SetClientId(clientId);
+            request->Record.SetDeviceUUID(uuids[0]);
+            request->Record.SetStartIndex(blockStart);
+            request->Record.SetBlockSize(DefaultBlockSize);
+            request->Record.SetVolumeRequestId(volumeRequestId);
+
+            auto sgList = ResizeIOVector(
+                *request->Record.MutableBlocks(),
+                1,
+                blockCount * DefaultBlockSize);
+
+            for (auto& buffer : sgList) {
+                memset(const_cast<char*>(buffer.Data()), 'Y', buffer.Size());
+            }
+
+            diskAgent.SendRequest(MakeDiskAgentServiceId(), std::move(request));
+        };
+
+        // Send write request. It's message TWriteOrZeroCompleted will be stolen.
+        sendWriteRequest(100, 1024, 10);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(!stolenWriteCompletedRequests.empty());
+
+        // N.B. We are delaying the internal TEvWriteOrZeroCompleted request.
+        // The response to the client was not delayed, so here we receive write and response.
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            diskAgent.RecvWriteDeviceBlocksResponse()->GetStatus());
+
+        // secure erase will be rejected since we have inflight write
+        diskAgent.SendSecureEraseDeviceRequest(uuids[0]);
+        auto response = diskAgent.RecvSecureEraseDeviceResponse();
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            response->Record.GetError().GetCode());
+
+        auto counter = counters->GetCounter(
+            "AppCriticalEvents/DiskAgentSecureEraseDuringIo",
+            true);
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 1);
+    }
+
     Y_UNIT_TEST(ShouldRejectMultideviceOverlappedRequests)
     {
         TTestBasicRuntime runtime;
@@ -2861,6 +2952,9 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             .With(spdk)
             .Build();
 
+        auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        InitCriticalEventsCounter(counters);
+
         TDiskAgentClient diskAgent(runtime);
         diskAgent.WaitReady();
 
@@ -2894,6 +2988,11 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         };
 
         io(E_REJECTED);
+
+        auto counter = counters->GetCounter(
+            "AppCriticalEvents/DiskAgentIoDuringSecureErase",
+            true);
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
 
         spdk->SecureEraseResult.SetValue(NProto::TError());
         runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(10));

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -673,22 +673,26 @@ TFuture<NProto::TError> TDiskAgentState::SecureErase(
         return MakeFuture(NProto::TError());
     }
 
-    auto onDeviceSecureErased =
+    auto onDeviceSecureEraseFinish =
         [weakRdmaTarget = std::weak_ptr<IRdmaTarget>(RdmaTarget),
          uuid](const TFuture<NProto::TError>& future)
     {
-        if (HasError(future.GetValue())) {
-            return;
-        }
         // The device has been secure erased and now a new client can use it.
         if (auto rdmaTarget = weakRdmaTarget.lock()) {
-            rdmaTarget->DeviceSecureErased(uuid);
+            rdmaTarget->DeviceSecureEraseFinish(uuid, future.GetValue());
         }
     };
 
+    if (RdmaTarget) {
+        auto error = RdmaTarget->DeviceSecureEraseStart(uuid);
+        if (HasError(error)) {
+            return MakeFuture(error);
+        }
+    }
+
     return device.StorageAdapter
         ->EraseDevice(AgentConfig->GetDeviceEraseMethod())
-        .Subscribe(std::move(onDeviceSecureErased));
+        .Subscribe(std::move(onDeviceSecureEraseFinish));
 }
 
 TFuture<NProto::TChecksumDeviceBlocksResponse> TDiskAgentState::Checksum(

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.h
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.h
@@ -30,7 +30,11 @@ struct TRdmaTargetConfig
 
 struct IRdmaTarget: IStartable
 {
-    virtual void DeviceSecureErased(const TString& deviceUUID) = 0;
+    virtual NProto::TError DeviceSecureEraseStart(
+        const TString& deviceUUID) = 0;
+    virtual void DeviceSecureEraseFinish(
+        const TString& deviceUUID,
+        const NProto::TError& error) = 0;
 };
 
 using TStorageAdapterPtr = std::shared_ptr<TStorageAdapter>;

--- a/cloud/blockstore/libs/storage/disk_agent/recent_blocks_tracker.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/recent_blocks_tracker.cpp
@@ -158,6 +158,11 @@ bool TRecentBlocksTracker::CheckInflight(
         });
 }
 
+bool TRecentBlocksTracker::HasInflight() const
+{
+    return !InflightBlocks.empty();
+}
+
 void TRecentBlocksTracker::AddInflight(
     ui64 requestId,
     const TBlockRange64& range)

--- a/cloud/blockstore/libs/storage/disk_agent/recent_blocks_tracker.h
+++ b/cloud/blockstore/libs/storage/disk_agent/recent_blocks_tracker.h
@@ -69,6 +69,9 @@ public:
     [[nodiscard]] bool CheckInflight(ui64 requestId, const TBlockRange64& range)
         const;
 
+    // Has inflight request tracked.
+    [[nodiscard]] bool HasInflight() const;
+
     // Add inflight request to track.
     void AddInflight(ui64 requestId, const TBlockRange64& range);
 


### PR DESCRIPTION
We encountered devices, after secure erase, which had a few non-zero 4K blocks. Since we suspect that there were in-flight I/Os during the NVMe deallocate, this commit will add extra protection and raise critical events in case we encounter such a situation.
