### PR TITLE
NBS-4983 Handle allocation shadow disk error

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -65,7 +65,7 @@ void TCheckpointStore::SetCheckpointRequestInProgress(ui64 requestId)
 
 void TCheckpointStore::SetCheckpointRequestFinished(
     ui64 requestId,
-    bool success,
+    bool completed,
     TString shadowDiskId,
     EShadowDiskState shadowDiskState)
 {
@@ -74,8 +74,8 @@ void TCheckpointStore::SetCheckpointRequestFinished(
         auto& checkpointRequest = GetRequest(requestId);
         Y_DEBUG_ABORT_UNLESS(
             checkpointRequest.State == ECheckpointRequestState::Saved);
-        checkpointRequest.State = success ? ECheckpointRequestState::Completed
-                                          : ECheckpointRequestState::Rejected;
+        checkpointRequest.State = completed ? ECheckpointRequestState::Completed
+                                            : ECheckpointRequestState::Rejected;
         checkpointRequest.ShadowDiskId = std::move(shadowDiskId);
         checkpointRequest.ShadowDiskState = shadowDiskState;
         Apply(checkpointRequest);

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -64,6 +64,7 @@ struct TCheckpointRequest
     TString ShadowDiskId;
     EShadowDiskState ShadowDiskState = EShadowDiskState::None;
     ui64 ShadowDiskProcessedBlockCount = 0;
+    TString CheckpointError;
 
     TCheckpointRequest(
             ui64 requestId,
@@ -89,7 +90,8 @@ struct TCheckpointRequest
             ECheckpointType type,
             TString shadowDiskId,
             EShadowDiskState shadowDiskState,
-            ui64 shadowDiskProcessedBlockCount)
+            ui64 shadowDiskProcessedBlockCount,
+            TString checkpointError)
         : RequestId(requestId)
         , CheckpointId(std::move(checkpointId))
         , Timestamp(timestamp)
@@ -99,6 +101,7 @@ struct TCheckpointRequest
         , ShadowDiskId(std::move(shadowDiskId))
         , ShadowDiskState(shadowDiskState)
         , ShadowDiskProcessedBlockCount(shadowDiskProcessedBlockCount)
+        , CheckpointError(std::move(checkpointError))
     {}
 };
 
@@ -112,6 +115,11 @@ struct TActiveCheckpointInfo
     EShadowDiskState ShadowDiskState = EShadowDiskState::None;
     ui64 ProcessedBlockCount = 0;
     bool HasShadowActor = false;
+
+    [[nodiscard]] bool IsShadowDiskBased() const;
+
+    // Does the checkpoint block write/zero requests.
+    [[nodiscard]] bool ShouldBlockWrites() const;
 };
 
 using TActiveCheckpointsMap = TMap<TString, TActiveCheckpointInfo>;

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -143,7 +143,7 @@ public:
     void SetCheckpointRequestInProgress(ui64 requestId);
     void SetCheckpointRequestFinished(
         ui64 requestId,
-        bool success,
+        bool completed,
         TString shadowDiskId,
         EShadowDiskState shadowDiskState);
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -124,8 +124,20 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
                 ECheckpointType::Normal,
                 "shadow-disk-6",
                 EShadowDiskState::Preparing,
-                512},
+                512,
+                TString()},
 
