### PR TITLE
[Disk Manager]: Test: Obtain the disk from the previous test

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/lib/disk_policy.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/disk_policy.py
@@ -62,7 +62,11 @@ class YcpFindDiskPolicy(DiskPolicy):
         self._name_regex = name_regex
 
     def obtain(self) -> Ycp.Disk:
-        disks = self._ycp.list_disks()
+        disks = sorted(
+            self._ycp.list_disks(),
+            key=lambda: disk.created_at,
+            reverse=True,
+        )
         for disk in disks:
             if re.match(self._name_regex, disk.name) and disk.zone_id == self._zone_id:
                 return disk


### PR DESCRIPTION
We used to obtain random disk for sync/eternal disk manager tests. This way, the race condition with cleanup scripts existing outside and removing disks older then X is possible. Use only disk from the previous tests for incremental disks.