### PR TITLE
blockstore loadtests: extracted common TStorageServiceConfig initialization code to a function, limiting bw by 32MiB/s in this function, using it in network-ssd/network-hdd loadtests

### DIFF
--- a/cloud/blockstore/tests/loadtest/local-checkpoint/test.py
+++ b/cloud/blockstore/tests/loadtest/local-checkpoint/test.py
@@ -3,44 +3,15 @@ import pytest
 import yatest.common as common
 
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
 import google.protobuf.json_format as protojson
 
 
-def parse_storage_config(param):
-    if param is None:
-        return None
-
-    return protojson.Parse(param, TStorageServiceConfig())
-
-
 def default_storage_config_patch():
-    bw = 1 << 7     # 128 MB/s
-    iops = 1 << 16
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
+    storage = storage_config_with_default_limits()
 
     storage.InactiveClientsTimeout = 10000
 

--- a/cloud/blockstore/tests/loadtest/local-checkpoint/test.py
+++ b/cloud/blockstore/tests/loadtest/local-checkpoint/test.py
@@ -7,8 +7,6 @@ from cloud.blockstore.tests.python.lib.config import storage_config_with_default
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
-import google.protobuf.json_format as protojson
-
 
 def default_storage_config_patch():
     storage = storage_config_with_default_limits()

--- a/cloud/blockstore/tests/loadtest/local-edgecase/test.py
+++ b/cloud/blockstore/tests/loadtest/local-edgecase/test.py
@@ -3,35 +3,14 @@ import pytest
 import yatest.common as common
 
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig, CT_LOAD
+from cloud.blockstore.config.storage_pb2 import CT_LOAD
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
 
 def default_storage_config_patch(tablet_version=1):
-    bw = 1 << 7     # 128 MB/s
-    iops = 1 << 16
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
+    storage = storage_config_with_default_limits()
 
     if tablet_version == 2:
         storage.BlockDigestsEnabled = True
@@ -44,7 +23,7 @@ def default_storage_config_patch(tablet_version=1):
 
 
 def storage_config_with_batching(tablet_version=1):
-    storage = TStorageServiceConfig()
+    storage = storage_config_with_default_limits()
     storage.WriteRequestBatchingEnabled = True
     storage.ThrottlingEnabled = False
 
@@ -57,7 +36,7 @@ def storage_config_with_batching(tablet_version=1):
 
 
 def storage_config_with_new_compaction():
-    storage = TStorageServiceConfig()
+    storage = storage_config_with_default_limits()
     storage.SSDCompactionType = CT_LOAD
     storage.HDDCompactionType = CT_LOAD
     storage.V1GarbageCompactionEnabled = True

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -3,8 +3,8 @@ import pytest
 
 import yatest.common as common
 
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
 from cloud.blockstore.public.sdk.python.client import CreateClient, Session
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import run_test
 
@@ -12,8 +12,7 @@ from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_
 
 
 def default_storage_config(cache_folder):
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
+    storage = storage_config_with_default_limits()
     storage.HDDSystemChannelPoolKind = "rot"
     storage.SSDSystemChannelPoolKind = "rot"
     storage.HybridSystemChannelPoolKind = "rot"

--- a/cloud/blockstore/tests/loadtest/local-endpoints/test.py
+++ b/cloud/blockstore/tests/loadtest/local-endpoints/test.py
@@ -5,8 +5,8 @@ import yatest.common as common
 from cloud.blockstore.config.client_pb2 import TClientConfig
 from cloud.blockstore.config.server_pb2 import \
     TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
 
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
@@ -30,30 +30,7 @@ class TestCase(object):
 
 
 def default_storage_config():
-    bw = 1 << 5     # 32 MB/s
-    iops = 1 << 12  # 4096 iops
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
-
+    storage = storage_config_with_default_limits()
     storage.InactiveClientsTimeout = 10000
     return storage
 

