### PR TITLE
NEBDUTY-603: added git reset --hard before git pull for nightly builds on our ci vm

### DIFF
--- a/cloud/storage/core/tools/ci/runner/run_all.sh
+++ b/cloud/storage/core/tools/ci/runner/run_all.sh
@@ -15,6 +15,7 @@ else
 fi
 
 cd $nbspath &&
+git reset --hard &&
 git pull
 
 "${nbspath}/ya" gc cache


### PR DESCRIPTION
Otherwise if someone breaks something in the working copy our nightly builds will be broken until we manually fix the working copy