### PR TITLE
NBS #179: switch fast path volume to regular path during migrations

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_events.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_events.cpp
@@ -2,6 +2,8 @@
 
 namespace NCloud::NBlockStore::NServer {
 
+using namespace NThreading;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -12,17 +14,23 @@ private:
     IEndpointEventHandlerPtr Handler;
 
 public:
-    void OnVolumeConnectionEstablished(const TString& diskId) override;
+    TFuture<NProto::TError> SwitchEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason) override;
     void Register(IEndpointEventHandlerPtr listener) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TEndpointEventProxy::OnVolumeConnectionEstablished(const TString& diskId)
+TFuture<NProto::TError> TEndpointEventProxy::SwitchEndpointIfNeeded(
+    const TString& diskId,
+    const TString& reason)
 {
     if (Handler) {
-        Handler->OnVolumeConnectionEstablished(diskId);
+        return Handler->SwitchEndpointIfNeeded(diskId, reason);
     }
+
+    return MakeFuture(MakeError(S_OK));
 }
 
 void TEndpointEventProxy::Register(IEndpointEventHandlerPtr listener)

--- a/cloud/blockstore/libs/endpoints/endpoint_events.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_events.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/blockstore/public/api/protos/volume.pb.h>
+#include <cloud/storage/core/libs/common/error.h>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -12,7 +13,9 @@ struct IEndpointEventHandler
 {
     virtual ~IEndpointEventHandler() = default;
 
-    virtual void OnVolumeConnectionEstablished(const TString& diskId) = 0;
+    virtual NThreading::TFuture<NProto::TError> SwitchEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason) = 0;
 };
 
 struct IEndpointEventProxy: public IEndpointEventHandler

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -138,6 +138,7 @@ private:
 
 public:
     ui32 AlterEndpointCounter = 0;
+    ui32 SwitchEndpointCounter = 0;
 
 public:
     TTestEndpointListener(
@@ -203,6 +204,8 @@ public:
         Y_UNUSED(request);
         Y_UNUSED(volume);
         Y_UNUSED(session);
+
+        ++SwitchEndpointCounter;
 
         return MakeFuture<NProto::TError>();
     }
@@ -366,7 +369,8 @@ IEndpointManagerPtr CreateEndpointManager(
     TBootstrap& bootstrap,
     THashMap<NProto::EClientIpcType, IEndpointListenerPtr> endpointListeners,
     IServerStatsPtr serverStats = CreateServerStatsStub(),
-    TString nbdSocketSuffix = "")
+    TString nbdSocketSuffix = "",
+    IEndpointEventProxyPtr endpointEventHandler = CreateEndpointEventProxy())
 {
     TSessionManagerOptions sessionManagerOptions;
     sessionManagerOptions.DefaultClientConfig.SetRequestTimeout(
@@ -394,7 +398,7 @@ IEndpointManagerPtr CreateEndpointManager(
         bootstrap.Logging,
         serverStats,
         bootstrap.Executor,
-        CreateEndpointEventProxy(),
+        std::move(endpointEventHandler),
         std::move(sessionManager),
         std::move(endpointListeners),
         std::move(nbdSocketSuffix));
@@ -1180,6 +1184,68 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
                 S_ALREADY,
                 response.GetError().GetCode(),
                 response.GetError());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldSwitchEndpointWhenNotified)
