### PR TITLE
issue-95: Compaction should rebase blocks in order not to write garbage blocks to dst blobs

### DIFF
--- a/cloud/filestore/libs/storage/tablet/rebase_logic.cpp
+++ b/cloud/filestore/libs/storage/tablet/rebase_logic.cpp
@@ -4,11 +4,11 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TRebaseResult RebaseMixedBlocks(
+TRebaseResult RebaseBlocks(
     TVector<TBlock>& blocks,
     ui64 lastCommitId,
-    TFindCheckpoint findCheckpoint,
-    TFindBlock findBlock)
+    const TFindCheckpoint& findCheckpoint,
+    const TFindBlock& findBlock)
 {
     TRebaseResult result;
 

--- a/cloud/filestore/libs/storage/tablet/rebase_logic.h
+++ b/cloud/filestore/libs/storage/tablet/rebase_logic.h
@@ -29,10 +29,10 @@ using TFindBlock = std::function<bool(ui64 nodeId, ui32 blockIndex)>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TRebaseResult RebaseMixedBlocks(
+TRebaseResult RebaseBlocks(
     TVector<TBlock>& blocks,
     ui64 lastCommitId,
-    TFindCheckpoint findCheckpoint,
-    TFindBlock findBlock);
+    const TFindCheckpoint& findCheckpoint,
+    const TFindBlock& findBlock);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -7,6 +7,7 @@
 
 #include "checkpoint.h"
 #include "helpers.h"
+#include "rebase_logic.h"
 #include "session.h"
 
 #include <cloud/filestore/libs/storage/model/channel_data_kind.h>
@@ -740,6 +741,8 @@ private:
         ui32 rangeId,
         const TPartialBlobId& blobId,
         const TVector<TBlock>& blocks);
+
+    TRebaseResult RebaseMixedBlocks(TVector<TBlock>& blocks) const;
 
     //
     // Garbage


### PR DESCRIPTION
Improves the following scenario:
1. WriteData(range1) -> blob1
2. WriteData(range2 which intersects with range1) -> blob2
3. Compaction -> blob3
4. Here the blocks from the intersection of range1 and range2 that were originally stored in blob1 and are in fact garbage get stored in blob3

This PR makes compaction discard those garbage blocks