### PR TITLE
NBS-4773 [blockstore] Fix checkpoint without data creation

### DIFF
--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -369,11 +369,18 @@ std::unique_ptr<TEvVolume::TEvDescribeBlocksRequest> TVolumeClient::CreateDescri
 std::unique_ptr<TEvService::TEvCreateCheckpointRequest>
 TVolumeClient::CreateCreateCheckpointRequest(
     const TString& checkpointId,
-    bool isLight)
+    bool isLight,
+    bool withoutData)
 {
     auto request = std::make_unique<TEvService::TEvCreateCheckpointRequest>();
     request->Record.SetCheckpointId(checkpointId);
-    request->Record.SetIsLight(isLight);
+    if (withoutData) {
+        request->Record.SetCheckpointType(NProto::ECheckpointType::WITHOUT_DATA);
+    } else if (isLight) {
+        request->Record.SetCheckpointType(NProto::ECheckpointType::LIGHT);
+    } else {
+        request->Record.SetCheckpointType(NProto::ECheckpointType::NORMAL);
+    }
     return request;
 }
 

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -393,7 +393,8 @@ public:
 
     std::unique_ptr<TEvService::TEvCreateCheckpointRequest> CreateCreateCheckpointRequest(
         const TString& checkpointId,
-        bool isLight = false);
+        bool isLight = false,
+        bool withoutData = false);
 
     std::unique_ptr<TEvService::TEvDeleteCheckpointRequest> CreateDeleteCheckpointRequest(
         const TString& checkpointId);

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -1905,9 +1905,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
             clientInfo.GetClientId(),
             1
         );
-
         volume.CreateCheckpoint("c1", false, true);
-
         volume.WriteBlocks(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),
@@ -1930,13 +1928,14 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
                 response->GetError().GetFlags(),
                 NProto::EF_SILENT));
         }
+
+        volume.CreateCheckpoint("c2");
+        volume.DeleteCheckpointData("c2");
         volume.WriteBlocks(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),
             2
         );
-        volume.CreateCheckpoint("c2", false, true);
-        volume.DeleteCheckpointData("c2");
 
         {
             // Read from checkpoint without data failed

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -1903,14 +1903,12 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         volume.WriteBlocks(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),
-            1
-        );
+            1);
         volume.CreateCheckpoint("c1", false, true);
         volume.WriteBlocks(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),
-            2
-        );
+            2);
 
         {
             // Read from checkpoint without data failed
@@ -1934,8 +1932,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         volume.WriteBlocks(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),
-            2
-        );
+            2);
 
         {
             // Read from checkpoint without data failed


### PR DESCRIPTION
The fix makes sure the withoutdata parameter is properly sent to the partition tablet. It's important to wait DM release (with [commit](https://github.com/ydb-platform/nbs/pull/102)) to merge this fix.