### PR TITLE
feature: omit yc-github-runner in favor of python script

### DIFF
--- a/.github/actions/ncp/action.yaml
+++ b/.github/actions/ncp/action.yaml
@@ -41,5 +41,5 @@ runs:
         export GITHUB_RUNNER_IPV4=$(ncp compute instance get ${{ inputs.instance_id }} --format json | jq -r .network_interfaces[].primary_v4_address.one_to_one_nat.address)
         echo "GITHUB_RUNNER_IPV4=${GITHUB_RUNNER_IPV4}" >> $GITHUB_ENV
         echo "runner_ipv4=${GITHUB_RUNNER_IPV4}" >> $GITHUB_OUTPUT
-        echo "ssh -i ~/.ssh/gh-runner github@${GITHUB_RUNNER_IPV4}" | tee -a $GITHUB_SUMMARY
+        echo "ssh github@${GITHUB_RUNNER_IPV4}" | tee -a $GITHUB_SUMMARY
 

--- a/.github/actions/runner_create/action.yaml
+++ b/.github/actions/runner_create/action.yaml
@@ -1,0 +1,130 @@
+name: Create runner VM
+description: Create runner VM using create-vm.py
+inputs:
+  org:
+    required: true
+    description: "org name"
+  team:
+    required: true
+    description: "team slug name"
+  repo_owner:
+    required: true
+    description: "repo owner"
+  repo:
+    required: true
+    description: "repo name"
+  service_account_key:
+    required: true
+    description: "service account key"
+  token:
+    required: true
+    description: "GITHUB_TOKEN"
+  vm_folder:
+    required: true
+    description: "vm folder"
+  vm_name:
+    required: true
+    description: "vm name"
+  vm_zone:
+    required: true
+    description: "vm zone"
+  vm_cpu:
+    required: true
+    description: "vm cpu"
+  vm_memory:
+    required: true
+    description: "vm memory"
+  vm_disk_type:
+    required: true
+    description: "vm disk type"
+  vm_disk_size:
+    required: true
+    description: "vm disk size"
+  vm_subnet:
+    required: true
+    description: "vm subnet"
+  vm_image:
+    required: true
+    description: "vm image id"
+  vm_labels:
+    required: true
+    description: "vm labels"
+  vm_user_passwd:
+    required: true
+    description: "vm user password"
+
+outputs:
+  label:
+    description: >-
+      Name of the unique label assigned to the runner.
+      The label is used in two cases:
+      - to use as the input of 'runs-on' property for the following jobs;
+      - to remove the runner from GitHub when it is not needed anymore.
+    value: ${{ steps.create-vm.outputs.label }}
+  instance-id:
+    description: >-
+      Instance id of the created runner.
+      The id is used to terminate the instance when the runner is not needed anymore.
+    value: ${{ steps.create-vm.outputs.instance-id }}
+  local-ipv4:
+    description: >-
+      Local ipv4 address of the created runner.
+      The address is used to connect to the runner via SSH.
+    value: ${{ steps.create-vm.outputs.local-ipv4 }}
+  external-ipv4:
+    description: >-
+      External ipv4 address of the created runner.
+      The address is used to connect to the runner via SSH.
+    value: ${{ steps.create-vm.outputs.external-ipv4 || '0.0.0.0' }}
+
+runs:
+  using: composite
+  steps:
+    - name: write service account key to file
+      shell: bash
+      run: |
+        export SERVICE_ACCOUNT_KEY=$(mktemp)
+        echo "SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY}" >> $GITHUB_ENV
+        echo "${key_contents}" > $SERVICE_ACCOUNT_KEY
+      env:
+        key_contents: ${{ inputs.service_account_key }}
+    - name: install dependencies
+      shell: bash
+      run: |
+        pip install yandexcloud==0.258.0 PyGithub==2.2.0
+    - name: create vm
+      id: create-vm
+      shell: bash
+      run: |
+        python .github/scripts/create-vm.py create \
+          --github-org "${ORG}" \
+          --github-team-slug "${TEAM}" \
+          --github-repo-owner "${REPO_OWNER}" \
+          --github-repo "${REPO}" \
+          --service-account-key "${SERVICE_ACCOUNT_KEY}" \
+          --name "${VM_NAME}" \
+          --folder-id "${VM_FOLDER}" \
+          --zone-id "${VM_ZONE}" \
+          --cpu "${VM_CPU}" --ram "${VM_MEMORY}" --disk-size "${VM_DISK_SIZE}" \
+          --disk-type "${VM_DISK_TYPE}" \
+          --subnet-id "${VM_SUBNET}" \
+          --image-id "$VM_IMAGE" \
+          --labels "$VM_LABELS" \
+          --apply
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        ORG: ${{ inputs.org }}
+        TEAM: ${{ inputs.team }}
+        REPO_OWNER: ${{ inputs.repo_owner }}
+        REPO: ${{ inputs.repo }}
+        VM_NAME: ${{ inputs.vm_name }}
+        VM_FOLDER: ${{ inputs.vm_folder }}
+        VM_ZONE: ${{ inputs.vm_zone }}
+        VM_CPU: ${{ inputs.vm_cpu }}
+        VM_MEMORY: ${{ inputs.vm_memory }}
+        VM_DISK_SIZE: ${{ inputs.vm_disk_size }}
+        VM_DISK_TYPE: ${{ inputs.vm_disk_type }}
+        VM_SUBNET: ${{ inputs.vm_subnet }}
+        VM_IMAGE: ${{ inputs.vm_image }}
+        VM_LABELS: ${{ inputs.vm_labels }}
+        VM_USER_PASSWD: ${{ inputs.vm_user_passwd }}

