### PR TITLE
Improve clang-format. Prefer return type on its own line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -179,7 +179,7 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyIndentedWhitespace: 0
-PenaltyReturnTypeOnItsOwnLine: 20000
+PenaltyReturnTypeOnItsOwnLine: 0
 PointerAlignment: Left
 PPIndentWidth:   -1
 QualifierAlignment: Leave


### PR DESCRIPTION
Форматируем так:
```
std::unique_ptr<TEvService::TEvGetCheckpointStatusRequest>
TVolumeClient::CreateGetCheckpointStatusRequest(const TString& checkpointId)
```
А было так:
```
std::unique_ptr<TEvService::TEvGetCheckpointStatusRequest> TVolumeClient::
    CreateGetCheckpointStatusRequest(const TString& checkpointId)
```