### PR TITLE
Add missed #include <thread>

### DIFF
--- a/cloud/storage/core/libs/vhost-client/vhost-client.h
+++ b/cloud/storage/core/libs/vhost-client/vhost-client.h
@@ -12,6 +12,7 @@
 #include <util/system/file.h>
 
 #include <array>
+#include <thread>
 
 namespace NVHost {
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Avoid
```
$(SOURCE_ROOT)/cloud/storage/core/libs/vhost-client/vhost-client.h:51:18: error: no member named 'thread' in namespace 'std'
    TVector<std::thread> QueueThreads;
  ```

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
