### PR TITLE
tweak ShouldHandleMutlipleQueues: wait for stats sync

### DIFF
--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -171,6 +171,11 @@ public:
 
     TSimpleStats GetStats(ui64 expectedCompleted) const
     {
+        // Without I/O, stats are synced every second and only if there is a 
+        // pending GetStats call. The first call to GetStats might not bring the
+        // latest stats; therefore, you need at least two calls so that the AIO
+        // backend will sync the stats.
+
         TSimpleStats prevStats;
         TSimpleStats stats;
         for (int i = 0; i != 5; ++i) {

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -423,7 +423,15 @@ Y_UNIT_TEST_SUITE(TServerTest)
         WaitAll(futures).Wait();
 
         TSimpleStats prevStats;
-        auto stats = Server->GetStats(prevStats);
+        TSimpleStats stats;
+
+        for (int i = 0; i != 5; ++i) {
+            stats = Server->GetStats(prevStats);
+            if (stats.Completed == requestCount) {
+                break;
+            }
+            Sleep(TDuration::Seconds(1));
+        }
 
         UNIT_ASSERT_VALUES_EQUAL(requestCount, stats.Submitted);
         UNIT_ASSERT_VALUES_EQUAL(requestCount, stats.Completed);


### PR DESCRIPTION
sometimes ShouldHandleMutlipleQueues fails because it can't get the actual stats.