### PR TITLE
Disk Agent switches to the Idle state when it can't find devices

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -259,4 +259,21 @@ STFUNC(TDiskAgentActor::StateWork)
     }
 }
 
+STFUNC(TDiskAgentActor::StateIdle)
+{
+    UpdateActorStatsSampled();
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvWakeup, HandleWakeup);
+
+        HFunc(NMon::TEvHttpInfo, HandleHttpInfo);
+
+        BLOCKSTORE_HANDLE_REQUEST(WaitReady, TEvDiskAgent)
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT);
+            break;
+    }
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -143,6 +143,7 @@ private:
 private:
     STFUNC(StateInit);
     STFUNC(StateWork);
+    STFUNC(StateIdle);
 
     void HandlePoisonPill(
         const NActors::TEvents::TEvPoisonPill::TPtr& ev,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -117,6 +117,17 @@ void TDiskAgentActor::HandleInitAgentCompleted(
     // resend pending requests
     SendPendingRequests(ctx, PendingRequests);
 
+    if (msg->Configs.empty()) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::DISK_AGENT,
+            "No devices: become idle");
+
+        Become(&TThis::StateIdle);
+
+        return;
+    }
+
     Become(&TThis::StateWork);
 
     SendRegisterRequest(ctx);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
@@ -29,10 +29,14 @@ void TDiskAgentActor::HandleHttpInfo(
     TStringStream out;
 
     HTML(out) {
-        if (RegistrationInProgress) {
-            DIV() { out << "Registration in progress"; }
+        if (CurrentStateFunc() == &TThis::StateIdle) {
+            DIV() { out << "Unregistered (Idle)"; }
         } else {
-            DIV() { out << "Registered"; }
+            if (RegistrationInProgress) {
+                DIV() { out << "Registration in progress"; }
+            } else {
+                DIV() { out << "Registered"; }
+            }
         }
 
         TAG(TH3) { out << "Devices"; }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
@@ -182,11 +182,6 @@ void TDiskAgentActor::SendRegisterRequest(const TActorContext& ctx)
         return;
     }
 
-    if (State->GetDevicesCount() == 0) {
-        LOG_WARN(ctx, TBlockStoreComponents::DISK_AGENT, "No devices to register");
-        return;
-    }
-
     RegistrationInProgress = true;
     NCloud::Send(
         ctx,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -20,8 +20,6 @@
 
 #include <util/folder/tempdir.h>
 
-#include <chrono>
-
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -30,8 +28,6 @@ using namespace NServer;
 using namespace NThreading;
 
 using namespace NDiskAgentTest;
-
-using namespace std::chrono_literals;
 
 namespace {
 


### PR DESCRIPTION
The point of the Idle state is to not spam to DR with RegisterAgent and UpdateAgentStats events.