### PR TITLE
NBSNEBIUS-105: ADD_HOST registers unknown devices

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -290,7 +290,7 @@ void TDiskRegistryActor::ScheduleDiskRegistryAgentListExpiredParamsCleanup(
 
 void TDiskRegistryActor::PostponeResponse(
     const TActorContext& ctx,
-    TVector<TString> devicesNeedToBeClean,
+    const TVector<TString>& devicesNeedToBeClean,
     TRequestInfoPtr requestInfo,
     TResponseFactory responseFactory)
 {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -12,7 +12,6 @@
 #include <util/stream/file.h>
 #include <util/string/join.h>
 #include <util/system/file.h>
-#include <util/string/join.h>
 
 namespace NCloud::NBlockStore::NStorage {
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -63,11 +63,14 @@ class TDiskRegistryActor final
         NActors::IActor::TReceiveFunc Func;
     };
 
+    using TResponseFactory = std::function<
+        NActors::IEventBasePtr (const NProto::TError&)>;
+
     struct TPendingWaitForDeviceCleanupRequest
     {
         THashSet<TDeviceId> PendingDevices;
         TRequestInfoPtr RequestInfo;
-        std::function<NActors::IEventBasePtr (const NProto::TError&)> ResponseFactory;
+        TResponseFactory ResponseFactory;
 
         void Reply(
             const NActors::TActorContext& ctx,
@@ -260,12 +263,11 @@ private:
         const TDeviceId& id,
         const NProto::TError& error);
 
-    void PostponeUpdateCmsHostDeviceStateResponse(
+    void PostponeResponse(
         const NActors::TActorContext& ctx,
-        TDuration timeout,
         TVector<TString> devicesNeedToBeClean,
-        TVector<TString> affectedDisks,
-        TRequestInfoPtr requestInfo);
+        TRequestInfoPtr requestInfo,
+        TResponseFactory responseFactory);
 
     void ProcessAutomaticallyReplacedDevices(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -265,7 +265,7 @@ private:
 
     void PostponeResponse(
         const NActors::TActorContext& ctx,
-        TVector<TString> devicesNeedToBeClean,
+        const TVector<TString>& devicesNeedToBeClean,
         TRequestInfoPtr requestInfo,
         TResponseFactory responseFactory);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -311,9 +311,10 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
     EraseIf(dirtyDevices, [&] (auto& d) {
         if (d.GetState() == NProto::DEVICE_STATE_ERROR) {
             LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-                "[%lu] Skip SecureErase for device '%s'. Device in error state",
+                "[%lu] Skip SecureErase for device '%s'. Device in error state: %s",
                 TabletID(),
-                d.GetDeviceUUID().c_str());
+                d.GetDeviceUUID().c_str(),
+                d.GetStateMessage().c_str());
 
             return true;
         }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
@@ -70,7 +70,6 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostDeviceState(
 
     args.Error = std::move(result.Error);
     args.AffectedDisks = std::move(result.AffectedDisks);
-    args.DevicesThatNeedToBeCleaned = std::move(result.DevicesThatNeedToBeCleaned);
     args.Timeout = result.Timeout;
 }
 
@@ -91,24 +90,6 @@ void TDiskRegistryActor::CompleteUpdateCmsHostDeviceState(
     StartMigration(ctx);
 
     using TResponse = TEvDiskRegistryPrivate::TEvUpdateCmsHostDeviceStateResponse;
-
-    if (!HasError(args.Error) && !args.DryRun && args.DevicesThatNeedToBeCleaned) {
-        PostponeResponse(
-            ctx,
-            std::move(args.DevicesThatNeedToBeCleaned),
-            args.RequestInfo,
-            [
-                timeout = args.Timeout,
-                affectedDisks = std::move(args.AffectedDisks)
-            ] (const NProto::TError& error) mutable -> NActors::IEventBasePtr {
-                return std::make_unique<TResponse>(
-                    error,
-                    timeout,
-                    std::move(affectedDisks));
-            });
-
-        return;
-    }
 
     auto response = std::make_unique<TResponse>(
         std::move(args.Error),

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
@@ -59,7 +59,6 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostState(
 
     args.TxTs = ctx.Now();
 
-
     args.Error = State->UpdateCmsHostState(
         db,
         args.Host,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
@@ -102,7 +102,7 @@ void TDiskRegistryActor::CompleteUpdateCmsHostState(
     if (!HasError(args.Error) && !args.DryRun && args.DevicesThatNeedToBeCleaned) {
         PostponeResponse(
             ctx,
-            std::move(args.DevicesThatNeedToBeCleaned),
+            args.DevicesThatNeedToBeCleaned,
             args.RequestInfo,
             [
                 timeout = args.Timeout,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
@@ -66,26 +66,8 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostState(
         args.TxTs,
         args.DryRun,
         args.AffectedDisks,
-        args.Timeout);
-
-    if (HasError(args.Error) || args.State != NProto::AGENT_STATE_ONLINE) {
-        return;
-    }
-
-    args.Error = State->RegisterUnknownDevices(db, args.Host, args.TxTs);
-    if (HasError(args.Error) || !Config->GetNonReplicatedDontSuspendDevices()) {
-        return;
-    }
-
-    args.Error = State->ResumeLocalDevices(db, args.Host, args.TxTs);
-    if (HasError(args.Error)) {
-        return;
-    }
-
-    auto [ids, error] = State->CollectDirtyLocalDevices(args.Host);
-
-    args.Error = std::move(error);
-    args.DevicesThatNeedToBeCleaned = std::move(ids);
+        args.Timeout,
+        args.DevicesThatNeedToBeCleaned);
 }
 
 void TDiskRegistryActor::CompleteUpdateCmsHostState(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5144,8 +5144,10 @@ NProto::TError TDiskRegistryState::RegisterUnknownDevices(
     for (auto& device: *agent.MutableUnknownDevices()) {
         ids.push_back(device.GetDeviceUUID());
 
-        device.SetState(NProto::DEVICE_STATE_ONLINE);
-        device.SetStateMessage("New device");
+        if (device.GetState() == NProto::DEVICE_STATE_ONLINE) {
+            device.SetStateMessage("New device");
+        }
+
         device.SetStateTs(now.MicroSeconds());
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5350,13 +5350,6 @@ auto TDiskRegistryState::UpdateCmsDeviceState(
                 now,
                 dryRun,
                 result.Timeout);
-
-            if (!HasError(result.Error)
-                    && IsDirtyDevice(device->GetDeviceUUID())
-                    && device->GetPoolKind() == NProto::DEVICE_POOL_KIND_LOCAL)
-            {
-                result.DevicesThatNeedToBeCleaned.push_back(device->GetDeviceUUID());
-            }
         } else {
             TString affectedDisk;
             result.Error = CmsRemoveDevice(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4894,7 +4894,7 @@ NProto::TError TDiskRegistryState::UpdateCmsHostState(
 
     ApplyAgentStateChange(db, *agent, now, affectedDisks);
 
-    if (newState != NProto::AGENT_STATE_ONLINE && result.GetCode() == S_OK) {
+    if (newState != NProto::AGENT_STATE_ONLINE && !HasError(result)) {
         SuspendLocalDevices(db, *agent);
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -618,7 +618,6 @@ public:
     {
         NProto::TError Error;
         TVector<TDiskId> AffectedDisks;
-        TVector<TDeviceId> DevicesThatNeedToBeCleaned;
         TDuration Timeout;
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -593,21 +593,8 @@ public:
         TInstant now,
         bool dryRun,
         TVector<TDiskId>& affectedDisks,
-        TDuration& timeout);
-
-    // adds all unknown devices from an agent to the DR's config
-    NProto::TError RegisterUnknownDevices(
-        TDiskRegistryDatabase& db,
-        const TString& agentId,
-        TInstant now);
-
-    TResultOrError<TVector<TDeviceId>> CollectDirtyLocalDevices(
-        const TAgentId& agentId);
-
-    NProto::TError ResumeLocalDevices(
-        TDiskRegistryDatabase& db,
-        const TAgentId& agentId,
-        TInstant now);
+        TDuration& timeout,
+        TVector<TDeviceId>& devicesThatNeedToBeClean);
 
     TMaybe<NProto::EAgentState> GetAgentState(const TString& agentId) const;
     TMaybe<TInstant> GetAgentCmsTs(const TString& agentId) const;
@@ -1222,6 +1209,19 @@ private:
         const THashMap<TDeviceId, NProto::TDeviceConfig>& oldConfigs) const;
 
     void ResetMigrationStartTsIfNeeded(TDiskState& disk);
+
+    // adds all unknown devices from an agent to the DR's config
+    NProto::TError RegisterUnknownDevices(
+        TDiskRegistryDatabase& db,
+        NProto::TAgentConfig& agent,
+        TInstant now);
+
+    TVector<TDeviceId> CollectDirtyLocalDevices(NProto::TAgentConfig& agent);
+
+    void ResumeLocalDevices(
+        TDiskRegistryDatabase& db,
+        NProto::TAgentConfig& agent,
+        TInstant now);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -595,6 +595,14 @@ public:
         TVector<TDiskId>& affectedDisks,
         TDuration& timeout);
 
+    // adds all unknown devices from an agent to the DR's config
+    NProto::TError RegisterUnknownDevices(
+        TDiskRegistryDatabase& db,
+        const TString& agentId,
+        TInstant now);
+
+    TVector<TDeviceId> CollectDirtyLocalDevices(const TAgentId& agentId);
+
     TMaybe<NProto::EAgentState> GetAgentState(const TString& agentId) const;
     TMaybe<TInstant> GetAgentCmsTs(const TString& agentId) const;
 
@@ -967,6 +975,11 @@ private:
         NProto::EAgentState newState,
         TInstant timestamp) const;
 
+    NProto::TError CheckAgentStateTransition(
+        const NProto::TAgentConfig& agent,
+        NProto::EAgentState newState,
+        TInstant timestamp) const;
+
     NProto::TError CheckDeviceStateTransition(
         const NProto::TDeviceConfig& device,
         NProto::EDeviceState newState,
@@ -1189,13 +1202,6 @@ private:
         TInstant now,
         bool dryRun,
         TDuration& timeout);
-
-    TUpdateCmsDeviceStateResult AddNewDevices(
-        TDiskRegistryDatabase& db,
-        NProto::TAgentConfig& agent,
-        const TString& path,
-        TInstant now,
-        bool dryRun);
 
     NProto::TError CmsRemoveDevice(
         TDiskRegistryDatabase& db,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -601,7 +601,13 @@ public:
         const TString& agentId,
         TInstant now);
 
-    TVector<TDeviceId> CollectDirtyLocalDevices(const TAgentId& agentId);
+    TResultOrError<TVector<TDeviceId>> CollectDirtyLocalDevices(
+        const TAgentId& agentId);
+
+    NProto::TError ResumeLocalDevices(
+        TDiskRegistryDatabase& db,
+        const TAgentId& agentId,
+        TInstant now);
 
     TMaybe<NProto::EAgentState> GetAgentState(const TString& agentId) const;
     TMaybe<TInstant> GetAgentCmsTs(const TString& agentId) const;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -5985,7 +5985,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 storageConfig->GetNonReplicatedInfraTimeout(),
                 result.Timeout);
             ASSERT_VECTORS_EQUAL(TVector{"disk-3"}, result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), result.DevicesThatNeedToBeCleaned);
 
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetDiskStateUpdates().size());
             const auto& update = state.GetDiskStateUpdates().back();
@@ -6043,7 +6042,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 TDuration(),
                 result.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), result.DevicesThatNeedToBeCleaned);
         });
 
         // mark agent is unavailable
@@ -7289,7 +7287,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.Error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration(), result.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), result.DevicesThatNeedToBeCleaned);
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -7304,7 +7301,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.Error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration(), result.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), result.DevicesThatNeedToBeCleaned);
         });
     }
 