--- a/cloud/blockstore/tests/loadtest/local-nemesis/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nemesis/test.py
@@ -5,39 +5,11 @@ import yatest.common as common
 
 from cloud.blockstore.config.client_pb2 import TClientConfig
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test, \
     get_restart_interval
 from cloud.storage.core.protos.endpoints_pb2 import EEndpointStorageType
-
-
-def default_storage_config_patch():
-    bw = 1 << 7     # 128 MB/s
-    iops = 1 << 16
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
-
-    return storage
 
 
 class TestCase(object):
@@ -98,7 +70,7 @@ def __run_test(test_case):
     env = LocalLoadTest(
         "",
         server_app_config=server,
-        storage_config_patches=[default_storage_config_patch()],
+        storage_config_patches=[storage_config_with_default_limits()],
         use_in_memory_pdisks=True,
         restart_interval=test_case.restart_interval,
     )

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -5,7 +5,8 @@ import yatest.common as common
 
 from cloud.blockstore.config.client_pb2 import TClientConfig
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig, CT_LOAD
+from cloud.blockstore.config.storage_pb2 import CT_LOAD
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test, \
     get_restart_interval
@@ -14,36 +15,11 @@ from cloud.storage.core.protos.endpoints_pb2 import EEndpointStorageType
 
 
 def default_storage_config():
-    bw = 1 << 7     # 128 MB/s
-    iops = 1 << 16
-
-    storage = TStorageServiceConfig()
+    storage = storage_config_with_default_limits()
 
     storage.SSDCompactionType = CT_LOAD
     storage.HDDCompactionType = CT_LOAD
     storage.V1GarbageCompactionEnabled = True
-
-    storage.ThrottlingEnabled = True
-    storage.ThrottlingEnabledSSD = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
-
     storage.DiskPrefixLengthWithBlockChecksumsInBlobs = 1 << 30
     storage.CheckBlockChecksumsInBlobsUponRead = True
 

--- a/cloud/blockstore/tests/loadtest/local-overlay/test.py
+++ b/cloud/blockstore/tests/loadtest/local-overlay/test.py
@@ -7,8 +7,6 @@ from cloud.blockstore.tests.python.lib.config import storage_config_with_default
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
-import google.protobuf.json_format as protojson
-
 
 def default_storage_config_patch(tablet_version):
     storage = storage_config_with_default_limits()

--- a/cloud/blockstore/tests/loadtest/local-overlay/test.py
+++ b/cloud/blockstore/tests/loadtest/local-overlay/test.py
@@ -3,44 +3,15 @@ import pytest
 import yatest.common as common
 
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
 import google.protobuf.json_format as protojson
 
 
-def parse_storage_config(param):
-    if param is None:
-        return None
-
-    return protojson.Parse(param, TStorageServiceConfig())
-
-
 def default_storage_config_patch(tablet_version):
-    bw = 1 << 7     # 128 MB/s
-    iops = 1 << 16
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
+    storage = storage_config_with_default_limits()
 
     storage.InactiveClientsTimeout = 10000
 

--- a/cloud/blockstore/tests/loadtest/local-v2/test.py
+++ b/cloud/blockstore/tests/loadtest/local-v2/test.py
@@ -3,44 +3,15 @@ import pytest
 import yatest.common as common
 
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
 import google.protobuf.json_format as protojson
 
 
-def parse_storage_config(param):
-    if param is None:
-        return None
-
-    return protojson.Parse(param, TStorageServiceConfig())
-
-
 def default_storage_config_patch():
-    bw = 1 << 7     # 128 MB/s
-    iops = 1 << 16
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
+    storage = storage_config_with_default_limits()
 
     storage.InactiveClientsTimeout = 10000
 

--- a/cloud/blockstore/tests/loadtest/local-v2/test.py
+++ b/cloud/blockstore/tests/loadtest/local-v2/test.py
@@ -7,8 +7,6 @@ from cloud.blockstore.tests.python.lib.config import storage_config_with_default
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
-import google.protobuf.json_format as protojson
-
 
 def default_storage_config_patch():
     storage = storage_config_with_default_limits()

