### PR TITLE
[Filestore] NBSNEBIUS-99: add counters for better introspective of data state

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -121,6 +121,10 @@ private:
         TRequestMetrics WriteBlob;
         TRequestMetrics PatchBlob;
 
+        // Compaction/cleanup stats
+        std::atomic<i64> MaxBlobsInRange{0};
+        std::atomic<i64> MaxDeletionsInRange{0};
+
         const NMetrics::IMetricsRegistryPtr StorageRegistry;
         const NMetrics::IMetricsRegistryPtr StorageFsRegistry;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -86,9 +86,14 @@ private:
         std::atomic<i64> AllocatedCompactionRangesCount{0};
         std::atomic<i64> UsedCompactionRangesCount{0};
 
-        std::atomic<i64> MixedBytesCount{0};
+        // Data stats
         std::atomic<i64> FreshBytesCount{0};
+        std::atomic<i64> MixedBytesCount{0};
+        std::atomic<i64> MixedBlobsCount{0};
+        std::atomic<i64> DeletionMarkersCount{0};
         std::atomic<i64> GarbageQueueSize{0};
+        std::atomic<i64> GarbageBytesCount{0};
+        std::atomic<i64> FreshBlocksCount{0};
 
         // Throttling
         std::atomic<i64> MaxReadBandwidth{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -96,9 +96,13 @@ void TIndexTabletActor::TMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(AllocatedCompactionRangesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(UsedCompactionRangesCount, EMetricType::MT_ABSOLUTE);
 
-    REGISTER_AGGREGATABLE_SUM(MixedBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(FreshBytesCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(MixedBytesCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(MixedBlobsCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(DeletionMarkersCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(GarbageQueueSize, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(GarbageBytesCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(FreshBlocksCount, EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(IdleTime, EMetricType::MT_DERIVATIVE);
     REGISTER_AGGREGATABLE_SUM(BusyTime, EMetricType::MT_DERIVATIVE);
@@ -191,9 +195,13 @@ void TIndexTabletActor::TMetrics::Update(
     Store(UsedHandlesCount, stats.GetUsedHandlesCount());
     Store(UsedLocksCount, stats.GetUsedLocksCount());
 
-    Store(MixedBytesCount, stats.GetMixedBlocksCount() * blockSize);
     Store(FreshBytesCount, stats.GetFreshBytesCount());
+    Store(MixedBytesCount, stats.GetMixedBlocksCount() * blockSize);
+    Store(MixedBlobsCount, stats.GetMixedBlobsCount());
+    Store(DeletionMarkersCount, stats.GetDeletionMarkersCount());
     Store(GarbageQueueSize, stats.GetGarbageQueueSize());
+    Store(GarbageBytesCount, stats.GetGarbageBlocksCount() * blockSize);
+    Store(FreshBlocksCount, stats.GetFreshBlocksCount());
 
     Store(MaxReadIops, performanceProfile.GetMaxReadIops());
     Store(MaxWriteIops, performanceProfile.GetMaxWriteIops());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -247,6 +247,26 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                 {"component", "storage_fs"},
                 {"host", "cluster"},
                 {"filesystem", "test"},
+                {"sensor", "MixedBlobsCount"}}, 0},
+            {{
+                {"component", "storage_fs"},
+                {"host", "cluster"},
+                {"filesystem", "test"},
+                {"sensor", "GarbageQueueSize"}}, 0},
+            {{
+                {"component", "storage_fs"},
+                {"host", "cluster"},
+                {"filesystem", "test"},
+                {"sensor", "GarbageBytesCount"}}, 0},
+            {{
+                {"component", "storage_fs"},
+                {"host", "cluster"},
+                {"filesystem", "test"},
+                {"sensor", "FreshBlocksCount"}}, 0},
+            {{
+                {"component", "storage_fs"},
+                {"host", "cluster"},
+                {"filesystem", "test"},
                 {"sensor", "PostponedRequests"}}, 0},
             {{
                 {"component", "storage_fs"},
@@ -287,7 +307,23 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             {{
                 {"component", "storage"},
                 {"type", "hdd"},
-                {"sensor", "UsedBytesCount"}}, 0}
+                {"sensor", "UsedBytesCount"}}, 0},
+            {{
+                {"component", "storage"},
+                {"type", "hdd"},
+                {"sensor", "MixedBlobsCount"}}, 0},
+            {{
+                {"component", "storage"},
+                {"type", "hdd"},
+                {"sensor", "GarbageQueueSize"}}, 0},
+            {{
+                {"component", "storage"},
+                {"type", "hdd"},
+                {"sensor", "GarbageBytesCount"}}, 0},
+            {{
+                {"component", "storage"},
+                {"type", "hdd"},
+                {"sensor", "FreshBlocksCount"}}, 0}
         });
         // clang-format on
     }
@@ -577,6 +613,47 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             {{{"sensor", "MaxDeletionsInRange"}}, countrRewrites * BlockGroupSize},
         });
         // clang-format on
+    }
+
+    Y_UNIT_TEST(ShouldProperlyReportDataMetrics)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(false);
+
+        TTestEnv env({}, storageConfig);
+        auto registry = env.GetRegistry();
+
+        env.CreateSubDomain("nfs");
+        const auto nodeIdx = env.CreateNode("nfs");
+        const auto tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+        const auto nodeId =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        const auto handle = CreateHandle(tablet, nodeId);
+
+        tablet.WriteData(handle, 1, DefaultBlockSize, static_cast<char>('a'));
+        const auto sz = DefaultBlockSize * BlockGroupSize;
+        tablet.WriteData(handle, sz * 10, sz, 'a');
+
+        tablet.AdvanceTime(TDuration::Seconds(15));
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(5));
+
+        TTestRegistryVisitor visitor;
+        // clang-format off
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{{"sensor", "FreshBytesCount"}, {"filesystem", "test"}},   DefaultBlockSize - 1},
+            {{{"sensor", "FreshBlocksCount"}, {"filesystem", "test"}},  1},
+            {{{"sensor", "MixedBlobsCount"}, {"filesystem", "test"}}, 1},
+            {{{"sensor", "MixedBytesCount"}, {"filesystem", "test"}}, sz},
+
+        });
+
+        // clang-format on
+
+        tablet.FlushBytes();
     }
 }
 


### PR DESCRIPTION
1. Add following counters to monitoring. They are present in `GetStorageStats` response, but were missing in monitoring
    * `MixedBlobsCount`
    * `DeletionMarkersCount`
    * `GarbageQueueSize`
    * `GarbageBytesCount`
    * `FreshBlocksCount`

2. Add following counters to keep better track of compaction map state:
    * `MaxBlobsInRange`
    * `MaxDeletionsInRange`

References #95 