@@ -7361,7 +7357,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, r.Error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(TDuration{}, r.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>{"disk-1"}, r.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), r.DevicesThatNeedToBeCleaned);
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -7377,7 +7372,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, r.Error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration{}, r.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), r.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), r.DevicesThatNeedToBeCleaned);
             UNIT_ASSERT_VALUES_EQUAL(2, state.GetDirtyDevices().size());
         });
 
@@ -7387,7 +7381,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL_C(S_OK, r.Error.GetCode(), r.Error);
             UNIT_ASSERT_VALUES_EQUAL(TDuration{}, r.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), r.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), r.DevicesThatNeedToBeCleaned);
             UNIT_ASSERT_VALUES_EQUAL(2, state.GetDirtyDevices().size());
         });
 
@@ -7397,7 +7390,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL_C(S_OK, r.Error.GetCode(), r.Error);
             UNIT_ASSERT_VALUES_EQUAL(TDuration{}, r.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), r.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), r.DevicesThatNeedToBeCleaned);
             UNIT_ASSERT_VALUES_EQUAL(2, state.GetDirtyDevices().size());
         });
     }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -5684,6 +5684,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         // agent-1: online -> warning
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agent1.GetAgentId(),
@@ -5691,7 +5692,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -5702,6 +5704,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(2, affectedDisks.size());
             UNIT_ASSERT_VALUES_EQUAL("disk-1", affectedDisks[0]);
             UNIT_ASSERT_VALUES_EQUAL("disk-3", affectedDisks[1]);
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             UNIT_ASSERT_VALUES_EQUAL(2, state.GetDiskStateUpdates().size());
             auto updates = state.GetDiskStateUpdates();
