### PR TITLE
issue-539: add service-side two-stage writes support for scaling throughput

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -240,4 +240,7 @@ message TStorageConfig
     // to release it in case of a client disconnect, this timeout is used.
     optional uint32 GenerateBlobIdsReleaseCollectBarrierTimeout = 345;
 
+    // If ThreeStageWriteEnabled is true, writes that exceed this threshold
+    // will use the three-stage write path. Similar to WriteBlobThreshold
+    optional uint32 ThreeStageWriteThreshold = 346;
 }

--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -55,11 +55,11 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ReleaseLock,                        __VA_ARGS__)                       \
     xxx(TestLock,                           __VA_ARGS__)                       \
                                                                                \
-    xxx(WriteData,                          __VA_ARGS__)                       \
     xxx(AllocateData,                       __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_HANDLE
 
 #define FILESTORE_SERVICE_REQUESTS_NO_HANDLE(xxx, ...)                         \
+    xxx(WriteData,                          __VA_ARGS__)                       \
     xxx(ReadData,                           __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_NO_HANDLE
 

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -140,6 +140,7 @@ namespace {
                                                                                \
     xxx(TwoStageReadEnabled,             bool,      false                     )\
     xxx(ThreeStageWriteEnabled,          bool,      false                     )\
+    xxx(ThreeStageWriteThreshold,        ui32,      64_KB                     )\
     xxx(EntryTimeout,                    TDuration, TDuration::Zero()         )\
     xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\
     xxx(AttrTimeout,                     TDuration, TDuration::Zero()         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -182,6 +182,7 @@ public:
 
     bool GetTwoStageReadEnabled() const;
     bool GetThreeStageWriteEnabled() const;
+    ui32 GetThreeStageWriteThreshold() const;
     TDuration GetEntryTimeout() const;
     TDuration GetNegativeEntryTimeout() const;
     TDuration GetAttrTimeout() const;

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -37,8 +37,8 @@ private:
 
 public:
     TWriteDataActor(
-        NProto::TWriteDataRequest request,
-        TRequestInfoPtr requestInfo)
+            NProto::TWriteDataRequest request,
+            TRequestInfoPtr requestInfo)
         : WriteRequest(std::move(request))
         , RequestInfo(std::move(requestInfo))
     {}
@@ -326,10 +326,11 @@ void TStorageServiceActor::HandleWriteData(
     ui32 blockSize = filestore.GetBlockSize();
 
     // TODO(debnatkh): Consider supporting unaligned writes
-    if (msg->Record.GetOffset() % blockSize == 0 &&
+    if (filestore.GetFeatures().GetThreeStageWriteEnabled() &&
+        msg->Record.GetOffset() % blockSize == 0 &&
         msg->Record.GetBuffer().Size() % blockSize == 0 &&
         msg->Record.GetBuffer().Size() >
-            filestore.GetFeatures().GetThreeStageWriteEnabled())
+            filestore.GetFeatures().GetThreeStageWriteThreshold())
     {
         LOG_DEBUG(
             ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -163,6 +163,9 @@ private:
                 TFileStoreComponents::SERVICE,
                 "WriteData error: %s",
                 errorReason.c_str());
+            // We still may receive some responses, but we do not want to
+            // process them
+            RemainingBlobsToWrite = std::numeric_limits<ui32>::max();
             return WriteData(ctx, errorReason);
         }
 

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -1,0 +1,275 @@
+#include "service_actor.h"
+
+#include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/storage/core/libs/tablet/model/commit.h>
+#include <library/cpp/iterator/enumerate.h>
+#include <cloud/storage/core/libs/tablet/model/partial_blob_id.h>
+
+#include <contrib/ydb/core/base/blobstorage.h>
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <utility>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TAtomicCounter REQUEST_COUNT = {0};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TWriteDataActor final: public TActorBootstrapped<TWriteDataActor>
+{
+private:
+    // Original request
+    NProto::TWriteDataRequest WriteRequest;
+    const TRequestInfoPtr RequestInfo;
+
+    // Issued blob id and asspciated data
+    NProtoPrivate::TIssueBlobResponse IssueBlobResponse;
+    NKikimr::TLogoBlobID BlobId;
+
+public:
+    TWriteDataActor(
+        NProto::TWriteDataRequest request,
+        TRequestInfoPtr requestInfo)
+        : WriteRequest(std::move(request))
+        , RequestInfo(std::move(requestInfo))
+    {}
+
+    void Bootstrap(const TActorContext& ctx)
+    {
+        auto request = std::make_unique<TEvIndexTablet::TEvIssueBlobRequest>();
+
+        request->Record.MutableHeaders()->CopyFrom(WriteRequest.GetHeaders());
+        request->Record.SetFileSystemId(WriteRequest.GetFileSystemId());
+        request->Record.SetNodeId(WriteRequest.GetNodeId());
+        request->Record.SetHandle(WriteRequest.GetHandle());
+        request->Record.SetOffset(WriteRequest.GetOffset());
+        request->Record.SetLength(WriteRequest.GetBuffer().size());
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "WriteDataActor started, data size: %lu, request: %s",
+            WriteRequest.GetBuffer().size(),
+            request->Record.DebugString().c_str());
+
+        ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+
+        Become(&TThis::StateWork);
+    }
+
+private:
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+            HFunc(TEvBlobStorage::TEvPutResult, HandleWriteBlobResponse);
+
+            HFunc(
+                TEvIndexTablet::TEvIssueBlobResponse,
+                HandleIssueBlobResponse);
+
+            HFunc(TEvService::TEvWriteDataResponse, HandleWriteDataResponse)
+
+                default
+                : HandleUnexpectedEvent(
+                      ev,
+                      TFileStoreComponents::SERVICE_WORKER);
+            break;
+        }
+    }
+
+    void HandleIssueBlobResponse(
+        const TEvIndexTablet::TEvIssueBlobResponse::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        const auto* msg = ev->Get();
+
+        // TODO(debnatkh): proper error handling
+
+        IssueBlobResponse.CopyFrom(msg->Record);
+        BlobId = LogoBlobIDFromLogoBlobID(IssueBlobResponse.GetBlobId());
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "IssueBlob response received: %s, blobId: %s",
+            IssueBlobResponse.DebugString().c_str(),
+            BlobId.ToString().c_str());
+
+        auto request = std::make_unique<TEvBlobStorage::TEvPut>(
+            BlobId,
+            WriteRequest.GetBuffer(),
+            TInstant::Max());
+
+        NKikimr::TActorId proxy =
+            MakeBlobStorageProxyID(IssueBlobResponse.GetBSGroupId());
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "Sending WriteBlob request to blob storage, blobId: %s, size: %lu",
+            BlobId.ToString().c_str(),
+            WriteRequest.GetBuffer().size());
+
+        SendToBSProxy(ctx, proxy, request.release(), 57);
+    }
+
+    void HandleWriteBlobResponse(
+        const TEvBlobStorage::TEvPutResult::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        // TODO(debnatkh): proper error handling
+
+        const auto* msg = ev->Get();
+
+        Y_UNUSED(ctx);
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "WriteBlob response received: %s",
+            msg->ToString().c_str());
+
+        if (msg->Status != NKikimrProto::OK) {
+            const auto errorReason = FormatError(
+                MakeError(MAKE_KIKIMR_ERROR(msg->Status), msg->ErrorReason));
+            // TODO(debnatkh): proper fallback
+            LOG_ERROR(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "WriteBlob failed: %s",
+                errorReason.c_str());
+        } else {
+            LOG_DEBUG(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "WriteBlob response is OK");
+        }
+
+        // Now we can send TEv to tablet
+
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvMarkWriteCompletedRequest>();
+
+        request->Record.MutableHeaders()->CopyFrom(WriteRequest.GetHeaders());
+        request->Record.SetFileSystemId(WriteRequest.GetFileSystemId());
+        request->Record.SetNodeId(WriteRequest.GetNodeId());
+        request->Record.SetHandle(WriteRequest.GetHandle());
+        request->Record.SetOffset(WriteRequest.GetOffset());
+        request->Record.SetLength(WriteRequest.GetBuffer().size());
+        LogoBlobIDFromLogoBlobID(BlobId, request->Record.MutableBlobId());
+        request->Record.SetCommitId(IssueBlobResponse.GetCommitId());
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "Sending TwoStageWrite request to tablet, blobId: %s",
+            BlobId.ToString().c_str());
+
+        ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+
+        // Once the request is completed, ServiceActor will be notified by the
+        // tablet (no, it will not)
+    }
+
+    void HandleWriteDataResponse(
+        const TEvService::TEvWriteDataResponse::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        auto* msg = ev->Get();
+
+        auto response = std::make_unique<TEvService::TEvWriteDataResponse>();
+        response->Record = std::move(msg->Record);
+        NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    }
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        Y_UNUSED(ev);
+        Die(ctx);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleWriteData(
+    const TEvService::TEvWriteDataRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    const auto& clientId = GetClientId(msg->Record);
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
+
+    auto* session = State->FindSession(sessionId, seqNo);
+    if (!session || session->ClientId != clientId || !session->SessionActor) {
+        auto response = std::make_unique<TEvService::TEvWriteDataResponse>(
+            ErrorInvalidSession(clientId, sessionId, seqNo));
+        return NCloud::Reply(ctx, *ev, std::move(response));
+    }
+    const NProto::TFileStore& filestore = session->FileStore;
+
+    if (!filestore.GetFeatures().GetTwoStageWriteEnabled()) {
+        // If two-stage write is disabled, forward the request to the tablet in
+        // the same way as all other requests.
+        ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
+        return;
+    }
+
+    auto [cookie, inflight] = CreateInFlightRequest(
+        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        session->MediaKind,
+        session->RequestStats,
+        ctx.Now());
+
+    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+
+    ui32 blockSize = filestore.GetBlockSize();
+
+    // TODO(debnatkh): Consider supporting non-aligned writes
+    if (msg->Record.GetOffset() % blockSize == 0 &&
+        msg->Record.GetBuffer().Size() % blockSize == 0 &&
+        msg->Record.GetBuffer().Size() >
+            filestore.GetFeatures().GetTwoStageWriteThreshold())
+    {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "Using two-stage write for request, size: %lu",
+            msg->Record.GetBuffer().Size());
+        NProto::TWriteDataRequest request;
+        request.CopyFrom(msg->Record);
+
+        auto requestInfo =
+            CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+
+        auto actor = std::make_unique<TWriteDataActor>(
+            std::move(request),
+            std::move(requestInfo));
+        NCloud::Register(ctx, std::move(actor));
+    } else {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "Forwarding WriteData request to tablet");
+        return ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -29,7 +29,7 @@ private:
     NProto::TWriteDataRequest WriteRequest;
     const TRequestInfoPtr RequestInfo;
 
