### PR TITLE
move EndpointStorage usage from endpoint_service to endpoint_manager

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -68,7 +68,7 @@ protected:
     NSpdk::ISpdkEnvPtr Spdk;
     ICachingAllocatorPtr Allocator;
     IStorageProviderPtr AioStorageProvider;
-    IEndpointServicePtr EndpointService;
+    IEndpointManagerPtr EndpointManager;
     IEndpointEventProxyPtr EndpointEventHandler;
     NRdma::IServerPtr RdmaServer;
     NRdma::IClientPtr RdmaClient;

--- a/cloud/blockstore/libs/endpoints/public.h
+++ b/cloud/blockstore/libs/endpoints/public.h
@@ -22,9 +22,6 @@ using IEndpointManagerPtr = std::shared_ptr<IEndpointManager>;
 struct IEndpointListener;
 using IEndpointListenerPtr = std::shared_ptr<IEndpointListener>;
 
-struct IEndpointService;
-using IEndpointServicePtr = std::shared_ptr<IEndpointService>;
-
 struct IEndpointEventHandler;
 using IEndpointEventHandlerPtr = std::shared_ptr<IEndpointEventHandler>;
 

--- a/cloud/blockstore/libs/endpoints/service_endpoint.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint.cpp
@@ -2,25 +2,11 @@
 
 #include "endpoint_manager.h"
 
-#include <cloud/blockstore/libs/client/config.h>
-#include <cloud/blockstore/libs/client/durable.h>
-#include <cloud/blockstore/libs/client/metric.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/service/context.h>
-#include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
-#include <cloud/storage/core/libs/common/verify.h>
-#include <cloud/storage/core/libs/coroutine/executor.h>
-#include <cloud/storage/core/libs/diagnostics/logging.h>
-#include <cloud/storage/core/libs/keyring/endpoints.h>
-
-#include <util/generic/guid.h>
-#include <util/generic/map.h>
-#include <util/generic/set.h>
-#include <util/system/mutex.h>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -31,160 +17,40 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TEndpointClient final
-    : public IBlockStore
-{
-private:
-    IEndpointManagerPtr EndpointManager;
-
-public:
-    TEndpointClient(IEndpointManagerPtr endpointManager)
-        : EndpointManager(std::move(endpointManager))
-    {}
-
-    void Start() override
-    {}
-
-    void Stop() override
-    {}
-
-    TStorageBuffer AllocateBuffer(size_t bytesCount) override
-    {
-        Y_UNUSED(bytesCount);
-        return nullptr;
-    }
-
-#define BLOCKSTORE_IMPLEMENT_METHOD(name, ...)                                 \
-    TFuture<NProto::T##name##Response> name(                                   \
-        TCallContextPtr ctx,                                                   \
-        std::shared_ptr<NProto::T##name##Request> request) override            \
-    {                                                                          \
-        Y_UNUSED(ctx);                                                         \
-        Y_UNUSED(request);                                                     \
-        return MakeFuture<NProto::T##name##Response>(TErrorResponse(           \
-            E_NOT_IMPLEMENTED, "Unsupported request"));                        \
-    }                                                                          \
-// BLOCKSTORE_IMPLEMENT_METHOD
-
-    BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_IMPLEMENT_METHOD)
-    BLOCKSTORE_IMPLEMENT_METHOD(KickEndpoint)
-    BLOCKSTORE_IMPLEMENT_METHOD(ListKeyrings)
-
-#undef BLOCKSTORE_IMPLEMENT_METHOD
-
-#define ENDPOINT_IMPLEMENT_METHOD(name, ...)                                   \
-    TFuture<NProto::T##name##Response> name(                                   \
-        TCallContextPtr ctx,                                                   \
-        std::shared_ptr<NProto::T##name##Request> req) override                \
-    {                                                                          \
-        return EndpointManager->name(std::move(ctx), std::move(req));          \
-    }                                                                          \
-// ENDPOINT_IMPLEMENT_METHOD
-
-    ENDPOINT_IMPLEMENT_METHOD(StartEndpoint)
-    ENDPOINT_IMPLEMENT_METHOD(StopEndpoint)
-    ENDPOINT_IMPLEMENT_METHOD(ListEndpoints)
-    ENDPOINT_IMPLEMENT_METHOD(DescribeEndpoint)
-    ENDPOINT_IMPLEMENT_METHOD(RefreshEndpoint)
-
-#undef ENDPOINT_IMPLEMENT_METHOD
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TEndpointService final
-    : public IEndpointService
-    , public std::enable_shared_from_this<TEndpointService>
+    : public IBlockStore
 {
 private:
     const IBlockStorePtr Service;
     const ITimerPtr Timer;
     const ISchedulerPtr Scheduler;
-    const TExecutorPtr Executor;
-    const IEndpointStoragePtr EndpointStorage;
     const IEndpointManagerPtr EndpointManager;
-
-    IMetricClientPtr RestoringClient;
-    TSet<TString> RestoringEndpoints;
-
-    TLog Log;
-
-    enum {
-        WaitingForRestoring = 0,
-        ReadingStorage = 1,
-        StartingEndpoints = 2,
-        Completed = 3,
-    };
-
-    TAtomic RestoringStage = WaitingForRestoring;
 
 public:
     TEndpointService(
             IBlockStorePtr service,
             ITimerPtr timer,
             ISchedulerPtr scheduler,
-            ILoggingServicePtr logging,
-            IRequestStatsPtr requestStats,
-            IVolumeStatsPtr volumeStats,
-            IServerStatsPtr serverStats,
-            TExecutorPtr executor,
-            IEndpointStoragePtr endpointStorage,
-            IEndpointManagerPtr endpointManager,
-            NProto::TClientConfig clientConfig)
+            IEndpointManagerPtr endpointManager)
         : Service(std::move(service))
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
-        , Executor(std::move(executor))
-        , EndpointStorage(std::move(endpointStorage))
         , EndpointManager(std::move(endpointManager))
