### PR TITLE
issue-539: add tablet-side stats for GenerateBlobIds/AddData requests

### DIFF
--- a/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
@@ -33,7 +33,11 @@ TAddDataActor::TAddDataActor(
     , CommitId(commitId)
     , Blobs(std::move(blobs))
     , WriteRange(writeRange)
-{}
+{
+    for (const auto& blob: Blobs) {
+        BlobsSize += blob.BlobId.BlobSize();
+    }
+}
 
 void TAddDataActor::Bootstrap(const TActorContext& ctx)
 {
@@ -88,6 +92,9 @@ void TAddDataActor::ReplyAndDie(
         using TCompletion = TEvIndexTabletPrivate::TEvAddDataCompleted;
         auto response = std::make_unique<TCompletion>(error);
         response->CommitId = CommitId;
+        response->Count = 1;
+        response->Size = BlobsSize;
+        response->Time = ctx.Now() - RequestInfo->StartedTs;
         NCloud::Send(ctx, Tablet, std::move(response));
     }
 

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.h
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.h
@@ -27,6 +27,7 @@ private:
     const ui64 CommitId;
     /*const*/ TVector<TMergedBlob> Blobs;
     const TWriteRange WriteRange;
+    ui32 BlobsSize = 0;
 
 public:
     TAddDataActor(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -136,6 +136,8 @@ private:
         TRequestMetrics ReadData;
         TRequestMetrics DescribeData;
         TRequestMetrics WriteData;
+        TRequestMetrics AddData;
+        TRequestMetrics GenerateBlobIds;
 
         // Compaction/cleanup stats
         std::atomic<i64> MaxBlobsInRange{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -206,6 +206,30 @@ void TIndexTabletActor::TMetrics::Register(
         AggregatableFsRegistry,
         {CreateLabel("request", "WriteData"), CreateLabel("histogram", "Time")});
 
+    REGISTER_AGGREGATABLE_SUM(
+        AddData.Count,
+        EMetricType::MT_DERIVATIVE);
+
+    REGISTER_AGGREGATABLE_SUM(
+        AddData.RequestBytes,
+        EMetricType::MT_DERIVATIVE);
+
+    AddData.Time.Register(
+        AggregatableFsRegistry,
+        {CreateLabel("request", "AddData"), CreateLabel("histogram", "Time")});
+
+    REGISTER_AGGREGATABLE_SUM(
+        GenerateBlobIds.Count,
+        EMetricType::MT_DERIVATIVE);
+
+    REGISTER_AGGREGATABLE_SUM(
+        GenerateBlobIds.RequestBytes,
+        EMetricType::MT_DERIVATIVE);
+
+    GenerateBlobIds.Time.Register(
+        AggregatableFsRegistry,
+        {CreateLabel("request", "GenerateBlobIds"), CreateLabel("histogram", "Time")});
+
     REGISTER_LOCAL(MaxBlobsInRange, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(MaxDeletionsInRange, EMetricType::MT_ABSOLUTE);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -256,7 +256,7 @@ struct TEvIndexTabletPrivate
     // AddData completion
     //
 
-    struct TAddDataCompleted
+    struct TAddDataCompleted: TDataOperationCompleted
     {
         ui64 CommitId = 0;
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -420,7 +420,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         {
             auto response = Tablet->GenerateBlobIds(id, handle, 0, sz);
             TVector<NKikimr::TLogoBlobID> blobIds;
-            for (const auto& blobId : response->Record.GetBlobs()) {
+            for (const auto& blobId: response->Record.GetBlobs()) {
                 auto blob = NKikimr::LogoBlobIDFromLogoBlobID(blobId.GetBlobId());
                 blobIds.push_back(blob);
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -417,6 +417,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             UNIT_ASSERT_VALUES_EQUAL(1, blobs.size());
         }
 
+        {
+            auto response = Tablet->GenerateBlobIds(id, handle, 0, sz);
+            TVector<NKikimr::TLogoBlobID> blobIds;
+            for (const auto& blobId : response->Record.GetBlobs()) {
+                auto blob = NKikimr::LogoBlobIDFromLogoBlobID(blobId.GetBlobId());
+                blobIds.push_back(blob);
+            }
+            Tablet->AddData(id, handle, 0, sz, blobIds, response->Record.GetCommitId());
+        }
+
         registry->Visit(TInstant::Zero(), Visitor);
         Visitor.ValidateExpectedHistogram({
             {{
@@ -439,6 +449,14 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                 {"histogram", "Time"},
                 {"filesystem", "test"},
                 {"request", "DescribeData"}}, 0},
+            {{
+                {"histogram", "Time"},
+                {"filesystem", "test"},
+                {"request", "GenerateBlobIds"}}, 0},
+            {{
+                {"histogram", "Time"},
+                {"filesystem", "test"},
+                {"request", "AddData"}}, 0},
         }, false);
         Visitor.ValidateExpectedHistogram({
             {{
@@ -465,6 +483,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             {{
                 {"sensor", "DescribeData.Count"},
                 {"filesystem", "test"}}, 1},
+            {{
+                {"sensor", "GenerateBlobIds.Count"},
+                {"filesystem", "test"}}, 1},
+            {{
+                {"sensor", "AddData.Count"},
+                {"filesystem", "test"}}, 1},
         });
         Visitor.ValidateExpectedCounters({
             {{
@@ -484,6 +508,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                 {"filesystem", "test"}}, sz},
             {{
                 {"sensor", "DescribeData.RequestBytes"},
+                {"filesystem", "test"}}, sz},
+            {{
+                {"sensor", "GenerateBlobIds.RequestBytes"},
+                {"filesystem", "test"}}, sz},
+            {{
+                {"sensor", "AddData.RequestBytes"},
                 {"filesystem", "test"}}, sz},
         });
 


### PR DESCRIPTION
Adding stats for `ThreeStageWrite` data path on the tablet side: generic counters for `GenerateBlobIds` and `AddData` requests.

References #539