### PR TITLE
NEBDUTY-1076: fix storage_discovery/test.py.test_change_layout

### DIFF
--- a/cloud/blockstore/tests/storage_discovery/test.py
+++ b/cloud/blockstore/tests/storage_discovery/test.py
@@ -675,7 +675,6 @@ def test_change_layout(
 
     assert bkp["Agents"][0]["AgentId"] == agent_id
     assert len(bkp["Agents"][0]["Devices"]) == 9
-    assert len(bkp["DirtyDevices"]) == 9
 
     disk_agent.kill()
 


### PR DESCRIPTION
The check of DirtyDevices has been removed because its value depends on many factors that are hard to control. For example in tsan tests DR/DA can clean some of the added devices before the check takes place.
