### PR TITLE
NEBDUTY-1076: fix rdma config not loading correctly when specified in cms

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -239,9 +239,6 @@ void TBootstrapYdb::InitKikimrService()
     }
 
     Configs->InitDiskAgentConfig();
-    // InitRdmaConfig should be called after InitDiskAgentConfig and
-    // InitServerConfig to backport legacy RDMA config
-    Configs->InitRdmaConfig();
 
     STORAGE_INFO("Configs initialized");
 
@@ -255,6 +252,13 @@ void TBootstrapYdb::InitKikimrService()
     }
 
     STORAGE_INFO("CMS configs initialized");
+
+    // InitRdmaConfig should be called after InitDiskAgentConfig,
+    // InitServerConfig and ApplyCMSConfigs to backport legacy
+    // RDMA config
+    Configs->InitRdmaConfig();
+
+    STORAGE_INFO("RDMA config initialized");
 
     auto logging = std::make_shared<TLoggingProxy>();
     auto monitoring = std::make_shared<TMonitoringProxy>();

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -316,9 +316,6 @@ void TBootstrap::InitKikimrService()
     }
 
     Configs->InitDiskAgentConfig();
-    // InitRdmaConfig should be called after InitDiskAgentConfig
-    // to backport legacy RDMA config
-    Configs->InitRdmaConfig();
 
     STORAGE_INFO("Configs initialized");
 
@@ -332,6 +329,12 @@ void TBootstrap::InitKikimrService()
     }
 
     STORAGE_INFO("CMS configs initialized");
+
+    // InitRdmaConfig should be called after InitDiskAgentConfig
+    // and ApplyCMSConfigs to backport legacy RDMA config
+    Configs->InitRdmaConfig();
+
+    STORAGE_INFO("RDMA config initialized");
 
     auto logging = std::make_shared<TLoggingProxy>();
     auto monitoring = std::make_shared<TMonitoringProxy>();


### PR DESCRIPTION
In the old scheme disk agent config can come from cms and override the config
from file.

In the new rdma config scheme rdma-config.txt file will be the authority for
rdma config. Nevertheless we need to stay backward compatible and load disk
agent config from cms in case there is no rdma-config.txt file present.

If rdma-config.txt file is present we will use the config from there and ignore
any other source of config.
