### PR TITLE
issue-324: added tablet-level metrics for WriteData/ReadData/DescribeData requests

### DIFF
--- a/cloud/filestore/libs/storage/core/request_info.h
+++ b/cloud/filestore/libs/storage/core/request_info.h
@@ -32,6 +32,9 @@ struct TRequestInfo
     const ui64 Started = GetCycleCount();
     ui64 ExecCycles = 0;
 
+    // ActorSystem start ts. Might be empty.
+    TInstant StartedTs;
+
     TRequestInfo() = default;
 
     TRequestInfo(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -125,6 +125,9 @@ private:
         TRequestMetrics ReadBlob;
         TRequestMetrics WriteBlob;
         TRequestMetrics PatchBlob;
+        TRequestMetrics ReadData;
+        TRequestMetrics DescribeData;
+        TRequestMetrics WriteData;
 
         // Compaction/cleanup stats
         std::atomic<i64> MaxBlobsInRange{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -165,6 +165,42 @@ void TIndexTabletActor::TMetrics::Register(
         AggregatableFsRegistry,
         {CreateLabel("request", "PatchBlob"), CreateLabel("histogram", "Time")});
 
+    REGISTER_AGGREGATABLE_SUM(
+        ReadData.Count,
+        EMetricType::MT_DERIVATIVE);
+
+    REGISTER_AGGREGATABLE_SUM(
+        ReadData.RequestBytes,
+        EMetricType::MT_DERIVATIVE);
+
+    ReadData.Time.Register(
+        AggregatableFsRegistry,
+        {CreateLabel("request", "ReadData"), CreateLabel("histogram", "Time")});
+
+    REGISTER_AGGREGATABLE_SUM(
+        DescribeData.Count,
+        EMetricType::MT_DERIVATIVE);
+
+    REGISTER_AGGREGATABLE_SUM(
+        DescribeData.RequestBytes,
+        EMetricType::MT_DERIVATIVE);
+
+    DescribeData.Time.Register(
+        AggregatableFsRegistry,
+        {CreateLabel("request", "DescribeData"), CreateLabel("histogram", "Time")});
+
+    REGISTER_AGGREGATABLE_SUM(
+        WriteData.Count,
+        EMetricType::MT_DERIVATIVE);
+
+    REGISTER_AGGREGATABLE_SUM(
+        WriteData.RequestBytes,
+        EMetricType::MT_DERIVATIVE);
+
+    WriteData.Time.Register(
+        AggregatableFsRegistry,
+        {CreateLabel("request", "WriteData"), CreateLabel("histogram", "Time")});
+
     REGISTER_LOCAL(MaxBlobsInRange, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(MaxDeletionsInRange, EMetricType::MT_ABSOLUTE);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -245,6 +245,14 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // ReadWrite completion
+    //
+
+    struct TReadWriteCompleted: TDataOperationCompleted, TOperationCompleted
+    {
+    };
+
+    //
     // AddBlob
     //
 
@@ -601,8 +609,8 @@ struct TEvIndexTabletPrivate
     using TEvUpdateCounters = TRequestEvent<TEmpty, EvUpdateCounters>;
     using TEvUpdateLeakyBucketCounters = TRequestEvent<TEmpty, EvUpdateLeakyBucketCounters>;
 
-    using TEvReadDataCompleted = TResponseEvent<TOperationCompleted, EvReadDataCompleted>;
-    using TEvWriteDataCompleted = TResponseEvent<TOperationCompleted, EvWriteDataCompleted>;
+    using TEvReadDataCompleted = TResponseEvent<TReadWriteCompleted, EvReadDataCompleted>;
+    using TEvWriteDataCompleted = TResponseEvent<TReadWriteCompleted, EvWriteDataCompleted>;
 };
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
The same metrics as for ReadBlob/WriteBlob/PatchBlob:
* Count
* RequestBytes
* Time

#324 