### PR TITLE
[CI]: Write run_all.sh output to the logs_dir

### DIFF
--- a/cloud/storage/core/tools/ci/runner/run_all.sh
+++ b/cloud/storage/core/tools/ci/runner/run_all.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
+
+
 logs_root="/var/www/build/logs"
+
+logs_dir="${logs_root}/run_$(date +%y_%m_%d__%H)" &&
+rm -rf "$logs_dir" &&
+mkdir -p "$logs_dir"
 
 exec 3>&1 4>&2
 trap 'exec 2>&4 1>&3' 0 1 2 3
-exec 1>"${logs_root}/run_all.out" 2>&1
+exec 1>"${logs_dir}/run_all.out" 2>&1
 
 d="/root"
 scripts="${d}/runner"
@@ -25,9 +31,6 @@ git pull
 
 "${nbspath}/ya" gc cache
 
-logs_dir="${logs_root}/run_$(date +%y_%m_%d__%H)" &&
-rm -rf "$logs_dir" &&
-mkdir -p "$logs_dir"
 find  "${logs_root}" -maxdepth 1 -mtime +7 -type d -exec rm -rf {} \;
 
 lineArr=()


### PR DESCRIPTION
Write run_all.sh output to the logs_dir for
 the run instead of the logs root