### PR TITLE
Remove redundant code that sends unauthorized request to sandbox proxy

### DIFF
--- a/cloud/filestore/tests/build_arcadia_test/__main__.py
+++ b/cloud/filestore/tests/build_arcadia_test/__main__.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from cloud.blockstore.pylibs import common
 from cloud.filestore.tests.build_arcadia_test.coreutils import \
     execute_coreutils_test
@@ -9,7 +7,7 @@ from .entrypoint import main
 if __name__ == '__main__':
     main(
         {
-            'nfs-coreutils': partial(execute_coreutils_test, clone_original_repo=True),
+            'nfs-coreutils': execute_coreutils_test,
         },
         common.ModuleFactories(
             common.make_test_result_processor_stub,

--- a/cloud/filestore/tests/build_arcadia_test/scripts/coreutils.sh
+++ b/cloud/filestore/tests/build_arcadia_test/scripts/coreutils.sh
@@ -4,21 +4,10 @@ sudo apt update
 sudo apt -y install python3 python-is-python3 git build-essential autoconf automake autopoint bison gperf libtool texinfo wget
 cd $mountPath
 
-if [ "$cloneOriginalRepo" == true ]; then
-    # If cloneOriginalRepo is set to true, fetch stable version from original repo
-    git clone --depth=1 --branch v9.3 --single-branch https://git.savannah.gnu.org/git/coreutils.git
-    cd coreutils
-    ./bootstrap
-else
-    # If cloneOriginalRepo is set to false, fetch uploaded version to sanbox (for isolation and reproducibility purposes)
+git clone --depth=1 --branch v9.3 --single-branch https://git.savannah.gnu.org/git/coreutils.git
+cd coreutils
+./bootstrap
 
-    # Download latest published resource with matching attribute
-    wget 'https://link/to/nbs_coreutils.tar' -O arch.tar
-    tar xvf arch.tar
-    cd coreutils
-    git config --global --add safe.directory $$(pwd)
-    sh -x bootstrap --no-git --gnulib-srcdir=../gnulib
-fi
 # Allow root user too run ./configure
 export FORCE_UNSAFE_CONFIGURE=1
 ./configure


### PR DESCRIPTION
Remove unused "else" branch in test that builds coreutils.

Code on this branch was sending anonymous requests to sandbox proxy, which soon will be prohibited.