### PR TITLE
mute nemesis test

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -5,6 +5,7 @@ cloud/blockstore/tests/resize-disk *
 cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests tests.TestShallowCopySnapshotWithRandomFailure
 cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests tests.TestShallowCopySnapshotWithRandomFailure/store_chunks_in_s3
 cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests tests.TestShallowCopySnapshotWithRandomFailure/store_chunks_in_ydb
+cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test tests.TestDiskServiceMigrateEmptyOverlayDiskWithoutAliveSrcImage
 cloud/filestore/tests/fio_index_migration/qemu-intrahost-migration-kikimr-nemesis-test *
 cloud/filestore/tests/fio_index_migration/qemu-intrahost-migration-kikimr-test *
 cloud/filestore/tests/fio_index_migration/qemu-intrahost-migration-local-test *

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -5,7 +5,7 @@ cloud/blockstore/tests/resize-disk *
 cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests tests.TestShallowCopySnapshotWithRandomFailure
 cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests tests.TestShallowCopySnapshotWithRandomFailure/store_chunks_in_s3
 cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests tests.TestShallowCopySnapshotWithRandomFailure/store_chunks_in_ydb
-cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test tests.TestDiskServiceMigrateEmptyOverlayDiskWithoutAliveSrcImage
+cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test tests.TestDiskServiceMigrate*
 cloud/filestore/tests/fio_index_migration/qemu-intrahost-migration-kikimr-nemesis-test *
 cloud/filestore/tests/fio_index_migration/qemu-intrahost-migration-kikimr-test *
 cloud/filestore/tests/fio_index_migration/qemu-intrahost-migration-local-test *

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test/ya.make
@@ -5,6 +5,9 @@ SET_APPEND(RECIPE_ARGS --multiple-nbs)
 SET_APPEND(RECIPE_ARGS --encryption)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
+FORK_SUBTESTS()
+SPLIT_FACTOR(4)
+
 GO_XTEST_SRCS(
     ../disk_service_test/disk_relocation_test.go
     ../disk_service_test/disk_service_test.go


### PR DESCRIPTION
mute test and specify split factor corresponding to it's chunk size based on the number of skipped tests in nightly builds e.g. https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/7967342719/1/nebius-x86-64/summary/ya-test.html