### PR TITLE
issue #324: DescribeData: offset calculation shouldn't use TBlock::BlockIndex since this block might be not initialized

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -99,10 +99,10 @@ void FillDescribeDataResponse(
     // using TMap to make responses more stable and, thus, easier to test
     TMap<TPartialBlobId, TBlocks> blobBlocks;
     NProtoPrivate::TFreshDataRange freshRange;
-    for (ui32 i = 0; i < args.Blocks.size(); ++i) {
+    for (ui64 i = 0; i < args.Blocks.size(); ++i) {
         const auto& block = args.Blocks[i];
         const auto& bytes = args.Bytes[i];
-        const ui64 curOffset = static_cast<ui64>(block.BlockIndex) * blockSize;
+        const ui64 curOffset = args.AlignedByteRange.Offset + i * blockSize;
 
         if (!block.BlobId && block.MinCommitId) {
             // it's a fresh block


### PR DESCRIPTION
Otherwise the offsets corresponding to the ranges that contain only fresh bytes are incorrect (shown in the added ut)