### PR TITLE
NBS-4967 Shadow disk statistics

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -1021,11 +1021,8 @@ void TShadowDiskActor::HandleShadowDiskCounters(
     const TEvVolume::TEvDiskRegistryBasedPartitionCounters::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    Y_UNUSED(ev);
-    Y_UNUSED(ctx);
-
-    // TODO. Do we need to count the statistics of the shadow disk in the source
-    // disk?
+    // Forward stat from shadow disk to volume.
+    ForwardMessageToActor(ev, ctx, VolumeActorId);
 }
 
 void TShadowDiskActor::HandleWakeup(

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -384,6 +384,9 @@ private:
     }
 
     void SendPartStatsToService(const NActors::TActorContext& ctx);
+    void DoSendPartStatsToService(
+        const NActors::TActorContext& ctx,
+        const TString& diskId);
     void SendSelfStatsToService(const NActors::TActorContext& ctx);
 
     void OnActivateExecutor(const NActors::TActorContext& ctx) override;
@@ -472,7 +475,13 @@ private:
     void ResetServicePipes(const NActors::TActorContext& ctx);
 
     void RegisterVolume(const NActors::TActorContext& ctx);
+    void DoRegisterVolume(
+        const NActors::TActorContext& ctx,
+        const TString& diskId);
     void UnregisterVolume(const NActors::TActorContext& ctx);
+    void DoUnregisterVolume(
+        const NActors::TActorContext& ctx,
+        const TString& diskId);
     void SendVolumeConfigUpdated(const NActors::TActorContext& ctx);
     void SendVolumeSelfCounters(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1351,6 +1351,14 @@ void TVolumeActor::CompleteUpdateCheckpointRequest(
          request.ReqType == ECheckpointRequestType::DeleteData) &&
          State->GetCheckpointStore().HasShadowActor(request.CheckpointId);
 
+    if (needToDestroyShadowActor) {
+        auto checkpointInfo =
+            State->GetCheckpointStore().GetCheckpoint(request.CheckpointId);
+        if (checkpointInfo && checkpointInfo->ShadowDiskId) {
+            DoUnregisterVolume(ctx, checkpointInfo->ShadowDiskId);
+        }
+    }
+
     State->SetCheckpointRequestFinished(
         request,
         args.Completed,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -655,12 +655,12 @@ void TVolumeActor::RenderCheckpoints(IOutputStream& out) const
                         TABLEH() { out << "Delete"; }
                     }
                 }
-                for (const auto& [r, checkpointType]:
+                for (const auto& [r, checkpointInfo]:
                     State->GetCheckpointStore().GetActiveCheckpoints())
                 {
                     TABLER() {
                         TABLED() { out << r; }
-                        TABLED() { out << checkpointType; }
+                        TABLED() { out << checkpointInfo; }
                         TABLED() {
                             BuildDeleteCheckpointButton(
                                 out,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -286,6 +286,7 @@ NActors::TActorId TVolumeActor::WrapNonreplActorIfNeeded(
             checkpointInfo);
 
         State->GetCheckpointStore().ShadowActorCreated(checkpointId);
+        DoRegisterVolume(ctx, checkpointInfo.ShadowDiskId);
     }
     return nonreplicatedActorId;
 }

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -838,13 +838,13 @@ EPublishingPolicy TVolumeState::CountersPolicy() const
                                      : EPublishingPolicy::Repl;
 }
 
-
-void TVolumeState::CreatePartitionStatInfo(
+TPartitionStatInfo& TVolumeState::CreatePartitionStatInfo(
     const TString& diskId,
     ui64 tabletId)
 {
     PartitionStatInfos.push_back(
         TPartitionStatInfo(diskId, tabletId, CountersPolicy()));
+    return PartitionStatInfos.back();
 }
 
 TPartitionStatInfo* TVolumeState::GetPartitionStatInfoByTabletId(ui64 tabletId)
@@ -870,6 +870,15 @@ TVolumeState::GetPartitionStatByDiskId(const TString& diskId)
             return &statInfo;
         }
     }
+
+    for (const auto& [checkpointId, checkpointInfo]:
+         GetCheckpointStore().GetActiveCheckpoints())
+    {
+        if (checkpointInfo.ShadowDiskId == diskId) {
+            return &CreatePartitionStatInfo(diskId, 0);
+        }
+    }
+
     return nullptr;
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -328,7 +328,8 @@ public:
 
     EPublishingPolicy CountersPolicy() const;
 
-    void CreatePartitionStatInfo(const TString& diskId, ui64 tabletId);
+    TPartitionStatInfo&
+    CreatePartitionStatInfo(const TString& diskId, ui64 tabletId);
 
     TPartitionStatInfo* GetPartitionStatInfoByTabletId(ui64 tabletId);
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_stats.cpp
@@ -430,6 +430,123 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             return nonEmptyReports == 3;
         }}, TDuration::Seconds(1));
     }
