### PR TITLE
[merge to stable-23-3] Silent E_NOT_FOUND in GetDependentDisks and UpdateDiskRegistryParams requests (#572)

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -245,9 +245,7 @@ public:
     void AugmentErrorFlags(NCloud::NProto::TError& error) const
     {
         if (MuteIOErrors) {
-            ui32 flags = error.GetFlags();
-            SetProtoFlag(flags, NCloud::NProto::EF_HW_PROBLEMS_DETECTED);
-            error.SetFlags(flags);
+            SetErrorProtoFlag(error, NCloud::NProto::EF_HW_PROBLEMS_DETECTED);
         }
     }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 
 #include <library/cpp/actors/core/actor_bootstrapped.h>
 #include <library/cpp/actors/core/events.h>
@@ -150,7 +151,11 @@ void TGetDependentDisksActor::HandleGetDependentDisksResponse(
 {
     auto* msg = ev->Get();
 
-    const auto& error = msg->GetError();
+    auto error = msg->GetError();
+    if (error.GetCode() == E_NOT_FOUND) {
+        SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
+    }
+
     if (HasError(error)) {
         HandleError(ctx, error);
         return;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_registry_params.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_registry_params.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry.h>
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 
 #include <library/cpp/actors/core/actor_bootstrapped.h>
 #include <library/cpp/actors/core/events.h>
@@ -130,9 +131,12 @@ void TUpdateDiskRegistryAgentListParamsActor::HandleUpdateDiskRegistryAgentListP
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-    const auto& error = msg->GetError();
+    auto error = msg->GetError();
+    if (error.GetCode() == E_NOT_FOUND) {
+        SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
+    }
 
-    if (FAILED(error.GetCode())) {
+    if (HasError(error)) {
         HandleError(ctx, error);
         return;
     }

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 #include <cloud/blockstore/libs/storage/protos_ydb/disk.pb.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
 #include <cloud/blockstore/private/api/protos/checkpoints.pb.h>
 #include <cloud/blockstore/private/api/protos/disk.pb.h>
 #include <cloud/blockstore/private/api/protos/volume.pb.h>
@@ -971,11 +972,11 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
         UNIT_ASSERT(describeReceived);
     }
 
-    Y_UNIT_TEST(ShouldForwardUpdateParamsRequestsToDiskRegistry)
+    void UpdateDiskRegistryAgentListParamsTest(
+        ui32 returnedCode,
+        ui32 expectedErrorFlags)
     {
-        auto drState = MakeIntrusive<TDiskRegistryState>();
-        TTestEnv env(1, 1, 4, 1, {drState});
-        auto& runtime = env.GetRuntime();
+        TTestEnv env(1, 1, 4, 1, MakeIntrusive<TDiskRegistryState>());
 
         NProto::TStorageServiceConfig config;
         ui32 nodeIdx = SetupTestEnv(env, config);
@@ -988,6 +989,7 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
         requestParams.SetNewNonReplicatedAgentMaxTimeoutMs(456);
 
         bool updateParamsReceived = false;
+        auto& runtime = env.GetRuntime();
         runtime.SetObserverFunc([&] (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
                 switch (event->GetTypeRewrite()) {
                     case TEvDiskRegistry::EvUpdateDiskRegistryAgentListParamsRequest: {
@@ -995,6 +997,12 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
                         auto* msg = event->Get<TEvDiskRegistry::TEvUpdateDiskRegistryAgentListParamsRequest>();
                         const auto& params = msg->Record.GetParams();
                         UNIT_ASSERT(google::protobuf::util::MessageDifferencer::Equals(requestParams, params));
+                        break;
+                    }
+                    case TEvDiskRegistry::EvUpdateDiskRegistryAgentListParamsResponse: {
+                        auto* msg = event->Get<TEvDiskRegistry::TEvUpdateDiskRegistryAgentListParamsResponse>();
+                        msg->Record.MutableError()->SetCode(returnedCode);
+                        break;
                     }
                 }
                 return TTestActorRuntime::DefaultObserverFunc(runtime, event);
@@ -1003,10 +1011,20 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
 
         TString buf;
         google::protobuf::util::MessageToJsonString(requestParams, &buf);
-        const auto response = service.ExecuteAction("updatediskregistryagentlistparams", buf);
+        service.SendExecuteActionRequest("updatediskregistryagentlistparams", buf);
+        const auto response = service.RecvExecuteActionResponse();
 
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
         UNIT_ASSERT(updateParamsReceived);
+        UNIT_ASSERT_VALUES_EQUAL(returnedCode, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(expectedErrorFlags, response->GetError().GetFlags());
+    }
+
+    Y_UNIT_TEST(ShouldForwardUpdateParamsRequestsToDiskRegistry) {
+        UpdateDiskRegistryAgentListParamsTest(S_OK, NProto::EF_NONE);
+    }
+
+    Y_UNIT_TEST(ShouldForwardUpdateParamsRequestsToDiskRegistryAndSilentNotFound) {
+        UpdateDiskRegistryAgentListParamsTest(E_NOT_FOUND, NProto::EF_SILENT);
     }
 
     Y_UNIT_TEST(ShouldFinishFillDisk)
@@ -1165,7 +1183,10 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
         service.DestroyVolume();
     }
 
-    void ShouldGetDependentDevicesTest(TVector<TString> returnedDiskIds)
+    void ShouldGetDependentDevicesTest(
+        TVector<TString> returnedDiskIds,
+        ui32 returnedCode,
+        ui32 expectedErrorFlags)
     {
         TTestEnv env(1, 1, 4, 1, MakeIntrusive<TDiskRegistryState>());
 
@@ -1189,10 +1210,10 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
                     }
                     case TEvDiskRegistry::EvGetDependentDisksResponse: {
                         auto* msg = event->Get<TEvDiskRegistry::TEvGetDependentDisksResponse>();
-                        msg->Record.ClearDependentDiskIds();
-                        for (const auto& id : returnedDiskIds) {
-                            msg->Record.AddDependentDiskIds(id);
-                        }
+                        msg->Record.MutableDependentDiskIds()->Add(
+                            returnedDiskIds.begin(),
+                            returnedDiskIds.end());
+                        msg->Record.MutableError()->SetCode(returnedCode);
                         break;
                     }
                 }
@@ -1200,31 +1221,41 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             }
         );
 
-        const auto response = service.ExecuteAction("GetDependentDisks", R"({"Host":"localhost"})");
+        NProto::TGetDependentDisksRequest request;
+        request.SetHost("localhost");
+        TString jsonInput;
+        google::protobuf::util::MessageToJsonString(request, &jsonInput);
+
+        service.SendExecuteActionRequest("GetDependentDisks", jsonInput);
+        const auto response = service.RecvExecuteActionResponse();
+
         UNIT_ASSERT(requestReceived);
+        UNIT_ASSERT_VALUES_EQUAL(returnedCode, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(expectedErrorFlags, response->GetError().GetFlags());
 
-        NJson::TJsonValue responseJson;
-        if (!NJson::ReadJsonTree(response->Record.GetOutput(), &responseJson, false)) {
-            UNIT_ASSERT(false);
+        if (returnedCode == S_OK) {
+            NProto::TGetDependentDisksResponse output;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                response->Record.GetOutput(), &output).ok());
+            ASSERT_VECTORS_EQUAL(returnedDiskIds, output.GetDependentDiskIds());
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL("", response->Record.GetOutput());
         }
-
-        const auto diskIdsJson = responseJson["DependentDiskIds"].GetArray();
-        TVector<TString> responseDiskIds;
-        for (const auto& diskIdJson: diskIdsJson) {
-            responseDiskIds.emplace_back(diskIdJson.GetString());
-        }
-        UNIT_ASSERT_VALUES_EQUAL(returnedDiskIds, responseDiskIds);
     }
-
 
     Y_UNIT_TEST(ShouldGetDependentDevicesNoDisks)
     {
-        ShouldGetDependentDevicesTest({});
+        ShouldGetDependentDevicesTest({}, S_OK, NProto::EF_NONE);
     }
 
     Y_UNIT_TEST(ShouldGetDependentDevicesMultipleDisks)
     {
-        ShouldGetDependentDevicesTest({"disk1", "disk2"});
+        ShouldGetDependentDevicesTest({"disk1", "disk2"}, S_OK, NProto::EF_NONE);
+    }
+
+    Y_UNIT_TEST(ShouldGetDependentDevicesAndSilentNotFound)
+    {
+        ShouldGetDependentDevicesTest({}, E_NOT_FOUND, NProto::EF_SILENT);
     }
 
     NProto::TChangeStorageConfigResponse ExecuteChangeStorageConfig(

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
 #include <cloud/storage/core/libs/api/hive_proxy.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/media.h>
 
 #include <ydb/core/tablet/tablet_setup.h>
@@ -50,9 +51,7 @@ using TEvInternalMountVolumeResponsePtr =
 NProto::TError MakeErrorSilent(const NProto::TError& error)
 {
     auto result = error;
-    ui32 flags = error.GetFlags();
-    SetProtoFlag(flags, NProto::EF_SILENT);
-    result.SetFlags(flags);
+    SetErrorProtoFlag(result, NProto::EF_SILENT);
     return result;
 }
 

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -143,9 +143,7 @@ void TDescribeSchemeActor::HandleDescribeSchemeResult(
 
         // TODO: return E_NOT_FOUND instead of StatusPathDoesNotExist
         if (status == NKikimrScheme::StatusPathDoesNotExist) {
-            ui32 flags = error.GetFlags();
-            SetProtoFlag(flags, NProto::EF_SILENT);
-            error.SetFlags(flags);
+            SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
         }
     }
 

--- a/cloud/storage/core/libs/common/helpers.h
+++ b/cloud/storage/core/libs/common/helpers.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <cloud/storage/core/protos/error.pb.h>
+
 #include <util/system/defaults.h>
 
 namespace NCloud {
@@ -22,6 +24,14 @@ void SetProtoFlag(ui32& flags, const T flag)
     if (iflag) {
         flags |= 1 << (iflag - 1);
     }
+}
+
+template <typename T>
+void SetErrorProtoFlag(NProto::TError& error, const T flag)
+{
+    auto flags = error.GetFlags();
+    SetProtoFlag(flags, flag);
+    error.SetFlags(flags);
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
cherry-pick of #572

* Silent E_NOT_FOUND in GetDependentDisks and UpdateDiskRegistryParams requests

* Update test for GetDependentDisk

* Update test for UpdateDiskRegistryAgentListParams

---------

Co-authored-by: Dmitry Razumov <dvrazumov@yandex-team.ru>