-    // generated blob id and asspciated data
+    // generated blob id and associated data
     NProtoPrivate::TGenerateBlobIdsResponse GenerateBlobIdsResponse;
 
     // WriteData state
@@ -238,8 +238,6 @@ private:
 
         // forward request through tablet proxy
         ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
-
-        // Should i die here?
     }
 
     void HandleWriteDataResponse(
@@ -309,7 +307,7 @@ void TStorageServiceActor::HandleWriteData(
     }
     const NProto::TFileStore& filestore = session->FileStore;
 
-    if (!filestore.GetFeatures().GetTwoStageWriteEnabled()) {
+    if (!filestore.GetFeatures().GetThreeStageWriteEnabled()) {
         // If two-stage write is disabled, forward the request to the tablet in
         // the same way as all other requests.
         ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
@@ -330,7 +328,7 @@ void TStorageServiceActor::HandleWriteData(
     if (msg->Record.GetOffset() % blockSize == 0 &&
         msg->Record.GetBuffer().Size() % blockSize == 0 &&
         msg->Record.GetBuffer().Size() >
-            filestore.GetFeatures().GetTwoStageWriteThreshold())
+            filestore.GetFeatures().GetThreeStageWriteEnabled())
     {
         LOG_DEBUG(
             ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -281,7 +281,7 @@ private:
         const TActorContext& ctx)
     {
         Y_UNUSED(ev);
-        Die(ctx);
+        HandleError(ctx, MakeError(E_REJECTED, "request cancelled"));
     }
 };
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2088,7 +2088,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             [&](TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvIndexTablet::EvGenerateBlobsRequest: {
+                    case TEvIndexTablet::EvGenerateBlobIdsRequest: {
                         if (!worker) {
                             worker = event->Sender;
                         }
@@ -2121,7 +2121,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                     .ReadData(headers, fs, nodeId, handle, offset, data.Size());
             // clang-format off
             UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
-            UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsRequest));
+            UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsRequest));
             UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataRequest));
             UNIT_ASSERT_VALUES_EQUAL(1, runtime.GetCounter(TEvIndexTabletPrivate::EvAddBlobRequest));
             UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTabletPrivate::EvWriteBlobRequest));
