### PR TITLE
fix: ternary-like expressions in github actions are weird. Also fix for missing rebase expressions

### DIFF
--- a/.github/workflows/build_and_test_cmake.yaml
+++ b/.github/workflows/build_and_test_cmake.yaml
@@ -53,12 +53,18 @@ jobs:
       with:
         submodules: true
         ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
+    - name: Rebase PR
+      if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+      shell: bash
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        git rebase origin/${{ github.event.pull_request.base.ref }}
     - name: Checkout
       uses: actions/checkout@v4
       if: github.event.pull_request.head.sha == ''
       with:
         submodules: true
-
     - name: Prepare s3cmd
       uses: ./.github/actions/s3cmd
       with:

--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -117,7 +117,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
@@ -165,7 +165,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: Rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
@@ -233,7 +233,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash

--- a/.github/workflows/build_and_test_on_demand_cmake.yaml
+++ b/.github/workflows/build_and_test_on_demand_cmake.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
@@ -105,7 +105,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: Rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
@@ -165,7 +165,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ contains(github.event.pull_request.labels.*.name, 'rebase') && 0 || 1 }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: rebase PR
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -85,6 +85,13 @@ jobs:
       with:
         submodules: true
         ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
+    - name: Rebase PR
+      if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+      shell: bash
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        git rebase origin/${{ github.event.pull_request.base.ref }}
     - name: Checkout
       uses: actions/checkout@v4
       if: github.event.pull_request.head.sha == ''

--- a/.github/workflows/github_actions_scripts.yaml
+++ b/.github/workflows/github_actions_scripts.yaml
@@ -51,8 +51,28 @@ jobs:
         EOF
       env:
         ACTIONS_TEST_DATA_VERSION: ${{ vars.ACTIONS_TEST_DATA_VERSION }}
+
+    - name: Checkout PR
+      uses: actions/checkout@v4
+      if: github.event.pull_request.head.sha != ''
+      with:
+        submodules: true
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
+    - name: Rebase PR
+      if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+      shell: bash
+      run: |
+        set -x
+        # git config is needed for some reason, idk why it works without
+        # it on self-hosted runners
+        git config --global user.email "github-actions@example.com"
+        git config --global user.name "GitHub Actions"
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        git rebase origin/${{ github.event.pull_request.base.ref }}
     - name: Checkout
       uses: actions/checkout@v4
+      if: github.event.pull_request.head.sha == ''
       with:
         submodules: true
     - name: Prepare VM


### PR DESCRIPTION
In github actions there is a ternary-like operator, but it is not really [ternary](https://docs.github.com/en/actions/learn-github-actions/expressions#example).

>  It is important to note that the first value after the && must be truthy. Otherwise, the value after the || will always be returned.

What means truthy?

> Note that in conditionals, falsy values (false, 0, -0, "", '', null) are coerced to false and truthy (true and other non-falsy values) are coerced to true.

And bug occurs because 0 is casted, for some reason, to false