### PR TITLE
[Filestore] NBSNEBIUS-121: TwoStageRead: add logging for `ReadData` fallback reason + fix ServiceActor not reporting `ReadData` counters

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -307,7 +307,7 @@ void TReadDataActor::HandleReadBlobResponse(
     const auto* msg = ev->Get();
 
     if (msg->Status != NKikimrProto::OK) {
-        TString errorReason = FormatError(
+        const auto errorReason = FormatError(
             MakeError(MAKE_KIKIMR_ERROR(msg->Status), msg->ErrorReason));
         LOG_WARN(
             ctx,
@@ -337,7 +337,7 @@ void TReadDataActor::HandleReadBlobResponse(
         const auto& blobRange = blobPiece.GetRanges(i);
         const auto& response = msg->Responses[i];
         if (response.Status != NKikimrProto::OK) {
-            TString errorReason = FormatError(
+            const auto errorReason = FormatError(
                 MakeError(MAKE_KIKIMR_ERROR(response.Status), "read error"));
             LOG_WARN(
                 ctx,
@@ -355,7 +355,7 @@ void TReadDataActor::HandleReadBlobResponse(
             response.Buffer.empty() ||
             response.Buffer.size() % BlockSize != 0)
         {
-            const TString error =
+            const auto error =
                 FormatError(MakeError(E_FAIL, "invalid response received"));
             LOG_WARN(
                 ctx,
@@ -431,7 +431,7 @@ void TReadDataActor::ReadData(
         ReadRequest.GetHandle(),
         ReadRequest.GetOffset(),
         ReadRequest.GetLength(),
-        fallbackReason.c_str());
+        fallbackReason.Quote().c_str());
 
     auto request = std::make_unique<TEvService::TEvReadDataRequest>();
     request->Record = std::move(ReadRequest);

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -223,7 +223,7 @@ void TReadDataActor::HandleDescribeDataResponse(
     const auto* msg = ev->Get();
 
     if (FAILED(msg->GetStatus())) {
-        ReadData(ctx, msg->GetErrorReason());
+        ReadData(ctx, FormatError(msg->GetError()));
         return;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -66,7 +66,7 @@ private:
         const TEvents::TEvPoisonPill::TPtr& ev,
         const TActorContext& ctx);
 
-    void ReadData(const TActorContext& ctx);
+    void ReadData(const TActorContext& ctx, const TString& fallbackReason);
 
     void HandleReadDataResponse(
         const TEvService::TEvReadDataResponse::TPtr& ev,
@@ -223,7 +223,7 @@ void TReadDataActor::HandleDescribeDataResponse(
     const auto* msg = ev->Get();
 
     if (FAILED(msg->GetStatus())) {
-        ReadData(ctx);
+        ReadData(ctx, msg->GetErrorReason());
         return;
     }
 
@@ -307,14 +307,14 @@ void TReadDataActor::HandleReadBlobResponse(
     const auto* msg = ev->Get();
 
     if (msg->Status != NKikimrProto::OK) {
+        TString errorReason = FormatError(
+            MakeError(MAKE_KIKIMR_ERROR(msg->Status), msg->ErrorReason));
         LOG_WARN(
             ctx,
             TFileStoreComponents::SERVICE,
             "ReadBlob error: %s",
-            FormatError(MakeError(
-                MAKE_KIKIMR_ERROR(msg->Status),
-                msg->ErrorReason)).c_str());
-        ReadData(ctx);
+            errorReason.c_str());
+        ReadData(ctx, errorReason);
 
         return;
     }
@@ -337,14 +337,14 @@ void TReadDataActor::HandleReadBlobResponse(
         const auto& blobRange = blobPiece.GetRanges(i);
         const auto& response = msg->Responses[i];
         if (response.Status != NKikimrProto::OK) {
+            TString errorReason = FormatError(
+                MakeError(MAKE_KIKIMR_ERROR(response.Status), "read error"));
             LOG_WARN(
                 ctx,
                 TFileStoreComponents::SERVICE,
                 "ReadBlob error: %s",
-                FormatError(MakeError(
-                    MAKE_KIKIMR_ERROR(response.Status),
-                    "read error")).c_str());
-            ReadData(ctx);
+                errorReason.c_str());
+            ReadData(ctx, errorReason);
 
             return;
         }
@@ -355,14 +355,14 @@ void TReadDataActor::HandleReadBlobResponse(
             response.Buffer.empty() ||
             response.Buffer.size() % BlockSize != 0)
         {
+            const TString error =
+                FormatError(MakeError(E_FAIL, "invalid response received"));
             LOG_WARN(
                 ctx,
                 TFileStoreComponents::SERVICE,
                 "ReadBlob error: %s",
-                FormatError(MakeError(
-                    E_FAIL,
-                    "invalid response received")).c_str());
-            ReadData(ctx);
+                error.c_str());
+            ReadData(ctx, error);
 
             return;
         }
@@ -417,18 +417,21 @@ void TReadDataActor::HandlePoisonPill(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TReadDataActor::ReadData(const TActorContext& ctx)
+void TReadDataActor::ReadData(
+    const TActorContext& ctx,
+    const TString& fallbackReason)
 {
     ReadDataFallbackEnabled = true;
 
     LOG_WARN(
         ctx,
         TFileStoreComponents::SERVICE,
-        "Falling back to ReadData for %lu, %lu, %lu, %lu",
+        "Falling back to ReadData for %lu, %lu, %lu, %lu. Message: %s",
         ReadRequest.GetNodeId(),
         ReadRequest.GetHandle(),
         ReadRequest.GetOffset(),
-        ReadRequest.GetLength());
+        ReadRequest.GetLength(),
+        fallbackReason.c_str());
 
     auto request = std::make_unique<TEvService::TEvReadDataRequest>();
     request->Record = std::move(ReadRequest);
@@ -570,8 +573,8 @@ void TStorageServiceActor::HandleReadData(
 
     auto [cookie, inflight] = CreateInFlightRequest(
         TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
-        NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT,
-        StatsRegistry->GetRequestStats(),
+        session->MediaKind,
+        session->RequestStats,
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1724,6 +1724,79 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(8, evGets);
         UNIT_ASSERT_VALUES_EQUAL(4, readDataResponses);
     }
+
+    Y_UNIT_TEST(ServiceShouldReportProperCountersDuringTwoPhaseRead)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const TString fs = "test";
+        service.CreateFileStore(fs, 1000);
+
+        {
+            NProto::TStorageConfig newConfig;
+            newConfig.SetTwoStageReadEnabled(true);
+            const auto response =
+                ExecuteChangeStorageConfig(std::move(newConfig), service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                response.GetStorageConfig().GetTwoStageReadEnabled(),
+                true);
+            TDispatchOptions options;
+            env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+        }
+
+        auto headers = service.InitSession(fs, "client");
+
+        ui64 nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+
+        ui64 handle =
+            service
+                .CreateHandle(headers, fs, nodeId, "", TCreateHandleArgs::RDWR)
+                ->Record.GetHandle();
+
+        TString data(4_KB, 'A');
+
+        TMutex m;
+        m.lock();
+
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadDataResponse: {
+                        m.lock();
+                        m.unlock();
+                        return false;
+                    }
+                }
+
+                return false;
+            });
+
+        service.WriteData(headers, fs, nodeId, handle, 0, data);
+        service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+
+        auto counters = env.GetCounters()
+                            ->FindSubgroup("component", "service_fs")
+                            ->FindSubgroup("host", "cluster")
+                            ->FindSubgroup("filesystem", fs)
+                            ->FindSubgroup("client", "client")
+                            ->FindSubgroup("request", "ReadData");
+        UNIT_ASSERT(counters);
+
+        // counters->OutputPlainText(Cerr, "\t");
+        UNIT_ASSERT_EQUAL(1, counters->GetCounter("Count")->GetAtomic());
+
+        m.unlock();
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1792,7 +1792,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                             ->FindSubgroup("request", "ReadData");
         UNIT_ASSERT(counters);
 
-        // counters->OutputPlainText(Cerr, "\t");
         UNIT_ASSERT_EQUAL(1, counters->GetCounter("Count")->GetAtomic());
 
         m.unlock();


### PR DESCRIPTION
1. Added `ReadData` fallback reason to logging of `NFS_SERVICE`
2. Fix the `TStorageServiceActor` not reporting `ReadData` counters and add a ut for it.
References #324 