### PR TITLE
add selfping sensor to track service actor load

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -955,4 +955,6 @@ message TStorageServiceConfig
     // Duration of attempts to connect to tablet for cached tablets before
     // switching to describe volume (in ms).
     optional uint32 VolumeProxyCacheRetryDuration = 360;
+
+    optional uint32 ServiceSelfPingInterval = 361;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -956,5 +956,7 @@ message TStorageServiceConfig
     // switching to describe volume (in ms).
     optional uint32 VolumeProxyCacheRetryDuration = 360;
 
+    // Service actor self ping measurement interval. Used to evaluate
+    // service actor load. Set in ms.
     optional uint32 ServiceSelfPingInterval = 361;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -111,7 +111,7 @@ TDuration MSeconds(ui32 value)
     xxx(MaxChangedBlocksRangeBlocksCount,           ui64,       1 << 20       )\
     xxx(CachedDiskAgentConfigPath,                  TString,    ""            )\
     xxx(CachedDiskAgentSessionsPath,                TString,    ""            )\
-    xxx(ServiceSelfPingInterval,        TDuration, TDuration::MilliSeconds(10))\
+    xxx(ServiceSelfPingInterval,                    TDuration,  MSeconds(10)  )\
 // BLOCKSTORE_STORAGE_CONFIG_RO
 
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -111,6 +111,7 @@ TDuration MSeconds(ui32 value)
     xxx(MaxChangedBlocksRangeBlocksCount,           ui64,       1 << 20       )\
     xxx(CachedDiskAgentConfigPath,                  TString,    ""            )\
     xxx(CachedDiskAgentSessionsPath,                TString,    ""            )\
+    xxx(ServiceSelfPingInterval,        TDuration, TDuration::MilliSeconds(10))\
 // BLOCKSTORE_STORAGE_CONFIG_RO
 
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -564,6 +564,8 @@ public:
     TDuration GetMaxAcquireShadowDiskTotalTimeoutWhenNonBlocked() const;
 
     TDuration GetVolumeProxyCacheRetryDuration() const;
+
+    TDuration GetServiceSelfPingInterval() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -68,11 +68,11 @@ void TServiceActor::RegisterCounters(const TActorContext& ctx)
 {
     Counters = CreateServiceCounters();
 
-    SelfPingMaxUsCounter = AppData(ctx)->
-        Counters->
-        GetSubgroup("counters", "blockstore")->
-        GetSubgroup("component", "service")->
-        GetCounter("SelfPingMaxUs", false);
+    SelfPingMaxUsCounter = AppData(ctx)
+        ->Counters
+        ->GetSubgroup("counters", "blockstore")
+        ->GetSubgroup("component", "service")
+        ->GetCounter("SelfPingMaxUs", false);
 
     ScheduleSelfPing(ctx);
 
@@ -134,12 +134,8 @@ void TServiceActor::UpdateCounters(const TActorContext& ctx)
         }
     }
 
-    if (SelfPingMaxUsCounter) {
-        auto val =
-            CyclesToDuration(SelfPingMaxUs) - Config->GetServiceSelfPingInterval();
-        *SelfPingMaxUsCounter = val.MicroSeconds();
-        SelfPingMaxUs = 0;
-    }
+    *SelfPingMaxUsCounter = CyclesToDuration(SelfPingMaxUs).MicroSeconds();
+    SelfPingMaxUs = 0;
 }
 
 void TServiceActor::UpdateActorStats(const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -59,6 +59,9 @@ private:
     bool HasPendingManuallyPreemptedVolumesUpdate = false;
     bool IsVolumeLivenessCheckRunning = false;
 
+    NMonitoring::TDynamicCounters::TCounterPtr SelfPingMaxUsCounter;
+    ui64 SelfPingMaxUs = 0;
+
 public:
     TServiceActor(
         TStorageConfigPtr config,
@@ -123,11 +126,17 @@ private:
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo);
 
+    void ScheduleSelfPing(const NActors::TActorContext& ctx);
+
 private:
     STFUNC(StateWork);
 
     void HandleWakeup(
         const NActors::TEvents::TEvWakeup::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleSelfPing(
+        const TEvServicePrivate::TEvSelfPing::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleHttpInfo(

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -261,6 +261,15 @@ struct TEvServicePrivate
     };
 
     //
+    // Ping notification
+    //
+
+    struct TSelfPing
+    {
+        ui64 StartCycles = 0;
+    };
+
+    //
     // Events declaration
     //
 
@@ -284,6 +293,7 @@ struct TEvServicePrivate
         EvInternalMountVolumeResponse,
         EvUpdateManuallyPreemptedVolume,
         EvSyncManuallyPreemptedVolumesComplete,
+        EvSelfPing,
 
         EvEnd
     };
@@ -371,6 +381,8 @@ struct TEvServicePrivate
         TSyncManuallyPreemptedVolumesComplete,
         EvSyncManuallyPreemptedVolumesComplete
     >;
+
+    using TEvSelfPing = TRequestEvent<TSelfPing, EvSelfPing>;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
@@ -2,8 +2,6 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
-#include <util/generic/size_literals.h>
-
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NKikimr;

--- a/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
@@ -12,7 +12,7 @@ using namespace NKikimr;
 
 Y_UNIT_TEST_SUITE(TServiceStatsTest)
 {
-    Y_UNIT_TEST(ShouldReportSelfPingStats)
+    Y_UNIT_TEST(ShouldReportSelfPingMaxUsSensor)
     {
         TTestEnv env;
         auto nodeIdx = SetupTestEnv(env);
@@ -20,10 +20,10 @@ Y_UNIT_TEST_SUITE(TServiceStatsTest)
 
         TServiceClient service {runtime, nodeIdx};
 
-        auto counter = runtime.GetAppData(nodeIdx).Counters->
-            GetSubgroup("counters", "blockstore")->
-            GetSubgroup("component", "service")->
-            GetCounter("SelfPingMaxUs", false);
+        auto counter = runtime.GetAppData(nodeIdx).Counters
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "service")
+            ->GetCounter("SelfPingMaxUs", false);
 
         {
             TDispatchOptions opts;

--- a/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_stats.cpp
@@ -1,0 +1,41 @@
+#include "service_ut.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TServiceStatsTest)
+{
+    Y_UNIT_TEST(ShouldReportSelfPingStats)
+    {
+        TTestEnv env;
+        auto nodeIdx = SetupTestEnv(env);
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service {runtime, nodeIdx};
+
+        auto counter = runtime.GetAppData(nodeIdx).Counters->
+            GetSubgroup("counters", "blockstore")->
+            GetSubgroup("component", "service")->
+            GetCounter("SelfPingMaxUs", false);
+
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back(TEvServicePrivate::EvSelfPing, 4);
+            runtime.DispatchEvents(opts);
+        }
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(15));
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_UNEQUAL(0, counter->Val());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/ut/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/ya.make
@@ -20,6 +20,7 @@ SRCS(
     service_ut_read_write.cpp
     service_ut_resume_device.cpp
     service_ut_start.cpp
+    service_ut_stats.cpp
     service_ut_update_config.cpp
 )
 


### PR DESCRIPTION
We evaluate service actor load by periodicaly sending requests to it and measuring time of passing the message queue.