### PR TITLE
NEBDUTY-982: Add retries to bypass recurring `Connection timed out during banner exchange` error

### DIFF
--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -9,6 +9,7 @@ import shlex
 import tarfile
 
 import library.python.fs as fs
+from library.python.retry import retry
 import library.python.testing.recipe
 
 from .qemu import Qemu
@@ -30,7 +31,7 @@ class QemuKvmRecipeException(Exception):
             "[[bad]]{}[[rst]]".format(msg))
 
 
-def start(argv):
+def _start(argv):
     args = _parse_args(argv)
     if args.instance_count > 1:
         pm = yatest.common.network.PortManager()
@@ -40,6 +41,24 @@ def start(argv):
 
     for inst_index in range(args.instance_count):
         start_instance(args, inst_index)
+
+# Retry is a workaround for the issue when ssh onto the qemu instance fails
+# with "Connection timed out during banner exchange". See CLOUD-142732
+@retry(max_times=10)
+def start(argv):
+    try:
+        logger.info("Trying to start qemu")
+        _start(argv)
+        logger.info("Instance(s) started successfully")
+    except Exception as e:
+        logger.error("Failed to start qemu")
+        logger.exception(e)
+        try:
+            logger.info("Trying to stop qemu")
+            stop(argv)
+        except:
+            pass
+        raise e
 
 
 def start_instance(args, inst_index):
@@ -73,6 +92,10 @@ def start_instance(args, inst_index):
     qemu.set_mount_paths(mount_paths)
     qemu.start()
 
+    recipe_set_env("QEMU_KVM_PID", str(qemu.qemu_bin.daemon.process.pid), inst_index)
+
+    logger.info("qemu pid is: '{}'".format(str(qemu.qemu_bin.daemon.process.pid)))
+
     ssh = SshToGuest(user=_get_ssh_user(args),
                      port=qemu.get_ssh_port(),
                      key=_get_ssh_key(args))
@@ -99,10 +122,6 @@ def start_instance(args, inst_index):
 
     if args.invoke_test:
         _prepare_test_environment(ssh, virtio)
-
-    recipe_set_env("QEMU_KVM_PID", str(qemu.qemu_bin.daemon.process.pid), inst_index)
-
-    logger.info("qemu pid is: '{}'".format(str(qemu.qemu_bin.daemon.process.pid)))
 
     if args.invoke_test:
         recipe_set_env("TEST_COMMAND_WRAPPER",

--- a/cloud/storage/core/tools/testing/qemu/lib/ya.make
+++ b/cloud/storage/core/tools/testing/qemu/lib/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     contrib/python/PyYAML
     contrib/python/retrying
     library/python/fs
+    library/python/retry
     library/python/testing/recipe
     contrib/ydb/tests/library
 )


### PR DESCRIPTION
Adding retries on the startup of the QEMU recipe is a workaround for similar issues: 
https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/8563837729/1/nebius-x86-64/summary/ya-test.html#FAIL