+    {
+        TMap<TString, NProto::TMountVolumeRequest> mountedVolumes;
+        TBootstrap bootstrap(CreateTestService(mountedVolumes));
+
+        auto endpointEventHandler = CreateEndpointEventProxy();
+        auto listener = std::make_shared<TTestEndpointListener>();
+        auto manager = CreateEndpointManager(
+            bootstrap,
+            {{ NProto::IPC_VHOST, listener }},
+            CreateServerStatsStub(),
+            "",
+            endpointEventHandler);
+
+        bootstrap.Start();
+
+        auto socketPath = "testSocketPath";
+        auto diskId = "testDiskId";
+
+        {
+            // without started endpoint SwitchEndpointIfNeeded is ignored
+            auto future = endpointEventHandler->SwitchEndpointIfNeeded(
+                diskId, "test");
+            auto error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                error);
+            UNIT_ASSERT_VALUES_EQUAL(0, listener->SwitchEndpointCounter);
+        }
+
+        NProto::TStartEndpointRequest startRequest;
+        SetDefaultHeaders(startRequest);
+        startRequest.SetUnixSocketPath(socketPath);
+        startRequest.SetDiskId(diskId);
+        startRequest.SetClientId(TestClientId);
+        startRequest.SetIpcType(NProto::IPC_VHOST);
+
+        {
+            auto future = StartEndpoint(*manager, startRequest);
+            auto response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError());
+        }
+
+        {
+            // with started endpoint SwitchEndpointIfNeeded leads to
+            // SwitchEndpoint call
+            auto future = endpointEventHandler->SwitchEndpointIfNeeded(
+                diskId,
+                "test");
+            auto error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                error);
+            UNIT_ASSERT_VALUES_EQUAL(1, listener->SwitchEndpointCounter);
         }
     }
 }

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -1187,7 +1187,7 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldSwitchEndpointWhenNotified)
+    Y_UNIT_TEST(ShouldSwitchEndpointWhenEndpointStarted)
     {
         TMap<TString, NProto::TMountVolumeRequest> mountedVolumes;
         TBootstrap bootstrap(CreateTestService(mountedVolumes));

--- a/cloud/blockstore/libs/endpoints/session_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager.cpp
@@ -687,7 +687,7 @@ TResultOrError<TEndpointPtr> TSessionManager::CreateEndpoint(
     if (Options.StrictContractValidation &&
         !volume.GetIsFastPathEnabled()   // switching fast path to slow path
                                          // during migration might lead to
-                                         // validation false posiitives
+                                         // validation false positives
     )
     {
         client = CreateValidationClient(

--- a/cloud/blockstore/libs/endpoints/session_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager.cpp
@@ -684,7 +684,12 @@ TResultOrError<TEndpointPtr> TSessionManager::CreateEndpoint(
             std::move(throttler));
     }
 
-    if (Options.StrictContractValidation) {
+    if (Options.StrictContractValidation &&
+        !volume.GetIsFastPathEnabled()   // switching fast path to slow path
+                                         // during migration might lead to
+                                         // validation false posiitives
+    )
+    {
         client = CreateValidationClient(
             Logging,
             Monitoring,

--- a/cloud/blockstore/libs/storage/api/volume.h
+++ b/cloud/blockstore/libs/storage/api/volume.h
@@ -206,6 +206,25 @@ struct TEvVolume
     };
 
     //
+    // PreparePartitionMigrationRequest
+    //
+    struct TPreparePartitionMigrationRequest
+    {
+    };
+
+    //
+    // PreparePartitionMigrationResponse
+    //
+    struct TPreparePartitionMigrationResponse
+    {
+        bool IsMigrationAllowed;
+
+        explicit TPreparePartitionMigrationResponse(bool isMigrationAllowed)
+            : IsMigrationAllowed(isMigrationAllowed)
+        {}
+    };
+
+    //
     // Events declaration
     //
 
@@ -293,6 +312,9 @@ struct TEvVolume
         EvChangeStorageConfigRequest = EvBegin + 54,
         EvChangeStorageConfigResponse = EvBegin + 55,
 
+        EvPreparePartitionMigrationRequest = EvBegin + 56,
+        EvPreparePartitionMigrationResponse = EvBegin + 57,
+
         EvEnd
     };
 
@@ -354,6 +376,16 @@ struct TEvVolume
     using TEvClearBaseDiskIdToTabletIdMapping = TRequestEvent<
         TClearBaseDiskIdToTabletIdMapping,
         EvClearBaseDiskIdToTabletIdMapping
+    >;
+
+    using TEvPreparePartitionMigrationRequest = TRequestEvent<
+        TPreparePartitionMigrationRequest,
+        EvPreparePartitionMigrationRequest
+    >;
+
+    using TEvPreparePartitionMigrationResponse = TRequestEvent<
+        TPreparePartitionMigrationResponse,
+        EvPreparePartitionMigrationResponse
     >;
 };
 

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -122,6 +122,7 @@ enum class EPublishingPolicy
     xxx(HasStorageConfigPatch,      Generic, Permanent,            __VA_ARGS__)\
     xxx(LongRunningReadBlob,        Generic, Expiring,             __VA_ARGS__)\
     xxx(LongRunningWriteBlob,       Generic, Expiring,             __VA_ARGS__)\
+    xxx(UseFastPath,                Generic, Permanent,            __VA_ARGS__)\
 
 
 #define BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(xxx, ...)            \

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -343,10 +343,10 @@ private:
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ITraceSerializerPtr TraceSerializer;
-    const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const NLogbroker::IServicePtr LogbrokerService;
     const NNotify::IServicePtr NotifyService;
     const NRdma::IClientPtr RdmaClient;
+    const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const bool IsDiskRegistrySpareNode;
 
 public:
@@ -361,6 +361,7 @@ public:
             NLogbroker::IServicePtr logbrokerService,
             NNotify::IServicePtr notifyService,
             NRdma::IClientPtr rdmaClient,
+            NServer::IEndpointEventHandlerPtr endpointEventHandler,
             bool isDiskRegistrySpareNode)
         : AppConfig(appConfig)
         , Logging(std::move(logging))
@@ -372,6 +373,7 @@ public:
         , LogbrokerService(std::move(logbrokerService))
         , NotifyService(std::move(notifyService))
         , RdmaClient(std::move(rdmaClient))
+        , EndpointEventHandler(std::move(endpointEventHandler))
         , IsDiskRegistrySpareNode(isDiskRegistrySpareNode)
     {}
 
@@ -387,6 +389,7 @@ public:
         auto logbrokerService = LogbrokerService;
         auto notifyService = NotifyService;
         auto rdmaClient = RdmaClient;
+        auto endpointEventHandler = EndpointEventHandler;
         auto logging = Logging;
 
         auto volumeFactory = [=] (const TActorId& owner, TTabletStorageInfo* storage) {
@@ -400,7 +403,8 @@ public:
                 profileLog,
                 blockDigestGenerator,
                 traceSerializer,
-                rdmaClient
+                rdmaClient,
+                endpointEventHandler
             );
             return actor.release();
         };
@@ -496,6 +500,7 @@ IActorSystemPtr CreateActorSystem(const TServerActorSystemArgs& sArgs)
             sArgs.LogbrokerService,
             sArgs.NotifyService,
             sArgs.RdmaClient,
+            sArgs.EndpointEventHandler,
             sArgs.IsDiskRegistrySpareNode));
     };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -11,6 +11,10 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+constexpr TDuration PrepareMigrationInterval = TDuration::Seconds(5);
