### PR TITLE
issue-541: added createsession and resetsession commands to filestore-client, testing create+reset+describe sessions in client tests

### DIFF
--- a/cloud/filestore/apps/client/lib/create_session.cpp
+++ b/cloud/filestore/apps/client/lib/create_session.cpp
@@ -1,0 +1,61 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/session.pb.h>
+
+#include <library/cpp/string_utils/base64/base64.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TCreateSessionCommand final
+    : public TFileStoreCommand
+{
+private:
+    TString SessionId;
+    ui64 SeqNo = 0;
+
+public:
+    TCreateSessionCommand()
+    {
+        Opts.AddLongOption("session-id")
+            .RequiredArgument("SESSION_ID")
+            .StoreResult(&SessionId);
+
+        Opts.AddLongOption("client-id")
+            .RequiredArgument("CLIENT_ID")
+            .StoreResult(&ClientId);
+
+        Opts.AddLongOption("seq-no")
+            .RequiredArgument("SEQ_NO")
+            .StoreResult(&SeqNo);
+    }
+
+    bool Execute() override
+    {
+        auto request = std::make_shared<NProto::TCreateSessionRequest>();
+        request->SetFileSystemId(FileSystemId);
+        request->MutableHeaders()->SetSessionId(SessionId);
+        request->MutableHeaders()->SetClientId(ClientId);
+        request->MutableHeaders()->SetSessionSeqNo(SeqNo);
+
+        TCallContextPtr ctx = MakeIntrusive<TCallContext>();
+        auto response = WaitFor(Client->CreateSession(ctx, std::move(request)));
+        CheckResponse(response);
+
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewCreateSessionCommand()
+{
+    return std::make_shared<TCreateSessionCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/create_session.cpp
+++ b/cloud/filestore/apps/client/lib/create_session.cpp
@@ -2,8 +2,6 @@
 
 #include <cloud/filestore/public/api/protos/session.pb.h>
 
-#include <library/cpp/string_utils/base64/base64.h>
-
 namespace NCloud::NFileStore::NClient {
 
 namespace {

--- a/cloud/filestore/apps/client/lib/factory.cpp
+++ b/cloud/filestore/apps/client/lib/factory.cpp
@@ -29,6 +29,8 @@ TCommandPtr NewStopEndpointCommand();
 TCommandPtr NewTouchCommand();
 TCommandPtr NewWriteCommand();
 TCommandPtr NewExecuteActionCommand();
+TCommandPtr NewCreateSessionCommand();
+TCommandPtr NewResetSessionCommand();
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -56,6 +58,8 @@ static const TMap<TString, TFactoryFunc> Commands = {
     { "touch", NewTouchCommand },
     { "write", NewWriteCommand },
     { "executeaction", NewExecuteActionCommand },
+    { "createsession", NewCreateSessionCommand },
+    { "resetsession", NewResetSessionCommand },
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/apps/client/lib/reset_session.cpp
+++ b/cloud/filestore/apps/client/lib/reset_session.cpp
@@ -1,0 +1,73 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/session.pb.h>
+
+#include <library/cpp/string_utils/base64/base64.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TResetSessionCommand final
+    : public TFileStoreCommand
+{
+private:
+    TString SessionId;
+    ui64 SeqNo = 0;
+    TString SessionState;
+
+public:
+    TResetSessionCommand()
+    {
+        Opts.AddLongOption("session-id")
+            .RequiredArgument("SESSION_ID")
+            .Required()
+            .StoreResult(&SessionId);
+
+        Opts.AddLongOption("client-id")
+            .RequiredArgument("CLIENT_ID")
+            .Required()
+            .StoreResult(&ClientId);
+
+        Opts.AddLongOption("seq-no")
+            .RequiredArgument("SEQ_NO")
+            .StoreResult(&SeqNo);
+
+        Opts.AddLongOption("session-state")
+            .RequiredArgument("BASE64_SESSION_STATE")
+            .StoreResult(&SessionState);
+    }
+
+    bool Execute() override
+    {
+        Headers.SetSessionId(SessionId);
+        Headers.SetClientId(ClientId);
+        Headers.SetSessionSeqNo(SeqNo);
+
+        auto request = CreateRequest<NProto::TResetSessionRequest>();
+        if (SessionState) {
+            request->SetSessionState(Base64Decode(SessionState));
+        }
+
+        auto response = WaitFor(Client->ResetSession(
+            PrepareCallContext(),
+            std::move(request)));
+
+        CheckResponse(response);
+
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewResetSessionCommand()
+{
+    return std::make_shared<TResetSessionCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/ya.make
+++ b/cloud/filestore/apps/client/lib/ya.make
@@ -4,6 +4,7 @@ SRCS(
     add_cluster_node.cpp
     command.cpp
     create.cpp
+    create_session.cpp
     describe.cpp
     destroy.cpp
     execute_action.cpp
@@ -18,6 +19,7 @@ SRCS(
     performance_profile_params.cpp
     read.cpp
     remove_cluster_node.cpp
+    reset_session.cpp
     resize.cpp
     rm.cpp
     start_endpoint.cpp

--- a/cloud/filestore/tests/client/canondata/result.json
+++ b/cloud/filestore/tests/client/canondata/result.json
@@ -8,6 +8,9 @@
     "test.test_create_mkdir_ls_write_destroy": {
         "uri": "file://test.test_create_mkdir_ls_write_destroy/results.txt"
     },
+    "test.test_describe_sessions": {
+        "uri": "file://test.test_describe_sessions/results.txt"
+    },
     "test.test_list_filestores": {
         "uri": "file://test.test_list_filestores/results.txt"
     }

--- a/cloud/filestore/tests/client/canondata/test.test_describe_sessions/results.txt
+++ b/cloud/filestore/tests/client/canondata/test.test_describe_sessions/results.txt
@@ -1,0 +1,14 @@
+{
+    "Sessions": [
+        {
+            "SessionId": "session0",
+            "ClientId": "client0",
+            "SessionState": "c29tZSBzZXNzaW9uIHN0YXRl"
+        },
+        {
+            "SessionId": "session1",
+            "ClientId": "client1",
+            "SessionState": "YW5vdGhlciBzZXNzaW9uIHN0YXRl"
+        }
+    ]
+}

--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -98,3 +98,32 @@ def test_list_filestores():
 
     ret = common.canonical_file(results_path, local=True)
     return ret
+
+
+def test_describe_sessions():
+    client, results_path = __init_test()
+
+    client.create("fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT)
+
+    # creating a bunch of sessions
+    client.create_session("fs0", "session0", "client0")
+    client.create_session("fs0", "session1", "client1")
+    client.reset_session(
+        "fs0",
+        "session0",
+        "client0",
+        "some session state".encode("utf-8"))
+    client.reset_session(
+        "fs0",
+        "session1",
+        "client1",
+        "another session state".encode("utf-8"))
+
+    out = client.execute_action("describesessions", {"FileSystemId": "fs0"})
+    sessions = json.loads(out)
+
+    with open(results_path, "w") as results_file:
+        json.dump(sessions, results_file, indent=4)
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret


### PR DESCRIPTION
Will use it in production in the following manner:
1. `filestore-client executeaction --action describesessions '{"FileSystemId": "some_fs_id"}'` - to get the list of sessions - both stateful and stateless
2. `filestore-client resetsession --filesystem some_fs_id --session-id some_stateless_session_id --client-id client_id --session-state some_state_base64` - to set the state of some stateless session using the state of one of the stateful sessions as a "reference"

#541 