### PR TITLE
NBS-1526 [disk manager] call mlock on dm process start

### DIFF
--- a/cloud/disk_manager/internal/pkg/util/mlock.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock.go
@@ -1,10 +1,78 @@
 package util
 
-type MemRange struct {
-	start  uint64
-	length uint64
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/ydb-platform/nbs/cloud/tasks/errors"
+)
+
+type memRange struct {
+	start uintptr
+	end   uintptr
 }
 
-func parseMemRange(line string) (MemRange, error) {
+type memItem struct {
+	memoryRange memRange
+	permissions string
+	offset      uintptr
+	device      string
+	inode       uint64
+	pathname    string
+}
 
+func parseMemRange(line string) (*memItem, error) {
+	var item memItem
+	_, err := fmt.Sscanf(
+		line,
+		"%x-%x %s %x %s %d %s",
+		&item.memoryRange.start,
+		&item.memoryRange.end,
+		&item.permissions,
+		&item.offset,
+		&item.device,
+		&item.inode,
+		&item.pathname,
+	)
+	return &item, err
+}
+
+func mlock(memoryRange memRange) error {
+	len := memoryRange.end - memoryRange.start
+	_, _, errno := syscall.Syscall(syscall.SYS_MLOCK, memoryRange.start, len, 0)
+	if errno != 0 {
+		return errors.NewNonRetriableErrorf("mlock syscall failed with errno %d", errno)
+	}
+	return nil
+}
+
+func shouldLockRange(item *memItem) bool {
+	return item.inode != 0 && item.permissions[0] == 'r'
+}
+
+func LockBinary() error {
+	maps, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return err
+	}
+	defer maps.Close()
+
+	scanner := bufio.NewScanner(maps)
+	for scanner.Scan() {
+		item, err := parseMemRange(scanner.Text())
+		if err != nil {
+			return err
+		}
+
+		if shouldLockRange(item) {
+			err = mlock(item.memoryRange)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/cloud/disk_manager/internal/pkg/util/mlock.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock.go
@@ -39,8 +39,19 @@ func parseProcMapsLine(line string) (*procMapsItem, error) {
 		&item.inode,
 		&item.pathname,
 	)
-	if err != nil && (err != io.EOF || n < 6) {
-		return nil, err
+	if err != nil {
+		// Line from /proc/[pid]/maps might not contain pathname.
+		// In this case we get io.EOF here.
+		// So we should handle io.EOF error separately.
+		if err != io.EOF {
+			return nil, err
+		}
+		// Regardless of pathname, line from /proc/<pid>/maps
+		// should contain at least 6 fields.
+		// See `man proc` for more info.
+		if n < 6 {
+			return nil, err
+		}
 	}
 	return &item, nil
 }

--- a/cloud/disk_manager/internal/pkg/util/mlock.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock.go
@@ -1,0 +1,10 @@
+package util
+
+type MemRange struct {
+	start  uint64
+	length uint64
+}
+
+func parseMemRange(line string) (MemRange, error) {
+
+}

--- a/cloud/disk_manager/internal/pkg/util/mlock.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"syscall"
 
@@ -25,7 +26,7 @@ type memItem struct {
 
 func parseMemRange(line string) (*memItem, error) {
 	var item memItem
-	_, err := fmt.Sscanf(
+	n, err := fmt.Sscanf(
 		line,
 		"%x-%x %s %x %s %d %s",
 		&item.memoryRange.start,
@@ -36,7 +37,10 @@ func parseMemRange(line string) (*memItem, error) {
 		&item.inode,
 		&item.pathname,
 	)
-	return &item, err
+	if err != nil && (err != io.EOF || n < 6) {
+		return nil, err
+	}
+	return &item, nil
 }
 
 func mlock(memoryRange memRange) error {

--- a/cloud/disk_manager/internal/pkg/util/mlock.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 )
 
+////////////////////////////////////////////////////////////////////////////////
+
 type memoryRange struct {
 	start uintptr
 	end   uintptr

--- a/cloud/disk_manager/internal/pkg/util/mlock_test.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock_test.go
@@ -1,0 +1,95 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMemoryItems(t *testing.T) {
+	type testCase struct {
+		line         string
+		itemExpected memItem
+	}
+	cases := []testCase{
+		testCase{
+			"02443000-02444000 r--p 02242000 fd:11 3016                               /usr/bin/yc-disk-manager",
+			memItem{memRange{0x2443000, 0x2444000}, "r--p", 0x2242000, "fd:11", 3016, "/usr/bin/yc-disk-manager"},
+		},
+		testCase{
+			"02563000-025b3000 rw-p 00000000 00:00 0 ",
+			memItem{memRange{0x2563000, 0x25b3000}, "rw-p", 0, "00:00", 0, ""},
+		},
+		testCase{
+			"ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]",
+			memItem{memRange{0xffffffffff600000, 0xffffffffff601000}, "r-xp", 0, "00:00", 0, "[vsyscall]"},
+		},
+	}
+
+	for _, testCase := range cases {
+		item, err := parseMemRange(testCase.line)
+		require.NoError(t, err)
+		require.EqualValues(t, testCase.itemExpected, *item)
+	}
+}
+
+func TestShouldLockRange(t *testing.T) {
+	type testCase struct {
+		line               string
+		shouldLockExpected bool
+	}
+	cases := []testCase{
+		testCase{
+			"00200000-02443000 r-xp 00000000 fd:11 3016                               /usr/bin/yc-disk-manager",
+			false,
+		},
+		testCase{
+			"02443000-02444000 r--p 02242000 fd:11 3016                               /usr/bin/yc-disk-manager",
+			false,
+		},
+		testCase{
+			"02563000-025b3000 rw-p 00000000 00:00 0 ",
+			false,
+		},
+		testCase{
+			"7fe4f2d4f000-7fe4f2d50000 rw-p 00000000 00:00 0 ",
+			false,
+		},
+		testCase{
+			"7fe4f2d50000-7fe4f3149000 ---p 00000000 00:00 0 ",
+			false,
+		},
+		testCase{
+			"7fe4f3149000-7fe4f3251000 r-xp 00000000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
+			false,
+		},
+		testCase{
+			"7fe4f3251000-7fe4f3450000 ---p 00108000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
+			false,
+		},
+		testCase{
+			"7fe4f3450000-7fe4f3451000 r--p 00107000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
+			false,
+		},
+		testCase{
+			"7fe4f3451000-7fe4f3452000 rw-p 00108000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
+			false,
+		},
+		testCase{
+			"ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]",
+			false,
+		},
+	}
+
+	for _, testCase := range cases {
+		item, err := parseMemRange(testCase.line)
+		require.NoError(t, err)
+		shouldLock := shouldLockRange(item)
+		require.EqualValues(t, testCase.shouldLockExpected, shouldLock)
+	}
+}
+
+func TestLockBinaryDoesNotFail(t *testing.T) {
+	err := LockBinary()
+	require.NoError(t, err)
+}

--- a/cloud/disk_manager/internal/pkg/util/mlock_test.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock_test.go
@@ -31,6 +31,10 @@ func TestParseMemoryItems(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, testCase.itemExpected, *item)
 	}
+
+	_, err := parseMemRange("02443000-02444000 r--p 02242000 fd:11")
+	require.Error(t, err)
+
 }
 
 func TestShouldLockRange(t *testing.T) {
@@ -41,11 +45,11 @@ func TestShouldLockRange(t *testing.T) {
 	cases := []testCase{
 		testCase{
 			"00200000-02443000 r-xp 00000000 fd:11 3016                               /usr/bin/yc-disk-manager",
-			false,
+			true,
 		},
 		testCase{
 			"02443000-02444000 r--p 02242000 fd:11 3016                               /usr/bin/yc-disk-manager",
-			false,
+			true,
 		},
 		testCase{
 			"02563000-025b3000 rw-p 00000000 00:00 0 ",
@@ -61,7 +65,7 @@ func TestShouldLockRange(t *testing.T) {
 		},
 		testCase{
 			"7fe4f3149000-7fe4f3251000 r-xp 00000000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
-			false,
+			true,
 		},
 		testCase{
 			"7fe4f3251000-7fe4f3450000 ---p 00108000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
@@ -69,11 +73,11 @@ func TestShouldLockRange(t *testing.T) {
 		},
 		testCase{
 			"7fe4f3450000-7fe4f3451000 r--p 00107000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
-			false,
+			true,
 		},
 		testCase{
 			"7fe4f3451000-7fe4f3452000 rw-p 00108000 fd:11 21683                      /lib/x86_64-linux-gnu/libm-2.23.so",
-			false,
+			true,
 		},
 		testCase{
 			"ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]",

--- a/cloud/disk_manager/internal/pkg/util/mlock_test.go
+++ b/cloud/disk_manager/internal/pkg/util/mlock_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+////////////////////////////////////////////////////////////////////////////////
+
 func TestParseMemoryItems(t *testing.T) {
 	type testCase struct {
 		line         string
@@ -34,7 +36,6 @@ func TestParseMemoryItems(t *testing.T) {
 
 	_, err := parseProcMapsLine("02443000-02444000 r--p 02242000 fd:11")
 	require.Error(t, err)
-
 }
 
 func TestShouldLockRange(t *testing.T) {
@@ -93,7 +94,7 @@ func TestShouldLockRange(t *testing.T) {
 	}
 }
 
-func TestLockBinaryDoesNotFail(t *testing.T) {
+func TestLockProcessMemoryDoesNotFail(t *testing.T) {
 	err := LockProcessMemory()
 	require.NoError(t, err)
 }

--- a/cloud/disk_manager/internal/pkg/util/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/util/tests/ya.make
@@ -1,0 +1,3 @@
+GO_TEST_FOR(cloud/disk_manager/internal/pkg/util)
+
+END()

--- a/cloud/disk_manager/internal/pkg/util/ya.make
+++ b/cloud/disk_manager/internal/pkg/util/ya.make
@@ -2,6 +2,7 @@ GO_LIBRARY()
 
 SRCS(
     json.go
+    mlock.go
     proto.go
 )
 

--- a/cloud/disk_manager/internal/pkg/util/ya.make
+++ b/cloud/disk_manager/internal/pkg/util/ya.make
@@ -6,4 +6,8 @@ SRCS(
     proto.go
 )
 
+GO_TEST_SRCS(mlock_test.go)
+
 END()
+
+RECURSE_FOR_TESTS(tests)

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -83,8 +83,9 @@ func run(
 	ctx = logging.SetLogger(ctx, logger)
 
 	logging.Info(ctx, "Locking process memory")
-	err := util.LockBinary()
+	err := util.LockProcessMemory()
 	if err != nil {
+		// TODO:_ why it is not logged normally?
 		logging.Error(ctx, "Failed to lock process memory")
 		return err
 	}

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -85,8 +85,7 @@ func run(
 	logging.Info(ctx, "Locking process memory")
 	err := util.LockProcessMemory()
 	if err != nil {
-		// TODO:_ why it is not logged normally?
-		logging.Error(ctx, "Failed to lock process memory")
+		logging.Error(ctx, "Failed to lock process memory: %v", err)
 		return err
 	}
 

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -7,8 +7,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/spf13/cobra"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/accounting"
 	internal_auth "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth"
@@ -84,10 +82,10 @@ func run(
 	logger := logging.NewLogger(config.LoggingConfig)
 	ctx = logging.SetLogger(ctx, logger)
 
-	logging.Info(ctx, "Locking virtual memory")
-	err := mlock()
+	logging.Info(ctx, "Locking process memory")
+	err := util.LockBinary()
 	if err != nil {
-		logging.Error(ctx, "Failed to lock virtual memory")
+		logging.Error(ctx, "Failed to lock process memory")
 		return err
 	}
 
@@ -278,9 +276,4 @@ func run(
 func ignoreSigpipe() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGPIPE)
-}
-
-// Prevents all current pages from being swapped out.
-func mlock() error {
-	return unix.Mlockall(syscall.MCL_CURRENT)
 }


### PR DESCRIPTION
Lock process memory ranges containing binary and .so files when process starts. Similar to nbs: https://github.com/ydb-platform/nbs/blob/main/cloud/storage/core/libs/daemon/mlock.cpp

After memory is locked, /proc/<pid>/status and /proc/<pid>/maps for dm process look like this:
[dm_memory_state.txt](https://github.com/ydb-platform/nbs/files/15027268/dm_memory_state.txt) 
As we see, 39572 kB are locked.

NOTE! Before starting dm with this change, LimitMEMLOCK parameter in [Service] section of `/usr/lib/systemd/system/yc-disk-manager.service` should be set. Otherwise the process will fail to lock memory and disk manager will not start. I suggest `LimitMEMLOCK=268435456` (256 MiB).