+
+////////////////////////////////////////////////////////////////////////////////
+
 TNonreplicatedPartitionMigrationActor::TNonreplicatedPartitionMigrationActor(
         TStorageConfigPtr config,
         IProfileLogPtr profileLog,
@@ -42,7 +46,9 @@ TNonreplicatedPartitionMigrationActor::TNonreplicatedPartitionMigrationActor(
 void TNonreplicatedPartitionMigrationActor::OnBootstrap(
     const NActors::TActorContext& ctx)
 {
-    StartWork(ctx, CreateSrcActor(ctx), CreateDstActor(ctx));
+    InitWork(ctx, CreateSrcActor(ctx), CreateDstActor(ctx));
+
+    PrepareForMigration(ctx);
 }
 
 bool TNonreplicatedPartitionMigrationActor::OnMessage(
@@ -52,6 +58,12 @@ bool TNonreplicatedPartitionMigrationActor::OnMessage(
     Y_UNUSED(ctx);
 
     switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvVolume::TEvPreparePartitionMigrationRequest,
+            HandlePreparePartitionMigrationRequest);
+        HFunc(
+            TEvVolume::TEvPreparePartitionMigrationResponse,
+            HandlePreparePartitionMigrationResponse);
         HFunc(TEvVolume::TEvMigrationStateUpdated, HandleMigrationStateUpdated);
         HFunc(
             TEvDiskRegistry::TEvFinishMigrationResponse,
@@ -235,6 +247,42 @@ void TNonreplicatedPartitionMigrationActor::HandleFinishMigrationResponse(
     if (GetErrorKind(error) == EErrorKind::ErrorRetriable) {
         FinishMigration(ctx, true);
     }
+}
+
+void TNonreplicatedPartitionMigrationActor::PrepareForMigration(
+    const NActors::TActorContext& ctx)
+{
+    auto request =
+        std::make_unique<TEvVolume::TEvPreparePartitionMigrationRequest>();
+
+    NCloud::Send(
+        ctx,
+        SrcConfig->GetParentActorId(),
+        std::move(request));
+}
+
+void TNonreplicatedPartitionMigrationActor::HandlePreparePartitionMigrationRequest(
+    const TEvVolume::TEvPreparePartitionMigrationRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    PrepareForMigration(ctx);
+}
+
+void TNonreplicatedPartitionMigrationActor::HandlePreparePartitionMigrationResponse(
+    const TEvVolume::TEvPreparePartitionMigrationResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    bool isMigrationAllowed = ev->Get()->IsMigrationAllowed;
+    if (!isMigrationAllowed) {
+        ctx.Schedule(
+            PrepareMigrationInterval,
+            new TEvVolume::TEvPreparePartitionMigrationRequest());
+        return;
+    }
+
+    StartWork(ctx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -46,6 +46,7 @@ public:
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
 
 private:
+    void PrepareForMigration(const NActors::TActorContext& ctx);
     void FinishMigration(const NActors::TActorContext& ctx, bool isRetry);
     NActors::TActorId CreateSrcActor(const NActors::TActorContext& ctx);
     NActors::TActorId CreateDstActor(const NActors::TActorContext& ctx);
@@ -56,6 +57,14 @@ private:
 
     void HandleFinishMigrationResponse(
         const TEvDiskRegistry::TEvFinishMigrationResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePreparePartitionMigrationRequest(
+        const TEvVolume::TEvPreparePartitionMigrationRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePreparePartitionMigrationResponse(
+        const TEvVolume::TEvPreparePartitionMigrationResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -58,8 +58,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 // To migrate data, it is necessary to inherit from this class. To get started,
-// you need to call the StartWork() method and pass the source and destination
-// actors to it.
+// you need to call the InitWork() method and pass the source and destination
+// actors to it. Then when you ready to run migration call StartWork()
 
 // About error handling. If migration errors occur, they cannot be fixed, on the
 // VolumeActor/PartitionActor side since DiskRegistry manages the allocation of
@@ -90,6 +90,7 @@ private:
 
     TProcessingBlocks ProcessingBlocks;
     bool MigrationInProgress = false;
+    bool MigrationStarted = false;
 
     TRequestsInProgress<ui64, TBlockRange64> WriteAndZeroRequestsInProgress{
         EAllowedRequests::WriteOnly};
@@ -130,11 +131,14 @@ public:
 
     virtual void Bootstrap(const NActors::TActorContext& ctx);
 
-    // Called from the inheritor to get started.
-    void StartWork(
+    // Called from the inheritor to initialize migration.
+    void InitWork(
         const NActors::TActorContext& ctx,
         NActors::TActorId srcActorId,
         NActors::TActorId dstActorId);
+
+    // Called from the inheritor to start migration.
+    void StartWork(const NActors::TActorContext& ctx);
 
     // Called from the inheritor to mark ranges that do not need to be
     // processed.

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -48,9 +48,8 @@ void TNonreplicatedPartitionMigrationCommonActor::StartWork(
 void TNonreplicatedPartitionMigrationCommonActor::ContinueMigrationIfNeeded(
     const NActors::TActorContext& ctx)
 {
-    if (!MigrationStarted
-            || MigrationInProgress
-            || !ProcessingBlocks.IsProcessingStarted())
+    if (!MigrationStarted || MigrationInProgress ||
+        !ProcessingBlocks.IsProcessingStarted())
     {
         return;
     }
@@ -208,7 +207,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleRangeMigrated(
 void TNonreplicatedPartitionMigrationCommonActor::ScheduleMigrateNextRange(
     const TActorContext& ctx)
 {
-    auto deadline =
+    const auto deadline =
         LastRangeMigrationStartTs + MigrationOwner->CalculateMigrationTimeout();
 
     if (ctx.Now() >= deadline) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -79,7 +79,7 @@ struct TTestEnv
             TMigrations migrations,
             NProto::EVolumeIOMode ioMode,
             bool useRdma,
-            TMigrationStatePtr migrationState = nullptr)
+            TMigrationStatePtr migrationState)
         : Runtime(runtime)
         , ActorId(0, "YYY")
         , VolumeActorId(0, "VVV")
@@ -231,7 +231,9 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
-            false);
+            false,
+            nullptr   // no migration state
+        );
 
         TPartitionClient client(runtime, env.ActorId);
 
@@ -263,7 +265,9 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
-            true);
+            true,
+            nullptr   // no migration state
+        );
 
         env.Rdma().InitAllEndpoints();
 
@@ -280,7 +284,9 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_ERROR_READ_ONLY,
-            false);
+            false,
+            nullptr   // no migration state
+        );
 
         // petya should be migrated => 3 ranges
         WaitForMigrations(runtime, 3);
@@ -295,7 +301,9 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
-            false);
+            false,
+            nullptr   // no migration state
+        );
 
         TPartitionClient client(runtime, env.ActorId);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -85,12 +85,25 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TMigrationState
+{
+    bool IsMigrationAllowed = true;
+};
+
+using TMigrationStatePtr = std::shared_ptr<TMigrationState>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TDummyActor final
     : public NActors::TActor<TDummyActor>
 {
+private:
+    TMigrationStatePtr MigrationState;
+
 public:
-    TDummyActor()
+    TDummyActor(TMigrationStatePtr migrationState = nullptr)
         : TActor(&TThis::StateWork)
+        , MigrationState(std::move(migrationState))
     {
     }
 
@@ -111,6 +124,8 @@ private:
             HFunc(TEvVolume::TEvResyncFinished, HandleResyncFinished);
 
             HFunc(TEvDiskRegistry::TEvFinishMigrationRequest, HandleFinishMigration);
+
+            HFunc(TEvVolume::TEvPreparePartitionMigrationRequest, HandlePreparePartitionMigration);
 
             default:
                 Y_ABORT("Unexpected event %x", ev->GetTypeRewrite());
@@ -175,6 +190,16 @@ private:
     {
         NCloud::Reply(ctx, *ev,
             std::make_unique<TEvDiskRegistry::TEvFinishMigrationResponse>());
+    }
+
+    void HandlePreparePartitionMigration(
+        const TEvVolume::TEvPreparePartitionMigrationRequest::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        NCloud::Reply(ctx, *ev,
+            std::make_unique<TEvVolume::TEvPreparePartitionMigrationResponse>(
+                MigrationState ? MigrationState->IsMigrationAllowed : true
+                ));
     }
 };
 
@@ -395,6 +420,34 @@ inline void WaitForMigrations(
     }
 
     UNIT_ASSERT_VALUES_EQUAL(rangeCount, migratedRanges);
+}
+
+inline void WaitForNoMigrations(NActors::TTestBasicRuntime& runtime, TDuration timeout)
+{
+    ui32 migratedRanges = 0;
+    runtime.SetObserverFunc([&] (auto& event) {
+        switch (event->GetTypeRewrite()) {
+            case TEvNonreplPartitionPrivate::EvRangeMigrated: {
+                auto* msg =
+                    event->template Get<TEvNonreplPartitionPrivate::TEvRangeMigrated>();
+                if (!HasError(msg->Error)) {
+                    ++migratedRanges;
+                }
+                break;
+            }
+        }
+        return NActors::TTestActorRuntime::DefaultObserverFunc(event);
+    });
+
+    NActors::TDispatchOptions options;
+    options.FinalEvents = {
+        NActors::TDispatchOptions::TFinalEventCondition(
+            TEvNonreplPartitionPrivate::EvRangeMigrated)
+    };
+
+    runtime.DispatchEvents(options, timeout);
+
+    UNIT_ASSERT_VALUES_EQUAL(0, migratedRanges);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -196,10 +196,11 @@ private:
         const TEvVolume::TEvPreparePartitionMigrationRequest::TPtr& ev,
         const NActors::TActorContext& ctx)
     {
-        NCloud::Reply(ctx, *ev,
+        NCloud::Reply(
+            ctx,
+            *ev,
             std::make_unique<TEvVolume::TEvPreparePartitionMigrationResponse>(
-                MigrationState ? MigrationState->IsMigrationAllowed : true
-                ));
+                MigrationState ? MigrationState->IsMigrationAllowed : true));
     }
 };
 

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
@@ -212,7 +212,7 @@ void TVolumeClientActor::HandleConnect(
         "Connection to tablet: " <<
         msg->TabletId <<
         " has been established");
-    EndpointEventHandler->OnVolumeConnectionEstablished(DiskId);
+    EndpointEventHandler->SwitchEndpointIfNeeded(DiskId, "volume connected");
 }
 
 void TVolumeClientActor::HandleDisconnect(

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -453,6 +453,7 @@ void TStartVolumeActor::StartTablet(const TActorContext& ctx)
             blockDigestGenerator,
             traceSerializer,
             rdmaClient,
+            endpointEventHandler,
             EVolumeStartMode::MOUNTED);
         return actor.release();
     };

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -242,7 +242,8 @@ ui32 TTestEnv::CreateBlockStoreNode(
             CreateProfileLogStub(),
             CreateBlockDigestGeneratorStub(),
             TraceSerializer,
-            nullptr // RdmaClient
+            nullptr, // RdmaClient
+            NServer::CreateEndpointEventProxy()
         );
         return actor.release();
     };

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -1,5 +1,6 @@
 #include "test_env.h"
 
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/storage/core/libs/common/media.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -691,7 +692,8 @@ std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
                 CreateLoggingService("console"),
                 "BLOCKSTORE_TRACE",
                 NLwTraceMonPage::TraceManager(false)),
