### PR TITLE
NBS-4960 [Disk Manager] support GetCheckpointStatus for snapshot creation

### DIFF
--- a/cloud/blockstore/public/sdk/go/client/discovery.go
+++ b/cloud/blockstore/public/sdk/go/client/discovery.go
@@ -755,6 +755,24 @@ func (client *discoveryClient) CreateCheckpoint(
 	return resp.(*protos.TCreateCheckpointResponse), err
 }
 
+func (client *discoveryClient) GetCheckpointStatus(
+	ctx context.Context,
+	req *protos.TGetCheckpointStatusRequest,
+) (*protos.TGetCheckpointStatusResponse, error) {
+
+	resp, err := client.executeRequest(
+		ctx,
+		func(ctx context.Context, impl ClientIface) (response, error) {
+			return impl.GetCheckpointStatus(ctx, req)
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*protos.TGetCheckpointStatusResponse), err
+}
+
 func (client *discoveryClient) DeleteCheckpoint(
 	ctx context.Context,
 	req *protos.TDeleteCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/durable.go
+++ b/cloud/blockstore/public/sdk/go/client/durable.go
@@ -464,6 +464,22 @@ func (client *durableClient) CreateCheckpoint(
 	return resp.(*protos.TCreateCheckpointResponse), err
 }
 
+func (client *durableClient) GetCheckpointStatus(
+	ctx context.Context,
+	req *protos.TGetCheckpointStatusRequest,
+) (*protos.TGetCheckpointStatusResponse, error) {
+
+	resp, err := client.executeRequest(
+		ctx,
+		req,
+		func(ctx context.Context) (response, error) {
+			return client.impl.GetCheckpointStatus(ctx, req)
+		},
+	)
+
+	return resp.(*protos.TGetCheckpointStatusResponse), err
+}
+
 func (client *durableClient) DeleteCheckpoint(
 	ctx context.Context,
 	req *protos.TDeleteCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/grpc.go
+++ b/cloud/blockstore/public/sdk/go/client/grpc.go
@@ -577,6 +577,24 @@ func (client *grpcClient) CreateCheckpoint(
 	return resp.(*protos.TCreateCheckpointResponse), err
 }
 
+func (client *grpcClient) GetCheckpointStatus(
+	ctx context.Context,
+	req *protos.TGetCheckpointStatusRequest,
+) (*protos.TGetCheckpointStatusResponse, error) {
+
+	if req.Headers == nil {
+		req.Headers = &protos.THeaders{}
+	}
+	resp, err := client.executeRequest(
+		ctx,
+		req,
+		func(ctx context.Context) (response, error) {
+			return client.impl.GetCheckpointStatus(ctx, req)
+		})
+
+	return resp.(*protos.TGetCheckpointStatusResponse), err
+}
+
 func (client *grpcClient) DeleteCheckpoint(
 	ctx context.Context,
 	req *protos.TDeleteCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/iface.go
+++ b/cloud/blockstore/public/sdk/go/client/iface.go
@@ -157,6 +157,11 @@ type ClientIface interface {
 		req *protos.TCreateCheckpointRequest,
 	) (*protos.TCreateCheckpointResponse, error)
 
+	GetCheckpointStatus(
+		ctx context.Context,
+		req *protos.TGetCheckpointStatusRequest,
+	) (*protos.TGetCheckpointStatusResponse, error)
+
 	DeleteCheckpoint(
 		ctx context.Context,
 		req *protos.TDeleteCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/safe_client.go
+++ b/cloud/blockstore/public/sdk/go/client/safe_client.go
@@ -285,6 +285,20 @@ func (client *safeClient) CreateCheckpoint(
 	return err
 }
 
+func (client *safeClient) GetCheckpointStatus(
+	ctx context.Context,
+	diskId string,
+	checkpointId string,
+) (protos.ECheckpointStatus, error) {
+	req := &protos.TGetCheckpointStatusRequest{
+		DiskId:       diskId,
+		CheckpointId: checkpointId,
+	}
+
+	resp, err := client.Impl.GetCheckpointStatus(ctx, req)
+	return resp.CheckpointStatus, err
+}
+
 func (client *safeClient) DeleteCheckpoint(
 	ctx context.Context,
 	diskId string,

--- a/cloud/blockstore/public/sdk/go/client/safe_client.go
+++ b/cloud/blockstore/public/sdk/go/client/safe_client.go
@@ -290,6 +290,7 @@ func (client *safeClient) GetCheckpointStatus(
 	diskId string,
 	checkpointId string,
 ) (protos.ECheckpointStatus, error) {
+
 	req := &protos.TGetCheckpointStatusRequest{
 		DiskId:       diskId,
 		CheckpointId: checkpointId,

--- a/cloud/blockstore/public/sdk/go/client/test_client.go
+++ b/cloud/blockstore/public/sdk/go/client/test_client.go
@@ -27,6 +27,7 @@ type listKeyringsHandlerFunc func(ctx context.Context, req *protos.TListKeyrings
 type describeEndpointHandlerFunc func(ctx context.Context, req *protos.TDescribeEndpointRequest) (*protos.TDescribeEndpointResponse, error)
 type refreshEndpointHandlerFunc func(ctx context.Context, req *protos.TRefreshEndpointRequest) (*protos.TRefreshEndpointResponse, error)
 type createCheckpointHandlerFunc func(ctx context.Context, req *protos.TCreateCheckpointRequest) (*protos.TCreateCheckpointResponse, error)
+type getCheckpointStatusHandlerFunc func(ctx context.Context, req *protos.TGetCheckpointStatusRequest) (*protos.TGetCheckpointStatusResponse, error)
 type deleteCheckpointHandlerFunc func(ctx context.Context, req *protos.TDeleteCheckpointRequest) (*protos.TDeleteCheckpointResponse, error)
 type getChangedBlocksHandlerFunc func(ctx context.Context, req *protos.TGetChangedBlocksRequest) (*protos.TGetChangedBlocksResponse, error)
 type describeVolumeHandlerFunc func(ctx context.Context, req *protos.TDescribeVolumeRequest) (*protos.TDescribeVolumeResponse, error)
@@ -68,6 +69,7 @@ type testClient struct {
 	DescribeEndpointHandler              describeEndpointHandlerFunc
 	RefreshEndpointHandler               refreshEndpointHandlerFunc
 	CreateCheckpointHandler              createCheckpointHandlerFunc
+	GetCheckpointStatusHandler           getCheckpointStatusHandlerFunc
 	DeleteCheckpointHandler              deleteCheckpointHandlerFunc
 	GetChangedBlocksHandler              getChangedBlocksHandlerFunc
 	DescribeVolumeHandler                describeVolumeHandlerFunc
@@ -369,6 +371,18 @@ func (client *testClient) CreateCheckpoint(
 	}
 
 	return &protos.TCreateCheckpointResponse{}, nil
+}
+
+func (client *testClient) GetCheckpointStatus(
+	ctx context.Context,
+	req *protos.TGetCheckpointStatusRequest,
+) (*protos.TGetCheckpointStatusResponse, error) {
+
+	if client.GetCheckpointStatusHandler != nil {
+		return client.GetCheckpointStatusHandler(ctx, req)
+	}
+
+	return &protos.TGetCheckpointStatusResponse{}, nil
 }
 
 func (client *testClient) DeleteCheckpoint(

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -716,6 +716,16 @@ func (c *client) CreateCheckpoint(
 	return wrapError(err)
 }
 
+func (c *client) GetCheckpointStatus(
+	ctx context.Context,
+	diskID string,
+	checkpointID string,
+) (CheckpointStatus, error) {
+
+	status, err := c.nbs.GetCheckpointStatus(ctx, diskID, checkpointID)
+	return CheckpointStatus(status), err
+}
+
 func (c *client) DeleteCheckpoint(
 	ctx context.Context,
 	diskID string,

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -723,7 +723,7 @@ func (c *client) GetCheckpointStatus(
 ) (CheckpointStatus, error) {
 
 	status, err := c.nbs.GetCheckpointStatus(ctx, diskID, checkpointID)
-	return CheckpointStatus(status), err
+	return CheckpointStatus(status), wrapError(err)
 }
 
 func (c *client) DeleteCheckpoint(

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -551,6 +551,19 @@ func parseCheckpointStatus(protoType protos.ECheckpointStatus) CheckpointStatus 
 	}
 }
 
+func (m CheckpointStatus) String() string {
+	switch m {
+	case CheckpointStatusNotReady:
+		return "CheckpointStatusNotReady"
+	case CheckpointStatusReady:
+		return "CheckpointStatusReady"
+	case CheckpointStatusError:
+		return "CheckpointStatusError"
+	default:
+		return "CheckpointStatusUnknown"
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func (c *client) Ping(ctx context.Context) (err error) {

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -547,7 +547,7 @@ func parseCheckpointStatus(protoType protos.ECheckpointStatus) CheckpointStatus 
 	case protos.ECheckpointStatus_ERROR:
 		return CheckpointStatusError
 	default:
-		return CheckpointStatusUnknown
+		return CheckpointStatusError
 	}
 }
 

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -538,6 +538,19 @@ func (t CheckpointType) toProto() protos.ECheckpointType {
 	}[t]
 }
 
+func parseCheckpointStatus(protoType protos.ECheckpointStatus) CheckpointStatus {
+	switch protoType {
+	case protos.ECheckpointStatus_NOT_READY:
+		return CheckpointStatusNotReady
+	case protos.ECheckpointStatus_READY:
+		return CheckpointStatusReady
+	case protos.ECheckpointStatus_ERROR:
+		return CheckpointStatusError
+	default:
+		return CheckpointStatusUnknown
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func (c *client) Ping(ctx context.Context) (err error) {
@@ -723,7 +736,7 @@ func (c *client) GetCheckpointStatus(
 ) (CheckpointStatus, error) {
 
 	status, err := c.nbs.GetCheckpointStatus(ctx, diskID, checkpointID)
-	return CheckpointStatus(status), wrapError(err)
+	return parseCheckpointStatus(status), wrapError(err)
 }
 
 func (c *client) DeleteCheckpoint(

--- a/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
@@ -98,6 +98,14 @@ const (
 	CheckpointTypeWithoutData
 )
 
+type CheckpointStatus uint32
+
+const ( // Must be in same order as protos.ECheckpointStatus.
+	CheckpointStatusNotReady CheckpointStatus = iota
+	CheckpointStatusReady
+	CheckpointStatusError
+)
+
 type CheckpointParams struct {
 	DiskID         string
 	CheckpointID   string
@@ -125,6 +133,12 @@ type Client interface {
 	DeleteWithFillGeneration(ctx context.Context, diskID string, fillGeneration uint64) error
 
 	CreateCheckpoint(ctx context.Context, params CheckpointParams) error
+
+	GetCheckpointStatus(
+		ctx context.Context,
+		diskID string,
+		checkpointID string,
+	) (CheckpointStatus, error)
 
 	DeleteCheckpoint(
 		ctx context.Context,

--- a/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
@@ -104,7 +104,6 @@ const (
 	CheckpointStatusNotReady CheckpointStatus = iota
 	CheckpointStatusReady
 	CheckpointStatusError
-	CheckpointStatusUnknown
 )
 
 type CheckpointParams struct {

--- a/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
@@ -100,10 +100,11 @@ const (
 
 type CheckpointStatus uint32
 
-const ( // Must be in same order as protos.ECheckpointStatus.
+const (
 	CheckpointStatusNotReady CheckpointStatus = iota
 	CheckpointStatusReady
 	CheckpointStatusError
+	CheckpointStatusUnknown
 )
 
 type CheckpointParams struct {

--- a/cloud/disk_manager/internal/pkg/clients/nbs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/mocks/client_mock.go
@@ -76,6 +76,16 @@ func (c *ClientMock) CreateCheckpoint(
 	return args.Error(0)
 }
 
+func (c *ClientMock) GetCheckpointStatus(
+	ctx context.Context,
+	diskID string,
+	checkpointID string,
+) (nbs.CheckpointStatus, error) {
+
+	args := c.Called(ctx, diskID, checkpointID)
+	return args.Get(0).(nbs.CheckpointStatus), args.Error(1)
+}
+
 func (c *ClientMock) DeleteCheckpoint(
 	ctx context.Context,
 	diskID string,

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -401,19 +401,15 @@ func (t *createSnapshotFromDiskTask) ensureCheckpointStatusReady(
 	case nbs.CheckpointStatusNotReady:
 		return errors.NewInterruptExecutionError()
 
-	case nbs.CheckpointStatusError, nbs.CheckpointStatusUnknown:
-		err := nbsClient.DeleteCheckpoint(
-			ctx,
-			diskID,
-			checkpointID,
-		)
-		if err != nil {
-			return err
-		}
-		return errors.NewRetriableErrorf("Failed to create checkpoint for disk %s.", diskID)
+	case nbs.CheckpointStatusError:
+		_ = nbsClient.DeleteCheckpoint(ctx, diskID, checkpointID)
+		return errors.NewRetriableErrorf("GetCheckpointStatus returned an error.")
 
 	case nbs.CheckpointStatusReady:
 		// Nothing to do.
+
+	case nbs.CheckpointStatusUnknown:
+		return errors.NewNonRetriableErrorf("Unknown checkpoint status")
 	}
 
 	return nil

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -98,7 +98,7 @@ func (t *createSnapshotFromDiskTask) run(
 		return nil, err
 	}
 
-	err = t.ensureCheckpointStatusReady(ctx, nbsClient, disk.DiskId, checkpointID)
+	err = t.ensureCheckpointReady(ctx, nbsClient, disk.DiskId, checkpointID)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (t *createSnapshotFromDiskTask) GetResponse() proto.Message {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func (t *createSnapshotFromDiskTask) ensureCheckpointStatusReady(
+func (t *createSnapshotFromDiskTask) ensureCheckpointReady(
 	ctx context.Context,
 	nbsClient nbs.Client,
 	diskID string,

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -407,9 +407,6 @@ func (t *createSnapshotFromDiskTask) ensureCheckpointReady(
 
 	case nbs.CheckpointStatusReady:
 		// Nothing to do.
-
-	case nbs.CheckpointStatusUnknown:
-		return errors.NewNonRetriableErrorf("Unknown checkpoint status")
 	}
 
 	return nil

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -98,7 +98,7 @@ func (t *createSnapshotFromDiskTask) run(
 		return nil, err
 	}
 
-	err = t.validateCheckpointStatus(ctx, nbsClient, disk.DiskId, checkpointID)
+	err = t.ensureCheckpointStatusReady(ctx, nbsClient, disk.DiskId, checkpointID)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (t *createSnapshotFromDiskTask) GetResponse() proto.Message {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func (t *createSnapshotFromDiskTask) validateCheckpointStatus(
+func (t *createSnapshotFromDiskTask) ensureCheckpointStatusReady(
 	ctx context.Context,
 	nbsClient nbs.Client,
 	diskID string,

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -391,6 +391,7 @@ func (t *createSnapshotFromDiskTask) ensureCheckpointReady(
 	if err != nil {
 		return err
 	}
+
 	logging.Debug(
 		ctx,
 		"Current CheckpointStatus: %v",

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -404,7 +404,7 @@ func (t *createSnapshotFromDiskTask) ensureCheckpointReady(
 
 	case nbs.CheckpointStatusError:
 		_ = nbsClient.DeleteCheckpoint(ctx, diskID, checkpointID)
-		return errors.NewRetriableErrorf("GetCheckpointStatus returned an error.")
+		return errors.NewRetriableErrorf("Filling the NRD disk replica ended with an error.")
 
 	case nbs.CheckpointStatusReady:
 		// Nothing to do.


### PR DESCRIPTION
For a network disk, GetCheckpointStatus returns Ready immediately. For an NRD disk, it will respond with NotReady until a replica is filled (after [NRD Snapshots](https://github.com/ydb-platform/nbs/issues/2) is closed).

This code checks the checkpointStatus, and:
    - For `CheckpointStatusNotReady`, it throws an `InterruptionError` (after which the task will restart).
    - For `CheckpointStatusError`, it deletes the checkpoint and throws a `RetriableError` (to try to create the checkpoint again).