### PR TITLE
NBSNEBIUS-219: Add SocketAccessMode option to NBS and NFS

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -171,6 +171,9 @@ message TServerConfig
 
     // Prefix for nbd device paths, e.g. "/dev/nbd"
     optional string NbdDevicePrefix = 109;
+
+    // Access mode for endpoint socket files
+    optional uint32 SocketAccessMode = 110;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -125,6 +125,7 @@ NVhost::TServerConfig CreateVhostServerConfig(const TServerAppConfig& config)
 {
     return NVhost::TServerConfig {
         .ThreadsCount = config.GetVhostThreadsCount(),
+        .SocketAccessMode = config.GetSocketAccessMode(),
         .Affinity = config.GetVhostAffinity()
     };
 }
@@ -135,6 +136,7 @@ NBD::TServerConfig CreateNbdServerConfig(const TServerAppConfig& config)
         .ThreadsCount = config.GetNbdThreadsCount(),
         .LimiterEnabled = config.GetNbdLimiterEnabled(),
         .MaxInFlightBytesPerThread = config.GetMaxInFlightBytesPerThread(),
+        .SocketAccessMode = config.GetSocketAccessMode(),
         .Affinity = config.GetNbdAffinity()
     };
 }
@@ -357,7 +359,8 @@ void TBootstrapBase::Init()
 
     GrpcEndpointListener = CreateSocketEndpointListener(
         Logging,
-        Configs->ServerConfig->GetUnixSocketBacklog());
+        Configs->ServerConfig->GetUnixSocketBacklog(),
+        Configs->ServerConfig->GetSocketAccessMode());
     endpointListeners.emplace(NProto::IPC_GRPC, GrpcEndpointListener);
 
     STORAGE_INFO("SocketEndpointListener initialized");
@@ -412,6 +415,7 @@ void TBootstrapBase::Init()
                 Configs->Options->SkipDeviceLocalityValidation
                     ? TString {}
                     : FQDNHostName(),
+                Configs->ServerConfig->GetSocketAccessMode(),
                 std::move(vhostEndpointListener));
 
             STORAGE_INFO("VHOST External Vhost EndpointListener initialized");

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -50,6 +50,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
 static constexpr TDuration TestRequestTimeout = TDuration::Seconds(42);
 static const TString TestClientId = "testClientId";
 
@@ -1011,7 +1012,10 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         TMap<TString, NProto::TMountVolumeRequest> mountedVolumes;
         bootstrap.Service = CreateTestService(mountedVolumes);
 
-        auto grpcListener = CreateSocketEndpointListener(bootstrap.Logging, 16);
+        auto grpcListener = CreateSocketEndpointListener(
+            bootstrap.Logging,
+            16,
+            MODE0660);
         grpcListener->SetClientStorageFactory(CreateClientStorageFactoryStub());
         bootstrap.EndpointListeners = {{ NProto::IPC_GRPC, grpcListener }};
 
@@ -1790,7 +1794,10 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         TMap<TString, NProto::TMountVolumeRequest> mountedVolumes;
         bootstrap.Service = CreateTestService(mountedVolumes);
 
-        auto grpcListener = CreateSocketEndpointListener(bootstrap.Logging, 16);
+        auto grpcListener = CreateSocketEndpointListener(
+            bootstrap.Logging,
+            16,
+            MODE0660);
         grpcListener->SetClientStorageFactory(CreateClientStorageFactoryStub());
         bootstrap.EndpointListeners = {{ NProto::IPC_GRPC, grpcListener }};
 

