### PR TITLE
[Disk Manager] add EOL to the file

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/tests/ya.make
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/ya.make
@@ -9,3 +9,4 @@ TEST_SRCS(
 )
 
 END()
+


### PR DESCRIPTION
to fix linter issue:
```
[2024-02-21 13:31:56]  * File cloud/disk_manager/test/acceptance/test_runner/tests/ya.make contains issues:
[2024-02-21 13:31:56]    - LINTER_ID_TRAILING_EOL: File should have EOL in the end
[2024-02-21 13:31:56]       cloud/disk_manager/test/acceptance/test_runner/tests/ya.make:13:6
```