### PR TITLE
issue #95: 1. deduplicating out-of-order compaction map chunk load requests in queue 2. limiting the number of out-of-order compaction map chunk load requests in queue

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -202,4 +202,7 @@ message TStorageConfig
 
     // Enables runtime config update tool.
     optional bool ConfigsDispatcherServiceEnabled = 332;
+
+    // Max inflight for out of order compaction map load requests.
+    optional uint32 MaxOutOfOrderCompactionMapLoadRequestsInQueue = 333;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -133,6 +133,7 @@ namespace {
             NCloud::NProto::AUTHORIZATION_IGNORE                              )\
                                                                                \
     xxx(TwoStageReadEnabled,             bool,      false                     )\
+    xxx(MaxOutOfOrderCompactionMapLoadRequestsInQueue,  ui32,      5          )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_DECLARE_CONFIG(name, type, value)                            \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -175,6 +175,7 @@ public:
     NCloud::NProto::EAuthorizationMode GetAuthorizationMode() const;
 
     bool GetTwoStageReadEnabled() const;
+    ui32 GetMaxOutOfOrderCompactionMapLoadRequestsInQueue() const;
 
     bool GetConfigsDispatcherServiceEnabled() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -414,14 +414,7 @@ void TIndexTabletActor::HandleLoadCompactionMapChunkCompleted(
     s.LoadQueue.pop_front();
     s.LoadChunkInProgress = false;
 
-    if (s.LoadQueue) {
-        // We still have more loading to do - sending the next load request
-        ctx.Send(
-            SelfId(),
-            new TEvIndexTabletPrivate::TEvLoadCompactionMapChunkRequest(
-                s.LoadQueue.front())
-        );
-    }
+    LoadNextCompactionMapChunkIfNeeded(ctx);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -606,6 +606,8 @@ void TIndexTabletActor::HandleDescribeData(
         msg->CallContext);
 
     TByteRange alignedByteRange = byteRange.AlignedSuperRange();
+    // TODO: implement a block buffer with lazy block allocation and use it
+    // here
     auto blockBuffer = CreateBlockBuffer(alignedByteRange);
 
     ExecuteTx<TReadData>(


### PR DESCRIPTION
Otherwise if we have a large FS and a lot of concurrent WriteData requests CompactionMap takes forever to load