### PR TITLE
NBS-4827 fix clientId usage for shadow disk

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
@@ -118,7 +118,7 @@ TResultOrError<bool> TDeviceClient::AcquireDevices(
                     > now)
         {
             return MakeError(E_BS_INVALID_SESSION, TStringBuilder()
-                << "Error acquire device " << uuid.Quote()
+                << "Error acquiring device " << uuid.Quote()
                 << " with client " << clientId.Quote()
                 << " already acquired by another client: "
                 << deviceState->WriterSession.Id.Quote());

--- a/cloud/blockstore/libs/storage/disk_agent/model/public.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/public.h
@@ -17,5 +17,6 @@ using TDiskAgentConfigPtr = std::shared_ptr<TDiskAgentConfig>;
 constexpr TStringBuf BackgroundOpsClientId = "migration";
 constexpr TStringBuf CheckHealthClientId = "check-health";
 constexpr TStringBuf AnyWriterClientId = "any-writer";
+constexpr TStringBuf ShadowDiskClientId = "shadow-disk-client";
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
+++ b/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry.h>
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h>
 
 #include <contrib/ydb/core/mind/local.h>
@@ -387,7 +388,9 @@ private:
             response->Record.MutableError()->CopyFrom(
                 MakeError(E_NOT_FOUND, "disk not found")
             );
-        } else if (clientId == disk->WriterClientId) {
+        } else if (
+            clientId == disk->WriterClientId || clientId == AnyWriterClientId)
+        {
             disk->WriterClientId = "";
         } else {
             auto it = Find(

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -229,12 +229,15 @@ void TAcquireShadowDiskActor::ReleaseShadowDisk(
     const NActors::TActorContext& ctx,
     bool retry)
 {
-    LOG_INFO_S(
-        ctx,
-        TBlockStoreComponents::VOLUME,
-        "Releasing shadow disk " << ShadowDiskId.Quote()
-                                 << (retry ? " (retry after undelivery)" : ""));
-
+    if (AcquireReason != TShadowDiskActor::EAcquireReason::PeriodicalReAcquire)
+    {
+        LOG_INFO_S(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "Releasing shadow disk "
+                << ShadowDiskId.Quote()
+                << (retry ? " (retry after undelivery)" : ""));
+    }
     SendRequestToDiskRegistry(ctx, MakeReleaseDiskRequest(), retry);
 }
 

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -17,6 +17,15 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Which clientId is trying to release the shadow disk.
+enum class EReleaseAttempt : ui64
+{
+    WithExpectedClientId,
+    ForceWithAnyClientId,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 TString
 MakeShadowDiskClientId(const TString& sourceDiskClientId, bool readOnlyMount)
 {
@@ -103,7 +112,7 @@ private:
 
 public:
     TAcquireShadowDiskActor(
-        const TStorageConfigPtr config,
+        const TStorageConfigPtr& config,
         TString shadowDiskId,
         const TDevices& shadowDiskDevices,
         TShadowDiskActor::EAcquireReason acquireReason,
@@ -118,7 +127,9 @@ public:
     void Bootstrap(const TActorContext& ctx);
 
 private:
-    void ReleaseShadowDisk(const NActors::TActorContext& ctx);
+    void ReleaseShadowDisk(
+        const NActors::TActorContext& ctx,
+        EReleaseAttempt releaseAttempt);
     void DescribeShadowDisk(const NActors::TActorContext& ctx);
     void AcquireShadowDisk(const NActors::TActorContext& ctx);
 
@@ -129,7 +140,7 @@ private:
     MakeAcquireDiskRequest() const;
 
     std::unique_ptr<TEvDiskRegistry::TEvReleaseDiskRequest>
-    MakeReleaseDiskRequest() const;
+    MakeReleaseDiskRequest(bool force) const;
 
     void HandleDiskRegistryError(
         const NActors::TActorContext& ctx,
@@ -175,7 +186,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////////
 
 TAcquireShadowDiskActor::TAcquireShadowDiskActor(
-        const TStorageConfigPtr config,
+        const TStorageConfigPtr& config,
         TString shadowDiskId,
         const TDevices& shadowDiskDevices,
         TShadowDiskActor::EAcquireReason acquireReason,
@@ -216,7 +227,7 @@ void TAcquireShadowDiskActor::Bootstrap(const TActorContext& ctx)
 {
     Become(&TThis::Work);
 
-    ReleaseShadowDisk(ctx);
+    ReleaseShadowDisk(ctx, EReleaseAttempt::WithExpectedClientId);
     DescribeShadowDisk(ctx);
     AcquireShadowDisk(ctx);
 
@@ -225,7 +236,7 @@ void TAcquireShadowDiskActor::Bootstrap(const TActorContext& ctx)
 }
 
 void TAcquireShadowDiskActor::ReleaseShadowDisk(
-    const NActors::TActorContext& ctx)
+    const NActors::TActorContext& ctx, EReleaseAttempt releaseAttempt)
 {
     if (!OldRwClientId || OldRwClientId == RwClientId) {
         WaitingForDiskToBeReleased = false;
@@ -234,15 +245,20 @@ void TAcquireShadowDiskActor::ReleaseShadowDisk(
     LOG_INFO_S(
         ctx,
         TBlockStoreComponents::VOLUME,
-        "Releasing shadow disk " << ShadowDiskId.Quote()
-                                 << " from old clientId "
-                                 << OldRwClientId.Quote());
+        "Releasing shadow disk "
+            << ShadowDiskId.Quote() << " from old clientId "
+            << OldRwClientId.Quote() << " use client id "
+            << (releaseAttempt == EReleaseAttempt::WithExpectedClientId
+                    ? "Expected"
+                    : "Any"));
 
     WaitingForDiskToBeReleased = true;
     NCloud::SendWithUndeliveryTracking(
         ctx,
         MakeDiskRegistryProxyServiceId(),
-        MakeReleaseDiskRequest());
+        MakeReleaseDiskRequest(
+            releaseAttempt == EReleaseAttempt::ForceWithAnyClientId),
+        static_cast<ui64>(releaseAttempt));
 }
 
 void TAcquireShadowDiskActor::DescribeShadowDisk(
@@ -310,12 +326,13 @@ TAcquireShadowDiskActor::MakeAcquireDiskRequest() const
 }
 
 std::unique_ptr<TEvDiskRegistry::TEvReleaseDiskRequest>
-TAcquireShadowDiskActor::MakeReleaseDiskRequest() const
+TAcquireShadowDiskActor::MakeReleaseDiskRequest(bool force) const
 {
     auto request = std::make_unique<TEvDiskRegistry::TEvReleaseDiskRequest>();
 
     request->Record.SetDiskId(ShadowDiskId);
-    request->Record.MutableHeaders()->SetClientId(OldRwClientId);
+    request->Record.MutableHeaders()->SetClientId(
+        force ? TString(AnyWriterClientId) : OldRwClientId);
     request->Record.SetVolumeGeneration(Generation);
     return request;
 }
@@ -462,13 +479,22 @@ void TAcquireShadowDiskActor::HandleReleaseDiskResponse(
 {
     auto* msg = ev->Get();
     auto& record = msg->Record;
+    auto releaseAttempt = static_cast<EReleaseAttempt>(ev->Cookie);
 
     if (HasError(record.GetError())) {
         LOG_WARN_S(
             ctx,
             TBlockStoreComponents::VOLUME,
             "Shadow disk " << ShadowDiskId.Quote() << " release error: "
-                           << FormatError(record.GetError()));
+                           << FormatError(record.GetError())
+                           << (releaseAttempt ==
+                                       EReleaseAttempt::WithExpectedClientId
+                                   ? ", will retry soon"
+                                   : ", will not retry"));
+        if (releaseAttempt == EReleaseAttempt::WithExpectedClientId) {
+            ReleaseShadowDisk(ctx, EReleaseAttempt::ForceWithAnyClientId);
+            return;
+        }
     }
 
     WaitingForDiskToBeReleased = false;
@@ -496,7 +522,7 @@ void TAcquireShadowDiskActor::HandleReleaseDiskRequestUndelivery(
     const NActors::TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReleaseShadowDisk(ctx);
+    ReleaseShadowDisk(ctx, static_cast<EReleaseAttempt>(ev->Cookie));
 }
 
 void TAcquireShadowDiskActor::HandleWakeup(

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -93,7 +93,9 @@ private:
     const NActors::TActorId SrcActorId;
 
     TString SourceDiskClientId;
-    TString OldSourceDiskClientId;
+    // We update CurrentShadowDiskClientId when get response from
+    // TAcquireShadowDiskActor with confirmation that we have successfully
+    // acquired shadow disk.
     TString CurrentShadowDiskClientId;
     TNonreplicatedPartitionConfigPtr DstConfig;
     NActors::TActorId DstActorId;

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -86,13 +86,15 @@ private:
     const NRdma::IClientPtr RdmaClient;
     const TNonreplicatedPartitionConfigPtr SrcConfig;
     const TString CheckpointId;
-    const TString SourceDiskId;
     const TString ShadowDiskId;
     const ui64 MountSeqNumber = 0;
     const ui32 Generation = 0;
     const NActors::TActorId VolumeActorId;
     const NActors::TActorId SrcActorId;
 
+    TString SourceDiskClientId;
+    TString OldSourceDiskClientId;
+    TString CurrentShadowDiskClientId;
     TNonreplicatedPartitionConfigPtr DstConfig;
     NActors::TActorId DstActorId;
     ui64 ProcessedBlockCount = 0;
@@ -112,7 +114,7 @@ public:
         NRdma::IClientPtr rdmaClient,
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr digestGenerator,
-        TString rwClientId,
+        TString sourceDiskClientId,
         ui64 mountSeqNumber,
         ui32 generation,
         TNonreplicatedPartitionConfigPtr srcConfig,
@@ -138,8 +140,8 @@ private:
     void AcquireShadowDisk(
         const NActors::TActorContext& ctx,
         EAcquireReason acquireReason);
-    void HandleAcquireDiskResponse(
-        const TEvDiskRegistry::TEvAcquireDiskResponse::TPtr& ev,
+    void HandleShadowDiskAcquired(
+        const TEvVolumePrivate::TEvShadowDiskAcquired::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void CreateShadowDiskConfig();
@@ -185,7 +187,7 @@ private:
         const NActors::TActorContext& ctx);
 
     template <typename TMethod>
-    bool HandleWriteZeroBlocks(
+    [[nodiscard]] bool HandleWriteZeroBlocks(
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
@@ -211,6 +213,10 @@ private:
 
     void HandleReacquireDisk(
         const TEvVolume::TEvReacquireDisk::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    [[nodiscard]] bool HandleRWClientIdChanged(
+        const TEvVolume::TEvRWClientIdChanged::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -266,6 +266,7 @@ NActors::TActorId TVolumeActor::WrapNonreplActorIfNeeded(
     {
         if (checkpointInfo.Data == ECheckpointData::DataDeleted ||
             checkpointInfo.ShadowDiskId.Empty() ||
+            checkpointInfo.ShadowDiskState == EShadowDiskState::Error ||
             State->GetCheckpointStore().HasShadowActor(checkpointId))
         {
             continue;

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -215,6 +215,24 @@ struct TEvVolumePrivate
     };
 
     //
+    // ShadowDiskAcquired
+    //
+
+    struct TShadowDiskAcquired
+    {
+        using TDevices =
+            google::protobuf::RepeatedPtrField<NProto::TDeviceConfig>;
+
+        NProto::TError Error;
+        TString ClientId;
+        TDevices Devices;
+
+        explicit TShadowDiskAcquired(NProto::TError error)
+            : Error(std::move(error))
+        {}
+    };
+
+    //
     //  UpdateShadowDiskStateRequest
     //
 
@@ -280,6 +298,7 @@ struct TEvVolumePrivate
         EvWriteOrZeroCompleted,
         EvUpdateReadWriteClientInfo,
         EvRemoveExpiredVolumeParams,
+        EvShadowDiskAcquired,
 
         EvEnd
     };
@@ -336,6 +355,11 @@ struct TEvVolumePrivate
     using TEvRemoveExpiredVolumeParams = TRequestEvent<
         TRemoveExpiredVolumeParams,
         EvRemoveExpiredVolumeParams
+    >;
+
+    using TEvShadowDiskAcquired = TRequestEvent<
+        TShadowDiskAcquired,
+        EvShadowDiskAcquired
     >;
 };
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -4083,7 +4083,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
 
         // Expect that the shadow disk was acquired by "shadow-disk-client".
         UNIT_ASSERT_VALUES_EQUAL(ShadowDiskClientId, acquireClientId);
-        UNIT_ASSERT_VALUES_EQUAL("", releaseClientId);
+        UNIT_ASSERT_VALUES_EQUAL(AnyWriterClientId, releaseClientId);
         acquireClientId = "";
         releaseClientId = "";
 


### PR DESCRIPTION
Столкнулся с проблемой создания теневого диска на боевом кластере из-за проверки clientId на строне диска-агентов.
Как сейчас работает:
1. во время наливки теневого диска он может захватываться либо клиентом который пишет на основной диск, либо "shadow-disk-client".
2. после наливки теневого диска он уже перемеонтируется "shadow-disk-client" навсегда
3. если в процессе наливки приходят-уходят клиенты, каждый раз происходит перемотирование.
4. после наливки - изменения клиента основного диска уже игнорируются
5. если происходит ошибка освобождения диска клиентом, которым последний раз захватили диск - делаем вторую попытку освобождения клиентом "any-writer", и не смотря на ее результат делаем попытку захвата диска.

Был вариант использовать клиента "migration", но он не требует захвата диска и выглядит как костыль.

Почему это не работало до исправления.
1. Сценарий когда клиента у диска источника нет: наливка читает с диска-источника клиентом "migration", это разрешается потому что это фоновый (background) запрос, и пытается писать на теневой диск клиентом "migration". Тут запись обламывается, потому что диска назначения захвачен на запись клиентом shadow-disk-client
2. Сценарий когда клиент у диска источника есть: наливка читает с диска-источника клиентом "migration", это разрешается потому что это фоновый (background) запрос, и пытается писать на теневой диск клиентом диска-источника. Тут запись обламывается, потому что диска назначения захвачен на запись клиентом shadow-client-id.

Сейчас учитывается оба сценария, и то что диск-источник может примонтироваться/отмонитроваться в процессе создания чекпоинта. 
Итого: если клиент есть - то теневой диск захватывается им же, чтобы записи, которые идут на диск источник, могли зеркалироваться и на теневой диск. А когда клиента нет, то мы захватываем теневой диск клиентом shadow-disk-client, потому-что нужно это сделать хоть каким-то клиентом.
