### PR TITLE
issue-196: block checksums should be calculated after we copy the data from the client's buffer to our buffer, otherwise our client may modify the data between the checksum calculation stage and the writeblob stage

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -506,13 +506,14 @@ void TCompactionActor::WriteBlobs(const TActorContext& ctx)
             auto request = std::make_unique<TEvPartitionPrivate::TEvWriteBlobRequest>(
                 rc.DataBlobId,
                 rc.BlobContent.GetGuardedSgList(),
+                0,      // blockSizeForChecksums
                 true);  // async
 
             if (!RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {
                 LWTRACK(
                     ForkFailed,
                     RequestInfo->CallContext->LWOrbit,
-                    "TEvPartitionPrivate::TEvWriteBlobRequest",
+                    "TEvPartitionPrivate::TvWriteBlobRequest",
                     RequestInfo->CallContext->RequestId);
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -513,7 +513,7 @@ void TCompactionActor::WriteBlobs(const TActorContext& ctx)
                 LWTRACK(
                     ForkFailed,
                     RequestInfo->CallContext->LWOrbit,
-                    "TEvPartitionPrivate::TvWriteBlobRequest",
+                    "TEvPartitionPrivate::TEvWriteBlobRequest",
                     RequestInfo->CallContext->RequestId);
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -194,6 +194,7 @@ void TFlushActor::WriteBlobs(const TActorContext& ctx)
         auto request = std::make_unique<TEvPartitionPrivate::TEvWriteBlobRequest>(
             req.BlobId,
             req.BlobContent.GetGuardedSgList(),
+            0,      // blockSizeForChecksums
             true);  // async
 
         if (!RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
@@ -318,7 +318,7 @@ void TPartitionActor::HandleWriteBlocksCompleted(
     if (msg->UnconfirmedBlobsAdded) {
         // blobs are confirmed, but AddBlobs request will be executed
         // (for this commit) later
-        State->BlobsConfirmed(commitId);
+        State->BlobsConfirmed(commitId, std::move(msg->BlobsToConfirm));
         Y_DEBUG_ABORT_UNLESS(msg->CollectGarbageBarrierAcquired);
         // commit & garbage queue barriers will be released when confirmed
         // blobs are added

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -218,7 +218,8 @@ void TWriteFreshBlocksActor::WriteBlob(const TActorContext& ctx)
         CombinedContext,
         blobId,
         std::move(BlobContent),
-        false);  // async
+        0,      // blockSizeForChecksums
+        false); // async
 
     NCloud::Send(
         ctx,
@@ -251,8 +252,10 @@ void TWriteFreshBlocksActor::NotifyCompleted(
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
     auto ev = std::make_unique<TEvent>(
         error,
-        false,  // collectGarbageBarrierAcquired
-        false); // unconfirmedBlobsAdded
+        false,                      // collectGarbageBarrierAcquired
+        false,                      // unconfirmedBlobsAdded
+        TVector<TBlobToConfirm>{}   // blobsToConfirm
+    );
 
     ev->ExecCycles = Requests.front().RequestInfo->GetExecCycles();
     ev->TotalCycles = Requests.front().RequestInfo->GetTotalCycles();

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -278,6 +278,9 @@ void TWriteMergedBlocksActor::NotifyCompleted(
     const NProto::TError& error)
 {
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
+    if (!BlockSizeForChecksums) {
+        BlobsToConfirm.clear();
+    }
     auto ev = std::make_unique<TEvent>(
         error,
         true,   // collectGarbageBarrierAcquired

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -52,15 +52,17 @@ public:
     };
 
 private:
+    const ui64 TabletId;
     const TActorId Tablet;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ui64 CommitId;
     const TRequestInfoPtr RequestInfo;
     TVector<TWriteBlobRequest> WriteBlobRequests;
+    TVector<TBlobToConfirm> BlobsToConfirm;
     const bool ReplyLocal;
     const bool ShouldAddUnconfirmedBlobs = false;
     const IWriteBlocksHandlerPtr WriteHandler;
-    const bool ChecksumsEnabled;
+    const ui32 BlockSizeForChecksums;
 
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
     size_t WriteBlobRequestsCompleted = 0;
@@ -72,6 +74,7 @@ private:
 
 public:
     TWriteMergedBlocksActor(
+        const ui64 tabletId,
         const TActorId& tablet,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui64 commitId,
@@ -80,7 +83,7 @@ public:
         bool replyLocal,
         bool shouldAddUnconfirmedBlobs,
         IWriteBlocksHandlerPtr writeHandler,
-        bool checksumsEnabled);
+        ui32 blockSizeForChecksums);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -98,7 +101,7 @@ private:
     void Reply(
         const TActorContext& ctx,
         TRequestInfo& requestInfo,
-        IEventBasePtr response);
+        IEventBasePtr response) const;
 
 private:
     STFUNC(StateWork);
@@ -123,6 +126,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TWriteMergedBlocksActor::TWriteMergedBlocksActor(
+        const ui64 tabletId,
         const TActorId& tablet,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui64 commitId,
@@ -131,8 +135,9 @@ TWriteMergedBlocksActor::TWriteMergedBlocksActor(
         bool replyLocal,
         bool shouldAddUnconfirmedBlobs,
         IWriteBlocksHandlerPtr writeHandler,
-        bool checksumsEnabled)
-    : Tablet(tablet)
+        ui32 blockSizeForChecksums)
+    : TabletId(tabletId)
+    , Tablet(tablet)
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , CommitId(commitId)
     , RequestInfo(std::move(requestInfo))
@@ -140,7 +145,7 @@ TWriteMergedBlocksActor::TWriteMergedBlocksActor(
     , ReplyLocal(replyLocal)
     , ShouldAddUnconfirmedBlobs(shouldAddUnconfirmedBlobs)
     , WriteHandler(std::move(writeHandler))
-    , ChecksumsEnabled(checksumsEnabled)
+    , BlockSizeForChecksums(blockSizeForChecksums)
 {}
 
 void TWriteMergedBlocksActor::Bootstrap(const TActorContext& ctx)
@@ -181,10 +186,6 @@ TGuardedSgList TWriteMergedBlocksActor::BuildBlobContentAndComputeChecksums(
             if (digest.Defined()) {
                 AffectedBlockInfos.push_back({blockIndex, *digest});
             }
-
-            if (ChecksumsEnabled) {
-                request.Checksums.push_back(ComputeDefaultDigest(block));
-            }
         }
     }
     return guardedSgList;
@@ -198,7 +199,9 @@ void TWriteMergedBlocksActor::WriteBlobs(const TActorContext& ctx)
 
         auto request = std::make_unique<TEvPartitionPrivate::TEvWriteBlobRequest>(
             req.BlobId,
-            std::move(guardedSglist));
+            std::move(guardedSglist),
+            BlockSizeForChecksums,
+            false); // async
 
         if (!RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {
             LWTRACK(
@@ -213,7 +216,8 @@ void TWriteMergedBlocksActor::WriteBlobs(const TActorContext& ctx)
         NCloud::Send(
             ctx,
             Tablet,
-            std::move(request));
+            std::move(request),
+            i);
     }
 }
 
@@ -245,19 +249,20 @@ void TWriteMergedBlocksActor::AddBlobs(
             ADD_WRITE_RESULT
         );
     } else {
-        TVector<TBlobToConfirm> blobs(Reserve(WriteBlobRequests.size()));
+        BlobsToConfirm.reserve(WriteBlobRequests.size());
 
         for (const auto& req: WriteBlobRequests) {
-            blobs.emplace_back(
+            BlobsToConfirm.emplace_back(
                 req.BlobId.UniqueId(),
                 req.WriteRange,
-                req.Checksums);
+                // checksums are not ready at this point
+                TVector<ui32>());
         }
 
         request = std::make_unique<TEvPartitionPrivate::TEvAddUnconfirmedBlobsRequest>(
             RequestInfo->CallContext,
             CommitId,
-            std::move(blobs));
+            BlobsToConfirm);
     }
 
     SafeToUseOrbit = false;