--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
@@ -209,7 +209,8 @@ class TSocketEndpointListener final
     : public ISocketEndpointListener
 {
 private:
-    const ui32 UnixSocketBacklog;
+    const ui32 SocketBacklog;
+    const ui32 SocketAccessMode;
 
     std::unique_ptr<NStorage::NServer::TEndpointPoller> EndpointPoller;
     IClientStorageFactoryPtr ClientStorageFactory;
@@ -219,8 +220,10 @@ private:
 public:
     TSocketEndpointListener(
             ILoggingServicePtr logging,
-            ui32 unixSocketBacklog)
-        : UnixSocketBacklog(unixSocketBacklog)
+            ui32 socketBacklog,
+            ui32 socketAccessMode)
+        : SocketBacklog(socketBacklog)
+        , SocketAccessMode(socketAccessMode)
     {
         Log = logging->CreateLog("BLOCKSTORE_SERVER");
     }
@@ -262,7 +265,8 @@ public:
 
         auto error = EndpointPoller->StartListenEndpoint(
             request.GetUnixSocketPath(),
-            UnixSocketBacklog,
+            SocketBacklog,
+            SocketAccessMode,
             false,  // multiClient
             NProto::SOURCE_FD_DATA_CHANNEL,
             ClientStorageFactory->CreateClientStorage(
@@ -316,11 +320,13 @@ public:
 
 ISocketEndpointListenerPtr CreateSocketEndpointListener(
     ILoggingServicePtr logging,
-    ui32 unixSocketBacklog)
+    ui32 socketBacklog,
+    ui32 socketAccessMode)
 {
     return std::make_unique<TSocketEndpointListener>(
         std::move(logging),
-        unixSocketBacklog);
+        socketBacklog,
+        socketAccessMode);
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.h
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.h
@@ -22,6 +22,7 @@ struct ISocketEndpointListener
 
 ISocketEndpointListenerPtr CreateSocketEndpointListener(
     ILoggingServicePtr logging,
-    ui32 unixSocketBacklog);
+    ui32 socketBacklog,
+    ui32 socketAccessMode);
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener_ut.cpp
@@ -38,6 +38,10 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
+
+////////////////////////////////////////////////////////////////////////////////
+
 using NStorage::NServer::IClientStorage;
 using NStorage::NServer::IClientStoragePtr;
 
@@ -274,7 +278,8 @@ TBootstrap CreateBootstrap(TOptions options)
 
     auto endpointListener = CreateSocketEndpointListener(
         testFactory.Logging,
-        options.UnixSocketBacklog);
+        options.UnixSocketBacklog,
+        MODE0660);
     endpointListener->SetClientStorageFactory(
         server->GetClientStorageFactory());
 
@@ -341,7 +346,7 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
         TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto clientStorage = std::make_shared<TTestClientStorage>();
-        auto listener = CreateSocketEndpointListener(logging, 16);
+        auto listener = CreateSocketEndpointListener(logging, 16, MODE0660);
         listener->SetClientStorageFactory(clientStorage);
         listener->Start();
         Y_DEFER {
@@ -386,7 +391,7 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
         TFsPath unixSocket(CreateGuidAsString() + ".sock");
 
         auto clientStorage = std::make_shared<TTestClientStorage>();
-        auto listener = CreateSocketEndpointListener(logging, 16);
+        auto listener = CreateSocketEndpointListener(logging, 16, MODE0660);
         listener->SetClientStorageFactory(clientStorage);
         listener->Start();
         Y_DEFER {
@@ -437,7 +442,8 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
 
         auto endpointListener = CreateSocketEndpointListener(
             testFactory.Logging,
-            unixSocketBacklog);
+            unixSocketBacklog,
+            MODE0660);
         endpointListener->SetClientStorageFactory(
             server->GetClientStorageFactory());
 
@@ -1112,7 +1118,7 @@ Y_UNIT_TEST_SUITE(TSocketEndpointListenerTest)
         TString unixSocket("./invalid/path/to/socket");
 
         auto clientStorage = std::make_shared<TTestClientStorage>();
-        auto listener = CreateSocketEndpointListener(logging, 16);
+        auto listener = CreateSocketEndpointListener(logging, 16, MODE0660);
         listener->SetClientStorageFactory(clientStorage);
         listener->Start();
         Y_DEFER {

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -38,6 +38,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TExecutorPtr executor,
     TString binaryPath,
     TString localAgentId,
+    ui32 socketAccessMode,
     IEndpointListenerPtr fallbackListener);
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
@@ -45,6 +46,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     IServerStatsPtr serverStats,
     TExecutorPtr executor,
     TString localAgentId,
+    ui32 socketAccessMode,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory);
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -251,6 +251,7 @@ struct TFixture
         ServerStats,
         Executor,
         LocalAgentId,
