### PR TITLE
NBS-4000 fix for background requests

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -34,7 +34,7 @@ private:
     const TVector<TDeviceRequest> DeviceRequests;
     const TNonreplicatedPartitionConfigPtr PartConfig;
     const TActorId Part;
-    const bool AssignIdToWriteAndZeroRequestsEnabled;
+    const bool AssignVolumeRequestId;
 
     TInstant StartTime;
     ui32 RequestsCompleted = 0;
@@ -48,7 +48,7 @@ public:
         TVector<TDeviceRequest> deviceRequests,
         TNonreplicatedPartitionConfigPtr partConfig,
         const TActorId& part,
-        bool assignIdToWriteAndZeroRequestsEnabled,
+        bool assignVolumeRequestId,
         bool replyLocal);
 
     void Bootstrap(const TActorContext& ctx);
@@ -86,15 +86,14 @@ TDiskAgentWriteActor::TDiskAgentWriteActor(
         TVector<TDeviceRequest> deviceRequests,
         TNonreplicatedPartitionConfigPtr partConfig,
         const TActorId& part,
-        bool assignIdToWriteAndZeroRequestsEnabled,
+        bool assignVolumeRequestId,
         bool replyLocal)
     : RequestInfo(std::move(requestInfo))
     , Request(std::move(request))
     , DeviceRequests(std::move(deviceRequests))
     , PartConfig(std::move(partConfig))
     , Part(part)
-    , AssignIdToWriteAndZeroRequestsEnabled(
-          assignIdToWriteAndZeroRequestsEnabled)
+    , AssignVolumeRequestId(assignVolumeRequestId)
     , ReplyLocal(replyLocal)
 {}
 
@@ -130,7 +129,7 @@ void TDiskAgentWriteActor::WriteBlocks(const TActorContext& ctx)
         request->Record.SetDeviceUUID(deviceRequest.Device.GetDeviceUUID());
         request->Record.SetStartIndex(deviceRequest.DeviceBlockRange.Start);
         request->Record.SetBlockSize(PartConfig->GetBlockSize());
-        if (AssignIdToWriteAndZeroRequestsEnabled) {
+        if (AssignVolumeRequestId) {
             request->Record.SetVolumeRequestId(RequestInfo->Cookie);
             request->Record.SetMultideviceRequest(DeviceRequests.size() > 1);
         }
@@ -351,6 +350,10 @@ void TNonreplicatedPartitionActor::HandleWriteBlocks(
         return;
     }
 
+    const bool assignVolumeRequestId =
+        Config->GetAssignIdToWriteAndZeroRequestsEnabled() &&
+        !msg->Record.GetHeaders().GetIsBackgroundRequest();
+
     auto actorId = NCloud::Register<TDiskAgentWriteActor>(
         ctx,
         requestInfo,
@@ -358,7 +361,7 @@ void TNonreplicatedPartitionActor::HandleWriteBlocks(
         std::move(deviceRequests),
         PartConfig,
         SelfId(),
-        Config->GetAssignIdToWriteAndZeroRequestsEnabled(),
+        assignVolumeRequestId,
         false); // replyLocal
 
     RequestsInProgress.AddWriteRequest(actorId, std::move(request));
@@ -440,6 +443,10 @@ void TNonreplicatedPartitionActor::HandleWriteBlocksLocal(
             msg->Record.BlocksCount,
             PartConfig->GetBlockSize()));
 
+    const bool assignVolumeRequestId =
+        Config->GetAssignIdToWriteAndZeroRequestsEnabled() &&
+        !msg->Record.GetHeaders().GetIsBackgroundRequest();
+
     auto actorId = NCloud::Register<TDiskAgentWriteActor>(
         ctx,
         requestInfo,
@@ -447,7 +454,7 @@ void TNonreplicatedPartitionActor::HandleWriteBlocksLocal(
         std::move(deviceRequests),
         PartConfig,
         SelfId(),
-        Config->GetAssignIdToWriteAndZeroRequestsEnabled(),
+        assignVolumeRequestId,
         true); // replyLocal
 
     RequestsInProgress.AddWriteRequest(actorId, std::move(request));

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -33,7 +33,7 @@ private:
     const TNonreplicatedPartitionConfigPtr PartConfig;
     const TActorId Part;
     const ui32 BlockSize;
-    const bool AssignIdToWriteAndZeroRequestsEnabled;
+    const bool AssignVolumeRequestId;
 
     TInstant StartTime;
     ui32 RequestsCompleted = 0;
@@ -48,7 +48,7 @@ public:
         TNonreplicatedPartitionConfigPtr partConfig,
         const TActorId& part,
         ui32 blockSize,
-        bool assignIdToWriteAndZeroRequestsEnabled);
+        bool assignVolumeRequestId);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -84,15 +84,14 @@ TDiskAgentZeroActor::TDiskAgentZeroActor(
         TNonreplicatedPartitionConfigPtr partConfig,
         const TActorId& part,
         ui32 blockSize,
-        bool assignIdToWriteAndZeroRequestsEnabled)
+        bool assignVolumeRequestId)
     : RequestInfo(std::move(requestInfo))
     , Request(std::move(request))
     , DeviceRequests(std::move(deviceRequests))
     , PartConfig(std::move(partConfig))
     , Part(part)
     , BlockSize(blockSize)
