### PR TITLE
NBSNEBIUS-69: refactor rdma config

### DIFF
--- a/cloud/blockstore/config/rdma.proto
+++ b/cloud/blockstore/config/rdma.proto
@@ -43,3 +43,14 @@ message TRdmaTarget
     TRdmaEndpoint Endpoint = 1;
     TRdmaServer Server = 2;
 }
+
+message TRdmaConfig
+{
+    bool ClientEnabled = 1;
+
+    TRdmaClient Client = 2;
+
+    bool ServerEnabled = 3;
+
+    TRdmaServer Server = 4;
+}

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -626,6 +626,9 @@ void TBootstrapBase::InitDbgConfigs()
     Configs->InitEndpointConfig();
     Configs->InitHostPerformanceProfile();
     Configs->InitDiskAgentConfig();
+    // InitRdmaConfig should be called after InitDiskAgentConfig and
+    // InitServerConfig to backport legacy RDMA config
+    Configs->InitRdmaConfig();
     Configs->InitDiskRegistryProxyConfig();
     Configs->InitDiagnosticsConfig();
     Configs->InitDiscoveryConfig();

--- a/cloud/blockstore/libs/daemon/common/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/common/config_initializer.h
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/discovery/config.h>
 #include <cloud/blockstore/libs/discovery/public.h>
+#include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/server/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
@@ -34,6 +35,7 @@ struct TConfigInitializerCommon
     TDiagnosticsConfigPtr DiagnosticsConfig;
     NSpdk::TSpdkEnvConfigPtr SpdkEnvConfig;
     NClient::THostPerformanceProfile HostPerformanceProfile;
+    NRdma::TRdmaConfigPtr RdmaConfig;
 
     TString Rack;
     TLog Log;
@@ -49,6 +51,7 @@ struct TConfigInitializerCommon
     void InitHostPerformanceProfile();
     void InitServerConfig();
     void InitSpdkEnvConfig();
+    void InitRdmaConfig();
 
     virtual bool GetUseNonreplicatedRdmaActor() const = 0;
     virtual TDuration GetInactiveClientsTimeout() const = 0;

--- a/cloud/blockstore/libs/daemon/common/options.cpp
+++ b/cloud/blockstore/libs/daemon/common/options.cpp
@@ -47,6 +47,11 @@ TOptionsCommon::TOptionsCommon()
         .RequiredArgument("FILE")
         .StoreResult(&DiscoveryConfig);
 
+    Opts.AddLongOption("rdma-file")
+        .RequiredArgument("FILE")
+        .DefaultValue("")
+        .StoreResult(&RdmaConfig);
+
     Opts.AddLongOption("temporary-server", "run temporary server for blue-green deployment")
         .NoArgument()
         .StoreTrue(&TemporaryServer);

--- a/cloud/blockstore/libs/daemon/common/options.h
+++ b/cloud/blockstore/libs/daemon/common/options.h
@@ -26,6 +26,7 @@ public:
     TString DiskAgentConfig;
     TString DiskRegistryProxyConfig;
     TString EndpointConfig;
+    TString RdmaConfig;
 
     enum class EServiceKind {
         Null   /* "null"   */ ,

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -15,6 +15,7 @@
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/rdma/iface/config.h>
 #include <cloud/blockstore/libs/rdma/iface/probes.h>
 #include <cloud/blockstore/libs/rdma/iface/server.h>
 #include <cloud/blockstore/libs/server/config.h>
@@ -167,15 +168,9 @@ public:
     }
 };
 
-NRdma::TServerConfigPtr CreateRdmaServerConfig(
-    NStorage::TDiskAgentConfig& agent)
+NRdma::TServerConfigPtr CreateRdmaServerConfig(NRdma::TRdmaConfig& config)
 {
-    const auto& target = agent.GetRdmaTarget();
-
-    if (target.HasServer()) {
-        return std::make_shared<NRdma::TServerConfig>(target.GetServer());
-    }
-    return std::make_shared<NRdma::TServerConfig>();
+    return std::make_shared<NRdma::TServerConfig>(config.GetServer());
 }
 
 }   // namespace
