### PR TITLE
Update placement groups view in monitoring

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -200,7 +200,7 @@ auto GetSortedDisksView(
     {
         auto makeComparableTuple = [&brokenDisks](const TDiskIterator& d){
             return std::make_tuple(
-                brokenDisks.contains(d->GetDiskId()),
+                !brokenDisks.contains(d->GetDiskId()),
                 d->GetPlacementPartitionIndex(),
                 d->GetDiskId()
             );

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -174,17 +174,6 @@ void DumpSquare(IOutputStream& out, const TStringBuf& color)
         << "</font>";
 }
 
-void DumpPlacementGroupStrategy(
-    IOutputStream& out,
-    NProto::EPlacementStrategy strategy)
-{
-    const TString prefix = "PLACEMENT_STRATEGY_";
-    const TString strategyName = EPlacementStrategy_Name(strategy);
-    out << (strategyName.length() > prefix.length()
-        ? strategyName.substr(prefix.length())
-        : strategyName);
-}
-
 using DiskInfoArray = ::google::protobuf::RepeatedPtrField<NProto::TPlacementGroupConfig_TDiskInfo>;
 auto GetSortedDisksView(
     const DiskInfoArray& disks,
@@ -1517,7 +1506,9 @@ void TDiskRegistryActor::RenderPlacementGroupList(
                         out << groupId;
                     }
                     TABLED() {
-                        DumpPlacementGroupStrategy(out, strategy);
+                        TStringBuf name = EPlacementStrategy_Name(strategy);
+                        name.AfterPrefix("PLACEMENT_STRATEGY_", name);
+                        out << name;
                     }
                     TABLED() {
                         size_t totalPartitionsCount = isPartitionGroup

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -1509,36 +1509,37 @@ void TDiskRegistryActor::RenderPlacementGroupList(
                     const bool isPartitionGroup = strategy == NProto::PLACEMENT_STRATEGY_PARTITION;
 
                     auto it = brokenGroups.find(groupId);
-                    const size_t brokenCount =
-                        it == brokenGroups.end()
-                            ? 0
-                            : it->second.Recently.GetBrokenPartitionCount();
+                    const size_t brokenPartitionsCount =
+                        it != brokenGroups.end()
+                            ? it->second.Recently.GetBrokenPartitionCount()
+                            : 0;
 
                     TABLED() {
-                        if (brokenCount > 0) {
-                            DumpSquare(out, brokenCount == 1 ? "orange" : "red");
-                        }
+                        const auto* color = brokenPartitionsCount == 0
+                                ? "green"
+                                : (brokenPartitionsCount == 1 ? "orange" : "red");
+                        DumpSquare(out, color);
                         out << groupId;
                     }
                     TABLED() {
                         DumpPlacementGroupStrategy(out, strategy);
                     }
                     TABLED() {
-                        size_t totalCount = isPartitionGroup ?
+                        size_t totalPartitionsCount = isPartitionGroup ?
                             groupInfo.Config.GetPlacementPartitionCount() :
                             groupInfo.Config.GetDisks().size();
 
                         out << Sprintf("%s: <font color=green>Fine: %zu</font>, ",
                             isPartitionGroup ? "Partitions" : "Disks",
-                            totalCount - brokenCount);
+                            totalPartitionsCount - brokenPartitionsCount);
 
-                        if(brokenCount > 0) {
+                        if(brokenPartitionsCount > 0) {
                             out << Sprintf("<font color=%s>Broken: %zu</font>, ",
-                            brokenCount == 1 ? "orange" : "red",
-                            brokenCount);
+                            brokenPartitionsCount == 1 ? "orange" : "red",
+                            brokenPartitionsCount);
                         }
 
-                        out << Sprintf("Total: %zu<br>", totalCount);
+                        out << Sprintf("Total: %zu<br>", totalPartitionsCount);
                     }
                     TABLED() {
                         if (groupInfo.Full) {
@@ -1573,7 +1574,7 @@ void TDiskRegistryActor::RenderPlacementGroupList(
                                         }
 
                                         const auto brokenDisks =
-                                            it == brokenGroups.end()
+                                            it != brokenGroups.end()
                                                 ? it->second.Recently.GetBrokenDisks()
                                                 : THashSet<TString>();
 
@@ -1584,8 +1585,8 @@ void TDiskRegistryActor::RenderPlacementGroupList(
                                         for (const auto& d: sortedDisks) {
                                             TABLER() {
                                                 TABLED() {
-                                                    const bool broken = brokenDisks.contains(d->GetDiskId());
-                                                    DumpSquare(out, broken ? "red" : "green");
+                                                    const bool isBroken = brokenDisks.contains(d->GetDiskId());
+                                                    DumpSquare(out, isBroken ? "red" : "green");
                                                     DumpDiskLink(out, TabletID(), d->GetDiskId());
                                                 }
                                                 TABLED() {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3642,9 +3642,9 @@ THashMap<TString, TBrokenGroupInfo> TDiskRegistryState::GatherBrokenGroupsInfo(
         auto res = groups.try_emplace(groupId, pg->Config.GetPlacementStrategy());
         TBrokenGroupInfo& info = res.first->second;
 
-        info.Total.Increment(disk.PlacementPartitionIndex);
+        info.Total.Increment(diskId, disk.PlacementPartitionIndex);
         if (now - period < disk.StateTs) {
-            info.Recently.Increment(disk.PlacementPartitionIndex);
+            info.Recently.Increment(diskId, disk.PlacementPartitionIndex);
         }
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -111,9 +111,9 @@ public:
         : Strategy(strategy)
     {}
 
-    void Increment(ui32 partitionIndex)
+    void Increment(const TString& diskId, ui32 partitionIndex)
     {
-        ++BrokenDiskCount;
+        BrokenDisks.insert(diskId);
         if (Strategy == NProto::EPlacementStrategy::PLACEMENT_STRATEGY_PARTITION) {
             BrokenPartitions.insert(partitionIndex);
         }
@@ -123,7 +123,7 @@ public:
     {
         switch (Strategy) {
             case NProto::EPlacementStrategy::PLACEMENT_STRATEGY_SPREAD:
-                return BrokenDiskCount;
+                return BrokenDisks.size();
             case NProto::EPlacementStrategy::PLACEMENT_STRATEGY_PARTITION:
                 return BrokenPartitions.size();
             default:
@@ -135,9 +135,14 @@ public:
         }
     }
 
+    [[nodiscard]] auto GetBrokenDisks() const
+    {
+        return BrokenDisks;
+    }
+
 private:
     NProto::EPlacementStrategy Strategy;
-    ui32 BrokenDiskCount = 0;
+    THashSet<TString> BrokenDisks;
     THashSet<ui32> BrokenPartitions;
 };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -135,7 +135,7 @@ public:
         }
     }
 
-    [[nodiscard]] auto GetBrokenDisks() const
+    [[nodiscard]] const THashSet<TString>& GetBrokenDisks() const
     {
         return BrokenDisks;
     }


### PR DESCRIPTION
Changes in placement group view:
* Added strategy type column
* Added disks/partition state column
* Disks are now sorted by states (broken first) and by partition_id

View before:
![before](https://github.com/ydb-platform/nbs/assets/153231895/074b02bf-9edd-4cbb-ae26-48a01cf57d28)

View after:
![after](https://github.com/ydb-platform/nbs/assets/153231895/a00843dd-d268-4add-97b6-b0a07f9953d1)
