### PR TITLE
NBS-4488: [Disk Manager] remove unused parametrs from disks table

### DIFF
--- a/cloud/disk_manager/internal/pkg/resources/disks.go
+++ b/cloud/disk_manager/internal/pkg/resources/disks.go
@@ -95,9 +95,6 @@ func (s *diskState) toDiskMeta() *DiskMeta {
 		FolderID:         s.folderID,
 		PlacementGroupID: s.placementGroupID,
 
-		BaseDiskID:           s.baseDiskID,
-		BaseDiskCheckpointID: s.baseDiskCheckpointID,
-
 		CreateTaskID: s.createTaskID,
 		CreatingAt:   s.creatingAt,
 		CreatedAt:    s.createdAt,
@@ -381,9 +378,6 @@ func (s *storageYDB) createDisk(
 		folderID:         disk.FolderID,
 		placementGroupID: disk.PlacementGroupID,
 
-		baseDiskID:           disk.BaseDiskID,
-		baseDiskCheckpointID: disk.BaseDiskCheckpointID,
-
 		createRequest: createRequest,
 		createTaskID:  disk.CreateTaskID,
 		creatingAt:    disk.CreatingAt,
@@ -471,9 +465,6 @@ func (s *storageYDB) diskCreated(
 	}
 
 	state.status = diskStatusReady
-	// Base disk id and checkpoint id become known after disk creation.
-	state.baseDiskID = disk.BaseDiskID
-	state.baseDiskCheckpointID = disk.BaseDiskCheckpointID
 	state.createdAt = disk.CreatedAt
 
 	err = s.updateDiskState(ctx, tx, state)

--- a/cloud/disk_manager/internal/pkg/resources/storage.go
+++ b/cloud/disk_manager/internal/pkg/resources/storage.go
@@ -24,9 +24,6 @@ type DiskMeta struct {
 	PlacementGroupID        string `json:"placement_group_id"`
 	PlacementPartitionIndex string `json:"placement_partition_index"`
 
-	BaseDiskID           string `json:"base_disk_id"`
-	BaseDiskCheckpointID string `json:"base_disk_checkpoint_id"`
-
 	CreateRequest proto.Message `json:"create_request"`
 	CreateTaskID  string        `json:"create_task_id"`
 	CreatingAt    time.Time     `json:"creating_at"`

--- a/cloud/disk_manager/internal/pkg/services/disks/create_overlay_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/create_overlay_disk_task.go
@@ -129,8 +129,6 @@ func (t *createOverlayDiskTask) Run(
 		return err
 	}
 
-	diskMeta.BaseDiskID = baseDiskID
-	diskMeta.BaseDiskCheckpointID = baseDiskCheckpointID
 	diskMeta.CreatedAt = time.Now()
 
 	return t.storage.DiskCreated(ctx, *diskMeta)


### PR DESCRIPTION
- we do use these parametrs
- now these parametrs can be not actual for disks

so, it will be better to remove them 