### PR TITLE
issue-122: pass blob checksums when adding unconfirmed blobs

### DIFF
--- a/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.cpp
@@ -1,11 +1,11 @@
-#include "blob_unique_id_with_range.h"
+#include "blob_to_confirm.h"
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 bool Overlaps(
-    const TCommitIdToBlobUniqueIdWithRange& blobs,
+    const TCommitIdToBlobsToConfirm& blobs,
     ui64 lowCommitId,
     ui64 highCommitId,
     const TBlockRange32& blockRange)

--- a/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h
+++ b/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h
@@ -15,6 +15,7 @@ struct TBlobToConfirm
 {
     ui64 UniqueId = 0;
     TBlockRange32 BlockRange;
+    TVector<ui32> Checksums;
 
     TBlobToConfirm() = default;
 
@@ -22,6 +23,16 @@ struct TBlobToConfirm
         : UniqueId(uniqueId)
         , BlockRange(blockRange)
     {}
+
+    TBlobToConfirm(
+            ui64 uniqueId,
+            const TBlockRange32& blockRange,
+            const TVector<ui32>& checksums)
+        : UniqueId(uniqueId)
+        , BlockRange(blockRange)
+        , Checksums(checksums)
+    {}
+
 };
 
 using TCommitIdToBlobsToConfirm = THashMap<ui64, TVector<TBlobToConfirm>>;

--- a/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h
+++ b/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h
@@ -11,24 +11,23 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TBlobUniqueIdWithRange
+struct TBlobToConfirm
 {
     ui64 UniqueId = 0;
     TBlockRange32 BlockRange;
 
-    TBlobUniqueIdWithRange() = default;
+    TBlobToConfirm() = default;
 
-    TBlobUniqueIdWithRange(ui64 uniqueId, const TBlockRange32& blockRange)
+    TBlobToConfirm(ui64 uniqueId, const TBlockRange32& blockRange)
         : UniqueId(uniqueId)
         , BlockRange(blockRange)
     {}
 };
 
-using TCommitIdToBlobUniqueIdWithRange =
-    THashMap<ui64, TVector<TBlobUniqueIdWithRange>>;
+using TCommitIdToBlobsToConfirm = THashMap<ui64, TVector<TBlobToConfirm>>;
 
 bool Overlaps(
-    const TCommitIdToBlobUniqueIdWithRange& blobs,
+    const TCommitIdToBlobsToConfirm& blobs,
     ui64 lowCommitId,
     ui64 highCommitId,
     const TBlockRange32& blockRange);

