### PR TITLE
NBSNEBIUS-45: fix MaxMigrationTime

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1186,6 +1186,8 @@ private:
     NProto::TError CheckDestructiveConfigurationChange(
         const NProto::TDeviceConfig& device,
         const THashMap<TDeviceId, NProto::TDeviceConfig>& oldConfigs) const;
+
+    void ResetMigrationStartTsIfNeeded(TDiskState& disk);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
reset MaxMigrationTime on the last finished device migration; show Start migration timestamp on the volume's mon. page (#374)