--- a/.github/actions/runner_create/action.yaml
+++ b/.github/actions/runner_create/action.yaml
@@ -1,5 +1,5 @@
 name: Create runner VM
-description: Create runner VM using create-vm.py
+description: Create runner VM using manage-vm.py
 inputs:
   org:
     required: true
@@ -96,7 +96,7 @@ runs:
       id: create-vm
       shell: bash
       run: |
-        python .github/scripts/create-vm.py create \
+        python .github/scripts/manage-vm.py create \
           --github-org "${ORG}" \
           --github-team-slug "${TEAM}" \
           --github-repo-owner "${REPO_OWNER}" \

--- a/.github/actions/runner_remove/action.yaml
+++ b/.github/actions/runner_remove/action.yaml
@@ -1,0 +1,50 @@
+name: Delete runner VM
+description: Delete runner VM using create-vm.py
+inputs:
+  repo_owner:
+    required: true
+    description: "repo owner"
+  repo:
+    required: true
+    description: "repo name"
+  service_account_key:
+    required: true
+    description: "service account key"
+  token:
+    required: true
+    description: "GITHUB_TOKEN"
+  vm_id:
+    required: true
+    description: "vm id"
+
+
+runs:
+  using: composite
+  steps:
+    - name: write service account key to file
+      shell: bash
+      run: |
+        export SERVICE_ACCOUNT_KEY=$(mktemp)
+        echo "SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY}" >> $GITHUB_ENV
+        echo "${key_contents}" > $SERVICE_ACCOUNT_KEY
+      env:
+        key_contents: ${{ inputs.service_account_key }}
+    - name: install dependencies
+      shell: bash
+      run: |
+        pip install yandexcloud==0.258.0 PyGithub==2.2.0
+    - name: remove vm
+      id: remove-vm
+      shell: bash
+      run: |
+        python .github/scripts/create-vm.py remove \
+          --github-repo-owner "${REPO_OWNER}" \
+          --github-repo "${REPO}" \
+          --service-account-key "${SERVICE_ACCOUNT_KEY}" \
+          --id "${VM_ID}" \
+          --apply
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        REPO_OWNER: ${{ inputs.repo_owner }}
+        REPO: ${{ inputs.repo }}
+        VM_ID: ${{ inputs.vm_id }}

--- a/.github/actions/runner_remove/action.yaml
+++ b/.github/actions/runner_remove/action.yaml
@@ -1,5 +1,5 @@
 name: Delete runner VM
-description: Delete runner VM using create-vm.py
+description: Delete runner VM using manage-vm.py
 inputs:
   repo_owner:
     required: true
@@ -37,7 +37,7 @@ runs:
       id: remove-vm
       shell: bash
       run: |
-        python .github/scripts/create-vm.py remove \
+        python .github/scripts/manage-vm.py remove \
           --github-repo-owner "${REPO_OWNER}" \
           --github-repo "${REPO}" \
           --service-account-key "${SERVICE_ACCOUNT_KEY}" \

