### PR TITLE
NBSNEBIUS-105: make MinSize & MaxSize parameters optional for the Pool Configs 

### DIFF
--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -109,8 +109,8 @@ message TStorageDiscoveryConfig
         optional string PoolName = 1;
 
         // The minimum allowed size of a device.
-        // It may be optional if Layout is specified: in this case MinSize will
-        // be set to Layout.HeaderSize + Layout.DeviceSize.
+        // If MinSize == 0 and Layout is specified then the minimum allowed size
+        // is Layout.HeaderSize + Layout.DeviceSize.
         optional uint64 MinSize = 2;
 
         // The maximum allowed size of a device. If not specified, then the

--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -107,7 +107,14 @@ message TStorageDiscoveryConfig
     message TPoolConfig
     {
         optional string PoolName = 1;
+
+        // The minimum allowed size of a device.
+        // It may be optional if Layout is specified: in this case MinSize will
+        // be set to Layout.HeaderSize + Layout.DeviceSize.
         optional uint64 MinSize = 2;
+
+        // The maximum allowed size of a device. If not specified, then the
+        // maximum size of the device is not limited.
         optional uint64 MaxSize = 3;
 
         optional TLayout Layout = 4;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -499,12 +499,8 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         auto& path = *discoveryConfig.AddPathConfigs();
         path.SetPathRegExp(TempDir.Path() / "nvme3n([0-9])");
         auto& pool = *path.AddPoolConfigs();
-
         // the IDs of the generated devices will differ from those in the config
         pool.SetHashSuffix("random");
-
-        pool.SetMinSize(DefaultFileSize);
-        pool.SetMaxSize(DefaultFileSize);
 
         auto state = CreateDiskAgentStateNull(
             CreateNullConfig({
@@ -1369,9 +1365,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
                 NProto::TStorageDiscoveryConfig discovery;
                 auto& path = *discovery.AddPathConfigs();
                 path.SetPathRegExp(TempDir.Path() / "nvme3n([0-9])");
-                auto& pool = *path.AddPoolConfigs();
-                pool.SetMinSize(DefaultFileSize);
-                pool.SetMaxSize(DefaultFileSize);
+                path.AddPoolConfigs();
 
                 return discovery;
             }(),
@@ -1449,8 +1443,6 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
                 // limit the number of devices to one
                 path.SetPathRegExp(TempDir.Path() / "nvme3n(1)");
                 auto& pool = *path.AddPoolConfigs();
-                pool.SetMinSize(DefaultFileSize);
-                pool.SetMaxSize(DefaultFileSize);
                 pool.SetPoolName("foo");
 
                 return discovery;
@@ -1526,7 +1518,6 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
             path.SetMaxDeviceCount(8);
 
             auto& pool = *path.AddPoolConfigs();
-            pool.SetMinSize(DefaultFileSize);
             pool.SetMaxSize(10 * DefaultFileSize);
 
             auto& layout = *pool.MutableLayout();
@@ -1622,9 +1613,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
             auto& path = *discovery.AddPathConfigs();
             path.SetPathRegExp(TempDir.Path() / "NVMENBS([0-9]+)");
 
-            auto& pool = *path.AddPoolConfigs();
-            pool.SetMinSize(DefaultFileSize);
-            pool.SetMaxSize(DefaultFileSize);
+            path.AddPoolConfigs();
 
             auto state = CreateDiskAgentStateNull(
                 CreateNullConfig({

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -1623,6 +1623,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
             path.SetPathRegExp(TempDir.Path() / "NVMENBS([0-9]+)");
 
             auto& pool = *path.AddPoolConfigs();
+            pool.SetMinSize(DefaultFileSize);
             pool.SetMaxSize(DefaultFileSize);
 
             auto state = CreateDiskAgentStateNull(

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_scanner.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_scanner.cpp
@@ -113,7 +113,19 @@ NProto::TError FindDevices(
 
                 const ui64 size = GetFileLength(path);
                 auto* pool = FindIfPtr(p.GetPoolConfigs(), [&] (const auto& pool) {
-                    return pool.GetMinSize() <= size && size <= pool.GetMaxSize();
+                    ui64 minSize = pool.GetMinSize();
+
+                    if (!minSize && pool.HasLayout()) {
+                        minSize =
+                            pool.GetLayout().GetHeaderSize() +
+                            pool.GetLayout().GetDeviceSize();
+                    }
+
+                    const ui64 maxSize = pool.GetMaxSize()
+                        ? pool.GetMaxSize()
+                        : size;
+
+                    return minSize <= size && size <= maxSize;
                 });
 
                 if (!pool) {

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_scanner_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_scanner_ut.cpp
@@ -274,6 +274,7 @@ Y_UNIT_TEST_SUITE(TDeviceScannerTest)
 
         auto& def = *nvme.AddPoolConfigs();
         auto& layout = *def.MutableLayout();
+        // MinSize & MaxSize are not specified
         layout.SetHeaderSize(8_KB);
         layout.SetDeviceSize(2_KB);
         layout.SetDevicePadding(1_KB);
@@ -301,6 +302,8 @@ Y_UNIT_TEST_SUITE(TDeviceScannerTest)
             return MakeError(S_OK);
         });
 
+        // NVMENBS01 was accepted because of implicit MinSize = 10Kb and
+        // the unlimited MaxSize.
         UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error.GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(1, r.size());
 
@@ -315,7 +318,7 @@ Y_UNIT_TEST_SUITE(TDeviceScannerTest)
         UNIT_ASSERT_VALUES_EQUAL(1, pathIndex);
     }
 
-    Y_UNIT_TEST_F(ShouldIgnoreTooSmallDevices, TFixture)
+    Y_UNIT_TEST_F(ShouldIgnoreDevicesThatAreTooSmall, TFixture)
     {
         PrepareFiles({
             { "dev/disk/by-partlabel/NVMENBS01", 9_KB },
@@ -327,6 +330,7 @@ Y_UNIT_TEST_SUITE(TDeviceScannerTest)
 
         auto& def = *nvme.AddPoolConfigs();
         auto& layout = *def.MutableLayout();
+        // MinSize & MaxSize are not specified
         layout.SetHeaderSize(8_KB);
         layout.SetDeviceSize(2_KB);
         layout.SetDevicePadding(1_KB);
@@ -338,6 +342,7 @@ Y_UNIT_TEST_SUITE(TDeviceScannerTest)
             return MakeError(S_OK);
         });
 
+        // NVMENBS01 wasn't accepted because of implicit MinSize = 10Kb
         UNIT_ASSERT_VALUES_EQUAL_C(E_NOT_FOUND, error.GetCode(), error.GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(0, success);
     }

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -233,14 +233,6 @@ bool TInitializer::ValidateStorageDiscoveryConfig() const
 
     for (const auto& path: config.GetPathConfigs()) {
         for (const auto& pool: path.GetPoolConfigs()) {
-            if (!pool.GetMinSize() && !pool.HasLayout()) {
-                STORAGE_WARN(
-                    "Bad pool configuration: the min size is not set. "
-                    "Config: " << pool);
-
-                return false;
-            }
-
             if (pool.HasLayout()) {
                 const auto& layout = pool.GetLayout();
 

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -233,10 +233,35 @@ bool TInitializer::ValidateStorageDiscoveryConfig() const
 
     for (const auto& path: config.GetPathConfigs()) {
         for (const auto& pool: path.GetPoolConfigs()) {
-            if (pool.HasLayout() && !pool.GetLayout().GetDeviceSize()) {
-                STORAGE_WARN("Bad pool configuration: " << pool);
+            if (!pool.GetMinSize() && !pool.HasLayout()) {
+                STORAGE_WARN(
+                    "Bad pool configuration: the min size is not set. "
+                    "Config: " << pool);
 
                 return false;
+            }
+
+            if (pool.HasLayout()) {
+                const auto& layout = pool.GetLayout();
+
+                if (!layout.GetDeviceSize()) {
+                    STORAGE_WARN(
+                        "Bad pool configuration: the device size is not set. "
+                        "Config: " << pool);
+
+                    return false;
+                }
+
+                if (pool.GetMinSize() && pool.GetMinSize() <
+                    layout.GetHeaderSize() + layout.GetDeviceSize())
+                {
+                    STORAGE_WARN(
+                        "Bad pool configuration: the min size is less than the "
+                        "minimum layout. "
+                        "Config: " << pool);
+
+                    return false;
+                }
             }
         }
     }


### PR DESCRIPTION
For convinience we can infer `MinSize` from the layout as `HeaderSize` + `DeviceSize`. And if `MaxSize` is set to 0 we can assume that is no limit on the device max size for the current `PoolConfig`. In that way the config looks cleaner. For example, the pool config below will be applied to any device with a size >= 94 GiB
```
PoolConfigs {
    Layout {
        HeaderSize: 1073741824    #  1 GiB
        DeviceSize: 99857989632   # 93 GiB
        DevicePadding: 33554432   # 32 MiB
    }
}
```