### PR TITLE
issue-999: TStorageServiceActor should not ignore TResizeFileStoreRequest::GetPerformanceProfile()

### DIFF
--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -441,6 +441,26 @@ ui32 NodesLimit(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#define PERFORMANCE_PROFILE_PARAMETERS_SIMPLE(xxx, ...)                        \
+    xxx(ThrottlingEnabled,                      __VA_ARGS__)                   \
+    xxx(BoostTime,                              __VA_ARGS__)                   \
+    xxx(BoostRefillTime,                        __VA_ARGS__)                   \
+    xxx(BurstPercentage,                        __VA_ARGS__)                   \
+    xxx(DefaultPostponedRequestWeight,          __VA_ARGS__)                   \
+    xxx(MaxPostponedWeight,                     __VA_ARGS__)                   \
+    xxx(MaxWriteCostMultiplier,                 __VA_ARGS__)                   \
+    xxx(MaxPostponedTime,                       __VA_ARGS__)                   \
+    xxx(MaxPostponedCount,                      __VA_ARGS__)                   \
+// PERFORMANCE_PROFILE_PARAMETERS_SIMPLE
+
+#define PERFORMANCE_PROFILE_PARAMETERS_AU(xxx, ...)                            \
+    xxx(MaxReadIops,                            __VA_ARGS__)                   \
+    xxx(MaxReadBandwidth,                       __VA_ARGS__)                   \
+    xxx(MaxWriteIops,                           __VA_ARGS__)                   \
+    xxx(MaxWriteBandwidth,                      __VA_ARGS__)                   \
+    xxx(BoostPercentage,                        __VA_ARGS__)                   \
+// PERFORMANCE_PROFILE_PARAMETERS_AU
+
 void SetupFileStorePerformanceAndChannels(
     bool allocateMixed0Channel,
     const TStorageConfig& config,
@@ -452,29 +472,25 @@ void SetupFileStorePerformanceAndChannels(
 
     OverrideStorageMediaKind(config, fileStore);
 
-#define SETUP_PARAMETER(name, ...)                                             \
+#define SETUP_PARAMETER_SIMPLE(name, ...)                                      \
     fileStore.SetPerformanceProfile##name(                                     \
         clientProfile.Get##name()                                              \
             ? clientProfile.Get##name()                                        \
-            : name(config, fileStore, ## __VA_ARGS__));                        \
-// SETUP_PARAMENTS
+            : name(config, fileStore));                                        \
+// SETUP_PARAMETER_AU
 
-    SETUP_PARAMETER(ThrottlingEnabled);
-    SETUP_PARAMETER(MaxReadIops, allocationUnitCount);
-    SETUP_PARAMETER(MaxReadBandwidth, allocationUnitCount);
-    SETUP_PARAMETER(MaxWriteIops, allocationUnitCount);
-    SETUP_PARAMETER(MaxWriteBandwidth, allocationUnitCount);
-    SETUP_PARAMETER(BoostTime);
-    SETUP_PARAMETER(BoostRefillTime);
-    SETUP_PARAMETER(BoostPercentage, allocationUnitCount);
-    SETUP_PARAMETER(BurstPercentage);
-    SETUP_PARAMETER(DefaultPostponedRequestWeight);
-    SETUP_PARAMETER(MaxPostponedWeight);
-    SETUP_PARAMETER(MaxWriteCostMultiplier);
-    SETUP_PARAMETER(MaxPostponedTime);
-    SETUP_PARAMETER(MaxPostponedCount);
+#define SETUP_PARAMETER_AU(name, ...)                                          \
+    fileStore.SetPerformanceProfile##name(                                     \
+        clientProfile.Get##name()                                              \
+            ? clientProfile.Get##name()                                        \
+            : name(config, fileStore, allocationUnitCount));                   \
+// SETUP_PARAMETER_SIMPLE
 
-#undef SETUP_PARAMENTER
+    PERFORMANCE_PROFILE_PARAMETERS_SIMPLE(SETUP_PARAMETER_SIMPLE);
+    PERFORMANCE_PROFILE_PARAMETERS_AU(SETUP_PARAMETER_AU);
+
+#undef SETUP_PARAMETER_SIMPLE
+#undef SETUP_PARAMETER_AU
 
     fileStore.SetNodesCount(NodesLimit(config, fileStore));
 
@@ -483,18 +499,6 @@ void SetupFileStorePerformanceAndChannels(
         allocateMixed0Channel,
         config,
         fileStore);
-}
-
-void SetupFileStorePerformanceAndChannels(
-    bool allocateMixed0Channel,
-    const TStorageConfig& config,
-    NKikimrFileStore::TConfig& fileStore)
-{
-    SetupFileStorePerformanceAndChannels(
-        allocateMixed0Channel,
-        config,
-        fileStore,
-        NProto::TFileStorePerformanceProfile());
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/model.h
+++ b/cloud/filestore/libs/storage/core/model.h
@@ -16,9 +16,4 @@ void SetupFileStorePerformanceAndChannels(
     NKikimrFileStore::TConfig& fileStore,
     const NProto::TFileStorePerformanceProfile& clientPerformanceProfile);
 
-void SetupFileStorePerformanceAndChannels(
-    bool allocateMixed0Channel,
-    const TStorageConfig& config,
-    NKikimrFileStore::TConfig& fileStore);
-
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -21,6 +21,21 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void SetupFileStorePerformanceAndChannels(
+    bool allocateMixed0Channel,
+    const TStorageConfig& config,
+    NKikimrFileStore::TConfig& fileStore)
+{
+    SetupFileStorePerformanceAndChannels(
+        allocateMixed0Channel,
+        config,
+        fileStore,
+        {}  // clientPerformanceProfile
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TConfigs
     : public NUnitTest::TBaseFixture
 {

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -1,5 +1,4 @@
 #include "service_actor.h"
-#include "cloud/filestore/public/api/protos/fs.pb.h"
 
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/storage/api/ss_proxy.h>

--- a/cloud/filestore/libs/storage/service/service_actor_describefsmodel.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_describefsmodel.cpp
@@ -33,7 +33,9 @@ void TStorageServiceActor::HandleDescribeFileStoreModel(
     SetupFileStorePerformanceAndChannels(
         false,  // do not allocate mixed0 channel
         *StorageConfig,
-        config);
+        config,
+        {}      // clientPerformanceProfile
+    );
 
     auto response = std::make_unique<TEvService::TEvDescribeFileStoreModelResponse>();
     auto* model = response->Record.MutableFileStoreModel();

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -161,6 +161,68 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.AssertResizeFileStoreFailed("test", 0);
     }
 
+    Y_UNIT_TEST(ShouldResizeFileStoreWithCustomPerformanceProfile)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const char* fsId = "test";
+        const auto initialBlockCount = 1'000;
+        const auto blockCount = 100'000'000;
+        const auto customMaxReadIops = 111;
+        const auto customMaxWriteIops = 222;
+        service.CreateFileStore("test", initialBlockCount);
+        auto resizeRequest = service.CreateResizeFileStoreRequest(
+            "test",
+            blockCount);
+        resizeRequest->Record.MutablePerformanceProfile()->SetMaxReadIops(
+            customMaxReadIops);
+        service.SendRequest(MakeStorageServiceId(), std::move(resizeRequest));
+        auto resizeResponse = service.RecvResizeFileStoreResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            resizeResponse->GetStatus(),
+            resizeResponse->GetErrorReason());
+
+        auto response = service.GetFileStoreInfo(fsId)->Record.GetFileStore();
+        UNIT_ASSERT_VALUES_EQUAL(fsId, response.GetFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(blockCount, response.GetBlocksCount());
+
+        auto profile = response.GetPerformanceProfile();
+        UNIT_ASSERT(!profile.GetThrottlingEnabled());
+        // autocalculated
+        UNIT_ASSERT_VALUES_EQUAL(600, profile.GetMaxWriteIops());
+        // custom
+        UNIT_ASSERT_VALUES_EQUAL(customMaxReadIops, profile.GetMaxReadIops());
+
+        resizeRequest = service.CreateResizeFileStoreRequest(
+            "test",
+            blockCount);
+        resizeRequest->Record.MutablePerformanceProfile()->SetMaxWriteIops(
+            customMaxWriteIops);
+
+        service.SendRequest(MakeStorageServiceId(), std::move(resizeRequest));
+        resizeResponse = service.RecvResizeFileStoreResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            resizeResponse->GetStatus(),
+            resizeResponse->GetErrorReason());
+
+        response = service.GetFileStoreInfo(fsId)->Record.GetFileStore();
+        UNIT_ASSERT_VALUES_EQUAL(fsId, response.GetFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(blockCount, response.GetBlocksCount());
+
+        profile = response.GetPerformanceProfile();
+        UNIT_ASSERT(!profile.GetThrottlingEnabled());
+        // custom
+        UNIT_ASSERT_VALUES_EQUAL(customMaxWriteIops, profile.GetMaxWriteIops());
+        // autocalculated
+        UNIT_ASSERT_VALUES_EQUAL(200, profile.GetMaxReadIops());
+    }
+
     Y_UNIT_TEST(ShouldResizeFileStoreAndAddChannels)
     {
         TTestEnv env;
@@ -208,7 +270,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
-        service.ResizeFileStore("test", 4_TB/DefaultBlockSize);
+        service.ResizeFileStore("test", 4_TB / DefaultBlockSize);
         UNIT_ASSERT(alterChannelsCount > 0);
         UNIT_ASSERT(alterChannelsCount > createChannelsCount);
     }

--- a/cloud/filestore/libs/storage/testlib/ss_proxy_client.h
+++ b/cloud/filestore/libs/storage/testlib/ss_proxy_client.h
@@ -91,7 +91,9 @@ public:
         SetupFileStorePerformanceAndChannels(
             false,  // do not allocate mixed0 channel
             *StorageConfig,
-            config);
+            config,
+            {}      // clientPerformanceProfile
+        );
 
         return std::make_unique<TEvSSProxy::TEvCreateFileStoreRequest>(config);
     }


### PR DESCRIPTION
filestore-client resize is unable to modify fs performance profile because of this

#999 