### PR TITLE
NBSNEBIUS-199: remove kubelet's lock from nbd device

### DIFF
--- a/cloud/blockstore/libs/nbd/ut/ya.make
+++ b/cloud/blockstore/libs/nbd/ut/ya.make
@@ -6,6 +6,7 @@ SRCS(
     client_handler_ut.cpp
     server_handler_ut.cpp
     server_ut.cpp
+    utils_ut.cpp
 )
 
 PEERDIR(

--- a/cloud/blockstore/libs/nbd/utils.cpp
+++ b/cloud/blockstore/libs/nbd/utils.cpp
@@ -1,8 +1,32 @@
 #include "utils.h"
 
+#include <util/generic/set.h>
 #include <util/stream/str.h>
+#include <util/stream/file.h>
+#include <util/string/split.h>
+#include <util/string/strip.h>
+#include <util/system/fs.h>
+
+#include <filesystem>
 
 namespace NCloud::NBlockStore::NBD {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString CleanBackingFilePath(TString path)
+{
+    // If the block device was deleted, the path will contain a "(deleted)" suffix
+    static const TString suffix = "(deleted)";
+    path = Strip(path);
+    if (path.EndsWith(suffix)) {
+        path = path.substr(0, path.length() - suffix.length());
+    }
+    return Strip(path);
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -39,6 +63,87 @@ TString PrintHostAndPort(const TNetworkAddress& addr)
         out << " ";
     }
     return out.Str();
+}
+
+TSet<TString> FindMountedFiles(
+    const TString& device,
+    const TString& mountInfoFile)
+{
+    static constexpr int deviceNameColumn = 3;
+    static constexpr int mountedFileColumn = 4;
+    static constexpr int correctColumnCount = 11;
+
+    if (!device.StartsWith("/dev/")) {
+        return {};
+    }
+
+    auto deviceName = device.substr(4);
+    TSet<TString> mountedFiles;
+    mountedFiles.insert(device);
+
+    if (!NFs::Exists(mountInfoFile)) {
+        return mountedFiles;
+    }
+
+    TIFStream is(mountInfoFile);
+    TString line;
+    while (is.ReadLine(line)) {
+        TVector<TString> items;
+        auto columnCount = Split(line, " ", items);
+        if (columnCount != correctColumnCount) {
+            continue;
+        }
+
+        if (items[deviceNameColumn] == deviceName) {
+            mountedFiles.insert(items[mountedFileColumn]);
+        }
+    }
+
+    return mountedFiles;
+}
+
+TVector<TString> FindLoopbackDevices(
+    const TSet<TString>& mountedFiles,
+    const TString& sysBlockDir)
+{
+    TVector<TString> loopbackDevices;
+
+    auto sysBlockItems = std::filesystem::directory_iterator{
+        sysBlockDir.c_str()};
+
+    for (const auto& entry: sysBlockItems) {
+        if (!entry.is_directory()) {
+            continue;
+        }
+
+        TString loopPath = entry.path().string();
+        if (!loopPath.StartsWith(sysBlockDir + "loop")) {
+            continue;
+        }
+
+        auto backingFile = loopPath + "/loop/backing_file";
+        if (!NFs::Exists(backingFile)) {
+            continue;
+        }
+
+        TFileInput in(backingFile);
+        auto data = in.ReadAll();
+        auto backingFilePath = CleanBackingFilePath(data);
+        if (!mountedFiles.contains(backingFilePath)) {
+            continue;
+        }
+
+        auto loopDevice = "/dev/" + TFsPath(loopPath).GetName();
+        loopbackDevices.push_back(loopDevice);
+    }
+
+    return loopbackDevices;
+}
+
+int RemoveLoopbackDevice(const TString& loopDevice)
+{
+    TString cmd = "losetup -d " + loopDevice;
+    return std::system(cmd.c_str());
 }
 
 }   // namespace NCloud::NBlockStore::NBD

--- a/cloud/blockstore/libs/nbd/utils.h
+++ b/cloud/blockstore/libs/nbd/utils.h
@@ -33,4 +33,14 @@ bool IsUnixAddress(const TNetworkAddress& addr);
 
 TString PrintHostAndPort(const TNetworkAddress& addr);
 
+TSet<TString> FindMountedFiles(
+    const TString& device,
+    const TString& mountInfoFile = "/proc/self/mountinfo");
+
+TVector<TString> FindLoopbackDevices(
+    const TSet<TString>& mountedFiles,
+    const TString& sysBlockDir = "/sys/block/");
+
+int RemoveLoopbackDevice(const TString& loopDevice);
+
 }   // namespace NCloud::NBlockStore::NBD