@@ -2200,7 +2200,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                     .ReadData(headers, fs, nodeId, handle, offset, data.Size());
             // clang-format off
             UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
-            UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsRequest));
+            UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsRequest));
             UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvAddDataRequest));
             UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataRequest));
             // clang-format on
@@ -2232,9 +2232,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 Y_UNUSED(runtime);
 
                 switch (event->GetTypeRewrite()) {
-                    case TEvIndexTablet::EvGenerateBlobsResponse: {
+                    case TEvIndexTablet::EvGenerateBlobIdsResponse: {
                         auto* msg = event->template Get<
-                            TEvIndexTablet::TEvGenerateBlobsResponse>();
+                            TEvIndexTablet::TEvGenerateBlobIdsResponse>();
                         msg->Record.MutableError()->CopyFrom(error);
                         break;
                     }
@@ -2267,7 +2267,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 .CreateHandle(headers, fs, nodeId, "", TCreateHandleArgs::RDWR)
                 ->Record.GetHandle();
 
-        // GenerateBlobsResponse fails
+        // GenerateBlobIdsResponse fails
         TString data = GenerateValidateData(256_KB);
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         auto readDataResult =
@@ -2275,7 +2275,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
         auto& runtime = env.GetRuntime();
         // clang-format off
-        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsResponse));
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsResponse));
         UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
         // clang-format on
         runtime.ClearCounters();
