### PR TITLE
issue-95: 1. outputting compaction and cleanup info on monpage (thresholds, scores, etc.) 2. adjusting compaction threshold to bs/default_bs ratio

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -386,13 +386,17 @@ NProto::TError TIndexTabletActor::IsDataOperationAllowed() const
 
 ui32 TIndexTabletActor::ScaleCompactionThreshold(ui32 t) const
 {
+    // Max needed for the freshly created FS case - GetBlockSize() returns 0
+    // before we process our first EvUpdateConfig event.
+    const ui32 blockSize = Max(GetBlockSize(), DefaultBlockSize);
+
     // Blob size has a limit specified in bytes whereas the capacity of a
     // single compaction range is actually specified in blocks - see
     // BlockGroupSize. That's why we need to scale the limit on the number
     // of blobs per range by something that's linear w.r.t. BlockSize.
     //
     // See issue #95.
-    const ui64 factor = GetBlockSize() / DefaultBlockSize;
+    const ui64 factor = blockSize / DefaultBlockSize;
     return Min<ui64>(Max<ui32>(), factor * t);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -366,6 +366,7 @@ private:
 
     NProto::TError IsDataOperationAllowed() const;
 
+    ui32 GetCompactionScoreFactor() const;
     TCompactionInfo GetCompactionInfo() const;
     TCleanupInfo GetCleanupInfo() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -366,7 +366,7 @@ private:
 
     NProto::TError IsDataOperationAllowed() const;
 
-    ui32 GetCompactionScoreFactor() const;
+    ui32 ScaleCompactionThreshold(ui32 t) const;
     TCompactionInfo GetCompactionInfo() const;
     TCleanupInfo GetCleanupInfo() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -3,7 +3,6 @@
 #include "public.h"
 
 #include "tablet_counters.h"
-#include "tablet_database.h"
 #include "tablet_private.h"
 #include "tablet_state.h"
 #include "tablet_tx.h"
@@ -366,6 +365,9 @@ private:
         const TByteRange& range);
 
     NProto::TError IsDataOperationAllowed() const;
