### PR TITLE
Silent E_NOT_FOUND in GetDependentDisks and UpdateDiskRegistryParams requests

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -245,9 +245,7 @@ public:
     void AugmentErrorFlags(NCloud::NProto::TError& error) const
     {
         if (MuteIOErrors) {
-            ui32 flags = error.GetFlags();
-            SetProtoFlag(flags, NCloud::NProto::EF_HW_PROBLEMS_DETECTED);
-            error.SetFlags(flags);
+            SetErrorProtoFlag(error, NCloud::NProto::EF_HW_PROBLEMS_DETECTED);
         }
     }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
@@ -151,7 +151,7 @@ void TGetDependentDisksActor::HandleGetDependentDisksResponse(
 {
     auto* msg = ev->Get();
 
-    const auto& error = msg->GetError();
+    auto error = msg->GetError();
     if (error.GetCode() == E_NOT_FOUND) {
         SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -151,7 +152,11 @@ void TGetDependentDisksActor::HandleGetDependentDisksResponse(
     auto* msg = ev->Get();
 
     const auto& error = msg->GetError();
-    if (HasError(error) && error.GetCode() != E_NOT_FOUND) {
+    if (error.GetCode() == E_NOT_FOUND) {
+        SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
+    }
+
+    if (HasError(error)) {
         HandleError(ctx, error);
         return;
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_registry_params.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_registry_params.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry.h>
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -130,9 +131,12 @@ void TUpdateDiskRegistryAgentListParamsActor::HandleUpdateDiskRegistryAgentListP
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-    const auto& error = msg->GetError();
+    auto error = msg->GetError();
+    if (error.GetCode() == E_NOT_FOUND) {
+        SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
+    }
 
-    if (FAILED(error.GetCode())) {
+    if (HasError(error)) {
         HandleError(ctx, error);
         return;
     }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
 #include <cloud/storage/core/libs/api/hive_proxy.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/media.h>
 
 #include <contrib/ydb/core/tablet/tablet_setup.h>
@@ -50,9 +51,7 @@ using TEvInternalMountVolumeResponsePtr =
 NProto::TError MakeErrorSilent(const NProto::TError& error)
 {
     auto result = error;
-    ui32 flags = error.GetFlags();
-    SetProtoFlag(flags, NProto::EF_SILENT);
-    result.SetFlags(flags);
+    SetErrorProtoFlag(result, NProto::EF_SILENT);
     return result;
 }
 

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -143,9 +143,7 @@ void TDescribeSchemeActor::HandleDescribeSchemeResult(
 
         // TODO: return E_NOT_FOUND instead of StatusPathDoesNotExist
         if (status == NKikimrScheme::StatusPathDoesNotExist) {
-            ui32 flags = error.GetFlags();
-            SetProtoFlag(flags, NProto::EF_SILENT);
-            error.SetFlags(flags);
+            SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
         }
     }
 

--- a/cloud/storage/core/libs/common/helpers.h
+++ b/cloud/storage/core/libs/common/helpers.h
@@ -2,9 +2,9 @@
 
 #include "public.h"
 
-#include <util/system/defaults.h>
-
 #include <cloud/storage/core/protos/error.pb.h>
+
+#include <util/system/defaults.h>
 
 namespace NCloud {
 

--- a/cloud/storage/core/libs/common/helpers.h
+++ b/cloud/storage/core/libs/common/helpers.h
@@ -33,6 +33,5 @@ void SetErrorProtoFlag(NProto::TError& error, const T flag)
     SetProtoFlag(flags, flag);
     error.SetFlags(flags);
 }
-}
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/common/helpers.h
+++ b/cloud/storage/core/libs/common/helpers.h
@@ -4,6 +4,8 @@
 
 #include <util/system/defaults.h>
 
+#include <cloud/storage/core/protos/error.pb.h>
+
 namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -22,6 +24,15 @@ void SetProtoFlag(ui32& flags, const T flag)
     if (iflag) {
         flags |= 1 << (iflag - 1);
     }
+}
+
+template <typename T>
+void SetErrorProtoFlag(NProto::TError& error, const T flag)
+{
+    auto flags = error.GetFlags();
+    SetProtoFlag(flags, flag);
+    error.SetFlags(flags);
+}
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
Some agents may be in inactive state: even though they exist and work, they are missing from DiskRegistry AgentList. In such case GetDependentDisk and UpdateDiskRegistryParams request leads to E_NOT_FOUND error causing false alert. 
This PR adds EF_SILENT flag to this error to suppress alert.