### PR TITLE
issue-324: removed IBlockBuffer::GetContent and GetContentRef methods, extracted CopyFileData implementation, rewritten it without GetContent/GetContentRef usage, added uts for it (preparation to implement a lazy-alloc block buffer to use it in HandleDescribeData)

### DIFF
--- a/cloud/filestore/libs/storage/model/block_buffer.h
+++ b/cloud/filestore/libs/storage/model/block_buffer.h
@@ -20,14 +20,21 @@ struct IBlockBuffer
     virtual TStringBuf GetUnalignedTail() = 0;
     virtual void SetBlock(size_t index, TStringBuf block) = 0;
     virtual void ClearBlock(size_t index) = 0;
-
-    virtual TStringBuf GetContentRef() = 0;
-    virtual TString GetContent() = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 IBlockBufferPtr CreateBlockBuffer(TByteRange byteRange);
 IBlockBufferPtr CreateBlockBuffer(TByteRange byteRange, TString buffer);
+
+////////////////////////////////////////////////////////////////////////////////
+
+void CopyFileData(
+    const TString& logTag,
+    const TByteRange origin,
+    const TByteRange aligned,
+    const ui64 fileSize,
+    IBlockBuffer& buffer,
+    TString* out);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+++ b/cloud/filestore/libs/storage/model/block_buffer_ut.cpp
@@ -2,15 +2,65 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/random/random.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TBlockBufferTest)
 {
-    Y_UNIT_TEST(Test)
+    struct TTest
     {
-        // TODO
+        TByteRange Range;
+        TByteRange AlignedRange;
+        TString Data;
+        IBlockBufferPtr BlockBuffer;
+        TString Out;
+
+        TTest(
+                ui64 offset,
+                ui64 length,
+                ui32 blockSize,
+                ui64 fileSize)
+            : Range(offset, length, blockSize)
+            , AlignedRange(Range.AlignedSuperRange())
+        {
+            Data.ReserveAndResize(AlignedRange.Length);
+            for (ui32 i = 0; i < Data.Size(); ++i) {
+                Data[i] = 'a' + RandomNumber<ui32>('z' - 'a' + 1);
+            }
+            BlockBuffer = CreateBlockBuffer(AlignedRange, Data);
+            CopyFileData(
+                "logtag",
+                Range,
+                AlignedRange,
+                fileSize,
+                *BlockBuffer,
+                &Out);
+        }
+    };
+
+    Y_UNIT_TEST(ShouldCopyFileDataAligned)
+    {
+        TTest test(100_KB, 8_KB, 4_KB, 200_KB);
+        UNIT_ASSERT_VALUES_EQUAL(test.Data, test.Out);
+    }
+
+    Y_UNIT_TEST(ShouldCopyFileDataUnaligned)
+    {
+        TTest test(101_KB, 10_KB, 4_KB, 107_KB);
+        UNIT_ASSERT_VALUES_EQUAL(
+            test.Data.substr(1_KB, 6_KB),
+            test.Out);
+    }
+
+    Y_UNIT_TEST(ShouldCopyFileDataUnalignedSmall)
+    {
+        TTest test(101_KB, 10_KB, 4_KB, 103_KB);
+        UNIT_ASSERT_VALUES_EQUAL(
+            test.Data.substr(1_KB, 2_KB),
+            test.Out);
     }
 }
 

--- a/cloud/filestore/libs/storage/model/ya.make
+++ b/cloud/filestore/libs/storage/model/ya.make
@@ -12,4 +12,8 @@ SRCS(
     utils.cpp
 )
 
+PEERDIR(
+    cloud/storage/core/libs/common
+)
+
 END()


### PR DESCRIPTION
CopyFileData implementation is not copypasted anymore and uses GetBlock(i) instead of GetContentRef

GetContentRef/GetContent cannot be implemented in a lazy-allocating BlockBuffer which is needed to optimize DescribeData request handler (which spends 30-50% of the time making useless allocations)