+
+    TCompactionInfo GetCompactionInfo() const;
+    TCleanupInfo GetCleanupInfo() const;
 
     void HandleWakeup(
         const NActors::TEvents::TEvWakeup::TPtr& ev,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1005,6 +1005,56 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         TAG(TH3) { out << "CompactionMap"; }
         DumpCompactionMap(out, TabletID(), GetCompactionMapStats(topSize));
 
+#define DUMP_INFO_FIELD(info, name)                                            \
+        TABLER() {                                                             \
+            TABLED() { out << #name; }                                         \
+            TABLED() { out << info.name; }                                     \
+        }                                                                      \
+// DUMP_INFO_FIELD
+
+        TAG(TH3) { out << "CompactionInfo"; }
+        TABLE_CLASS("table table-bordered") {
+            TABLEHEAD() {
+                TABLER() {
+                    TABLEH() { out << "Parameter"; }
+                    TABLEH() { out << "Value"; }
+                }
+            }
+
+            const auto compactionInfo = GetCompactionInfo();
+            DUMP_INFO_FIELD(compactionInfo, Threshold);
+            DUMP_INFO_FIELD(compactionInfo, ThresholdAverage);
+            DUMP_INFO_FIELD(compactionInfo, GarbageThreshold);
+            DUMP_INFO_FIELD(compactionInfo, GarbageThresholdAverage);
+            DUMP_INFO_FIELD(compactionInfo, Score);
+            DUMP_INFO_FIELD(compactionInfo, RangeId);
+            DUMP_INFO_FIELD(compactionInfo, GarbagePercentage);
+            DUMP_INFO_FIELD(compactionInfo, AverageScore);
+            DUMP_INFO_FIELD(compactionInfo, NewCompactionEnabled);
+            DUMP_INFO_FIELD(compactionInfo, ShouldCompact);
+        }
+
+        TAG(TH3) { out << "CleanupInfo"; }
+        TABLE_CLASS("table table-bordered") {
+            TABLEHEAD() {
+                TABLER() {
+                    TABLEH() { out << "Parameter"; }
+                    TABLEH() { out << "Value"; }
+                }
+            }
+
+            const auto cleanupInfo = GetCleanupInfo();
+            DUMP_INFO_FIELD(cleanupInfo, Threshold);
+            DUMP_INFO_FIELD(cleanupInfo, ThresholdAverage);
+            DUMP_INFO_FIELD(cleanupInfo, Score);
+            DUMP_INFO_FIELD(cleanupInfo, RangeId);
+            DUMP_INFO_FIELD(cleanupInfo, AverageScore);
+            DUMP_INFO_FIELD(cleanupInfo, NewCleanupEnabled);
+            DUMP_INFO_FIELD(cleanupInfo, ShouldCleanup);
+        }
+
+#undef DUMP_INFO_FIELD
+
         TAG(TH3) {
             if (!IsForcedRangeOperationRunning()) {
                 BuildMenuButton(out, "compact-all");

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -660,7 +660,9 @@ public:
         }
     };
 
-    bool IsWriteAllowed(const TBackpressureThresholds& thresholds) const;
+    bool IsWriteAllowed(
+        const TBackpressureThresholds& thresholds,
+        TString* message) const;
 
     //
     // FreshBytes

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -48,6 +48,75 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TCompactionInfo
+{
+    const ui32 Threshold;
+    const ui32 ThresholdAverage;
+    const ui32 GarbageThreshold;
+    const ui32 GarbageThresholdAverage;
+    const ui32 Score;
+    const ui32 RangeId;
+    const double GarbagePercentage;
+    const double AverageScore;
+    const bool NewCompactionEnabled;
+    const bool ShouldCompact;
+
+    TCompactionInfo(
+            ui32 threshold,
+            ui32 thresholdAverage,
+            ui32 garbageThreshold,
+            ui32 garbageThresholdAverage,
+            ui32 score,
+            ui32 rangeId,
+            double garbagePercentage,
+            double averageScore,
+            bool newCompactionEnabled,
+            bool shouldCompact)
+        : Threshold(threshold)
+        , ThresholdAverage(thresholdAverage)
+        , GarbageThreshold(garbageThreshold)
+        , GarbageThresholdAverage(garbageThresholdAverage)
+        , Score(score)
+        , RangeId(rangeId)
+        , GarbagePercentage(garbagePercentage)
+        , AverageScore(averageScore)
+        , NewCompactionEnabled(newCompactionEnabled)
+        , ShouldCompact(shouldCompact)
+    {
+    }
+};
+
+struct TCleanupInfo
+{
+    const ui32 Threshold;
+    const ui32 ThresholdAverage;
+    const ui32 Score;
+    const ui32 RangeId;
+    const double AverageScore;
+    const bool NewCleanupEnabled;
+    const bool ShouldCleanup;
+
+    TCleanupInfo(
+            ui32 threshold,
+            ui32 thresholdAverage,
+            ui32 score,
+            ui32 rangeId,
+            double averageScore,
+            bool newCleanupEnabled,
+            bool shouldCleanup)
+        : Threshold(threshold)
+        , ThresholdAverage(thresholdAverage)
+        , Score(score)
+        , RangeId(rangeId)
+        , AverageScore(averageScore)
+        , NewCleanupEnabled(newCleanupEnabled)
+        , ShouldCleanup(shouldCleanup)
+    {
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TIndexTabletState
 {
 private:

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1381,12 +1381,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.DestroyHandle(handle);
     }
 
-    TABLET_TEST(ShouldAutomaticallyRunCompaction)
+    TABLET_TEST_16K(ShouldAutomaticallyRunCompaction)
     {
         const auto block = tabletConfig.BlockSize;
+        const auto threshold = 8 * DefaultBlockSize / block;
 
         NProto::TStorageConfig storageConfig;
-        storageConfig.SetCompactionThreshold(5);
+        storageConfig.SetCompactionThreshold(threshold);
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(2 * block);
 
@@ -1420,14 +1421,23 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // blob 3
         tablet.WriteData(handle, 0, 2 * block, 'd');
 
+        // blob 4
+        tablet.WriteData(handle, 0, 2 * block, 'e');
+
+        // blob 5
+        tablet.WriteData(handle, 0, 2 * block, 'f');
+
+        // blob 6
+        tablet.WriteData(handle, 0, 2 * block, 'g');
+
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 4);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 7);
         }
 
-        // blob 4
-        tablet.WriteData(handle, 2 * block, 2 * block, 'e');
+        // blob 7
+        tablet.WriteData(handle, 2 * block, 2 * block, 'h');
 
         {
             auto response = tablet.GetStorageStats();
@@ -1438,13 +1448,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         {
             auto response = tablet.ReadData(handle, 0, 2 * block);
             const auto& buffer = response->Record.GetBuffer();
-            UNIT_ASSERT(CompareBuffer(buffer, 2 * block, 'd'));
+            UNIT_ASSERT(CompareBuffer(buffer, 2 * block, 'g'));
         }
 
         {
             auto response = tablet.ReadData(handle, 2 * block, 2 * block);
             const auto& buffer = response->Record.GetBuffer();
-            UNIT_ASSERT(CompareBuffer(buffer, 2 * block, 'e'));
+            UNIT_ASSERT(CompareBuffer(buffer, 2 * block, 'h'));
         }
 
         tablet.DestroyHandle(handle);
@@ -3669,14 +3679,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(2, requests.size());
     }
 
-    TABLET_TEST(BackgroundOperationsShouldNotGetStuckForeverDuringCompactionMapLoading)
+    TABLET_TEST_16K(BackgroundOperationsShouldNotGetStuckForeverDuringCompactionMapLoading)
     {
         const auto block = tabletConfig.BlockSize;
+        const auto thresholdInBlobs = 8;
+        const auto threshold = thresholdInBlobs * DefaultBlockSize / block;
 
         NProto::TStorageConfig storageConfig;
         // hard to test anything apart from Compaction - it shares
         // EOperationState with Cleanup and FlushBytes
-        storageConfig.SetCompactionThreshold(2);
+        storageConfig.SetCompactionThreshold(threshold);
         // Flush has a separate EOperationState
         storageConfig.SetFlushThreshold(1);
         storageConfig.SetLoadedCompactionRangesPerTx(2);
@@ -3768,10 +3780,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         // this write should succeed - it targets the range that should be
         // loaded at this point of time
-        tablet.SendWriteDataRequest(handle, 0, 2 * block, 'a');
-        {
-            auto response = tablet.RecvWriteDataResponse();
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        for (ui32 i = 0; i < thresholdInBlobs - 1; ++i) {
+            tablet.SendWriteDataRequest(handle, 0, 2 * block, 'a');
+            {
+                auto response = tablet.RecvWriteDataResponse();
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            }
         }
 
         // Compaction should've been triggered and its operation state should've


### PR DESCRIPTION
1. Outputting compaction and cleanup info on tablet monpage: actual thresholds, scores, etc - all the info needed to understand the reasons to run/not to run compaction/cleanup
2. Adjusting compaction threshold to the BlockSize/DefaultBlockSize ratio to avoid infinite compaction loops for filesystems with large BlockSize (see issue #95 for details)

#95 