### PR TITLE
issue #324: storing NProto::TFileStore in session state to use it in the two stage read implementation in TServiceActor

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -792,21 +792,26 @@ void TStorageServiceActor::HandleSessionCreated(
                 msg->FileStore.GetFileSystemId(),
                 msg->ClientId);
 
+            const auto mediaKind = static_cast<NProto::EStorageMediaKind>(
+                msg->FileStore.GetStorageMediaKind());
+
             session = State->CreateSession(
                 msg->ClientId,
-                msg->FileStore.GetFileSystemId(),
+                msg->FileStore,
                 msg->SessionId,
                 msg->SessionState,
                 msg->SessionSeqNo,
                 msg->ReadOnly,
-                static_cast<NProto::EStorageMediaKind>(msg->FileStore.GetStorageMediaKind()),
+                mediaKind,
                 std::move(stats),
                 actorId,
                 msg->TabletId);
 
             Y_ABORT_UNLESS(session);
         } else {
-            session->UpdateSessionState(msg->SessionState);
+            session->UpdateSessionState(
+                msg->SessionState,
+                msg->FileStore);
             session->AddSubSession(msg->SessionSeqNo, msg->ReadOnly);
             session->SessionActor = actorId;
         }

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -226,7 +226,9 @@ void TStorageServiceActor::HandleDestroySession(
             "Another create or destroy request is in progress"));
     }
 
-    if (session->ClientId != clientId || session->FileSystemId != fsId) {
+    if (session->ClientId != clientId
+            || session->FileStore.GetFileSystemId() != fsId)
+    {
         return reply(ErrorInvalidSession(clientId, sessionId, seqNo));
     }
 
@@ -265,7 +267,7 @@ void TStorageServiceActor::HandleDestroySession(
         StorageConfig,
         std::move(requestInfo),
         session->ClientId,
-        session->FileSystemId,
+        session->FileStore.GetFileSystemId(),
         session->SessionId,
         seqNo);
 
@@ -281,7 +283,7 @@ void TStorageServiceActor::HandleSessionDestroyed(
     auto* session = State->FindSession(msg->SessionId, msg->SeqNo);
     if (session) {
         session->CreateDestroyState = ESessionCreateDestroyState::STATE_NONE;
-        const auto fsId = session->FileSystemId;
+        const auto fsId = session->FileStore.GetFileSystemId();
         const auto clientId = session->ClientId;
         if (!State->RemoveSession(msg->SessionId, msg->SeqNo)) {
             StatsRegistry->Unregister(fsId, clientId);

--- a/cloud/filestore/libs/storage/service/service_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_monitoring.cpp
@@ -98,7 +98,7 @@ void TStorageServiceActor::RenderSessions(IOutputStream& out)
                         DumpFsLink(
                             out,
                             session.TabletId,
-                            session.FileSystemId
+                            session.FileStore.GetFileSystemId()
                         );
                     }
                     TABLED() { out << session.SessionId; }

--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -59,7 +59,7 @@ TIncompleteRequest TInFlightRequest::ToIncompleteRequest(ui64 nowCycles) const
 
 TSessionInfo* TStorageServiceState::CreateSession(
     TString clientId,
-    TString fileSystemId,
+    NProto::TFileStore fileStore,
     TString sessionId,
     TString sessionState,
     ui64 seqNo,
@@ -74,7 +74,7 @@ TSessionInfo* TStorageServiceState::CreateSession(
     if (it == SessionById.end()) {
         auto session = std::make_unique<TSessionInfo>();
         session->ClientId = std::move(clientId);
-        session->FileSystemId = std::move(fileSystemId);
+        session->FileStore = std::move(fileStore);
         session->SessionId = std::move(sessionId);
         session->SessionState = std::move(sessionState);
         session->MediaKind = mediaKind,

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -77,7 +77,7 @@ struct TSessionInfo
     : public TIntrusiveListItem<TSessionInfo>
 {
     TString ClientId;
-    TString FileSystemId;
+    NProto::TFileStore FileStore;
     TString SessionId;
     TString SessionState;
     NCloud::NProto::EStorageMediaKind MediaKind;
@@ -87,7 +87,8 @@ struct TSessionInfo
     ui64 TabletId = 0;
 
     THashMap<ui64, std::pair<bool, TInstant>> SubSessions;
-    ESessionCreateDestroyState CreateDestroyState = ESessionCreateDestroyState::STATE_NONE;
+    ESessionCreateDestroyState CreateDestroyState =
+        ESessionCreateDestroyState::STATE_NONE;
 
     bool ShouldStop = false;
 
@@ -102,9 +103,10 @@ struct TSessionInfo
         }
     }
 
-    void UpdateSessionState(TString state)
+    void UpdateSessionState(TString state, NProto::TFileStore fileStore)
     {
         SessionState = std::move(state);
+        FileStore = std::move(fileStore);
     }
 
     void AddSubSession(ui64 seqNo, bool readOnly)
@@ -172,7 +174,7 @@ private:
 public:
     TSessionInfo* CreateSession(
         TString clientId,
-        TString fileSystemId,
+        NProto::TFileStore fileStore,
         TString sessionId,
         TString sessionState,
         ui64 seqNo,


### PR DESCRIPTION
It contains feature flags, block size, etc.