### PR TITLE
issue-499: Disk acquire cache in DR

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -911,4 +911,10 @@ message TStorageServiceConfig
 
     // Enables runtime config update tool.
     optional bool ConfigsDispatcherServiceEnabled = 347;
+
+    // Amount of time after which the disk registry will not send cached disk
+    // acquire request on the disk agent restart (ms).
+    // Note: it should be larger than ClientRemountPeriod, otherwise it's
+    // useless.
+    optional uint32 CachedAcquireRequestLifetimeThreshold = 348;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -916,5 +916,5 @@ message TStorageServiceConfig
     // acquire request on the disk agent restart (ms).
     // Note: it should be larger than ClientRemountPeriod, otherwise it's
     // useless.
-    optional uint32 CachedAcquireRequestLifetimeThreshold = 348;
+    optional uint32 CachedAcquireRequestLifetime = 348;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -463,7 +463,7 @@ TDuration MSeconds(ui32 value)
     xxx(DiskPrefixLengthWithBlockChecksumsInBlobs, ui64,      0               )\
     xxx(CheckBlockChecksumsInBlobsUponRead,        bool,      false           )\
     xxx(ConfigsDispatcherServiceEnabled,           bool,      false           )\
-    xxx(CachedAcquireRequestLifetimeThreshold,     TDuration, Seconds(10)     )\
+    xxx(CachedAcquireRequestLifetime,              TDuration, Seconds(40)     )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -463,6 +463,7 @@ TDuration MSeconds(ui32 value)
     xxx(DiskPrefixLengthWithBlockChecksumsInBlobs, ui64,      0               )\
     xxx(CheckBlockChecksumsInBlobsUponRead,        bool,      false           )\
     xxx(ConfigsDispatcherServiceEnabled,           bool,      false           )\
+    xxx(CachedAcquireRequestLifetimeThreshold,     TDuration, Seconds(10)     )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -525,7 +525,7 @@ public:
 
     bool GetConfigsDispatcherServiceEnabled() const;
 
-    TDuration GetCachedAcquireRequestLifetimeThreshold() const;
+    TDuration GetCachedAcquireRequestLifetime() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -524,6 +524,8 @@ public:
     bool GetCheckBlockChecksumsInBlobsUponRead() const;
 
     bool GetConfigsDispatcherServiceEnabled() const;
+
+    TDuration GetCachedAcquireRequestLifetimeThreshold() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -10,7 +10,7 @@
 
 #include <util/datetime/base.h>
 #include <util/stream/file.h>
-#include "util/string/join.h"
+#include <util/string/join.h>
 #include <util/system/file.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -852,6 +852,19 @@ void TDiskRegistryActor::OnDiskReleased(
             AcquireCacheByAgentId.erase(it);
         }
     }
+}
+
+void TDiskRegistryActor::OnDiskDeallocated(const TDiskId& diskId)
+{
+    for (auto& [_, request]: AcquireCacheByAgentId) {
+        EraseNodesIf(
+            request,
+            [&diskId](const auto& item)
+            { return item.first.DiskId == diskId; });
+    }
+    EraseNodesIf(
+        AcquireCacheByAgentId,
+        [](const auto& item) { return item.second.empty(); });
 }
 
 void TDiskRegistryActor::SendCachedAcquireRequestsToAgent(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -126,14 +126,9 @@ private:
         TDiskId DiskId;
         TString ClientId;
 
-        bool operator<(const TCachedAcquireKey& other) const
-        {
-            auto tie = [](const TCachedAcquireKey& key)
-            {
-                return std::tie(key.DiskId, key.ClientId);
-            };
-            return tie(*this) < tie(other);
-        }
+        friend std::strong_ordering operator<=>(
+            const TCachedAcquireKey&,
+            const TCachedAcquireKey&) = default;
     };
 
     using TCachedAcquireRequests =
