### PR TITLE
[CI]: Increase disk detection timeout for sync test

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -81,7 +81,7 @@ class VirtualDevicesToIdMapper:
         )
         return self.get_disk_id_to_device_path_mapping(udevadm_output)
 
-    def wait_for_disk_to_appear(self, disk_id: str, timeout_sec: int = 60) -> str:
+    def wait_for_disk_to_appear(self, disk_id: str, timeout_sec: int = 120) -> str:
         _logger.info(
             "Started waiting for disk %s to appear in the guest system, waiting for %d",
             disk_id,


### PR DESCRIPTION
In some cases, 60 seconds is not enough for the os to detect the disk. Wait 120 seconds instead.