### PR TITLE
fix NRD acquire: allow acquiring empty list of devices

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
@@ -136,7 +136,7 @@ void TAcquireDiskActor::Bootstrap(const TActorContext& ctx)
     Become(&TThis::StateAcquire);
 
     if (Devices.empty()) {
-        FinishAcquireDisk(ctx, MakeError(E_REJECTED, "nothing to acquire"));
+        FinishAcquireDisk(ctx, {});
         return;
     }
 
@@ -439,6 +439,15 @@ void TDiskRegistryActor::HandleAcquireDisk(
         devices.insert(devices.end(),
             std::make_move_iterator(replica.begin()),
             std::make_move_iterator(replica.end()));
+    }
+
+    if (devices.empty()) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskRegistry::TEvAcquireDiskResponse>());
+
+        return;
     }
 
     auto actor = NCloud::Register<TAcquireDiskActor>(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_session.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_session.cpp
@@ -615,10 +615,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         breakAgent("agent-2");
 
+        // It is OK to successfully acquire empty device list
         {
             diskRegistry.SendAcquireDiskRequest("disk-1", "session-1");
             auto response = diskRegistry.RecvAcquireDiskResponse();
-            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
             UNIT_ASSERT_VALUES_EQUAL(0, response->Record.DevicesSize());
         }


### PR DESCRIPTION
Если не позволять захватывать сессию с пустым списком девайсов (был E_REJECTED), то (например при выходе всех агентов диска) вольюм будет ретраить захват сессии вечно, зажгутся алерты - машинерия по маскировке ошибок NRD не будет работать.