-    {
-        Log = logging->CreateLog("BLOCKSTORE_SERVER");
-
-        IBlockStorePtr client = std::make_shared<TEndpointClient>(
-            EndpointManager);
-
-        NProto::TClientAppConfig config;
-        *config.MutableClientConfig() = std::move(clientConfig);
-        auto appConfig = std::make_shared<TClientAppConfig>(std::move(config));
-        auto retryPolicy = CreateRetryPolicy(appConfig);
-
-        client = CreateDurableClient(
-            std::move(appConfig),
-            std::move(client),
-            std::move(retryPolicy),
-            logging,
-            Timer,
-            Scheduler,
-            std::move(requestStats),
-            std::move(volumeStats));
-
-        RestoringClient = CreateMetricClient(
-            std::move(client),
-            std::move(logging),
-            std::move(serverStats));
-    }
+    {}
 
     void Start() override
     {
         Service->Start();
-        RestoringClient->Start();
     }
 
     void Stop() override
     {
-        RestoringClient->Stop();
         Service->Stop();
     }
 
     TStorageBuffer AllocateBuffer(size_t bytesCount) override
     {
         return Service->AllocateBuffer(bytesCount);
-    }
-
-    size_t CollectRequests(
-        const TIncompleteRequestsCollector& collector) override
-    {
-        return RestoringClient->CollectRequests(collector);
     }
 
 #define STORAGE_IMPLEMENT_METHOD(name, ...)                                    \
@@ -202,17 +68,11 @@ public:
 
 #define ENDPOINT_IMPLEMENT_METHOD(name, ...)                                   \
     TFuture<NProto::T##name##Response> name(                                   \
-        TCallContextPtr callContext,                                           \
-        std::shared_ptr<NProto::T##name##Request> request) override            \
+        TCallContextPtr ctx,                                                   \
+        std::shared_ptr<NProto::T##name##Request> req) override                \
     {                                                                          \
-        auto timeout = request->GetHeaders().GetRequestTimeout();              \
-        auto future = Executor->Execute([                                      \
-            ctx = std::move(callContext),                                      \
-            req = std::move(request),                                          \
-            this] () mutable                                                   \
-        {                                                                      \
-            return Do##name(std::move(ctx), std::move(req));                   \
-        });                                                                    \
+        auto timeout = req->GetHeaders().GetRequestTimeout();                  \
+        auto future = EndpointManager->name(std::move(ctx), std::move(req));   \
         return CreateTimeoutFuture(future, TDuration::MilliSeconds(timeout));  \
     }                                                                          \
 // ENDPOINT_IMPLEMENT_METHOD
@@ -221,220 +81,7 @@ public:
 
 #undef ENDPOINT_IMPLEMENT_METHOD
 
-    TFuture<void> RestoreEndpoints() override
-    {
-        AtomicSet(RestoringStage, ReadingStorage);
-        return Executor->Execute([this] () mutable {
-            auto future = DoRestoreEndpoints();
-            AtomicSet(RestoringStage, StartingEndpoints);
-            Executor->WaitFor(future);
-            AtomicSet(RestoringStage, Completed);
-        });
-    }
-
 private:
