### PR TITLE
Rebase fix

### DIFF
--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -145,6 +145,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
       - name: Rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash

--- a/.github/workflows/build_and_test_on_demand_cmake.yaml
+++ b/.github/workflows/build_and_test_on_demand_cmake.yaml
@@ -85,6 +85,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
       - name: Rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash


### PR DESCRIPTION
By default checkout fetches only latest commit `fetch-depth: 1`.
To rebase we need to fetch some amount of commits PR commits + previous one, and then you can rebase it. But in GA you cant determine amount of commits to fetch so we fetch all `fetch-depth: 0` but realistically we can fetch some ambigious amount like 100 and this should be enough in most cases.