@@ -292,6 +287,7 @@ private:
         TVector<TAgentAcquireDevicesCachedRequest> sentAcquireRequests);
     void OnDiskReleased(
         const TVector<TAgentReleaseDevicesCachedRequest>& sentReleaseRequests);
+    void OnDiskDeallocated(const TDiskId& diskId);
     void SendCachedAcquireRequestsToAgent(
         const NActors::TActorContext& ctx,
         const NProto::TAgentConfig& config);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -121,20 +121,6 @@ private:
 
     THashMap<TString, TAgentRegInfo> AgentRegInfo;
 
-    struct TCachedAcquireKey
-    {
-        TDiskId DiskId;
-        TString ClientId;
-
-        friend std::strong_ordering operator<=>(
-            const TCachedAcquireKey&,
-            const TCachedAcquireKey&) = default;
-    };
-
-    using TCachedAcquireRequests =
-        TMap<TCachedAcquireKey, TAgentAcquireDevicesCachedRequest>;
-    THashMap<TString, TCachedAcquireRequests> AcquireCacheByAgentId;
-
     // Requests in-progress
     THashSet<NActors::TActorId> Actors;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -137,7 +137,7 @@ private:
     };
 
     using TCachedAcquireRequests =
-        TMap<TCachedAcquireKey, TAgentAcquireDiskCachedRequest>;
+        TMap<TCachedAcquireKey, TAgentAcquireDevicesCachedRequest>;
     THashMap<TString, TCachedAcquireRequests> AcquireCacheByAgentId;
 
     // Requests in-progress
@@ -289,9 +289,9 @@ private:
     void ProcessAutomaticallyReplacedDevices(const NActors::TActorContext& ctx);
 
     void OnDiskAcquired(
-        TVector<TAgentAcquireDiskCachedRequest> sentAcquireRequests);
+        TVector<TAgentAcquireDevicesCachedRequest> sentAcquireRequests);
     void OnDiskReleased(
-        const TVector<TAgentReleaseDiskCachedRequest>& sentReleaseRequests);
+        const TVector<TAgentReleaseDevicesCachedRequest>& sentReleaseRequests);
     void SendCachedAcquireRequestsToAgent(
         const NActors::TActorContext& ctx,
         const NProto::TAgentConfig& config);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -121,6 +121,9 @@ private:
 
     THashMap<TString, TAgentRegInfo> AgentRegInfo;
 
+    THashMap<TString, TDeque<TAgentAcquireDiskCachedRequest>>
+        AcquireCacheByAgentId;
+
     // Requests in-progress
     THashSet<NActors::TActorId> Actors;
 
@@ -268,6 +271,14 @@ private:
         TRequestInfoPtr requestInfo);
 
     void ProcessAutomaticallyReplacedDevices(const NActors::TActorContext& ctx);
+
+    void OnDiskAcquired(
+        TVector<TAgentAcquireDiskCachedRequest> sentAcquireRequests);
+    void OnDiskReleased(
+        const TVector<TAgentReleaseDiskCachedRequest>& sentReleaseRequests);
+    void SendCachedAcquireRequestsToAgent(
+        const NActors::TActorContext& ctx,
+        const NProto::TAgentConfig& config);
 
     void RenderHtmlInfo(TInstant now, IOutputStream& out) const;
     void RenderState(IOutputStream& out) const;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -121,8 +121,24 @@ private:
 
     THashMap<TString, TAgentRegInfo> AgentRegInfo;
 
-    THashMap<TString, TDeque<TAgentAcquireDiskCachedRequest>>
-        AcquireCacheByAgentId;
+    struct TCachedAcquireKey
+    {
+        TDiskId DiskId;
+        TString ClientId;
+
+        bool operator<(const TCachedAcquireKey& other) const
+        {
+            auto tie = [](const TCachedAcquireKey& key)
+            {
+                return std::tie(key.DiskId, key.ClientId);
+            };
+            return tie(*this) < tie(other);
+        }
+    };
+
+    using TCachedAcquireRequests =
+        TMap<TCachedAcquireKey, TAgentAcquireDiskCachedRequest>;
+    THashMap<TString, TCachedAcquireRequests> AcquireCacheByAgentId;
 
     // Requests in-progress
     THashSet<NActors::TActorId> Actors;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