@@ -267,10 +262,10 @@ void TBootstrap::InitProfileLog()
     }
 }
 
-void TBootstrap::InitRdmaServer(NStorage::TDiskAgentConfig& config)
+void TBootstrap::InitRdmaServer(NRdma::TRdmaConfig& config)
 {
     try {
-        if (config.HasRdmaTarget()) {
+        if (config.GetServerEnabled()) {
             RdmaServer = ServerModuleFactories->RdmaServerFactory(
                 Logging,
                 Monitoring,
@@ -321,6 +316,9 @@ void TBootstrap::InitKikimrService()
     }
 
     Configs->InitDiskAgentConfig();
+    // InitRdmaConfig should be called after InitDiskAgentConfig
+    // to backport legacy RDMA config
+    Configs->InitRdmaConfig();
 
     STORAGE_INFO("Configs initialized");
 
@@ -378,7 +376,9 @@ void TBootstrap::InitKikimrService()
                 break;
         }
 
-        InitRdmaServer(config);
+        if (Configs->RdmaConfig) {
+            InitRdmaServer(*Configs->RdmaConfig);
+        }
     }
 
     Allocator = CreateCachingAllocator(
@@ -409,6 +409,7 @@ void TBootstrap::InitKikimrService()
     args.AppConfig = Configs->KikimrConfig;
     args.StorageConfig = Configs->StorageConfig;
     args.DiskAgentConfig = Configs->DiskAgentConfig;
+    args.RdmaConfig = Configs->RdmaConfig;
     args.DiskRegistryProxyConfig = Configs->DiskRegistryProxyConfig;
     args.AsyncLogger = AsyncLogger;
     args.Spdk = Spdk;

--- a/cloud/blockstore/libs/disk_agent/bootstrap.h
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.h
@@ -93,7 +93,7 @@ private:
     void InitProfileLog();
     void InitKikimrService();
 
-    void InitRdmaServer(NStorage::TDiskAgentConfig& config);
+    void InitRdmaServer(NRdma::TRdmaConfig& config);
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/disk_agent/config_initializer.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.cpp
@@ -3,6 +3,7 @@
 #include "options.h"
 
 #include <cloud/blockstore/libs/diagnostics/config.h>
+#include <cloud/blockstore/libs/rdma/iface/config.h>
 #include <cloud/blockstore/libs/server/config.h>
 #include <cloud/blockstore/libs/spdk/iface/config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
@@ -202,6 +203,25 @@ void TConfigInitializer::InitFeaturesConfig()
 
     FeaturesConfig =
         std::make_shared<NFeatures::TFeaturesConfig>(featuresConfig);
+}
+
+void TConfigInitializer::InitRdmaConfig()
+{
+    NProto::TRdmaConfig rdmaConfig;
+
+    if (Options->RdmaConfig) {
+        ParseProtoTextFromFileRobust(Options->RdmaConfig, rdmaConfig);
+    } else {
+        // no rdma config file is given fallback to legacy config
+        if (DiskAgentConfig->DeprecatedHasRdmaTarget()) {
+            rdmaConfig.SetServerEnabled(true);
+            const auto& rdmaTarget = DiskAgentConfig->DeprecatedGetRdmaTarget();
+            rdmaConfig.MutableServer()->CopyFrom(rdmaTarget.GetServer());
+        }
+    }
+
+    RdmaConfig =
+        std::make_shared<NRdma::TRdmaConfig>(rdmaConfig);
 }
 
 NKikimrConfig::TLogConfig TConfigInitializer::GetLogConfig() const

--- a/cloud/blockstore/libs/disk_agent/config_initializer.h
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/common/public.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
+#include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/server/public.h>
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/spdk/iface/config.h>
@@ -34,6 +35,7 @@ struct TConfigInitializer
     TDiagnosticsConfigPtr DiagnosticsConfig;
     NSpdk::TSpdkEnvConfigPtr SpdkEnvConfig;
     NFeatures::TFeaturesConfigPtr FeaturesConfig;
+    NRdma::TRdmaConfigPtr RdmaConfig;
 
     TString Rack;
 
@@ -52,6 +54,7 @@ struct TConfigInitializer
     void InitServerConfig();
     void InitSpdkEnvConfig();
     void InitFeaturesConfig();
+    void InitRdmaConfig();
 
     NKikimrConfig::TLogConfig GetLogConfig() const;
     NKikimrConfig::TMonitoringConfig GetMonitoringConfig() const;

--- a/cloud/blockstore/libs/disk_agent/options.cpp
+++ b/cloud/blockstore/libs/disk_agent/options.cpp
@@ -24,6 +24,11 @@ TOptions::TOptions()
         .RequiredArgument("FILE")
         .StoreResult(&FeaturesConfig);
 
+    Opts.AddLongOption("rdma-file")
+        .RequiredArgument("FILE")
+        .DefaultValue("")
+        .StoreResult(&RdmaConfig);
+
     Opts.AddLongOption("syslog-service")
         .RequiredArgument("STR")
         .StoreResult(&SysLogService);

--- a/cloud/blockstore/libs/disk_agent/options.h
+++ b/cloud/blockstore/libs/disk_agent/options.h
@@ -19,6 +19,7 @@ struct TOptions
     TString DiskAgentConfig;
     TString DiskRegistryProxyConfig;
     TString FeaturesConfig;
+    TString RdmaConfig;
 
     TString SysLogService;
 

--- a/cloud/blockstore/libs/rdma/iface/config.cpp
+++ b/cloud/blockstore/libs/rdma/iface/config.cpp
@@ -1,0 +1,11 @@
+#include "config.h"
+
+namespace NCloud::NBlockStore::NRdma {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TRdmaConfig::TRdmaConfig(NProto::TRdmaConfig config)
+    : Config(config)
+{}
+
+}   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/config.h
+++ b/cloud/blockstore/libs/rdma/iface/config.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/config/rdma.pb.h>
+
+namespace NCloud::NBlockStore::NRdma {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRdmaConfig
+{
+private:
+    const NProto::TRdmaConfig Config;
+
+public:
+    explicit TRdmaConfig(NProto::TRdmaConfig config = {});
+
+    auto GetClientEnabled() const
+    {
+        return Config.GetClientEnabled();
+    }
+
+    auto GetClient() const
+    {
+        return Config.GetClient();
+    }
+
+    auto GetServerEnabled() const
+    {
+        return Config.GetServerEnabled();
+    }
+
+    auto GetServer() const
+    {
+        return Config.GetServer();
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/public.h
+++ b/cloud/blockstore/libs/rdma/iface/public.h
@@ -53,4 +53,7 @@ using TProtoMessagePtr = std::unique_ptr<TProtoMessage>;
 
 class TProtoMessageSerializer;
 
+class TRdmaConfig;
+using TRdmaConfigPtr = std::shared_ptr<TRdmaConfig>;
+
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/ya.make
+++ b/cloud/blockstore/libs/rdma/iface/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     client.cpp
+    config.cpp
     probes.cpp
     protobuf.cpp
     protocol.cpp

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -293,4 +293,15 @@ void TServerAppConfig::DumpHtml(IOutputStream& out) const
 #undef BLOCKSTORE_CONFIG_DUMP
 }
 
+bool TServerAppConfig::DeprecatedGetRdmaClientEnabled() const
+{
+    return GetRdmaClientEnabled();
+}
+
+const NProto::TRdmaClient&
+TServerAppConfig::DeprecatedGetRdmaClientConfig() const
+{
+    return ServerConfig->GetRdmaClientConfig();
+}
+
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -120,13 +120,17 @@ public:
     ui32 GetMaxReadIops() const;
     ui32 GetMaxWriteIops() const;
     TDuration GetMaxBurstTime() const;
-    bool GetRdmaClientEnabled() const;
+    bool DeprecatedGetRdmaClientEnabled() const;
+    const NProto::TRdmaClient& DeprecatedGetRdmaClientConfig() const;
     NCloud::NProto::EEndpointStorageType GetEndpointStorageType() const;
     TString GetEndpointStorageDir() const;
     TString GetVhostServerPath() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;
+
+private:
+    bool GetRdmaClientEnabled() const;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent.cpp
@@ -11,6 +11,7 @@ using namespace NActors;
 IActorPtr CreateDiskAgent(
     TStorageConfigPtr config,
     TDiskAgentConfigPtr agentConfig,
+    NRdma::TRdmaConfigPtr rdmaConfig,
     NSpdk::ISpdkEnvPtr spdk,
     ICachingAllocatorPtr allocator,
     IStorageProviderPtr storageProvider,
@@ -23,6 +24,7 @@ IActorPtr CreateDiskAgent(
     return std::make_unique<TDiskAgentActor>(
         std::move(config),
         std::move(agentConfig),
+        std::move(rdmaConfig),
         std::move(spdk),
         std::move(allocator),
         std::move(storageProvider),

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent.h
@@ -17,6 +17,7 @@ namespace NCloud::NBlockStore::NStorage {
 NActors::IActorPtr CreateDiskAgent(
     TStorageConfigPtr config,
     TDiskAgentConfigPtr agentConfig,
+    NRdma::TRdmaConfigPtr rdmaConfig,
     NSpdk::ISpdkEnvPtr spdk,
     ICachingAllocatorPtr allocator,
     IStorageProviderPtr storageProvider,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -21,6 +21,7 @@ using namespace NKikimr;
 TDiskAgentActor::TDiskAgentActor(
         TStorageConfigPtr config,
         TDiskAgentConfigPtr agentConfig,
+        NRdma::TRdmaConfigPtr rdmaConfig,
         NSpdk::ISpdkEnvPtr spdk,
         ICachingAllocatorPtr allocator,
         IStorageProviderPtr storageProvider,
@@ -31,6 +32,7 @@ TDiskAgentActor::TDiskAgentActor(
         NNvme::INvmeManagerPtr nvmeManager)
     : Config(std::move(config))
     , AgentConfig(std::move(agentConfig))
+    , RdmaConfig(std::move(rdmaConfig))
     , Spdk(std::move(spdk))
     , Allocator(std::move(allocator))
     , StorageProvider(std::move(storageProvider))

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -45,6 +45,7 @@ class TDiskAgentActor final
 private:
     const TStorageConfigPtr Config;
     const TDiskAgentConfigPtr AgentConfig;
+    const NRdma::TRdmaConfigPtr RdmaConfig;
     const NSpdk::ISpdkEnvPtr Spdk;
     const ICachingAllocatorPtr Allocator;
     const IStorageProviderPtr StorageProvider;
@@ -78,6 +79,7 @@ public:
     TDiskAgentActor(
         TStorageConfigPtr config,
         TDiskAgentConfigPtr agentConfig,
+        NRdma::TRdmaConfigPtr rdmaConfig,
         NSpdk::ISpdkEnvPtr spdk,
         ICachingAllocatorPtr allocator,
         IStorageProviderPtr storageProvider,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -21,6 +21,7 @@ void TDiskAgentActor::InitAgent(const TActorContext& ctx)
     State = std::make_unique<TDiskAgentState>(
         Config,
         AgentConfig,
+        RdmaConfig,
         Spdk,
         Allocator,
         StorageProvider,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
+#include <cloud/blockstore/libs/rdma/iface/config.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/storage.h>
 #include <cloud/blockstore/libs/spdk/iface/env.h>
@@ -242,6 +243,7 @@ TVector<IProfileLog::TBlockInfo> ComputeDigest(
 TDiskAgentState::TDiskAgentState(
         TStorageConfigPtr storageConfig,
         TDiskAgentConfigPtr agentConfig,
+        NRdma::TRdmaConfigPtr rdmaConfig,
         NSpdk::ISpdkEnvPtr spdk,
         ICachingAllocatorPtr allocator,
         IStorageProviderPtr storageProvider,
@@ -252,6 +254,7 @@ TDiskAgentState::TDiskAgentState(
         NNvme::INvmeManagerPtr nvmeManager)
     : StorageConfig(std::move(storageConfig))
     , AgentConfig(std::move(agentConfig))
+    , RdmaConfig(std::move(rdmaConfig))
     , Spdk(std::move(spdk))
     , Allocator(std::move(allocator))
     , StorageProvider(std::move(storageProvider))
@@ -427,7 +430,7 @@ void TDiskAgentState::InitRdmaTarget(TRdmaTargetConfig rdmaTargetConfig)
     if (RdmaServer) {
         THashMap<TString, TStorageAdapterPtr> devices;
 
-        auto endpoint = AgentConfig->GetRdmaTarget().GetEndpoint();
+        auto endpoint = AgentConfig->GetRdmaEndpoint();
 
         if (endpoint.GetHost().empty()) {
             endpoint.SetHost(FQDNHostName());

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -44,6 +44,7 @@ private:
 private:
     const TStorageConfigPtr StorageConfig;
     const TDiskAgentConfigPtr AgentConfig;
+    const NRdma::TRdmaConfigPtr RdmaConfig;
     const NSpdk::ISpdkEnvPtr Spdk;
     const ICachingAllocatorPtr Allocator;
     const IStorageProviderPtr StorageProvider;
@@ -66,6 +67,7 @@ public:
     TDiskAgentState(
         TStorageConfigPtr storageConfig,
         TDiskAgentConfigPtr agentConfig,
+        NRdma::TRdmaConfigPtr rdmaConfig,
         NSpdk::ISpdkEnvPtr spdk,
         ICachingAllocatorPtr allocator,
         IStorageProviderPtr storageProvider,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -152,6 +152,7 @@ auto CreateDiskAgentStateSpdk(TDiskAgentConfigPtr config)
     return std::make_unique<TDiskAgentState>(
         CreateStorageConfig(),
         std::move(config),
+        nullptr,    // rdmaConfig
         NSpdk::CreateEnvStub(),
         CreateTestAllocator(),
         nullptr,   // storageProvider
@@ -341,6 +342,7 @@ struct TFiles
         return std::make_unique<TDiskAgentState>(
             CreateStorageConfig(),
             std::move(config),
+            nullptr,    // rdmaConfig
             nullptr,    // spdk
             CreateTestAllocator(),
             NServer::CreateNullStorageProvider(),
@@ -510,6 +512,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         TDiskAgentState state(
             CreateStorageConfig(),
             config,
+            nullptr,    // rdmaConfig
             nullptr,    // spdk
             CreateTestAllocator(),
             std::make_shared<TStorageProvider>(THashSet<TString>{
@@ -721,6 +724,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
                 TDiskAgentState state(
                     CreateStorageConfig(),
                     config,
+                    nullptr,    // rdmaConfig
                     nullptr,    // spdk
                     CreateTestAllocator(),
                     std::make_shared<TStorageProvider>(THashSet<TString>{
@@ -791,6 +795,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         TDiskAgentState state(
             CreateStorageConfig(),
             std::make_shared<TDiskAgentConfig>(std::move(config), "rack"),
+            nullptr,    // rdmaConfig
             nullptr,    // spdk
             CreateTestAllocator(),
             NServer::CreateNullStorageProvider(),
@@ -1210,6 +1215,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         TDiskAgentState state(
             CreateStorageConfig(),
             config,
+            nullptr,    // rdmaConfig
             nullptr,    // spdk
             CreateTestAllocator(),
             std::make_shared<TTestStorageProvider>(storageState),
@@ -1367,6 +1373,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         auto state = std::make_unique<TDiskAgentState>(
             CreateStorageConfig(),
             config,
+            nullptr,    // rdmaConfig
             nullptr,    // spdk
             CreateTestAllocator(),
             std::make_shared<TTestStorageProvider>(storageState),
@@ -1446,6 +1453,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         auto state = std::make_unique<TDiskAgentState>(
             CreateStorageConfig(),
             config,
+            nullptr,    // rdmaConfig
             nullptr,    // spdk
             CreateTestAllocator(),
             std::make_shared<TTestStorageProvider>(storageState),
@@ -1525,6 +1533,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
                     .DiscoveryConfig = discoveryConfig,
                     .CachedConfigPath = CachedConfigPath
                 }),
+                nullptr,    // rdmaConfig
                 nullptr,    // spdk
                 CreateTestAllocator(),
                 std::make_shared<TTestStorageProvider>(storageState),

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -55,12 +55,17 @@ public:
         return Config.GetNvmeTarget();
     }
 
-    auto GetRdmaTarget()
+    auto GetRdmaEndpoint()
+    {
+        return Config.GetRdmaTarget().GetEndpoint();
+    }
+
+    auto DeprecatedGetRdmaTarget()
     {
         return Config.GetRdmaTarget();
     }
 
-    auto HasRdmaTarget()
+    auto DeprecatedHasRdmaTarget()
     {
         return Config.HasRdmaTarget();
     }

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -355,6 +355,7 @@ TTestEnv TTestEnvBuilder::Build()
     auto diskAgent = CreateDiskAgent(
         config,
         agentConfig,
+        nullptr,    // rdmaConfig
         Spdk,
         allocator,
         StorageProvider,

--- a/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.cpp
@@ -101,6 +101,7 @@ public:
             auto diskAgent = CreateDiskAgent(
                 Args.StorageConfig,
                 Args.DiskAgentConfig,
+                Args.RdmaConfig,
                 Args.Spdk,
                 Args.Allocator,
                 Args.AioStorageProvider,

--- a/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.h
@@ -32,6 +32,7 @@ struct TDiskAgentActorSystemArgs
 
     TStorageConfigPtr StorageConfig;
     TDiskAgentConfigPtr DiskAgentConfig;
+    NRdma::TRdmaConfigPtr RdmaConfig;
     TDiskRegistryProxyConfigPtr DiskRegistryProxyConfig;
 
     ILoggingServicePtr Logging;

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -279,6 +279,7 @@ public:
             auto diskAgent = CreateDiskAgent(
                 Args.StorageConfig,
                 Args.DiskAgentConfig,
+                Args.RdmaConfig,
                 Args.Spdk,
                 Args.Allocator,
                 Args.AioStorageProvider,

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.h
@@ -41,6 +41,7 @@ struct TServerActorSystemArgs
     TDiagnosticsConfigPtr DiagnosticsConfig;
     TStorageConfigPtr StorageConfig;
     TDiskAgentConfigPtr DiskAgentConfig;
+    NRdma::TRdmaConfigPtr RdmaConfig;
     TDiskRegistryProxyConfigPtr DiskRegistryProxyConfig;
 
     ILoggingServicePtr Logging;


### PR DESCRIPTION
Add a dedicated config file rdma.txt which will contain Rdma Client/Server
configuration.

The old RDMA Server/Client config declaration is still present in
Server/DiskAgent configs and copied into the new unified rdma config when no
`--rdma-file` parameter provided. The methods to access the old config are
marked as `Deprecated`.

After we switch to new config in all clusters we can safely remove the old
config fields