@@ -5767,6 +5770,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agent1.GetAgentId(),
@@ -5774,7 +5778,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts + TDuration::Seconds(10),
                 false, // dryRun
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -5782,6 +5787,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     - TDuration::Seconds(10),
                 timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             UNIT_ASSERT_VALUES_EQUAL(4, state.GetDiskStateUpdates().size());
         });
 
@@ -5791,6 +5797,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agent1.GetAgentId(),
@@ -5798,11 +5805,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts + TDuration::Seconds(10),
                 false, // dryRun
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration(), timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             UNIT_ASSERT_VALUES_EQUAL(4, state.GetDiskStateUpdates().size());
         });
 
@@ -5868,6 +5877,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agent1.GetAgentId(),
@@ -5875,7 +5885,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -5884,6 +5895,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
             Sort(affectedDisks);
             UNIT_ASSERT_VALUES_EQUAL(2, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             UNIT_ASSERT_VALUES_EQUAL("disk-1", affectedDisks[0]);
             UNIT_ASSERT_VALUES_EQUAL("disk-3", affectedDisks[1]);
 
@@ -5904,6 +5916,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agent1.GetAgentId(),
@@ -5911,13 +5924,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
                 storageConfig->GetNonReplicatedInfraTimeout() / 2,
                 timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
 
         ts += storageConfig->GetNonReplicatedInfraTimeout() / 2
@@ -5927,6 +5942,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agent1.GetAgentId(),
@@ -5934,13 +5950,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts + TDuration::Seconds(10),
                 false, // dryRun
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
                 storageConfig->GetNonReplicatedInfraTimeout(),
                 timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
     }
 