@@ -195,20 +195,18 @@ TVector<TAcquireDiskActor::TSentRequest<TRequest>> TAcquireDiskActor::SendReques
     TVector<TSentRequest<TRequest>> sentRequests;
     while (it != Devices.end()) {
         auto request = std::make_unique<TRequest>();
-        TSentRequest<TRequest> requestCopy{TString(), std::make_unique<TRequest>()};
+        TSentRequest<TRequest> requestCopy{
+            it->GetAgentId(),
+            std::make_unique<TRequest>()};
         PrepareRequest(request->Record);
         PrepareRequest(requestCopy.Request->Record);
 
-        requestCopy.AgentId = it->GetAgentId();
         const ui32 nodeId = it->GetNodeId();
-
-        TEvDiskAgent::TEvAcquireDevicesRequest a;
 
         for (; it != Devices.end() && it->GetNodeId() == nodeId; ++it) {
             Y_ABORT_UNLESS(it->GetAgentId() == requestCopy.AgentId);
             *request->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
-            *requestCopy.Request->Record.AddDeviceUUIDs() =
-                it->GetDeviceUUID();
+            *requestCopy.Request->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
         }
 
         ++PendingRequests;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
@@ -34,7 +34,7 @@ private:
 
     int PendingRequests = 0;
 
-    TVector<TAgentAcquireDiskCachedRequest> SentAcquireRequests;
+    TVector<TAgentAcquireDevicesCachedRequest> SentAcquireRequests;
 
 public:
     TAcquireDiskActor(
@@ -152,7 +152,7 @@ void TAcquireDiskActor::Bootstrap(const TActorContext& ctx)
     for (auto& x: sentRequests) {
         SentAcquireRequests.emplace_back(
             std::move(x.AgentId),
-            std::move(x.Request),
+            std::move(x.Request->Record),
             now);
     }
 }
@@ -204,7 +204,6 @@ TVector<TAcquireDiskActor::TSentRequest<TRequest>> TAcquireDiskActor::SendReques
         const ui32 nodeId = it->GetNodeId();
 
         for (; it != Devices.end() && it->GetNodeId() == nodeId; ++it) {
-            Y_ABORT_UNLESS(it->GetAgentId() == requestCopy.AgentId);
             *request->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
             *requestCopy.Request->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
         }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
@@ -318,6 +318,8 @@ void TDiskRegistryActor::CompleteRemoveDisk(
             "RemoveDisk error: %s. DiskId=%s",
             FormatError(args.Error).c_str(),
             args.DiskId.Quote().c_str());
+    } else {
+        OnDiskDeallocated(args.DiskId);
     }
 
     auto response = std::make_unique<TEvDiskRegistry::TEvDeallocateDiskResponse>();

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
@@ -181,6 +181,8 @@ void TDiskRegistryActor::CompleteAddAgent(
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 
+    SendCachedAcquireRequestsToAgent(ctx, args.Config);
+
     ReallocateDisks(ctx);
     NotifyUsers(ctx);
     PublishDiskStates(ctx);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
@@ -28,7 +28,7 @@ private:
     TVector<NProto::TDeviceConfig> Devices;
     int PendingRequests = 0;
 
-    TVector<TAgentReleaseDiskCachedRequest> SentReleaseRequests;
+    TVector<TAgentReleaseDevicesCachedRequest> SentReleaseRequests;
 
 public:
     TReleaseDiskActor(
@@ -118,18 +118,16 @@ void TReleaseDiskActor::Bootstrap(const TActorContext& ctx)
     while (it != Devices.end()) {
         auto request =
             std::make_unique<TEvDiskAgent::TEvReleaseDevicesRequest>();
-        auto requestCopy =
-            std::make_unique<TEvDiskAgent::TEvReleaseDevicesRequest>();
+        NProto::TReleaseDevicesRequest requestCopy;
         PrepareRequest(request->Record);
-        PrepareRequest(requestCopy->Record);
+        PrepareRequest(requestCopy);
 
         const ui32 nodeId = it->GetNodeId();
         const TString& agentId = it->GetAgentId();
 
         for (; it != Devices.end() && it->GetNodeId() == nodeId; ++it) {
-            Y_ABORT_UNLESS(it->GetAgentId() == agentId);
             *request->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
-            *requestCopy->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
+            *requestCopy.AddDeviceUUIDs() = it->GetDeviceUUID();
         }
 
         ++PendingRequests;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
@@ -114,7 +114,7 @@ void TReleaseDiskActor::Bootstrap(const TActorContext& ctx)
         return d.GetNodeId();
     });
 
-    auto* it = Devices.begin();
+    auto it = Devices.begin();
     while (it != Devices.end()) {
         auto request =
             std::make_unique<TEvDiskAgent::TEvReleaseDevicesRequest>();

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
@@ -28,6 +28,8 @@ private:
     TVector<NProto::TDeviceConfig> Devices;
     int PendingRequests = 0;
 
+    TVector<TAgentReleaseDiskCachedRequest> SentReleaseRequests;
+
 public:
     TReleaseDiskActor(
         const TActorId& owner,
@@ -41,6 +43,7 @@ public:
     void Bootstrap(const TActorContext& ctx);
 
 private:
+    void PrepareRequest(NProto::TReleaseDevicesRequest& request);
     void RemoveDiskSession(const TActorContext& ctx);
     void ReplyAndDie(const TActorContext& ctx, NProto::TError error);
 
@@ -96,6 +99,13 @@ TReleaseDiskActor::TReleaseDiskActor(
     ActivityType = TBlockStoreActivities::DISK_REGISTRY_WORKER;
 }
 
+void TReleaseDiskActor::PrepareRequest(NProto::TReleaseDevicesRequest& request)
+{
+    request.MutableHeaders()->SetClientId(ClientId);
+    request.SetDiskId(DiskId);
+    request.SetVolumeGeneration(VolumeGeneration);
+}
+
 void TReleaseDiskActor::Bootstrap(const TActorContext& ctx)
 {
     Become(&TThis::StateWork);
@@ -104,21 +114,26 @@ void TReleaseDiskActor::Bootstrap(const TActorContext& ctx)
         return d.GetNodeId();
     });
 
-    auto it = Devices.begin();
+    auto* it = Devices.begin();
     while (it != Devices.end()) {
         auto request =
             std::make_unique<TEvDiskAgent::TEvReleaseDevicesRequest>();
-        request->Record.MutableHeaders()->SetClientId(ClientId);
-        request->Record.SetDiskId(DiskId);
-        request->Record.SetVolumeGeneration(VolumeGeneration);
+        auto requestCopy =
+            std::make_unique<TEvDiskAgent::TEvReleaseDevicesRequest>();
+        PrepareRequest(request->Record);
+        PrepareRequest(requestCopy->Record);
 
         const ui32 nodeId = it->GetNodeId();
+        const TString& agentId = it->GetAgentId();
 
         for (; it != Devices.end() && it->GetNodeId() == nodeId; ++it) {
+            Y_ABORT_UNLESS(it->GetAgentId() == agentId);
             *request->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
+            *requestCopy->Record.AddDeviceUUIDs() = it->GetDeviceUUID();
         }
 
         ++PendingRequests;
+        SentReleaseRequests.emplace_back(agentId, std::move(requestCopy));
         NCloud::Send(
             ctx,
             MakeDiskAgentServiceId(nodeId),
@@ -131,8 +146,11 @@ void TReleaseDiskActor::Bootstrap(const TActorContext& ctx)
 
 void TReleaseDiskActor::RemoveDiskSession(const TActorContext& ctx)
 {
-    auto request = std::make_unique<TEvDiskRegistryPrivate::TEvRemoveDiskSessionRequest>(
-        DiskId, ClientId);
+    auto request =
+        std::make_unique<TEvDiskRegistryPrivate::TEvRemoveDiskSessionRequest>(
+            DiskId,
+            ClientId,
+            std::move(SentReleaseRequests));
 
     NCloud::Send(ctx, Owner, std::move(request));
 }
@@ -342,6 +360,8 @@ void TDiskRegistryActor::HandleRemoveDiskSession(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
+
+    OnDiskReleased(msg->SentRequests);
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -87,6 +87,19 @@ struct TAgentReleaseDevicesCachedRequest
     NProto::TReleaseDevicesRequest Request;
 };
 
+struct TCachedAcquireKey
+{
+    TString DiskId;
+    TString ClientId;
+
+    friend std::strong_ordering operator<=>(
+        const TCachedAcquireKey&,
+        const TCachedAcquireKey&) = default;
+};
+
+using TCachedAcquireRequests =
+    TMap<TCachedAcquireKey, TAgentAcquireDevicesCachedRequest>;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TBrokenDiskInfo

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -2,15 +2,16 @@
 
 #include "public.h"
 
+#include "cloud/blockstore/libs/storage/api/disk_agent.h"
+
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
-
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
+#include <util/generic/queue.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
-#include <util/generic/queue.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -70,6 +71,21 @@ struct TUserNotificationKey
         : EntityId(std::move(entityId))
         , SeqNo(seqNo)
     {}
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TAgentAcquireDiskCachedRequest
+{
+    TString AgentId;
+    std::unique_ptr<TEvDiskAgent::TEvAcquireDevicesRequest> Request;
+    TInstant RequestTime;
+};
+
+struct TAgentReleaseDiskCachedRequest
+{
+    TString AgentId;
+    std::unique_ptr<TEvDiskAgent::TEvReleaseDevicesRequest> Request;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -178,10 +194,15 @@ struct TEvDiskRegistryPrivate
     {
         TString DiskId;
         TString ClientId;
+        TVector<TAgentAcquireDiskCachedRequest> SentRequests;
 
-        TFinishAcquireDiskRequest(TString diskId, TString clientId)
+        TFinishAcquireDiskRequest(
+                TString diskId,
+                TString clientId,
+                TVector<TAgentAcquireDiskCachedRequest> sentRequests)
             : DiskId(std::move(diskId))
             , ClientId(std::move(clientId))
+            , SentRequests(std::move(sentRequests))
         {}
     };
 
@@ -196,12 +217,15 @@ struct TEvDiskRegistryPrivate
     {
         TString DiskId;
         TString ClientId;
+        TVector<TAgentReleaseDiskCachedRequest> SentRequests;
 
         TRemoveDiskSessionRequest(
                 TString diskId,
-                TString clientId)
+                TString clientId,
+                TVector<TAgentReleaseDiskCachedRequest> sentRequests)
             : DiskId(std::move(diskId))
             , ClientId(std::move(clientId))
+            , SentRequests(std::move(sentRequests))
         {}
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -2,10 +2,9 @@
 
 #include "public.h"
 
-#include "cloud/blockstore/libs/storage/api/disk_agent.h"
-
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
@@ -75,17 +74,17 @@ struct TUserNotificationKey
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TAgentAcquireDiskCachedRequest
+struct TAgentAcquireDevicesCachedRequest
 {
     TString AgentId;
-    std::unique_ptr<TEvDiskAgent::TEvAcquireDevicesRequest> Request;
+    NProto::TAcquireDevicesRequest Request;
     TInstant RequestTime;
 };
 
-struct TAgentReleaseDiskCachedRequest
+struct TAgentReleaseDevicesCachedRequest
 {
     TString AgentId;
-    std::unique_ptr<TEvDiskAgent::TEvReleaseDevicesRequest> Request;
+    NProto::TReleaseDevicesRequest Request;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -194,12 +193,12 @@ struct TEvDiskRegistryPrivate
     {
         TString DiskId;
         TString ClientId;
-        TVector<TAgentAcquireDiskCachedRequest> SentRequests;
+        TVector<TAgentAcquireDevicesCachedRequest> SentRequests;
 
         TFinishAcquireDiskRequest(
                 TString diskId,
                 TString clientId,
-                TVector<TAgentAcquireDiskCachedRequest> sentRequests)
+                TVector<TAgentAcquireDevicesCachedRequest> sentRequests)
             : DiskId(std::move(diskId))
             , ClientId(std::move(clientId))
             , SentRequests(std::move(sentRequests))
@@ -217,12 +216,12 @@ struct TEvDiskRegistryPrivate
     {
         TString DiskId;
         TString ClientId;
-        TVector<TAgentReleaseDiskCachedRequest> SentRequests;
+        TVector<TAgentReleaseDevicesCachedRequest> SentRequests;
 
         TRemoveDiskSessionRequest(
                 TString diskId,
                 TString clientId,
-                TVector<TAgentReleaseDiskCachedRequest> sentRequests)
+                TVector<TAgentReleaseDevicesCachedRequest> sentRequests)
             : DiskId(std::move(diskId))
             , ClientId(std::move(clientId))
             , SentRequests(std::move(sentRequests))

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.cpp
@@ -58,8 +58,9 @@ void TDiskRegistrySelfCounters::Init(
         counters->GetCounter("PlacementGroupsWithBrokenSinglePartition");
     PlacementGroupsWithBrokenTwoOrMorePartitions =
         counters->GetCounter("PlacementGroupsWithBrokenTwoOrMorePartitions");
-    MeanTimeBetweenFailures =
-        counters->GetCounter("MeanTimeBetweenFailures");
+    CachedAcquireDevicesRequestAmount =
+        counters->GetCounter("CachedAcquireDevicesRequestAmount");
+    MeanTimeBetweenFailures = counters->GetCounter("MeanTimeBetweenFailures");
     AutomaticallyReplacedDevices =
         counters->GetCounter("AutomaticallyReplacedDevices");
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.h
@@ -81,6 +81,7 @@ struct TDiskRegistrySelfCounters
     TCounterPtr PlacementGroupsWithBrokenTwoOrMorePartitions;
     TCounterPtr MeanTimeBetweenFailures;
     TCounterPtr AutomaticallyReplacedDevices;
+    TCounterPtr CachedAcquireDevicesRequestAmount;
 
     TCumulativeCounter QueryAvailableStorageErrors;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3956,6 +3956,14 @@ void TDiskRegistryState::PublishCounters(TInstant now)
     SelfCounters.PlacementGroupsWithBrokenTwoOrMorePartitions->Set(
         placementGroupsWithBrokenTwoOrMorePartitions);
 
+    size_t cachedAcquireDevicesRequestAmount = Accumulate(
+        AcquireCacheByAgentId.begin(),
+        AcquireCacheByAgentId.end(),
+        0,
+        [](size_t sum, const auto& item) { return sum + item.second.size(); });
+    SelfCounters.CachedAcquireDevicesRequestAmount->Set(
+        cachedAcquireDevicesRequestAmount);
+
     auto replicaCountStats = ReplicaTable.CalculateReplicaCountStats();
     SelfCounters.Mirror2Disks->Set(replicaCountStats.Mirror2DiskMinus0);
     SelfCounters.Mirror2DisksMinus1->Set(replicaCountStats.Mirror2DiskMinus1);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -327,6 +327,8 @@ private:
 
     NDiskRegistry::TNotificationSystem NotificationSystem;
 
+    THashMap<TString, TCachedAcquireRequests> AcquireCacheByAgentId;
+
 public:
     TDiskRegistryState(
         ILoggingServicePtr logging,
@@ -788,6 +790,11 @@ public:
     const TReplicaTable& GetReplicaTable() const
     {
         return ReplicaTable;
+    }
+
+    THashMap<TString, TCachedAcquireRequests>& GetAcquireCacheByAgentId()
+    {
+        return AcquireCacheByAgentId;
     }
 
     TDuration GetRejectAgentTimeout(TInstant now, const TString& agentId) const

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_session.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_session.cpp
@@ -412,7 +412,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         const NProto::TStorageServiceConfig storageConfig =
             CreateDefaultStorageConfig();
         runtime->AdvanceCurrentTime(TDuration::MilliSeconds(
-            storageConfig.GetCachedAcquireRequestLifetimeThreshold() * 2));
+            storageConfig.GetCachedAcquireRequestLifetime() * 2));
         runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
         // This register shouldn't send acquire requests because too much time
         // passed since the last acquire.
@@ -621,7 +621,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             auto response = diskRegistry.RemoveDiskSession(
                 "disk-1",
                 "session-1",
-                TVector<TAgentReleaseDiskCachedRequest>());
+                TVector<TAgentReleaseDevicesCachedRequest>());
             UNIT_ASSERT(!HasError(response->GetError()));
         }
     }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -19,6 +19,7 @@ NProto::TStorageServiceConfig CreateDefaultStorageConfig()
     configProto.SetMirroredMigrationStartAllowed(true);
     configProto.SetAllocationUnitNonReplicatedSSD(10);
     configProto.SetDiskRegistryVolumeConfigUpdatePeriod(5000);
+    configProto.SetCachedAcquireRequestLifetimeThreshold(10000);
 
     return configProto;
 }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -19,7 +19,7 @@ NProto::TStorageServiceConfig CreateDefaultStorageConfig()
     configProto.SetMirroredMigrationStartAllowed(true);
     configProto.SetAllocationUnitNonReplicatedSSD(10);
     configProto.SetDiskRegistryVolumeConfigUpdatePeriod(5000);
-    configProto.SetCachedAcquireRequestLifetime(40000);
+    configProto.SetCachedAcquireRequestLifetime(1000 * 60 * 60);
 
     return configProto;
 }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -19,7 +19,7 @@ NProto::TStorageServiceConfig CreateDefaultStorageConfig()
     configProto.SetMirroredMigrationStartAllowed(true);
     configProto.SetAllocationUnitNonReplicatedSSD(10);
     configProto.SetDiskRegistryVolumeConfigUpdatePeriod(5000);
-    configProto.SetCachedAcquireRequestLifetimeThreshold(10000);
+    configProto.SetCachedAcquireRequestLifetime(40000);
 
     return configProto;
 }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -743,10 +743,16 @@ public:
             std::move(devices));
     }
 
