### PR TITLE
issue-487 NBS-4829 [disk manager]: make possible to add arbitrary logging field to context, write fields from context in ydb client logger

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -295,8 +295,7 @@ func NewNbsClient(
 
 func NewContextWithToken(token string) context.Context {
 	ctx := headers.SetOutgoingAccessToken(context.Background(), token)
-	// TODO:_ back
-	return logging.SetLogger(ctx, logging.NewJournaldLogger(logging.DebugLevel))
+	return logging.SetLogger(ctx, logging.NewStderrLogger(logging.DebugLevel))
 }
 
 func NewContext() context.Context {

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -295,7 +295,8 @@ func NewNbsClient(
 
 func NewContextWithToken(token string) context.Context {
 	ctx := headers.SetOutgoingAccessToken(context.Background(), token)
-	return logging.SetLogger(ctx, logging.NewStderrLogger(logging.DebugLevel))
+	// TODO:_ back
+	return logging.SetLogger(ctx, logging.NewJournaldLogger(logging.DebugLevel))
 }
 
 func NewContext() context.Context {

--- a/cloud/tasks/logging/fields.go
+++ b/cloud/tasks/logging/fields.go
@@ -15,14 +15,6 @@ type Field = log.Field
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO:_ names of constants. Moreover, do we need them?
-// const Component = "COMPONENT"
-// const TaskID = "TASK_ID"
-// const DiskID = "DISK_ID"
-// const SnapshotID = "SNAPSHOT_ID"
-// const ImageID = "IMAGE_ID"
-
-// TODO:_ move component constants somewhere else?
 const ComponentYDB = "YDB"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,26 +79,25 @@ func WithFields(ctx context.Context, fields ...Field) context.Context {
 	return ctxlog.WithFields(ctx, fields...)
 }
 
-// TODO:_SetLoggingFields -> WithFieldsFromHeaders
-func SetLoggingFields(ctx context.Context) context.Context {
+func WithGeneralFields(ctx context.Context) context.Context {
 	fields := make([]log.Field, 0)
 
 	idempotencyKey := headers.GetIdempotencyKey(ctx)
 	if len(idempotencyKey) != 0 {
-		fields = append(fields, log.String("IDEMPOTENCY_KEY", idempotencyKey))
+		fields = append(fields, log.String(idempotencyKeyKey, idempotencyKey))
 	}
 
 	requestID := headers.GetRequestID(ctx)
 	if len(requestID) != 0 {
-		fields = append(fields, log.String("REQUEST_ID", requestID))
+		fields = append(fields, log.String(requestIdKey, requestID))
 	}
 
 	operationID := headers.GetOperationID(ctx)
 	if len(operationID) != 0 {
-		fields = append(fields, log.String("OPERATION_ID", operationID))
+		fields = append(fields, log.String(operationIdKey, operationID))
 	}
 
-	fields = append(fields, log.String("SYSLOG_IDENTIFIER", "disk-manager"))
+	fields = append(fields, log.String(syslogIdentifierKey, "disk-manager"))
 
 	return ctxlog.WithFields(ctx, fields...)
 }

--- a/cloud/tasks/logging/fields.go
+++ b/cloud/tasks/logging/fields.go
@@ -15,6 +15,15 @@ type Field = log.Field
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// TODO:_ names of constants. Moreover, do we need them?
+// const Component = "COMPONENT"
+// const TaskID = "TASK_ID"
+// const DiskID = "DISK_ID"
+// const SnapshotID = "SNAPSHOT_ID"
+// const ImageID = "IMAGE_ID"
+
+////////////////////////////////////////////////////////////////////////////////
+
 func String(key, value string) Field {
 	return log.String(key, value)
 }
@@ -49,6 +58,33 @@ func Any(key string, value interface{}) Field {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+func NewComponentField(value string) Field {
+	return String("COMPONENT", value)
+}
+
+func NewTaskIDField(value string) Field {
+	return String("TASK_ID", value)
+}
+
+func NewDiskIDField(value string) Field {
+	return String("DISK_ID", value)
+}
+
+func NewSnapshotIDField(value string) Field {
+	return String("SNAPSHOT_ID", value)
+}
+
+func NewImageIDField(value string) Field {
+	return String("IMAGE_ID", value)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func WithFields(ctx context.Context, fields ...Field) context.Context {
+	return ctxlog.WithFields(ctx, fields...)
+}
+
+// TODO:_SetLoggingFields -> WithFieldsFromHeaders
 func SetLoggingFields(ctx context.Context) context.Context {
 	fields := make([]log.Field, 0)
 

--- a/cloud/tasks/logging/fields.go
+++ b/cloud/tasks/logging/fields.go
@@ -22,6 +22,9 @@ type Field = log.Field
 // const SnapshotID = "SNAPSHOT_ID"
 // const ImageID = "IMAGE_ID"
 
+// TODO:_ move component constants somewhere else?
+const ComponentYDB = "YDB"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func String(key, value string) Field {

--- a/cloud/tasks/logging/fields.go
+++ b/cloud/tasks/logging/fields.go
@@ -79,7 +79,7 @@ func WithFields(ctx context.Context, fields ...Field) context.Context {
 	return ctxlog.WithFields(ctx, fields...)
 }
 
-func WithGeneralFields(ctx context.Context) context.Context {
+func WithCommonFields(ctx context.Context) context.Context {
 	fields := make([]log.Field, 0)
 
 	idempotencyKey := headers.GetIdempotencyKey(ctx)

--- a/cloud/tasks/logging/journald_logger.go
+++ b/cloud/tasks/logging/journald_logger.go
@@ -62,7 +62,7 @@ func getField(field log.Field) rawField {
 	}
 }
 
-// Takes the latest value for each key
+// Gets the latest value for each key
 func getFieldsMap(fields ...log.Field) map[string]string {
 	if len(fields) == 0 {
 		return nil
@@ -77,8 +77,8 @@ func getFieldsMap(fields ...log.Field) map[string]string {
 	return vars
 }
 
-// Takes the latest value for each key
-// Preserves order of fields
+// Gets the latest value for each key
+// Preserves the order of fields
 func deduplicateFields(
 	fields ...rawField,
 ) (deduplicated []rawField) {
@@ -118,7 +118,6 @@ type journaldLoggerFileds struct {
 }
 
 func newJournaldLoggerFileds(fields ...log.Field) (ff journaldLoggerFileds) {
-	fmt.Printf("newJournaldLoggerFileds: len = %d, %v\n", len(fields), fields)
 	ff.journaldFields = make(map[string]string)
 
 	var messageFieldsAll []rawField
@@ -127,14 +126,11 @@ func newJournaldLoggerFileds(fields ...log.Field) (ff journaldLoggerFileds) {
 		if f.Key() == syslogIdentifierKey {
 			rawField := getField(f)
 			ff.journaldFields[rawField.key] = rawField.value
-			fmt.Printf("journald: %v\n", rawField)
 		} else if f.Key() == log.DefaultErrorFieldName && f.Type() == log.FieldTypeError {
 			ff.errorField = f.Error().Error()
-			fmt.Printf("error: %v\n", ff.errorField)
 		} else {
 			rawField := getField(f)
 			messageFieldsAll = append(messageFieldsAll, rawField)
-			fmt.Printf("message: %v\n", rawField)
 		}
 	}
 

--- a/cloud/tasks/logging/journald_logger.go
+++ b/cloud/tasks/logging/journald_logger.go
@@ -19,6 +19,11 @@ import (
 // -> journaldLogger.structuredLogWithCaller
 const callerSkipOffset = 4
 
+const idempotencyKeyKey = "IDEMPOTENCY_KEY"
+const requestIdKey = "REQUEST_ID"
+const operationIdKey = "OPERATION_ID"
+const syslogIdentifierKey = "SYSLOG_IDENTIFIER"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func getPriority(level Level) journal.Priority {
@@ -42,50 +47,100 @@ func getPriority(level Level) journal.Priority {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func getFields(fields ...log.Field) map[string]string {
+type rawField struct {
+	key   string
+	value string
+}
+
+func getField(field log.Field) rawField {
+	// The variable name must be in uppercase and consist only of characters,
+	// numbers and underscores, and may not begin with an underscore:
+	// https://www.freedesktop.org/software/systemd/man/sd_journal_print.html
+	return rawField{
+		key:   strings.ToUpper(field.Key()),
+		value: fmt.Sprintf("%v", field.Any()),
+	}
+}
+
+// Takes the latest value for each key
+func getFieldsMap(fields ...log.Field) map[string]string {
 	if len(fields) == 0 {
 		return nil
 	}
 
 	vars := make(map[string]string)
 	for _, f := range fields {
-		// The variable name must be in uppercase and consist only of characters,
-		// numbers and underscores, and may not begin with an underscore:
-		// https://www.freedesktop.org/software/systemd/man/sd_journal_print.html
-		key := strings.ToUpper(f.Key())
-		vars[key] = fmt.Sprintf("%v", f.Any())
+		rawField := getField(f)
+		vars[rawField.key] = rawField.value
 	}
 
 	return vars
+}
+
+// Takes the latest value for each key
+// Preserves order of fields
+func deduplicateFields(
+	fields ...rawField,
+) (deduplicated []rawField) {
+
+	fieldsMap := make(map[string]string)
+	for _, f := range fields {
+		fieldsMap[f.key] = f.value
+	}
+
+	for _, f := range fields {
+		if value, ok := fieldsMap[f.key]; ok {
+			deduplicated = append(
+				deduplicated,
+				rawField{key: f.key, value: value},
+			)
+			delete(fieldsMap, f.key)
+		}
+	}
+
+	return
+}
+
+func serializeFields(fields []rawField) (fieldsStr string) {
+	for idx, f := range fields {
+		fieldsStr += f.key + ": " + f.value
+		if idx+1 < len(fields) {
+			fieldsStr += ", "
+		}
+	}
+	return
 }
 
 type journaldLoggerFileds struct {
 	journaldFields map[string]string
-	messageFields  map[string]string
+	messageFields  []rawField
 	errorField     string
 }
 
-func newJournaldLoggerFileds(fields ...log.Field) journaldLoggerFileds {
-	var journaldFields []Field
-	var messageFields []Field
-	// TODO:_ improve naming of 'fields' variables
-	var vars journaldLoggerFileds
+func newJournaldLoggerFileds(fields ...log.Field) (ff journaldLoggerFileds) {
+	fmt.Printf("newJournaldLoggerFileds: len = %d, %v\n", len(fields), fields)
+	ff.journaldFields = make(map[string]string)
+
+	var messageFieldsAll []rawField
 
 	for _, f := range fields {
-		// TODO:_ constant for SYSLOG_IDENTIFIER?
-		if f.Key() == "SYSLOG_IDENTIFIER" {
-			journaldFields = append(journaldFields, f)
+		if f.Key() == syslogIdentifierKey {
+			rawField := getField(f)
+			ff.journaldFields[rawField.key] = rawField.value
+			fmt.Printf("journald: %v\n", rawField)
 		} else if f.Key() == log.DefaultErrorFieldName && f.Type() == log.FieldTypeError {
-			vars.errorField = f.Error().Error()
+			ff.errorField = f.Error().Error()
+			fmt.Printf("error: %v\n", ff.errorField)
 		} else {
-			messageFields = append(messageFields, f)
+			rawField := getField(f)
+			messageFieldsAll = append(messageFieldsAll, rawField)
+			fmt.Printf("message: %v\n", rawField)
 		}
 	}
 
-	vars.journaldFields = getFields(journaldFields...)
-	vars.messageFields = getFields(messageFields...)
+	ff.messageFields = deduplicateFields(messageFieldsAll...)
 
-	return vars
+	return
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -119,26 +174,28 @@ func (l *journaldLogger) structuredLogWithCaller(
 	msg string,
 	fields ...log.Field,
 ) {
-	rawFields := newJournaldLoggerFileds(fields...)
-	for key, value := range rawFields.messageFields {
-		msg = key + ": " + value + ", " + msg
+	ff := newJournaldLoggerFileds(fields...)
+
+	if len(ff.messageFields) > 0 {
+		msg = serializeFields(ff.messageFields) + " => " + msg
 	}
+	msg = "=> " + msg
 
 	msg = strings.ToUpper(level.String()) + " " + msg
 
 	if len(l.name) > 0 {
-		msg = l.name + " => " + msg
+		msg = l.name + " " + msg
 	}
 
 	if fileName, lineNumber, function, ok := captureStacktrace(l.callerSkip + callerSkipOffset); ok {
 		// See: https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html#CODE_FILE=
-		callerFields := getFields(
+		callerFields := getFieldsMap(
 			log.String("code_file", fileName),
 			log.Int("code_line", lineNumber),
 			log.String("code_func", function),
 		)
 		for key, value := range callerFields {
-			rawFields.journaldFields[key] = value
+			ff.journaldFields[key] = value
 		}
 
 		// Short link to the file and line within the file.
@@ -146,11 +203,11 @@ func (l *journaldLogger) structuredLogWithCaller(
 		msg = caller + " " + msg
 	}
 
-	if len(rawFields.errorField) > 0 {
-		msg += " => " + rawFields.errorField
+	if len(ff.errorField) > 0 {
+		msg += " => " + ff.errorField
 	}
 
-	err := journal.Send(msg, getPriority(level), rawFields.journaldFields)
+	err := journal.Send(msg, getPriority(level), ff.journaldFields)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to write to journald %v\n", err)
 	}

--- a/cloud/tasks/logging/journald_logger.go
+++ b/cloud/tasks/logging/journald_logger.go
@@ -122,13 +122,21 @@ func newJournaldLoggerFileds(fields ...log.Field) (ff journaldLoggerFileds) {
 
 	var messageFieldsAll []rawField
 
+	journaldFieldsKeys := map[string]struct{}{
+		idempotencyKeyKey:   {},
+		requestIdKey:        {},
+		operationIdKey:      {},
+		syslogIdentifierKey: {},
+	}
+
 	for _, f := range fields {
-		if f.Key() == syslogIdentifierKey {
+		if _, ok := journaldFieldsKeys[f.Key()]; ok {
 			rawField := getField(f)
 			ff.journaldFields[rawField.key] = rawField.value
-		} else if f.Key() == log.DefaultErrorFieldName && f.Type() == log.FieldTypeError {
+		}
+		if f.Key() == log.DefaultErrorFieldName && f.Type() == log.FieldTypeError {
 			ff.errorField = f.Error().Error()
-		} else {
+		} else if f.Key() != syslogIdentifierKey {
 			rawField := getField(f)
 			messageFieldsAll = append(messageFieldsAll, rawField)
 		}

--- a/cloud/tasks/logging/journald_tests/journald_logger_test.go
+++ b/cloud/tasks/logging/journald_tests/journald_logger_test.go
@@ -173,7 +173,6 @@ func testJournaldLog(t *testing.T, reader *journaldReader) {
 	entries := reader.readEntries(t, 4)
 
 	pc, callerFile, lineNo, ok := runtime.Caller(0)
-	fmt.Printf("line no: %d", lineNo)
 	require.True(t, ok)
 
 	frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
@@ -263,7 +262,7 @@ func testJournaldLogWithAdditionalFields(t *testing.T, reader *journaldReader) {
 }
 
 func TestJournaldLog(t *testing.T) {
-	reader := journaldReader{readCount: 0}
-	testJournaldLog(t, &reader)
-	testJournaldLogWithAdditionalFields(t, &reader)
+	reader := &journaldReader{readCount: 0}
+	testJournaldLog(t, reader)
+	testJournaldLogWithAdditionalFields(t, reader)
 }

--- a/cloud/tasks/logging/journald_tests/journald_logger_test.go
+++ b/cloud/tasks/logging/journald_tests/journald_logger_test.go
@@ -27,6 +27,9 @@ import (
 type journaldEntry struct {
 	message          string
 	priority         journal.Priority
+	idempotencyKey   string
+	requestID        string
+	operationID      string
 	syslogIdentifier string
 	codeFile         string
 	codeLine         string
@@ -54,6 +57,21 @@ func parseJournaldEntry(data []byte) (journaldEntry, error) {
 		return journaldEntry{}, fmt.Errorf("PRIORITY field is not an int %w", err)
 	}
 
+	idempotencyKey, ok := entry["IDEMPOTENCY_KEY"]
+	if !ok {
+		return journaldEntry{}, fmt.Errorf("No IDEMPOTENCY_KEY field")
+	}
+
+	requestID, ok := entry["REQUEST_ID"]
+	if !ok {
+		return journaldEntry{}, fmt.Errorf("No IDEMPOTENCY_KEY field")
+	}
+
+	operationID, ok := entry["OPERATION_ID"]
+	if !ok {
+		return journaldEntry{}, fmt.Errorf("No OPERATION_ID field")
+	}
+
 	syslogIdentifier, ok := entry["SYSLOG_IDENTIFIER"]
 	if !ok {
 		return journaldEntry{}, fmt.Errorf("No SYSLOG_IDENTIFIER field")
@@ -77,6 +95,9 @@ func parseJournaldEntry(data []byte) (journaldEntry, error) {
 	return journaldEntry{
 		message:          message,
 		priority:         journal.Priority(priority),
+		idempotencyKey:   idempotencyKey,
+		requestID:        requestID,
+		operationID:      operationID,
 		syslogIdentifier: syslogIdentifier,
 		codeFile:         codeFile,
 		codeLine:         codeLine,
@@ -186,6 +207,9 @@ func testJournaldLog(t *testing.T, reader *journaldReader) {
 			{
 				message:          fmt.Sprintf("%s:%d INFO => %s => happened", caller, lineNo-7, fields),
 				priority:         journal.PriInfo,
+				idempotencyKey:   "idempID",
+				requestID:        "reqID",
+				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
 				codeLine:         strconv.Itoa(lineNo - 7),
@@ -194,6 +218,9 @@ func testJournaldLog(t *testing.T, reader *journaldReader) {
 			{
 				message:          fmt.Sprintf("%s:%d WARN => %s => happened", caller, lineNo-6, fields),
 				priority:         journal.PriWarning,
+				idempotencyKey:   "idempID",
+				requestID:        "reqID",
+				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
 				codeLine:         strconv.Itoa(lineNo - 6),
@@ -202,6 +229,9 @@ func testJournaldLog(t *testing.T, reader *journaldReader) {
 			{
 				message:          fmt.Sprintf("%s:%d ERROR => %s => happened", caller, lineNo-5, fields),
 				priority:         journal.PriErr,
+				idempotencyKey:   "idempID",
+				requestID:        "reqID",
+				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
 				codeLine:         strconv.Itoa(lineNo - 5),
@@ -210,6 +240,9 @@ func testJournaldLog(t *testing.T, reader *journaldReader) {
 			{
 				message:          fmt.Sprintf("%s:%d FATAL => %s => happened", caller, lineNo-4, fields),
 				priority:         journal.PriCrit,
+				idempotencyKey:   "idempID",
+				requestID:        "reqID",
+				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
 				codeLine:         strconv.Itoa(lineNo - 4),

--- a/cloud/tasks/logging/journald_tests/journald_logger_test.go
+++ b/cloud/tasks/logging/journald_tests/journald_logger_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,9 +27,6 @@ import (
 type journaldEntry struct {
 	message          string
 	priority         journal.Priority
-	idempotencyKey   string
-	requestID        string
-	operationID      string
 	syslogIdentifier string
 	codeFile         string
 	codeLine         string
@@ -55,21 +54,6 @@ func parseJournaldEntry(data []byte) (journaldEntry, error) {
 		return journaldEntry{}, fmt.Errorf("PRIORITY field is not an int %w", err)
 	}
 
-	idempotencyKey, ok := entry["IDEMPOTENCY_KEY"]
-	if !ok {
-		return journaldEntry{}, fmt.Errorf("No IDEMPOTENCY_KEY field")
-	}
-
-	requestID, ok := entry["REQUEST_ID"]
-	if !ok {
-		return journaldEntry{}, fmt.Errorf("No IDEMPOTENCY_KEY field")
-	}
-
-	operationID, ok := entry["OPERATION_ID"]
-	if !ok {
-		return journaldEntry{}, fmt.Errorf("No OPERATION_ID field")
-	}
-
 	syslogIdentifier, ok := entry["SYSLOG_IDENTIFIER"]
 	if !ok {
 		return journaldEntry{}, fmt.Errorf("No SYSLOG_IDENTIFIER field")
@@ -93,9 +77,6 @@ func parseJournaldEntry(data []byte) (journaldEntry, error) {
 	return journaldEntry{
 		message:          message,
 		priority:         journal.Priority(priority),
-		idempotencyKey:   idempotencyKey,
-		requestID:        requestID,
-		operationID:      operationID,
 		syslogIdentifier: syslogIdentifier,
 		codeFile:         codeFile,
 		codeLine:         codeLine,
@@ -128,20 +109,38 @@ func parseJournaldEntries(data []byte) ([]journaldEntry, error) {
 	return entries, nil
 }
 
-func runJournalctl() ([]byte, error) {
+type journaldReader struct {
+	readCount int
+}
+
+func (r *journaldReader) readEntries(
+	t *testing.T,
+	expectedNewEntriesCount int,
+) (entries []journaldEntry) {
 	// We want our messages to show up in journalctl, wait for them to sync.
 	// journalctl --sync does not work here, because it requires special
 	// access rights which are not expected on a developer's machine.
 	<-time.After(time.Second)
 
 	pid := os.Getpid()
-	return exec.Command(
+	data, err := exec.Command(
 		"journalctl",
 		"-o",
 		"json",
 		fmt.Sprintf("_PID=%v", pid),
 		"--no-pager",
 	).Output()
+	require.NoError(t, err)
+
+	entries, err = parseJournaldEntries(data)
+	require.NoError(t, err)
+
+	actualNewEntriesCount := len(entries) - r.readCount
+	require.EqualValues(t, expectedNewEntriesCount, actualNewEntriesCount)
+
+	entries = entries[r.readCount:]
+	r.readCount += actualNewEntriesCount
+	return
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -160,7 +159,7 @@ func newContext(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func TestJournaldLogInfo(t *testing.T) {
+func testJournaldLog(t *testing.T, reader *journaldReader) {
 	logger := logging.NewJournaldLogger(logging.InfoLevel)
 	ctx := logging.SetLogger(newContext("idempID", "reqID", "opID"), logger)
 
@@ -171,66 +170,100 @@ func TestJournaldLogInfo(t *testing.T) {
 	logging.Error(ctx, "happened")
 	logging.Fatal(ctx, "happened")
 
-	data, err := runJournalctl()
-	require.NoError(t, err)
-
-	entries, err := parseJournaldEntries(data)
-	require.NoError(t, err)
+	entries := reader.readEntries(t, 4)
 
 	pc, callerFile, lineNo, ok := runtime.Caller(0)
+	fmt.Printf("line no: %d", lineNo)
 	require.True(t, ok)
 
 	frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
 	caller := path.Base(callerFile)
 
+	fields := "IDEMPOTENCY_KEY: idempID, REQUEST_ID: reqID, OPERATION_ID: opID"
+
 	assert.EqualValues(
 		t,
 		[]journaldEntry{
 			{
-				message:          fmt.Sprintf("%s:%d INFO happened", caller, lineNo-11),
+				message:          fmt.Sprintf("%s:%d INFO => %s => happened", caller, lineNo-7, fields),
 				priority:         journal.PriInfo,
-				idempotencyKey:   "idempID",
-				requestID:        "reqID",
-				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
-				codeLine:         strconv.Itoa(lineNo - 11),
+				codeLine:         strconv.Itoa(lineNo - 7),
 				codeFunc:         frame.Function,
 			},
 			{
-				message:          fmt.Sprintf("%s:%d WARN happened", caller, lineNo-10),
+				message:          fmt.Sprintf("%s:%d WARN => %s => happened", caller, lineNo-6, fields),
 				priority:         journal.PriWarning,
-				idempotencyKey:   "idempID",
-				requestID:        "reqID",
-				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
-				codeLine:         strconv.Itoa(lineNo - 10),
+				codeLine:         strconv.Itoa(lineNo - 6),
 				codeFunc:         frame.Function,
 			},
 			{
-				message:          fmt.Sprintf("%s:%d ERROR happened", caller, lineNo-9),
+				message:          fmt.Sprintf("%s:%d ERROR => %s => happened", caller, lineNo-5, fields),
 				priority:         journal.PriErr,
-				idempotencyKey:   "idempID",
-				requestID:        "reqID",
-				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
-				codeLine:         strconv.Itoa(lineNo - 9),
+				codeLine:         strconv.Itoa(lineNo - 5),
 				codeFunc:         frame.Function,
 			},
 			{
-				message:          fmt.Sprintf("%s:%d FATAL happened", caller, lineNo-8),
+				message:          fmt.Sprintf("%s:%d FATAL => %s => happened", caller, lineNo-4, fields),
 				priority:         journal.PriCrit,
-				idempotencyKey:   "idempID",
-				requestID:        "reqID",
-				operationID:      "opID",
 				syslogIdentifier: "disk-manager",
 				codeFile:         callerFile,
-				codeLine:         strconv.Itoa(lineNo - 8),
+				codeLine:         strconv.Itoa(lineNo - 4),
 				codeFunc:         frame.Function,
 			},
 		},
 		entries,
 	)
+}
+
+func testJournaldLogWithAdditionalFields(t *testing.T, reader *journaldReader) {
+	logger := logging.NewJournaldLogger(logging.InfoLevel)
+	ctx := logging.SetLogger(newContext("idempID", "reqID", "opID"), logger)
+
+	ctx = logging.WithFields(ctx, logging.NewComponentField("component"), logging.Int("some_field", 713))
+
+	logging.Info(ctx, "happened one")
+
+	err := errors.New("some error")
+	ctx = logging.WithFields(ctx, logging.String("another_field", "value"), logging.ErrorValue(err))
+
+	logging.Info(ctx, "happened two")
+
+	// Should log the latest value for duplicating keys.
+	ctx = logging.WithFields(ctx, logging.Int("some_field", 714))
+
+	logging.Info(ctx, "happened three")
+
+	entries := reader.readEntries(t, 3)
+
+	var messageSuffixes []string
+	for _, entry := range entries {
+		// Consider the suffix after the first occurance of "=>",
+		// i.e. the fields and the message body.
+		idx := strings.Index(entry.message, "=>") + 3
+		messageSuffixes = append(messageSuffixes, entry.message[idx:])
+	}
+
+	expectedSuffixes := []string{
+		"IDEMPOTENCY_KEY: idempID, REQUEST_ID: reqID, OPERATION_ID: opID, COMPONENT: component, SOME_FIELD: 713 => happened one",
+		"IDEMPOTENCY_KEY: idempID, REQUEST_ID: reqID, OPERATION_ID: opID, COMPONENT: component, SOME_FIELD: 713, ANOTHER_FIELD: value => happened two => some error",
+		"IDEMPOTENCY_KEY: idempID, REQUEST_ID: reqID, OPERATION_ID: opID, COMPONENT: component, SOME_FIELD: 714, ANOTHER_FIELD: value => happened three => some error",
+	}
+
+	assert.EqualValues(
+		t,
+		expectedSuffixes,
+		messageSuffixes,
+	)
+}
+
+func TestJournaldLog(t *testing.T) {
+	reader := journaldReader{readCount: 0}
+	testJournaldLog(t, &reader)
+	testJournaldLogWithAdditionalFields(t, &reader)
 }

--- a/cloud/tasks/logging/logger.go
+++ b/cloud/tasks/logging/logger.go
@@ -33,7 +33,7 @@ type loggerKey struct{}
 type loggerNameKey struct{}
 
 func SetLogger(ctx context.Context, logger Logger) context.Context {
-	return SetLoggingFields(context.WithValue(ctx, loggerKey{}, logger))
+	return WithGeneralFields(context.WithValue(ctx, loggerKey{}, logger))
 }
 
 func GetLogger(ctx context.Context) Logger {

--- a/cloud/tasks/logging/logger.go
+++ b/cloud/tasks/logging/logger.go
@@ -33,7 +33,7 @@ type loggerKey struct{}
 type loggerNameKey struct{}
 
 func SetLogger(ctx context.Context, logger Logger) context.Context {
-	return WithGeneralFields(context.WithValue(ctx, loggerKey{}, logger))
+	return WithCommonFields(context.WithValue(ctx, loggerKey{}, logger))
 }
 
 func GetLogger(ctx context.Context) Logger {

--- a/cloud/tasks/logging/logger_test.go
+++ b/cloud/tasks/logging/logger_test.go
@@ -107,10 +107,10 @@ func TestLogTrace(t *testing.T) {
 		"Trace",
 		"Stuff happened",
 		[]log.Field{
-			log.String("IDEMPOTENCY_KEY", "idempID"),
-			log.String("REQUEST_ID", "reqID"),
-			log.String("OPERATION_ID", "opID"),
-			log.String("SYSLOG_IDENTIFIER", "disk-manager"),
+			log.String(idempotencyKeyKey, "idempID"),
+			log.String(requestIdKey, "reqID"),
+			log.String(operationIdKey, "opID"),
+			log.String(syslogIdentifierKey, "disk-manager"),
 		},
 	)
 
@@ -125,10 +125,10 @@ func TestLogDebug(t *testing.T) {
 		"Debug",
 		"Stuff happened",
 		[]log.Field{
-			log.String("IDEMPOTENCY_KEY", "idempID"),
-			log.String("REQUEST_ID", "reqID"),
-			log.String("OPERATION_ID", "opID"),
-			log.String("SYSLOG_IDENTIFIER", "disk-manager"),
+			log.String(idempotencyKeyKey, "idempID"),
+			log.String(requestIdKey, "reqID"),
+			log.String(operationIdKey, "opID"),
+			log.String(syslogIdentifierKey, "disk-manager"),
 		},
 	)
 
@@ -143,10 +143,10 @@ func TestLogInfo(t *testing.T) {
 		"Info",
 		"Stuff happened",
 		[]log.Field{
-			log.String("IDEMPOTENCY_KEY", "idempID"),
-			log.String("REQUEST_ID", "reqID"),
-			log.String("OPERATION_ID", "opID"),
-			log.String("SYSLOG_IDENTIFIER", "disk-manager"),
+			log.String(idempotencyKeyKey, "idempID"),
+			log.String(requestIdKey, "reqID"),
+			log.String(operationIdKey, "opID"),
+			log.String(syslogIdentifierKey, "disk-manager"),
 		},
 	)
 
@@ -161,10 +161,10 @@ func TestLogWarn(t *testing.T) {
 		"Warn",
 		"Stuff happened",
 		[]log.Field{
-			log.String("IDEMPOTENCY_KEY", "idempID"),
-			log.String("REQUEST_ID", "reqID"),
-			log.String("OPERATION_ID", "opID"),
-			log.String("SYSLOG_IDENTIFIER", "disk-manager"),
+			log.String(idempotencyKeyKey, "idempID"),
+			log.String(requestIdKey, "reqID"),
+			log.String(operationIdKey, "opID"),
+			log.String(syslogIdentifierKey, "disk-manager"),
 		},
 	)
 
@@ -179,10 +179,10 @@ func TestLogError(t *testing.T) {
 		"Error",
 		"Stuff happened",
 		[]log.Field{
-			log.String("IDEMPOTENCY_KEY", "idempID"),
-			log.String("REQUEST_ID", "reqID"),
-			log.String("OPERATION_ID", "opID"),
-			log.String("SYSLOG_IDENTIFIER", "disk-manager"),
+			log.String(idempotencyKeyKey, "idempID"),
+			log.String(requestIdKey, "reqID"),
+			log.String(operationIdKey, "opID"),
+			log.String(syslogIdentifierKey, "disk-manager"),
 		},
 	)
 
@@ -197,10 +197,10 @@ func TestLogFatal(t *testing.T) {
 		"Fatal",
 		"Stuff happened",
 		[]log.Field{
-			log.String("IDEMPOTENCY_KEY", "idempID"),
-			log.String("REQUEST_ID", "reqID"),
-			log.String("OPERATION_ID", "opID"),
-			log.String("SYSLOG_IDENTIFIER", "disk-manager"),
+			log.String(idempotencyKeyKey, "idempID"),
+			log.String(requestIdKey, "reqID"),
+			log.String(operationIdKey, "opID"),
+			log.String(syslogIdentifierKey, "disk-manager"),
 		},
 	)
 

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -291,6 +291,7 @@ func (r *runnerForRun) run(
 		}
 	}()
 
+	ctx = logging.WithFields(ctx, logging.NewTaskIDField(execCtx.GetTaskID()))
 	return task.Run(ctx, execCtx)
 }
 
@@ -360,6 +361,7 @@ func (r *runnerForCancel) executeTask(
 		taskID,
 	)
 
+	ctx = logging.WithFields(ctx, logging.NewTaskIDField(execCtx.GetTaskID()))
 	err := task.Cancel(ctx, execCtx)
 
 	if ctx.Err() != nil {

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -291,7 +291,6 @@ func (r *runnerForRun) run(
 		}
 	}()
 
-	ctx = logging.WithFields(ctx, logging.NewTaskIDField(execCtx.GetTaskID()))
 	return task.Run(ctx, execCtx)
 }
 
@@ -361,7 +360,6 @@ func (r *runnerForCancel) executeTask(
 		taskID,
 	)
 
-	ctx = logging.WithFields(ctx, logging.NewTaskIDField(execCtx.GetTaskID()))
 	err := task.Cancel(ctx, execCtx)
 
 	if ctx.Err() != nil {
@@ -523,7 +521,7 @@ func lockAndExecuteTask(
 	runCtx = headers.Append(runCtx, taskState.Metadata.Vals())
 	// All derived tasks should be pinned to the same storage folder.
 	runCtx = setStorageFolder(runCtx, taskState.StorageFolder)
-	runCtx = logging.SetLoggingFields(runCtx)
+	runCtx = logging.WithGeneralFields(runCtx)
 
 	execCtx := newExecutionContext(task, taskStorage, taskState)
 

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -521,7 +521,7 @@ func lockAndExecuteTask(
 	runCtx = headers.Append(runCtx, taskState.Metadata.Vals())
 	// All derived tasks should be pinned to the same storage folder.
 	runCtx = setStorageFolder(runCtx, taskState.StorageFolder)
-	runCtx = logging.WithGeneralFields(runCtx)
+	runCtx = logging.WithCommonFields(runCtx)
 
 	execCtx := newExecutionContext(task, taskStorage, taskState)
 


### PR DESCRIPTION
Added methods that allow to add logging fields to context. Used that methods to improve ydb client logging: now it writes field from context.

Examples of rows after these changes:
```
Feb 27 13:00:29 d9hnumvcrda87ck5kbpm disk-manager[305304]: ydb_logger.go:73 DEBUG => COMPONENT: YDB, YDB_LOG_NAME: ydb.driver.resolver.init, ENDPOINT: localhost:32648, DATABASE: /Root, SECURE: false => start
Feb 27 13:00:29 d9hnumvcrda87ck5kbpm disk-manager[305304]: factory.go:69 DEBUG => calling client.Close for &{0xc0005c2480 300000000000 500000000 0x17f5fe0 0xc0004b0260}, localhost:17106
```
(in 'real' logs there also will be request id, idempotency key and operation id fiedls)