### PR TITLE
NBSNEBIUS-146: don't generate critical events on health check read during secure erase (#699)

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -2994,6 +2994,36 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             true);
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
 
+        // Read during secure erase from HealthCheck client doesn't generate
+        // critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            ReadDeviceBlocks(
+                runtime,
+                diskAgent,
+                "uuid",
+                0,
+                1,
+                TString(CheckHealthClientId))
+                    ->Record.GetError()
+                    .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
+
+        // Write zero during secure erase from HealthCheck client generates
+        // critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            ZeroDeviceBlocks(
+                runtime,
+                diskAgent,
+                "uuid",
+                0,
+                1,
+                TString(CheckHealthClientId))
+                    ->Record.GetError()
+                    .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 4);
+
         spdk->SecureEraseResult.SetValue(NProto::TError());
         runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(10));
 

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -368,7 +368,14 @@ private:
         TString* overlapDetails) const
     {
         if (synchronizedData.SecureEraseInProgress) {
-            ReportDiskAgentIoDuringSecureErase();
+            ReportDiskAgentIoDuringSecureErase(
+                TStringBuilder()
+                << " Device=" << requestDetails.DeviceUUID
+                << ", ClientId=" << requestDetails.ClientId
+                << ", StartIndex=" << requestDetails.Range.Start
+                << ", BlocksCount=" << requestDetails.Range.Size()
+                << ", IsWrite=1"
+                << ", IsRdma=1");
             *overlapDetails = "Secure erase in progress";
             return ECheckRange::ResponseRejected;
         }
@@ -508,6 +515,22 @@ private:
             request.GetDeviceUUID(),
             request.GetHeaders().GetClientId(),
             NProto::VOLUME_ACCESS_READ_ONLY);
+
+        auto token = GetAccessToken(request.GetDeviceUUID());
+        if (token->SecureEraseInProgress) {
+            const auto& clientId = request.GetHeaders().GetClientId();
+            if (clientId != CheckHealthClientId) {
+                ReportDiskAgentIoDuringSecureErase(
+                    TStringBuilder()
+                    << " Device=" << request.GetDeviceUUID()
+                    << ", ClientId=" << clientId
+                    << ", StartIndex=" << request.GetStartIndex()
+                    << ", BlocksCount=" << request.GetBlocksCount()
+                    << ", IsWrite=0"
+                    << ", IsRdma=1");
+            }
+            return MakeError(E_REJECTED, "Secure erase in progress");
+        }
 
         auto req = std::make_shared<NProto::TReadBlocksRequest>();
 


### PR DESCRIPTION
Additionally report non health check reads during secure erase and add extra info to the critical event report
