### PR TITLE
NBS-4503 [nbs] restart volume tablet on local mount when needed

### DIFF
--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -116,6 +116,9 @@ message TAddClientResponse
 
     // Expected pipe generation. Deprecated.
     uint32 ExpectedPipeGeneration = 6;
+
+    // Signal that volume table should be restarted.
+    bool ForceTabletRestart = 7;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -117,7 +117,7 @@ message TAddClientResponse
     // Expected pipe generation. Deprecated.
     uint32 ExpectedPipeGeneration = 6;
 
-    // Signal that volume table should be restarted.
+    // Signal that volume tablet should be restarted.
     bool ForceTabletRestart = 7;
 }
 

--- a/cloud/blockstore/libs/storage/service/service_state.h
+++ b/cloud/blockstore/libs/storage/service/service_state.h
@@ -34,6 +34,8 @@ struct TClientInfo
     TInstant LastActivityTime;
     ui64 LastMountTick = 0;
     TString ClientVersionInfo;
+    ui64 FillSeqNumber = 0;
+    ui64 FillGeneration = 0;
 
     // IPC info
     NProto::EClientIpcType IpcType = NProto::IPC_GRPC;

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5220,8 +5220,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(1, sessionActorDeathCnt);
     }
 
-    // TODO:_ better name of the test
-    Y_UNIT_TEST(ShouldRestartVolumeTabletWhenNeeded)
+    Y_UNIT_TEST(ShouldRestartVolumeTabletOnLocalMountIfNeeded)
     {
         TTestEnv env(1, 1);
         auto unmountClientsTimeout = TDuration::Seconds(10);
@@ -5253,11 +5252,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             const NProto::EVolumeAccessMode accessMode = NProto::VOLUME_ACCESS_READ_WRITE
         ) -> std::pair<uint64_t, uint64_t>
         {
-            // TODO:_ remove this
-            static int count = 0;
-            ++count;
-            std::cerr << "MOUNT " << count << std::endl;
-
             auto statResponseBefore = service1.StatVolume(DefaultDiskId);
 
             auto response = service.MountVolume(
@@ -5279,9 +5273,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             );
 
             auto statResponseAfter = service1.StatVolume(DefaultDiskId);
-
-            std::cerr << "Generation before: " << statResponseBefore->Record.GetVolumeGeneration() << std::endl;
-            std::cerr << "Generation after: " << statResponseAfter->Record.GetVolumeGeneration() << std::endl;
 
             return {
                 statResponseBefore->Record.GetVolumeGeneration(),
@@ -5417,7 +5408,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldHandleMountRequestSingleClient)
+    Y_UNIT_TEST(ShouldHandleMountRequestsSingleClient)
     {
         TTestEnv env(1, 1);
         auto unmountClientsTimeout = TDuration::Seconds(10);
@@ -5446,11 +5437,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             const ui64 fillGeneration,
             EWellKnownResultCodes expectedResult)
         {
-            // TODO:_ remove this
-            static int count = 0;
-            ++count;
-            std::cerr << "MOUNT " << count << std::endl;
-
             auto statResponseBefore = service.StatVolume(DefaultDiskId);
 
             service.SendMountVolumeRequest(
@@ -5474,16 +5460,12 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             );
 
             auto statResponseAfter = service.StatVolume(DefaultDiskId);
-
-            std::cerr << "Generation before: " << statResponseBefore->Record.GetVolumeGeneration() << std::endl;
-            std::cerr << "Generation after: " << statResponseAfter->Record.GetVolumeGeneration() << std::endl;
         };
 
         uint64_t mountSeqNumber = 10;
         uint64_t fillSeqNumber = 10;
 
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
-        // TODO:_ comment here
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_ALREADY);
         mountVolume(mountSeqNumber, fillSeqNumber - 1, fillGeneration, E_PRECONDITION_FAILED);
@@ -5491,7 +5473,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_ALREADY);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration - 1, E_PRECONDITION_FAILED);
-        // TODO:_ check it fails without your changes
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -4777,7 +4777,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         TServiceClient service(runtime, nodeIdx);
 