@@ -276,7 +281,8 @@ void TWriteMergedBlocksActor::NotifyCompleted(
     auto ev = std::make_unique<TEvent>(
         error,
         true,   // collectGarbageBarrierAcquired
-        UnconfirmedBlobsAdded);
+        UnconfirmedBlobsAdded,
+        std::move(BlobsToConfirm));
 
     ev->ExecCycles = RequestInfo->GetExecCycles();
     ev->TotalCycles = RequestInfo->GetTotalCycles();
@@ -331,7 +337,7 @@ void TWriteMergedBlocksActor::ReplyAndDie(
 void TWriteMergedBlocksActor::Reply(
     const TActorContext& ctx,
     TRequestInfo& requestInfo,
-    IEventBasePtr response)
+    IEventBasePtr response) const
 {
     if (SafeToUseOrbit) {
         LWTRACK(
@@ -350,7 +356,7 @@ void TWriteMergedBlocksActor::HandleWriteBlobResponse(
     const TEvPartitionPrivate::TEvWriteBlobResponse::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto* msg = ev->Get();
+    auto* msg = ev->Get();
 
     RequestInfo->AddExecCycles(msg->ExecCycles);
 
@@ -358,12 +364,33 @@ void TWriteMergedBlocksActor::HandleWriteBlobResponse(
         return;
     }
 
-    Y_ABORT_UNLESS(WriteBlobRequestsCompleted < WriteBlobRequests.size());
+    STORAGE_VERIFY(
+        ev->Cookie < WriteBlobRequests.size(),
+        TWellKnownEntityTypes::TABLET,
+        TabletId);
+
+    if (BlobsToConfirm.empty()) {
+        WriteBlobRequests[ev->Cookie].Checksums =
+            std::move(msg->BlockChecksums);
+    } else {
+        STORAGE_VERIFY(
+            BlobsToConfirm.size() == WriteBlobRequests.size(),
+            TWellKnownEntityTypes::TABLET,
+            TabletId);
+
+        BlobsToConfirm[ev->Cookie].Checksums = std::move(msg->BlockChecksums);
+    }
+
+    STORAGE_VERIFY(
+        WriteBlobRequestsCompleted < WriteBlobRequests.size(),
+        TWellKnownEntityTypes::TABLET,
+        TabletId);
+
     if (++WriteBlobRequestsCompleted < WriteBlobRequests.size()) {
         return;
     }
 
-    for (auto context: ForkedCallContexts) {
+    for (const auto& context: ForkedCallContexts) {
         RequestInfo->CallContext->LWOrbit.Join(context->LWOrbit);
     }
 
@@ -520,6 +547,7 @@ void TPartitionActor::WriteMergedBlocks(
 
     auto actor = NCloud::Register<TWriteMergedBlocksActor>(
         ctx,
+        TabletID(),
         SelfId(),
         BlockDigestGenerator,
         commitId,
@@ -528,7 +556,7 @@ void TPartitionActor::WriteMergedBlocks(
         requestInBuffer.Data.ReplyLocal,
         shouldAddUnconfirmedBlobs,
         std::move(requestInBuffer.Data.Handler),
-        checksumsEnabled
+        checksumsEnabled ? State->GetBlockSize() : 0
     );
     Actors.Insert(actor);
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -279,6 +279,10 @@ void TWriteMergedBlocksActor::NotifyCompleted(
 {
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
     if (!BlockSizeForChecksums) {
+        // this structure is needed only to transfer block checksums to
+        // PartState - passing it without checksums will trigger a couple
+        // of debug asserts and is actually pointless even if we didn't have
+        // those asserts
         BlobsToConfirm.clear();
     }
     auto ev = std::make_unique<TEvent>(

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
@@ -47,33 +47,33 @@ public:
             const bool Empty;
             const TRequestInfoPtr RequestInfo;
             const bool ReplyLocal;
-            const TVector<ui32> Checksums;
 
             TSubRequest(
                     const TBlockRange32 writeRange,
                     const bool empty,
                     TRequestInfoPtr requestInfo,
-                    bool replyLocal,
-                    TVector<ui32> checksums)
+                    bool replyLocal)
                 : WriteRange(writeRange)
                 , Empty(empty)
                 , RequestInfo(std::move(requestInfo))
                 , ReplyLocal(replyLocal)
-                , Checksums(std::move(checksums))
             {
             }
         };
 
         TPartialBlobId BlobId;
         TVector<TSubRequest> SubRequests;
+        TVector<ui32> Checksums;
     };
 
 private:
+    const ui64 TabletId;
     const TActorId Tablet;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ui64 CommitId;
-    const TVector<TRequest> Requests;
+    TVector<TRequest> Requests;
     const IWriteBlocksHandlerPtr WriteHandler;
+    const ui32 BlockSizeForChecksums;
 
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
     size_t RequestsCompleted = 0;
@@ -83,11 +83,13 @@ private:
 
 public:
     TWriteMixedBlocksActor(
+        const ui64 tabletId,
         const TActorId& tablet,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui64 commitId,
         TVector<TRequest> requests,
-        IWriteBlocksHandlerPtr writeHandler);
+        IWriteBlocksHandlerPtr writeHandler,
+        ui32 blockSizeForChecksums);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -126,16 +128,20 @@ private:
 };
 
 TWriteMixedBlocksActor::TWriteMixedBlocksActor(
+        const ui64 tabletId,
         const TActorId& tablet,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui64 commitId,
         TVector<TRequest> requests,
-        IWriteBlocksHandlerPtr writeHandler)
-    : Tablet(tablet)
+        IWriteBlocksHandlerPtr writeHandler,
+        ui32 blockSizeForChecksums)
+    : TabletId(tabletId)
+    , Tablet(tablet)
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , CommitId(commitId)
     , Requests(std::move(requests))
     , WriteHandler(std::move(writeHandler))
+    , BlockSizeForChecksums(blockSizeForChecksums)
 {}
 
 void TWriteMixedBlocksActor::Bootstrap(const TActorContext& ctx)
@@ -225,7 +231,9 @@ void TWriteMixedBlocksActor::WriteBlobs(const TActorContext& ctx)
 
         auto request = std::make_unique<TEvPartitionPrivate::TEvWriteBlobRequest>(
             req.BlobId,
-            std::move(guardedSglist));
+            std::move(guardedSglist),
+            BlockSizeForChecksums,
+            false); // async
 
         for (const auto& sr: req.SubRequests) {
             if (!sr.RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {
@@ -251,21 +259,13 @@ void TWriteMixedBlocksActor::AddBlobs(const TActorContext& ctx)
 {
     TVector<TAddMixedBlob> blobs(Reserve(Requests.size()));
 
-    for (const auto& req: Requests) {
-        ui32 blockCount = 0;
-        TVector<ui32> blocks(Reserve(blockCount));
-        TVector<ui32> checksums(Reserve(blockCount));
+    for (auto& req: Requests) {
+        TVector<ui32> blocks;
 
         for (const auto& sr: req.SubRequests) {
             if (!sr.Empty) {
-                blockCount += sr.WriteRange.Size();
-
                 for (ui32 idx: xrange(sr.WriteRange)) {
                     blocks.push_back(idx);
-                }
-
-                for (const auto& checksum: sr.Checksums) {
-                    checksums.push_back(checksum);
                 }
             }
             if (!sr.RequestInfo->CallContext->LWOrbit.Fork(CombinedContext->LWOrbit)) {
@@ -277,7 +277,10 @@ void TWriteMixedBlocksActor::AddBlobs(const TActorContext& ctx)
             }
         }
 
-        blobs.emplace_back(req.BlobId, std::move(blocks), std::move(checksums));
+        blobs.emplace_back(
+            req.BlobId,
+            std::move(blocks),
+            std::move(req.Checksums));
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -302,8 +305,10 @@ void TWriteMixedBlocksActor::NotifyCompleted(
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
     auto ev = std::make_unique<TEvent>(
         error,
-        true,   // collectGarbageBarrierAcquired
-        false); // unconfirmedBlobsAdded
+        true,                       // collectGarbageBarrierAcquired
+        false,                      // unconfirmedBlobsAdded
+        TVector<TBlobToConfirm>{}   // blobsToConfirm
+    );
 
     ui32 blocksCount = 0;
     ui64 waitCycles = 0;
@@ -390,11 +395,18 @@ void TWriteMixedBlocksActor::HandleWriteBlobResponse(
     const TEvPartitionPrivate::TEvWriteBlobResponse::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto* msg = ev->Get();
+    auto* msg = ev->Get();
 
-    for (const auto& sr: Requests[ev->Cookie].SubRequests) {
+    STORAGE_VERIFY(
+        ev->Cookie < Requests.size(),
+        TWellKnownEntityTypes::TABLET,
+        TabletId);
+
+    auto& request = Requests[ev->Cookie];
+    for (const auto& sr: request.SubRequests) {
         sr.RequestInfo->AddExecCycles(msg->ExecCycles);
     }
+    request.Checksums = std::move(msg->BlockChecksums);
 
     if (HandleError(ctx, msg->GetError())) {
         return;
@@ -485,6 +497,8 @@ bool TPartitionActor::WriteMixedBlocks(
     State->GetCommitQueue().AcquireBarrier(commitId);
     State->GetGarbageQueue().AcquireBarrier(commitId);
 
+    bool checksumsEnabled = false;
+
     for (const auto& group: groups) {
         requests.emplace_back();
 
@@ -496,37 +510,25 @@ bool TPartitionActor::WriteMixedBlocks(
                 );
             }
 
-            LOG_TRACE(ctx, TBlockStoreComponents::PARTITION,
+            LOG_DEBUG(ctx, TBlockStoreComponents::PARTITION,
                 "[%lu] Writing mixed blocks @%lu (range: %s)",
                 TabletID(),
                 commitId,
                 DescribeRange(request->Data.Range).data()
             );
 
-            TVector<ui32> checksums;
-
             const ui32 checksumBoundary =
                 Config->GetDiskPrefixLengthWithBlockChecksumsInBlobs()
                 / State->GetBlockSize();
-            const bool checksumsEnabled =
-                request->Data.Range.Start < checksumBoundary;
-
-            if (checksumsEnabled) {
-                auto sgList = request->Data.Handler->GetBlocks(
-                    ConvertRangeSafe(request->Data.Range));
-                if (auto g = sgList.Acquire()) {
-                    for (const auto& blockContent: g.Get()) {
-                        checksums.push_back(ComputeDefaultDigest(blockContent));
-                    }
-                }
+            if (request->Data.Range.Start < checksumBoundary) {
+                checksumsEnabled = true;
             }
 
             requests.back().SubRequests.emplace_back(
                 request->Data.Range,
                 !request->Weight,
                 request->Data.RequestInfo,
-                request->Data.ReplyLocal,
-                std::move(checksums)
+                request->Data.ReplyLocal
             );
         }
 
@@ -543,11 +545,13 @@ bool TPartitionActor::WriteMixedBlocks(
 
     auto actor = NCloud::Register<TWriteMixedBlocksActor>(
         ctx,
+        TabletID(),
         SelfId(),
         BlockDigestGenerator,
         commitId,
         std::move(requests),
-        std::move(writeHandler)
+        std::move(writeHandler),
+        checksumsEnabled ? State->GetBlockSize() : 0
     );
     Actors.Insert(actor);
 

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -665,15 +665,28 @@ void TPartitionState::ConfirmedBlobsAdded(
     CommitQueue.ReleaseBarrier(commitId);
 }
 
-void TPartitionState::BlobsConfirmed(ui64 commitId)
+void TPartitionState::BlobsConfirmed(
+    ui64 commitId,
+    TVector<TBlobToConfirm> blobs)
 {
     auto it = UnconfirmedBlobs.find(commitId);
     Y_DEBUG_ABORT_UNLESS(it != UnconfirmedBlobs.end());
 
-    auto& blobs = it->second;
-    const auto blobCount = blobs.size();
+    auto& dstBlobs = it->second;
+    const auto blobCount = dstBlobs.size();
+    Y_DEBUG_ABORT_UNLESS(blobCount == blobs.size());
+    for (ui32 i = 0; i < Min(blobCount, blobs.size()); ++i) {
+        const auto blockRange = dstBlobs[i].BlockRange;
+        Y_DEBUG_ABORT_UNLESS(dstBlobs[i].UniqueId == blobs[i].UniqueId);
+        Y_DEBUG_ABORT_UNLESS(blockRange.Start == blobs[i].BlockRange.Start);
+        Y_DEBUG_ABORT_UNLESS(blockRange.End == blobs[i].BlockRange.End);
+        Y_DEBUG_ABORT_UNLESS(blockRange.Size() == blobs[i].Checksums.size());
+        if (dstBlobs[i].UniqueId == blobs[i].UniqueId) {
+            dstBlobs[i].Checksums = std::move(blobs[i]).Checksums;
+        }
+    }
 
-    ConfirmedBlobs[commitId] = std::move(blobs);
+    ConfirmedBlobs[commitId] = std::move(dstBlobs);
     ConfirmedBlobCount += blobCount;
 
     UnconfirmedBlobs.erase(it);

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -1345,7 +1345,7 @@ public:
 
     void ConfirmedBlobsAdded(TPartitionDatabase& db, ui64 commitId);
 
-    void BlobsConfirmed(ui64 commitId);
+    void BlobsConfirmed(ui64 commitId, TVector<TBlobToConfirm> blobs);
 
     //
     // AddConfirmedBlobs

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -9689,6 +9689,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                     if (spoofWriteBlobs) {
                         auto response =
                             std::make_unique<TEvPartitionPrivate::TEvWriteBlobResponse>();
+                        response->BlockChecksums.resize(1);
                         runtime->Send(new IEventHandle(
                             event->Sender,
                             event->Recipient,

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -10710,6 +10710,40 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
+    void EnableReadBlobCorruption(TTestActorRuntime& runtime)
+    {
+        std::shared_ptr<TGuardedSgList> sgList;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    sgList = std::make_shared<TGuardedSgList>(msg->Sglist);
+
+                    break;
+                }
+                case TEvPartitionCommonPrivate::EvReadBlobResponse: {
+                    auto g = sgList->Acquire();
+                    UNIT_ASSERT(g);
+                    UNIT_ASSERT_VALUES_UNEQUAL(0, g.Get().size());
+
+                    const char* block = g.Get()[0].Data();
+                    memset(const_cast<char*>(block), '0', DefaultBlockSize);
+                    break;
+                }
+            }
+            return false;
+        });
+
+    }
+
     Y_UNIT_TEST(ShouldDetectBlockCorruptionInBlobsWhenAddingUnconfirmedBlobs)
     {
         constexpr ui32 blockCount = 1024 * 1024;
@@ -10724,35 +10758,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         const auto range = TBlockRange32::WithLength(0, 1024);
         partition.WriteBlocks(range, 1);
 
-        TGuardedSgList sgList;
-        int corruptValue = 0;
-        auto corruptData = [&] () {
-            auto g = sgList.Acquire();
-            UNIT_ASSERT(g);
-            UNIT_ASSERT_VALUES_UNEQUAL(0, g.Get().size());
-
-            const char* block = g.Get()[0].Data();
-            memset(const_cast<char*>(block), corruptValue, DefaultBlockSize);
-        };
-
-        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
-                switch (event->GetTypeRewrite()) {
-                    case TEvPartitionCommonPrivate::EvReadBlobRequest: {
-                        using TEv =
-                            TEvPartitionCommonPrivate::TEvReadBlobRequest;
-                        auto* msg = event->Get<TEv>();
-                        sgList = msg->Sglist;
-
-                        break;
-                    }
-                    case TEvPartitionCommonPrivate::EvReadBlobResponse: {
-                        corruptData();
-                        break;
-                    }
-                }
-                return TTestActorRuntime::DefaultObserverFunc(event);
-            }
-        );
+        EnableReadBlobCorruption(*runtime);
 
         // direct read should fail
         TVector<TString> blocks;
@@ -10766,6 +10772,127 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldProperlyCalculateBlockChecksumsForBatchedWrites)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto config = DefaultConfig();
+        // enabling batching + checksum checks
+        config.SetCheckBlockChecksumsInBlobsUponRead(true);
+        config.SetWriteRequestBatchingEnabled(true);
+        // removing the dependency on the current defaults
+        config.SetWriteBlobThreshold(128_KB);
+        config.SetMaxBlobRangeSize(128_MB);
+        // disabling flush
+        config.SetFlushThreshold(1_GB);
+        // enabling fresh channel writes to make stats check a bit more
+        // convenient
+        config.SetFreshChannelCount(1);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> processQueue;
+        bool intercept = true;
+
+        runtime->SetEventFilter([&] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionPrivate::EvProcessWriteQueue: {
+                    if (intercept) {
+                        processQueue.reset(event.Release());
+                        intercept = false;
+
+                        return true;
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+
+        // the following 14 blocks get batched into mixed blob 1
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208792, 1),
+            'a');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208796, 1),
+            'b');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208799, 1),
+            'c');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208864, 1),
+            'd');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208866, 10),
+            'e');
+        // the following 17 blocks get batched into mixed blob 2
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(251925, 17),
+            'f');
+        // and the remaining block goes to fresh blocks
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(800000, 1),
+            'g');
+
+        runtime->DispatchEvents({}, TDuration::Seconds(2));
+        runtime->Send(processQueue.release());
+        partition.RecvWriteBlocksResponse();
+
+        // checking that mixed batching has actually worked
+        {
+            const auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+        }
+
+        // checking that we don't run into a failed checksum check upon read
+        {
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(
+                blocks,
+                1024,
+                TString::TUninitialized(DefaultBlockSize));
+            partition.SendReadBlocksLocalRequest(
+                TBlockRange32::WithLength(208792, 1024),
+                std::move(sglist));
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        EnableReadBlobCorruption(*runtime);
+
+        // checking that we actually saved the checksums
+        {
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(
+                blocks,
+                1024,
+                TString::TUninitialized(DefaultBlockSize));
+            partition.SendReadBlocksLocalRequest(
+                TBlockRange32::WithLength(208792, 1024),
+                std::move(sglist));
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/protos/part.proto
+++ b/cloud/blockstore/libs/storage/protos/part.proto
@@ -177,7 +177,8 @@ message TBlobMeta
     // corresponding flag in TStorageServiceConfig is set.
     // May contain zeroes. Zeroes are treated as "no checksum" and thus
     // verification doesn't work for actual zero checksums.
-    repeated uint32 BlockChecksums = 3;
+    reserved 3;
+    repeated uint32 BlockChecksums = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#196 