### PR TITLE
Remove endpoint from storage when client stop it. Fix typo.

### DIFF
--- a/cloud/filestore/libs/endpoint/service.cpp
+++ b/cloud/filestore/libs/endpoint/service.cpp
@@ -331,10 +331,7 @@ NProto::TStopEndpointResponse TEndpointManager::DoStopEndpoint(
 
     const auto& response = future.GetValue();
     if (SUCCEEDED(response.GetError().GetCode())) {
-        auto config = it->second.Config;
-        if (config.GetPersistent()) {
-            Storage->RemoveEndpoint(request.GetSocketPath());
-        }
+        Storage->RemoveEndpoint(request.GetSocketPath());
     }
 
     Endpoints.erase(it);

--- a/cloud/storage/core/tools/common/go/configurator/configurator.go
+++ b/cloud/storage/core/tools/common/go/configurator/configurator.go
@@ -552,15 +552,15 @@ func contains(collection []string, target string) bool {
 	return false
 }
 
-func (g *ConfigGenerator) Generate(ctx context.Context, whileListCluster []string) error {
+func (g *ConfigGenerator) Generate(ctx context.Context, whiteListCluster []string) error {
 	g.LogInfo(
 		ctx,
 		"Start generation for service: %v",
 		g.spec.ServiceSpec.ServiceName)
 
-	genAllClusters := len(whileListCluster) == 0
+	genAllClusters := len(whiteListCluster) == 0
 	for cluster, clusterConfig := range g.spec.ServiceSpec.Clusters {
-		if !genAllClusters && !contains(whileListCluster, cluster) {
+		if !genAllClusters && !contains(whiteListCluster, cluster) {
 			continue
 		}
 		for _, zone := range clusterConfig.Zones {


### PR DESCRIPTION
When client stop endpoint we should remove this endpoint from endpoint storage.
It doesn’t matter whether this endpoint was persistent or not.
It also doesn’t matter if we have errors during stopping.