### PR TITLE
NBS-4902: [Disk Manager] fix race condition in migrate disk task

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/disks/migrate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/migrate_disk_task.go
@@ -255,6 +255,19 @@ func (t *migrateDiskTask) start(
 		} else {
 			t.state.RelocateInfo = &protos.RelocateInfo{}
 		}
+	} else if len(t.state.RelocateInfo.TargetBaseDiskID) != 0 {
+		// Need to check that RelocateInfo is still actual.
+		// OverlayDiskRebasing should be idempotent.
+		err := t.poolStorage.OverlayDiskRebasing(ctx, storage.RebaseInfo{
+			OverlayDisk:      t.request.Disk,
+			BaseDiskID:       t.state.RelocateInfo.BaseDiskID,
+			TargetZoneID:     t.request.DstZoneId,
+			TargetBaseDiskID: t.state.RelocateInfo.TargetBaseDiskID,
+			SlotGeneration:   t.state.RelocateInfo.SlotGeneration,
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	if !t.state.IsDiskCloned {


### PR DESCRIPTION
scenario of race condition:
1) migration is created, fillGeneration = 5
2) migration is created, fillGeneration = 6
3) complete RelocateOverlayDiskTx for migration with fillGeneration = 6
4) complete RelocateOverlayDiskTx for migration with fillGeneration = 5 (this step causing cancellation of previous base disk rebasing)
5) migration with fillGeneration = 6 is trying to clone src volume and get error because base disk from relocateInfo does not exists

**migration with fillGeneration = 5 will not cancel because dst volume is located in different zone than in migration with fillGeneration = 6**