+        S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR,
         CreateFallbackListener(),
         CreateExternalEndpointFactory());
 

--- a/cloud/blockstore/libs/nbd/server.h
+++ b/cloud/blockstore/libs/nbd/server.h
@@ -36,6 +36,7 @@ struct TServerConfig
     size_t ThreadsCount = 1;
     bool LimiterEnabled = false;
     size_t MaxInFlightBytesPerThread = 128_MB;
+    ui32 SocketAccessMode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     TAffinity Affinity;
 };
 

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 
 #include <util/generic/size_literals.h>
+#include <util/system/sysstat.h>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -11,6 +12,8 @@ namespace {
 using TStrings = TVector<TString>;
 
 ////////////////////////////////////////////////////////////////////////////////
+
+static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
 
 constexpr TDuration Seconds(int s)
 {
@@ -89,6 +92,7 @@ constexpr TDuration Seconds(int s)
     xxx(EndpointStorageDir,          TString,               {}                )\
     xxx(VhostServerPath,             TString,               {}                )\
     xxx(NbdDevicePrefix,             TString,               "/dev/nbd"        )\
+    xxx(SocketAccessMode,            ui32,                  MODE0660          )\
 // BLOCKSTORE_SERVER_CONFIG
 
 #define BLOCKSTORE_SERVER_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -126,6 +126,7 @@ public:
     TString GetEndpointStorageDir() const;
     TString GetVhostServerPath() const;
     TString GetNbdDevicePrefix() const;
+    ui32 GetSocketAccessMode() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;

--- a/cloud/blockstore/libs/server/server.cpp
+++ b/cloud/blockstore/libs/server/server.cpp
@@ -1140,6 +1140,7 @@ void TServer::StartListenUnixSocket(
     auto error = EndpointPoller->StartListenEndpoint(
         unixSocketPath,
         backlog,
+        S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR, // accessMode
         true,   // multiClient
         NProto::SOURCE_FD_CONTROL_CHANNEL,
         SessionStorage->CreateClientStorage(UdsService));

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -113,6 +113,7 @@ private:
     const IDeviceHandlerPtr DeviceHandler;
     const TString SocketPath;
     const TStorageOptions Options;
+    const ui32 SocketAccessMode;
     IVhostDevicePtr VhostDevice;
 
     TIntrusiveList<TRequest> RequestsInFlight;
@@ -125,11 +126,13 @@ public:
             TAppContext& appCtx,
             IDeviceHandlerPtr deviceHandler,
             TString socketPath,
-            const TStorageOptions& options)
+            const TStorageOptions& options,
+            ui32 socketAccessMode)
         : AppCtx(appCtx)
         , DeviceHandler(std::move(deviceHandler))
         , SocketPath(std::move(socketPath))
         , Options(options)
+        , SocketAccessMode(socketAccessMode)
     {}
 
     void SetVhostDevice(IVhostDevicePtr vhostDevice)
@@ -153,8 +156,7 @@ public:
             return error;
         }
 