@@ -2303,7 +2303,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
         // clang-format off
         UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
-        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsResponse));
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsResponse));
         UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
         // clang-format on
 
@@ -2319,7 +2319,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 Y_UNUSED(runtime);
 
                 switch (event->GetTypeRewrite()) {
-                    case TEvIndexTablet::EvGenerateBlobsResponse: {
+                    case TEvIndexTablet::EvGenerateBlobIdsResponse: {
                         if (!worker) {
                             worker = event->Sender;
                         }
@@ -2349,7 +2349,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         // clang-format off
         UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
-        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsResponse));
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsResponse));
         UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
         UNIT_ASSERT_VALUES_EQUAL(8, evPuts);
         // clang-format on

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2037,6 +2037,323 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(1, reassignedChannels[0]);
         UNIT_ASSERT_VALUES_EQUAL(4, reassignedChannels[1]);
     }
+
+    TString GenerateValidateData(ui32 size)
+    {
+        TString data(size, '\0');
+        for (ui32 i = 0; i < size; ++i) {
+            data[i] = 'A' + (i % 25);
+        }
+        return data;
+    }
+
+    Y_UNIT_TEST(ShouldPerformTwoStageWrites)
+    {
+        TTestEnv env;
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const TString fs = "test";
+        service.CreateFileStore(fs, 1000);
+
+        {
+            NProto::TStorageConfig newConfig;
+            newConfig.SetTwoStageWriteEnabled(true);
+            newConfig.SetTwoStageWriteThreshold(1);
+            const auto response =
+                ExecuteChangeStorageConfig(std::move(newConfig), service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                response.GetStorageConfig().GetTwoStageWriteEnabled(),
+                true);
+            UNIT_ASSERT_VALUES_EQUAL(
+                response.GetStorageConfig().GetTwoStageWriteThreshold(),
+                1);
+            TDispatchOptions options;
+            env.GetRuntime().DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        auto headers = service.InitSession(fs, "client");
+        ui64 nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+        ui64 handle =
+            service
+                .CreateHandle(headers, fs, nodeId, "", TCreateHandleArgs::RDWR)
+                ->Record.GetHandle();
+
+        ui32 putRequestCount = 0;
+        TActorId worker;
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTablet::EvGenerateBlobsRequest: {
+                        if (!worker) {
+                            worker = event->Sender;
+                        }
+                    }
+                    case TEvBlobStorage::EvPut: {
+                        if (event->Sender == worker &&
+                            event->Recipient.IsService() &&
+                            event->Recipient.ServiceId().StartsWith("bsproxy"))
+                        {
+                            ++putRequestCount;
+                        }
+                    }
+
+                    break;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto& runtime = env.GetRuntime();
+
+        auto validateWriteData =
+            [&](ui64 offset, ui64 size, ui32 expectedPutCount)
+        {
+            auto data = GenerateValidateData(size);
+
+            service.WriteData(headers, fs, nodeId, handle, offset, data);
+            auto readDataResult =
+                service
+                    .ReadData(headers, fs, nodeId, handle, offset, data.Size());
+            // clang-format off
+            UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
+            UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsRequest));
+            UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataRequest));
+            UNIT_ASSERT_VALUES_EQUAL(1, runtime.GetCounter(TEvIndexTabletPrivate::EvAddBlobRequest));
+            UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTabletPrivate::EvWriteBlobRequest));
+            UNIT_ASSERT_VALUES_EQUAL(1, runtime.GetCounter(TEvService::EvWriteDataResponse));
+            UNIT_ASSERT_VALUES_EQUAL(putRequestCount, expectedPutCount);
+            // clang-format on
+            runtime.ClearCounters();
+            putRequestCount = 0;
+            worker = TActorId();
+        };
+
+        validateWriteData(0, DefaultBlockSize, 1);
+        validateWriteData(DefaultBlockSize, DefaultBlockSize, 1);
+        validateWriteData(0, DefaultBlockSize * BlockGroupSize, 1);
+        validateWriteData(0, DefaultBlockSize * BlockGroupSize * 2, 2);
+        validateWriteData(
+            DefaultBlockSize,
+            DefaultBlockSize * BlockGroupSize * 10,
+            11);
+        validateWriteData(0, DefaultBlockSize * BlockGroupSize * 3, 3);
+        // Currently there are 1 + 1 + 64 + 64 + 64 * 10 + 64 * 3 = 962 blocks
+        // out of 1000. Therefore, the next write should fail
+
+        auto data =
+            GenerateValidateData(DefaultBlockSize * BlockGroupSize * 30);
+
+        auto response =
+            service.AssertWriteDataFailed(headers, fs, nodeId, handle, 0, data);
+        auto error = STATUS_FROM_CODE(response->GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(error, (ui32)NProto::E_FS_NOSPC);
+    }
+
+    Y_UNIT_TEST(ShouldNotUseTwoStageWriteForSmallOrUnaligned)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const TString fs = "test";
+        service.CreateFileStore(fs, 1000);
+
+        {
+            NProto::TStorageConfig newConfig;
+            newConfig.SetTwoStageWriteEnabled(true);
+            const auto response =
+                ExecuteChangeStorageConfig(std::move(newConfig), service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                response.GetStorageConfig().GetTwoStageWriteEnabled(),
+                true);
+            TDispatchOptions options;
+            env.GetRuntime().DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        auto headers = service.InitSession(fs, "client");
+        ui64 nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+        ui64 handle =
+            service
+                .CreateHandle(headers, fs, nodeId, "", TCreateHandleArgs::RDWR)
+                ->Record.GetHandle();
+
+        auto& runtime = env.GetRuntime();
+
+        auto validateWriteData = [&](ui64 offset, ui64 size)
+        {
+            auto data = GenerateValidateData(size);
+
+            service.WriteData(headers, fs, nodeId, handle, offset, data);
+            auto readDataResult =
+                service
+                    .ReadData(headers, fs, nodeId, handle, offset, data.Size());
+            // clang-format off
+            UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
+            UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsRequest));
+            UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvAddDataRequest));
+            UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataRequest));
+            // clang-format on
+            runtime.ClearCounters();
+        };
+
+        validateWriteData(0, 4_KB);
+        validateWriteData(4_KB, 4_KB);
+        validateWriteData(1, 128_KB);
+    }
+
+    Y_UNIT_TEST(ShouldFallbackTwoStageWrite)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const TString fs = "test";
+        service.CreateFileStore(fs, 1000);
+
+        NProto::TError error;
+        error.SetCode(E_REJECTED);
+
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTablet::EvGenerateBlobsResponse: {
+                        auto* msg = event->template Get<
+                            TEvIndexTablet::TEvGenerateBlobsResponse>();
+                        msg->Record.MutableError()->CopyFrom(error);
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        {
+            NProto::TStorageConfig newConfig;
+            newConfig.SetTwoStageWriteEnabled(true);
+            const auto response =
+                ExecuteChangeStorageConfig(std::move(newConfig), service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                response.GetStorageConfig().GetTwoStageWriteEnabled(),
+                true);
+            TDispatchOptions options;
+            env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+        }
+
+        auto headers = service.InitSession(fs, "client");
+
+        ui64 nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+
+        ui64 handle =
+            service
+                .CreateHandle(headers, fs, nodeId, "", TCreateHandleArgs::RDWR)
+                ->Record.GetHandle();
+
+        // GenerateBlobsResponse fails
+        TString data = GenerateValidateData(256_KB);
+        service.WriteData(headers, fs, nodeId, handle, 0, data);
+        auto readDataResult =
+            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+        UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
+        auto& runtime = env.GetRuntime();
+        // clang-format off
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsResponse));
+        UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
+        // clang-format on
+        runtime.ClearCounters();
+
+        // AddDataResponse fails
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTablet::EvAddDataResponse: {
+                        auto* msg = event->template Get<
+                            TEvIndexTablet::TEvAddDataResponse>();
+                        msg->Record.MutableError()->CopyFrom(error);
+                        break;
+                    }
+                }
+                return false;
+            });
+        data = GenerateValidateData(256_KB);
+        service.WriteData(headers, fs, nodeId, handle, 0, data);
+        readDataResult =
+            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+        UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
+        // clang-format off
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsResponse));
+        UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
+        // clang-format on
+
+        // TEvGet fails
+
+        runtime.ClearCounters();
+
+        TActorId worker;
+        ui32 evPuts = 0;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTablet::EvGenerateBlobsResponse: {
+                        if (!worker) {
+                            worker = event->Sender;
+                        }
+                        break;
+                    }
+                    case TEvBlobStorage::EvPutResult: {
+                        auto* msg =
+                            event->template Get<TEvBlobStorage::TEvPutResult>();
+                        if (event->Recipient == worker) {
+                            if (evPuts == 0) {
+                                msg->Status = NKikimrProto::ERROR;
+                            }
+                            ++evPuts;
+                        }
+                        return false;
+                    }
+                }
+
+                return false;
+            });
+
+        data = GenerateValidateData(256_KB);
+        service.WriteData(headers, fs, nodeId, handle, 0, data);
+        readDataResult =
+            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+        UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
+
+        // clang-format off
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
+        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobsResponse));
+        UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
+        UNIT_ASSERT_VALUES_EQUAL(8, evPuts);
+        // clang-format on
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2047,7 +2047,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         return data;
     }
 