-    , AssignIdToWriteAndZeroRequestsEnabled(
-          assignIdToWriteAndZeroRequestsEnabled)
+    , AssignVolumeRequestId(assignVolumeRequestId)
 {}
 
 void TDiskAgentZeroActor::Bootstrap(const TActorContext& ctx)
@@ -123,7 +122,7 @@ void TDiskAgentZeroActor::ZeroBlocks(const TActorContext& ctx)
         request->Record.SetStartIndex(deviceRequest.DeviceBlockRange.Start);
         request->Record.SetBlockSize(BlockSize);
         request->Record.SetBlocksCount(deviceRequest.DeviceBlockRange.Size());
-        if (AssignIdToWriteAndZeroRequestsEnabled) {
+        if (AssignVolumeRequestId) {
             request->Record.SetVolumeRequestId(RequestInfo->Cookie);
             request->Record.SetMultideviceRequest(DeviceRequests.size() > 1);
         }
@@ -301,6 +300,10 @@ void TNonreplicatedPartitionActor::HandleZeroBlocks(
         return;
     }
 
+    const bool assignVolumeRequestId =
+        Config->GetAssignIdToWriteAndZeroRequestsEnabled() &&
+        !msg->Record.GetHeaders().GetIsBackgroundRequest();
+
     auto actorId = NCloud::Register<TDiskAgentZeroActor>(
         ctx,
         requestInfo,
@@ -309,7 +312,7 @@ void TNonreplicatedPartitionActor::HandleZeroBlocks(
         PartConfig,
         SelfId(),
         PartConfig->GetBlockSize(),
-        Config->GetAssignIdToWriteAndZeroRequestsEnabled());
+        assignVolumeRequestId);
 
     RequestsInProgress.AddWriteRequest(actorId, std::move(request));
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -239,6 +239,10 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
 
     TVector<TDeviceRequestInfo> requests;
 
+    const bool assignVolumeRequestId =
+        AssignIdToWriteAndZeroRequestsEnabled &&
+        !msg->Record.GetHeaders().GetIsBackgroundRequest();
+
     for (auto& r: deviceRequests) {
         auto ep = AgentId2Endpoint[r.Device.GetAgentId()];
         Y_ABORT_UNLESS(ep);
@@ -248,7 +252,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
         deviceRequest.SetDeviceUUID(r.Device.GetDeviceUUID());
         deviceRequest.SetStartIndex(r.DeviceBlockRange.Start);
         deviceRequest.SetBlockSize(PartConfig->GetBlockSize());
-        if (AssignIdToWriteAndZeroRequestsEnabled) {
+        if (assignVolumeRequestId) {
             deviceRequest.SetVolumeRequestId(requestInfo->Cookie);
             deviceRequest.SetMultideviceRequest(deviceRequests.size() > 1);
         }
@@ -379,6 +383,10 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
 
     TVector<TDeviceRequestInfo> requests;
 
+    const bool assignVolumeRequestId =
+        AssignIdToWriteAndZeroRequestsEnabled &&
+        !msg->Record.GetHeaders().GetIsBackgroundRequest();
+
     ui64 blocks = 0;
     for (auto& r: deviceRequests) {
         auto ep = AgentId2Endpoint[r.Device.GetAgentId()];
@@ -389,7 +397,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
         deviceRequest.SetDeviceUUID(r.Device.GetDeviceUUID());
         deviceRequest.SetStartIndex(r.DeviceBlockRange.Start);
         deviceRequest.SetBlockSize(PartConfig->GetBlockSize());
-        if (AssignIdToWriteAndZeroRequestsEnabled) {
+        if (assignVolumeRequestId) {
             deviceRequest.SetVolumeRequestId(requestInfo->Cookie);
             deviceRequest.SetMultideviceRequest(deviceRequests.size() > 1);
         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -187,6 +187,10 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
 
     TVector<TDeviceRequestInfo> requests;
 
+    const bool assignVolumeRequestId =
+        AssignIdToWriteAndZeroRequestsEnabled &&
+        !msg->Record.GetHeaders().GetIsBackgroundRequest();
+
     for (auto& r: deviceRequests) {
         auto ep = AgentId2Endpoint[r.Device.GetAgentId()];
         Y_ABORT_UNLESS(ep);
@@ -197,7 +201,7 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         deviceRequest.SetStartIndex(r.DeviceBlockRange.Start);
         deviceRequest.SetBlocksCount(r.DeviceBlockRange.Size());
         deviceRequest.SetBlockSize(PartConfig->GetBlockSize());
-        if (AssignIdToWriteAndZeroRequestsEnabled) {
+        if (assignVolumeRequestId) {
             deviceRequest.SetVolumeRequestId(requestInfo->Cookie);
             deviceRequest.SetMultideviceRequest(deviceRequests.size() > 1);
         }


### PR DESCRIPTION
Для фоновых запросов в cookie запросов лежит не номер запроса вольюма, а просто какая-та чиселка. Она пробрасывалась в дискагенты, и так это не ноль, то происходило отклонение таких фоновых запросов. Что поломало ресинхронизацию дисков. 