### PR TITLE
Static linking flag for easy debugging

### DIFF
--- a/build/conf/opensource.conf
+++ b/build/conf/opensource.conf
@@ -1,5 +1,6 @@
 EXPORT_CMAKE=no
 EXPORT_GRADLE=no
+FORCE_STATIC_LINKING=no
 
 when ($OPENSOURCE == "yes" || $OPENSOURCE_PROJECT == "ymake" || $OPENSOURCE_PROJECT == "ya") {
     YA_OPENSOURCE=yes
@@ -24,9 +25,11 @@ when ($OPENSOURCE == "yes") {
     USE_DYNAMIC_LIBFUSE=yes
     USE_MKL=no
     VALIDATE_DATA=no
-    _USE_AIO=dynamic
-    _USE_ICONV=dynamic
-    _USE_IDN=dynamic
+    when ($FORCE_STATIC_LINKING != "yes") {
+        _USE_AIO=dynamic
+        _USE_ICONV=dynamic
+        _USE_IDN=dynamic
+    }
 }
 
 # Extra macros to control how gradle export works


### PR DESCRIPTION
Дабы проще дебажить и подкладывать бинари на лабу добавил один флаг. 

Можно указывать либо при сборке:
`ya make -D FORCE_STATIC_LINKING=yes`
Либо сразу в ~/.ya/ya.conf
`[FORCE_STATIC_LINKING]`