### PR TITLE
Remove launch of ttl-watcher

### DIFF
--- a/.github/workflows/nightly-index-rebuild.yaml
+++ b/.github/workflows/nightly-index-rebuild.yaml
@@ -25,26 +25,6 @@ jobs:
         folder_prefix: nebius-
         build_preset: "release"
         user: runner
-    - name: Create objects lifecycle main repo
-      if: ${{ github.repository == 'ydb-platform/nbs'}}
-      shell: bash
-      run: |
-        set -x
-        echo "::group::set-up-objects-life-cycle"
-        python3 .github/scripts/ttl-watcher.py s3://${S3_BUCKET}/${GITHUB_REPOSITORY}/ -vv --apply
-        echo "::endgroup::"
-      env:
-        S3_BUCKET: ${{ vars.AWS_BUCKET }}
-    - name: Create objects lifecycle non-main repo
-      if: ${{ github.repository != 'ydb-platform/nbs'}}
-      shell: bash
-      run: |
-        set -x
-        echo "::group::set-up-objects-life-cycle"
-        python3 .github/scripts/ttl-watcher.py s3://${S3_BUCKET}/${GITHUB_REPOSITORY}/ --ttl default=7d -vv --apply
-        echo "::endgroup::"
-      env:
-        S3_BUCKET: ${{ vars.AWS_BUCKET }}
     - name: Create indices for repo
       shell: bash
       run: |


### PR DESCRIPTION
Seem like there is internal limit on 1000 lifecycle rules and this script simply would not work