### PR TITLE
offload the session cache update to the IO pool

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.cpp
@@ -1,0 +1,108 @@
+#include "session_cache_actor.h"
+
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/kikimr/components.h>
+
+#include <cloud/storage/core/libs/actors/helpers.h>
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+
+#include <util/system/fs.h>
+
+using namespace NActors;
+
+namespace NCloud::NBlockStore::NStorage::NDiskAgent {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSessionCacheActor
+    : public TActorBootstrapped<TSessionCacheActor>
+{
+private:
+    const TString CachePath;
+
+    TVector<NProto::TDiskAgentDeviceSession> Sessions;
+    TRequestInfoPtr RequestInfo;
+    NActors::IEventBasePtr Response;
+
+public:
+    TSessionCacheActor(
+            TVector<NProto::TDiskAgentDeviceSession> sessions,
+            TString cachePath,
+            TRequestInfoPtr requestInfo,
+            NActors::IEventBasePtr response)
+        : CachePath {std::move(cachePath)}
+        , Sessions {std::move(sessions)}
+        , RequestInfo {std::move(requestInfo)}
+        , Response {std::move(response)}
+    {
+        ActivityType = TBlockStoreComponents::DISK_AGENT_WORKER;
+    }
+
+    void Bootstrap(const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TSessionCacheActor::Bootstrap(const TActorContext& ctx)
+{
+    try {
+        NProto::TDiskAgentDeviceSessionCache proto;
+        proto.MutableSessions()->Assign(
+            std::make_move_iterator(Sessions.begin()),
+            std::make_move_iterator(Sessions.end())
+        );
+
+        const TString tmpPath {CachePath + ".tmp"};
+
+        SerializeToTextFormat(proto, tmpPath);
+
+        if (!NFs::Rename(tmpPath, CachePath)) {
+            char buf[64] = {};
+
+            const auto ec = errno;
+            ythrow TServiceError {MAKE_SYSTEM_ERROR(ec)}
+                << strerror_r(ec, buf, sizeof(buf));
+        }
+    } catch (...) {
+        LOG_ERROR_S(
+            ctx,
+            ActivityType,
+            "Can't update session cache: " << CurrentExceptionMessage());
+
+        ReportDiskAgentSessionCacheUpdateError();
+    }
+
+    NCloud::Reply(
+        ctx,
+        *RequestInfo,
+        std::move(Response));
+
+    Die(ctx);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<IActor> CreateSessionCacheActor(
+    TVector<NProto::TDiskAgentDeviceSession> sessions,
+    TString cachePath,
+    TRequestInfoPtr requestInfo,
+    NActors::IEventBasePtr response)
+{
+    return std::make_unique<TSessionCacheActor>(
+        std::move(sessions),
+        std::move(cachePath),
+        std::move(requestInfo),
+        std::move(response));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NDiskAgent

--- a/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cloud/blockstore/config/disk.pb.h>
+
+#include <cloud/blockstore/libs/storage/core/request_info.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NStorage::NDiskAgent {
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<NActors::IActor> CreateSessionCacheActor(
+    TVector<NProto::TDiskAgentDeviceSession> sessions,
+    TString cachePath,
+    TRequestInfoPtr requestInfo,
+    NActors::IEventBasePtr response);
+
+}   // namespace NCloud::NBlockStore::NStorage::NDiskAgent

--- a/cloud/blockstore/libs/storage/disk_agent/actors/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/ya.make
@@ -1,0 +1,20 @@
+LIBRARY()
+
+SRCS(
+    session_cache_actor.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/disk_agent/model
+
+    cloud/storage/core/libs/actors
+    cloud/storage/core/protos
+
+    contrib/ydb/library/actors/core
+    contrib/ydb/core/protos
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+)

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -15,6 +15,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/pending_request.h>
+#include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/recent_blocks_tracker.h>
 
@@ -131,6 +132,11 @@ private:
         const TString& deviceId);
 
     TRecentBlocksTracker& GetRecentBlocksTracker(const TString& deviceUUID);
+
+    void UpdateSessionCacheAndRespond(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo,
+        NActors::IEventBasePtr response);
 
 private:
     STFUNC(StateInit);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_acquire.cpp
@@ -2,6 +2,8 @@
 
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
+#include <contrib/ydb/core/base/appdata.h>
+
 #include <util/string/join.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -56,7 +58,7 @@ void TDiskAgentActor::HandleAcquireDevices(
                 << ", uuids=" << JoinSeq(",", uuids)
         );
 
-        State->AcquireDevices(
+        const bool updated = State->AcquireDevices(
             uuids,
             clientId,
             ctx.Now(),
@@ -66,6 +68,17 @@ void TDiskAgentActor::HandleAcquireDevices(
             record.GetVolumeGeneration());
 
         if (!Spdk || !record.HasRateLimits()) {
+            // If something has changed in sessions we should update the session
+            // cache (if it was configured). To do this, we spawn a special actor
+            // that updates the session cache and responds to the acquire request.
+            if (updated && AgentConfig->GetCachedSessionsPath()) {
+                UpdateSessionCacheAndRespond(
+                    ctx,
+                    std::move(requestInfo),
+                    std::make_unique<TEvDiskAgent::TEvAcquireDevicesResponse>());
+                return;
+            }
+
             reply(NProto::TError());
             return;
         }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_release.cpp
@@ -1,5 +1,7 @@
 #include "disk_agent_actor.h"
 
+#include <contrib/ydb/core/base/appdata.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -25,6 +27,20 @@ void TDiskAgentActor::HandleReleaseDevices(
             record.GetHeaders().GetClientId(),
             record.GetDiskId(),
             record.GetVolumeGeneration());
+
+        // We should update the session cache (if it was configured) with every
+        // release request.
+        if (AgentConfig->GetCachedSessionsPath()) {
+            UpdateSessionCacheAndRespond(
+                ctx,
+                CreateRequestInfo(
+                    ev->Sender,
+                    ev->Cookie,
+                    ev->Get()->CallContext),
+                std::move(response));
+
+            return;
+        }
     } catch (const TServiceError& e) {
         *response->Record.MutableError() = MakeError(e.GetCode(), e.what());
     }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -5,6 +5,8 @@
 #include "rdma_target.h"
 #include "storage_with_stats.h"
 
+#include <cloud/blockstore/config/disk.pb.h>
+
 #include <cloud/blockstore/libs/common/public.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/nvme/public.h>
@@ -113,7 +115,9 @@ public:
     TVector<TDeviceClient::TSessionInfo> GetReaderSessions(
         const TString& uuid) const;
 
-    void AcquireDevices(
+    // @return `true` if any session has been updated (excluding `LastActivityTs`
+    // field) or a new one has been added.
+    bool AcquireDevices(
         const TVector<TString>& uuids,
         const TString& clientId,
         TInstant now,
@@ -127,6 +131,8 @@ public:
         const TString& clientId,
         const TString& diskId,
         ui32 volumeGeneration);
+
+    TVector<NProto::TDiskAgentDeviceSession> GetSessions() const;
 
     void DisableDevice(const TString& uuid);
     void EnableDevice(const TString& uuid);
@@ -160,7 +166,6 @@ private:
 
     void InitRdmaTarget(TRdmaTargetConfig rdmaTargetConfig);
 
-    void UpdateSessionCache(TDeviceClient& client) const;
     void RestoreSessions(TDeviceClient& client) const;
 };
 

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -304,6 +304,8 @@ TTestEnv TTestEnvBuilder::Build()
     // }
     // Runtime.SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
 
+    Runtime.SetLogPriority(TBlockStoreComponents::DISK_AGENT, NLog::PRI_INFO);
+
     Runtime.SetRegistrationObserverFunc(
         [] (auto& runtime, const auto& parentId, const auto& actorId)
     {

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
@@ -135,9 +135,9 @@ public:
         const TString& clientId,
         const NProto::EVolumeAccessMode accessMode,
         const ui64 mountSeqNumber = 0,
-        const NSpdk::TDeviceRateLimits& limits = {},
         const TString& diskId = "",
-        const ui32 volumeGeneration = 0)
+        const ui32 volumeGeneration = 0,
+        const NSpdk::TDeviceRateLimits& limits = {})
     {
         auto request = std::make_unique<TEvDiskAgent::TEvAcquireDevicesRequest>();
 

--- a/cloud/blockstore/libs/storage/disk_agent/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ya.make
@@ -33,6 +33,7 @@ PEERDIR(
     cloud/blockstore/libs/spdk/iface
     cloud/blockstore/libs/storage/api
     cloud/blockstore/libs/storage/core
+    cloud/blockstore/libs/storage/disk_agent/actors
     cloud/blockstore/libs/storage/disk_agent/model
     cloud/blockstore/libs/storage/disk_common
     cloud/blockstore/libs/storage/model
@@ -52,6 +53,7 @@ PEERDIR(
 END()
 
 RECURSE(
+    actors
     model
 )
 


### PR DESCRIPTION
In order not to block the User thread pool (where read/write requests are executed), the session cache update was moved to a special actor that runs in the IO thread pool. 

Issue #170