+
+    Y_UNIT_TEST(ShouldSendPartitionStatsForShadowDisk)
+    {
+        constexpr ui64 DiskBlockCount = 32768;
+        constexpr ui64 DiskBlockSize = 4096;
+        constexpr ui64 DiskByteCount = DiskBlockCount * DiskBlockSize;
+        constexpr ui32 WriteBlockCount = 2;
+        constexpr ui32 ReadFromSourceBlockCount = 5;
+        constexpr ui32 ReadFromCheckpointBlockCount = 10;
+
+        NProto::TStorageServiceConfig config;
+        config.SetUseShadowDisksForNonreplDiskCheckpoints(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        struct TReadAndWriteByteCount
+        {
+            ui64 ReadByteCount = 0;
+            ui64 WriteByteCount = 0;
+        };
+        TMap<TString, TReadAndWriteByteCount> statsForDisks;
+        auto statEventInterceptor = [&](TAutoPtr<IEventHandle>& event)
+        {
+            if (event->Recipient == MakeStorageStatsServiceId() &&
+                event->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+            {
+                auto* msg =
+                    event->Get<TEvStatsService::TEvVolumePartCounters>();
+                statsForDisks[msg->DiskId].ReadByteCount +=
+                    msg->DiskCounters->RequestCounters.ReadBlocks.RequestBytes;
+                statsForDisks[msg->DiskId].WriteByteCount +=
+                    msg->DiskCounters->RequestCounters.WriteBlocks.RequestBytes;
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+        runtime->SetObserverFunc(statEventInterceptor);
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            DiskBlockCount,
+            "vol0");
+
+        volume.WaitReady();
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(clientInfo);
+
+        // Create checkpoint.
+        volume.CreateCheckpoint("c1");
+
+        // Reconnect pipe since partition has restarted.
+        volume.ReconnectPipe();
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+
+        // Write to the source disk. These writes will be mirrored to the shadow
+        // disk too.
+        volume.WriteBlocks(
+            TBlockRange64::WithLength(
+                DiskBlockCount - WriteBlockCount - 1,
+                WriteBlockCount),
+            clientInfo.GetClientId(),
+            GetBlockContent(2));
+
+        // Read from the source disk.
+        volume.ReadBlocks(
+            TBlockRange64::WithLength(0, ReadFromSourceBlockCount),
+            clientInfo.GetClientId());
+
+        // Wait for checkpoint get ready.
+        for (;;) {
+            auto status = volume.GetCheckpointStatus("c1");
+            if (status->Record.GetCheckpointStatus() ==
+                NProto::ECheckpointStatus::READY)
+            {
+                break;
+            }
+            runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+
+        // Read from checkpoint.
+        volume.ReadBlocks(
+            TBlockRange64::WithLength(0, ReadFromCheckpointBlockCount),
+            clientInfo.GetClientId(),
+            "c1");
+
+        // Wait for stats send to StorageStatsService.
+        runtime->AdvanceCurrentTime(UpdateCountersInterval);
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        runtime->AdvanceCurrentTime(UpdateCountersInterval);
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        // Validate bytes count for source and shadow disks.
+        UNIT_ASSERT_VALUES_EQUAL(2, statsForDisks.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            DiskByteCount + ReadFromSourceBlockCount * DiskBlockSize,
+            statsForDisks["vol0"].ReadByteCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            WriteBlockCount * DiskBlockSize,
+            statsForDisks["vol0"].WriteByteCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadFromCheckpointBlockCount * DiskBlockSize,
+            statsForDisks["vol0c1"].ReadByteCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            DiskByteCount + WriteBlockCount * DiskBlockSize,
+            statsForDisks["vol0c1"].WriteByteCount);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
Статистика для мониторингов по теневому диску.

Основная идея что мы регистрируем теневой диск, когда он появляется. И разрегистрируем в StorageService когда чекпоинт удаляет свой теневой диск.