-    Y_UNIT_TEST(ShouldPerformTwoStageWrites)
+    Y_UNIT_TEST(ShouldPerformThreeStageWrites)
     {
         TTestEnv env;
 
@@ -2057,15 +2057,15 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         {
             NProto::TStorageConfig newConfig;
-            newConfig.SetTwoStageWriteEnabled(true);
-            newConfig.SetTwoStageWriteThreshold(1);
+            newConfig.SetThreeStageWriteEnabled(true);
+            newConfig.SetThreeStageWriteThreshold(1);
             const auto response =
                 ExecuteChangeStorageConfig(std::move(newConfig), service);
             UNIT_ASSERT_VALUES_EQUAL(
-                response.GetStorageConfig().GetTwoStageWriteEnabled(),
+                response.GetStorageConfig().GetThreeStageWriteEnabled(),
                 true);
             UNIT_ASSERT_VALUES_EQUAL(
-                response.GetStorageConfig().GetTwoStageWriteThreshold(),
+                response.GetStorageConfig().GetThreeStageWriteThreshold(),
                 1);
             TDispatchOptions options;
             env.GetRuntime().DispatchEvents(options, TDuration::Seconds(1));
@@ -2154,7 +2154,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(error, (ui32)NProto::E_FS_NOSPC);
     }
 
-    Y_UNIT_TEST(ShouldNotUseTwoStageWriteForSmallOrUnaligned)
+    Y_UNIT_TEST(ShouldNotUseThreeStageWriteForSmallOrUnaligned)
     {
         TTestEnv env;
         env.CreateSubDomain("nfs");
@@ -2167,11 +2167,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         {
             NProto::TStorageConfig newConfig;
-            newConfig.SetTwoStageWriteEnabled(true);
+            newConfig.SetThreeStageWriteEnabled(true);
             const auto response =
                 ExecuteChangeStorageConfig(std::move(newConfig), service);
             UNIT_ASSERT_VALUES_EQUAL(
-                response.GetStorageConfig().GetTwoStageWriteEnabled(),
+                response.GetStorageConfig().GetThreeStageWriteEnabled(),
                 true);
             TDispatchOptions options;
             env.GetRuntime().DispatchEvents(options, TDuration::Seconds(1));
@@ -2212,7 +2212,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         validateWriteData(1, 128_KB);
     }
 
-    Y_UNIT_TEST(ShouldFallbackTwoStageWrite)
+    Y_UNIT_TEST(ShouldFallbackThreeStageWrite)
     {
         TTestEnv env;
         env.CreateSubDomain("nfs");
@@ -2244,11 +2244,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         {
             NProto::TStorageConfig newConfig;
-            newConfig.SetTwoStageWriteEnabled(true);
+            newConfig.SetThreeStageWriteEnabled(true);
             const auto response =
                 ExecuteChangeStorageConfig(std::move(newConfig), service);
             UNIT_ASSERT_VALUES_EQUAL(
-                response.GetStorageConfig().GetTwoStageWriteEnabled(),
+                response.GetStorageConfig().GetThreeStageWriteEnabled(),
                 true);
             TDispatchOptions options;
             env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2050,6 +2050,10 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     Y_UNIT_TEST(ShouldPerformThreeStageWrites)
     {
         TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
 
         TServiceClient service(env.GetRuntime(), nodeIdx);
         const TString fs = "test";

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2323,7 +2323,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 Y_UNUSED(runtime);
 
                 switch (event->GetTypeRewrite()) {
-                    case TEvIndexTablet::EvGenerateBlobIdsResponse: {
+                    case TEvIndexTablet::EvGenerateBlobIdsRequest: {
                         if (!worker) {
                             worker = event->Sender;
                         }
@@ -2352,10 +2352,10 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
         // clang-format off
-        UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
+        UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
         UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsResponse));
         UNIT_ASSERT_VALUES_EQUAL(3, runtime.GetCounter(TEvService::EvWriteDataResponse));
-        UNIT_ASSERT_VALUES_EQUAL(8, evPuts);
+        UNIT_ASSERT_VALUES_EQUAL(1, evPuts);
         // clang-format on
     }
 }

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -28,6 +28,7 @@ SRCS(
     service_actor_readdata.cpp
     service_actor_statfs.cpp
     service_actor_update_stats.cpp
+    service_actor_writedata.cpp
     service_state.cpp
 )
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -605,6 +605,7 @@ STFUNC(TIndexTabletActor::StateWork)
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvIndexTabletPrivate::TEvReadDataCompleted, HandleReadDataCompleted);
         HFunc(TEvIndexTabletPrivate::TEvWriteDataCompleted, HandleWriteDataCompleted);
+        HFunc(TEvIndexTabletPrivate::TEvAddDataCompleted, HandleAddDataCompleted);
 
         HFunc(TEvIndexTabletPrivate::TEvUpdateCounters, HandleUpdateCounters);
         HFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters, HandleUpdateLeakyBucketCounters);
@@ -652,6 +653,7 @@ STFUNC(TIndexTabletActor::StateZombie)
 
         IgnoreFunc(TEvIndexTabletPrivate::TEvReadDataCompleted);
         IgnoreFunc(TEvIndexTabletPrivate::TEvWriteDataCompleted);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvAddDataCompleted);
 
         // tablet related requests
         IgnoreFunc(TEvents::TEvPoisonPill);
@@ -688,6 +690,7 @@ STFUNC(TIndexTabletActor::StateBroken)
 
         IgnoreFunc(TEvIndexTabletPrivate::TEvReadDataCompleted);
         IgnoreFunc(TEvIndexTabletPrivate::TEvWriteDataCompleted);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvAddDataCompleted);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -417,6 +417,10 @@ private:
         const TEvIndexTabletPrivate::TEvWriteDataCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleAddDataCompleted(
+        const TEvIndexTabletPrivate::TEvAddDataCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     bool HandleRequests(STFUNC_SIG);
     bool RejectRequests(STFUNC_SIG);
     bool RejectRequestsByBrokenTablet(STFUNC_SIG);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -20,8 +20,8 @@ void FillFeatures(const TStorageConfig& config, NProto::TFileStore& fileStore)
     features->SetNegativeEntryTimeout(
         config.GetNegativeEntryTimeout().MilliSeconds());
     features->SetAttrTimeout(config.GetAttrTimeout().MilliSeconds());
-    features->SetTwoStageWriteEnabled(config.GetTwoStageWriteEnabled());
-    features->SetTwoStageWriteThreshold(config.GetTwoStageWriteThreshold());
+    features->SetThreeStageWriteEnabled(config.GetThreeStageWriteEnabled());
+    features->SetThreeStageWriteThreshold(config.GetThreeStageWriteThreshold());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -20,6 +20,8 @@ void FillFeatures(const TStorageConfig& config, NProto::TFileStore& fileStore)
     features->SetNegativeEntryTimeout(
         config.GetNegativeEntryTimeout().MilliSeconds());
     features->SetAttrTimeout(config.GetAttrTimeout().MilliSeconds());
+    features->SetTwoStageWriteEnabled(config.GetTwoStageWriteEnabled());
+    features->SetTwoStageWriteThreshold(config.GetTwoStageWriteThreshold());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -253,6 +253,15 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // AddData completion
+    //
+
+    struct TAddDataCompleted
+    {
+        ui64 CommitId = 0;
+    };
+
+    //
     // AddBlob
     //
 
@@ -613,6 +622,7 @@ struct TEvIndexTabletPrivate
 
         EvReadDataCompleted,
         EvWriteDataCompleted,
+        EvAddDataCompleted,
 
         EvReleaseCollectBarrier,
 
@@ -633,6 +643,7 @@ struct TEvIndexTabletPrivate
 
     using TEvReadDataCompleted = TResponseEvent<TReadWriteCompleted, EvReadDataCompleted>;
     using TEvWriteDataCompleted = TResponseEvent<TReadWriteCompleted, EvWriteDataCompleted>;
+    using TEvAddDataCompleted = TResponseEvent<TAddDataCompleted, EvAddDataCompleted>;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -827,13 +827,19 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
 
         config.SetTwoStageReadEnabled(true);
+        config.SetThreeStageWriteEnabled(true);
+        config.SetThreeStageWriteThreshold(10_MB);
         config.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
         config.SetNegativeEntryTimeout(TDuration::Seconds(1).MilliSeconds());
         config.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
+
         features.SetTwoStageReadEnabled(true);
         features.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
         features.SetNegativeEntryTimeout(TDuration::Seconds(1).MilliSeconds());
         features.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
+        features.SetThreeStageWriteEnabled(true);
+        features.SetThreeStageWriteThreshold(10_MB);
+
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -824,6 +824,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
     {
         NProto::TStorageConfig config;
         NProto::TFileStoreFeatures features;
+        features.SetThreeStageWriteThreshold(64_KB);
+
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
 
         config.SetTwoStageReadEnabled(true);

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -18,6 +18,7 @@ message TFileStoreFeatures
     uint32 NegativeEntryTimeout = 3;
     uint32 AttrTimeout = 4;
     bool ThreeStageWriteEnabled = 5;
+    uint32 ThreeStageWriteThreshold = 6;
 }
 
 message TFileStore

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
@@ -1,4 +1,4 @@
 TwoStageReadEnabled: true
 NewCompactionEnabled: true
 NewCleanupEnabled: true
-TwoStageWriteEnabled: true
+ThreeStageWriteEnabled: true

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
@@ -1,3 +1,4 @@
 TwoStageReadEnabled: true
 NewCompactionEnabled: true
 NewCleanupEnabled: true
+TwoStageWriteEnabled: true


### PR DESCRIPTION
Continuation of #707, references #539.

Add the ability to perform client-side writes:

1. BlobIds are issued to a client via a `GenerateBlobIds` request.
2. Data is written directly to the BlobStorage
3. On the completion `AddData` request is called to complete the write.

On any error, a fallback to a regular write path is used.
