### PR TITLE
issue-573: CreateSessionActor should start its wakeup cycle only after its first successful session creation attempt

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -13,6 +13,9 @@ namespace NCloud::NFileStore{
     xxx(TabletBSFailure)                                                       \
     xxx(TabletCommitIdOverflow)                                                \
     xxx(VfsQueueRunningError)                                                  \
+    xxx(MissingSessionId)                                                      \
+    xxx(CreateSessionError)                                                    \
+    xxx(DescribeFileStoreError)                                                \
 // FILESTORE_CRITICAL_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1528,6 +1528,94 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.DestroySession(headers);
     }
 
+    Y_UNIT_TEST(ShouldProperlyProcessSlowSessionCreation)
+    {
+        NProto::TStorageConfig config;
+        config.SetIdleSessionTimeout(5'000); // 5s
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        auto& runtime = env.GetRuntime();
+
+        // enabling scheduling for all actors
+        runtime.SetRegistrationObserverFunc(
+            [] (auto& runtime, const auto& parentId, const auto& actorId) {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore("test", 1000);
+
+        THeaders headers = {"test", "client", "", 0};
+
+        // delaying session creation response
+        bool rescheduled = false;
+        ui32 createSessionResponses = 0;
+        TActorId createSessionActor;
+
+        runtime.SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeFileStoreResponse: {
+                        createSessionActor = event->Recipient;
+
+                        break;
+                    }
+                    case TEvIndexTablet::EvCreateSessionResponse: {
+                        ++createSessionResponses;
+
+                        if (!rescheduled) {
+                            runtime.Schedule(event, TDuration::Seconds(10), nodeIdx);
+                            rescheduled = true;
+                            return true;
+                        }
+
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        // creating session
+        service.SendCreateSessionRequest(headers);
+        auto response = service.RecvCreateSessionResponse();
+        headers.SessionId = response->Record.GetSession().GetSessionId();
+        // immediately pinging session to signal that it's not idle
+        service.PingSession(headers);
+
+        // just checking that we observed the events that we are expecting
+        UNIT_ASSERT(rescheduled);
+        UNIT_ASSERT_VALUES_EQUAL(1, createSessionResponses);
+
+        // can't call RebootTablet here because it resets our registration
+        // observer and thus disables wakeup event scheduling
+        auto msg = std::make_unique<TEvTabletPipe::TEvClientDestroyed>(
+            static_cast<ui64>(0),
+            TActorId(),
+            TActorId());
+
+        runtime.Send(
+            new IEventHandle(
+                createSessionActor,
+                runtime.AllocateEdgeActor(nodeIdx),
+                msg.release(),
+                0, // flags
+                0),
+            nodeIdx);
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        // checking that session was recreated
+        UNIT_ASSERT_VALUES_EQUAL(2, createSessionResponses);
+
+        service.DestroySession(headers);
+    }
+
     Y_UNIT_TEST(UnsuccessfulSessionActorShouldStopWorking)
     {
         NProto::TStorageConfig config;


### PR DESCRIPTION
Fixing the following race:
1. create pipe
2. pipe created successfully, sending CreateSessionRequest to the tablet, starting the wakeup cycle
3. tablet is slow to respond, HandleWakeup doesn't see any recent ping attempts and decides that this session is idle => wakeup cycle stops
4. tablet finally responds

This race actually has no disastrous consequences after https://github.com/ydb-platform/nbs/pull/589 but it's still useful to have an additional safety measure here.

This PR also adds some critical events for the session creation errors received from the tablet.

#573 