### PR TITLE
Get rid of EnableNodeIdentifier setting because of its deprecation

### DIFF
--- a/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.cpp
@@ -160,7 +160,6 @@ IActorSystemPtr CreateDiskAgentActorSystem(const TDiskAgentActorSystemArgs& daAr
     servicesMask.EnableTxProxy = 1;
     servicesMask.EnableIcbService = 1;
     servicesMask.EnableLocalService = 0;    // configured manually
-    servicesMask.EnableNodeIdentifier = 1;
     servicesMask.EnableConfigsDispatcher =
         daArgs.StorageConfig->GetConfigsDispatcherServiceEnabled();
 

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -520,7 +520,6 @@ IActorSystemPtr CreateActorSystem(const TServerActorSystemArgs& sArgs)
     servicesMask.EnableTxProxy = 1;
     servicesMask.EnableIcbService = 1;
     servicesMask.EnableLocalService = 0;    // configured manually
-    servicesMask.EnableNodeIdentifier = 1;
     servicesMask.EnableSchemeBoardMonitoring = 1;
     servicesMask.EnableConfigsDispatcher =
         storageConfig->GetConfigsDispatcherServiceEnabled();

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -334,7 +334,6 @@ void TActorSystem::Init()
     servicesMask.EnableTxProxy = 1;
     servicesMask.EnableIcbService = 1;
     servicesMask.EnableLocalService = 0;    // configured manually
-    servicesMask.EnableNodeIdentifier = 1;
     servicesMask.EnableSchemeBoardMonitoring = 1;
     servicesMask.EnableConfigsDispatcher =
         Args.StorageConfig->GetConfigsDispatcherServiceEnabled();


### PR DESCRIPTION
This setting was deprecated here https://github.com/ydb-platform/ydb/pull/688