### PR TITLE
issue-95: not counting backpressure errors until compaction state becomes fully loaded

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -316,7 +316,8 @@ void TIndexTabletActor::HandleWriteData(
         }
 
         if (!IsWriteAllowed(BuildBackpressureThresholds())) {
-            if (++BackpressureErrorCount >=
+            if (CompactionStateLoadStatus.Finished
+                    && ++BackpressureErrorCount >=
                     Config->GetMaxBackpressureErrorsBeforeSuicide())
             {
                 LOG_WARN(ctx, TFileStoreComponents::TABLET_WORKER,


### PR DESCRIPTION
Most probably tablet suicide won't be triggered due to high compaction map load times because our current limit on the backpressure error count is quite high. But nevertheless let's add this check - just in case.

#95 