### PR TITLE
issue-541: added counters: StatefulSessionsCount, StatelessSessionsCount, SessionTimeouts

### DIFF
--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -271,4 +271,10 @@ using TSessionOwnerMap = THashMap<NActors::TActorId, TSession*>;
 using TSessionClientMap = THashMap<TString, TSession*>;
 using TSessionHistoryList = TDeque<TSessionHistoryEntry>;
 
+struct TSessionsStats
+{
+    ui32 StatefulSessionsCount = 0;
+    ui32 StatelessSessionsCount = 0;
+};
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -82,6 +82,9 @@ private:
         std::atomic<i64> UsedSessionsCount{0};
         std::atomic<i64> UsedHandlesCount{0};
         std::atomic<i64> UsedLocksCount{0};
+        std::atomic<i64> StatefulSessionsCount{0};
+        std::atomic<i64> StatelessSessionsCount{0};
+        std::atomic<i64> SessionTimeouts{0};
 
         std::atomic<i64> AllocatedCompactionRangesCount{0};
         std::atomic<i64> UsedCompactionRangesCount{0};
@@ -146,7 +149,8 @@ private:
             const NProto::TFileSystem& fileSystem,
             const NProto::TFileSystemStats& stats,
             const NProto::TFileStorePerformanceProfile& performanceProfile,
-            const TCompactionMapStats& compactionStats);
+            const TCompactionMapStats& compactionStats,
+            const TSessionsStats& sessionsStats);
     } Metrics;
 
     const IProfileLogPtr ProfileLog;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
@@ -185,6 +185,10 @@ void TIndexTabletActor::HandleCleanupSessions(
         return;
     }
 
+    Metrics.SessionTimeouts.fetch_add(
+        sessions.size(),
+        std::memory_order_relaxed);
+
     TVector<NProto::TSession> list(sessions.size());
     for (size_t i = 0; i < sessions.size(); ++i) {
         list[i].CopyFrom(*sessions[i]);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -201,12 +201,12 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 ctx);
 
             return;
-        } else {
-            LOG_INFO(ctx, TFileStoreComponents::TABLET,
-                "%s CreateSession: no session available for client c: %s",
-                LogTag.c_str(),
-                clientId.c_str());
         }
+
+        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+            "%s CreateSession: no session available for client c: %s",
+            LogTag.c_str(),
+            clientId.c_str());
     }
 
     if (!sessionId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -447,6 +447,7 @@ public:
         const TSessionHistoryEntry& entry, size_t maxEntryCount);
 
     TVector<TMonSessionInfo> GetActiveSessions() const;
+    TSessionsStats CalculateSessionsStats() const;
 
 private:
     TSession* CreateSession(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -412,6 +412,24 @@ TVector<TMonSessionInfo> TIndexTabletState::GetActiveSessions() const
     return sessions;
 }
 
+TSessionsStats TIndexTabletState::CalculateSessionsStats() const
+{
+    TSessionsStats stats;
+
+    // recalculating these stats on purpose to be able to perform basic
+    // validation of the counters (UsedSessionsCount should be equal to the sum
+    // of Stateless and Stateful SessionsCount)
+    for (const auto& s: Impl->Sessions) {
+        if (s.GetSessionState()) {
+            ++stats.StatefulSessionsCount;
+        } else {
+            ++stats.StatelessSessionsCount;
+        }
+    }
+
+    return stats;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Handles
 

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -358,6 +358,11 @@ public:
             rangeId);
     }
 
+    auto CreateCleanupSessionsRequest()
+    {
+        return std::make_unique<TEvIndexTabletPrivate::TEvCleanupSessionsRequest>();
+    }
+
     //
     // TEvService
     //


### PR DESCRIPTION
#541 

Stateless sessions and session cleanup upon timeout usually indicate problems. Right now session timeouts happen due to our bugs more often than due to ungraceful guest shutdown.