### PR TITLE
add selfping sensor to track service actor load

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -955,4 +955,6 @@ message TStorageServiceConfig
     // Duration of attempts to connect to tablet for cached tablets before
     // switching to describe volume (in ms).
     optional uint32 VolumeProxyCacheRetryDuration = 360;
+
+    optional uint32 ServiceSelfPingInterval = 361;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -956,5 +956,7 @@ message TStorageServiceConfig
     // switching to describe volume (in ms).
     optional uint32 VolumeProxyCacheRetryDuration = 360;
 
+    // Service actor self ping measurement interval. Used to evaluate
+    // service actor load. Set in ms.
     optional uint32 ServiceSelfPingInterval = 361;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -111,6 +111,7 @@ TDuration MSeconds(ui32 value)
     xxx(MaxChangedBlocksRangeBlocksCount,           ui64,       1 << 20       )\
     xxx(CachedDiskAgentConfigPath,                  TString,    ""            )\
     xxx(CachedDiskAgentSessionsPath,                TString,    ""            )\
+    xxx(ServiceSelfPingInterval,        TDuration, TDuration::MilliSeconds(10))\
 // BLOCKSTORE_STORAGE_CONFIG_RO
 
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -564,6 +564,8 @@ public:
     TDuration GetMaxAcquireShadowDiskTotalTimeoutWhenNonBlocked() const;
 
     TDuration GetVolumeProxyCacheRetryDuration() const;
+
+    TDuration GetServiceSelfPingInterval() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -136,9 +136,9 @@ void TServiceActor::UpdateCounters(const TActorContext& ctx)
 
     if (SelfPingMaxUsCounter) {
         auto val =
-            CyclesToDuration(SelfPingMaxUs) - Config->GetServiceSelfPingInterval();
+            CyclesToDuration(SelfPingMaxCycles) - Config->GetServiceSelfPingInterval();
         *SelfPingMaxUsCounter = val.MicroSeconds();
-        SelfPingMaxUs = 0;
+        SelfPingMaxCycles = 0;
     }
 }
 