-            rdmaClient
+            rdmaClient,
+            NServer::CreateEndpointEventProxy()
         );
         return tablet.release();
     };

--- a/cloud/blockstore/libs/storage/volume/volume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume.cpp
@@ -19,6 +19,7 @@ IActorPtr CreateVolumeTablet(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     ITraceSerializerPtr traceSerializer,
     NRdma::IClientPtr rdmaClient,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     EVolumeStartMode startMode)
 {
     return std::make_unique<TVolumeActor>(
@@ -30,6 +31,7 @@ IActorPtr CreateVolumeTablet(
         std::move(blockDigestGenerator),
         std::move(traceSerializer),
         std::move(rdmaClient),
+        std::move(endpointEventHandler),
         startMode);
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume.h
+++ b/cloud/blockstore/libs/storage/volume/volume.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
@@ -30,6 +31,7 @@ NActors::IActorPtr CreateVolumeTablet(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     ITraceSerializerPtr traceSerializer,
     NRdma::IClientPtr rdmaClient,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
     EVolumeStartMode startMode = EVolumeStartMode::ONLINE);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -57,6 +57,7 @@ TVolumeActor::TVolumeActor(
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ITraceSerializerPtr traceSerializer,
         NRdma::IClientPtr rdmaClient,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         EVolumeStartMode startMode)
     : TActor(&TThis::StateBoot)
     , TTabletBase(owner, std::move(storage))
@@ -67,6 +68,7 @@ TVolumeActor::TVolumeActor(
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , TraceSerializer(std::move(traceSerializer))
     , RdmaClient(std::move(rdmaClient))
+    , EndpointEventHandler(std::move(endpointEventHandler))
     , StartMode(startMode)
     , ThrottlerLogger(
         TabletID(),
@@ -937,6 +939,8 @@ STFUNC(TVolumeActor::StateWork)
         HFunc(TEvPartition::TEvGarbageCollectorCompleted, HandleGarbageCollectorCompleted);
 
         HFunc(TEvLocal::TEvTabletMetrics, HandleTabletMetrics);
+
+        HFunc(TEvVolume::TEvPreparePartitionMigrationRequest, HandlePreparePartitionMigration);
 
         HFunc(TEvVolume::TEvUpdateMigrationState, HandleUpdateMigrationState);
         HFunc(TEvVolume::TEvUpdateResyncState, HandleUpdateResyncState);

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -190,6 +190,7 @@ private:
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ITraceSerializerPtr TraceSerializer;
     const NRdma::IClientPtr RdmaClient;
+    NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const EVolumeStartMode StartMode;
     TVolumeThrottlerLogger ThrottlerLogger;
 
@@ -349,6 +350,7 @@ public:
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ITraceSerializerPtr traceSerializer,
         NRdma::IClientPtr rdmaClient,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler,
         EVolumeStartMode startMode);
     ~TVolumeActor() override;
 
@@ -750,6 +752,10 @@ private:
 
     void HandleUpdateMigrationState(
         const TEvVolume::TEvUpdateMigrationState::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePreparePartitionMigration(
+        const TEvVolume::TEvPreparePartitionMigrationRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleUpdateResyncState(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -1075,6 +1075,13 @@ void TVolumeActor::RenderConfig(IOutputStream& out) const
                 }
 
                 TABLER() {
+                    TABLED() { out << "UseFastPath"; }
+                    TABLED() {
+                        out << State->GetUseFastPath();
+                    }
+                }
+
+                TABLER() {
                     TABLED() { out << "Throttler"; }
                     TABLED() {
                         const auto& tp = State->GetThrottlingPolicy();

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -371,7 +371,9 @@ void TVolumeActor::SendSelfStatsToService(const TActorContext& ctx)
     simple.LastVolumeLoadTime.Set(GetLoadTime().MicroSeconds());
     simple.LastVolumeStartTime.Set(GetStartTime().MicroSeconds());
     simple.HasStorageConfigPatch.Set(HasStorageConfigPatch);
-    simple.UseFastPath.Set(State->GetUseFastPath());
+    simple.UseFastPath.Set(
+        State->GetUseFastPath() &&
+        State->GetMeta().GetMigrations().size() == 0);
 
     SendVolumeSelfCounters(ctx);
     VolumeSelfCounters = CreateVolumeSelfCounters(CountersPolicy);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -371,6 +371,7 @@ void TVolumeActor::SendSelfStatsToService(const TActorContext& ctx)
     simple.LastVolumeLoadTime.Set(GetLoadTime().MicroSeconds());
     simple.LastVolumeStartTime.Set(GetStartTime().MicroSeconds());
     simple.HasStorageConfigPatch.Set(HasStorageConfigPatch);
+    simple.UseFastPath.Set(State->GetUseFastPath());
 
     SendVolumeSelfCounters(ctx);
     VolumeSelfCounters = CreateVolumeSelfCounters(CountersPolicy);

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -184,6 +184,7 @@ void TVolumeState::Reset()
         || StorageConfig->IsUseRdmaFeatureEnabled(
             Meta.GetConfig().GetCloudId(),
             Meta.GetConfig().GetFolderId());
+    UseFastPath = false;
     UseRdmaForThisVolume = false;
     AcceptInvalidDiskAllocationResponse = false;
 
@@ -236,6 +237,8 @@ void TVolumeState::Reset()
             UseRdmaForThisVolume = true;
         } else if (tag == "max-timed-out-device-state-duration") {
             TDuration::TryParse(value, MaxTimedOutDeviceStateDuration);
+        } else if (tag == "use-fastpath") {
+            UseFastPath = true;
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -143,6 +143,7 @@ private:
     bool TrackUsedBlocks = false;
     bool MaskUnusedBlocks = false;
     bool UseRdma = false;
+    bool UseFastPath = false;
     bool UseRdmaForThisVolume = false;
     bool RdmaUnavailable = false;
     TDuration MaxTimedOutDeviceStateDuration;
@@ -566,6 +567,11 @@ public:
     bool GetUseRdmaForThisVolume() const
     {
         return UseRdmaForThisVolume;
+    }
+
+    bool GetUseFastPath() const
+    {
+        return UseFastPath;
     }
 
     void SetRdmaUnavailable()

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -7252,7 +7252,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             }
         );
 
-        volume.WaitReady();
+        volume.UpdateVolumeConfig();
 
         UNIT_ASSERT(externalBootHappened);
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -7167,6 +7167,69 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(mapping["Unknown"], "Not found");
     }
 
+    Y_UNIT_TEST(ShouldGetUseFastPathStats)
+    {
+        NProto::TStorageServiceConfig config;
+        auto runtime = PrepareTestActorRuntime(config);
+
+        ui32 hasUseFastPathCounter = 0;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->Recipient == MakeStorageStatsServiceId() &&
+                    event->GetTypeRewrite() ==
+                        TEvStatsService::EvVolumeSelfCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumeSelfCounters>();
+
+                    hasUseFastPathCounter =
+                        msg->VolumeSelfCounters->Simple.UseFastPath.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        TVolumeClient volume(*runtime);
+
+        int version = 0;
+
+        auto updateConfig = [&](auto tags)
+        {
+            volume.UpdateVolumeConfig(
+                0,       // maxBandwidth
+                0,       // maxIops
+                0,       // burstPercentage
+                0,       // maxPostponedWeight
+                false,   // throttlingEnabled
+                ++version,
+                NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+                1024,       // block count per partition
+                "vol0",     // diskId
+                "cloud",    // cloudId
+                "folder",   // folderId
+                1,          // partition count
+                0,          // blocksPerStripe
+                tags);
+            volume.WaitReady();
+        };
+
+        auto checkUseFastPath = [&](auto expectedVal)
+        {
+            volume.SendToPipe(
+                std::make_unique<TEvVolumePrivate::TEvUpdateCounters>());
+            runtime->DispatchEvents({}, TDuration::Seconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(expectedVal, hasUseFastPathCounter);
+        };
+
+        updateConfig("");
+        checkUseFastPath(0);
+
+        updateConfig("use-fastpath");
+        checkUseFastPath(1);
+    }
+
     Y_UNIT_TEST(ShouldDisableByFlag)
     {
         NProto::TStorageServiceConfig config;
@@ -7189,7 +7252,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             }
         );
 
-        volume.UpdateVolumeConfig();
+        volume.WaitReady();
 
         UNIT_ASSERT(externalBootHappened);
 


### PR DESCRIPTION
When volume starts migration the endpoint will be switched to use regular data
path (NRD volume through actor system).

Additionally when "use-fastpath" added/removed to volume tags the endpoint will
switch to use fast/regular data path

Additionally resolves #312
