### PR TITLE
issue-324: implemented LazyBlockBuffer and using it in TIndexTabletActor::HandleDescribeData

### DIFF
--- a/cloud/filestore/libs/storage/model/block_buffer.h
+++ b/cloud/filestore/libs/storage/model/block_buffer.h
@@ -26,6 +26,7 @@ struct IBlockBuffer
 
 IBlockBufferPtr CreateBlockBuffer(TByteRange byteRange);
 IBlockBufferPtr CreateBlockBuffer(TByteRange byteRange, TString buffer);
+IBlockBufferPtr CreateLazyBlockBuffer(TByteRange byteRange);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -207,6 +207,7 @@ void ApplyFreshDataRange(
         targetBuffer);
 
     // NB: we assume that underlying target data is a continuous buffer
+    // TODO: don't make such an assumption - use GetBlock(i) API
     memcpy(
         targetData,
         sourceFreshData.GetContent().data() +

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1545,8 +1545,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
-        // fresh blocks
-        data = TString(4_KB, 'a');
+        // fresh blocks - adding multiple adjacent blocks is important here to
+        // catch some subtle bugs
+        data = TString(8_KB, 'a');
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         readDataResult =
             service.ReadData(headers, fs, nodeId, handle, 0, data.Size());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -602,9 +602,7 @@ void TIndexTabletActor::HandleDescribeData(
     requestInfo->StartedTs = ctx.Now();
 
     TByteRange alignedByteRange = byteRange.AlignedSuperRange();
-    // TODO: implement a block buffer with lazy block allocation and use it
-    // here
-    auto blockBuffer = CreateBlockBuffer(alignedByteRange);
+    auto blockBuffer = CreateLazyBlockBuffer(alignedByteRange);
 
     ExecuteTx<TReadData>(
         ctx,


### PR DESCRIPTION
Getting rid of unneeded allocations during DescribeData request processing (perf profile shows that those allocations really hurt our performance)

#324 