-        uint64_t fillGeneration = 1;
+        ui64 fillGeneration = 1;
         {
             auto request = service.CreateCreateVolumeRequest();
             request->Record.SetFillGeneration(fillGeneration);
@@ -5233,7 +5233,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         TServiceClient service1(runtime, nodeIdx);
         TServiceClient service2(runtime, nodeIdx);
 
-        uint64_t fillGeneration = 1;
+        ui64 fillGeneration = 1;
 
         {
             auto request = service1.CreateCreateVolumeRequest();
@@ -5250,7 +5250,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             const ui64 fillSeqNumber,
             const ui64 fillGeneration,
             const NProto::EVolumeAccessMode accessMode = NProto::VOLUME_ACCESS_READ_WRITE
-        ) -> std::pair<uint64_t, uint64_t>
+        ) -> std::pair<ui64, ui64>
         {
             auto statResponseBefore = service1.StatVolume(DefaultDiskId);
 
@@ -5279,8 +5279,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 statResponseAfter->Record.GetVolumeGeneration()};
         };
 
-        uint64_t mountSeqNumber = 0;
-        uint64_t fillSeqNumber = 0;
+        ui64 mountSeqNumber = 0;
+        ui64 fillSeqNumber = 0;
 
         {
             auto [generationBefore, generationAfter] = mountVolume(
@@ -5420,7 +5420,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         TServiceClient service(runtime, nodeIdx);
 
-        uint64_t fillGeneration = 10;
+        ui64 fillGeneration = 10;
 
         {
             auto request = service.CreateCreateVolumeRequest();
@@ -5462,8 +5462,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             auto statResponseAfter = service.StatVolume(DefaultDiskId);
         };
 
-        uint64_t mountSeqNumber = 10;
-        uint64_t fillSeqNumber = 10;
+        ui64 mountSeqNumber = 10;
+        ui64 fillSeqNumber = 10;
 
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5224,9 +5224,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
     {
         TTestEnv env(1, 1);
         auto unmountClientsTimeout = TDuration::Seconds(10);
-        ui32 nodeIdx = SetupTestEnvWithMultipleMount(
-            env,
-            unmountClientsTimeout);
+        ui32 nodeIdx =
+            SetupTestEnvWithMultipleMount(env, unmountClientsTimeout);
 
         auto& runtime = env.GetRuntime();
 
@@ -5241,16 +5240,19 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             service1.SendRequest(MakeStorageServiceId(), std::move(request));
 
             auto response = service1.RecvCreateVolumeResponse();
-            UNIT_ASSERT_VALUES_EQUAL_C(S_OK, response->GetStatus(), response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetStatus());
         }
 
-        auto mountVolume = [&](
-            TServiceClient& service,
-            const ui64 mountSeqNumber,
-            const ui64 fillSeqNumber,
-            const ui64 fillGeneration,
-            const NProto::EVolumeAccessMode accessMode = NProto::VOLUME_ACCESS_READ_WRITE
-        ) -> std::pair<ui64, ui64>
+        auto mountVolume =
+            [&](TServiceClient& service,
+                const ui64 mountSeqNumber,
+                const ui64 fillSeqNumber,
+                const ui64 fillGeneration,
+                const NProto::EVolumeAccessMode accessMode =
+                    NProto::VOLUME_ACCESS_READ_WRITE) -> std::pair<ui64, ui64>
         {
             auto statResponseBefore = service1.StatVolume(DefaultDiskId);
 
@@ -5269,8 +5271,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 response->GetStatus(),
-                response->GetErrorReason()
-            );
+                response->GetErrorReason());
 
             auto statResponseAfter = service1.StatVolume(DefaultDiskId);
 
@@ -5288,7 +5289,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         ++fillSeqNumber;
@@ -5298,7 +5302,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         {
@@ -5320,7 +5327,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         service1.UnmountVolume(DefaultDiskId);
@@ -5331,7 +5341,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         {
@@ -5346,8 +5359,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 response->GetStatus(),
-                response->GetErrorReason()
-            );
+                response->GetErrorReason());
         }
 
         fillGeneration = 0;