--- a/.github/scripts/create-vm.py
+++ b/.github/scripts/create-vm.py
@@ -1,0 +1,462 @@
+import os
+import grpc
+import json
+import requests
+import math
+import logging
+import argparse
+import yaml
+import random
+import string
+from github import Github, Auth as GithubAuth
+from yandexcloud import SDK, RetryInterceptor, backoff_linear_with_jitter
+from yandex.cloud.compute.v1.instance_service_pb2_grpc import InstanceServiceStub
+from yandex.cloud.compute.v1.instance_pb2 import Instance
+from yandex.cloud.compute.v1.instance_service_pb2 import (
+    CreateInstanceRequest,
+    ResourcesSpec,
+    AttachedDiskSpec,
+    NetworkInterfaceSpec,
+    PrimaryAddressSpec,
+    OneToOneNatSpec,
+    DeleteInstanceRequest,
+    CreateInstanceMetadata,
+    DeleteInstanceMetadata,
+)
+from yandex.cloud.compute.v1.instance_pb2 import IpVersion
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s: %(levelname)s: %(message)s"
+)
+
+
+def output(key, value, secret=False):
+    GITHUB_OUTPUT = os.environ.get("GITHUB_OUTPUT")
+
+    if GITHUB_OUTPUT:
+        with open(GITHUB_OUTPUT, "a") as fp:
+            fp.write(f"{key}={value}\n")
+
+    logging.info(f"echo \"{key}={'******' if secret else value}\" >> $GITHUB_OUTPUT")
+
+
+def generate_github_label():
+    generated_string = "".join(
+        random.choices(string.ascii_lowercase + string.digits, k=8)
+    )
+    logging.info(f"Generated label: {generated_string}")
+    return generated_string
+
+
+class KeyValueAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa: U100
+        kv_dict = {}
+        for item in values.split(","):
+            key, value = item.split("=")
+            kv_dict[key] = value
+        setattr(namespace, self.dest, kv_dict)
+
+
+def fetch_github_team_public_keys(gh, github_org, team_slug):
+    org = gh.get_organization(github_org)
+    team = org.get_team_by_slug(team_slug)
+    members = [member for member in team.get_members()]
+
+    ssh_keys = []
+    logging.info(
+        f"Fetching SSH keys for members: {[member.login for member in members]}"
+    )
+    for member in members:
+        member_keys = []
+        for key in member.get_keys():
+            member_keys.append(key.key)
+            ssh_keys.append(key.key)
+
+        logging.debug(f"Fetched {len(member_keys)} SSH keys for {member.login}")
+
+    logging.debug(f"Fetched SSH keys: {ssh_keys}")
+    return ssh_keys
+
+
+def generate_cloud_init_script(user, ssh_keys, owner, repo, token, version, label):
+
+    script = [
+        "#!/bin/bash",
+        "set -x",
+        "mkdir -p /actions-runner && cd /actions-runner",
+        'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64";; esac',
+        f"export FILENAME=actions-runner-linux-${{ARCH}}-{version}.tar.gz",
+        # https://github.com/actions/runner/releases/download/v2.314.1/actions-runner-linux-x64-2.314.1.tar.gz
+        f'[ -f "$FILENAME" ] || curl -O -L "https://github.com/actions/runner/releases/download/v{version}/$FILENAME"',
+        'tar xzf "./$FILENAME"',
+        "export RUNNER_ALLOW_RUNASROOT=1",
+        f"./config.sh  --labels {label} --url https://github.com/{owner}/{repo} --token {token}",
+        "./run.sh",
+    ]
+
+    cloud_init = {}
+    cloud_init["ssh_pwauth"] = False
+    cloud_init["users"] = [
+        {
+            "name": user,
+            "sudo": "ALL=(ALL) NOPASSWD:ALL",
+            "passwd": os.environ["VM_USER_PASSWD"],
+            "shell": "/bin/bash",
+            "ssh_authorized_keys": ssh_keys,
+        }
+    ]
+    cloud_init["runcmd"] = ["\n".join(script)]
+    logging.info(
+        f"Cloud-init: \n{yaml.dump(cloud_init, default_flow_style=False, width=math.inf)}".replace(
+            token, "****"
+        )
+    )
+    return (
+        "#cloud-config\n"
+        + yaml.dump(cloud_init, default_flow_style=False, width=math.inf),  # noqa: W503
+        ssh_keys,
+    )
+
+
+def get_runner_token(github_repo_owner, github_repo, github_token):
+    result = requests.post(
+        f"https://api.github.com/repos/{github_repo_owner}/{github_repo}/actions/runners/registration-token",
+        headers={
+            "Authorization": f"Bearer {github_token}",
+            "Accept": "application/vnd.github+json",
+            "X-Github-Api-Version": "2022-11-28",
+        },
+    ).json()
+
+    token = result.get("token")
+    if token:
+        # Mask the token in the logs
+        print(f"::add-mask::{token}")
+        logging.debug(f"Got runner registration token: {token}")
+        return token
+    else:
+        raise ValueError(f"Failed to get runner registration token: {result}")
+
+
+def create_vm(sdk, args):
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+
+    gh = Github(auth=GithubAuth.Token(GITHUB_TOKEN))
+
+    runner_registration_token = get_runner_token(
+        args.github_repo_owner, args.github_repo, GITHUB_TOKEN
+    )
+
+    ssh_keys = fetch_github_team_public_keys(gh, args.github_org, args.github_team_slug)
+
+    # fmt: off
+    standard_v2_cpu = [
+        2, 4, 6, 8, 10, 12, 14, 16, 20, 24,
+        28, 32, 36, 40, 44, 48, 52, 56, 60
+    ]
+    # fmt: on
+    if args.platform_id == "standard-v2" and args.cpu not in standard_v2_cpu:
+        raise ValueError(
+            f"CPU cores must be {', '.join(standard_v2_cpu)} for standard-v2 platform"
+        )
+
+    if args.ram % args.cpu != 0:
+        raise ValueError("RAM must be a multiple of CPU cores (1,2,4 etc)")
+
+    if (
+        args.disk_type in ["network-ssd-nonreplicated", "network-ssd-io-m3"]
+        and args.disk_size % 93 != 0  # noqa: W503
+    ):
+        raise ValueError(
+            "Disk size must be a multiple of 93GB for the selected disk type"
+        )
+
+    runner_github_label = generate_github_label()
+
+    user_data, ssh_keys = generate_cloud_init_script(
+        args.user,
+        ssh_keys,
+        args.github_repo_owner,
+        args.github_repo,
+        runner_registration_token,
+        args.github_runner_version,
+        runner_github_label,
+    )
+
+    labels = args.labels
+    labels["runner-label"] = runner_github_label
+
+    request = CreateInstanceRequest(
+        name=args.name,
+        folder_id=args.folder_id,
+        zone_id=args.zone_id,
+        platform_id=args.platform_id,
+        resources_spec=ResourcesSpec(
+            memory=args.ram * 1024 * 1024 * 1024, cores=args.cpu, core_fraction=100
+        ),
+        boot_disk_spec=AttachedDiskSpec(
+            auto_delete=True,
+            mode=AttachedDiskSpec.Mode.READ_WRITE,
+            disk_spec=AttachedDiskSpec.DiskSpec(
+                type_id=args.disk_type,
+                size=args.disk_size * 1024 * 1024 * 1024,
+                image_id=args.image_id,
+            ),
+        ),
+        labels=labels,
+        network_interface_specs=[
+            NetworkInterfaceSpec(
+                subnet_id=args.subnet_id,
+                primary_v4_address_spec=PrimaryAddressSpec(
+                    one_to_one_nat_spec=OneToOneNatSpec(ip_version=IpVersion.IPV4)
+                ),
+            )
+        ],
+        metadata={
+            "user-data": user_data,
+            "ssh-keys": "\n".join([f"{args.user}:{key}" for key in ssh_keys]),
+            "serial-port-enable": "1",
+        },
+    )
+
+    # Create the VM
+    if args.apply:
+        result = sdk.create_operation_and_get_result(
+            request=request,
+            service=InstanceServiceStub,
+            method_name="Create",
+            response_type=Instance,
+            meta_type=CreateInstanceMetadata,
+            timeout=args.timeout,
+            logger=logging.getLogger(),
+        )
+        instance_id = result.response.id
+        name = result.response.name
+        primary_ipv4 = result.response.network_interfaces[0].primary_v4_address
+        external_ipv4 = primary_ipv4.one_to_one_nat.address
+        local_ipv4 = primary_ipv4.address
+        if instance_id:
+            logging.info(
+                f"Created VM {name} with ID {instance_id} and label {runner_github_label}"
+            )
+            output("instance-id", instance_id)
+            output("label", runner_github_label)
+            output("local-ipv4", local_ipv4)
+            if external_ipv4:
+                output("external-ipv4", external_ipv4)
+        else:
+            logging.error(f"Failed to create VM with request: {request}")
+            logging.error(f"Response: {result}")
+    else:
+        logging.info(f"Would create VM with request: {request}")
+
+
+def remove_runner_from_github(github_repo_owner, github_repo, vm_id, apply):
+    github_token = os.environ["GITHUB_TOKEN"]
+
+    gh = Github(auth=GithubAuth.Token(github_token))
+    runners = gh.get_repo(
+        f"{github_repo_owner}/{github_repo}"
+    ).get_self_hosted_runners()
+
+    runner_id = None
+    for runner in runners:
+        if runner.name == str(vm_id):
+            runner_id = runner.id
+            break
+
+    if runner_id is None:
+        logging.info(f"Runner with name {vm_id} not found")
+        raise ValueError(f"Runner with name {vm_id} not found")
+
+    if apply:
+        delete_status_code = requests.delete(
+            f"https://api.github.com/repos/{github_repo_owner}/{github_repo}/actions/runners/{runner_id}",
+            headers={
+                "Authorization": f"Bearer {github_token}",
+                "Accept": "application/vnd.github+json",
+                "X-Github-Api-Version": "2022-11-28",
+            },
+        ).status_code
+
+        if delete_status_code == 204:
+            return True
+        else:
+            raise ValueError(f"Failed to remove runner with name {vm_id}")
+    else:
+        logging.info(f"Would remove runner with name {vm_id} and id {runner_id}")
+
+
+def remove_vm(sdk, args):
+    remove_runner_from_github(
+        args.github_repo_owner, args.github_repo, args.id, args.apply
+    )
+
+    if args.apply:
+
+        try:
+            result = sdk.create_operation_and_get_result(
+                request=DeleteInstanceRequest(instance_id=args.id),
+                service=InstanceServiceStub,
+                method_name="Delete",
+                response_type=Instance,
+                meta_type=DeleteInstanceMetadata,
+                timeout=args.timeout,
+                logger=logging.getLogger(),
+            )
+
+            logging.info(f"Deleted VM with ID {args.id}")
+        except Exception as e:
+            logging.error(f"Failed to delete VM with ID {args.id}")
+            logging.error(f"Response: {result}")
+            raise e
+    else:
+        logging.info(f"Would delete VM with ID {args.id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="action", help="Action to perform")
+    parser.add_argument(
+        "--api-endpoint",
+        default="api.ai.nebius.cloud",
+        help="API Endpoint",
+    )
+
+    create = subparsers.add_parser("create", help="Create a new VM")
+    create.add_argument(
+        "--github-org",
+        required=True,
+        default="ydb-platform",
+        help="GitHub organization name (we will fetch SSH keys from this org)",
+    )
+
+    create.add_argument(
+        "--github-team-slug",
+        required=True,
+        default="NBS",
+        help="Slug of the GitHub team within the organization",
+    )
+
+    create.add_argument(
+        "--github-repo-owner",
+        required=True,
+        default="ydb-platform",
+        help="GitHub repository owner name",
+    )
+    create.add_argument(
+        "--github-repo",
+        required=True,
+        default="nbs",
+        help="GitHub repository name",
+    )
+
+    create.add_argument(
+        "--github-runner-version",
+        default="2.308.0",
+        help="GitHub Runner version",
+    )
+
+    create.add_argument(
+        "--service-account-key",
+        required=True,
+        help="Path to the service account key file",
+    )
+    create.add_argument(
+        "--folder-id",
+        required=True,
+        default="bjeuq5o166dq4ukv3eec",
+        help="Folder ID where the VM will be created",
+    )
+    create.add_argument("--name", default="", help="VM name")
+    create.add_argument(
+        "--zone-id", default="eu-north1-c", required=True, help="Zone ID for the VM"
+    )
+    create.add_argument("--platform-id", default="standard-v2", help="Platform ID")
+    create.add_argument(
+        "--cpu", type=int, default=60, required=True, help="Number of CPU cores"
+    )
+    create.add_argument(
+        "--ram", type=int, default=240, required=True, help="Amount of RAM in GB"
+    )
+    create.add_argument(
+        "--disk-type",
+        default="network-ssd-nonreplicated",
+        choices=[
+            "network-ssd",
+            "network-hdd",
+            "network-ssd-nonreplicated",
+            "network-ssd-io-m3",
+        ],
+        help="Type of disk",
+    )
+    create.add_argument(
+        "--disk-size", type=int, required=True, default=930, help="Disk size in GB"
+    )
+    create.add_argument(
+        "--image-id", type=str, required=True, help="Image ID to use for the VM"
+    )
+    create.add_argument("--subnet-id", required=True, help="Subnet ID for the VM")
+    create.add_argument("--user", default="github", help="Username for the VM")
+    create.add_argument(
+        "--labels",
+        action=KeyValueAction,
+        default="",
+        help="Label for the VM (k=v,k2=v2)",
+    )
+
+    create.add_argument("--retry-time", default=10, help="How often to retry (seconds)")
+    create.add_argument(
+        "--timeout", default=600, help="How long to wait for creation (seconds)"
+    )
+    create.add_argument("--apply", action="store_true", help="Apply the changes")
+
+    remove = subparsers.add_parser("remove", help="Remove an existing VM")
+    remove.add_argument(
+        "--service-account-key",
+        required=True,
+        help="Path to the service account key file",
+    )
+    remove.add_argument("--id", required=True, help="ID of the VM to remove")
+
+    remove.add_argument(
+        "--github-repo-owner",
+        required=True,
+        default="ydb-platform",
+        help="GitHub repository owner name",
+    )
+    remove.add_argument(
+        "--github-repo",
+        required=True,
+        default="nbs",
+        help="GitHub repository name",
+    )
+
+    remove.add_argument("--retry-time", default=10, help="How often to retry (seconds)")
+    remove.add_argument(
+        "--timeout", default=600, help="How long to wait for removal (seconds)"
+    )
+    remove.add_argument("--apply", action="store_true", help="Apply the changes")
+
+    create.set_defaults(func=create_vm)
+    remove.set_defaults(func=remove_vm)
+
+    args = parser.parse_args()
+
+    interceptor = RetryInterceptor(
+        max_retry_count=args.timeout / args.retry_time,
+        retriable_codes=[grpc.StatusCode.UNAVAILABLE],
+        back_off_func=backoff_linear_with_jitter(args.retry_time, 0),
+    )
+
+    with open(args.service_account_key, "r") as fp:
+        sdk = SDK(
+            service_account_key=json.load(fp),
+            endpoint=args.api_endpoint,
+            interceptor=interceptor,
+        )
+
+    if hasattr(args, "func"):
+        args.func(sdk, args)
+    else:
+        parser.print_help()

--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -99,7 +99,6 @@ on:
         default: "12"
         description: "--test-threads in ya test"
 
-
 jobs:
   provide-runner:
     name: Start self-hosted runner
@@ -107,37 +106,58 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     outputs:
-      label: ${{ steps.start-yc-runner.outputs.label }}
-      instance-id: ${{ steps.start-yc-runner.outputs.instance-id }}
+      label: ${{ steps.start-runner.outputs.label }}
+      instance-id: ${{ steps.start-runner.outputs.instance-id }}
+      runner_ipv4: ${{ steps.start-runner.outputs.external-ipv4 }}
+      runner_local_ipv4: ${{ steps.start-runner.outputs.local-ipv4 }}
     steps:
-      - name: Start YC runner
-        id: start-yc-runner
+      - name: checkout PR
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+      - name: rebase PR
+        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        shell: bash
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+      - name: checkout
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: true
+      - name: Start runner
+        id: start-runner
         if: always()
-        uses: librarian/yc-github-runner@0.0.15
+        uses: ./.github/actions/runner_create
         timeout-minutes: 60
         with:
-          mode: start
-          yc-sa-json-credentials: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          folder-id: bjeuq5o166dq4ukv3eec
-          image-id: ${{ vars.IMAGE_ID_2204 }}
-          disk-size: '1023GB'
-          disk-type: network-ssd-nonreplicated
-          platform-id: standard-v2
-          cores: 60
-          memory: 240GB
-          core-fraction: 100
-          zone-id: eu-north1-c
-          subnet-id: f8uh0ml4rhb45nde9p75
-          user: github
-          ssh-public-key: ${{ secrets.RUNNER_PUBLIC_KEY }}
+          org: ydb-platform
+          team: NBS
+          repo_owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          service_account_key: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          vm_folder: bjeuq5o166dq4ukv3eec
+          vm_name: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || format('run-{0}-{1}', github.run_id, github.run_attempt) }}
+          vm_zone: eu-north1-c
+          vm_cpu: 60
+          vm_memory: 240
+          vm_disk_type: network-ssd-nonreplicated
+          vm_disk_size: 1023
+          vm_subnet: f8uh0ml4rhb45nde9p75
+          vm_image: ${{ vars.IMAGE_ID_2204 }}
+          vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2}', github.event.pull_request.number, github.run_id, github.run_attempt) || format('run={0}-{1}', github.run_id, github.run_attempt) }}
+          vm_user_passwd: ${{ secrets.VM_USER_PASSWD }}
+
 
   prepare-vm:
-    name: Prepare runner [id=${{ needs.provide-runner.outputs.instance-id }}]
+    name: Prepare runner [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     needs: provide-runner
     runs-on: [ self-hosted, "${{ needs.provide-runner.outputs.label }}" ]
-    outputs:
-      runner_ipv4: ${{ steps.configure-ncp.outputs.runner_ipv4 }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -150,31 +170,18 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          git fetch origin main
-          git rebase origin/main
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
       - name: Checkout
         uses: actions/checkout@v4
         if: github.event.pull_request.head.sha == ''
         with:
           submodules: true
-      - id: configure-ncp
-        name: Configure NCP
-        uses: ./.github/actions/ncp
-        with:
-          instance_id: ${{ needs.provide-runner.outputs.instance-id }}
-          sa_json: ${{ secrets.NEBIUS_GITHUB_USER_SA_JSON}}
-      - id: configure-authorized-keys
-        name: Configure authorized_keys
-        uses: ./.github/actions/ssh_keys
-        with:
-          org: ydb-platform
-          team: nbs
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Prepare VM
         uses: ./.github/actions/prepare
 
   build-and-test:
-    name: Build and test NBS [id=${{ needs.provide-runner.outputs.instance-id }} ip=${{ needs.prepare-vm.outputs.runner_ipv4 }}]
+    name: Build and test NBS [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     uses: ./.github/workflows/build_and_test_ya.yaml
     needs:
       - provide-runner
@@ -183,7 +190,7 @@ jobs:
       runner_kind: self-hosted
       runner_label: ${{ needs.provide-runner.outputs.label }}
       runner_instance_id: ${{ needs.provide-runner.outputs.instance-id }}
-      runner_ipv4: ${{ needs.prepare-vm.outputs.runner_ipv4 }}
+      runner_ipv4: ${{ needs.provide-runner.outputs.runner_ipv4 }}
       build_target: ${{ inputs.build_target }}
       test_target: ${{ inputs.test_target }}
       build_preset: ${{ inputs.build_preset }}
@@ -212,7 +219,7 @@ jobs:
         run: sleep ${{ needs.build-and-test.outputs.sleep_after_tests }}
 
   release-runner:
-    name: Release self-hosted runner ${{ needs.provide-runner.outputs.instance-id }}
+    name: Release self-hosted runner [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     needs:
       - provide-runner  # required to get output from the start-runner job
       - build-and-test  # required to wait when the main job is done
@@ -220,15 +227,31 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Stop YC runner
-        uses: librarian/yc-github-runner@0.0.15
+      - name: checkout PR
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+      - name: rebase PR
+        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        shell: bash
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+      - name: checkout
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: true
+      - name: Stop runner
+        uses: ./.github/actions/runner_remove
         if: always()
         timeout-minutes: 60
         with:
-          mode: stop
-          yc-sa-json-credentials: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.provide-runner.outputs.label }}
-          instance-id: ${{ needs.provide-runner.outputs.instance-id }}
-          folder-id: bjeuq5o166dq4ukv3eec
-          subnet-id: f8uh0ml4rhb45nde9p75
+          service_account_key: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          repo_owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          vm_id: ${{ needs.provide-runner.outputs.instance-id }}

--- a/.github/workflows/build_and_test_on_demand_cmake.yaml
+++ b/.github/workflows/build_and_test_on_demand_cmake.yaml
@@ -47,37 +47,57 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     outputs:
-      label: ${{ steps.start-yc-runner.outputs.label }}
-      instance-id: ${{ steps.start-yc-runner.outputs.instance-id }}
+      label: ${{ steps.start-runner.outputs.label }}
+      instance-id: ${{ steps.start-runner.outputs.instance-id }}
+      runner_ipv4: ${{ steps.start-runner.outputs.external-ipv4 }}
+      runner_local_ipv4: ${{ steps.start-runner.outputs.local-ipv4 }}
     steps:
-      - name: Start YC runner
-        id: start-yc-runner
+      - name: checkout PR
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+      - name: rebase PR
+        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        shell: bash
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+      - name: checkout
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: true
+      - name: Start runner
+        id: start-runner
         if: always()
-        uses: librarian/yc-github-runner@0.0.15
+        uses: ./.github/actions/runner_create
         timeout-minutes: 60
         with:
-          mode: start
-          yc-sa-json-credentials: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          folder-id: bjeuq5o166dq4ukv3eec
-          image-id: ${{ vars.IMAGE_ID_2204 }}
-          disk-size: '1023GB'
-          disk-type: network-ssd-nonreplicated
-          platform-id: standard-v2
-          cores: 60
-          memory: 120GB
-          core-fraction: 100
-          zone-id: eu-north1-c
-          subnet-id: f8uh0ml4rhb45nde9p75
-          user: github
-          ssh-public-key: ${{ secrets.RUNNER_PUBLIC_KEY }}
+          org: ydb-platform
+          team: NBS
+          repo_owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          service_account_key: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          vm_folder: bjeuq5o166dq4ukv3eec
+          vm_name: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || format('run-{0}-{1}', github.run_id, github.run_attempt) }}
+          vm_zone: eu-north1-c
+          vm_cpu: 60
+          vm_memory: 240
+          vm_disk_type: network-ssd-nonreplicated
+          vm_disk_size: 1023
+          vm_subnet: f8uh0ml4rhb45nde9p75
+          vm_image: ${{ vars.IMAGE_ID_2204 }}
+          vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2}', github.event.pull_request.number, github.run_id, github.run_attempt) || format('run={0}-{1}', github.run_id, github.run_attempt) }}
+          vm_user_passwd: ${{ secrets.VM_USER_PASSWD }}
 
   prepare-vm:
-    name: Prepare runner
+    name: Prepare runner [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     needs: provide-runner
     runs-on: [ self-hosted, "${{ needs.provide-runner.outputs.label }}" ]
-    outputs:
-      runner_ipv4: ${{ steps.configure-ncp.outputs.runner_ipv4 }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -90,31 +110,18 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          git fetch origin stable-23-3
-          git rebase origin/stable-23-3
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
       - name: Checkout
         uses: actions/checkout@v4
         if: github.event.pull_request.head.sha == ''
         with:
           submodules: true
-      - id: configure-ncp
-        name: Configure NCP
-        uses: ./.github/actions/ncp
-        with:
-          instance_id: ${{ needs.provide-runner.outputs.instance-id }}
-          sa_json: ${{ secrets.NEBIUS_GITHUB_USER_SA_JSON}}
-      - id: configure-authorized-keys
-        name: Configure authorized_keys
-        uses: ./.github/actions/ssh_keys
-        with:
-          org: ydb-platform
-          team: nbs
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Prepare VM
         uses: ./.github/actions/prepare
 
   build-and-test:
-    name: Build and test NBS [id=${{ needs.provide-runner.outputs.instance-id }} ip=${{ needs.prepare-vm.outputs.runner_ipv4 }}]
+    name: Build and test NBS [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     uses: ./.github/workflows/build_and_test_cmake.yaml
     needs:
       - provide-runner
@@ -123,7 +130,7 @@ jobs:
       runner_kind: self-hosted
       runner_label: ${{ needs.provide-runner.outputs.label }}
       runner_instance_id: ${{ needs.provide-runner.outputs.instance-id }}
-      runner_ipv4: ${{ needs.prepare-vm.outputs.runner_ipv4 }}
+      runner_ipv4: ${{ needs.provide-runner.outputs.runner_ipv4 }}
       build_preset: ${{ inputs.build_preset }}
       run_build: ${{ inputs.run_build }}
       run_tests: ${{ inputs.run_tests }}
@@ -144,7 +151,7 @@ jobs:
         run: sleep ${{ needs.build-and-test.outputs.sleep_after_tests }}
 
   release-runner:
-    name: Release self-hosted runner ${{ needs.provide-runner.outputs.instance-id }}
+    name: Release self-hosted runner [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     needs:
       - provide-runner  # required to get output from the start-runner job
       - build-and-test  # required to wait when the main job is done
@@ -152,15 +159,31 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Stop YC runner
-        uses: librarian/yc-github-runner@0.0.15
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+      - name: rebase PR
+        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        shell: bash
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+      - name: checkout
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: true
+      - name: Stop runner
+        uses: ./.github/actions/runner_remove
         if: always()
         timeout-minutes: 60
         with:
-          mode: stop
-          yc-sa-json-credentials: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.provide-runner.outputs.label }}
-          instance-id: ${{ needs.provide-runner.outputs.instance-id }}
-          folder-id: bjeuq5o166dq4ukv3eec
-          subnet-id: f8uh0ml4rhb45nde9p75
+          service_account_key: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          repo_owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          vm_id: ${{ needs.provide-runner.outputs.instance-id }}


### PR DESCRIPTION
I replaced js github action with python one mostly because of that nobody knows js in the team and modifications and bugfixes are very difficult + python sdk can change endpoint without uploading the same code to npm repo.

Also I incorporated few useful features that before required additional steps in prepare stage:
1. Getting and adding ssh keys for github user (api calls and setting ssh keys at the creation of vm is faster)
2. Showing ip addresses is basically free now (it is in response of CreateInstanceRequest)

Future plans are:
1. Move it to separate repo and maybe create docker action
2. Test if we can launch runner as `github` user, not root (to remove annoying `sudo -H -E everywhere` and everything)