@@ -6329,6 +6347,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[0].GetAgentId(),
@@ -6336,12 +6355,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
 
             UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
             UNIT_ASSERT_VALUES_EQUAL("disk-1", affectedDisks[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             /*
              * migrations shouldn't start for STORAGE_MEDIA_HDD_NONREPLICATED
@@ -6363,6 +6384,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[1].GetAgentId(),
@@ -6370,11 +6392,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
 
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             /*
              * migrations shouldn't start for STORAGE_MEDIA_HDD_NONREPLICATED
@@ -6393,6 +6417,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[2].GetAgentId(),
@@ -6400,7 +6425,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -6409,6 +6435,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
             UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
             UNIT_ASSERT_VALUES_EQUAL("disk-2", affectedDisks[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             /*
              * migrations shouldn't start for STORAGE_MEDIA_HDD_NONREPLICATED
@@ -6455,6 +6482,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[2].GetAgentId(),
@@ -6462,7 +6490,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -6471,6 +6500,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 cmsTimeout);
 
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
 
         state.PublishCounters(ts + h);
@@ -6486,6 +6516,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[2].GetAgentId(),
@@ -6493,7 +6524,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             // timeout should just wrap
@@ -6502,6 +6534,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 cmsTimeout);
 
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
 
         state.PublishCounters(ts);
@@ -6521,6 +6554,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[2].GetAgentId(),
@@ -6528,11 +6562,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
 
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
 
         state.PublishCounters(ts);
@@ -6789,6 +6825,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[0].GetAgentId(),
@@ -6796,12 +6833,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
 
             UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
             UNIT_ASSERT_VALUES_EQUAL("disk-1", affectedDisks[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             /*
              * migrations shouldn't start for STORAGE_MEDIA_HDD_NONREPLICATED
@@ -6820,6 +6859,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 agents[1].GetAgentId(),
@@ -6827,7 +6867,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false, // dryRun
                 affectedDisks,
-                cmsTimeout);
+                cmsTimeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -6836,6 +6877,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
             UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
             UNIT_ASSERT_VALUES_EQUAL("disk-2", affectedDisks[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             /*
              * migrations shouldn't start for STORAGE_MEDIA_HDD_NONREPLICATED
@@ -7420,6 +7462,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 "agent-1",
@@ -7427,16 +7470,19 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts,
                 false,
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             auto error = state.UpdateCmsHostState(
                 db,
                 "agent-1",
@@ -7444,11 +7490,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 ts + TDuration::Seconds(10),
                 true,
                 affectedDisks,
-                timeout);
+                timeout,
+                devicesThatNeedToBeClean);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
         });
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -154,7 +154,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
 
             UNIT_ASSERT_VALUES_EQUAL(4, state.GetDirtyDevices().size());
             ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.DevicesThatNeedToBeCleaned);
             UNIT_ASSERT_VALUES_EQUAL(TDuration {}, result.Timeout);
             UNIT_ASSERT_VALUES_EQUAL(0, state.GetSuspendedDevices().size());
             UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
@@ -240,7 +239,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 result.Error.GetCode(),
                 result.Error);
             ASSERT_VECTORS_EQUAL(TVector<TString>{"vol0"}, result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.DevicesThatNeedToBeCleaned);
             UNIT_ASSERT_VALUES_UNEQUAL(TDuration {}, result.Timeout);
         });
 
@@ -268,7 +266,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             UNIT_ASSERT_SUCCESS(result.Error);
 
             ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.DevicesThatNeedToBeCleaned);
             UNIT_ASSERT_VALUES_EQUAL(TDuration {}, result.Timeout);
 
             TVector<NProto::TDeviceConfig> devices;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -96,7 +96,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 agentConfig.DevicesSize(),
                 state.GetDirtyDevices().size());
-            UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
+
+            // We have one broken device
+            UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-1.5",
+                state.GetBrokenDevices()[0].GetDeviceUUID());
 
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetAgents().size());
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -62,11 +62,22 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
-            UNIT_ASSERT_SUCCESS(state.RegisterUnknownDevices(
+            TVector<TString> affectedDisks;
+            TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
+            UNIT_ASSERT_SUCCESS(state.UpdateCmsHostState(
                 db,
                 agentConfig.GetAgentId(),
-                Now()));
+                NProto::AGENT_STATE_ONLINE,
+                Now(),
+                false,  // dryRun
+                affectedDisks,
+                timeout,
+                devicesThatNeedToBeClean));
 
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+            UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetConfig().KnownAgentsSize());
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetConfigVersion());
             UNIT_ASSERT_VALUES_EQUAL(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
@@ -458,10 +458,22 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
-            UNIT_ASSERT_SUCCESS(state.RegisterUnknownDevices(
+            TVector<TString> affectedDisks;
+            TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
+            UNIT_ASSERT_SUCCESS(state.UpdateCmsHostState(
                 db,
                 agentConfig.GetAgentId(),
-                Now()));
+                NProto::AGENT_STATE_ONLINE,
+                Now(),
+                false,  // dryRun
+                affectedDisks,
+                timeout,
+                devicesThatNeedToBeClean));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+            UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
 
             const auto d = state.GetDevice(testDeviceId);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -1178,7 +1178,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.Error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Timeout);
             ASSERT_VECTORS_EQUAL(TVector<TString>(), result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>(), result.DevicesThatNeedToBeCleaned);
         });
 
         TDiskInfo diskInfo;
@@ -2171,7 +2170,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                 timeout = result.Timeout;
 
                 ASSERT_VECTORS_EQUAL(TVector{"disk-1/0"}, result.AffectedDisks);
-                ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.DevicesThatNeedToBeCleaned);
             }
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
@@ -2287,7 +2285,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                 timeout = result.Timeout;
 
                 ASSERT_VECTORS_EQUAL(TVector<TString>(), result.AffectedDisks);
-                ASSERT_VECTORS_EQUAL(TVector<TString>(), result.DevicesThatNeedToBeCleaned);
             }
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -2147,6 +2147,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
 
             if (isAgent) {
                 TVector<TString> affectedDisks;
+                TVector<TString> devicesThatNeedToBeClean;
                 error = state.UpdateCmsHostState(
                     db,
                     agentConfig1.GetAgentId(),
@@ -2154,9 +2155,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                     changeStateTs,
                     false,  // dryRun
                     affectedDisks,
-                    timeout);
+                    timeout,
+                    devicesThatNeedToBeClean);
 
                 ASSERT_VECTORS_EQUAL(TVector{"disk-1/0"}, affectedDisks);
+                UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             } else {
                 auto result = state.UpdateCmsDeviceState(
                     db,
@@ -2262,6 +2265,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
 
             if (isAgent) {
                 TVector<TString> affectedDisks;
+                TVector<TString> devicesThatNeedToBeClean;
                 error = state.UpdateCmsHostState(
                     db,
                     agentConfig1.GetAgentId(),
@@ -2269,9 +2273,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                     changeStateTs,
                     false,  // dryRun
                     affectedDisks,
-                    timeout);
+                    timeout,
+                    devicesThatNeedToBeClean);
 
                 ASSERT_VECTORS_EQUAL(TVector<TString>(), affectedDisks);
+                UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             } else {
                 auto result = state.UpdateCmsDeviceState(
                     db,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pending_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pending_cleanup.cpp
@@ -88,7 +88,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePendingCleanupTest)
                 result.Error.GetCode(),
                 result.Error);
             ASSERT_VECTORS_EQUAL(TVector{"vol0"}, result.AffectedDisks);
-            ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.DevicesThatNeedToBeCleaned);
         });
 
         TString target;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
@@ -302,6 +302,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
         WriteTx([&] (auto db) {
             TVector<TString> affectedDisks;
             TDuration timeout;
+            TVector<TString> devicesThatNeedToBeClean;
             UNIT_ASSERT_SUCCESS(state.UpdateCmsHostState(
                 db,
                 Agents[2].GetAgentId(),
@@ -309,8 +310,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 TInstant::FromValue(2),
                 false,  // dryRun
                 affectedDisks,
-                timeout));
+                timeout,
+                devicesThatNeedToBeClean));
 
+            UNIT_ASSERT_VALUES_EQUAL(0, devicesThatNeedToBeClean.size());
             for (const auto& d: Agents[2].GetDevices()) {
                 UNIT_ASSERT_C(state.IsSuspendedDevice(d.GetDeviceUUID()), d);
             }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -661,6 +661,7 @@ struct TTxDiskRegistry
 
         NProto::TError Error;
         TVector<TString> AffectedDisks;
+        TVector<TString> DevicesThatNeedToBeCleaned;
         TInstant TxTs;
         TDuration Timeout;
 
@@ -678,6 +679,7 @@ struct TTxDiskRegistry
         void Clear()
         {
             AffectedDisks.clear();
+            DevicesThatNeedToBeCleaned.clear();
             Error.Clear();
         }
     };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -623,7 +623,6 @@ struct TTxDiskRegistry
 
         NProto::TError Error;
         TVector<TString> AffectedDisks;
-        TVector<TString> DevicesThatNeedToBeCleaned;
         TInstant TxTs;
         TDuration Timeout;
 
@@ -643,7 +642,6 @@ struct TTxDiskRegistry
         void Clear()
         {
             AffectedDisks.clear();
-            DevicesThatNeedToBeCleaned.clear();
             Error.Clear();
         }
     };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_wait_device.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_wait_device.cpp
@@ -296,7 +296,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryWaitDeviceTest)
             auto response = RecvAddHostResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(1, response.ActionResultsSize(), response);
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_TRY_AGAIN,
+                E_INVALID_STATE,
                 response.GetActionResults(0).GetResult().GetCode(),
                 response);
         }

--- a/cloud/blockstore/public/sdk/python/client/safe_client.py
+++ b/cloud/blockstore/public/sdk/python/client/safe_client.py
@@ -765,6 +765,8 @@ class _SafeClient(object):
     def query_available_storage_async(
             self,
             agent_ids,
+            storage_pool_name=None,
+            storage_pool_kind=None,
             idempotence_id=None,
             timestamp=None,
             trace_id=None,
@@ -772,6 +774,8 @@ class _SafeClient(object):
 
         request = protos.TQueryAvailableStorageRequest(
             AgentIds=agent_ids,
+            StoragePoolName=storage_pool_name,
+            StoragePoolKind=storage_pool_kind,
         )
 
         future = futures.Future()
@@ -796,6 +800,8 @@ class _SafeClient(object):
     def query_available_storage(
             self,
             agent_ids,
+            storage_pool_name=None,
+            storage_pool_kind=None,
             idempotence_id=None,
             timestamp=None,
             trace_id=None,
@@ -803,6 +809,8 @@ class _SafeClient(object):
 
         request = protos.TQueryAvailableStorageRequest(
             AgentIds=agent_ids,
+            StoragePoolName=storage_pool_name,
+            StoragePoolKind=storage_pool_kind,
         )
         return self.__impl.query_available_storage(
             request,

--- a/cloud/blockstore/tests/external_endpoint/test.py
+++ b/cloud/blockstore/tests/external_endpoint/test.py
@@ -124,6 +124,8 @@ def start_nbs_daemon(ydb, fake_vhost_server):
     server.VhostEnabled = True
     server.VhostServerPath = fake_vhost_server.path
 
+    cfg.files["storage"].NonReplicatedDontSuspendDevices = True
+
     daemon = start_nbs(cfg)
 
     yield daemon
@@ -155,15 +157,13 @@ def setup_env(nbs, disk_agent, data_path):
 
     request = TCmsActionRequest()
 
-    for i in range(2):
-        action = request.Actions.add()
-        action.Type = TAction.ADD_DEVICE
-        action.Host = get_fqdn()
-        action.Device = os.path.join(data_path, f"NVMENBS{i + 1:02}")
+    action = request.Actions.add()
+    action.Type = TAction.ADD_HOST
+    action.Host = get_fqdn()
 
     response = client.cms_action(request)
 
-    assert len(response.ActionResults) == 2
+    assert len(response.ActionResults) == 1
     for r in response.ActionResults:
         assert r.Result.Code == 0, r
 

--- a/cloud/blockstore/tests/local_ssd/cloud-blockstore-tests-local_ssd
+++ b/cloud/blockstore/tests/local_ssd/cloud-blockstore-tests-local_ssd
@@ -1,1 +1,0 @@
-/home/sharpeye/.ya/build/symres/1bc9932793ad033b1496b596150fc117/cloud-blockstore-tests-local_ssd

--- a/cloud/blockstore/tests/local_ssd/cloud-blockstore-tests-local_ssd
+++ b/cloud/blockstore/tests/local_ssd/cloud-blockstore-tests-local_ssd
@@ -1,0 +1,1 @@
+/home/sharpeye/.ya/build/symres/1bc9932793ad033b1496b596150fc117/cloud-blockstore-tests-local_ssd

--- a/cloud/blockstore/tests/local_ssd/test.py
+++ b/cloud/blockstore/tests/local_ssd/test.py
@@ -1,0 +1,304 @@
+import os
+import pytest
+import time
+import json
+
+from cloud.blockstore.public.sdk.python.client import CreateClient
+from cloud.blockstore.public.sdk.python.protos import TCmsActionRequest, \
+    TAction, STORAGE_POOL_KIND_GLOBAL, STORAGE_MEDIA_SSD_LOCAL
+
+from cloud.blockstore.tests.python.lib.config import NbsConfigurator, \
+    generate_disk_agent_txt
+from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
+    start_disk_agent, get_fqdn
+
+import yatest.common as yatest_common
+
+from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+    ensure_path_exists
+
+
+DEFAULT_DEVICE_SIZE = 1024**2             # 1 MiB
+DEFAULT_DEVICE_RAW_SIZE = 1024**2 + 4096  # ~ 1 MiB
+
+LOCAL_DEVICE_SIZE = 9437184      # 9 MiB
+LOCAL_DEVICE_RAW_SIZE = 9999872  # 19531*512 B ~ 9.5 MiB
+
+KNOWN_DEVICE_POOLS = {
+    "KnownDevicePools": [
+        {"Name": "9Mb", "Kind": "DEVICE_POOL_KIND_LOCAL", "AllocationUnit": LOCAL_DEVICE_SIZE},
+        {"Name": "1Mb", "Kind": "DEVICE_POOL_KIND_GLOBAL", "AllocationUnit": DEFAULT_DEVICE_SIZE},
+    ]}
+
+
+def _add_host(client, agent_id):
+    request = TCmsActionRequest()
+    action = request.Actions.add()
+    action.Type = TAction.ADD_HOST
+    action.Host = agent_id
+
+    return client.cms_action(request)
+
+
+def _backup(client):
+    response = client.execute_action(
+        action="BackupDiskRegistryState",
+        input_bytes=str.encode('{"BackupLocalDB": true}'))
+
+    return json.loads(response)["Backup"]
+
+
+@pytest.fixture(name='ydb')
+def start_ydb_cluster():
+
+    ydb_cluster = start_ydb()
+
+    yield ydb_cluster
+
+    ydb_cluster.stop()
+
+
+@pytest.fixture(name='agent_id')
+def get_agent_id():
+    return get_fqdn()
+
+
+@pytest.fixture(name='data_path')
+def create_data_path():
+
+    p = get_unique_path_for_current_test(
+        output_path=yatest_common.output_path(),
+        sub_folder="data")
+
+    p = os.path.join(p, "dev", "disk", "by-partlabel")
+    ensure_path_exists(p)
+
+    return p
+
+
+@pytest.fixture(name='disk_agent_config')
+def create_disk_agent_config(ydb, data_path):
+    cfg = NbsConfigurator(ydb, 'disk-agent')
+    cfg.generate_default_nbs_configs()
+    cfg.files["disk-agent"] = generate_disk_agent_txt(
+        agent_id='',
+        device_erase_method='DEVICE_ERASE_METHOD_NONE',  # speed up tests
+        storage_discovery_config={
+            "PathConfigs": [{
+                "PathRegExp": f"{data_path}/NVMENBS([0-9]+)",
+                "PoolConfigs": [{
+                    "PoolName": "1Mb",
+                    "MinSize": DEFAULT_DEVICE_RAW_SIZE,
+                    "MaxSize": DEFAULT_DEVICE_RAW_SIZE
+                }]}, {
+                "PathRegExp": f"{data_path}/NVMECOMPUTE([0-9]+)",
+                "BlockSize": 512,
+                "PoolConfigs": [{
+                    "PoolName": "9Mb",
+                    "HashSuffix": "-local",
+                    "MinSize": LOCAL_DEVICE_RAW_SIZE,
+                    "MaxSize": LOCAL_DEVICE_RAW_SIZE
+                }]}
+            ]})
+
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def create_device_files(data_path):
+
+    def create_file(name, size):
+        with open(os.path.join(data_path, name), 'wb') as f:
+            f.seek(size-1)
+            f.write(b'\0')
+            f.flush()
+
+    for i in range(6):
+        create_file(f"NVMENBS{i + 1:02}", DEFAULT_DEVICE_RAW_SIZE)
+
+    for i in range(4):
+        create_file(f"NVMECOMPUTE{i + 1:02}", LOCAL_DEVICE_RAW_SIZE)
+
+
+def test_add_host_with_legacy_local_ssd(
+        ydb,
+        agent_id,
+        data_path,
+        disk_agent_config):
+
+    nbs_config = NbsConfigurator(ydb)
+    nbs_config.generate_default_nbs_configs()
+
+    # do not resume local devices on ADD_HOST action
+    nbs_config.files["storage"].NonReplicatedDontSuspendDevices = False
+
+    nbs = start_nbs(nbs_config)
+
+    client = CreateClient(f"localhost:{nbs.port}")
+    client.execute_action(
+        action="DiskRegistrySetWritableState",
+        input_bytes=str.encode('{"State": true}'))
+    client.update_disk_registry_config(KNOWN_DEVICE_POOLS)
+
+    disk_agent = start_disk_agent(disk_agent_config)
+    disk_agent.wait_for_registration()
+
+    _add_host(client, agent_id)
+
+    # 6 devices were added; 4 local devices were added and suspended
+
+    storage = client.query_available_storage(
+        [agent_id],
+        storage_pool_name="1Mb",
+        storage_pool_kind=STORAGE_POOL_KIND_GLOBAL)
+
+    assert len(storage) == 1
+    assert storage[0].AgentId == agent_id
+    assert storage[0].ChunkCount == 6, storage
+    assert storage[0].ChunkSize == DEFAULT_DEVICE_SIZE
+
+    # we can't see the local devices
+    storage = client.query_available_storage([agent_id])
+    assert len(storage) == 1
+    assert storage[0].AgentId == agent_id
+    assert storage[0].ChunkCount == 0
+    assert storage[0].ChunkSize == 0
+
+    # wait for the secure erase of the non local devices
+    while True:
+        bkp = _backup(client)
+        if len(bkp["DirtyDevices"]) == 4:
+            break
+        time.sleep(0.1)
+
+    assert len(bkp["DirtyDevices"]) == 4
+    assert len(bkp["SuspendedDevices"]) == 4
+
+    client.create_volume_from_device(
+        "vol0",
+        agent_id,
+        os.path.join(data_path, "NVMECOMPUTE01"))
+
+    client.create_volume_from_device(
+        "vol1",
+        agent_id,
+        os.path.join(data_path, "NVMECOMPUTE02"))
+
+    # now we can see 2 local devices
+    storage = client.query_available_storage([agent_id])
+    assert len(storage) == 1
+    assert storage[0].AgentId == agent_id
+    assert storage[0].ChunkCount == 2
+    assert storage[0].ChunkSize == LOCAL_DEVICE_SIZE
+
+    bkp = _backup(client)
+
+    assert len(bkp["DirtyDevices"]) == 2
+    assert len(bkp["SuspendedDevices"]) == 2
+
+    client.resume_device(agent_id, os.path.join(data_path, "NVMECOMPUTE03"))
+    client.resume_device(agent_id, os.path.join(data_path, "NVMECOMPUTE04"))
+
+    # wait for the secure erase of the local devices
+    while True:
+        bkp = _backup(client)
+        if len(bkp.get("DirtyDevices", [])) == 0:
+            break
+        time.sleep(0.1)
+
+    assert len(bkp.get("DirtyDevices", [])) == 0
+    assert len(bkp.get("SuspendedDevices", [])) == 0
+
+    # and now we can see all the local devices
+    storage = client.query_available_storage([agent_id])
+    assert len(storage) == 1
+    assert storage[0].AgentId == agent_id
+    assert storage[0].ChunkCount == 4
+    assert storage[0].ChunkSize == LOCAL_DEVICE_SIZE
+
+    vol0 = client.stat_volume("vol0")["Volume"]
+
+    assert vol0.DiskId == "vol0"
+    assert vol0.BlockSize == 512
+    assert vol0.BlockSize * vol0.BlocksCount == LOCAL_DEVICE_RAW_SIZE
+    assert len(vol0.Devices) == 1
+    assert vol0.Devices[0].BlockCount == LOCAL_DEVICE_RAW_SIZE // 512
+    assert vol0.Devices[0].AgentId == agent_id
+    assert vol0.Devices[0].DeviceName == os.path.join(data_path, "NVMECOMPUTE01")
+
+    vol1 = client.stat_volume("vol1")["Volume"]
+
+    assert vol1.DiskId == "vol1"
+    assert vol1.BlockSize == 512
+    assert vol1.BlockSize * vol0.BlocksCount == LOCAL_DEVICE_RAW_SIZE
+    assert len(vol1.Devices) == 1
+    assert vol1.Devices[0].BlockCount == LOCAL_DEVICE_RAW_SIZE // 512
+    assert vol1.Devices[0].AgentId == agent_id
+    assert vol1.Devices[0].DeviceName == os.path.join(data_path, "NVMECOMPUTE02")
+
+    disk_agent.kill()
+    nbs.kill()
+
+
+def test_add_host(
+        ydb,
+        agent_id,
+        data_path,
+        disk_agent_config):
+
+    nbs_config = NbsConfigurator(ydb)
+    nbs_config.generate_default_nbs_configs()
+
+    # resume local devices on ADD_HOST action
+    nbs_config.files["storage"].NonReplicatedDontSuspendDevices = True
+
+    nbs = start_nbs(nbs_config)
+
+    client = CreateClient(f"localhost:{nbs.port}")
+    client.execute_action(
+        action="DiskRegistrySetWritableState",
+        input_bytes=str.encode('{"State": true}'))
+    client.update_disk_registry_config(KNOWN_DEVICE_POOLS)
+
+    disk_agent = start_disk_agent(disk_agent_config)
+    disk_agent.wait_for_registration()
+
+    _add_host(client, agent_id)
+
+    # 10 devices were added
+
+    # we can see the local devices immediately
+    storage = client.query_available_storage([agent_id])
+    assert len(storage) == 1
+    assert storage[0].AgentId == agent_id
+    assert storage[0].ChunkCount == 4
+    assert storage[0].ChunkSize == LOCAL_DEVICE_SIZE
+
+    storage = client.query_available_storage(
+        [agent_id],
+        storage_pool_name="1Mb",
+        storage_pool_kind=STORAGE_POOL_KIND_GLOBAL)
+
+    assert len(storage) == 1
+    assert storage[0].AgentId == agent_id
+    assert storage[0].ChunkCount == 6, storage
+    assert storage[0].ChunkSize == DEFAULT_DEVICE_SIZE
+
+    # wait for all devices
+    while True:
+        bkp = _backup(client)
+        if len(bkp.get("DirtyDevices", [])) == 0:
+            break
+        time.sleep(0.1)
+
+    assert len(bkp.get("DirtyDevices", [])) == 0
+    assert len(bkp.get("SuspendedDevices", [])) == 0
+
+    client.create_volume(
+        "vol0",
+        block_size=512,
+        blocks_count=4*LOCAL_DEVICE_SIZE//512,
+        storage_media_kind=STORAGE_MEDIA_SSD_LOCAL)
+
+    disk_agent.kill()
+    nbs.kill()

--- a/cloud/blockstore/tests/local_ssd/ya.make
+++ b/cloud/blockstore/tests/local_ssd/ya.make
@@ -2,8 +2,6 @@ PY3TEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
-TIMEOUT(60)
-
 TEST_SRCS(test.py)
 
 DEPENDS(

--- a/cloud/blockstore/tests/local_ssd/ya.make
+++ b/cloud/blockstore/tests/local_ssd/ya.make
@@ -1,0 +1,20 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+TIMEOUT(60)
+
+TEST_SRCS(test.py)
+
+DEPENDS(
+    cloud/blockstore/apps/client
+    cloud/blockstore/apps/disk_agent
+    cloud/blockstore/apps/server
+    contrib/ydb/apps/ydbd
+)
+
+PEERDIR(
+    cloud/blockstore/tests/python/lib
+)
+
+END()

--- a/cloud/blockstore/tests/ya.make
+++ b/cloud/blockstore/tests/ya.make
@@ -15,6 +15,7 @@ RECURSE(
     infra-cms
     loadtest
     loadtest/remote
+    local_ssd
     monitoring
     mount
     notify


### PR DESCRIPTION
Теперь по команде `ADD_HOST` все незарегистрированные девайсы на агенте регистрируются в `DR`. При этом, если не выставлен флаг `NonReplicatedDontSuspendDevices`, все локальные девайсы остаются в состоянии `suspend`. Вывести их из этого состояния можно будет только с помощью `ResumeDevice` или `CreateVolumeFromDevice` (пример того, как это может выглядеть, можно посмотреть в новых тестах из `local_ssd/`).

Возможность регистрации девайсов через `ADD_DEVICE` удалена (функция `AddNewDevices`), т.к. в ней нет необходимости.
В связи с этим, метод `PostponeUpdateCmsHostDeviceStateResponse` унесен из `disk_registry_actor_update_cms_device_state.cpp` в `disk_registry_actor.cpp`, переименован в `PostponeResponse` и сделан независимым от типа ответа.

Соответственно, во всех тестах, где нужно было регистировать девайсы, они теперь регистрируются черех `ADD_HOST`, а не `ADD_DEVICE`.