--- a/cloud/blockstore/tests/loadtest/local/test.py
+++ b/cloud/blockstore/tests/loadtest/local/test.py
@@ -9,8 +9,6 @@ from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
 from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
-import google.protobuf.json_format as protojson
-
 
 def default_storage_config(tablet_version, cache_folder):
     storage = storage_config_with_default_limits()

--- a/cloud/blockstore/tests/loadtest/local/test.py
+++ b/cloud/blockstore/tests/loadtest/local/test.py
@@ -3,7 +3,7 @@ import pytest
 import yatest.common as common
 
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
-from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
+from cloud.blockstore.tests.python.lib.config import storage_config_with_default_limits
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
@@ -12,37 +12,8 @@ from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_
 import google.protobuf.json_format as protojson
 
 
-def parse_storage_config(param):
-    if param is None:
-        return None
-
-    return protojson.Parse(param, TStorageServiceConfig())
-
-
 def default_storage_config(tablet_version, cache_folder):
-    bw = 1 << 6     # 64 MiB/s
-    iops = 1 << 12  # 4096 IOPS
-
-    storage = TStorageServiceConfig()
-    storage.ThrottlingEnabled = True
-
-    storage.SSDUnitReadBandwidth = bw
-    storage.SSDUnitWriteBandwidth = bw
-    storage.SSDMaxReadBandwidth = bw
-    storage.SSDMaxWriteBandwidth = bw
-    storage.SSDUnitReadIops = iops
-    storage.SSDUnitWriteIops = iops
-    storage.SSDMaxReadIops = iops
-    storage.SSDMaxWriteIops = iops
-
-    storage.HDDUnitReadBandwidth = bw
-    storage.HDDUnitWriteBandwidth = bw
-    storage.HDDMaxReadBandwidth = bw
-    storage.HDDMaxWriteBandwidth = bw
-    storage.HDDUnitReadIops = iops
-    storage.HDDUnitWriteIops = iops
-    storage.HDDMaxReadIops = iops
-    storage.HDDMaxWriteIops = iops
+    storage = storage_config_with_default_limits()
 
     storage.InactiveClientsTimeout = 10000
     storage.DiskPrefixLengthWithBlockChecksumsInBlobs = 1 << 30  # 1 GiB

--- a/cloud/blockstore/tests/python/lib/config.py
+++ b/cloud/blockstore/tests/python/lib/config.py
@@ -301,3 +301,32 @@ def generate_disk_agent_txt(
             ParseDict(storage_discovery_config, TStorageDiscoveryConfig()))
 
     return config
+
+
+def storage_config_with_default_limits():
+    bw = 1 << 5     # 32 MiB/s
+    iops = 1 << 16
+
+    storage = TStorageServiceConfig()
+    storage.ThrottlingEnabledSSD = True
+    storage.ThrottlingEnabled = True
+
+    storage.SSDUnitReadBandwidth = bw
+    storage.SSDUnitWriteBandwidth = bw
+    storage.SSDMaxReadBandwidth = bw
+    storage.SSDMaxWriteBandwidth = bw
+    storage.SSDUnitReadIops = iops
+    storage.SSDUnitWriteIops = iops
+    storage.SSDMaxReadIops = iops
+    storage.SSDMaxWriteIops = iops
+
+    storage.HDDUnitReadBandwidth = bw
+    storage.HDDUnitWriteBandwidth = bw
+    storage.HDDMaxReadBandwidth = bw
+    storage.HDDMaxWriteBandwidth = bw
+    storage.HDDUnitReadIops = iops
+    storage.HDDUnitWriteIops = iops
+    storage.HDDMaxReadIops = iops
+    storage.HDDMaxWriteIops = iops
+
+    return storage


### PR DESCRIPTION
Just getting rid of code duplication + setting a proper bandwidth limit to decrease the chance of using up all available space in blobstorage (this will make loadtests more stable) 