-    auto CreateRemoveDiskSessionRequest(TString diskId, TString clientId)
+    auto CreateRemoveDiskSessionRequest(
+        TString diskId,
+        TString clientId,
+        TVector<TAgentReleaseDiskCachedRequest> sentRequests)
     {
-        return std::make_unique<TEvDiskRegistryPrivate::TEvRemoveDiskSessionRequest>(
-            std::move(diskId), std::move(clientId));
+        return std::make_unique<
+            TEvDiskRegistryPrivate::TEvRemoveDiskSessionRequest>(
+            std::move(diskId),
+            std::move(clientId),
+            std::move(sentRequests));
     }
 
     auto CreateUpdateAgentStatsRequest(NProto::TAgentStats stats)

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -746,7 +746,7 @@ public:
     auto CreateRemoveDiskSessionRequest(
         TString diskId,
         TString clientId,
-        TVector<TAgentReleaseDiskCachedRequest> sentRequests)
+        TVector<TAgentReleaseDevicesCachedRequest> sentRequests)
     {
         return std::make_unique<
             TEvDiskRegistryPrivate::TEvRemoveDiskSessionRequest>(


### PR DESCRIPTION
fixes #499.

Проверил на лабе, подложив бинари. Чтобы результат был явно видео на глаз, пришлось увеличить время между аквайрами до 15 секунд, т.к. по дефолту там сейчас всего 4 (`ClientRemountPeriod`).