### PR TITLE
issue-539: extract writedata actor into separate location + add TABLET_VERIFY for ReleaseCollectBarrier

### DIFF
--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -1,0 +1,168 @@
+#include "tablet_writedata.h"
+
+#include <cloud/filestore/libs/service/context.h>
+#include <cloud/filestore/libs/storage/api/service.h>
+#include <cloud/filestore/libs/storage/core/request_info.h>
+#include <cloud/filestore/libs/storage/core/probes.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+LWTRACE_USING(FILESTORE_STORAGE_PROVIDER);
+
+////////////////////////////////////////////////////////////////////////////////
+
+TWriteDataActor::TWriteDataActor(
+        ITraceSerializerPtr traceSerializer,
+        TString logTag,
+        TActorId tablet,
+        TRequestInfoPtr requestInfo,
+        ui64 commitId,
+        TVector<TMergedBlob> blobs,
+        TWriteRange writeRange)
+    : TraceSerializer(std::move(traceSerializer))
+    , LogTag(std::move(logTag))
+    , Tablet(tablet)
+    , RequestInfo(std::move(requestInfo))
+    , CommitId(commitId)
+    , Blobs(std::move(blobs))
+    , WriteRange(writeRange)
+{
+    for (const auto& blob: Blobs) {
+        BlobsSize += blob.BlobContent.Size();
+    }
+}
+
+void TWriteDataActor::Bootstrap(const TActorContext& ctx)
+{
+    FILESTORE_TRACK(
+        RequestReceived_TabletWorker,
+        RequestInfo->CallContext,
+        "WriteData");
+
+    WriteBlob(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TWriteDataActor::WriteBlob(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvIndexTabletPrivate::TEvWriteBlobRequest>(
+        RequestInfo->CallContext
+    );
+
+    for (auto& blob: Blobs) {
+        request->Blobs.emplace_back(blob.BlobId, std::move(blob.BlobContent));
+    }
+
+    NCloud::Send(ctx, Tablet, std::move(request));
+}
+
+void TWriteDataActor::HandleWriteBlobResponse(
+    const TEvIndexTabletPrivate::TEvWriteBlobResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    if (FAILED(msg->GetStatus())) {
+        ReplyAndDie(ctx, msg->GetError());
+        return;
+    }
+
+    AddBlob(ctx);
+}
+
+void TWriteDataActor::AddBlob(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvIndexTabletPrivate::TEvAddBlobRequest>(
+        RequestInfo->CallContext
+    );
+    request->Mode = EAddBlobMode::Write;
+    request->WriteRanges.push_back(WriteRange);
+
+    for (const auto& blob: Blobs) {
+        request->MergedBlobs.emplace_back(
+            blob.BlobId,
+            blob.Block,
+            blob.BlocksCount);
+    }
+
+    NCloud::Send(ctx, Tablet, std::move(request));
+}
+
+void TWriteDataActor::HandleAddBlobResponse(
+    const TEvIndexTabletPrivate::TEvAddBlobResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    ReplyAndDie(ctx, msg->GetError());
+}
+
+void TWriteDataActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
+}
+
+void TWriteDataActor::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProto::TError& error)
+{
+    {
+        // notify tablet
+        using TCompletion = TEvIndexTabletPrivate::TEvWriteDataCompleted;
+        auto response = std::make_unique<TCompletion>(error);
+        response->CommitId = CommitId;
+        response->Count = 1;
+        response->Size = BlobsSize;
+        response->Time = ctx.Now() - RequestInfo->StartedTs;
+        NCloud::Send(ctx, Tablet, std::move(response));
+    }
+
+    FILESTORE_TRACK(
+        ResponseSent_TabletWorker,
+        RequestInfo->CallContext,
+        "WriteData");
+
+    if (RequestInfo->Sender != Tablet) {
+        auto response = std::make_unique<TEvService::TEvWriteDataResponse>(error);
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET_WORKER,
+            "%s WriteData: #%lu completed (%s)",
+            LogTag.c_str(),
+            RequestInfo->CallContext->RequestId,
+            FormatError(response->Record.GetError()).c_str());
+
+        BuildTraceInfo(
+            TraceSerializer,
+            RequestInfo->CallContext,
+            response->Record);
+        BuildThrottlerInfo(*RequestInfo->CallContext, response->Record);
+
+        NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    }
+
+    Die(ctx);
+}
+
+STFUNC(TWriteDataActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(TEvIndexTabletPrivate::TEvWriteBlobResponse, HandleWriteBlobResponse);
+        HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            break;
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -7,7 +7,6 @@
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
-
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.h
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.h
@@ -1,0 +1,65 @@
+#include <cloud/filestore/libs/diagnostics/throttler_info_serializer.h>
+#include <cloud/filestore/libs/diagnostics/trace_serializer.h>
+#include <cloud/filestore/libs/storage/core/public.h>
+#include <cloud/filestore/libs/storage/tablet/tablet_private.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TWriteDataActor final: public TActorBootstrapped<TWriteDataActor>
+{
+private:
+    const ITraceSerializerPtr TraceSerializer;
+
+    const TString LogTag;
+    const TActorId Tablet;
+    const TRequestInfoPtr RequestInfo;
+
+    const ui64 CommitId;
+    /*const*/ TVector<TMergedBlob> Blobs;
+    const TWriteRange WriteRange;
+    ui32 BlobsSize = 0;
+
+public:
+    TWriteDataActor(
+        ITraceSerializerPtr traceSerializer,
+        TString logTag,
+        TActorId tablet,
+        TRequestInfoPtr requestInfo,
+        ui64 commitId,
+        TVector<TMergedBlob> blobs,
+        TWriteRange writeRange);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void WriteBlob(const TActorContext& ctx);
+    void HandleWriteBlobResponse(
+        const TEvIndexTabletPrivate::TEvWriteBlobResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void AddBlob(const TActorContext& ctx);
+    void HandleAddBlobResponse(
+        const TEvIndexTabletPrivate::TEvAddBlobResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void
+    ReplyAndDie(const TActorContext& ctx, const NProto::TError& error = {});
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/actors/ya.make
+++ b/cloud/filestore/libs/storage/tablet/actors/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+
+SRCS(
+    tablet_writedata.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/tablet/model
+)
+
+END()

--- a/cloud/filestore/libs/storage/tablet/actors/ya.make
+++ b/cloud/filestore/libs/storage/tablet/actors/ya.make
@@ -1,6 +1,5 @@
 LIBRARY()
 
-
 SRCS(
     tablet_writedata.cpp
 )

--- a/cloud/filestore/libs/storage/tablet/model/garbage_queue.h
+++ b/cloud/filestore/libs/storage/tablet/model/garbage_queue.h
@@ -46,7 +46,7 @@ public:
     //
 
     void AcquireCollectBarrier(ui64 commitId);
-    void ReleaseCollectBarrier(ui64 commitId);
+    [[ nodiscard ]] bool TryReleaseCollectBarrier(ui64 commitId);
 
     ui64 GetCollectCommitId() const;
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/registry.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
+
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -3,7 +3,6 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/registry.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
-
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>
@@ -354,6 +353,12 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
 
     return NProto::TError{};
 }
+
+template NProto::TError
+TIndexTabletActor::ValidateWriteRequest<NProto::TWriteDataRequest>(
+    const TActorContext& ctx,
+    const NProto::TWriteDataRequest& request,
+    const TByteRange& range);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -319,6 +319,44 @@ void TIndexTabletActor::ResetThrottlingPolicy()
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template <typename TRequest>
+NProto::TError TIndexTabletActor::ValidateWriteRequest(
+    const TActorContext& ctx,
+    const TRequest& request,
+    const TByteRange& range)
+{
+    if (auto error = ValidateRange(range); HasError(error)) {
+        return error;
+    }
+
+    auto* handle = FindHandle(request.GetHandle());
+    if (!handle || handle->GetSessionId() != GetSessionId(request)) {
+        return ErrorInvalidHandle(request.GetHandle());
+    }
+
+    if (!IsWriteAllowed(BuildBackpressureThresholds())) {
+        if (CompactionStateLoadStatus.Finished &&
+            ++BackpressureErrorCount >=
+                Config->GetMaxBackpressureErrorsBeforeSuicide())
+        {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::TABLET_WORKER,
+                "%s Suiciding after %u backpressure errors",
+                LogTag.c_str(),
+                BackpressureErrorCount);
+
+            Suicide(ctx);
+        }
+
+        return MakeError(E_REJECTED, "rejected due to backpressure");
+    }
+
+    return NProto::TError{};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 NProto::TError TIndexTabletActor::IsDataOperationAllowed() const
 {
     if (!CompactionStateLoadStatus.Finished) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -353,6 +353,12 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    template <typename TRequest>
+    NProto::TError ValidateWriteRequest(
+        const NActors::TActorContext& ctx,
+        const TRequest& request,
+        const TByteRange& range);
+
     NProto::TError IsDataOperationAllowed() const;
 
     void HandleWakeup(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -122,7 +122,7 @@ void TIndexTabletActor::CompleteTx_Cleanup(
 
     BlobIndexOpState.Complete();
     ReleaseMixedBlocks(args.RangeId);
-    ReleaseCollectBarrier(args.CollectBarrier);
+    TABLET_VERIFY(TryReleaseCollectBarrier(args.CollectBarrier));
 
     FILESTORE_TRACK(
         ResponseSent_Tablet,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -664,7 +664,7 @@ void TIndexTabletActor::HandleCompactionCompleted(
         FormatError(msg->GetError()).c_str());
 
     ReleaseMixedBlocks(msg->MixedBlocksRanges);
-    ReleaseCollectBarrier(msg->CommitId);
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
 
     BlobIndexOpState.Complete();
     EnqueueBlobIndexOpIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -255,7 +255,7 @@ void TIndexTabletActor::CompleteTx_DeleteCheckpoint(
         FormatError(args.Error).c_str());
 
     ReleaseMixedBlocks(args.MixedBlocksRanges);
-    ReleaseCollectBarrier(args.CollectBarrier);
+    TABLET_VERIFY(TryReleaseCollectBarrier(args.CollectBarrier));
 
     auto response = std::make_unique<TEvIndexTabletPrivate::TEvDeleteCheckpointResponse>(args.Error);
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -377,7 +377,7 @@ void TIndexTabletActor::HandleFlushCompleted(
         LogTag.c_str(),
         FormatError(msg->GetError()).c_str());
 
-    ReleaseCollectBarrier(msg->CommitId);
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
     FlushState.Complete();
 
     WorkerActors.erase(ev->Sender);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -829,7 +829,7 @@ void TIndexTabletActor::HandleFlushBytesCompleted(
         FormatError(msg->GetError()).c_str());
 
     ReleaseMixedBlocks(msg->MixedBlocksRanges);
-    ReleaseCollectBarrier(msg->CollectCommitId);
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CollectCommitId));
     WorkerActors.erase(ev->Sender);
 
     auto requestInfo = CreateRequestInfo(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -565,7 +565,7 @@ void TIndexTabletActor::HandleReadDataCompleted(
     const auto* msg = ev->Get();
 
     ReleaseMixedBlocks(msg->MixedBlocksRanges);
-    ReleaseCollectBarrier(msg->CommitId);
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
     WorkerActors.erase(ev->Sender);
 
     Metrics.ReadData.Count.fetch_add(msg->Count, std::memory_order_relaxed);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -286,7 +286,7 @@ void TIndexTabletActor::HandleWriteBatchCompleted(
             FormatError(msg->GetError()).c_str());
     }
 
-    ReleaseCollectBarrier(msg->CommitId);
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
 
     WorkerActors.erase(ev->Sender);
     EnqueueBlobIndexOpIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -149,8 +149,6 @@ void TIndexTabletActor::HandleWriteDataCompleted(
 {
     const auto* msg = ev->Get();
 
-
-
     TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
 
     WorkerActors.erase(ev->Sender);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -1,13 +1,10 @@
 #include "tablet_actor.h"
 
-#include "helpers.h"
-
 #include <cloud/filestore/libs/diagnostics/throttler_info_serializer.h>
 #include <cloud/filestore/libs/diagnostics/trace_serializer.h>
+#include <cloud/filestore/libs/storage/tablet/actors/tablet_writedata.h>
 #include <cloud/filestore/libs/storage/tablet/model/blob_builder.h>
 #include <cloud/filestore/libs/storage/tablet/model/split_range.h>
-
-#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <util/generic/set.h>
 #include <util/generic/string.h>
@@ -19,210 +16,6 @@ using namespace NActors;
 
 using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
-
-namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-class TWriteDataActor final
-    : public TActorBootstrapped<TWriteDataActor>
-{
-private:
-    const ITraceSerializerPtr TraceSerializer;
-
-    const TString LogTag;
-    const TActorId Tablet;
-    const TRequestInfoPtr RequestInfo;
-
-    const ui64 CommitId;
-    /*const*/ TVector<TMergedBlob> Blobs;
-    const TWriteRange WriteRange;
-    ui32 BlobsSize = 0;
-
-public:
-    TWriteDataActor(
-        ITraceSerializerPtr traceSerializer,
-        TString logTag,
-        TActorId tablet,
-        TRequestInfoPtr requestInfo,
-        ui64 commitId,
-        TVector<TMergedBlob> blobs,
-        TWriteRange writeRange);
-
-    void Bootstrap(const TActorContext& ctx);
-
-private:
-    STFUNC(StateWork);
-
-    void WriteBlob(const TActorContext& ctx);
-    void HandleWriteBlobResponse(
-        const TEvIndexTabletPrivate::TEvWriteBlobResponse::TPtr& ev,
-        const TActorContext& ctx);
-
-    void AddBlob(const TActorContext& ctx);
-    void HandleAddBlobResponse(
-        const TEvIndexTabletPrivate::TEvAddBlobResponse::TPtr& ev,
-        const TActorContext& ctx);
-
-    void HandlePoisonPill(
-        const TEvents::TEvPoisonPill::TPtr& ev,
-        const TActorContext& ctx);
-
-    void ReplyAndDie(
-        const TActorContext& ctx,
-        const NProto::TError& error = {});
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-TWriteDataActor::TWriteDataActor(
-        ITraceSerializerPtr traceSerializer,
-        TString logTag,
-        TActorId tablet,
-        TRequestInfoPtr requestInfo,
-        ui64 commitId,
-        TVector<TMergedBlob> blobs,
-        TWriteRange writeRange)
-    : TraceSerializer(std::move(traceSerializer))
-    , LogTag(std::move(logTag))
-    , Tablet(tablet)
-    , RequestInfo(std::move(requestInfo))
-    , CommitId(commitId)
-    , Blobs(std::move(blobs))
-    , WriteRange(writeRange)
-{
-    for (const auto& blob: Blobs) {
-        BlobsSize += blob.BlobContent.Size();
-    }
-}
-
-void TWriteDataActor::Bootstrap(const TActorContext& ctx)
-{
-    FILESTORE_TRACK(
-        RequestReceived_TabletWorker,
-        RequestInfo->CallContext,
-        "WriteData");
-
-    WriteBlob(ctx);
-    Become(&TThis::StateWork);
-}
-
-void TWriteDataActor::WriteBlob(const TActorContext& ctx)
-{
-    auto request = std::make_unique<TEvIndexTabletPrivate::TEvWriteBlobRequest>(
-        RequestInfo->CallContext
-    );
-
-    for (auto& blob: Blobs) {
-        request->Blobs.emplace_back(blob.BlobId, std::move(blob.BlobContent));
-    }
-
-    NCloud::Send(ctx, Tablet, std::move(request));
-}
-
-void TWriteDataActor::HandleWriteBlobResponse(
-    const TEvIndexTabletPrivate::TEvWriteBlobResponse::TPtr& ev,
-    const TActorContext& ctx)
-{
-    const auto* msg = ev->Get();
-
-    if (FAILED(msg->GetStatus())) {
-        ReplyAndDie(ctx, msg->GetError());
-        return;
-    }
-
-    AddBlob(ctx);
-}
-
-void TWriteDataActor::AddBlob(const TActorContext& ctx)
-{
-    auto request = std::make_unique<TEvIndexTabletPrivate::TEvAddBlobRequest>(
-        RequestInfo->CallContext
-    );
-    request->Mode = EAddBlobMode::Write;
-    request->WriteRanges.push_back(WriteRange);
-
-    for (const auto& blob: Blobs) {
-        request->MergedBlobs.emplace_back(
-            blob.BlobId,
-            blob.Block,
-            blob.BlocksCount);
-    }
-
-    NCloud::Send(ctx, Tablet, std::move(request));
-}
-
-void TWriteDataActor::HandleAddBlobResponse(
-    const TEvIndexTabletPrivate::TEvAddBlobResponse::TPtr& ev,
-    const TActorContext& ctx)
-{
-    const auto* msg = ev->Get();
-    ReplyAndDie(ctx, msg->GetError());
-}
-
-void TWriteDataActor::HandlePoisonPill(
-    const TEvents::TEvPoisonPill::TPtr& ev,
-    const TActorContext& ctx)
-{
-    Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
-}
-
-void TWriteDataActor::ReplyAndDie(
-    const TActorContext& ctx,
-    const NProto::TError& error)
-{
-    {
-        // notify tablet
-        using TCompletion = TEvIndexTabletPrivate::TEvWriteDataCompleted;
-        auto response = std::make_unique<TCompletion>(error);
-        response->CommitId = CommitId;
-        response->Count = 1;
-        response->Size = BlobsSize;
-        response->Time = ctx.Now() - RequestInfo->StartedTs;
-        NCloud::Send(ctx, Tablet, std::move(response));
-    }
-
-    FILESTORE_TRACK(
-        ResponseSent_TabletWorker,
-        RequestInfo->CallContext,
-        "WriteData");
-
-    if (RequestInfo->Sender != Tablet) {
-        auto response = std::make_unique<TEvService::TEvWriteDataResponse>(error);
-        LOG_DEBUG(ctx, TFileStoreComponents::TABLET_WORKER,
-            "%s WriteData: #%lu completed (%s)",
-            LogTag.c_str(),
-            RequestInfo->CallContext->RequestId,
-            FormatError(response->Record.GetError()).c_str());
-
-        BuildTraceInfo(
-            TraceSerializer,
-            RequestInfo->CallContext,
-            response->Record);
-        BuildThrottlerInfo(*RequestInfo->CallContext, response->Record);
-
-        NCloud::Reply(ctx, *RequestInfo, std::move(response));
-    }
-
-    Die(ctx);
-}
-
-STFUNC(TWriteDataActor::StateWork)
-{
-    switch (ev->GetTypeRewrite()) {
-        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
-
-        HFunc(TEvIndexTabletPrivate::TEvWriteBlobResponse, HandleWriteBlobResponse);
-        HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
-
-        default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
-            break;
-    }
-}
-
-}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -303,33 +96,9 @@ void TIndexTabletActor::HandleWriteData(
         }
     }
 
-    auto validator = [&] (const NProto::TWriteDataRequest& request) {
-        if (auto error = ValidateRange(range); HasError(error)) {
-            return error;
-        }
-
-        auto* handle = FindHandle(request.GetHandle());
-        if (!handle || handle->GetSessionId() != GetSessionId(request)) {
-            return ErrorInvalidHandle(request.GetHandle());
-        }
-
-        if (!IsWriteAllowed(BuildBackpressureThresholds())) {
-            if (CompactionStateLoadStatus.Finished
-                    && ++BackpressureErrorCount >=
-                    Config->GetMaxBackpressureErrorsBeforeSuicide())
-            {
-                LOG_WARN(ctx, TFileStoreComponents::TABLET_WORKER,
-                    "%s Suiciding after %u backpressure errors",
-                    LogTag.c_str(),
-                    BackpressureErrorCount);
-
-                Suicide(ctx);
-            }
-
-            return MakeError(E_REJECTED, "rejected due to backpressure");
-        }
-
-        return NProto::TError{};
+    auto validator = [&](const NProto::TWriteDataRequest& request)
+    {
+        return ValidateWriteRequest(ctx, request, range);
     };
 
     if (!AcceptRequest<TEvService::TWriteDataMethod>(ev, ctx, validator)) {
@@ -380,7 +149,9 @@ void TIndexTabletActor::HandleWriteDataCompleted(
 {
     const auto* msg = ev->Get();
 
-    ReleaseCollectBarrier(msg->CommitId);
+
+
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
 
     WorkerActors.erase(ev->Sender);
     EnqueueBlobIndexOpIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -765,7 +765,7 @@ public:
     }
 
     void AcquireCollectBarrier(ui64 commitId);
-    void ReleaseCollectBarrier(ui64 commitId);
+    bool TryReleaseCollectBarrier(ui64 commitId);
 
     ui64 GetCollectCommitId() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -921,9 +921,10 @@ void TIndexTabletState::AcquireCollectBarrier(ui64 commitId)
     Impl->GarbageQueue.AcquireCollectBarrier(commitId);
 }
 
-void TIndexTabletState::ReleaseCollectBarrier(ui64 commitId)
+// returns true if the barrier was present
+bool TIndexTabletState::TryReleaseCollectBarrier(ui64 commitId)
 {
-    Impl->GarbageQueue.ReleaseCollectBarrier(commitId);
+    return Impl->GarbageQueue.TryReleaseCollectBarrier(commitId);
 }
 
 ui64 TIndexTabletState::GetCollectCommitId() const

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -87,6 +87,7 @@ PEERDIR(
     cloud/filestore/libs/storage/api
     cloud/filestore/libs/storage/core
     cloud/filestore/libs/storage/model
+    cloud/filestore/libs/storage/tablet/actors
     cloud/filestore/libs/storage/tablet/model
     cloud/filestore/libs/storage/tablet/protos
 


### PR DESCRIPTION
Some preliminary changes for #539, as mentioned here: https://github.com/ydb-platform/nbs/pull/707#pullrequestreview-1948429394

1. Extract `TWriteDataActor` into a separate file
2. Replace `ReleaseCollectBarrier` with `TryReleaseCollectBarrier`, add `TABLET_VERIFY` for validating the result
3. Extract the validator from the `HandleWriteData` method into a separate method.