@@ -5358,7 +5370,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         ++mountSeqNumber;
@@ -5368,7 +5383,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         {
@@ -5390,7 +5408,10 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 mountSeqNumber,
                 fillSeqNumber,
                 fillGeneration);
-            UNIT_ASSERT_LE_C(generationBefore + 1, generationAfter, "volume should restart");
+            UNIT_ASSERT_LE_C(
+                generationBefore + 1,
+                generationAfter,
+                "volume should restart");
         }
 
         ++mountSeqNumber;
@@ -5412,9 +5433,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
     {
         TTestEnv env(1, 1);
         auto unmountClientsTimeout = TDuration::Seconds(10);
-        ui32 nodeIdx = SetupTestEnvWithMultipleMount(
-            env,
-            unmountClientsTimeout);
+        ui32 nodeIdx =
+            SetupTestEnvWithMultipleMount(env, unmountClientsTimeout);
 
         auto& runtime = env.GetRuntime();
 
@@ -5428,14 +5448,16 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             service.SendRequest(MakeStorageServiceId(), std::move(request));
 
             auto response = service.RecvCreateVolumeResponse();
-            UNIT_ASSERT_VALUES_EQUAL_C(S_OK, response->GetStatus(), response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetStatus());
         }
 
-        auto mountVolume = [&](
-            const ui64 mountSeqNumber,
-            const ui64 fillSeqNumber,
-            const ui64 fillGeneration,
-            EWellKnownResultCodes expectedResult)
+        auto mountVolume = [&](const ui64 mountSeqNumber,
+                               const ui64 fillSeqNumber,
+                               const ui64 fillGeneration,
+                               EWellKnownResultCodes expectedResult)
         {
             auto statResponseBefore = service.StatVolume(DefaultDiskId);
 
@@ -5456,8 +5478,7 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 expectedResult,
                 response->GetStatus(),
-                response->GetErrorReason()
-            );
+                response->GetErrorReason());
 
             auto statResponseAfter = service.StatVolume(DefaultDiskId);
         };
@@ -5468,11 +5489,19 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_ALREADY);
-        mountVolume(mountSeqNumber, fillSeqNumber - 1, fillGeneration, E_PRECONDITION_FAILED);
+        mountVolume(
+            mountSeqNumber,
+            fillSeqNumber - 1,
+            fillGeneration,
+            E_PRECONDITION_FAILED);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_OK);
         mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration, S_ALREADY);
-        mountVolume(mountSeqNumber, fillSeqNumber, fillGeneration - 1, E_PRECONDITION_FAILED);
+        mountVolume(
+            mountSeqNumber,
+            fillSeqNumber,
+            fillGeneration - 1,
+            E_PRECONDITION_FAILED);
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -203,8 +203,6 @@ private:
 
     void RequestVolumeStop(const TActorContext& ctx);
 
-    void RestartVolume(const TActorContext& ctx);
-
     void NotifyAndDie(const TActorContext& ctx);
 
     void LockVolume(const TActorContext& ctx);
@@ -576,12 +574,6 @@ void TMountRequestActor::RequestVolumeStop(const TActorContext& ctx)
     NCloud::Send(ctx, Params.SessionActorId, std::move(request));
 }
 