@@ -216,7 +216,7 @@ void TServiceActor::HandleSelfPing(
     const TEvServicePrivate::TEvSelfPing::TPtr& ev,
     const TActorContext& ctx)
 {
-    SelfPingMaxUs = std::max(SelfPingMaxUs, GetCycleCount() - ev->Get()->StartCycles);
+    SelfPingMaxCycles = std::max(SelfPingMaxCycles, GetCycleCount() - ev->Get()->StartCycles);
     ScheduleSelfPing(ctx);
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -59,6 +59,9 @@ private:
     bool HasPendingManuallyPreemptedVolumesUpdate = false;
     bool IsVolumeLivenessCheckRunning = false;
 
+    NMonitoring::TDynamicCounters::TCounterPtr SelfPingMaxUsCounter;
+    ui64 SelfPingMaxUs = 0;
+
 public:
     TServiceActor(
         TStorageConfigPtr config,
@@ -123,11 +126,17 @@ private:
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo);
 
+    void ScheduleSelfPing(const NActors::TActorContext& ctx);
+
 private:
     STFUNC(StateWork);
 
     void HandleWakeup(
         const NActors::TEvents::TEvWakeup::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleSelfPing(
+        const TEvServicePrivate::TEvSelfPing::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleHttpInfo(

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -60,7 +60,7 @@ private:
     bool IsVolumeLivenessCheckRunning = false;
 
     NMonitoring::TDynamicCounters::TCounterPtr SelfPingMaxUsCounter;
-    ui64 SelfPingMaxUs = 0;
+    ui64 SelfPingMaxCycles = 0;
 
 public:
     TServiceActor(

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -261,6 +261,15 @@ struct TEvServicePrivate
     };
 
     //
+    // Ping notification
+    //
+
+    struct TSelfPing
+    {
+        ui64 StartCycles = 0;
+    };
+
+    //
     // Events declaration
     //
 
@@ -284,6 +293,7 @@ struct TEvServicePrivate
         EvInternalMountVolumeResponse,
         EvUpdateManuallyPreemptedVolume,
         EvSyncManuallyPreemptedVolumesComplete,
+        EvSelfPing,
 
         EvEnd
     };
@@ -371,6 +381,8 @@ struct TEvServicePrivate
         TSyncManuallyPreemptedVolumesComplete,
         EvSyncManuallyPreemptedVolumesComplete
     >;
+
+    using TEvSelfPing = TRequestEvent<TSelfPing, EvSelfPing>;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
@@ -1,0 +1,41 @@
+#include "service_ut.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TServiceStatsTest)
+{
+    Y_UNIT_TEST(ShouldReportSelfPingStats)
+    {
+        TTestEnv env;
+        auto nodeIdx = SetupTestEnv(env);
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service {runtime, nodeIdx};
+
+        auto counter = runtime.GetAppData(nodeIdx).Counters->
+            GetSubgroup("counters", "blockstore")->
+            GetSubgroup("component", "service")->
+            GetCounter("SelfPingMaxUs", false);
+
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back(TEvServicePrivate::EvSelfPing, 4);
+            runtime.DispatchEvents(opts);
+        }
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(15));
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_UNEQUAL(0, counter->Val());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
@@ -12,7 +12,7 @@ using namespace NKikimr;
 
 Y_UNIT_TEST_SUITE(TServiceStatsTest)
 {
-    Y_UNIT_TEST(ShouldReportSelfPingStats)
+    Y_UNIT_TEST(ShouldReportSelfPingMaxUsSensor)
     {
         TTestEnv env;
         auto nodeIdx = SetupTestEnv(env);

--- a/cloud/blockstore/libs/storage/service/ut/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/ya.make
@@ -20,6 +20,7 @@ SRCS(
     service_ut_read_write.cpp
     service_ut_resume_device.cpp
     service_ut_start.cpp
+    service_ut_stats.cpp
     service_ut_update_config.cpp
 )
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -8,6 +8,24 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool TActiveCheckpointInfo::IsShadowDiskBased() const
+{
+    return ShadowDiskState != EShadowDiskState::None;
+}
+
+bool TActiveCheckpointInfo::ShouldBlockWrites() const
+{
+    if (Type == ECheckpointType::Light) {
+        return false;
+    }
+    if (Data == ECheckpointData::DataDeleted) {
+        return false;
+    }
+    return !IsShadowDiskBased();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 TCheckpointStore::TCheckpointStore(
     TVector<TCheckpointRequest> checkpointRequests,
     const TString& diskID)
@@ -65,7 +83,7 @@ void TCheckpointStore::SetCheckpointRequestInProgress(ui64 requestId)
 
 void TCheckpointStore::SetCheckpointRequestFinished(
     ui64 requestId,
-    bool success,
+    bool completed,
     TString shadowDiskId,
     EShadowDiskState shadowDiskState)
 {
@@ -74,8 +92,8 @@ void TCheckpointStore::SetCheckpointRequestFinished(
         auto& checkpointRequest = GetRequest(requestId);
         Y_DEBUG_ABORT_UNLESS(
             checkpointRequest.State == ECheckpointRequestState::Saved);
-        checkpointRequest.State = success ? ECheckpointRequestState::Completed
-                                          : ECheckpointRequestState::Rejected;
+        checkpointRequest.State = completed ? ECheckpointRequestState::Completed
+                                            : ECheckpointRequestState::Rejected;
         checkpointRequest.ShadowDiskId = std::move(shadowDiskId);
         checkpointRequest.ShadowDiskState = shadowDiskState;
         Apply(checkpointRequest);
@@ -89,10 +107,9 @@ void TCheckpointStore::SetShadowDiskState(
     EShadowDiskState shadowDiskState,
     ui64 processedBlockCount)
 {
+    Y_DEBUG_ABORT_UNLESS(shadowDiskState != EShadowDiskState::None);
+
     if (auto* checkpointData = ActiveCheckpoints.FindPtr(checkpointId)) {
-        if (shadowDiskState == EShadowDiskState::Ready) {
-            checkpointData->Data = ECheckpointData::DataPresent;
-        }
         checkpointData->ShadowDiskState = shadowDiskState;
         checkpointData->ProcessedBlockCount = processedBlockCount;
 
@@ -295,11 +312,7 @@ void TCheckpointStore::CalcCheckpointsState()
 {
     CheckpointBlockingWritesExists = AnyOf(
         ActiveCheckpoints,
-        [](const auto& it)
-        {
-            return it.second.Data == ECheckpointData::DataPresent &&
-                   it.second.ShadowDiskId.empty();
-        });
+        [](const auto& it) { return it.second.ShouldBlockWrites(); });
 }
 
 void TCheckpointStore::Apply(const TCheckpointRequest& checkpointRequest)

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -124,8 +124,20 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
                 ECheckpointType::Normal,
                 "shadow-disk-6",
                 EShadowDiskState::Preparing,
-                512},
+                512,
+                TString()},
 
+            TCheckpointRequest{
+                14,
+                "checkpoint-7",
+                TInstant::Now(),
+                ECheckpointRequestType::Create,
+                ECheckpointRequestState::Completed,
+                ECheckpointType::Normal,
+                TString(),
+                EShadowDiskState::Error,
+                0,
+                "disk-error"},
         };
         TCheckpointStore store(
             TVector<TCheckpointRequest>{
@@ -140,27 +152,26 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(true, store.HasRequestToExecute(&requestId));
         UNIT_ASSERT_VALUES_EQUAL(10, requestId);
         auto checkpoints = store.GetActiveCheckpoints();
-        UNIT_ASSERT_VALUES_EQUAL(4, checkpoints.size());
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-1"));
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-2"));
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-5"));
-        UNIT_ASSERT_VALUES_EQUAL(true, checkpoints.contains("checkpoint-5"));
-        UNIT_ASSERT_VALUES_EQUAL(
-            true,
-            store.DoesCheckpointHaveData("checkpoint-2"));
-        UNIT_ASSERT_VALUES_EQUAL(
-            false,
-            store.DoesCheckpointHaveData("checkpoint-1"));
-        UNIT_ASSERT_VALUES_EQUAL(
-            false,
-            store.DoesCheckpointHaveData("checkpoint-5"));
+        UNIT_ASSERT_VALUES_EQUAL(5, checkpoints.size());
+        UNIT_ASSERT(checkpoints.contains("checkpoint-1"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-2"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-5"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-6"));
+        UNIT_ASSERT(checkpoints.contains("checkpoint-7"));
+        UNIT_ASSERT(!store.DoesCheckpointHaveData("checkpoint-1"));
+        UNIT_ASSERT(store.DoesCheckpointHaveData("checkpoint-2"));
+        UNIT_ASSERT(!store.DoesCheckpointHaveData("checkpoint-5"));
+        UNIT_ASSERT(store.DoesCheckpointHaveData("checkpoint-6"));
+        UNIT_ASSERT(store.DoesCheckpointHaveData("checkpoint-7"));
 
         // The checkpoint without the shadow disk has the correct state.
+        UNIT_ASSERT(!checkpoints["checkpoint-1"].IsShadowDiskBased());
         UNIT_ASSERT_VALUES_EQUAL(
             checkpoints["checkpoint-1"].ShadowDiskState,
             EShadowDiskState::None);
 
         // Checkpoint with the shadow disk loads the state.
+        UNIT_ASSERT(checkpoints["checkpoint-6"].IsShadowDiskBased());
         UNIT_ASSERT_VALUES_EQUAL(
             checkpoints["checkpoint-6"].ShadowDiskId,
             "shadow-disk-6");
@@ -170,6 +181,12 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(
             checkpoints["checkpoint-6"].ProcessedBlockCount,
             512);
+
+        // Checkpoint with disk error.
+        UNIT_ASSERT(checkpoints["checkpoint-7"].IsShadowDiskBased());
+        UNIT_ASSERT_VALUES_EQUAL(
+            EShadowDiskState::Error,
+            checkpoints["checkpoint-7"].ShadowDiskState);
     }
 
     Y_UNIT_TEST(CreateFail)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -104,7 +104,7 @@ NProto::ECheckpointStatus GetCheckpointStatus(const TActiveCheckpointInfo& check
             return NProto::ECheckpointStatus::ERROR;
     }
 
-    if (checkpointInfo.ShadowDiskId.Empty()) {
+    if (!checkpointInfo.IsShadowDiskBased()) {
         return NProto::ECheckpointStatus::READY;
     }
 
@@ -167,6 +167,7 @@ public:
     void UpdateCheckpointRequest(
         const TActorContext& ctx,
         bool completed,
+        std::optional<TString> error,
         TString shadowDiskId);
     void ReplyAndDie(const TActorContext& ctx);
 
@@ -280,6 +281,7 @@ template <typename TMethod>
 void TCheckpointActor<TMethod>::UpdateCheckpointRequest(
     const TActorContext& ctx,
     bool completed,
+    std::optional<TString> error,
     TString shadowDiskId)
 {
     LOG_DEBUG(ctx, TBlockStoreComponents::VOLUME,
@@ -299,6 +301,7 @@ void TCheckpointActor<TMethod>::UpdateCheckpointRequest(
             std::move(requestInfo),
             RequestId,
             completed,
+            std::move(error),
             std::move(shadowDiskId));
 
     auto event = std::make_unique<IEventHandle>(
@@ -442,8 +445,9 @@ void TCheckpointActor<TMethod>::HandleResponse(
         // request as completed.
         UpdateCheckpointRequest(
             ctx,
-            true,   // Completed
-            {}      // ShadowDiskId
+            true,           // Completed
+            std::nullopt,   // Error
+            {}              // ShadowDiskId
         );
     }
 }
@@ -457,22 +461,25 @@ void TCheckpointActor<TMethod>::HandleAllocateCheckpointResponse(
 
     JoinTraces(ev->Cookie);
 
-    if (FAILED(msg->GetStatus())) {
+    bool success = !HasError(msg->Record);
+    if (!success) {
         Error = msg->GetError();
 
-        NCloud::Send(
+        LOG_ERROR(
             ctx,
-            VolumeActorId,
-            std::make_unique<TEvents::TEvPoisonPill>());
-
-        ReplyAndDie(ctx);
-        return;
+            TBlockStoreComponents::VOLUME,
+            "For disk %s could not create shadow disk for checkpoint %s, "
+            "error: %s",
+            DiskId.Quote().c_str(),
+            CheckpointId.Quote().c_str(),
+            FormatError(Error).c_str());
     }
 
     UpdateCheckpointRequest(
         ctx,
         true,   // Completed
-        msg->Record.GetShadowDiskId());
+        success ? std::nullopt : std::optional<TString>(FormatError(Error)),
+        success ? msg->Record.GetShadowDiskId() : "ERROR");
 }
 
 template <typename TMethod>
@@ -498,8 +505,9 @@ void TCheckpointActor<TMethod>::HandleDeallocateCheckpointResponse(
 
     UpdateCheckpointRequest(
         ctx,
-        true,   // Completed
-        {}      // ShadowDiskId
+        true,           // Completed
+        std::nullopt,   // Error
+        {}              // ShadowDiskId
     );
 }
 
@@ -630,14 +638,14 @@ void TCheckpointActor<TMethod>::DoActionForDiskRegistryBasedPartition(
 
     if (!CheckpointId) {
         Error = MakeError(E_ARGUMENT, "empty checkpoint name");
-        UpdateCheckpointRequest(ctx, false, {});
+        UpdateCheckpointRequest(ctx, false, "empty checkpoint name", {});
         return;
     }
 
     if (!CreateCheckpointShadowDisk) {
         // It is not required to send requests to the actor, we reject
         // zero/write requests in TVolume (see CanExecuteWriteRequest).
-        UpdateCheckpointRequest(ctx, true, {});
+        UpdateCheckpointRequest(ctx, true, std::nullopt, {});
         return;
     }
 
@@ -773,7 +781,9 @@ void TVolumeActor::CreateCheckpointLightRequest(
         requestId,
         true,        // Completed
         TString(),   // ShadowDiskId
-        EShadowDiskState::None);
+        EShadowDiskState::None,
+        TString()   // Error
+    );
 }
 
 void TVolumeActor::DeleteCheckpointLightRequest(
@@ -798,7 +808,9 @@ void TVolumeActor::DeleteCheckpointLightRequest(
         requestId,
         true,        // Completed
         TString(),   // ShadowDiskId
-        EShadowDiskState::None);
+        EShadowDiskState::None,
+        TString()   // Error
+    );
 }
 
 void TVolumeActor::GetChangedBlocksForLightCheckpoints(
@@ -1061,14 +1073,23 @@ void TVolumeActor::HandleUpdateCheckpointRequest(
 {
     auto* msg = ev->Get();
 
+    EShadowDiskState shadowDiskState = EShadowDiskState::None;
+    if (!msg->Completed || msg->Error) {
+        shadowDiskState = EShadowDiskState::Error;
+    } else if (msg->ShadowDiskId) {
+        shadowDiskState = EShadowDiskState::New;
+    } else {
+        shadowDiskState = EShadowDiskState::None;
+    }
+
     ExecuteTx<TUpdateCheckpointRequest>(
         ctx,
         std::move(msg->RequestInfo),
         msg->RequestId,
         msg->Completed,
         msg->ShadowDiskId,
-        msg->ShadowDiskId.empty() ? EShadowDiskState::None
-                                  : EShadowDiskState::New);
+        shadowDiskState,
+        msg->Error.value_or(""));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1327,7 +1348,8 @@ void TVolumeActor::ExecuteUpdateCheckpointRequest(
         args.RequestId,
         args.Completed,
         args.ShadowDiskId,
-        args.ShadowDiskState);
+        args.ShadowDiskState,
+        args.ErrorMessage.value_or(""));
 }
 
 void TVolumeActor::CompleteUpdateCheckpointRequest(
@@ -1367,6 +1389,7 @@ void TVolumeActor::CompleteUpdateCheckpointRequest(
 
     const bool needToCreateShadowActor =
         request.ReqType == ECheckpointRequestType::Create &&
+        request.ShadowDiskState != EShadowDiskState::Error &&
         !request.ShadowDiskId.Empty() &&
         !State->GetCheckpointStore().HasShadowActor(request.CheckpointId);
 
@@ -1439,8 +1462,6 @@ void TVolumeActor::CompleteUpdateShadowDiskState(
     const TCheckpointRequest& request =
         State->GetCheckpointStore().GetRequestById(args.RequestId);
 
-    auto newState = static_cast<EShadowDiskState>(args.ShadowDiskState);
-
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::VOLUME,
@@ -1450,18 +1471,18 @@ void TVolumeActor::CompleteUpdateShadowDiskState(
         request.CheckpointId.Quote().c_str(),
         request.ShadowDiskId.Quote().c_str(),
         args.ProcessedBlockCount,
-        ToString(newState).c_str());
+        ToString(args.ShadowDiskState).c_str());
 
     State->GetCheckpointStore().SetShadowDiskState(
         request.CheckpointId,
-        newState,
+        args.ShadowDiskState,
         args.ProcessedBlockCount);
 
     NCloud::Reply(
         ctx,
         *args.RequestInfo,
         std::make_unique<TEvVolumePrivate::TEvUpdateShadowDiskStateResponse>(
-            newState,
+            args.ShadowDiskState,
             args.ProcessedBlockCount));
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -267,9 +267,9 @@ NActors::TActorId TVolumeActor::WrapNonreplActorIfNeeded(
          State->GetCheckpointStore().GetActiveCheckpoints())
     {
         if (checkpointInfo.Data == ECheckpointData::DataDeleted ||
-            checkpointInfo.ShadowDiskId.Empty() ||
+            !checkpointInfo.IsShadowDiskBased() ||
             checkpointInfo.ShadowDiskState == EShadowDiskState::Error ||
-            State->GetCheckpointStore().HasShadowActor(checkpointId))
+            checkpointInfo.HasShadowActor)
         {
             continue;
         }

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -455,7 +455,8 @@ void TVolumeDatabase::UpdateCheckpointRequest(
     ui64 requestId,
     bool completed,
     const TString& shadowDiskId,
-    EShadowDiskState shadowDiskState)
+    EShadowDiskState shadowDiskState,
+    const TString& error)
 {
     using TTable = TVolumeSchema::CheckpointRequests;
 
@@ -466,7 +467,8 @@ void TVolumeDatabase::UpdateCheckpointRequest(
         NIceDb::TUpdate<TTable::State>(static_cast<ui32>(state)),
         NIceDb::TUpdate<TTable::ShadowDiskId>(shadowDiskId),
         NIceDb::TUpdate<TTable::ShadowDiskState>(
-            static_cast<ui32>(shadowDiskState)));
+            static_cast<ui32>(shadowDiskState)),
+        NIceDb::TUpdate<TTable::CheckpointError>(error));
 }
 
 void TVolumeDatabase::UpdateShadowDiskState(
@@ -551,7 +553,8 @@ bool TVolumeDatabase::ReadCheckpointRequests(
                 it.GetValue<TTable::ShadowDiskId>(),
                 static_cast<EShadowDiskState>(
                     it.GetValue<TTable::ShadowDiskState>()),
-                it.GetValue<TTable::ShadowDiskProcessedBlockCount>());
+                it.GetValue<TTable::ShadowDiskProcessedBlockCount>(),
+                it.GetValue<TTable::CheckpointError>());
         }
 
         if (!it.Next()) {

--- a/cloud/blockstore/libs/storage/volume/volume_database.h
+++ b/cloud/blockstore/libs/storage/volume/volume_database.h
@@ -114,7 +114,8 @@ public:
         ui64 requestId,
         bool completed,
         const TString& shadowDiskId,
-        EShadowDiskState shadowDiskState);
+        EShadowDiskState shadowDiskState,
+        const TString& error);
     void UpdateShadowDiskState(
         ui64 requestId,
         ui64 processedBlockCount,

--- a/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
@@ -280,12 +280,14 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 1,
                 true,
                 "shadow-disk-id",
-                EShadowDiskState::New);
+                EShadowDiskState::New,
+                TString());
             db.UpdateCheckpointRequest(
                 3,
                 false,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                "Error message");
         });
 
         executor.ReadTx([&] (TVolumeDatabase db) {
@@ -324,6 +326,7 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
             UNIT_ASSERT_VALUES_EQUAL(3, requests[2].RequestId);
             UNIT_ASSERT_VALUES_EQUAL("zzz", requests[2].CheckpointId);
             UNIT_ASSERT_VALUES_EQUAL("", requests[2].ShadowDiskId);
+            UNIT_ASSERT_VALUES_EQUAL("Error message", requests[2].CheckpointError);
             UNIT_ASSERT_VALUES_EQUAL(
                 TInstant::Seconds(333),
                 requests[2].Timestamp
@@ -365,7 +368,8 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                     1,
                     true,
                     "shadow-disk-id",
-                    EShadowDiskState::New);
+                    EShadowDiskState::New,
+                    TString());
             });
 
         executor.ReadTx(
@@ -609,22 +613,26 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 1,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
             db.UpdateCheckpointRequest(
                 2,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
             db.UpdateCheckpointRequest(
                 3,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
             db.UpdateCheckpointRequest(
                 4,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
         });
 
         executor.ReadTx([&] (TVolumeDatabase db) {
@@ -772,7 +780,8 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 5,
                 true,
                 "",
-                EShadowDiskState::None);
+                EShadowDiskState::None,
+                TString());
         });
 
         executor.ReadTx([&] (TVolumeDatabase db) {

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -157,16 +157,19 @@ struct TEvVolumePrivate
         TRequestInfoPtr RequestInfo;
         ui64 RequestId;
         bool Completed;
+        std::optional<TString> Error;
         TString ShadowDiskId;
 
         TUpdateCheckpointRequestRequest(
                 TRequestInfoPtr requestInfo,
                 ui64 requestId,
                 bool completed,
+                std::optional<TString> error,
                 TString shadowDiskId)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
             , Completed(completed)
+            , Error(std::move(error))
             , ShadowDiskId(std::move(shadowDiskId))
         {
         }

--- a/cloud/blockstore/libs/storage/volume/volume_schema.h
+++ b/cloud/blockstore/libs/storage/volume/volume_schema.h
@@ -154,6 +154,11 @@ struct TVolumeSchema
         {
         };
 
+        struct CheckpointError
+            : public Column<10, NKikimr::NScheme::NTypeIds::String>
+        {
+        };
+
         using TKey = TableKey<RequestId>;
         using TColumns = TableColumns<
             RequestId,
@@ -164,7 +169,8 @@ struct TVolumeSchema
             CheckpointType,
             ShadowDiskId,
             ShadowDiskProcessedBlockCount,
-            ShadowDiskState>;
+            ShadowDiskState,
+            CheckpointError>;
     };
 
     struct NonReplPartStats

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -891,13 +891,13 @@ bool TVolumeState::GetMuteIOErrors() const
 
 void TVolumeState::SetCheckpointRequestFinished(
     const TCheckpointRequest& request,
-    bool success,
+    bool completed,
     TString shadowDiskId,
     EShadowDiskState shadowDiskState)
 {
     GetCheckpointStore().SetCheckpointRequestFinished(
         request.RequestId,
-        success,
+        completed,
         std::move(shadowDiskId),
         shadowDiskState);
     if (GetCheckpointStore().GetLightCheckpoints().empty()) {

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -426,18 +426,21 @@ struct TTxVolume
         const bool Completed;
         const TString ShadowDiskId;
         const EShadowDiskState ShadowDiskState;
+        const std::optional<TString> ErrorMessage;
 
         TUpdateCheckpointRequest(
                 TRequestInfoPtr requestInfo,
                 ui64 requestId,
                 bool completed,
                 TString shadowDiskId,
-                EShadowDiskState shadowDiskState)
+                EShadowDiskState shadowDiskState,
+                std::optional<TString> errorMessage)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
             , Completed(completed)
             , ShadowDiskId(std::move(shadowDiskId))
             , ShadowDiskState(shadowDiskState)
+            , ErrorMessage(std::move(errorMessage))
         {}
 
         void Clear()

--- a/cloud/blockstore/public/sdk/go/client/safe_client.go
+++ b/cloud/blockstore/public/sdk/go/client/safe_client.go
@@ -297,7 +297,7 @@ func (client *safeClient) GetCheckpointStatus(
 	}
 
 	resp, err := client.Impl.GetCheckpointStatus(ctx, req)
-	return resp.CheckpointStatus, err
+	return resp.GetCheckpointStatus(), err
 }
 
 func (client *safeClient) DeleteCheckpoint(


### PR DESCRIPTION
We evaluate service actor load by periodicaly sending requests to it and measuring time of passing the message queue.