### PR TITLE
issue-479: get rid of TxxxStoreActivities class

### DIFF
--- a/cloud/blockstore/libs/kikimr/components.h
+++ b/cloud/blockstore/libs/kikimr/components.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "cloud/storage/core/libs/kikimr/components_start.h"
+
 #include <contrib/ydb/core/base/events.h>
 #include <contrib/ydb/library/services/services.pb.h>
 
@@ -61,7 +63,7 @@ struct TBlockStoreComponents
 {
     enum
     {
-        START = 1024,   // TODO
+        START = TComponentsStart::BlockStoreComponentsStart,
 
 #define BLOCKSTORE_DECLARE_COMPONENT(component)                                \
         component,                                                             \

--- a/cloud/blockstore/libs/kikimr/components.h
+++ b/cloud/blockstore/libs/kikimr/components.h
@@ -2,7 +2,7 @@
 
 #include "public.h"
 
-#include <loud/storage/core/libs/kikimr/components_start.h>
+#include <cloud/storage/core/libs/kikimr/components_start.h>
 
 #include <contrib/ydb/core/base/events.h>
 #include <contrib/ydb/library/services/services.pb.h>

--- a/cloud/blockstore/libs/kikimr/components.h
+++ b/cloud/blockstore/libs/kikimr/components.h
@@ -55,6 +55,7 @@ namespace NCloud::NBlockStore {
     xxx(LOCAL_STORAGE)                                                         \
     xxx(EXTERNAL_ENDPOINT)                                                     \
     BLOCKSTORE_ACTORS(xxx)                                                     \
+    xxx(USER_STATS)                                                            \
 // BLOCKSTORE_COMPONENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/kikimr/components.h
+++ b/cloud/blockstore/libs/kikimr/components.h
@@ -129,20 +129,4 @@ struct TBlockStorePrivateEvents
         "END expected to be < EventSpaceEnd(NKikimr::TKikimrEvents::BLOCKSTORE)");
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
-struct TBlockStoreActivities
-{
-    enum
-    {
-#define BLOCKSTORE_DECLARE_COMPONENT(component)                                \
-        component = NKikimrServices::TActivity::BLOCKSTORE_##component,        \
-// BLOCKSTORE_DECLARE_COMPONENT
-
-        BLOCKSTORE_ACTORS(BLOCKSTORE_DECLARE_COMPONENT)
-
-#undef BLOCKSTORE_DECLARE_COMPONENT
-    };
-};
-
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/kikimr/components.h
+++ b/cloud/blockstore/libs/kikimr/components.h
@@ -2,7 +2,7 @@
 
 #include "public.h"
 
-#include "cloud/storage/core/libs/kikimr/components_start.h"
+#include <loud/storage/core/libs/kikimr/components_start.h>
 
 #include <contrib/ydb/core/base/events.h>
 #include <contrib/ydb/library/services/services.pb.h>

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -228,6 +228,7 @@ public:
 
         auto storageUserStats =
             NCloud::NStorage::NUserStats::CreateStorageUserStats(
+                TBlockStoreComponents::USER_STATS,
                 "blockstore",
                 "BlockStore",
                 Args.UserCounterProviders);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_garbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_garbage.cpp
@@ -88,8 +88,7 @@ THttpGarbageActor::THttpGarbageActor(
     , TabletId(tabletId)
     , Action(action)
     , BlobIds(std::move(blobIds))
-{
-}
+{}
 
 void THttpGarbageActor::Bootstrap(const TActorContext& ctx)
 {

--- a/cloud/filestore/libs/storage/api/components.h
+++ b/cloud/filestore/libs/storage/api/components.h
@@ -2,7 +2,7 @@
 
 #include "public.h"
 
-#include "cloud/storage/core/libs/kikimr/components_start.h"
+#include <cloud/storage/core/libs/kikimr/components_start.h>
 
 #include <contrib/ydb/core/base/events.h>
 #include <contrib/ydb/library/services/services.pb.h>

--- a/cloud/filestore/libs/storage/api/components.h
+++ b/cloud/filestore/libs/storage/api/components.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "cloud/storage/core/libs/kikimr/components_start.h"
+
 #include <contrib/ydb/core/base/events.h>
 #include <contrib/ydb/library/services/services.pb.h>
 
@@ -41,7 +43,7 @@ struct TFileStoreComponents
 {
     enum
     {
-        START = 2048,   // TODO
+        START = TComponentsStart::FileStoreComponentsStart,
 
 #define FILESTORE_DECLARE_COMPONENT(component)                                 \
         component,                                                             \

--- a/cloud/filestore/libs/storage/api/components.h
+++ b/cloud/filestore/libs/storage/api/components.h
@@ -59,22 +59,6 @@ const TString& GetComponentName(int component);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TFileStoreActivities
-{
-    enum
-    {
-#define FILESTORE_DECLARE_COMPONENT(component)                                 \
-        component = NKikimrServices::TActivity::FILESTORE_##component,         \
-// FILESTORE_DECLARE_COMPONENT
-
-        FILESTORE_ACTORS(FILESTORE_DECLARE_COMPONENT)
-
-#undef FILESTORE_DECLARE_COMPONENT
-    };
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TFileStoreEvents
 {
     enum

--- a/cloud/filestore/libs/storage/api/components.h
+++ b/cloud/filestore/libs/storage/api/components.h
@@ -35,6 +35,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(FUSE)                                                                  \
     xxx(CLIENT)                                                                \
     xxx(AUTH)                                                                  \
+    xxx(USER_STATS)                                                            \
 // FILESTORE_COMPONENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/api/ya.make
+++ b/cloud/filestore/libs/storage/api/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     cloud/filestore/private/api/protos
     cloud/filestore/public/api/protos
     cloud/storage/core/libs/common
+    cloud/storage/core/libs/kikimr
     contrib/ydb/library/actors/core
     contrib/ydb/core/base
     contrib/ydb/core/protos

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -144,6 +144,7 @@ public:
         //
 
         auto storageUserStats = NUserStats::CreateStorageUserStats(
+            TFileStoreComponents::USER_STATS,
             "filestore",
             "FileStore",
             {Args.UserCounters});

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -576,7 +576,7 @@ void TIndexTabletActor::RebootTabletOnCommitOverflow(
     const TActorContext& ctx,
     const TString& request)
 {
-    LOG_ERROR(ctx, TFileStoreActivities::TABLET,
+    LOG_ERROR(ctx, TFileStoreComponents::TABLET,
         "%s CommitId overflow in %s. Restarting",
         LogTag.c_str(),
         request.c_str());

--- a/cloud/storage/core/libs/kikimr/components.h
+++ b/cloud/storage/core/libs/kikimr/components.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "components_start.h"
 #include "public.h"
 
 #include <contrib/ydb/core/base/events.h>

--- a/cloud/storage/core/libs/kikimr/components.h
+++ b/cloud/storage/core/libs/kikimr/components.h
@@ -15,14 +15,9 @@ namespace NCloud {
 
 #define STORAGE_ACTORS(xxx)                                                    \
     xxx(HIVE_PROXY)                                                            \
-// STORAGE_ACTORS
-
-////////////////////////////////////////////////////////////////////////////////
-
-#define STORAGE_COMPONENTS(xxx)                                                \
     xxx(AUTH)                                                                  \
     xxx(USER_STATS)                                                            \
-// STORAGE_COMPONENTS
+// STORAGE_ACTORS
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -38,9 +33,6 @@ struct TStorageEvents
 // STORAGE_DECLARE_COMPONENT
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
-
-        AUTH_START,
-        AUTH_END = AUTH_START + 100,
 
 #undef STORAGE_DECLARE_COMPONENT
 
@@ -66,12 +58,6 @@ struct TStoragePrivateEvents
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
 
-        AUTH_START,
-        AUTH_END = AUTH_START + 100,
-
-        USER_STATS_START,
-        USER_STATS_END = USER_STATS_START + 100,
-
 #undef STORAGE_DECLARE_COMPONENT
 
         END
@@ -90,11 +76,10 @@ struct TStorageComponents
         START = 3096,   // TODO
 
 #define STORAGE_DECLARE_COMPONENT(component)                                   \
-        component ,                                                            \
+        component,                                                             \
 // STORAGE_DECLARE_COMPONENT
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
-        STORAGE_COMPONENTS(STORAGE_DECLARE_COMPONENT)
 
 #undef STORAGE_DECLARE_COMPONENT
 

--- a/cloud/storage/core/libs/kikimr/components.h
+++ b/cloud/storage/core/libs/kikimr/components.h
@@ -19,6 +19,13 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#define STORAGE_COMPONENTS(xxx)                                                \
+    xxx(AUTH)                                                                  \
+    xxx(USER_STATS)                                                            \
+// STORAGE_COMPONENTS
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TStorageEvents
 {
     enum
@@ -76,19 +83,22 @@ struct TStoragePrivateEvents
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TStorageActivities
+struct TStorageComponents
 {
     enum
     {
+        START = 3096,   // TODO
+
 #define STORAGE_DECLARE_COMPONENT(component)                                   \
-        component = NKikimrServices::TActivity::CLOUD_STORAGE_##component,     \
+        component ,                                                            \
 // STORAGE_DECLARE_COMPONENT
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
+        STORAGE_COMPONENTS(STORAGE_DECLARE_COMPONENT)
 
-        AUTH = NKikimrServices::TActivity::BLOCKSTORE_AUTH,
-        USER_STATS = NKikimrServices::TActivity::BLOCKSTORE_USER_STATS
 #undef STORAGE_DECLARE_COMPONENT
+
+        END
     };
 };
 

--- a/cloud/storage/core/libs/kikimr/components.h
+++ b/cloud/storage/core/libs/kikimr/components.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "components_start.h"
 #include "public.h"
 
 #include <contrib/ydb/core/base/events.h>
@@ -15,6 +16,9 @@ namespace NCloud {
 
 #define STORAGE_ACTORS(xxx)                                                    \
     xxx(HIVE_PROXY)                                                            \
+// STORAGE_ACTORS
+
+#define STORAGE_COMPONENTS(xxx)                                                \
     xxx(AUTH)                                                                  \
     xxx(USER_STATS)                                                            \
 // STORAGE_ACTORS
@@ -33,6 +37,9 @@ struct TStorageEvents
 // STORAGE_DECLARE_COMPONENT
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
+
+        AUTH_START,
+        AUTH_END = AUTH_START + 100,
 
 #undef STORAGE_DECLARE_COMPONENT
 
@@ -58,6 +65,12 @@ struct TStoragePrivateEvents
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
 
+        AUTH_START,
+        AUTH_END = AUTH_START + 100,
+
+        USER_STATS_START,
+        USER_STATS_END = USER_STATS_START + 100,
+
 #undef STORAGE_DECLARE_COMPONENT
 
         END
@@ -73,13 +86,14 @@ struct TStorageComponents
 {
     enum
     {
-        START = 3096,   // TODO
+        START = TComponentsStart::StorageComponentsStart,
 
 #define STORAGE_DECLARE_COMPONENT(component)                                   \
         component,                                                             \
 // STORAGE_DECLARE_COMPONENT
 
         STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
+        STORAGE_COMPONENTS(STORAGE_DECLARE_COMPONENT)
 
 #undef STORAGE_DECLARE_COMPONENT
 

--- a/cloud/storage/core/libs/kikimr/components.h
+++ b/cloud/storage/core/libs/kikimr/components.h
@@ -18,11 +18,6 @@ namespace NCloud {
     xxx(HIVE_PROXY)                                                            \
 // STORAGE_ACTORS
 
-#define STORAGE_COMPONENTS(xxx)                                                \
-    xxx(AUTH)                                                                  \
-    xxx(USER_STATS)                                                            \
-// STORAGE_ACTORS
-
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TStorageEvents
@@ -78,27 +73,6 @@ struct TStoragePrivateEvents
 
     static_assert(END < EventSpaceEnd(NKikimr::TKikimrEvents::ES_CLOUD_STORAGE_PRIVATE),
         "END expected to be < EventSpaceEnd(NKikimr::TKikimrEvents::ES_CLOUD_STORAGE_PRIVATE)");
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TStorageComponents
-{
-    enum
-    {
-        START = TComponentsStart::StorageComponentsStart,
-
-#define STORAGE_DECLARE_COMPONENT(component)                                   \
-        component,                                                             \
-// STORAGE_DECLARE_COMPONENT
-
-        STORAGE_ACTORS(STORAGE_DECLARE_COMPONENT)
-        STORAGE_COMPONENTS(STORAGE_DECLARE_COMPONENT)
-
-#undef STORAGE_DECLARE_COMPONENT
-
-        END
-    };
 };
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/kikimr/components_start.cpp
+++ b/cloud/storage/core/libs/kikimr/components_start.cpp
@@ -1,0 +1,1 @@
+#include "components_start.h"

--- a/cloud/storage/core/libs/kikimr/components_start.h
+++ b/cloud/storage/core/libs/kikimr/components_start.h
@@ -9,7 +9,7 @@ struct TComponentsStart
     enum
     {
         BlockStoreComponentsStart = 1024,
-        FileStoreComponentsStart = 1024
+        FileStoreComponentsStart = 2048
     };
 };
 

--- a/cloud/storage/core/libs/kikimr/components_start.h
+++ b/cloud/storage/core/libs/kikimr/components_start.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TComponentsStart
+{
+    enum
+    {
+        BlockStoreComponentsStart = 1024,
+        FileStoreComponentsStart = 1024,
+        StorageComponentsStart = 2048
+    };
+};
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/kikimr/components_start.h
+++ b/cloud/storage/core/libs/kikimr/components_start.h
@@ -9,8 +9,7 @@ struct TComponentsStart
     enum
     {
         BlockStoreComponentsStart = 1024,
-        FileStoreComponentsStart = 1024,
-        StorageComponentsStart = 2048
+        FileStoreComponentsStart = 1024
     };
 };
 

--- a/cloud/storage/core/libs/kikimr/ya.make
+++ b/cloud/storage/core/libs/kikimr/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     actorsystem.cpp
+    components_start.cpp
     components.cpp
     config_initializer.cpp
     events.cpp

--- a/cloud/storage/core/libs/kikimr/ya.make
+++ b/cloud/storage/core/libs/kikimr/ya.make
@@ -2,8 +2,8 @@ LIBRARY()
 
 SRCS(
     actorsystem.cpp
-    components_start.cpp
     components.cpp
+    components_start.cpp
     config_initializer.cpp
     events.cpp
     helpers.cpp

--- a/cloud/storage/core/libs/user_stats/user_stats.cpp
+++ b/cloud/storage/core/libs/user_stats/user_stats.cpp
@@ -7,11 +7,13 @@ namespace NCloud::NStorage::NUserStats {
 ////////////////////////////////////////////////////////////////////////////////
 
 NActors::IActorPtr CreateStorageUserStats(
+    int component,
     TString path,
     TString title,
     TVector<IUserMetricsSupplierPtr> providers)
 {
     return std::make_unique<TUserStatsActor>(
+        component,
         std::move(path),
         std::move(title),
         std::move(providers));

--- a/cloud/storage/core/libs/user_stats/user_stats.h
+++ b/cloud/storage/core/libs/user_stats/user_stats.h
@@ -8,6 +8,7 @@ namespace NCloud::NStorage::NUserStats {
 ////////////////////////////////////////////////////////////////////////////////
 
 NActors::IActorPtr CreateStorageUserStats(
+    int component,
     TString path,
     TString title,
     TVector<IUserMetricsSupplierPtr> providers);

--- a/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
+++ b/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
@@ -19,10 +19,12 @@ namespace NCloud::NStorage::NUserStats {
 ////////////////////////////////////////////////////////////////////////////////
 
 TUserStatsActor::TUserStatsActor(
+        int component,
         TString path,
         TString title,
         TVector<IUserMetricsSupplierPtr> providers)
     : Providers(std::move(providers))
+    , Component(component)
     , Path(std::move(path))
     , Title(std::move(title))
 {}
@@ -144,7 +146,7 @@ STFUNC(TUserStatsActor::StateWork)
         HFunc(TEvUserStats::TEvUserStatsProviderCreate, HandleUserStatsProviderCreate);
 
         default:
-            HandleUnexpectedEvent(ev, TStorageComponents::USER_STATS);
+            HandleUnexpectedEvent(ev, Component);
     }
 }
 

--- a/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
+++ b/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
@@ -144,7 +144,7 @@ STFUNC(TUserStatsActor::StateWork)
         HFunc(TEvUserStats::TEvUserStatsProviderCreate, HandleUserStatsProviderCreate);
 
         default:
-            HandleUnexpectedEvent(ev, TStorageActivities::USER_STATS);
+            HandleUnexpectedEvent(ev, TStorageComponents::USER_STATS);
     }
 }
 

--- a/cloud/storage/core/libs/user_stats/user_stats_actor.h
+++ b/cloud/storage/core/libs/user_stats/user_stats_actor.h
@@ -18,11 +18,13 @@ private:
     TRWMutex Lock;
     TVector<IUserMetricsSupplierPtr> Providers;
 
+    const int Component;
     const TString Path;
     const TString Title;
 
 public:
     TUserStatsActor(
+        int component,
         TString path,
         TString title,
         TVector<IUserMetricsSupplierPtr> providers);


### PR DESCRIPTION
1. Removed TBlockStoreActivities, TFileStoreActivities, TStorageActivities
2. Moved some components magic numbers to separate header
3. Now TUserStats actor takes log component parameter, like in hive proxy and auth component. This was done because it is more clear to define storage components in terms of  NFS and NBS components, not a separate entity. Plus this eliminates the need for initializing logger for storage components. 