### PR TITLE
NEBDUTY-965: fix thread sanitizer errors in ut

### DIFF
--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -8,6 +8,8 @@
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
+#include <util/system/sanitizers.h>
+
 #include <libaio.h>
 
 #include <thread>
@@ -362,7 +364,9 @@ void TAioBackend::CompletionThreadFunc()
         for (int i = 0; i != ret; ++i) {
             if (events[i].data) {
                 auto* req = static_cast<TAioCompoundRequest*>(events[i].data);
+                NSan::Acquire(req);
                 iocb* sub = events[i].obj;
+                NSan::Acquire(sub);
 
                 vhd_bdev_io_result result = VHD_BDEV_SUCCESS;
 
@@ -386,6 +390,7 @@ void TAioBackend::CompletionThreadFunc()
             }
 
             auto* req = static_cast<TAioRequest*>(events[i].obj);
+            NSan::Acquire(req);
 
             vhd_bdev_io_result result = VHD_BDEV_SUCCESS;
             auto* bio = vhd_get_bdev_io(req->Io);

--- a/cloud/blockstore/vhost-server/request_aio.cpp
+++ b/cloud/blockstore/vhost-server/request_aio.cpp
@@ -3,6 +3,7 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <util/generic/strbuf.h>
+#include <util/system/sanitizers.h>
 
 #include <algorithm>
 
@@ -81,11 +82,13 @@ void PrepareCompoundIO(
         sreq->data = req;
 
         batch.push_back(sreq);
+        NSan::Release(sreq);
 
         ptr += count;
         totalBytes -= count;
         deviceOffset = 0;
     }
+    NSan::Release(req);
 }
 
 }   // namespace
@@ -198,6 +201,7 @@ void PrepareIO(
     STORAGE_DEBUG("Prepared IO request with addr: %p", req);
 
     batch.push_back(req);
+    NSan::Release(req);
 }
 
 }   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -180,14 +180,12 @@ void TServer::Stop()
 {
     STORAGE_INFO("Stopping the server");
 
-    {
-        auto promise = NewPromise();
-        vhd_unregister_blockdev(Handler, [] (void* opaque) {
-            static_cast<TPromise<void>*>(opaque)->SetValue();
-        }, &promise);
+    auto promise = NewPromise();
+    vhd_unregister_blockdev(Handler, [] (void* opaque) {
+        static_cast<TPromise<void>*>(opaque)->SetValue();
+    }, &promise);
 
-        promise.GetFuture().Wait();
-    }
+    promise.GetFuture().Wait();
 
     // 2. Stop request queues. For each do:
     // 2.1 Stop a request queue


### PR DESCRIPTION
- NEBDUTY-965: promise object passed as pointer to different thread released too early
- NEBDUTY-965: Remove unsafe debug code in vhost-server aio backend
- NEBDUTY-965: help tsan to deduce happens-before relation properly in vhost-server
- NEBDUTY-965: avoid data race when reading WaitMode from rdma client config
