### PR TITLE
NBSNEBIUS-146: don't generate critical events on health check read during secure erase

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -23,7 +23,8 @@ constexpr bool IsWriteDeviceMethod =
     std::is_same_v<T, TEvDiskAgent::TZeroDeviceBlocksMethod>;
 
 template <typename T>
-constexpr bool IsReadDeviceMethod = !IsWriteDeviceMethod<T>;
+constexpr bool IsReadDeviceMethod =
+    std::is_same_v<T, TEvDiskAgent::TReadDeviceBlocksMethod>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -198,7 +199,7 @@ void TDiskAgentActor::PerformIO(
                 << " Device=" << deviceUUID
                 << ", ClientId=" << clientId
                 << ", StartIndex=" << range.Start
-                << ", EndIndex=" << range.End
+                << ", BlocksCount=" << range.Size()
                 << ", IsWrite=" << IsWriteDeviceMethod<TMethod>
                 << ", IsRdma=0");
         }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -191,9 +191,9 @@ void TDiskAgentActor::PerformIO(
         clientId.c_str());
 
     if (SecureErasePendingRequests.contains(deviceUUID)) {
-        const bool allowedReadingDuringSecureErase =
+        const bool isHealthCheckRead =
             IsReadDeviceMethod<TMethod> && clientId == CheckHealthClientId;
-        if (!allowedReadingDuringSecureErase) {
+        if (!isHealthCheckRead) {
             ReportDiskAgentIoDuringSecureErase(
                 TStringBuilder()
                 << " Device=" << deviceUUID

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -3004,7 +3004,9 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                 "uuid",
                 0,
                 1,
-                TString(CheckHealthClientId))->Record.GetError().GetCode());
+                TString(CheckHealthClientId))
+                    ->Record.GetError()
+                    .GetCode());
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
 
         // Write zero during secure erase from HealthCheck client generates
@@ -3017,7 +3019,9 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                 "uuid",
                 0,
                 1,
-                TString(CheckHealthClientId))->Record.GetError().GetCode());
+                TString(CheckHealthClientId))
+                    ->Record.GetError()
+                    .GetCode());
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 4);
 
         spdk->SecureEraseResult.SetValue(NProto::TError());

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -2994,6 +2994,36 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             true);
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
 
+        // Read during secure erase from HealthCheck client doesn't generate
+        // critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            ReadDeviceBlocks(
+                runtime,
+                diskAgent,
+                "uuid",
+                0,
+                1,
+                TString(CheckHealthClientId))
+                ->Record.GetError()
+                .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
+
+        // Write zero during secure erase from HealthCheck client generates
+        // critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            ZeroDeviceBlocks(
+                runtime,
+                diskAgent,
+                "uuid",
+                0,
+                1,
+                TString(CheckHealthClientId))
+                ->Record.GetError()
+                .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 4);
+
         spdk->SecureEraseResult.SetValue(NProto::TError());
         runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(10));
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -3004,9 +3004,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                 "uuid",
                 0,
                 1,
-                TString(CheckHealthClientId))
-                ->Record.GetError()
-                .GetCode());
+                TString(CheckHealthClientId))->Record.GetError().GetCode());
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
 
         // Write zero during secure erase from HealthCheck client generates
@@ -3019,9 +3017,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                 "uuid",
                 0,
                 1,
-                TString(CheckHealthClientId))
-                ->Record.GetError()
-                .GetCode());
+                TString(CheckHealthClientId))->Record.GetError().GetCode());
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 4);
 
         spdk->SecureEraseResult.SetValue(NProto::TError());

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -373,7 +373,7 @@ private:
                 << " Device=" << requestDetails.DeviceUUID
                 << ", ClientId=" << requestDetails.ClientId
                 << ", StartIndex=" << requestDetails.Range.Start
-                << ", EndIndex=" << requestDetails.Range.End
+                << ", BlocksCount=" << requestDetails.Range.Size()
                 << ", IsWrite=1"
                 << ", IsRdma=1");
             *overlapDetails = "Secure erase in progress";
@@ -525,8 +525,7 @@ private:
                     << " Device=" << request.GetDeviceUUID()
                     << ", ClientId=" << clientId
                     << ", StartIndex=" << request.GetStartIndex()
-                    << ", EndIndex="
-                    << (request.GetStartIndex() + request.GetBlocksCount() - 1)
+                    << ", BlocksCount=" << request.GetBlocksCount()
                     << ", IsWrite=0"
                     << ", IsRdma=1");
             }


### PR DESCRIPTION
Additionally report non health check reads during secure erase and add aditional
info to the critical event report