--- a/cloud/blockstore/libs/nbd/utils_ut.cpp
+++ b/cloud/blockstore/libs/nbd/utils_ut.cpp
@@ -1,0 +1,121 @@
+#include "utils.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+
+#include <util/folder/tempdir.h>
+#include <util/stream/file.h>
+
+namespace NCloud::NBlockStore::NBD {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TUtilsTest)
+{
+    Y_UNIT_TEST(ShouldFindMountedFiles)
+    {
+        auto mountInfoStr = R"(
+            356 355 0:49 / /proc rw,nosuid,nodev,noexec,relatime shared:146 - proc proc rw
+            357 355 0:50 / /dev rw,nosuid shared:147 - tmpfs tmpfs rw,size=65536k,mode=755,inode64
+            358 357 0:51 / /dev/pts rw,nosuid,noexec,relatime shared:155 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+            359 355 0:52 / /sys ro,nosuid,nodev,noexec,relatime shared:176 - sysfs sysfs ro
+            360 359 0:29 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:203 - cgroup2 cgroup rw,nsdelegate,memory_recursiveprot
+            361 357 0:48 / /dev/mqueue rw,nosuid,nodev,noexec,relatime shared:158 - mqueue mqueue rw
+            362 357 0:53 / /dev/shm rw,nosuid,nodev,noexec,relatime shared:172 - tmpfs shm rw,size=65536k,inode64
+            363 355 252:2 /var/lib/docker/volumes/minikube/_data /var rw,relatime shared:205 master:1 - ext4 /dev/vda2 rw
+            364 355 0:54 / /run rw,nosuid,nodev,noexec,relatime shared:206 - tmpfs tmpfs rw,inode64
+            366 355 0:56 / /tmp rw,nosuid,nodev,noexec,relatime shared:207 - tmpfs tmpfs rw,inode64
+            368 355 252:2 /usr/lib/modules /usr/lib/modules ro,relatime shared:234 - ext4 /dev/vda2 rw
+            173 357 0:51 /0 /dev/console rw,nosuid,noexec,relatime shared:175 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+            200 364 0:57 / /run/lock rw,nosuid,nodev,noexec,relatime shared:282 - tmpfs tmpfs rw,size=5120k,inode64
+            211 357 0:59 / /dev/hugepages rw,relatime shared:284 - hugetlbfs hugetlbfs rw,pagesize=2M
+            224 359 0:7 / /sys/kernel/debug rw,nosuid,nodev,noexec,relatime shared:285 - debugfs debugfs rw
+            227 359 0:12 / /sys/kernel/tracing rw,nosuid,nodev,noexec,relatime shared:288 - tracefs tracefs rw
+            228 359 0:34 / /sys/fs/fuse/connections rw,nosuid,nodev,noexec,relatime shared:289 - fusectl fusectl rw
+            511 364 0:60 / /run/credentials/systemd-sysusers.service ro,nosuid,nodev,noexec,relatime shared:290 - ramfs none rw,mode=700
+            229 209 0:36 / /proc/sys/fs/binfmt_misc rw,nosuid,nodev,noexec,relatime shared:291 - binfmt_misc binfmt_misc rw
+            236 355 252:2 /var/lib/docker/volumes/minikube/_data/data /data rw,relatime shared:205 master:1 - ext4 /dev/vda2 rw
+            244 366 252:2 /var/lib/docker/volumes/minikube/_data/hostpath_pv /tmp/hostpath_pv rw,relatime shared:205 master:1 - ext4 /dev/vda2 rw
+            252 366 252:2 /var/lib/docker/volumes/minikube/_data/hostpath-provisioner /tmp/hostpath-provisioner rw,relatime shared:205 master:1 - ext4 /dev/vda2 rw
+            272 364 0:4 net:[4026533085] /run/docker/netns/default rw shared:293 - nsfs nsfs rw
+            854 364 0:4 net:[4026533185] /run/docker/netns/d8ef02b88399 rw shared:316 - nsfs nsfs rw
+            959 363 0:182 / /var/lib/docker/containers/blabla1/mounts/shm rw,nosuid,nodev,noexec,relatime shared:321 - tmpfs shm rw,size=65536k,inode64
+            932 363 0:180 / /var/lib/docker/containers/blabla2/mounts/shm rw,nosuid,nodev,noexec,relatime shared:322 - tmpfs shm rw,size=65536k,inode64
+            826 363 0:139 / /var/lib/kubelet/pods/5f8a1a7e-d9f0-48be-97d3-8d655855d5fc/volumes/kubernetes.io~projected/kube-api-access-mgmsb rw,relatime shared:308 - tmpfs tmpfs rw,size=393216k,inode64
+            831 363 0:143 / /var/lib/kubelet/pods/05108687-5f0d-42c7-890d-bd2dd69d6466/volumes/kubernetes.io~projected/kube-api-access-lz87t rw,relatime shared:309 - tmpfs tmpfs rw,size=262144k,inode64
+            847 363 0:144 / /var/lib/docker/containers/blabla3/mounts/shm rw,nosuid,nodev,noexec,relatime shared:312 - tmpfs shm rw,size=65536k,inode64
+            869 363 0:163 / /var/lib/docker/containers/blabla4/mounts/shm rw,nosuid,nodev,noexec,relatime shared:323 - tmpfs shm rw,size=65536k,inode64
+            894 363 0:177 / /var/lib/kubelet/pods/blabla5/volumes/kubernetes.io~projected/kube-api-access-wf5ls rw,relatime shared:317 - tmpfs tmpfs rw,size=165029212k,inode64
+            1008 363 0:243 /nbd1 /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-blabla6/blabla5 rw,nosuid shared:335 - tmpfs tmpfs rw,size=65536k,mode=755,inode64
+            1009 363 0:243 /nbd1 /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/pvc-blabla6/dev/blabla5 rw shared:335 - tmpfs tmpfs rw,size=65536k,mode=755,inode64
+            1015 363 0:253 / /var/lib/docker/containers/blabla7/mounts/shm rw,nosuid,nodev,noexec,relatime shared:337 - tmpfs shm rw,size=65536k,inode64
+            1428 364 0:4 net:[4026533292] /run/docker/netns/5dc95378b825 rw shared:338 - nsfs nsfs rw
+        )";
+
+        TTempDir dir;
+        auto mountInfoPath = dir.Path() / "mountinfo";
+        TOFStream(mountInfoPath.GetPath()).Write(mountInfoStr);
+
+        auto mountedFiles = FindMountedFiles(
+            "/dev/nbd1",
+            mountInfoPath.GetPath());
+
+        TSet<TString> expectedFiles = {
+            "/dev/nbd1",
+            "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-blabla6/blabla5",
+            "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/pvc-blabla6/dev/blabla5",
+        };
+        UNIT_ASSERT_VALUES_EQUAL(expectedFiles, mountedFiles);
+    }
+
+    Y_UNIT_TEST(ShouldFindLoopbackDevices)
+    {
+        TTempDir sysBlockDir;
+
+        TSet<TString> mountedFiles = {
+            "/dev/nbd1",
+            "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-blabla6/blabla5",
+            "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/pvc-blabla6/dev/blabla5",
+        };
+
+        TFsPath backingFile;
+        backingFile = sysBlockDir.Path() / "loop0" / "loop" / "backing_file";
+        backingFile.Parent().MkDirs();
+        TOFStream(backingFile.GetPath()).Write(R"(
+            /var/lib/snapd/snaps/lxd_27428.snap
+            )");
+
+        backingFile = sysBlockDir.Path() / "loop1" / "loop" / "backing_file";
+        backingFile.Parent().MkDirs();
+        TOFStream(backingFile.GetPath()).Write(R"(
+            /var/lib/snapd/snaps/core20_2105.snap
+            )");
+
+        backingFile = sysBlockDir.Path() / "loop2" / "loop" / "backing_file";
+        backingFile.Parent().MkDirs();
+        TOFStream(backingFile.GetPath()).Write(R"(
+            /
+            )");
+
+        backingFile = sysBlockDir.Path() / "loop3" / "loop" / "backing_file";
+        backingFile.Parent().MkDirs();
+        TOFStream(backingFile.GetPath()).Write(R"(
+            /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/pvc-blabla6/dev/blabla5
+            )");
+
+        backingFile = sysBlockDir.Path() / "loop4" / "loop" / "backing_file";
+        backingFile.Parent().MkDirs();
+        TOFStream(backingFile.GetPath()).Write(R"(
+            /var/lib/snapd/snaps/core20_2182.snap
+            )");
+
+        auto loopbackDevices = FindLoopbackDevices(
+            mountedFiles,
+            sysBlockDir.Path());
+
+        TVector<TString> expectedDevices = {"/dev/loop3"};
+        UNIT_ASSERT_VALUES_EQUAL(expectedDevices, loopbackDevices);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NBD


### PR DESCRIPTION
Kubelet makes a loop device when attaches block device. The reason is described here: https://github.com/kubernetes/kubernetes/blob/a309fadbac3339bc8db9ae0a928a33b8e81ef10f/pkg/volume/util/util.go#L519 

This loop device blocks reconnecting to the block device when NBS is restarting.
So in this PR NBS removes corresponding loop device before starting endpoint.