### PR TITLE
issue-579: introduced NegativeEntryTimeout for entry_timeout returned to the client in case of errors, passing this timeout to TFileSystemConfig via NProto::TFileStore::Features which gets the values from TStorageConfig

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -28,4 +28,8 @@ message TFileSystemConfig
 
     // Filesystem max buffer size per request.
     optional uint32 MaxBufferSize = 8;
+
+    // Inode entry timeout for negative responses (responses with errors).
+    // The most notable one is ENOENT for getattr.
+    optional uint32 NegativeEntryTimeout = 9;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -210,4 +210,10 @@ message TStorageConfig
     // number of backpressure errors. Needed to automatically recover after
     // various races that may happen during index tablet startup due to bugs.
     optional uint32 MaxBackpressureErrorsBeforeSuicide = 334;
+
+    // Params that are passed to filestore-vhost via TCreateSessionResponse via
+    // TFilestore::Features. They do not have any effect on the tablet itself.
+    optional uint32 EntryTimeout = 335;
+    optional uint32 NegativeEntryTimeout = 336;
+    optional uint32 AttrTimeout = 337;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -133,6 +133,9 @@ namespace {
             NCloud::NProto::AUTHORIZATION_IGNORE                              )\
                                                                                \
     xxx(TwoStageReadEnabled,             bool,      false                     )\
+    xxx(EntryTimeout,                    TDuration, TDuration::Zero()         )\
+    xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\
+    xxx(AttrTimeout,                     TDuration, TDuration::Zero()         )\
     xxx(MaxOutOfOrderCompactionMapLoadRequestsInQueue,  ui32,      5          )\
     xxx(MaxBackpressureErrorsBeforeSuicide,             ui32,      1000       )\
 // FILESTORE_STORAGE_CONFIG

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -175,6 +175,10 @@ public:
     NCloud::NProto::EAuthorizationMode GetAuthorizationMode() const;
 
     bool GetTwoStageReadEnabled() const;
+    TDuration GetEntryTimeout() const;
+    TDuration GetNegativeEntryTimeout() const;
+    TDuration GetAttrTimeout() const;
+
     ui32 GetMaxOutOfOrderCompactionMapLoadRequestsInQueue() const;
 
     bool GetConfigsDispatcherServiceEnabled() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -15,6 +15,10 @@ void FillFeatures(const TStorageConfig& config, NProto::TFileStore& fileStore)
 {
     auto* features = fileStore.MutableFeatures();
     features->SetTwoStageReadEnabled(config.GetTwoStageReadEnabled());
+    features->SetEntryTimeout(config.GetEntryTimeout().MilliSeconds());
+    features->SetNegativeEntryTimeout(
+        config.GetNegativeEntryTimeout().MilliSeconds());
+    features->SetAttrTimeout(config.GetAttrTimeout().MilliSeconds());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -827,7 +827,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
 
         config.SetTwoStageReadEnabled(true);
+        config.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
+        config.SetNegativeEntryTimeout(TDuration::Seconds(1).MilliSeconds());
+        config.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
         features.SetTwoStageReadEnabled(true);
+        features.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
+        features.SetNegativeEntryTimeout(TDuration::Seconds(1).MilliSeconds());
+        features.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
     }
 }

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -17,6 +17,7 @@ namespace {
                                                                                \
     xxx(LockRetryTimeout,       TDuration,      TDuration::Seconds(1)         )\
     xxx(EntryTimeout,           TDuration,      TDuration::Seconds(15)        )\
+    xxx(NegativeEntryTimeout,   TDuration,      TDuration::Zero()             )\
     xxx(AttrTimeout,            TDuration,      TDuration::Seconds(15)        )\
                                                                                \
     xxx(XAttrCacheLimit,        ui32,           512                           )\

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -27,6 +27,7 @@ public:
 
     TDuration GetLockRetryTimeout() const;
     TDuration GetEntryTimeout() const;
+    TDuration GetNegativeEntryTimeout() const;
     TDuration GetAttrTimeout() const;
 
     ui32 GetXAttrCacheLimit() const;

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_node.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_node.cpp
@@ -38,7 +38,8 @@ void TFileSystem::Lookup(
                         response.GetNode());
                 } else {
                     fuse_entry_param entry = {};
-                    entry.entry_timeout = Config->GetEntryTimeout().Seconds();
+                    entry.entry_timeout =
+                        Config->GetNegativeEntryTimeout().Seconds();
                     self->ReplyEntry(
                         *callContext,
                         error,

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -736,6 +736,17 @@ private:
             config.SetMaxBufferSize(pages * NSystemInfo::GetPageSize());
         }
 
+        const auto& features = filestore.GetFeatures();
+        if (features.GetEntryTimeout()) {
+            config.SetEntryTimeout(features.GetEntryTimeout());
+        }
+        if (features.GetNegativeEntryTimeout()) {
+            config.SetNegativeEntryTimeout(features.GetNegativeEntryTimeout());
+        }
+        if (features.GetAttrTimeout()) {
+            config.SetAttrTimeout(features.GetAttrTimeout());
+        }
+
         return std::make_shared<TFileSystemConfig>(config);
     }
 

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -14,6 +14,9 @@ option go_package = "github.com/ydb-platform/nbs/cloud/filestore/public/api/prot
 message TFileStoreFeatures
 {
     bool TwoStageReadEnabled = 1;
+    uint32 EntryTimeout = 2;
+    uint32 NegativeEntryTimeout = 3;
+    uint32 AttrTimeout = 4;
 }
 
 message TFileStore


### PR DESCRIPTION
By default the caching of negative fuse lookup (getattr) responses is disabled. Can be enabled again via TStorageConfig - either globally or for specific filesystems (via the changestorageconfig private api action). entry_timeout and attr_timeout for normal responses can be configured in the same manner now (if needed).

#571 