+            TCheckpointRequest{
+                14,
+                "checkpoint-7",
+                TInstant::Now(),
+                ECheckpointRequestType::Create,
+                ECheckpointRequestState::Completed,
+                ECheckpointType::Normal,
+                TString(),
+                EShadowDiskState::Error,
+                0,
+                "disk-error"},
         };
         TCheckpointStore store(
             TVector<TCheckpointRequest>{
@@ -140,27 +152,26 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(true, store.HasRequestToExecute(&requestId));
         UNIT_ASSERT_VALUES_EQUAL(10, requestId);
         auto checkpoints = store.GetActiveCheckpoints();
-        UNIT_ASSERT_VALUES_EQUAL(4, checkpoints.size());
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-1"));
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-2"));
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-5"));
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-5"));
-        UNIT_ASSERT_VALUES_EQUAL(
-            true,
-            store.DoesCheckpointHaveData("checkpoint-2"));
-        UNIT_ASSERT_VALUES_EQUAL(
-            false,
-            store.DoesCheckpointHaveData("checkpoint-1"));
-        UNIT_ASSERT_VALUES_EQUAL(
-            false,
-            store.DoesCheckpointHaveData("checkpoint-5"));
+        UNIT_ASSERT_VALUES_EQUAL(5, checkpoints.size());
+        UNIT_ASSERT(checkpoints.contains("checkpoint-1"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-2"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-5"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-6"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-7"));
+        UNIT_ASSERT(!store.DoesCheckpointHaveData("checkpoint-1"));
+        UNIT_ASSERT(store.DoesCheckpointHaveData("checkpoint-2"));
+        UNIT_ASSERT(!store.DoesCheckpointHaveData("checkpoint-5"));
+        UNIT_ASSERT(store.DoesCheckpointHaveData("checkpoint-6"));
+        UNIT_ASSERT(store.DoesCheckpointHaveData("checkpoint-7"));
 
         // The checkpoint without the shadow disk has the correct state.
+        UNIT_ASSERT(!checkpoints["checkpoint-1"].IsShadowDiskBased());
         UNIT_ASSERT_VALUES_EQUAL(
             checkpoints["checkpoint-1"].ShadowDiskState,
             EShadowDiskState::None);
 
         // Checkpoint with the shadow disk loads the state.
+        UNIT_ASSERT(checkpoints["checkpoint-6"].IsShadowDiskBased());
         UNIT_ASSERT_VALUES_EQUAL(
             checkpoints["checkpoint-6"].ShadowDiskId,
             "shadow-disk-6");
@@ -170,6 +181,12 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(
             checkpoints["checkpoint-6"].ProcessedBlockCount,
             512);
+
+        // Checkpoint with disk error.
+        UNIT_ASSERT(checkpoints["checkpoint-7"].IsShadowDiskBased());
+        UNIT_ASSERT_VALUES_EQUAL(
+            EShadowDiskState::Error,
+            checkpoints["checkpoint-7"].ShadowDiskState);
     }
 
     Y_UNIT_TEST(CreateFail)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1349,7 +1349,7 @@ void TVolumeActor::ExecuteUpdateCheckpointRequest(
         args.Completed,
         args.ShadowDiskId,
         args.ShadowDiskState,
-        args.Error.value_or(""));
+        args.ErrorMessage.value_or(""));
 }
 
 void TVolumeActor::CompleteUpdateCheckpointRequest(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -267,9 +267,9 @@ NActors::TActorId TVolumeActor::WrapNonreplActorIfNeeded(
          State->GetCheckpointStore().GetActiveCheckpoints())
     {
         if (checkpointInfo.Data == ECheckpointData::DataDeleted ||
-            checkpointInfo.ShadowDiskId.Empty() ||
+            !checkpointInfo.IsShadowDiskBased() ||
             checkpointInfo.ShadowDiskState == EShadowDiskState::Error ||
-            State->GetCheckpointStore().HasShadowActor(checkpointId))
+            checkpointInfo.HasShadowActor)
         {
             continue;
         }

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -455,7 +455,8 @@ void TVolumeDatabase::UpdateCheckpointRequest(
     ui64 requestId,
     bool completed,
     const TString& shadowDiskId,
-    EShadowDiskState shadowDiskState)
+    EShadowDiskState shadowDiskState,
+    const TString& error)
 {
     using TTable = TVolumeSchema::CheckpointRequests;
 
@@ -466,7 +467,8 @@ void TVolumeDatabase::UpdateCheckpointRequest(
         NIceDb::TUpdate<TTable::State>(static_cast<ui32>(state)),
         NIceDb::TUpdate<TTable::ShadowDiskId>(shadowDiskId),
         NIceDb::TUpdate<TTable::ShadowDiskState>(
-            static_cast<ui32>(shadowDiskState)));
+            static_cast<ui32>(shadowDiskState)),
+        NIceDb::TUpdate<TTable::CheckpointError>(error));
 }
 
 void TVolumeDatabase::UpdateShadowDiskState(
@@ -551,7 +553,8 @@ bool TVolumeDatabase::ReadCheckpointRequests(
                 it.GetValue<TTable::ShadowDiskId>(),
                 static_cast<EShadowDiskState>(
                     it.GetValue<TTable::ShadowDiskState>()),
-                it.GetValue<TTable::ShadowDiskProcessedBlockCount>());
+                it.GetValue<TTable::ShadowDiskProcessedBlockCount>(),
+                it.GetValue<TTable::CheckpointError>());
         }
 
         if (!it.Next()) {

--- a/cloud/blockstore/libs/storage/volume/volume_database.h
+++ b/cloud/blockstore/libs/storage/volume/volume_database.h
@@ -114,7 +114,8 @@ public:
         ui64 requestId,
         bool completed,
         const TString& shadowDiskId,
-        EShadowDiskState shadowDiskState);
+        EShadowDiskState shadowDiskState,
+        const TString& error);
     void UpdateShadowDiskState(
         ui64 requestId,
         ui64 processedBlockCount,

--- a/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
@@ -280,12 +280,14 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 1,
                 true,
                 "shadow-disk-id",
-                EShadowDiskState::New);
+                EShadowDiskState::New,
+                TString());
             db.UpdateCheckpointRequest(
                 3,
                 false,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                "Error message");
         });
 
         executor.ReadTx([&] (TVolumeDatabase db) {
@@ -324,6 +326,7 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
             UNIT_ASSERT_VALUES_EQUAL(3, requests[2].RequestId);
             UNIT_ASSERT_VALUES_EQUAL("zzz", requests[2].CheckpointId);
             UNIT_ASSERT_VALUES_EQUAL("", requests[2].ShadowDiskId);
+            UNIT_ASSERT_VALUES_EQUAL("Error message", requests[2].CheckpointError);
             UNIT_ASSERT_VALUES_EQUAL(
                 TInstant::Seconds(333),
                 requests[2].Timestamp
@@ -365,7 +368,8 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                     1,
                     true,
                     "shadow-disk-id",
-                    EShadowDiskState::New);
+                    EShadowDiskState::New,
+                    TString());
             });
 
         executor.ReadTx(
@@ -609,22 +613,26 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 1,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
             db.UpdateCheckpointRequest(
                 2,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
             db.UpdateCheckpointRequest(
                 3,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
             db.UpdateCheckpointRequest(
                 4,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
         });
 
         executor.ReadTx([&] (TVolumeDatabase db) {
@@ -772,7 +780,8 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 5,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
         });
 
         executor.ReadTx([&] (TVolumeDatabase db) {

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -157,19 +157,19 @@ struct TEvVolumePrivate
         TRequestInfoPtr RequestInfo;
         ui64 RequestId;
         bool Completed;
-        bool Success;
+        std::optional<TString> Error;
         TString ShadowDiskId;
 
         TUpdateCheckpointRequestRequest(
                 TRequestInfoPtr requestInfo,
                 ui64 requestId,
                 bool completed,
-                bool success,
+                std::optional<TString> error,
                 TString shadowDiskId)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
             , Completed(completed)
-            , Success(success)
+            , Error(std::move(error))
             , ShadowDiskId(std::move(shadowDiskId))
         {
         }

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -157,16 +157,19 @@ struct TEvVolumePrivate
         TRequestInfoPtr RequestInfo;
         ui64 RequestId;
         bool Completed;
+        bool Success;
         TString ShadowDiskId;
 
         TUpdateCheckpointRequestRequest(
                 TRequestInfoPtr requestInfo,
                 ui64 requestId,
                 bool completed,
+                bool success,
                 TString shadowDiskId)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
             , Completed(completed)
+            , Success(success)
             , ShadowDiskId(std::move(shadowDiskId))
         {
         }

--- a/cloud/blockstore/libs/storage/volume/volume_schema.h
+++ b/cloud/blockstore/libs/storage/volume/volume_schema.h
@@ -154,6 +154,12 @@ struct TVolumeSchema
         {
         };
 
+        struct CheckpointError
+            : public Column<10, NKikimr::NScheme::NTypeIds::String>
+        {
+        };
+
+
         using TKey = TableKey<RequestId>;
         using TColumns = TableColumns<
             RequestId,
@@ -164,7 +170,8 @@ struct TVolumeSchema
             CheckpointType,
             ShadowDiskId,
             ShadowDiskProcessedBlockCount,
-            ShadowDiskState>;
+            ShadowDiskState,
+            CheckpointError>;
     };
 
     struct NonReplPartStats

--- a/cloud/blockstore/libs/storage/volume/volume_schema.h
+++ b/cloud/blockstore/libs/storage/volume/volume_schema.h
@@ -159,7 +159,6 @@ struct TVolumeSchema
         {
         };
 
-
         using TKey = TableKey<RequestId>;
         using TColumns = TableColumns<
             RequestId,

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -891,13 +891,13 @@ bool TVolumeState::GetMuteIOErrors() const
 
 void TVolumeState::SetCheckpointRequestFinished(
     const TCheckpointRequest& request,
-    bool success,
+    bool completed,
     TString shadowDiskId,
     EShadowDiskState shadowDiskState)
 {
     GetCheckpointStore().SetCheckpointRequestFinished(
         request.RequestId,
-        success,
+        completed,
         std::move(shadowDiskId),
         shadowDiskState);
     if (GetCheckpointStore().GetLightCheckpoints().empty()) {

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -426,7 +426,7 @@ struct TTxVolume
         const bool Completed;
         const TString ShadowDiskId;
         const EShadowDiskState ShadowDiskState;
-        const std::optional<TString> Error;
+        const std::optional<TString> ErrorMessage;
 
         TUpdateCheckpointRequest(
                 TRequestInfoPtr requestInfo,
@@ -434,13 +434,13 @@ struct TTxVolume
                 bool completed,
                 TString shadowDiskId,
                 EShadowDiskState shadowDiskState,
-                std::optional<TString> error)
+                std::optional<TString> errorMessage)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
             , Completed(completed)
             , ShadowDiskId(std::move(shadowDiskId))
             , ShadowDiskState(shadowDiskState)
-            , Error(std::move(error))
+            , ErrorMessage(std::move(errorMessage))
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -426,18 +426,21 @@ struct TTxVolume
         const bool Completed;
         const TString ShadowDiskId;
         const EShadowDiskState ShadowDiskState;
+        const std::optional<TString> Error;
 
         TUpdateCheckpointRequest(
                 TRequestInfoPtr requestInfo,
                 ui64 requestId,
                 bool completed,
                 TString shadowDiskId,
-                EShadowDiskState shadowDiskState)
+                EShadowDiskState shadowDiskState,
+                std::optional<TString> error)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
             , Completed(completed)
             , ShadowDiskId(std::move(shadowDiskId))
             , ShadowDiskState(shadowDiskState)
+            , Error(std::move(error))
         {}
 
         void Clear()


### PR DESCRIPTION
Обработка ошибки от disk-registry, если тот не смог аллоцировать теневой диск.