-void TMountRequestActor::RestartVolume(const TActorContext& ctx)
-{
-    IsVolumeRestaring = true;
-    RequestVolumeStop(ctx);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void TMountRequestActor::LockVolume(const TActorContext& ctx)
@@ -648,7 +640,8 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
         AddClientRequestCompleted = true;
 
         if (msg->Record.GetForceTabletRestart() && MountMode == NProto::VOLUME_MOUNT_LOCAL) {
-            RestartVolume(ctx);
+            IsVolumeRestaring = true;
+            RequestVolumeStop(ctx);
             return;
         }
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -703,12 +703,6 @@ void TMountRequestActor::HandleWaitReadyResponse(
     const TActorContext& ctx)
 {
     Error = ev->Get()->Record.GetError();
-
-    if (IsVolumeRestaring && SUCCEEDED(Error.GetCode())) {
-        RequestVolumeStart(ctx);
-        return;
-    }
-
     NotifyAndDie(ctx);
 }
 
@@ -799,6 +793,10 @@ void TMountRequestActor::HandleStopVolumeResponse(
     IsTabletAcquired = false;
 
     if (!FAILED(Error.GetCode())) {
+        if (IsVolumeRestaring) {
+            RequestVolumeStart(ctx);
+            return;
+        }
         WaitForVolume(ctx, Config->GetLocalStartAddClientTimeout());
         return;
     }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -180,7 +180,7 @@ private:
 
     bool IsTabletAcquired = false;
     bool VolumeSessionRestartRequired = false;
-    bool IsVolumeRestaring = false;
+    bool IsVolumeRestarting = false;
 
 public:
     TMountRequestActor(
@@ -642,7 +642,7 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
         if (msg->Record.GetForceTabletRestart() &&
             MountMode == NProto::VOLUME_MOUNT_LOCAL)
         {
-            IsVolumeRestaring = true;
+            IsVolumeRestarting = true;
             RequestVolumeStop(ctx);
             return;
         }
@@ -753,7 +753,7 @@ void TMountRequestActor::HandleStartVolumeResponse(
     const auto& error = msg->GetError();
     const auto& mountMode = Request.GetVolumeMountMode();
 
-    IsVolumeRestaring = false;
+    IsVolumeRestarting = false;
 
     if (!AddClientRequestCompleted) {
         Volume = msg->VolumeInfo;
@@ -788,7 +788,7 @@ void TMountRequestActor::HandleStopVolumeResponse(
     IsTabletAcquired = false;
 
     if (!FAILED(Error.GetCode())) {
-        if (IsVolumeRestaring) {
+        if (IsVolumeRestarting) {
             RequestVolumeStart(ctx);
             return;
         }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -639,7 +639,9 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
     if (SUCCEEDED(error.GetCode())) {
         AddClientRequestCompleted = true;
 
-        if (msg->Record.GetForceTabletRestart() && MountMode == NProto::VOLUME_MOUNT_LOCAL) {
+        if (msg->Record.GetForceTabletRestart() &&
+            MountMode == NProto::VOLUME_MOUNT_LOCAL)
+        {
             IsVolumeRestaring = true;
             RequestVolumeStop(ctx);
             return;
@@ -937,7 +939,8 @@ TVolumeSessionActor::TMountRequestProcResult TVolumeSessionActor::ProcessMountRe
 
     if (mountSeqNumber != clientInfo->MountSeqNumber ||
         fillSeqNumber != clientInfo->FillSeqNumber ||
-        fillGeneration != clientInfo->FillGeneration) {
+        fillGeneration != clientInfo->FillGeneration)
+    {
         // If mountSeqNumber, fillSeqNumber or fillGeneration
         // has changed in MountVolumeRequest from client
         // then let volume know about this

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -666,6 +666,11 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
             RequestVolumeStop(ctx);
             return;
         }
+
+        if (msg->Record.GetForceTabletRestart()) {
+            RequestVolumeStop(ctx);
+            return;
+        }
     } else if (VolumeStarted || error.GetCode() == E_BS_MOUNT_CONFLICT) {
         RequestVolumeStop(ctx);
         return;

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -846,9 +846,11 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     const TEvServicePrivate::TEvStartVolumeRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    std::cerr << "HandleStartVolumeRequest" << std::endl;
     const auto& diskId = VolumeInfo->DiskId;
 
     if (!StartVolumeActor) {
+        std::cerr << "HandleStartVolumeRequest: !StartVolumeActor" << std::endl;
         LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
             "Starting volume %s locally",
             diskId.Quote().data());
@@ -870,6 +872,7 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     }
 
     if (VolumeInfo->State == TVolumeInfo::STOPPING) {
+        std::cerr << "HandleStartVolumeRequest: STOPPING" << std::endl;
         auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
             MakeError(E_REJECTED, TStringBuilder()
                 << "Volume " << diskId << " is being stopped"));
@@ -880,6 +883,7 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     }
 
     if (VolumeInfo->State == TVolumeInfo::STARTED) {
+        std::cerr << "HandleStartVolumeRequest: STARTED" << std::endl;
         LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
             "Volume is already started");
         auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
@@ -887,6 +891,7 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }
+    std::cerr << "HandleStartVolumeRequest: HMM" << std::endl;
 }
 
 void TVolumeSessionActor::HandleVolumeTabletStatus(

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -846,11 +846,9 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     const TEvServicePrivate::TEvStartVolumeRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    std::cerr << "HandleStartVolumeRequest" << std::endl;
     const auto& diskId = VolumeInfo->DiskId;
 
     if (!StartVolumeActor) {
-        std::cerr << "HandleStartVolumeRequest: !StartVolumeActor" << std::endl;
         LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
             "Starting volume %s locally",
             diskId.Quote().data());
@@ -872,7 +870,6 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     }
 
     if (VolumeInfo->State == TVolumeInfo::STOPPING) {
-        std::cerr << "HandleStartVolumeRequest: STOPPING" << std::endl;
         auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
             MakeError(E_REJECTED, TStringBuilder()
                 << "Volume " << diskId << " is being stopped"));
@@ -883,7 +880,6 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     }
 
     if (VolumeInfo->State == TVolumeInfo::STARTED) {
-        std::cerr << "HandleStartVolumeRequest: STARTED" << std::endl;
         LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
             "Volume is already started");
         auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
@@ -891,7 +887,6 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }
-    std::cerr << "HandleStartVolumeRequest: HMM" << std::endl;
 }
 
 void TVolumeSessionActor::HandleVolumeTabletStatus(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -365,6 +365,7 @@ void TVolumeActor::ExecuteAddClient(
     TTransactionContext& tx,
     TTxVolume::TAddClient& args)
 {
+    std::cerr << "ExecuteAddClient" << std::endl;
     Y_ABORT_UNLESS(State);
 
     auto now = ctx.Now();
@@ -446,10 +447,18 @@ void TVolumeActor::ExecuteAddClient(
                 State->LogRemoveClient(ctx.Now(), clientId, "Stale", {}));
         }
 
+        std::cerr << "Writing client" << std::endl;
         db.WriteClient(args.Info);
 
-        if (args.Info.GetFillGeneration() > 0 &&
-                IsReadWriteMode(args.Info.GetVolumeAccessMode())) {
+        // TODO:_ we rely on the fact that dm always mounts with positive fill seq no. Is it ok?
+        // TODO:_ can we rely on the fact that 'ordinary' mounts always have zero fill seq no?
+        // If it does not hold, than we will reboot tablet on every 'ordinary' mount.
+        // TODO:_ what if zero fill generations arrive before we finish fill?
+        // And will IsFillFinished update in meta after alter volume?
+        // TODO:_ can be simplified if we don't allow zero fill generation when fill is not finished
+        if (IsReadWriteMode(args.Info.GetVolumeAccessMode()) &&
+                (args.Info.GetFillGeneration() > 0 ||
+                State->GetMeta().GetVolumeConfig().GetIsFillFinished())) {
             State->UpdateFillSeqNumberInMeta(args.Info.GetFillSeqNumber());
             db.WriteMeta(State->GetMeta());
         }
@@ -460,6 +469,8 @@ void TVolumeActor::CompleteAddClient(
     const TActorContext& ctx,
     TTxVolume::TAddClient& args)
 {
+    std::cerr << "CompleteAddClient" << std::endl;
+
     Y_DEFER {
         PendingClientRequests.pop_front();
         ProcessNextPendingClientRequest(ctx);
@@ -485,6 +496,7 @@ void TVolumeActor::CompleteAddClient(
         clientId.Quote().data(),
         diskId.Quote().data());
 
+    std::cerr << "Creating TEvAddClientResponse" << std::endl;
     auto response = std::make_unique<TEvVolume::TEvAddClientResponse>();
     *response->Record.MutableError() = std::move(args.Error);
     response->Record.SetTabletId(TabletID());

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -449,8 +449,9 @@ void TVolumeActor::ExecuteAddClient(
         db.WriteClient(args.Info);
 
         if (IsReadWriteMode(args.Info.GetVolumeAccessMode()) &&
-                (args.Info.GetFillGeneration() > 0 ||
-                State->GetMeta().GetVolumeConfig().GetIsFillFinished())) {
+            (args.Info.GetFillGeneration() > 0 ||
+             State->GetMeta().GetVolumeConfig().GetIsFillFinished()))
+        {
             State->UpdateFillSeqNumberInMeta(args.Info.GetFillSeqNumber());
             db.WriteMeta(State->GetMeta());
         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -365,7 +365,6 @@ void TVolumeActor::ExecuteAddClient(
     TTransactionContext& tx,
     TTxVolume::TAddClient& args)
 {
-    std::cerr << "ExecuteAddClient" << std::endl;
     Y_ABORT_UNLESS(State);
 
     auto now = ctx.Now();
@@ -447,15 +446,8 @@ void TVolumeActor::ExecuteAddClient(
                 State->LogRemoveClient(ctx.Now(), clientId, "Stale", {}));
         }
 
-        std::cerr << "Writing client" << std::endl;
         db.WriteClient(args.Info);
 
-        // TODO:_ we rely on the fact that dm always mounts with positive fill seq no. Is it ok?
-        // TODO:_ can we rely on the fact that 'ordinary' mounts always have zero fill seq no?
-        // If it does not hold, than we will reboot tablet on every 'ordinary' mount.
-        // TODO:_ what if zero fill generations arrive before we finish fill?
-        // And will IsFillFinished update in meta after alter volume?
-        // TODO:_ can be simplified if we don't allow zero fill generation when fill is not finished
         if (IsReadWriteMode(args.Info.GetVolumeAccessMode()) &&
                 (args.Info.GetFillGeneration() > 0 ||
                 State->GetMeta().GetVolumeConfig().GetIsFillFinished())) {
@@ -469,8 +461,6 @@ void TVolumeActor::CompleteAddClient(
     const TActorContext& ctx,
     TTxVolume::TAddClient& args)
 {
-    std::cerr << "CompleteAddClient" << std::endl;
-
     Y_DEFER {
         PendingClientRequests.pop_front();
         ProcessNextPendingClientRequest(ctx);
@@ -496,7 +486,6 @@ void TVolumeActor::CompleteAddClient(
         clientId.Quote().data(),
         diskId.Quote().data());
 
-    std::cerr << "Creating TEvAddClientResponse" << std::endl;
     auto response = std::make_unique<TEvVolume::TEvAddClientResponse>();
     *response->Record.MutableError() = std::move(args.Error);
     response->Record.SetTabletId(TabletID());

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -386,6 +386,7 @@ void TVolumeActor::ExecuteAddClient(
         args.RequestInfo->Sender,
         now);
     args.Error = std::move(res.Error);
+    args.ForceTabletRestart = res.ForceTabletRestart;
 
     TVolumeDatabase db(tx.DB);
     db.WriteHistory(
@@ -488,6 +489,7 @@ void TVolumeActor::CompleteAddClient(
     *response->Record.MutableError() = std::move(args.Error);
     response->Record.SetTabletId(TabletID());
     response->Record.SetClientId(clientId);
+    response->Record.SetForceTabletRestart(args.ForceTabletRestart);
 
     auto& volumeConfig = State->GetMeta().GetVolumeConfig();
     auto* volumeInfo = response->Record.MutableVolume();

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -493,6 +493,8 @@ TVolumeState::TAddClientResult TVolumeState::AddClient(
     }
 
     if (readWriteAccess) {
+        res.ForceTabletRestart = clientId != ReadWriteAccessClientId ||
+            ShouldForceTabletRestart(info);
         ReadWriteAccessClientId = clientId;
         MountSeqNumber = info.GetMountSeqNumber();
     }
@@ -760,6 +762,14 @@ bool TVolumeState::CanAcceptClient(
     }
 
     return newFillSeqNumber >= Meta.GetFillSeqNumber();
+}
+
+bool TVolumeState::ShouldForceTabletRestart(
+    const NProto::TVolumeClientInfo& info)
+{
+    return info.GetMountSeqNumber() != MountSeqNumber ||
+        info.GetFillSeqNumber() != Meta.GetFillSeqNumber() ||
+        info.GetFillGeneration() != Meta.GetVolumeConfig().GetFillGeneration();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -765,7 +765,7 @@ bool TVolumeState::CanAcceptClient(
 }
 
 bool TVolumeState::ShouldForceTabletRestart(
-    const NProto::TVolumeClientInfo& info)
+    const NProto::TVolumeClientInfo& info) const
 {
     return info.GetMountSeqNumber() != MountSeqNumber ||
         info.GetFillSeqNumber() != Meta.GetFillSeqNumber();

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -433,14 +433,6 @@ TVolumeState::TAddClientResult TVolumeState::AddClient(
 
     TAddClientResult res;
 
-    std::cerr << "cliend it: " << clientId
-        << ", new FillSeqNumber: " << info.GetFillSeqNumber()
-        << ", current FillSeqNumber: " << Meta.GetFillSeqNumber()
-        << ", proposed FillGeneration: " << info.GetFillGeneration()
-        << ", actual FillGeneration: " << Meta.GetVolumeConfig().GetFillGeneration()
-        << ", is disk filling finished: " << Meta.GetVolumeConfig().GetIsFillFinished()
-        << std::endl;
-
     if (!clientId) {
         res.Error = MakeError(E_ARGUMENT, "ClientId not specified");
         return res;
@@ -745,11 +737,6 @@ bool TVolumeState::CanPreemptClient(
     TInstant referenceTimestamp,
     ui64 newClientMountSeqNumber)
 {
-    std::cerr << "CanPreemptClient" << std::endl;
-    std::cerr << "IsClientStale: " << IsClientStale(oldClientId, referenceTimestamp)
-              << ", newClientMountSeqNumber: " << newClientMountSeqNumber
-              << ", MountSeqNumber: " << MountSeqNumber << std::endl;
-    // TODO:_ why || here?
     return
         IsClientStale(oldClientId, referenceTimestamp) ||
             newClientMountSeqNumber > MountSeqNumber;
@@ -777,7 +764,6 @@ bool TVolumeState::CanAcceptClient(
     return newFillSeqNumber >= Meta.GetFillSeqNumber();
 }
 
-// TODO:_ better naming or check client id here?
 bool TVolumeState::ShouldForceTabletRestart(
     const NProto::TVolumeClientInfo& info)
 {

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -433,6 +433,14 @@ TVolumeState::TAddClientResult TVolumeState::AddClient(
 
     TAddClientResult res;
 
+    std::cerr << "cliend it: " << clientId
+        << ", new FillSeqNumber: " << info.GetFillSeqNumber()
+        << ", current FillSeqNumber: " << Meta.GetFillSeqNumber()
+        << ", proposed FillGeneration: " << info.GetFillGeneration()
+        << ", actual FillGeneration: " << Meta.GetVolumeConfig().GetFillGeneration()
+        << ", is disk filling finished: " << Meta.GetVolumeConfig().GetIsFillFinished()
+        << std::endl;
+
     if (!clientId) {
         res.Error = MakeError(E_ARGUMENT, "ClientId not specified");
         return res;
@@ -737,6 +745,11 @@ bool TVolumeState::CanPreemptClient(
     TInstant referenceTimestamp,
     ui64 newClientMountSeqNumber)
 {
+    std::cerr << "CanPreemptClient" << std::endl;
+    std::cerr << "IsClientStale: " << IsClientStale(oldClientId, referenceTimestamp)
+              << ", newClientMountSeqNumber: " << newClientMountSeqNumber
+              << ", MountSeqNumber: " << MountSeqNumber << std::endl;
+    // TODO:_ why || here?
     return
         IsClientStale(oldClientId, referenceTimestamp) ||
             newClientMountSeqNumber > MountSeqNumber;
@@ -764,12 +777,12 @@ bool TVolumeState::CanAcceptClient(
     return newFillSeqNumber >= Meta.GetFillSeqNumber();
 }
 
+// TODO:_ better naming or check client id here?
 bool TVolumeState::ShouldForceTabletRestart(
     const NProto::TVolumeClientInfo& info)
 {
     return info.GetMountSeqNumber() != MountSeqNumber ||
-        info.GetFillSeqNumber() != Meta.GetFillSeqNumber() ||
-        info.GetFillGeneration() != Meta.GetVolumeConfig().GetFillGeneration();
+        info.GetFillSeqNumber() != Meta.GetFillSeqNumber();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -494,7 +494,7 @@ TVolumeState::TAddClientResult TVolumeState::AddClient(
 
     if (readWriteAccess) {
         res.ForceTabletRestart = clientId != ReadWriteAccessClientId ||
-            ShouldForceTabletRestart(info);
+                                 ShouldForceTabletRestart(info);
         ReadWriteAccessClientId = clientId;
         MountSeqNumber = info.GetMountSeqNumber();
     }
@@ -768,7 +768,7 @@ bool TVolumeState::ShouldForceTabletRestart(
     const NProto::TVolumeClientInfo& info) const
 {
     return info.GetMountSeqNumber() != MountSeqNumber ||
-        info.GetFillSeqNumber() != Meta.GetFillSeqNumber();
+           info.GetFillSeqNumber() != Meta.GetFillSeqNumber();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -653,7 +653,7 @@ private:
         ui64 newFillSeqNumber,
         ui64 proposedFillGeneration);
 
-    bool ShouldForceTabletRestart(const NProto::TVolumeClientInfo& info);
+    bool ShouldForceTabletRestart(const NProto::TVolumeClientInfo& info) const;
 
     THistoryLogKey AllocateHistoryLogKey(TInstant timestamp);
 

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -412,6 +412,7 @@ public:
     {
         NProto::TError Error;
         TVector<TString> RemovedClientIds;
+        bool ForceTabletRestart = false;
 
         TAddClientResult() = default;
 
@@ -651,6 +652,8 @@ private:
     bool CanAcceptClient(
         ui64 newFillSeqNumber,
         ui64 proposedFillGeneration);
+
+    bool ShouldForceTabletRestart(const NProto::TVolumeClientInfo& info);
 
     THistoryLogKey AllocateHistoryLogKey(TInstant timestamp);
 

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -232,6 +232,7 @@ struct TTxVolume
         TInstant WriterLastActivityTimestamp;
         bool WriterChanged = false;
         NProto::TError Error;
+        bool ForceTabletRestart = false;
 
         TAddClient(
                 TRequestInfoPtr requestInfo,
@@ -249,6 +250,7 @@ struct TTxVolume
             WriterLastActivityTimestamp = {};
             WriterChanged = false;
             Error.Clear();
+            ForceTabletRestart = false;
         }
     };
 


### PR DESCRIPTION
Restart volume tablet on local read-write mount if one of the following is true:
- client id changed
- mount seq number changed
- fill generation changed

Also add check of fillSeqNumber and fillGeneration in TVolumeSessionActor::ProcessMountRequest [here](https://github.com/ydb-platform/nbs/pull/797/files#diff-d4a5c28978ff23eec206ee6f023ceafccf0fc03ad05913c7af03974f2babaff7R947)