-    bool IsEndpointRestoring(const TString& socket)
-    {
-        switch (AtomicGet(RestoringStage)) {
-            case WaitingForRestoring: return false;
-            case ReadingStorage: return true;
-            case StartingEndpoints: return RestoringEndpoints.contains(socket);
-            case Completed: return false;
-        }
-        return false;
-    }
-
-    NProto::TStartEndpointResponse DoStartEndpoint(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TStartEndpointRequest> request)
-    {
-        if (IsEndpointRestoring(request->GetUnixSocketPath())) {
-            return TErrorResponse(E_REJECTED, "endpoint is restoring now");
-        }
-
-        auto req = *request;
-        auto future = EndpointManager->StartEndpoint(
-            std::move(ctx),
-            std::move(request));
-
-        auto response = Executor->WaitFor(future);
-        if (HasError(response)) {
-            return response;
-        }
-
-        if (req.GetPersistent()) {
-            AddEndpointToStorage(req);
-        }
-
-        return response;
-    }
-
-    NProto::TStopEndpointResponse DoStopEndpoint(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TStopEndpointRequest> request)
-    {
-        if (IsEndpointRestoring(request->GetUnixSocketPath())) {
-            return TErrorResponse(E_REJECTED, "endpoint is restoring now");
-        }
-
-        auto socketPath = request->GetUnixSocketPath();
-        auto future = EndpointManager->StopEndpoint(
-            std::move(ctx),
-            std::move(request));
-
-        auto response = Executor->WaitFor(future);
-        if (HasError(response)) {
-            return response;
-        }
-
-        EndpointStorage->RemoveEndpoint(socketPath);
-        return response;
-    }
-
-    NProto::TListEndpointsResponse DoListEndpoints(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TListEndpointsRequest> request)
-    {
-        auto future = EndpointManager->ListEndpoints(
-            std::move(ctx),
-            std::move(request));
-
-        auto response = Executor->WaitFor(future);
-        response.SetEndpointsWereRestored(
-            AtomicGet(RestoringStage) == Completed);
-        return response;
-    }
-
-    NProto::TKickEndpointResponse DoKickEndpoint(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TKickEndpointRequest> request)
-    {
-        auto [str, error] = EndpointStorage->GetEndpoint(
-            ToString(request->GetKeyringId()));
-
-        if (HasError(error)) {
-            return TErrorResponse(error);
-        }
-
-        auto startReq = DeserializeEndpoint<NProto::TStartEndpointRequest>(str);
-
-        if (!startReq) {
-            return TErrorResponse(E_INVALID_STATE, TStringBuilder()
-                << "Failed to deserialize endpoint with key "
-                << request->GetKeyringId());
-        }
-
-        startReq->MutableHeaders()->MergeFrom(request->GetHeaders());
-
-        STORAGE_INFO("Kick StartEndpoint request: " << *startReq);
-        auto response = DoStartEndpoint(
-            std::move(ctx),
-            std::move(startReq));
-
-        return TErrorResponse(response.GetError());
-    }
-
-    NProto::TListKeyringsResponse DoListKeyrings(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TListKeyringsRequest> request)
-    {
-        Y_UNUSED(ctx);
-        Y_UNUSED(request);
-
-        auto [storedIds, error] = EndpointStorage->GetEndpointIds();
-        if (HasError(error)) {
-            return TErrorResponse(error);
-        }
-
-        NProto::TListKeyringsResponse response;
-        auto& endpoints = *response.MutableEndpoints();
-
-        endpoints.Reserve(storedIds.size());
-
-        for (auto keyringId: storedIds) {
-            auto& endpoint = *endpoints.Add();
-            endpoint.SetKeyringId(keyringId);
-
-            auto [str, error] = EndpointStorage->GetEndpoint(keyringId);
-            if (HasError(error)) {
-                STORAGE_WARN("Failed to get endpoint from storage, ID: "
-                    << keyringId << ", error: " << FormatError(error));
-                continue;
-            }
-
-            auto req = DeserializeEndpoint<NProto::TStartEndpointRequest>(str);
-            if (!req) {
-                STORAGE_WARN("Failed to deserialize endpoint from storage, ID: "
-                    << keyringId);
-                continue;
-            }
-
-            endpoint.MutableRequest()->CopyFrom(*req);
-        }
-
-        return response;
-    }
-
-    NProto::TDescribeEndpointResponse DoDescribeEndpoint(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TDescribeEndpointRequest> request)
-    {
-        if (IsEndpointRestoring(request->GetUnixSocketPath())) {
-            return TErrorResponse(E_REJECTED, "endpoint is restoring now");
-        }
-
-        auto future = EndpointManager->DescribeEndpoint(
-            std::move(ctx),
-            std::move(request));
-        return Executor->WaitFor(future);
-    }
-
-    NProto::TRefreshEndpointResponse DoRefreshEndpoint(
-        TCallContextPtr ctx,
-        std::shared_ptr<NProto::TRefreshEndpointRequest> request)
-    {
-        if (IsEndpointRestoring(request->GetUnixSocketPath())) {
-            return TErrorResponse(E_REJECTED, "endpoint is restoring now");
-        }
-
-        auto future = EndpointManager->RefreshEndpoint(
-            std::move(ctx),
-            std::move(request));
-        return Executor->WaitFor(future);
-    }
-
-    TFuture<void> DoRestoreEndpoints();
-
-    NProto::TError AddEndpointToStorage(
-        const NProto::TStartEndpointRequest& request)
-    {
-        auto [data, error] = SerializeEndpoint(request);
-        if (HasError(error)) {
-            return error;
-        }
-
-        error = EndpointStorage->AddEndpoint(request.GetUnixSocketPath(), data);
-        if (HasError(error)) {
-            return error;
-        }
-
-        return {};
-    }
-
-    void HandleRestoredEndpoint(
-        const TString& socketPath,
-        const NProto::TError& error)
-    {
-        if (HasError(error)) {
-            STORAGE_ERROR("Failed to start endpoint " << socketPath.Quote()
-                << ", error:" << FormatError(error));
-        }
-
-        Executor->Execute([socketPath, this] () mutable {
-            RestoringEndpoints.erase(socketPath);
-        });
-    }
-
     template <typename T>
     TFuture<T> CreateTimeoutFuture(const TFuture<T>& future, TDuration timeout)
     {
@@ -456,106 +103,21 @@ private:
     }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