-        int mode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
-        auto err = Chmod(SocketPath.c_str(), mode);
+        auto err = Chmod(SocketPath.c_str(), SocketAccessMode);
 
         if (err != 0) {
             NProto::TError error;
@@ -379,6 +381,7 @@ private:
     const TString Name;
     TExecutorCounters::TExecutorScope ExecutorScope;
     const IVhostQueuePtr VhostQueue;
+    const ui32 SocketAccessMode;
     TAffinity Affinity;
 
     TMap<TString, TEndpointPtr> Endpoints;
@@ -388,11 +391,13 @@ public:
             TAppContext& appCtx,
             TString name,
             IVhostQueuePtr vhostQueue,
+            ui32 socketAccessMode,
             const TAffinity& affinity)
         : AppCtx(appCtx)
         , Name(std::move(name))
         , ExecutorScope(AppCtx.ServerStats->StartExecutor())
         , VhostQueue(std::move(vhostQueue))
+        , SocketAccessMode(socketAccessMode)
         , Affinity(affinity)
     {}
 
@@ -427,7 +432,8 @@ public:
             AppCtx,
             std::move(deviceHandler),
             socketPath,
-            options);
+            options,
+            SocketAccessMode);
 
         auto vhostDevice = VhostQueue->CreateDevice(
             socketPath,
@@ -827,6 +833,7 @@ void TServer::InitExecutors()
             *this,
             TStringBuilder() << "VHOST" << i,
             std::move(vhostQueue),
+            Config.SocketAccessMode,
             Config.Affinity);
 
         Executors.push_back(std::move(executor));

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -11,6 +11,8 @@
 
 #include <library/cpp/threading/future/future.h>
 
