### PR TITLE
issue-95: operations that can potentially cause Truncate should not be allowed until compaction map gets fully loaded

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -319,6 +319,17 @@ void TIndexTabletActor::ResetThrottlingPolicy()
 
 ////////////////////////////////////////////////////////////////////////////////
 
+NProto::TError TIndexTabletActor::IsDataOperationAllowed() const
+{
+    if (!CompactionStateLoadStatus.Finished) {
+        return MakeError(E_REJECTED, "compaction state not loaded yet");
+    }
+
+    return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TIndexTabletActor::HandleWakeup(
     const TEvents::TEvWakeup::TPtr& ev,
     const TActorContext& ctx)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -353,6 +353,8 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    NProto::TError IsDataOperationAllowed() const;
+
     void HandleWakeup(
         const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -60,6 +60,16 @@ void TIndexTabletActor::HandleAllocateData(
     const TEvService::TEvAllocateDataRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvService::TEvAllocateDataResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto validator = [&] (const NProto::TAllocateDataRequest& request) {
         return ValidateRequest(request, GetBlockSize());
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -18,6 +18,16 @@ void TIndexTabletActor::HandleDeleteCheckpoint(
     const TEvIndexTabletPrivate::TEvDeleteCheckpointRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvIndexTabletPrivate::TEvDeleteCheckpointResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroycheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroycheckpoint.cpp
@@ -252,6 +252,16 @@ void TIndexTabletActor::HandleDestroyCheckpoint(
     const TEvService::TEvDestroyCheckpointRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvService::TEvDestroyCheckpointResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto* msg = ev->Get();
 
     const auto& checkpointId = msg->Record.GetCheckpointId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -13,6 +13,16 @@ void TIndexTabletActor::HandleDestroyHandle(
     const TEvService::TEvDestroyHandleRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvService::TEvDestroyHandleResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     if (!AcceptRequest<TEvService::TDestroyHandleMethod>(ev, ctx)) {
         return;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -13,6 +13,16 @@ void TIndexTabletActor::HandleDestroySession(
     const TEvIndexTablet::TEvDestroySessionRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto* msg = ev->Get();
 
     const auto& clientId = GetClientId(msg->Record);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -39,6 +39,21 @@ void TIndexTabletActor::HandleSetNodeAttr(
     const TEvService::TEvSetNodeAttrRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    auto* msg = ev->Get();
+
+    const auto flags = msg->Record.GetFlags();
+    if (HasFlag(flags, NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE)) {
+        if (auto error = IsDataOperationAllowed(); HasError(error)) {
+            NCloud::Reply(
+                ctx,
+                *ev,
+                std::make_unique<TEvService::TEvSetNodeAttrResponse>(
+                    std::move(error)));
+
+            return;
+        }
+    }
+
     auto validator = [&] (const NProto::TSetNodeAttrRequest& request) {
         return ValidateRequest(request, GetBlockSize());
     };
@@ -46,7 +61,6 @@ void TIndexTabletActor::HandleSetNodeAttr(
     if (!AcceptRequest<TEvService::TSetNodeAttrMethod>(ev, ctx, validator)) {
         return;
     }
-    auto* msg = ev->Get();
     auto requestInfo = CreateRequestInfo(
         ev->Sender,
         ev->Cookie,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
@@ -155,6 +155,16 @@ void TIndexTabletActor::HandleTruncate(
     const TEvIndexTabletPrivate::TEvTruncateRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvIndexTabletPrivate::TEvTruncateResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -32,6 +32,16 @@ void TIndexTabletActor::HandleUnlinkNode(
     const TEvService::TEvUnlinkNodeRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvService::TEvUnlinkNodeResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto* session = AcceptRequest<TEvService::TUnlinkNodeMethod>(ev, ctx, ValidateRequest);
     if (!session) {
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
@@ -15,6 +15,16 @@ void TIndexTabletActor::HandleZeroRange(
     const TEvIndexTabletPrivate::TEvZeroRangeRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (auto error = IsDataOperationAllowed(); HasError(error)) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvIndexTabletPrivate::TEvZeroRangeResponse>(
+                std::move(error)));
+
+        return;
+    }
+
     auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -3785,6 +3785,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 static_cast<ui32>(stats.GetBlobIndexOpState()));
         }
 
+        env.GetRuntime().Send(loadChunk.Release(), nodeIdx);
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
         tablet.DestroyHandle(handle);
     }
 
@@ -3877,6 +3880,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 static_cast<ui32>(EOperationState::Idle),
                 static_cast<ui32>(stats.GetFlushState()));
         }
+
+        env.GetRuntime().Send(loadChunk.Release(), nodeIdx);
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
 
         tablet.DestroyHandle(handle);
     }


### PR DESCRIPTION
If a Truncate operation is executed before CompactionMap gets fully loaded, there is a chance that this Truncate op may cause a CompactionMap update based on 0 stats for the corresponding compaction range => real compaction stats for that range can be lost => automatic Compaction will work less efficiently.

#95 