### PR TITLE
fix ActorSystem hanging on DiskAgent' shutdown

### DIFF
--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -522,8 +522,8 @@ void TBootstrap::Start()
     START_COMPONENT(TraceProcessor);
     START_COMPONENT(Spdk);
     START_COMPONENT(RdmaServer);
-    START_COMPONENT(ActorSystem);
     START_COMPONENT(FileIOService);
+    START_COMPONENT(ActorSystem);
 
     // we need to start scheduler after all other components for 2 reasons:
     // 1) any component can schedule a task that uses a dependency that hasn't
@@ -553,8 +553,11 @@ void TBootstrap::Stop()
     // scheduled tasks and shutting down of component dependencies
     STOP_COMPONENT(Scheduler);
 
-    STOP_COMPONENT(FileIOService);
     STOP_COMPONENT(ActorSystem);
+    // stop FileIOService after ActorSystem to ensure that there are no
+    // in-flight I/O requests from TDiskAgentActor
+    STOP_COMPONENT(FileIOService);
+
     STOP_COMPONENT(Spdk);
     STOP_COMPONENT(RdmaServer);
     STOP_COMPONENT(TraceProcessor);


### PR DESCRIPTION
Due to stopping `FileIOService` before `ActorSystem`, some IO requests may hang.

[Here](https://github.com/ydb-platform/nbs/blob/cfac667d68c82641ca86bfea585461cbc24a7530/cloud/blockstore/libs/disk_agent/bootstrap.cpp#L556) we stop the `FileIOService`. This leads to the [stopping](https://github.com/ydb-platform/nbs/blob/cfac667d68c82641ca86bfea585461cbc24a7530/cloud/storage/core/libs/aio/service.cpp#L118) of a thread that invokes `io_getevents`. So requests that were in the completion queue after `Stop` was invoked can't be handled. In turn, the destructor of `TDiskAgentState` (somewhere inside the actor system) destroys [Devices](https://github.com/ydb-platform/nbs/blob/cfac667d68c82641ca86bfea585461cbc24a7530/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h#L57) and invokes a [destructor](https://github.com/ydb-platform/nbs/blob/cfac667d68c82641ca86bfea585461cbc24a7530/cloud/blockstore/libs/service/storage.cpp#L613) of `TStorageAdapter` where we [fall](https://github.com/ydb-platform/nbs/blob/cfac667d68c82641ca86bfea585461cbc24a7530/cloud/blockstore/libs/service/storage.cpp#L544) asleep for a few seconds due to the above-mentioned hanged IO requests.

To fix the problem we should stop `FileIOService` after `ActorSystem`.