+#include <util/system/sysstat.h>
+
 namespace NCloud::NBlockStore::NVhost {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,6 +52,7 @@ struct IServer
 struct TServerConfig
 {
     size_t ThreadsCount = 1;
+    ui32 SocketAccessMode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     TAffinity Affinity;
 };
 

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -104,6 +104,10 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("INT")
         .StoreResult(&QueueCount);
 
+    opts.AddLongOption('a', "socket-access-mode")
+        .RequiredArgument("INT")
+        .StoreResult(&SocketAccessMode);
+
     opts.AddLongOption('v', "verbose", "output level for diagnostics messages")
         .OptionalArgument("STR")
         .StoreResultDef(&VerboseLevel);

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -5,6 +5,7 @@
 #include <util/generic/size_literals.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
+#include <util/system/sysstat.h>
 
 namespace NCloud::NBlockStore::NVHostServer {
 
@@ -30,6 +31,7 @@ struct TOptions
     ui32 BatchSize = 1024;
     ui32 BlockSize = 512;
     ui32 QueueCount = 0;
+    ui32 SocketAccessMode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
 
     TString LogType = "json";
     TString VerboseLevel = "info";

--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -22,7 +22,6 @@
 #include <util/stream/printf.h>
 #include <util/system/datetime.h>
 #include <util/system/file.h>
-#include <util/system/sysstat.h>
 
 #include <atomic>
 #include <span>
@@ -154,8 +153,7 @@ void TServer::Start(const TOptions& options)
     Y_ABORT_UNLESS(Handler, "vhd_register_blockdev: Can't register device");
 
     if (!options.NoChmod) {
-        const int mode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
-        if (int err = Chmod(SocketPath.c_str(), mode)) {
+        if (int err = Chmod(SocketPath.c_str(), options.SocketAccessMode)) {
             Y_ABORT(
                 "failed to chmod socket %s: %s",
                 SocketPath.c_str(),

--- a/cloud/filestore/config/vhost.proto
+++ b/cloud/filestore/config/vhost.proto
@@ -29,6 +29,9 @@ message TVhostServiceConfig
     optional bool RequireEndpointsKeyring = 4;
     optional NCloud.NProto.EEndpointStorageType EndpointStorageType = 5;
     optional string EndpointStorageDir = 6;
+
+    // Access mode for endpoint socket files
+    optional uint32 SocketAccessMode = 7;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -278,7 +278,8 @@ void TBootstrapVhost::InitEndpoints()
     EndpointManager = CreateEndpointManager(
         Logging,
         EndpointStorage,
-        EndpointListener);
+        EndpointListener,
+        Configs->VhostServiceConfig->GetSocketAccessMode());
 }
 
 void TBootstrapVhost::InitNullEndpoints()

--- a/cloud/filestore/libs/endpoint/service.h
+++ b/cloud/filestore/libs/endpoint/service.h
@@ -14,7 +14,8 @@ namespace NCloud::NFileStore {
 IEndpointManagerPtr CreateEndpointManager(
     ILoggingServicePtr logging,
     IEndpointStoragePtr storage,
-    IEndpointListenerPtr listener);
+    IEndpointListenerPtr listener,
+    ui32 socketAccessMode);
 
 IEndpointManagerPtr CreateNullEndpointManager();
 

--- a/cloud/filestore/libs/endpoint/service_ut.cpp
+++ b/cloud/filestore/libs/endpoint/service_ut.cpp
@@ -15,6 +15,7 @@
 
 #include <util/generic/guid.h>
 #include <util/generic/scope.h>
+#include <util/system/sysstat.h>
 
 namespace NCloud::NFileStore::NServer {
 
@@ -24,6 +25,8 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr TDuration WaitTimeout = TDuration::Seconds(5);
+
+static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -177,7 +180,8 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto service = CreateEndpointManager(
             CreateLoggingService("console"),
             endpointStorage,
-            listener);
+            listener,
+            MODE0660);
         service->Start();
 
         auto strOrError = SerializeEndpoint(start);
@@ -256,7 +260,8 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto service = CreateEndpointManager(
             CreateLoggingService("console"),
             endpointStorage,
-            listener);
+            listener,
+            MODE0660);
         service->Start();
 
         auto strOrError = SerializeEndpoint(start);
@@ -376,7 +381,8 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         auto service = CreateEndpointManager(
             CreateLoggingService("console"),
             endpointStorage,
-            listener);
+            listener,
+            MODE0660);
         service->Start();
 
         Y_DEFER {

--- a/cloud/filestore/libs/endpoint_vhost/config.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/config.cpp
@@ -2,9 +2,15 @@
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
+#include <util/system/sysstat.h>
+
 namespace NCloud::NFileStore::NVhost {
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -17,6 +23,7 @@ namespace {
         NCloud::NProto::EEndpointStorageType,                                  \
         NCloud::NProto::ENDPOINT_STORAGE_KEYRING                              )\
     xxx(EndpointStorageDir,         TString,                {}                )\
+    xxx(SocketAccessMode,           ui32,                   MODE0660          )\
 // VHOST_SERVICE_CONFIG
 
 #define VHOST_SERVICE_DECLARE_CONFIG(name, type, value)                        \

--- a/cloud/filestore/libs/endpoint_vhost/config.h
+++ b/cloud/filestore/libs/endpoint_vhost/config.h
@@ -27,6 +27,7 @@ public:
     bool GetRequireEndpointsKeyring() const;
     NCloud::NProto::EEndpointStorageType GetEndpointStorageType() const;
     TString GetEndpointStorageDir() const;
+    ui32 GetSocketAccessMode() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -1374,6 +1374,7 @@ private:
         auto error = EndpointPoller->StartListenEndpoint(
             unixSocketPath,
             backlog,
+            S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR, // accessMode
             true,   // multiClient
             NProto::SOURCE_FD_CONTROL_CHANNEL,
             AppCtx.SessionStorage->CreateClientStorage());

--- a/cloud/storage/core/libs/uds/endpoint_poller.h
+++ b/cloud/storage/core/libs/uds/endpoint_poller.h
@@ -30,6 +30,7 @@ public:
     NProto::TError StartListenEndpoint(
         const TString& unixSocketPath,
         ui32 backlog,
+        int accessMode,
         bool multiClient,
         NProto::ERequestSource source,
         IClientStoragePtr clientStorage);


### PR DESCRIPTION
NBS and NFS create sockets with access permissions specified in this option.
We need it in k8s to give custom permissions to sockets.