### PR TITLE
[Filestore] issue-539: add client-side stats for GenerateBlobIds/AddData requests

### DIFF
--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -194,6 +194,30 @@ void InitProfileLogRequestInfo(
 template <>
 void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
+    const NProtoPrivate::TGenerateBlobIdsRequest& request)
+{
+    auto* rangeInfo = profileLogRequest.AddRanges();
+    rangeInfo->SetNodeId(request.GetNodeId());
+    rangeInfo->SetHandle(request.GetHandle());
+    rangeInfo->SetOffset(request.GetOffset());
+    rangeInfo->SetBytes(request.GetLength());
+}
+
+template <>
+void InitProfileLogRequestInfo(
+    NProto::TProfileLogRequestInfo& profileLogRequest,
+    const NProtoPrivate::TAddDataRequest& request)
+{
+    auto* rangeInfo = profileLogRequest.AddRanges();
+    rangeInfo->SetNodeId(request.GetNodeId());
+    rangeInfo->SetHandle(request.GetHandle());
+    rangeInfo->SetOffset(request.GetOffset());
+    rangeInfo->SetBytes(request.GetLength());
+}
+
+template <>
+void InitProfileLogRequestInfo(
+    NProto::TProfileLogRequestInfo& profileLogRequest,
     const NProto::TWriteDataRequest& request)
 {
     auto* rangeInfo = profileLogRequest.AddRanges();
@@ -448,6 +472,8 @@ void InitProfileLogRequestInfo(
     IMPLEMENT_DEFAULT_METHOD(KickEndpoint, NProto)
     IMPLEMENT_DEFAULT_METHOD(ExecuteAction, NProto)
     IMPLEMENT_DEFAULT_METHOD(DescribeData, NProtoPrivate)
+    IMPLEMENT_DEFAULT_METHOD(GenerateBlobIds, NProtoPrivate)
+    IMPLEMENT_DEFAULT_METHOD(AddData, NProtoPrivate)
 
 #undef IMPLEMENT_DEFAULT_METHOD
 

--- a/cloud/filestore/libs/service/auth_scheme.cpp
+++ b/cloud/filestore/libs/service/auth_scheme.cpp
@@ -41,6 +41,8 @@ TPermissionList GetRequestPermissions(EFileStoreRequest requestType)
         case EFileStoreRequest::ReleaseLock:
         case EFileStoreRequest::TestLock:
         case EFileStoreRequest::DescribeData:
+        case EFileStoreRequest::GenerateBlobIds:
+        case EFileStoreRequest::AddData:
             return CreatePermissionList({});
 
         case EFileStoreRequest::AddClusterNode:

--- a/cloud/filestore/libs/service/request.cpp
+++ b/cloud/filestore/libs/service/request.cpp
@@ -116,6 +116,8 @@ ui64 CreateRequestId()
 static const TString RequestNames[] = {
     FILESTORE_REQUESTS(FILESTORE_DECLARE_REQUEST)
     "DescribeData",
+    "GenerateBlobIds",
+    "AddData",
 };
 
 static_assert(

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -128,6 +128,8 @@ enum class EFileStoreRequest
 {
     FILESTORE_REQUESTS(FILESTORE_DECLARE_REQUEST)
     DescribeData,
+    GenerateBlobIds,
+    AddData,
     MAX
 };
 

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -34,13 +34,27 @@ private:
 
     // WriteData state
     ui32 RemainingBlobsToWrite = 0;
+    bool WriteDataFallbackEnabled = false;
+
+    // Stats for reporting
+    IRequestStatsPtr RequestStats;
+    IProfileLogPtr ProfileLog;
+    TMaybe<TInFlightRequest> InFlightRequest;
+    const NCloud::NProto::EStorageMediaKind MediaKind;
+
 
 public:
     TWriteDataActor(
             NProto::TWriteDataRequest request,
-            TRequestInfoPtr requestInfo)
+            TRequestInfoPtr requestInfo,
+            IRequestStatsPtr requestStats,
+            IProfileLogPtr profileLog,
+            NCloud::NProto::EStorageMediaKind mediaKind)
         : WriteRequest(std::move(request))
         , RequestInfo(std::move(requestInfo))
+        , RequestStats(std::move(requestStats))
+        , ProfileLog(std::move(profileLog))
+        , MediaKind(mediaKind)
     {}
 
     void Bootstrap(const TActorContext& ctx)
@@ -54,6 +68,21 @@ public:
         request->Record.SetHandle(WriteRequest.GetHandle());
         request->Record.SetOffset(WriteRequest.GetOffset());
         request->Record.SetLength(WriteRequest.GetBuffer().size());
+
+        RequestInfo->CallContext->RequestType = EFileStoreRequest::GenerateBlobIds;
+        InFlightRequest.ConstructInPlace(
+            TRequestInfo(
+                RequestInfo->Sender,
+                RequestInfo->Cookie,
+                RequestInfo->CallContext),
+            ProfileLog,
+            MediaKind,
+            RequestStats);
+        InFlightRequest->Start(ctx.Now());
+        InitProfileLogRequestInfo(
+            InFlightRequest->ProfileLogRequest,
+            request->Record);
+
 
         LOG_DEBUG(
             ctx,
@@ -94,6 +123,16 @@ private:
         const TActorContext& ctx)
     {
         const auto* msg = ev->Get();
+
+        Y_DEBUG_ABORT_UNLESS(InFlightRequest);
+
+        InFlightRequest->Complete(ctx.Now(), msg->GetError());
+        FinalizeProfileLogRequestInfo(
+            InFlightRequest->ProfileLogRequest,
+            msg->Record);
+        // After the GenerateBlobIds response is received, we continue to consider the
+        // request as a WriteData request
+        RequestInfo->CallContext->RequestType = EFileStoreRequest::WriteData;
 
         if (HasError(msg->GetError())) {
             WriteData(ctx, msg->GetError());
@@ -151,6 +190,9 @@ private:
         const TEvBlobStorage::TEvPutResult::TPtr& ev,
         const TActorContext& ctx)
     {
+        if (WriteDataFallbackEnabled) {
+            return;
+        }
         const auto* msg = ev->Get();
 
         if (msg->Status != NKikimrProto::OK) {
@@ -163,7 +205,6 @@ private:
                 msg->ErrorReason.Quote().c_str());
             // We still may receive some responses, but we do not want to
             // process them
-            RemainingBlobsToWrite = std::numeric_limits<ui32>::max();
             return WriteData(ctx, error);
         }
 
@@ -194,6 +235,21 @@ private:
         }
         request->Record.SetCommitId(GenerateBlobIdsResponse.GetCommitId());
 
+        RequestInfo->CallContext->RequestType = EFileStoreRequest::AddData;
+        InFlightRequest.ConstructInPlace(
+            TRequestInfo(
+                RequestInfo->Sender,
+                RequestInfo->Cookie,
+                RequestInfo->CallContext),
+            ProfileLog,
+            MediaKind,
+            RequestStats);
+        InFlightRequest->Start(ctx.Now());
+        InitProfileLogRequestInfo(
+            InFlightRequest->ProfileLogRequest,
+            request->Record);
+
+
         LOG_DEBUG(
             ctx,
             TFileStoreComponents::SERVICE,
@@ -208,6 +264,13 @@ private:
         const TActorContext& ctx)
     {
         auto* msg = ev->Get();
+
+        Y_DEBUG_ABORT_UNLESS(InFlightRequest);
+        InFlightRequest->Complete(ctx.Now(), msg->GetError());
+        FinalizeProfileLogRequestInfo(
+            InFlightRequest->ProfileLogRequest,
+            msg->Record);
+        RequestInfo->CallContext->RequestType = EFileStoreRequest::WriteData;
 
         if (HasError(msg->GetError())) {
             return WriteData(ctx, msg->GetError());
@@ -224,6 +287,7 @@ private:
      */
     void WriteData(const TActorContext& ctx, const NProto::TError& error)
     {
+        WriteDataFallbackEnabled = true;
         LOG_WARN(
             ctx,
             TFileStoreComponents::SERVICE,
@@ -316,14 +380,6 @@ void TStorageServiceActor::HandleWriteData(
         return;
     }
 
-    auto [cookie, inflight] = CreateInFlightRequest(
-        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
-        session->MediaKind,
-        session->RequestStats,
-        ctx.Now());
-
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-
     ui32 blockSize = filestore.GetBlockSize();
 
     // TODO(debnatkh): Consider supporting unaligned writes
@@ -339,12 +395,23 @@ void TStorageServiceActor::HandleWriteData(
             "Using three-stage write for request, size: %lu",
             msg->Record.GetBuffer().Size());
 
+        auto [cookie, inflight] = CreateInFlightRequest(
+            TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+            session->MediaKind,
+            session->RequestStats,
+            ctx.Now());
+
+        InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+
         auto requestInfo =
             CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
         auto actor = std::make_unique<TWriteDataActor>(
             std::move(msg->Record),
-            std::move(requestInfo));
+            std::move(requestInfo),
+            session->RequestStats,
+            ProfileLog,
+            session->MediaKind);
         NCloud::Register(ctx, std::move(actor));
     } else {
         LOG_DEBUG(

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2153,6 +2153,39 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             service.AssertWriteDataFailed(headers, fs, nodeId, handle, DefaultBlockSize * 641, data);
         auto error = STATUS_FROM_CODE(response->GetError().GetCode());
         UNIT_ASSERT_VALUES_EQUAL((ui32)NProto::E_FS_NOSPC, error);
+
+        auto counters = env.GetCounters()
+                            ->FindSubgroup("component", "service_fs")
+                            ->FindSubgroup("host", "cluster")
+                            ->FindSubgroup("filesystem", fs)
+                            ->FindSubgroup("client", "client");
+        {
+            auto subgroup = counters->FindSubgroup("request", "GenerateBlobIds");
+            UNIT_ASSERT(subgroup);
+            UNIT_ASSERT_VALUES_EQUAL(
+                7,
+                subgroup->GetCounter("Count")->GetAtomic());
+        }
+        {
+            auto subgroup = counters->FindSubgroup("request", "AddData");
+            UNIT_ASSERT(subgroup);
+            // Out of 7 writes, only the last one must have failed
+            UNIT_ASSERT_VALUES_EQUAL(
+                6,
+                subgroup->GetCounter("Count")->GetAtomic());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                subgroup->GetCounter("Errors")->GetAtomic());
+
+        }
+        {
+            auto subgroup = counters->FindSubgroup("request", "WriteData");
+            UNIT_ASSERT(subgroup);
+            UNIT_ASSERT_VALUES_EQUAL(
+                7,
+                subgroup->GetCounter("Count")->GetAtomic());
+        }
+
     }
 
     Y_UNIT_TEST(ShouldNotUseThreeStageWriteForSmallOrUnalignedRequests)

--- a/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
@@ -96,82 +96,87 @@ Y_UNIT_TEST_SUITE(TDumpTest)
 
         UNIT_ASSERT_VALUES_EQUAL(66, requests.size());
 
-#define TEST_REQUEST_TYPE(index, id, name)                                     \
+        ui32 index = 0;
+#define TEST_REQUEST_TYPE(id, name)                                            \
     UNIT_ASSERT_VALUES_EQUAL(id, requests[index].Id);                          \
     UNIT_ASSERT_VALUES_EQUAL(#name, requests[index].Name);                     \
+    ++index;
 // TEST_REQUEST_TYPE
 
+
         // Public
-        TEST_REQUEST_TYPE(0, 0, Ping);
-        TEST_REQUEST_TYPE(1, 1, PingSession);
-        TEST_REQUEST_TYPE(2, 2, CreateFileStore);
-        TEST_REQUEST_TYPE(3, 3, DestroyFileStore);
-        TEST_REQUEST_TYPE(4, 4, AlterFileStore);
-        TEST_REQUEST_TYPE(5, 5, ResizeFileStore);
-        TEST_REQUEST_TYPE(6, 6, DescribeFileStoreModel);
-        TEST_REQUEST_TYPE(7, 7, GetFileStoreInfo);
-        TEST_REQUEST_TYPE(8, 8, ListFileStores);
-        TEST_REQUEST_TYPE(9, 9, CreateSession);
-        TEST_REQUEST_TYPE(10, 10, DestroySession);
-        TEST_REQUEST_TYPE(11, 11, AddClusterNode);
-        TEST_REQUEST_TYPE(12, 12, RemoveClusterNode);
-        TEST_REQUEST_TYPE(13, 13, ListClusterNodes);
-        TEST_REQUEST_TYPE(14, 14, AddClusterClients);
-        TEST_REQUEST_TYPE(15, 15, RemoveClusterClients);
-        TEST_REQUEST_TYPE(16, 16, ListClusterClients);
-        TEST_REQUEST_TYPE(17, 17, UpdateCluster);
-        TEST_REQUEST_TYPE(18, 18, CreateCheckpoint);
-        TEST_REQUEST_TYPE(19, 19, DestroyCheckpoint);
-        TEST_REQUEST_TYPE(20, 20, ExecuteAction);
-        TEST_REQUEST_TYPE(21, 21, StatFileStore);
-        TEST_REQUEST_TYPE(22, 22, SubscribeSession);
-        TEST_REQUEST_TYPE(23, 23, GetSessionEvents);
-        TEST_REQUEST_TYPE(24, 24, ResetSession);
-        TEST_REQUEST_TYPE(25, 25, ResolvePath);
-        TEST_REQUEST_TYPE(26, 26, CreateNode);
-        TEST_REQUEST_TYPE(27, 27, UnlinkNode);
-        TEST_REQUEST_TYPE(28, 28, RenameNode);
-        TEST_REQUEST_TYPE(29, 29, AccessNode);
-        TEST_REQUEST_TYPE(30, 30, ListNodes);
-        TEST_REQUEST_TYPE(31, 31, ReadLink);
-        TEST_REQUEST_TYPE(32, 32, SetNodeAttr);
-        TEST_REQUEST_TYPE(33, 33, GetNodeAttr);
-        TEST_REQUEST_TYPE(34, 34, SetNodeXAttr);
-        TEST_REQUEST_TYPE(35, 35, GetNodeXAttr);
-        TEST_REQUEST_TYPE(36, 36, ListNodeXAttr);
-        TEST_REQUEST_TYPE(37, 37, RemoveNodeXAttr);
-        TEST_REQUEST_TYPE(38, 38, CreateHandle);
-        TEST_REQUEST_TYPE(39, 39, DestroyHandle);
-        TEST_REQUEST_TYPE(40, 40, AcquireLock);
-        TEST_REQUEST_TYPE(41, 41, ReleaseLock);
-        TEST_REQUEST_TYPE(42, 42, TestLock);
-        TEST_REQUEST_TYPE(43, 43, ReadData);
-        TEST_REQUEST_TYPE(44, 44, WriteData);
-        TEST_REQUEST_TYPE(45, 45, AllocateData);
-        TEST_REQUEST_TYPE(46, 46, GetSessionEventsStream);
-        TEST_REQUEST_TYPE(47, 47, StartEndpoint);
-        TEST_REQUEST_TYPE(48, 48, StopEndpoint);
-        TEST_REQUEST_TYPE(49, 49, ListEndpoints);
-        TEST_REQUEST_TYPE(50, 50, KickEndpoint);
-        TEST_REQUEST_TYPE(51, 51, DescribeData);
+        TEST_REQUEST_TYPE(0, Ping);
+        TEST_REQUEST_TYPE(1, PingSession);
+        TEST_REQUEST_TYPE(2, CreateFileStore);
+        TEST_REQUEST_TYPE(3, DestroyFileStore);
+        TEST_REQUEST_TYPE(4, AlterFileStore);
+        TEST_REQUEST_TYPE(5, ResizeFileStore);
+        TEST_REQUEST_TYPE(6, DescribeFileStoreModel);
+        TEST_REQUEST_TYPE(7, GetFileStoreInfo);
+        TEST_REQUEST_TYPE(8, ListFileStores);
+        TEST_REQUEST_TYPE(9, CreateSession);
+        TEST_REQUEST_TYPE(10, DestroySession);
+        TEST_REQUEST_TYPE(11, AddClusterNode);
+        TEST_REQUEST_TYPE(12, RemoveClusterNode);
+        TEST_REQUEST_TYPE(13, ListClusterNodes);
+        TEST_REQUEST_TYPE(14, AddClusterClients);
+        TEST_REQUEST_TYPE(15, RemoveClusterClients);
+        TEST_REQUEST_TYPE(16, ListClusterClients);
+        TEST_REQUEST_TYPE(17, UpdateCluster);
+        TEST_REQUEST_TYPE(18, CreateCheckpoint);
+        TEST_REQUEST_TYPE(19, DestroyCheckpoint);
+        TEST_REQUEST_TYPE(20, ExecuteAction);
+        TEST_REQUEST_TYPE(21, StatFileStore);
+        TEST_REQUEST_TYPE(22, SubscribeSession);
+        TEST_REQUEST_TYPE(23, GetSessionEvents);
+        TEST_REQUEST_TYPE(24, ResetSession);
+        TEST_REQUEST_TYPE(25, ResolvePath);
+        TEST_REQUEST_TYPE(26, CreateNode);
+        TEST_REQUEST_TYPE(27, UnlinkNode);
+        TEST_REQUEST_TYPE(28, RenameNode);
+        TEST_REQUEST_TYPE(29, AccessNode);
+        TEST_REQUEST_TYPE(30, ListNodes);
+        TEST_REQUEST_TYPE(31, ReadLink);
+        TEST_REQUEST_TYPE(32, SetNodeAttr);
+        TEST_REQUEST_TYPE(33, GetNodeAttr);
+        TEST_REQUEST_TYPE(34, SetNodeXAttr);
+        TEST_REQUEST_TYPE(35, GetNodeXAttr);
+        TEST_REQUEST_TYPE(36, ListNodeXAttr);
+        TEST_REQUEST_TYPE(37, RemoveNodeXAttr);
+        TEST_REQUEST_TYPE(38, CreateHandle);
+        TEST_REQUEST_TYPE(39, DestroyHandle);
+        TEST_REQUEST_TYPE(40, AcquireLock);
+        TEST_REQUEST_TYPE(41, ReleaseLock);
+        TEST_REQUEST_TYPE(42, TestLock);
+        TEST_REQUEST_TYPE(43, ReadData);
+        TEST_REQUEST_TYPE(44, WriteData);
+        TEST_REQUEST_TYPE(45, AllocateData);
+        TEST_REQUEST_TYPE(46, GetSessionEventsStream);
+        TEST_REQUEST_TYPE(47, StartEndpoint);
+        TEST_REQUEST_TYPE(48, StopEndpoint);
+        TEST_REQUEST_TYPE(49, ListEndpoints);
+        TEST_REQUEST_TYPE(50, KickEndpoint);
+        TEST_REQUEST_TYPE(51, DescribeData);
+        TEST_REQUEST_TYPE(52, GenerateBlobIds);
+        TEST_REQUEST_TYPE(53, AddData);
 
         // Fuse
-        TEST_REQUEST_TYPE(52, 1001, Flush);
-        TEST_REQUEST_TYPE(53, 1002, Fsync);
+        TEST_REQUEST_TYPE(1001, Flush);
+        TEST_REQUEST_TYPE(1002, Fsync);
 
         // Tablet
-        TEST_REQUEST_TYPE(54, 10001, Flush);
-        TEST_REQUEST_TYPE(55, 10002, FlushBytes);
-        TEST_REQUEST_TYPE(56, 10003, Compaction);
-        TEST_REQUEST_TYPE(57, 10004, Cleanup);
-        TEST_REQUEST_TYPE(58, 10005, TrimBytes);
-        TEST_REQUEST_TYPE(59, 10006, CollectGarbage);
-        TEST_REQUEST_TYPE(60, 10007, DeleteGarbage);
-        TEST_REQUEST_TYPE(61, 10008, ReadBlob);
-        TEST_REQUEST_TYPE(62, 10009, WriteBlob);
-        TEST_REQUEST_TYPE(63, 10010, AddBlob);
-        TEST_REQUEST_TYPE(64, 10011, TruncateRange);
-        TEST_REQUEST_TYPE(65, 10012, ZeroRange);
+        TEST_REQUEST_TYPE(10001, Flush);
+        TEST_REQUEST_TYPE(10002, FlushBytes);
+        TEST_REQUEST_TYPE(10003, Compaction);
+        TEST_REQUEST_TYPE(10004, Cleanup);
+        TEST_REQUEST_TYPE(10005, TrimBytes);
+        TEST_REQUEST_TYPE(10006, CollectGarbage);
+        TEST_REQUEST_TYPE(10007, DeleteGarbage);
+        TEST_REQUEST_TYPE(10008, ReadBlob);
+        TEST_REQUEST_TYPE(10009, WriteBlob);
+        TEST_REQUEST_TYPE(10010, AddBlob);
+        TEST_REQUEST_TYPE(10011, TruncateRange);
+        TEST_REQUEST_TYPE(10012, ZeroRange);
 
 #undef TEST_REQUEST_TYPE
     }

--- a/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
@@ -94,7 +94,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
     {
         const auto requests = GetRequestTypes();
 
-        UNIT_ASSERT_VALUES_EQUAL(66, requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(68, requests.size());
 
         ui32 index = 0;
 #define TEST_REQUEST_TYPE(id, name)                                            \


### PR DESCRIPTION
Adding stats for `ThreeStageWrite` data path on the service side: generic counters for `GenerateBlobIds` and `AddData` requests.