### PR TITLE
issue-852: TReadAheadCache implementation + ut + fixed its usage a bit

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -247,7 +247,11 @@ message TStorageConfig
     // ReadAhead cache params. Used upon DescribeData requests.
     // If ReadAheadCacheRangeSize is not 0 the requested ranges may be widened
     // to this value and the results will be cached to serve future describe
-    // requests.
+    // requests. The requested range is widened if the previous 32 DescribeData
+    // requests represent a pattern which is similar to sequential. The similar
+    // part is controlled by the ReadAheadMaxGapPercentage parameter which
+    // regulates the maximum number of skipped bytes in an otherwise sequential
+    // pattern.
     optional uint32 ReadAheadCacheMaxNodes = 347;
     optional uint32 ReadAheadCacheMaxResultsPerNode = 348;
     optional uint32 ReadAheadCacheRangeSize = 349;

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -251,4 +251,5 @@ message TStorageConfig
     optional uint32 ReadAheadCacheMaxNodes = 347;
     optional uint32 ReadAheadCacheMaxResultsPerNode = 348;
     optional uint32 ReadAheadCacheRangeSize = 349;
+    optional uint32 ReadAheadMaxGapPercentage = 350;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -144,6 +144,7 @@ namespace {
     xxx(ReadAheadCacheMaxNodes,                 ui32,       1024              )\
     xxx(ReadAheadCacheMaxResultsPerNode,        ui32,       32                )\
     xxx(ReadAheadCacheRangeSize,                ui32,       0                 )\
+    xxx(ReadAheadMaxGapPercentage,              ui32,       20                )\
     xxx(EntryTimeout,                    TDuration, TDuration::Zero()         )\
     xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\
     xxx(AttrTimeout,                     TDuration, TDuration::Zero()         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -198,6 +198,7 @@ public:
     ui32 GetReadAheadCacheMaxNodes() const;
     ui32 GetReadAheadCacheMaxResultsPerNode() const;
     ui32 GetReadAheadCacheRangeSize() const;
+    ui32 GetReadAheadMaxGapPercentage() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/storage/model/range.h
+++ b/cloud/filestore/libs/storage/model/range.h
@@ -10,8 +10,8 @@ namespace NCloud::NFileStore::NStorage {
 
 struct TByteRange
 {
-    const ui64 Offset;
-    const ui64 Length;
+    ui64 Offset;
+    ui64 Length;
     const ui32 BlockSize;
 
     TByteRange(ui64 offset, ui64 length, ui32 blockSize)
@@ -20,6 +20,15 @@ struct TByteRange
         , BlockSize(blockSize)
     {
         Y_ABORT_UNLESS(BlockSize);
+    }
+
+    TByteRange(const TByteRange& rhs) = default;
+    TByteRange& operator=(const TByteRange& rhs)
+    {
+        Y_DEBUG_ABORT_UNLESS(BlockSize == rhs.BlockSize);
+        Offset = rhs.Offset;
+        Length = rhs.Length;
+        return *this;
     }
 
     ui64 End() const

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead.cpp
@@ -2,6 +2,45 @@
 
 namespace NCloud::NFileStore::NStorage {
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool IsCloseToSequential(
+    const TRingBuffer<TReadAheadCache::TRange>& byteRanges,
+    ui32 maxGapPercentage)
+{
+    if (byteRanges.Size() == 0) {
+        return false;
+    }
+
+    TVector<TReadAheadCache::TRange> tmp(Reserve(byteRanges.Size()));
+    for (ui32 i = 0; i < byteRanges.Size(); ++i) {
+        tmp.push_back(byteRanges.Front(i));
+    }
+    SortBy(tmp, [] (const TReadAheadCache::TRange& range) {
+        return std::make_pair(range.Offset, range.Length);
+    });
+
+    const ui64 totalLength = tmp.back().End() - tmp.front().Offset;
+    if (totalLength < 1_MB) {
+        return false;
+    }
+
+    double totalGap = 0;
+    for (ui32 i = 1; i < tmp.size(); ++i) {
+        const auto& prev = tmp[i - 1];
+        const auto& cur = tmp[i];
+        if (prev.End() < cur.Offset) {
+            totalGap += cur.Offset - prev.End();
+        }
+    }
+
+    return totalGap * 100 / totalLength <= maxGapPercentage;
+}
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TReadAheadCache::TReadAheadCache(IAllocator* allocator)
@@ -16,19 +55,33 @@ TReadAheadCache::~TReadAheadCache() = default;
 void TReadAheadCache::Reset(
     ui32 maxNodes,
     ui32 maxResultsPerNode,
-    ui32 rangeSize)
+    ui32 rangeSize,
+    ui32 maxGapPercentage)
 {
-    Y_UNUSED(maxNodes);
-    Y_UNUSED(maxResultsPerNode);
-    Y_UNUSED(rangeSize);
+    MaxNodes = maxNodes;
+    MaxResultsPerNode = maxResultsPerNode;
+    RangeSize = rangeSize;
+    MaxGapPercentage = maxGapPercentage;
+    NodeStates.clear();
 }
 
 bool TReadAheadCache::TryFillResult(
-    const NProtoPrivate::TDescribeDataRequest& request,
+    ui64 nodeId,
+    const TByteRange& range,
     NProtoPrivate::TDescribeDataResponse* response)
 {
-    Y_UNUSED(request);
-    Y_UNUSED(response);
+    auto* nodeState = NodeStates.FindPtr(nodeId);
+    if (!nodeState) {
+        return false;
+    }
+
+    for (ui32 i = 0; i < nodeState->DescribeResults.Size(); ++i) {
+        const auto& result = nodeState->DescribeResults.Back(i);
+        if (result.Range.Overlaps(range)) {
+            *response = result.Response;
+            return true;
+        }
+    }
 
     return false;
 }
@@ -37,23 +90,47 @@ TMaybe<TByteRange> TReadAheadCache::RegisterDescribe(
     ui64 nodeId,
     const TByteRange inputRange)
 {
-    Y_UNUSED(nodeId);
-    Y_UNUSED(inputRange);
+    if (!RangeSize) {
+        return {};
+    }
+
+    auto& nodeState = Access(nodeId);
+    nodeState.LastRanges.PushBack(TRange(inputRange));
+    if (IsCloseToSequential(nodeState.LastRanges, MaxGapPercentage)
+            && inputRange.Length < RangeSize)
+    {
+        return TByteRange(inputRange.Offset, RangeSize, inputRange.BlockSize);
+    }
 
     return {};
 }
 
 void TReadAheadCache::InvalidateCache(ui64 nodeId)
 {
-    NodeId2DescribeResults.clear(nodeId);
+    NodeStates.clear(nodeId);
 }
 
 void TReadAheadCache::RegisterResult(
     ui64 nodeId,
+    const TByteRange& range,
     const NProtoPrivate::TDescribeDataResponse& result)
 {
-    Y_UNUSED(nodeId);
-    Y_UNUSED(result);
+    Access(nodeId).DescribeResults.PushBack({TRange(range), result});
+}
+
+TReadAheadCache::TNodeState& TReadAheadCache::Access(ui64 nodeId)
+{
+    // TODO: LRU eviction
+    if (NodeStates.size() > MaxNodes) {
+        NodeStates.clear();
+    }
+
+    auto& nodeState = NodeStates[nodeId];
+    if (!nodeState.DescribeResults.Capacity()) {
+        nodeState.DescribeResults.Reset(MaxResultsPerNode);
+    }
+
+    return nodeState;
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead.cpp
@@ -15,14 +15,18 @@ bool IsCloseToSequential(
     }
 
     TVector<TReadAheadCache::TRange> tmp(Reserve(byteRanges.Size()));
+    ui64 minOffset = Max<ui64>();
+    ui64 maxEnd = 0;
     for (ui32 i = 0; i < byteRanges.Size(); ++i) {
         tmp.push_back(byteRanges.Front(i));
+        minOffset = Min(minOffset, tmp.back().Offset);
+        maxEnd = Max(maxEnd, tmp.back().End());
     }
     SortBy(tmp, [] (const TReadAheadCache::TRange& range) {
         return std::make_pair(range.Offset, range.Length);
     });
 
-    const ui64 totalLength = tmp.back().End() - tmp.front().Offset;
+    const ui64 totalLength = maxEnd - minOffset;
     if (totalLength < 1_MB) {
         return false;
     }

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead.h
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead.h
@@ -5,6 +5,8 @@
 #include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
+#include <cloud/storage/core/libs/common/ring_buffer.h>
+
 #include <util/generic/deque.h>
 #include <util/generic/hash.h>
 #include <util/generic/maybe.h>
@@ -16,12 +18,67 @@ namespace NCloud::NFileStore::NStorage {
 
 class TReadAheadCache
 {
-    using TDescribeResults = TDeque<NProtoPrivate::TDescribeDataResponse>;
-    using TNodeId2DescribeResults = THashMap<ui64, TDescribeResults>;
+public:
+    struct TRange
+    {
+        ui64 Offset = 0;
+        ui32 Length = 0;
+
+        TRange() = default;
+
+        explicit TRange(const TByteRange& byteRange)
+            : Offset(byteRange.Offset)
+            , Length(byteRange.Length)
+        {
+        }
+
+        [[nodiscard]] ui64 End() const
+        {
+            return Offset + Length;
+        }
+
+        [[nodiscard]] bool Overlaps(const TByteRange& byteRange) const
+        {
+            return TByteRange(
+                Offset,
+                Length,
+                byteRange.BlockSize).Overlaps(byteRange);
+        }
+    };
+
+private:
+    struct TDescribeResult
+    {
+        TRange Range;
+        NProtoPrivate::TDescribeDataResponse Response;
+    };
+
+    using TDescribeResults = TRingBuffer<TDescribeResult>;
+    using TByteRanges = TRingBuffer<TRange>;
+
+    struct TNodeState
+    {
+        static const ui32 RANGE_COUNT = 32;
+        TByteRanges LastRanges;
+        TDescribeResults DescribeResults;
+
+        TNodeState()
+            : LastRanges(RANGE_COUNT)
+            , DescribeResults(0)
+        {
+        }
+    };
+
+    using TNodeStates = THashMap<ui64, TNodeState>;
 
 private:
     IAllocator* Allocator;
-    TNodeId2DescribeResults NodeId2DescribeResults;
+    TNodeStates NodeStates;
+
+    ui32 MaxNodes = 0;
+    ui32 MaxResultsPerNode = 0;
+    ui32 RangeSize = 0;
+    ui32 MaxGapPercentage = 0;
 
 public:
     TReadAheadCache(IAllocator* allocator);
@@ -30,10 +87,12 @@ public:
     void Reset(
         ui32 maxNodes,
         ui32 maxResultsPerNode,
-        ui32 rangeSize);
+        ui32 rangeSize,
+        ui32 maxGapPercentage);
 
     bool TryFillResult(
-        const NProtoPrivate::TDescribeDataRequest& request,
+        ui64 nodeId,
+        const TByteRange& range,
         NProtoPrivate::TDescribeDataResponse* response);
 
     // returns the suggested range to describe
@@ -43,7 +102,11 @@ public:
     void InvalidateCache(ui64 nodeId);
     void RegisterResult(
         ui64 nodeId,
+        const TByteRange& range,
         const NProtoPrivate::TDescribeDataResponse& result);
+
+private:
+    TNodeState& Access(ui64 nodeId);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead_ut.cpp
@@ -1,0 +1,165 @@
+#include "read_ahead.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/vector.h>
+#include <util/string/printf.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TDefaultCache: TReadAheadCache
+{
+    TDefaultCache()
+        : TReadAheadCache(TDefaultAllocator::Instance())
+    {
+        Reset(1024, 32, 1_MB, 20);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TReadAheadTest)
+{
+    Y_UNIT_TEST(ShouldDetectPureSequentialRead)
+    {
+        const ui64 nodeId = 111;
+        const ui32 blockSize = 4_KB;
+        const ui32 requestSize = 32 * blockSize;
+
+        TDefaultCache cache;
+
+        TMaybe<TByteRange> r;
+        ui64 offset = 0;
+        while (offset < 1_MB - requestSize) {
+            r = cache.RegisterDescribe(
+                nodeId,
+                TByteRange(offset, requestSize, blockSize));
+            UNIT_ASSERT_C(!r, r.GetRef().Describe());
+            offset += requestSize;
+        }
+
+        while (offset < 10_MB) {
+            r = cache.RegisterDescribe(
+                nodeId,
+                TByteRange(offset, requestSize, blockSize));
+            UNIT_ASSERT(r);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TByteRange(offset, 1_MB, blockSize).Describe(),
+                r->Describe());
+            offset += requestSize;
+        }
+
+        r = cache.RegisterDescribe(
+            nodeId,
+            TByteRange(100_MB, requestSize, blockSize));
+        UNIT_ASSERT_C(!r, r.GetRef().Describe());
+    }
+
+    Y_UNIT_TEST(ShouldDetectAlmostSequentialRead)
+    {
+        const ui64 nodeId = 111;
+        const ui32 blockSize = 4_KB;
+
+        TDefaultCache cache;
+        TMaybe<TByteRange> r;
+        r = cache.RegisterDescribe(nodeId, TByteRange(0, 128_KB, blockSize));
+        UNIT_ASSERT_C(!r, r.GetRef().Describe());
+        r = cache.RegisterDescribe(nodeId, TByteRange(128_KB, 128_KB, blockSize));
+        UNIT_ASSERT_C(!r, r.GetRef().Describe());
+        r = cache.RegisterDescribe(nodeId, TByteRange(512_KB, 256_KB, blockSize));
+        UNIT_ASSERT_C(!r, r.GetRef().Describe());
+        r = cache.RegisterDescribe(nodeId, TByteRange(384_KB, 128_KB, blockSize));
+        UNIT_ASSERT_C(!r, r.GetRef().Describe());
+        r = cache.RegisterDescribe(nodeId, TByteRange(768_KB, 256_KB, blockSize));
+        UNIT_ASSERT(r);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TByteRange(768_KB, 1_MB, blockSize).Describe(),
+            r->Describe());
+        r = cache.RegisterDescribe(
+            nodeId,
+            TByteRange(1_MB + 256_KB, 256_KB, blockSize));
+        UNIT_ASSERT_C(!r, r.GetRef().Describe());
+        r = cache.RegisterDescribe(
+            nodeId,
+            TByteRange(1_MB + 512_KB, 384_KB, blockSize));
+        UNIT_ASSERT(r);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TByteRange(1_MB + 512_KB, 1_MB, blockSize).Describe(),
+            r->Describe());
+    }
+
+    Y_UNIT_TEST(ShouldCacheResults)
+    {
+        TDefaultCache cache;
+
+        auto makeRange = [] (ui64 offset, ui32 len) {
+            return TByteRange(offset, len, 4_KB);
+        };
+        auto registerResult = [&] (ui64 nodeId, ui64 offset, ui32 len) {
+            NProtoPrivate::TDescribeDataResponse result;
+            auto* f = result.AddFreshDataRanges();
+            f->SetContent(Sprintf("n=%lu,o=%lu,l=%u", nodeId, offset, len));
+
+            cache.RegisterResult(nodeId, makeRange(offset, len), result);
+        };
+        auto fillResult = [&] (ui64 nodeId, ui64 offset, ui32 len) {
+            NProtoPrivate::TDescribeDataResponse result;
+            if (cache.TryFillResult(nodeId, makeRange(offset, len), &result)) {
+                const auto& fdr = result.GetFreshDataRanges();
+                UNIT_ASSERT_VALUES_EQUAL(1, fdr.size());
+                return fdr[0].GetContent();
+            }
+            return TString();
+        };
+        registerResult(111, 0, 1_MB);
+        registerResult(111, 1_MB, 1_MB);
+        registerResult(111, 2_MB, 1_MB);
+        registerResult(222, 100_MB, 1_MB);
+        registerResult(222, 105_MB, 1_MB);
+
+        UNIT_ASSERT_VALUES_EQUAL("", fillResult(333, 0, 1_MB));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=111,o=0,l=1048576",
+            fillResult(111, 0, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=111,o=0,l=1048576",
+            fillResult(111, 1_MB - 128_KB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=111,o=1048576,l=1048576",
+            fillResult(111, 1_MB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=111,o=1048576,l=1048576",
+            fillResult(111, 2_MB - 128_KB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=111,o=2097152,l=1048576",
+            fillResult(111, 2_MB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=111,o=2097152,l=1048576",
+            fillResult(111, 3_MB - 128_KB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL("", fillResult(111, 3_MB, 128_KB));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=222,o=104857600,l=1048576",
+            fillResult(222, 100_MB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=222,o=104857600,l=1048576",
+            fillResult(222, 101_MB - 128_KB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL("", fillResult(222, 101_MB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL("", fillResult(222, 105_MB - 128_KB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=222,o=110100480,l=1048576",
+            fillResult(222, 105_MB, 128_KB));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "n=222,o=110100480,l=1048576",
+            fillResult(222, 106_MB - 128_KB, 128_KB));
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ut/ya.make
@@ -13,6 +13,7 @@ SRCS(
     mixed_blocks_ut.cpp
     operation_ut.cpp
     range_locks_ut.cpp
+    read_ahead_ut.cpp
     split_range_ut.cpp
     throttling_policy_ut.cpp
 )

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -105,7 +105,8 @@ void TIndexTabletState::LoadState(
     Impl->ReadAheadCache.Reset(
         config.GetReadAheadCacheMaxNodes(),
         config.GetReadAheadCacheMaxResultsPerNode(),
-        config.GetReadAheadCacheRangeSize());
+        config.GetReadAheadCacheRangeSize(),
+        config.GetReadAheadMaxGapPercentage());
 }
 
 void TIndexTabletState::UpdateConfig(

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -983,7 +983,8 @@ private:
 
 public:
     bool TryFillDescribeResult(
-        const NProtoPrivate::TDescribeDataRequest& request,
+        ui64 nodeId,
+        const TByteRange& range,
         NProtoPrivate::TDescribeDataResponse* response);
     TMaybe<TByteRange> RegisterDescribe(
         ui64 nodeId,
@@ -991,6 +992,7 @@ public:
     void InvalidateReadAheadCache(ui64 nodeId);
     void RegisterReadAheadResult(
         ui64 nodeId,
+        const TByteRange& range,
         const NProtoPrivate::TDescribeDataResponse& result);
 };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1106,10 +1106,11 @@ void TIndexTabletState::CompleteForcedRangeOperation()
 // ReadAhead
 
 bool TIndexTabletState::TryFillDescribeResult(
-    const NProtoPrivate::TDescribeDataRequest& request,
+    ui64 nodeId,
+    const TByteRange& range,
     NProtoPrivate::TDescribeDataResponse* response)
 {
-    return Impl->ReadAheadCache.TryFillResult(request, response);
+    return Impl->ReadAheadCache.TryFillResult(nodeId, range, response);
 }
 
 TMaybe<TByteRange> TIndexTabletState::RegisterDescribe(
@@ -1126,9 +1127,10 @@ void TIndexTabletState::InvalidateReadAheadCache(ui64 nodeId)
 
 void TIndexTabletState::RegisterReadAheadResult(
     ui64 nodeId,
+    const TByteRange& range,
     const NProtoPrivate::TDescribeDataResponse& result)
 {
-    Impl->ReadAheadCache.RegisterResult(nodeId, result);
+    Impl->ReadAheadCache.RegisterResult(nodeId, range, result);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/storage/core/libs/common/ring_buffer.h
+++ b/cloud/storage/core/libs/common/ring_buffer.h
@@ -19,6 +19,12 @@ public:
         , Buffer(capacity)
     {}
 
+    void Reset(size_t capacity)
+    {
+        Buffer = TVector<T>(capacity);
+        Clear();
+    }
+
     std::optional<T> PopFront()
     {
         if (IsEmpty()) {


### PR DESCRIPTION
LRU eviction is a TODO - currently I simply drop the whole cache when its size reaches MaxNodes. It's not a blocker though - this TODO can be implemented sometime later.

Tablet ut will come in the next PR.

#852 