--- a/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h
+++ b/cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h
@@ -13,16 +13,9 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 struct TBlobToConfirm
 {
-    ui64 UniqueId = 0;
+    ui64 UniqueId;
     TBlockRange32 BlockRange;
     TVector<ui32> Checksums;
-
-    TBlobToConfirm() = default;
-
-    TBlobToConfirm(ui64 uniqueId, const TBlockRange32& blockRange)
-        : UniqueId(uniqueId)
-        , BlockRange(blockRange)
-    {}
 
     TBlobToConfirm(
             ui64 uniqueId,

--- a/cloud/blockstore/libs/storage/partition/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ya.make
@@ -8,7 +8,7 @@ GENERATE_ENUM_SERIALIZATION(operation_status.h)
 SRCS(
     barrier.cpp
     blob_index.cpp
-    blob_unique_id_with_range.cpp
+    blob_to_confirm.cpp
     block.cpp
     block_index.cpp
     block_mask.cpp

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -286,7 +286,7 @@ void TPartitionActor::HandleAddConfirmedBlobs(
                 MakePartialBlobId(commitId, blob.UniqueId),
                 blob.BlockRange,
                 TBlockMask(), // skipMask
-                TVector<ui32>() /* TODO: checksums */);
+                blob.Checksums);
         }
 
         auto request = std::make_unique<TRequest>(

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -245,7 +245,7 @@ void TWriteMergedBlocksActor::AddBlobs(
             ADD_WRITE_RESULT
         );
     } else {
-        TVector<TBlobUniqueIdWithRange> blobs(Reserve(WriteBlobRequests.size()));
+        TVector<TBlobToConfirm> blobs(Reserve(WriteBlobRequests.size()));
 
         for (const auto& req: WriteBlobRequests) {
             blobs.emplace_back(req.BlobId.UniqueId(), req.WriteRange);

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -248,7 +248,10 @@ void TWriteMergedBlocksActor::AddBlobs(
         TVector<TBlobToConfirm> blobs(Reserve(WriteBlobRequests.size()));
 
         for (const auto& req: WriteBlobRequests) {
-            blobs.emplace_back(req.BlobId.UniqueId(), req.WriteRange);
+            blobs.emplace_back(
+                req.BlobId.UniqueId(),
+                req.WriteRange,
+                req.Checksums);
         }
 
         request = std::make_unique<TEvPartitionPrivate::TEvAddUnconfirmedBlobsRequest>(

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -1281,6 +1281,7 @@ void TPartitionDatabase::WriteUnconfirmedBlob(
 {
     using TTable = TPartitionSchema::UnconfirmedBlobs;
 
+    // TODO: persist blob checksums (issue-122)
     Table<TTable>()
         .Key(blobId.CommitId(), blobId.UniqueId())
         .Update(

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -1277,7 +1277,7 @@ bool TPartitionDatabase::ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds)
 
 void TPartitionDatabase::WriteUnconfirmedBlob(
     const TPartialBlobId& blobId,
-    const TBlobUniqueIdWithRange& blob)
+    const TBlobToConfirm& blob)
 {
     using TTable = TPartitionSchema::UnconfirmedBlobs;
 
@@ -1298,8 +1298,7 @@ void TPartitionDatabase::DeleteUnconfirmedBlob(const TPartialBlobId& blobId)
         .Delete();
 }
 
-bool TPartitionDatabase::ReadUnconfirmedBlobs(
-    TCommitIdToBlobUniqueIdWithRange& blobs)
+bool TPartitionDatabase::ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs)
 {
     using TTable = TPartitionSchema::UnconfirmedBlobs;
 

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -1318,7 +1318,11 @@ bool TPartitionDatabase::ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs)
             it.GetValue<TTable::RangeStart>(),
             it.GetValue<TTable::RangeEnd>());
 
-        blobs[commitId].emplace_back(uniqueId, blockRange);
+        blobs[commitId].emplace_back(
+            uniqueId,
+            blockRange,
+            TVector<ui32>() /* TODO: checksums */
+        );
 
         if (!it.Next()) {
             return false;   // not ready

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -5,7 +5,7 @@
 #include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/storage/core/compaction_map.h>
 #include <cloud/blockstore/libs/storage/partition/model/blob_index.h>
-#include <cloud/blockstore/libs/storage/partition/model/blob_unique_id_with_range.h>
+#include <cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h>
 #include <cloud/blockstore/libs/storage/partition/model/block.h>
 #include <cloud/blockstore/libs/storage/partition/model/block_mask.h>
 #include <cloud/blockstore/libs/storage/partition/model/checkpoint.h>
@@ -211,10 +211,10 @@ public:
 
     void WriteUnconfirmedBlob(
         const TPartialBlobId& blobId,
-        const TBlobUniqueIdWithRange& blob);
+        const TBlobToConfirm& blob);
     void DeleteUnconfirmedBlob(const TPartialBlobId& blobId);
 
-    bool ReadUnconfirmedBlobs(TCommitIdToBlobUniqueIdWithRange& blobs);
+    bool ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -9,7 +9,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
 #include <cloud/blockstore/libs/storage/model/channel_permissions.h>
-#include <cloud/blockstore/libs/storage/partition/model/blob_unique_id_with_range.h>
+#include <cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h>
 #include <cloud/blockstore/libs/storage/partition/model/block.h>
 #include <cloud/blockstore/libs/storage/partition/model/block_mask.h>
 #include <cloud/blockstore/libs/storage/protos/part.pb.h>
@@ -656,13 +656,13 @@ struct TEvPartitionPrivate
     struct TAddUnconfirmedBlobsRequest
     {
         ui64 CommitId = 0;
-        TVector<TBlobUniqueIdWithRange> Blobs;
+        TVector<TBlobToConfirm> Blobs;
 
         TAddUnconfirmedBlobsRequest() = default;
 
         TAddUnconfirmedBlobsRequest(
                 ui64 commitId,
-                TVector<TBlobUniqueIdWithRange> blobs)
+                TVector<TBlobToConfirm> blobs)
             : CommitId(commitId)
             , Blobs(std::move(blobs))
         {}

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -617,7 +617,7 @@ bool TPartitionState::OverlapsConfirmedBlobs(
 }
 
 void TPartitionState::InitUnconfirmedBlobs(
-    TCommitIdToBlobUniqueIdWithRange blobs)
+    TCommitIdToBlobsToConfirm blobs)
 {
     UnconfirmedBlobs = std::move(blobs);
     UnconfirmedBlobCount = 0;
@@ -632,7 +632,7 @@ void TPartitionState::InitUnconfirmedBlobs(
 void TPartitionState::WriteUnconfirmedBlob(
     TPartitionDatabase& db,
     ui64 commitId,
-    const TBlobUniqueIdWithRange& blob)
+    const TBlobToConfirm& blob)
 {
     auto blobId = MakePartialBlobId(commitId, blob.UniqueId);
     db.WriteUnconfirmedBlob(blobId, blob);

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -15,7 +15,7 @@
 #include <cloud/blockstore/libs/storage/core/write_buffer_request.h>
 #include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
 #include <cloud/blockstore/libs/storage/model/channel_permissions.h>
-#include <cloud/blockstore/libs/storage/partition/model/blob_unique_id_with_range.h>
+#include <cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h>
 #include <cloud/blockstore/libs/storage/partition/model/block_index.h>
 #include <cloud/blockstore/libs/storage/partition/model/checkpoint.h>
 #include <cloud/blockstore/libs/storage/partition/model/cleanup_queue.h>
@@ -1298,15 +1298,15 @@ public:
     }
 
 private:
-    TCommitIdToBlobUniqueIdWithRange UnconfirmedBlobs;
+    TCommitIdToBlobsToConfirm UnconfirmedBlobs;
     ui32 UnconfirmedBlobCount = 0;
     // contains entries from UnconfirmedBlobs that have been confirmed but have
     // not yet been added to the index
-    TCommitIdToBlobUniqueIdWithRange ConfirmedBlobs;
+    TCommitIdToBlobsToConfirm ConfirmedBlobs;
     ui32 ConfirmedBlobCount = 0;
 
 public:
-    const TCommitIdToBlobUniqueIdWithRange& GetUnconfirmedBlobs() const
+    const TCommitIdToBlobsToConfirm& GetUnconfirmedBlobs() const
     {
         return UnconfirmedBlobs;
     }
@@ -1316,7 +1316,7 @@ public:
         return UnconfirmedBlobCount;
     }
 
-    const TCommitIdToBlobUniqueIdWithRange& GetConfirmedBlobs() const
+    const TCommitIdToBlobsToConfirm& GetConfirmedBlobs() const
     {
         return ConfirmedBlobs;
     }
@@ -1336,12 +1336,12 @@ public:
         ui64 highCommitId,
         const TBlockRange32& blockRange) const;
 
-    void InitUnconfirmedBlobs(TCommitIdToBlobUniqueIdWithRange blobs);
+    void InitUnconfirmedBlobs(TCommitIdToBlobsToConfirm blobs);
 
     void WriteUnconfirmedBlob(
         TPartitionDatabase& db,
         ui64 commitId,
-        const TBlobUniqueIdWithRange& blob);
+        const TBlobToConfirm& blob);
 
     void ConfirmedBlobsAdded(TPartitionDatabase& db, ui64 commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -9,7 +9,7 @@
 #include <cloud/blockstore/libs/storage/core/block_handler.h>
 #include <cloud/blockstore/libs/storage/core/compaction_map.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
-#include <cloud/blockstore/libs/storage/partition/model/blob_unique_id_with_range.h>
+#include <cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h>
 #include <cloud/blockstore/libs/storage/partition/model/block.h>
 #include <cloud/blockstore/libs/storage/partition/model/block_mask.h>
 #include <cloud/blockstore/libs/storage/partition/model/checkpoint.h>
@@ -109,7 +109,7 @@ struct TTxPartition
         TVector<TCleanupQueueItem> CleanupQueue;
         TVector<TPartialBlobId> NewBlobs;
         TVector<TPartialBlobId> GarbageBlobs;
-        TCommitIdToBlobUniqueIdWithRange UnconfirmedBlobs;
+        TCommitIdToBlobsToConfirm UnconfirmedBlobs;
 
         explicit TLoadState(ui64 blocksCount)
             : UsedBlocks(blocksCount)
@@ -1115,12 +1115,12 @@ struct TTxPartition
     {
         const TRequestInfoPtr RequestInfo;
         ui64 CommitId = 0;
-        TVector<TBlobUniqueIdWithRange> Blobs;
+        TVector<TBlobToConfirm> Blobs;
 
         TAddUnconfirmedBlobs(
                 TRequestInfoPtr requestInfo,
                 ui64 commitId,
-                TVector<TBlobUniqueIdWithRange> blobs)
+                TVector<TBlobToConfirm> blobs)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
             , Blobs(std::move(blobs))


### PR DESCRIPTION
#122 

For now, checksums are not persisted, so they will disappear after partition tablet restart