### PR TITLE
issue-702: logging removed handles and nodes for the handles that are destroyed upon session reset; added request id to error messages in responses

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -87,6 +87,12 @@ void TIndexTabletActor::CompleteResponse(
         callContext->RequestId,
         FormatError(response.GetError()).c_str());
 
+    if (HasError(response.GetError())) {
+        auto* e = response.MutableError();
+        e->SetMessage(TStringBuilder()
+            << e->GetMessage() << ", request-id: " << callContext->RequestId);
+    }
+
     FILESTORE_TRACK(
         ResponseSent_Tablet,
         callContext,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -127,8 +127,21 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
         auto nodeId = handle->GetNodeId();
         DestroyHandle(db, &*(handle++));
 
+        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+            "%s Removing handle upon session reset s:%s n:%lu",
+            LogTag.c_str(),
+            args.SessionId.c_str(),
+            nodeId);
+
         auto it = args.Nodes.find(nodeId);
         if (it != args.Nodes.end() && !HasOpenHandles(nodeId)) {
+            LOG_INFO(ctx, TFileStoreComponents::TABLET,
+                "%s Removing node upon session reset s:%s n:%lu (size %lu)",
+                LogTag.c_str(),
+                args.SessionId.c_str(),
+                nodeId,
+                it->Attrs.GetSize());
+
             RemoveNode(
                 db,
                 *it,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -90,7 +90,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
     }
 
     if (!args.ChildRef) {
-        args.Error = ErrorInvalidTarget(args.ParentNodeId);
+        args.Error = ErrorInvalidTarget(args.ParentNodeId, args.Name);
         return true;
     }
 


### PR DESCRIPTION
Sometimes session reset may cause large truncate operations which lead to problems like #702. We need to see what exactly is being done during the reset operation. Also it's convenient to have request ids in error messages to make request-error matching easier. 