### PR TITLE
issue-757: Daemon should wait when terminating or killing process

### DIFF
--- a/cloud/storage/core/tools/common/python/daemon.py
+++ b/cloud/storage/core/tools/common/python/daemon.py
@@ -87,12 +87,16 @@ class Daemon(object):
         self.__verify_process()
         logger.info("terminating process")
         self.__process.terminate()
+        self.__process.wait(check_exit_code=False)
+        self.__process = None
 
     # Should be guarded by self.__lock.
     def __kill_process(self):
         self.__verify_process()
         logger.info("killing process")
         self.__process.kill()
+        self.__process.wait(check_exit_code=False)
+        self.__process = None
 
     # Should be guarded by self.__lock.
     def __ping(self):
@@ -182,7 +186,6 @@ class Daemon(object):
                     self.__timer = None
 
                 self.__terminate_process()
-                self.__process = None
 
     def kill(self):
         with self.__lock:
@@ -192,7 +195,6 @@ class Daemon(object):
                     self.__timer = None
 
                 self.__kill_process()
-                self.__process = None
 
     @property
     def command(self):


### PR DESCRIPTION
#757 

Otherwise, we can get 'address already in use' error when restarting daemon in tests https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/tests/python/lib/nbs_runner.py#L624 