### PR TITLE
topic api: use a single write session

### DIFF
--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
@@ -142,7 +142,7 @@ public:
 
     void Stop() override
     {
-        std::unique_lock lock {DriverMutex};
+        std::lock_guard lock {DriverMutex};
 
         if (Driver) {
             Driver->Stop(false);

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
@@ -142,7 +142,7 @@ public:
 
     void Stop() override
     {
-        std::lock_guard lock {DriverMutex};
+        std::lock_guard lock{DriverMutex};
 
         if (Driver) {
             Driver->Stop(false);
@@ -209,8 +209,10 @@ private:
 
         if (!HasError(error)) {
             // just in case
-            error =
-                MakeError(E_FAIL, "unexpected success: " + event.DebugString());
+            error = MakeError(
+                E_FAIL,
+                TStringBuilder()
+                    << "unexpected success: " << event.DebugString());
         }
 
         return error;
@@ -260,7 +262,7 @@ private:
 
     const NYdb::TDriver& GetDriver()
     {
-        std::unique_lock lock{DriverMutex};
+        std::lock_guard lock{DriverMutex};
         if (!Driver) {
             Driver = std::make_unique<NYdb::TDriver>(CreateDriverConfig());
         }

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
@@ -96,15 +96,16 @@ public:
         , Logging(std::move(logging))
     {}
 
-    TFuture<NProto::TError>
-    Write(TVector<TMessage> messages, TInstant now) override
+    TFuture<NProto::TError> Write(
+        TVector<TMessage> messages,
+        TInstant now) override
     {
         if (messages.empty()) {
             return MakeFuture(MakeError(S_OK));
         }
 
         if (WriteInProgress.test_and_set()) {
-            return MakeFuture(MakeError(E_REJECTED, "Write in progress"));
+            return MakeFuture(MakeError(E_TRY_AGAIN, "Write in progress"));
         }
 
         Y_DEBUG_ABORT_UNLESS(!Batch);

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
@@ -258,7 +258,7 @@ private:
         WaitEvent();
     }
 
-    NYdb::TDriver& GetDriver()
+    const NYdb::TDriver& GetDriver()
     {
         std::unique_lock lock{DriverMutex};
         if (!Driver) {

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/ut/ya.make
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/ut/ya.make
@@ -2,14 +2,6 @@ UNITTEST_FOR(cloud/blockstore/libs/logbroker/topic_api_impl)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
-IF (OPENSOURCE)
-    # TODO(NBS-4760): fix tests and remove tags
-    TAG(
-        ya:not_autocheck
-        ya:manual
-    )
-ENDIF()
-
 SRCS(
     topic_api_ut.cpp
 )


### PR DESCRIPTION
Due to the fact that the ReadyToAccept event sometimes does not arrive for a new session (bug?), the session is now being reused.