### PR TITLE
Fix shadow disk acquiring #2

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -471,13 +471,7 @@ void TAcquireShadowDiskActor::HandlePoisonPill(
     const TEvents::TEvPoisonPill::TPtr& ev,
     const TActorContext& ctx)
 {
-    NCloud::Reply(
-        ctx,
-        *CreateRequestInfo(
-            ev->Sender,
-            ev->Cookie,
-            MakeIntrusive<TCallContext>()),
-        std::make_unique<TEvents::TEvPoisonTaken>());
+    NCloud::Reply(ctx, *ev, std::make_unique<TEvents::TEvPoisonTaken>());
     ReplyAndDie(ctx, MakeError(E_REJECTED));
 }
 

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -358,7 +358,7 @@ void TAcquireShadowDiskActor::ReplyAndDie(
     auto response =
         std::make_unique<TEvVolumePrivate::TEvShadowDiskAcquired>(error);
     if (!HasError(error)) {
-        response->Devices.Swap(&AcquiredShadowDiskDevices);
+        response->Devices.Swap(&ShadowDiskDevices);
         response->ClientId = RwClientId;
     }
 

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -474,9 +474,12 @@ void TAcquireShadowDiskActor::HandlePoisonPill(
     const TEvents::TEvPoisonPill::TPtr& ev,
     const TActorContext& ctx)
 {
-    Y_UNUSED(ev);
+    auto poisoner = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        MakeIntrusive<TCallContext>());
 
-    ReplyAndDie(ctx, MakeError(E_REJECTED));
+    NCloud::Reply(ctx, *poisoner, std::make_unique<TEvents::TEvPoisonTaken>());
 }
 
 void TAcquireShadowDiskActor::MaybeReady(const NActors::TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -93,9 +93,8 @@ private:
     const NActors::TActorId SrcActorId;
 
     TString SourceDiskClientId;
-    // We update CurrentShadowDiskClientId when get response from
-    // TAcquireShadowDiskActor with confirmation that we have successfully
-    // acquired shadow disk.
+    // We update CurrentShadowDiskClientId when send request to
+    // TAcquireShadowDiskActor with desired clientId.
     TString CurrentShadowDiskClientId;
     TNonreplicatedPartitionConfigPtr DstConfig;
     NActors::TActorId DstActorId;

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -93,7 +93,7 @@ private:
     const NActors::TActorId SrcActorId;
 
     TString SourceDiskClientId;
-    // We update CurrentShadowDiskClientId when send request to
+    // We update CurrentShadowDiskClientId when we send request to
     // TAcquireShadowDiskActor with desired clientId.
     TString CurrentShadowDiskClientId;
     TNonreplicatedPartitionConfigPtr DstConfig;

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -236,6 +236,8 @@ public:
 
     void ReconnectPipe();
 
+    // Attention! During reboot the filter set via runtime->SetObserverFunc()
+    // will not get messages.
     void RebootTablet();
 
     void RebootSysTablet();

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -4112,15 +4112,16 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         acquireClientId = "";
         releaseClientId = "";
 
-        // Connecting a new client should not lead to reacquiring.
+        // Connecting a new client should lead to reacquiring with the same
+        // ShadowDiskClientId.
         auto clientInfo3 = CreateVolumeClientInfo(
             NProto::VOLUME_ACCESS_READ_WRITE,
             NProto::VOLUME_MOUNT_LOCAL,
             0);
         volume.RemoveClient(clientInfo2.GetClientId());
         volume.AddClient(clientInfo3);
-        UNIT_ASSERT_VALUES_EQUAL("", acquireClientId);
-        UNIT_ASSERT_VALUES_EQUAL("", releaseClientId);
+        UNIT_ASSERT_VALUES_EQUAL(ShadowDiskClientId, acquireClientId);
+        UNIT_ASSERT_VALUES_EQUAL(AnyWriterClientId, releaseClientId);
     }
 
     Y_UNIT_TEST(ShouldAcquireShadowDiskEvenIfReleaseFailed)


### PR DESCRIPTION
Исправлено:
1. в ответе на acquire список девайсов может приходить в другом порядке, не как в describe.
2. теперь мы считаем что захватили диски клиентом не в момент получения ответа, а в момент отправки запроса на захват диска. И убрал все проверки, чтобы не было рассинхронизации понимания кем захвачен теневой диск - просто делаю его захват тем клиентом, которым нужно.
3. обрабатываю PoisonPill в  TAcquireShadowDiskActor
4.  и самое главное - использую устройства в том порядке, как их вернул describe.
