### PR TITLE
Fix example setup script

### DIFF
--- a/example/0-setup.sh
+++ b/example/0-setup.sh
@@ -126,6 +126,6 @@ format_disk rot 64G
 setup_nonrepl_disk_registry
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-test -d static && ln -s "${SCRIPT_DIR}/static" static
-test -d dynamic && ln -s "${SCRIPT_DIR}/dynamic" dynamic
-test -d nbs && ln -s "${SCRIPT_DIR}/nbs" nbs
+test -d static || ln -s "${SCRIPT_DIR}/static" static
+test -d dynamic || ln -s "${SCRIPT_DIR}/dynamic" dynamic
+test -d nbs || ln -s "${SCRIPT_DIR}/nbs" nbs

--- a/example/0-setup.sh
+++ b/example/0-setup.sh
@@ -126,6 +126,6 @@ format_disk rot 64G
 setup_nonrepl_disk_registry
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-test -f static && ln -s "${SCRIPT_DIR}/static" static
-test -f dynamic && ln -s "${SCRIPT_DIR}/dynamic" dynamic
-test -f nbs && ln -s "${SCRIPT_DIR}/nbs" nbs
+test -d static && ln -s "${SCRIPT_DIR}/static" static
+test -d dynamic && ln -s "${SCRIPT_DIR}/dynamic" dynamic
+test -d nbs && ln -s "${SCRIPT_DIR}/nbs" nbs


### PR DESCRIPTION
From ```test``` man page:

```
       -d FILE
              FILE exists and is a directory

       -e FILE
              FILE exists

       -f FILE
              FILE exists and is a regular file
```

So these ```test``` commands will always fail.

This pr fixes it