-TFuture<void> TEndpointService::DoRestoreEndpoints()
-{
-    auto [storedIds, error] = EndpointStorage->GetEndpointIds();
-    if (HasError(error)) {
-        STORAGE_ERROR("Failed to get endpoints from storage: "
-            << FormatError(error));
-        ReportEndpointRestoringError();
-        return MakeFuture();
-    }
-
-    STORAGE_INFO("Found " << storedIds.size() << " endpoints in storage");
-
-    TString clientId = CreateGuidAsString() + "_bootstrap";
-
-    TVector<TFuture<void>> futures;
-
-    for (auto keyringId: storedIds) {
-        auto [str, error] = EndpointStorage->GetEndpoint(keyringId);
-        if (HasError(error)) {
-            // NBS-3678
-            STORAGE_WARN("Failed to restore endpoint. ID: " << keyringId
-                << ", error: " << FormatError(error));
-            continue;
-        }
-
-        auto request = DeserializeEndpoint<NProto::TStartEndpointRequest>(str);
-
-        if (!request) {
-            ReportEndpointRestoringError();
-            STORAGE_ERROR("Failed to deserialize request. ID: " << keyringId);
-            continue;
-        }
-
-        auto& headers = *request->MutableHeaders();
-
-        if (!headers.GetClientId()) {
-            headers.SetClientId(clientId);
-        }
-
-        auto requestId = headers.GetRequestId();
-        if (!requestId) {
-            headers.SetRequestId(CreateRequestId());
-        }
-
-        auto socketPath = request->GetUnixSocketPath();
-        RestoringEndpoints.insert(socketPath);
-
-        auto future = RestoringClient->StartEndpoint(
-            MakeIntrusive<TCallContext>(requestId),
-            std::move(request));
-
-        auto weakPtr = weak_from_this();
-        future.Subscribe([weakPtr, socketPath] (const auto& f) {
-            const auto& response = f.GetValue();
-            if (HasError(response)) {
-                ReportEndpointRestoringError();
-            }
-
-            if (auto ptr = weakPtr.lock()) {
-                ptr->HandleRestoredEndpoint(socketPath, response.GetError());
-            }
-        });
-
-        futures.push_back(future.IgnoreResult());
-    }
-
-    return WaitAll(futures);
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IEndpointServicePtr CreateMultipleEndpointService(
+IBlockStorePtr CreateMultipleEndpointService(
     IBlockStorePtr service,
     ITimerPtr timer,
     ISchedulerPtr scheduler,
-    ILoggingServicePtr logging,
-    IRequestStatsPtr requestStats,
-    IVolumeStatsPtr volumeStats,
-    IServerStatsPtr serverStats,
-    TExecutorPtr executor,
-    IEndpointStoragePtr endpointStorage,
-    IEndpointManagerPtr endpointManager,
-    NProto::TClientConfig clientConfig)
+    IEndpointManagerPtr endpointManager)
 {
     return std::make_shared<TEndpointService>(
         std::move(service),
         std::move(timer),
         std::move(scheduler),
-        std::move(logging),
-        std::move(requestStats),
-        std::move(volumeStats),
-        std::move(serverStats),
-        std::move(executor),
-        std::move(endpointStorage),
-        std::move(endpointManager),
-        std::move(clientConfig));
+        std::move(endpointManager));
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/service_endpoint.h
+++ b/cloud/blockstore/libs/endpoints/service_endpoint.h
@@ -5,37 +5,16 @@
 #include <cloud/blockstore/config/client.pb.h>
 
 #include <cloud/blockstore/libs/common/public.h>
-#include <cloud/blockstore/libs/diagnostics/incomplete_requests.h>
-#include <cloud/blockstore/libs/diagnostics/public.h>
-#include <cloud/blockstore/libs/service/service.h>
-
-#include <cloud/storage/core/libs/coroutine/public.h>
-#include <cloud/storage/core/libs/keyring/public.h>
+#include <cloud/blockstore/libs/service/public.h>
 
 namespace NCloud::NBlockStore::NServer {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IEndpointService
-    : public IBlockStore
-    , public IIncompleteRequestProvider
-{
-    virtual NThreading::TFuture<void> RestoreEndpoints() = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-IEndpointServicePtr CreateMultipleEndpointService(
+IBlockStorePtr CreateMultipleEndpointService(
     IBlockStorePtr service,
     ITimerPtr timer,
     ISchedulerPtr scheduler,
-    ILoggingServicePtr logging,
-    IRequestStatsPtr requestStats,
-    IVolumeStatsPtr volumeStats,
-    IServerStatsPtr serverStats,
-    TExecutorPtr executor,
-    IEndpointStoragePtr endpointStorage,
-    IEndpointManagerPtr endpointManager,
-    NProto::TClientConfig clientConfig);
+    IEndpointManagerPtr endpointManager);
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -37,37 +37,52 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TTestEndpointListener final
+struct TTestEndpointListener final
     : public IEndpointListener
 {
-public:
-    NThreading::TFuture<NProto::TError> StartEndpoint(
-        const NProto::TStartEndpointRequest& request,
-        const NProto::TVolume& volume,
-        NClient::ISessionPtr session) override
+    using TStartEndpointHandler = std::function<TFuture<NProto::TError>(
+        const NProto::TStartEndpointRequest& request)>;
+    using TStopEndpointHandler = std::function<TFuture<NProto::TError>(
+        const TString& socketPath)>;
+
+    TStartEndpointHandler StartEndpointHandler = [] (
+        const NProto::TStartEndpointRequest& request)
     {
         Y_UNUSED(request);
-        Y_UNUSED(volume);
-        Y_UNUSED(session);
-        return MakeFuture(NProto::TError());
-    }
+        return MakeFuture(NProto::TError{});
+    };
 
-    NThreading::TFuture<NProto::TError> AlterEndpoint(
-        const NProto::TStartEndpointRequest& request,
-        const NProto::TVolume& volume,
-        NClient::ISessionPtr session) override
-    {
-        Y_UNUSED(request);
-        Y_UNUSED(volume);
-        Y_UNUSED(session);
-        return MakeFuture(NProto::TError());
-    }
-
-    NThreading::TFuture<NProto::TError> StopEndpoint(
-        const TString& socketPath) override
+    TStopEndpointHandler StopEndpointHandler = [] (const TString& socketPath)
     {
         Y_UNUSED(socketPath);
+        return MakeFuture(NProto::TError{});
+    };
+
+    TFuture<NProto::TError> StartEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
+        return StartEndpointHandler(request);
+    }
+
+    TFuture<NProto::TError> AlterEndpoint(
+        const NProto::TStartEndpointRequest& request,
+        const NProto::TVolume& volume,
+        NClient::ISessionPtr session) override
+    {
+        Y_UNUSED(request);
+        Y_UNUSED(volume);
+        Y_UNUSED(session);
         return MakeFuture(NProto::TError());
+    }
+
+    TFuture<NProto::TError> StopEndpoint(
+        const TString& socketPath) override
+    {
+        return StopEndpointHandler(socketPath);
     }
 
     NProto::TError RefreshEndpoint(
@@ -79,7 +94,7 @@ public:
         return NProto::TError();
     }
 
-    NThreading::TFuture<NProto::TError> SwitchEndpoint(
+    TFuture<NProto::TError> SwitchEndpoint(
         const NProto::TStartEndpointRequest& request,
         const NProto::TVolume& volume,
         NClient::ISessionPtr session) override
@@ -97,27 +112,41 @@ struct TTestSessionManager final
     : public ISessionManager
 {
     using TCreateSessionHandler
-        = std::function<NThreading::TFuture<TSessionOrError>()>;
+        = std::function<TFuture<TSessionOrError>()>;
 
     using TRemoveSessionHandler
-        = std::function<NThreading::TFuture<NProto::TError>()>;
+        = std::function<TFuture<NProto::TError>()>;
 
     using TAlterSessionHandler
-        = std::function<NThreading::TFuture<NProto::TError>()>;
+        = std::function<TFuture<NProto::TError>()>;
 
     using TGetSessionHandler
-        = std::function<NThreading::TFuture<TSessionOrError>()>;
+        = std::function<TFuture<TSessionOrError>()>;
 
     using TGetProfileHandler
         = std::function<TResultOrError<NProto::TClientPerformanceProfile>()>;
 
-    TCreateSessionHandler CreateSessionHandler;
-    TRemoveSessionHandler RemoveSessionHandler;
-    TAlterSessionHandler AlterSessionHandler;
-    TGetSessionHandler GetSessionHandler;
-    TGetProfileHandler GetProfileHandler;
+    TCreateSessionHandler CreateSessionHandler = [] () {
+        return MakeFuture<TSessionOrError>(TSessionInfo());
+    };
 
-    NThreading::TFuture<TSessionOrError> CreateSession(
+    TRemoveSessionHandler RemoveSessionHandler = [] () {
+        return MakeFuture(NProto::TError());
+    };
+
+    TAlterSessionHandler AlterSessionHandler = [] () {
+        return MakeFuture(NProto::TError());
+    };
+
+    TGetSessionHandler GetSessionHandler = [] () {
+        return MakeFuture<TSessionOrError>(TSessionInfo());
+    };
+
+    TGetProfileHandler GetProfileHandler = [] () {
+        return NProto::TClientPerformanceProfile();
+    };
+
+    TFuture<TSessionOrError> CreateSession(
         TCallContextPtr callContext,
         const NProto::TStartEndpointRequest& request) override
     {
@@ -126,7 +155,7 @@ struct TTestSessionManager final
         return CreateSessionHandler();
     }
 
-    NThreading::TFuture<NProto::TError> RemoveSession(
+    TFuture<NProto::TError> RemoveSession(
         TCallContextPtr callContext,
         const TString& socketPath,
         const NProto::THeaders& headers) override
@@ -137,7 +166,7 @@ struct TTestSessionManager final
         return RemoveSessionHandler();
     }
 
-    NThreading::TFuture<NProto::TError> AlterSession(
+    TFuture<NProto::TError> AlterSession(
         TCallContextPtr callContext,
         const TString& socketPath,
         NProto::EVolumeAccessMode accessMode,
@@ -154,7 +183,7 @@ struct TTestSessionManager final
         return AlterSessionHandler();
     }
 
-    NThreading::TFuture<TSessionOrError> GetSession(
+    TFuture<TSessionOrError> GetSession(
         TCallContextPtr callContext,
         const TString& socketPath,
         const NProto::THeaders& headers) override
@@ -175,38 +204,8 @@ struct TTestSessionManager final
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TTestEndpointManager final
-    : public IEndpointManager
-{
-#define ENDPOINT_IMPLEMENT_METHOD(name, ...)                                   \
-    using T##name##Handler = std::function<                                    \
-        NThreading::TFuture<NProto::T##name##Response>(                        \
-            std::shared_ptr<NProto::T##name##Request> request)                 \
-        >;                                                                     \
-                                                                               \
-    T##name##Handler name##Handler;                                            \
-    TFuture<NProto::T##name##Response> name(                                   \
-        TCallContextPtr ctx,                                                   \
-        std::shared_ptr<NProto::T##name##Request> request) override            \
-    {                                                                          \
-        Y_UNUSED(ctx);                                                         \
-        return name##Handler(std::move(request));                              \
-    }                                                                          \
-// ENDPOINT_IMPLEMENT_METHOD
-
-    ENDPOINT_IMPLEMENT_METHOD(StartEndpoint)
-    ENDPOINT_IMPLEMENT_METHOD(StopEndpoint)
-    ENDPOINT_IMPLEMENT_METHOD(ListEndpoints)
-    ENDPOINT_IMPLEMENT_METHOD(DescribeEndpoint)
-    ENDPOINT_IMPLEMENT_METHOD(RefreshEndpoint)
-
-#undef ENDPOINT_IMPLEMENT_METHOD
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 NProto::TKickEndpointResponse KickEndpoint(
-    IBlockStore& service,
+    IEndpointManager& service,
     ui32 keyringId,
     ui32 requestId = 42)
 {
@@ -220,7 +219,6 @@ NProto::TKickEndpointResponse KickEndpoint(
 
      return future.GetValue(TDuration::Seconds(5));
 }
-
 
 }   // namespace
 
@@ -247,20 +245,19 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         TString diskId = "testDiskId";
         auto ipcType = NProto::IPC_GRPC;
 
-        TVector<std::shared_ptr<NProto::TStartEndpointRequest>> endpoints;
-        auto endpointManager = std::make_shared<TTestEndpointManager>();
-        endpointManager->StartEndpointHandler = [&] (
-            std::shared_ptr<NProto::TStartEndpointRequest> request)
+        TMap<TString, NProto::TStartEndpointRequest> endpoints;
+        auto listener = std::make_shared<TTestEndpointListener>();
+        listener->StartEndpointHandler = [&] (
+            const NProto::TStartEndpointRequest& request)
         {
-            endpoints.push_back(std::move(request));
-            return MakeFuture(NProto::TStartEndpointResponse());
+            endpoints.emplace(request.GetUnixSocketPath(), request);
+            return MakeFuture(NProto::TError{});
         };
 
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
+        auto endpointManager = CreateEndpointManager(
             CreateWallClockTimer(),
             CreateSchedulerStub(),
             CreateLoggingService("console"),
@@ -268,9 +265,13 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            endpointManager,
-            {});
+            {{ ipcType, listener }},
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
         NProto::TStartEndpointRequest request;
         request.SetUnixSocketPath(unixSocket);
@@ -289,13 +290,13 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         {
             ui32 requestId = 325;
             auto response = KickEndpoint(
-                *endpointService,
+                *endpointManager,
                 keyringId,
                 requestId);
             UNIT_ASSERT(!HasError(response));
 
             UNIT_ASSERT_VALUES_EQUAL(1, endpoints.size());
-            const auto& endpoint = *endpoints[0];
+            const auto& endpoint = endpoints.begin()->second;
 
             google::protobuf::util::MessageDifferencer comparator;
             request.MutableHeaders()->SetRequestId(requestId);
@@ -304,7 +305,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         {
             auto wrongKeyringId = keyringId + 42;
-            auto response = KickEndpoint(*endpointService, wrongKeyringId);
+            auto response = KickEndpoint(*endpointManager, wrongKeyringId);
             UNIT_ASSERT(HasError(response)
                 && response.GetError().GetCode() == E_INVALID_STATE);
         }
@@ -349,26 +350,26 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         executor->Start();
 
         auto endpointManager = CreateEndpointManager(
-            logging,
+            CreateWallClockTimer(),
+            CreateSchedulerStub(),
+            CreateLoggingService("console"),
+            CreateRequestStatsStub(),
+            CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
             CreateEndpointEventProxy(),
             sessionManager,
+            endpointStorage,
             {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
-            "");
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
         auto endpointService = CreateMultipleEndpointService(
             std::make_shared<TTestService>(),
             CreateWallClockTimer(),
             scheduler,
-            logging,
-            CreateRequestStatsStub(),
-            CreateVolumeStatsStub(),
-            CreateServerStatsStub(),
-            executor,
-            endpointStorage,
-            endpointManager,
-            {});
+            endpointManager);
 
         const TString diskId = "testDiskId";
         const TString socketPath = "testSocket";
@@ -478,20 +479,19 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
     Y_UNIT_TEST(ShouldThrowCriticalEventIfFailedToRestoreEndpoint)
     {
-        const TString wrongSocketPath = "wrong.socket";
+        const TString wrongSocketPath = "wrongSocket";
         size_t startedEndpointCount = 0;
 
-        auto endpointManager = std::make_shared<TTestEndpointManager>();
-        endpointManager->StartEndpointHandler = [&] (
-            std::shared_ptr<NProto::TStartEndpointRequest> request)
+        auto listener = std::make_shared<TTestEndpointListener>();
+        listener->StartEndpointHandler = [&] (
+            const NProto::TStartEndpointRequest& request)
         {
-            if (request->GetUnixSocketPath() == wrongSocketPath) {
-                return MakeFuture<NProto::TStartEndpointResponse>(
-                    TErrorResponse(E_FAIL));
+            if (request.GetUnixSocketPath().StartsWith(wrongSocketPath)) {
+                return MakeFuture(MakeError(E_FAIL));
             }
 
             ++startedEndpointCount;
-            return MakeFuture(NProto::TStartEndpointResponse());
+            return MakeFuture(NProto::TError{});
         };
 
         NMonitoring::TDynamicCountersPtr counters = new NMonitoring::TDynamicCounters();
@@ -527,7 +527,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         for (size_t i = 0; i < wrongSocketCount; ++i) {
             NProto::TStartEndpointRequest request;
-            request.SetUnixSocketPath(wrongSocketPath);
+            request.SetUnixSocketPath(wrongSocketPath + ToString(i));
 
             auto strOrError = SerializeEndpoint(request);
             UNIT_ASSERT_C(!HasError(strOrError), strOrError.GetError());
@@ -540,7 +540,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         for (size_t i = 0; i < correctCount; ++i) {
             NProto::TStartEndpointRequest request;
-            request.SetUnixSocketPath("endpoint.sock");
+            request.SetUnixSocketPath("testSocket" + ToString(i + 1));
 
             auto strOrError = SerializeEndpoint(request);
             UNIT_ASSERT_C(!HasError(strOrError), strOrError.GetError());
@@ -554,8 +554,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
+        auto endpointManager = CreateEndpointManager(
             CreateWallClockTimer(),
             CreateSchedulerStub(),
             CreateLoggingService("console"),
@@ -563,11 +562,15 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            endpointManager,
-            {});
+            {{ NProto::IPC_GRPC, listener }},
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
-        endpointService->RestoreEndpoints().Wait();
+        endpointManager->RestoreEndpoints().Wait();
 
         UNIT_ASSERT_VALUES_EQUAL(
             wrongDataCount + wrongSocketCount,
@@ -592,8 +595,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
+        auto endpointManager = CreateEndpointManager(
             CreateWallClockTimer(),
             CreateSchedulerStub(),
             CreateLoggingService("console"),
@@ -601,11 +603,15 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            std::make_shared<TTestEndpointManager>(),
-            {});
+            {}, // listeners
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
-        endpointService->RestoreEndpoints().Wait();
+        endpointManager->RestoreEndpoints().Wait();
 
         UNIT_ASSERT_VALUES_EQUAL(1, static_cast<int>(*configCounter));
 
@@ -626,8 +632,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
+        auto endpointManager = CreateEndpointManager(
             CreateWallClockTimer(),
             CreateSchedulerStub(),
             CreateLoggingService("console"),
@@ -635,11 +640,15 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            std::make_shared<TTestEndpointManager>(),
-            {});
+            {}, // listeners
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
-        endpointService->RestoreEndpoints().Wait();
+        endpointManager->RestoreEndpoints().Wait();
 
         UNIT_ASSERT_VALUES_EQUAL(0, static_cast<int>(*configCounter));
 
@@ -648,21 +657,14 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
     Y_UNIT_TEST(ShouldHandleRestoreFlagInListEndpointsResponse)
     {
-        auto trigger = NewPromise<NProto::TStartEndpointResponse>();
+        auto trigger = NewPromise<NProto::TError>();
 
-        auto endpointManager = std::make_shared<TTestEndpointManager>();
-        endpointManager->StartEndpointHandler = [&] (
-            std::shared_ptr<NProto::TStartEndpointRequest> request)
+        auto listener = std::make_shared<TTestEndpointListener>();
+        listener->StartEndpointHandler = [&] (
+            const NProto::TStartEndpointRequest& request)
         {
             Y_UNUSED(request);
             return trigger;
-        };
-
-        endpointManager->ListEndpointsHandler = [&] (
-            std::shared_ptr<NProto::TListEndpointsRequest> request)
-        {
-            Y_UNUSED(request);
-            return MakeFuture(NProto::TListEndpointsResponse());
         };
 
         const TString dirPath = "./" + CreateGuidAsString();
@@ -681,7 +683,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         for (size_t i = 0; i < endpointCount; ++i) {
             NProto::TStartEndpointRequest request;
-            request.SetUnixSocketPath("endpoint.sock");
+            request.SetUnixSocketPath("testSocket" + ToString(i + 1));
 
             auto strOrError = SerializeEndpoint(request);
             UNIT_ASSERT_C(!HasError(strOrError), strOrError.GetError());
@@ -695,8 +697,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
+        auto endpointManager = CreateEndpointManager(
             CreateWallClockTimer(),
             CreateSchedulerStub(),
             CreateLoggingService("console"),
@@ -704,26 +705,30 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            endpointManager,
-            {});
+            {{ NProto::IPC_GRPC, listener }},
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
-        auto restoreFuture = endpointService->RestoreEndpoints();
+        auto restoreFuture = endpointManager->RestoreEndpoints();
         UNIT_ASSERT(!restoreFuture.HasValue());
 
         {
-            auto future = endpointService->ListEndpoints(
+            auto future = endpointManager->ListEndpoints(
                 MakeIntrusive<TCallContext>(),
                 std::make_shared<NProto::TListEndpointsRequest>());
             auto response = future.GetValue(TDuration::Seconds(1));
             UNIT_ASSERT(!response.GetEndpointsWereRestored());
         }
 
-        trigger.SetValue(NProto::TStartEndpointResponse());
+        trigger.SetValue(NProto::TError());
         restoreFuture.Wait();
 
         {
-            auto future = endpointService->ListEndpoints(
+            auto future = endpointManager->ListEndpoints(
                 MakeIntrusive<TCallContext>(),
                 std::make_shared<NProto::TListEndpointsRequest>());
             auto response = future.GetValue(TDuration::Seconds(1));
@@ -735,20 +740,6 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
     Y_UNIT_TEST(ShouldListKeyrings)
     {
-        auto endpointManager = std::make_shared<TTestEndpointManager>();
-        endpointManager->StartEndpointHandler = [&] (
-            std::shared_ptr<NProto::TStartEndpointRequest> request)
-        {
-            Y_UNUSED(request);
-            return MakeFuture(NProto::TStartEndpointResponse());
-        };
-        endpointManager->StopEndpointHandler = [&] (
-            std::shared_ptr<NProto::TStopEndpointRequest> request)
-        {
-            Y_UNUSED(request);
-            return MakeFuture(NProto::TStopEndpointResponse());
-        };
-
         const TString dirPath = "./" + CreateGuidAsString();
         auto endpointStorage = CreateFileEndpointStorage(dirPath);
         auto mutableStorage = CreateFileMutableEndpointStorage(dirPath);
@@ -784,8 +775,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
+        auto endpointManager = CreateEndpointManager(
             CreateWallClockTimer(),
             CreateSchedulerStub(),
             CreateLoggingService("console"),
@@ -793,11 +783,15 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            endpointManager,
-            {});
+            {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
-        auto future = endpointService->ListKeyrings(
+        auto future = endpointManager->ListKeyrings(
             MakeIntrusive<TCallContext>(),
             std::make_shared<NProto::TListKeyringsRequest>());
 
@@ -823,7 +817,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             request->SetPersistent(true);
             ++endpointCount;
 
-            auto future = endpointService->StartEndpoint(
+            auto future = endpointManager->StartEndpoint(
                 MakeIntrusive<TCallContext>(),
                 request);
             auto response = future.GetValue(TDuration::Seconds(5));
@@ -831,7 +825,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         {
-            auto future = endpointService->ListKeyrings(
+            auto future = endpointManager->ListKeyrings(
                 MakeIntrusive<TCallContext>(),
                 std::make_shared<NProto::TListKeyringsRequest>());
 
@@ -847,7 +841,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             request->SetIpcType(NProto::IPC_GRPC);
             request->SetPersistent(false);
 
-            auto future = endpointService->StartEndpoint(
+            auto future = endpointManager->StartEndpoint(
                 MakeIntrusive<TCallContext>(),
                 request);
             auto response = future.GetValue(TDuration::Seconds(5));
@@ -855,7 +849,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         {
-            auto future = endpointService->ListKeyrings(
+            auto future = endpointManager->ListKeyrings(
                 MakeIntrusive<TCallContext>(),
                 std::make_shared<NProto::TListKeyringsRequest>());
 
@@ -869,7 +863,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             request->SetUnixSocketPath("testPersistentSocket" + ToString(i + 1));
             --endpointCount;
 
-            auto future = endpointService->StopEndpoint(
+            auto future = endpointManager->StopEndpoint(
                 MakeIntrusive<TCallContext>(),
                 request);
             auto response = future.GetValue(TDuration::Seconds(5));
@@ -877,7 +871,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         {
-            auto future = endpointService->ListKeyrings(
+            auto future = endpointManager->ListKeyrings(
                 MakeIntrusive<TCallContext>(),
                 std::make_shared<NProto::TListKeyringsRequest>());
 
@@ -890,7 +884,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             auto request = std::make_shared<NProto::TStopEndpointRequest>();
             request->SetUnixSocketPath("testTemporarySocket" + ToString(i + 1));
 
-            auto future = endpointService->StopEndpoint(
+            auto future = endpointManager->StopEndpoint(
                 MakeIntrusive<TCallContext>(),
                 request);
             auto response = future.GetValue(TDuration::Seconds(5));
@@ -898,7 +892,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         {
-            auto future = endpointService->ListKeyrings(
+            auto future = endpointManager->ListKeyrings(
                 MakeIntrusive<TCallContext>(),
                 std::make_shared<NProto::TListKeyringsRequest>());
 
@@ -912,14 +906,19 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
     Y_UNIT_TEST(ShouldHandleParallelStartStopEndpoints)
     {
-        auto startPromise = NewPromise<ISessionManager::TSessionOrError>();
+        auto startPromise = NewPromise<NProto::TError>();
         auto stopPromise = NewPromise<NProto::TError>();
 
-        auto sessionManager = std::make_shared<TTestSessionManager>();
-        sessionManager->CreateSessionHandler = [&] () {
+        auto listener = std::make_shared<TTestEndpointListener>();
+        listener->StartEndpointHandler = [&] (
+            const NProto::TStartEndpointRequest& request)
+        {
+            Y_UNUSED(request);
             return startPromise.GetFuture();
         };
-        sessionManager->RemoveSessionHandler = [&] () {
+        listener->StopEndpointHandler = [&] (const TString& socketPath)
+        {
+            Y_UNUSED(socketPath);
             return stopPromise.GetFuture();
         };
 
@@ -932,26 +931,20 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         executor->Start();
 
         auto endpointManager = CreateEndpointManager(
-            logging,
-            CreateServerStatsStub(),
-            executor,
-            CreateEndpointEventProxy(),
-            sessionManager,
-            {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
-            "");
-
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
             CreateWallClockTimer(),
             CreateSchedulerStub(),
-            logging,
+            CreateLoggingService("console"),
             CreateRequestStatsStub(),
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            endpointManager,
-            {});
+            {{ NProto::IPC_GRPC, listener }},
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
         auto unixSocket = "testSocket";
 
@@ -971,16 +964,16 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto ctx = MakeIntrusive<TCallContext>();
 
         {
-            auto future1 = endpointService->StartEndpoint(ctx, startRequest);
-            auto future2 = endpointService->StartEndpoint(ctx, startRequest);
+            auto future1 = endpointManager->StartEndpoint(ctx, startRequest);
+            auto future2 = endpointManager->StartEndpoint(ctx, startRequest);
             UNIT_ASSERT(!future1.HasValue());
             UNIT_ASSERT(!future2.HasValue());
 
-            auto future3 = endpointService->StartEndpoint(ctx, otherStartRequest);
+            auto future3 = endpointManager->StartEndpoint(ctx, otherStartRequest);
             auto response3 = future3.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT_C(response3.GetError().GetCode() == E_REJECTED, response3.GetError());
 
-            auto future = endpointService->StopEndpoint(ctx, stopRequest);
+            auto future = endpointManager->StopEndpoint(ctx, stopRequest);
             auto response = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT(response.GetError().GetCode() == E_REJECTED);
 
@@ -993,12 +986,12 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         {
-            auto future1 = endpointService->StopEndpoint(ctx, stopRequest);
-            auto future2 = endpointService->StopEndpoint(ctx, stopRequest);
+            auto future1 = endpointManager->StopEndpoint(ctx, stopRequest);
+            auto future2 = endpointManager->StopEndpoint(ctx, stopRequest);
             UNIT_ASSERT(!future1.HasValue());
             UNIT_ASSERT(!future2.HasValue());
 
-            auto future3 = endpointService->StartEndpoint(ctx, otherStartRequest);
+            auto future3 = endpointManager->StartEndpoint(ctx, otherStartRequest);
             auto response3 = future3.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT(response3.GetError().GetCode() == E_REJECTED);
 
@@ -1031,17 +1024,18 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         TAtomic trigger = 0;
         TManualEvent event;
 
-        auto sessionManager = std::make_shared<TTestSessionManager>();
-        sessionManager->CreateSessionHandler = [&] () {
+        auto listener = std::make_shared<TTestEndpointListener>();
+        listener->StartEndpointHandler = [&] (
+            const NProto::TStartEndpointRequest& request)
+        {
+            Y_UNUSED(request);
+
             NProto::TError error;
             if (!AtomicGet(trigger)) {
                 error.SetCode(E_TIMEOUT);
             }
             event.Signal();
-            return MakeFuture(ISessionManager::TSessionOrError(error));
-        };
-        sessionManager->RemoveSessionHandler = [&] () {
-            return MakeFuture(NProto::TError());
+            return MakeFuture(error);
         };
 
         auto scheduler = CreateScheduler();
@@ -1050,36 +1044,28 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             scheduler->Stop();
         };
 
-        auto logging = CreateLoggingService("console");
-
         auto executor = TExecutor::Create("TestService");
         executor->Start();
 
         auto endpointManager = CreateEndpointManager(
-            logging,
-            CreateServerStatsStub(),
-            executor,
-            CreateEndpointEventProxy(),
-            sessionManager,
-            {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
-            "");
-
-        auto endpointService = CreateMultipleEndpointService(
-            std::make_shared<TTestService>(),
             CreateWallClockTimer(),
             scheduler,
-            logging,
+            CreateLoggingService("console"),
             CreateRequestStatsStub(),
             CreateVolumeStatsStub(),
             CreateServerStatsStub(),
             executor,
+            CreateEndpointEventProxy(),
+            std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            endpointManager,
-            {});
+            {{ NProto::IPC_GRPC, listener }},
+            {}, // clientConfig
+            ""  // nbdSocketSuffix
+        );
 
-        endpointService->Start();
+        endpointManager->Start();
         Y_DEFER {
-            endpointService->Stop();
+            endpointManager->Stop();
         };
 
         auto unixSocket = "testSocket";
@@ -1103,9 +1089,9 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             strOrError.GetResult());
         UNIT_ASSERT_C(!HasError(error), error);
 
-        auto restoreFuture = endpointService->RestoreEndpoints();
+        auto restoreFuture = endpointManager->RestoreEndpoints();
 
-        auto stopFuture = endpointService->StopEndpoint(ctx, stopRequest);
+        auto stopFuture = endpointManager->StopEndpoint(ctx, stopRequest);
         auto stopResponse = stopFuture.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT(stopResponse.GetError().GetCode() == E_REJECTED);
 
@@ -1116,7 +1102,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         UNIT_ASSERT(restoreFuture.Wait(TDuration::Seconds(5)));
         UNIT_ASSERT(restoreFuture.HasValue());
 
-        auto future = endpointService->StopEndpoint(ctx, stopRequest);
+        auto future = endpointManager->StopEndpoint(ctx, stopRequest);
         auto response = future.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT(response.GetError().GetCode() == S_OK);
 


### PR DESCRIPTION
EndpointManager should implement all endpoint methods (including KickEndpoint and restore endpoints).

EndpointService should be just adapter from IBlockStore to IEndpointManager.