### PR TITLE
REMOVE_HOST should wait for local devices to be cleaned

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4700,6 +4700,12 @@ bool TDiskRegistryState::HasDependentSsdDisks(
             continue;
         }
 
+        if (d.GetPoolKind() == NProto::DEVICE_POOL_KIND_LOCAL &&
+            PendingCleanup.FindDiskId(d.GetDeviceUUID()))
+        {
+            return true;
+        }
+
         const auto diskId = FindDisk(d.GetDeviceUUID());
 
         if (!diskId) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_cms.cpp
@@ -33,61 +33,140 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-auto CmsAction(TDiskRegistryClient& dr, NProto::TAction action)
+struct TFixture
+    : public NUnitTest::TBaseFixture
 {
-    TVector<NProto::TAction> actions {action};
+    std::unique_ptr<NActors::TTestActorRuntime> Runtime;
+    std::optional<TDiskRegistryClient> DiskRegistry;
 
-    auto response = dr.CmsAction(actions);
+    void SetUpRuntime(std::unique_ptr<NActors::TTestActorRuntime> runtime)
+    {
+        Runtime = std::move(runtime);
 
-    UNIT_ASSERT_VALUES_EQUAL(1, response->Record.ActionResultsSize());
-    const auto& r = response->Record.GetActionResults(0);
+        DiskRegistry.emplace(*Runtime);
+        DiskRegistry->WaitReady();
+    }
 
-    return std::make_pair(r.GetResult(), r.GetTimeout());
-}
+    auto CmsAction(NProto::TAction action)
+    {
+        auto response = DiskRegistry->CmsAction(TVector {action});
 
-auto RemoveHost(TDiskRegistryClient& dr, const TString& agentId)
-{
-    NProto::TAction action;
-    action.SetHost(agentId);
-    action.SetType(NProto::TAction::REMOVE_HOST);
+        UNIT_ASSERT_VALUES_EQUAL(1, response->Record.ActionResultsSize());
+        const auto& r = response->Record.GetActionResults(0);
 
-    return CmsAction(dr, std::move(action));
-}
+        return std::make_pair(r.GetResult(), r.GetTimeout());
+    }
 
-auto AddHost(TDiskRegistryClient& dr, const TString& agentId)
-{
-    NProto::TAction action;
-    action.SetHost(agentId);
-    action.SetType(NProto::TAction::ADD_HOST);
+    auto RemoveHost(const TString& agentId)
+    {
+        NProto::TAction action;
+        action.SetHost(agentId);
+        action.SetType(NProto::TAction::REMOVE_HOST);
 
-    return CmsAction(dr, std::move(action));
-}
+        return CmsAction(std::move(action));
+    }
 
-auto AddDevice(
-    TDiskRegistryClient& dr,
-    const TString& agentId,
-    const TString& path)
-{
-    NProto::TAction action;
-    action.SetHost(agentId);
-    action.SetType(NProto::TAction::ADD_DEVICE);
-    action.SetDevice(path);
+    auto AddHost(const TString& agentId)
+    {
+        NProto::TAction action;
+        action.SetHost(agentId);
+        action.SetType(NProto::TAction::ADD_HOST);
 
-    return CmsAction(dr, std::move(action));
-}
+        return CmsAction(std::move(action));
+    }
 
-auto RemoveDevice(
-    TDiskRegistryClient& dr,
-    const TString& agentId,
-    const TString& path)
-{
-    NProto::TAction action;
-    action.SetHost(agentId);
-    action.SetType(NProto::TAction::REMOVE_DEVICE);
-    action.SetDevice(path);
+    auto AddDevice(const TString& agentId, const TString& path)
+    {
+        NProto::TAction action;
+        action.SetHost(agentId);
+        action.SetType(NProto::TAction::ADD_DEVICE);
+        action.SetDevice(path);
 
-    return CmsAction(dr, std::move(action));
-}
+        return CmsAction(std::move(action));
+    }
+
+    auto RemoveDevice(const TString& agentId, const TString& path)
+    {
+        NProto::TAction action;
+        action.SetHost(agentId);
+        action.SetType(NProto::TAction::REMOVE_DEVICE);
+        action.SetDevice(path);
+
+        return CmsAction(std::move(action));
+    }
+
+    void ShouldRestoreCMSTimeoutAfterReboot(auto removeAction)
+    {
+        const auto agent = CreateAgentConfig("agent-1", {
+            Device("dev-1", "uuid-1", "rack-1", 10_GB)
+        });
+
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
+
+        DiskRegistry->SetWritableState(true);
+
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, { agent }));
+
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
+
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
+
+        ui32 cmsTimeout = 0;
+        {
+            auto [error, timeout] = removeAction();
+
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
+            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
+
+            cmsTimeout = timeout;
+        }
+
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+
+        {
+            auto [error, timeout] = removeAction();
+
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
+            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
+            UNIT_ASSERT_GT(cmsTimeout, timeout);
+        }
+
+        DiskRegistry->RebootTablet();
+        DiskRegistry->WaitReady();
+
+        {
+            auto [error, timeout] = removeAction();
+
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
+            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
+            UNIT_ASSERT_GT(cmsTimeout, timeout);
+        }
+
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+
+        {
+            auto [error, timeout] = removeAction();
+
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
+            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
+            UNIT_ASSERT_VALUES_EQUAL(cmsTimeout, timeout);
+        }
+
+        DiskRegistry->MarkDiskForCleanup("vol1");
+        DiskRegistry->DeallocateDisk("vol1");
+
+        {
+            auto [error, timeout] = removeAction();
+
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(0, timeout);
+        }
+    }
+};
 
 }   // namespace
 
@@ -95,29 +174,27 @@ auto RemoveDevice(
 
 Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 {
-    Y_UNIT_TEST(ShouldRemoveAgentsUponCmsRequest)
+    Y_UNIT_TEST_F(ShouldRemoveAgentsUponCmsRequest, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAndWaitForAgents(*runtime, {agent});
+        RegisterAndWaitForAgents(*Runtime, {agent});
 
         TString freeDevice;
         TString diskDevice;
         {
-            auto response = diskRegistry.AllocateDisk("vol1", 10_GB);
+            auto response = DiskRegistry->AllocateDisk("vol1", 10_GB);
             const auto& msg = response->Record;
             UNIT_ASSERT_VALUES_EQUAL(1, msg.DevicesSize());
             diskDevice = msg.GetDevices(0).GetDeviceUUID();
@@ -129,7 +206,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         ui32 cmsTimeout = 0;
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
@@ -138,169 +215,161 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
 
         // request will be ignored
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
 
         {
-            diskRegistry.SendAllocateDiskRequest("vol2", 10_GB);
-            auto response = diskRegistry.RecvAllocateDiskResponse();
+            DiskRegistry->SendAllocateDiskRequest("vol2", 10_GB);
+            auto response = DiskRegistry->RecvAllocateDiskResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_BS_DISK_ALLOCATION_FAILED, response->GetStatus());
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
             UNIT_ASSERT_LT(timeout, cmsTimeout);
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
             UNIT_ASSERT_VALUES_EQUAL(timeout, cmsTimeout);
         }
 
-        diskRegistry.ChangeDeviceState(freeDevice, NProto::EDeviceState::DEVICE_STATE_ERROR);
+        DiskRegistry->ChangeDeviceState(freeDevice, NProto::EDeviceState::DEVICE_STATE_ERROR);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeDeviceState(diskDevice, NProto::EDeviceState::DEVICE_STATE_ERROR);
+        DiskRegistry->ChangeDeviceState(diskDevice, NProto::EDeviceState::DEVICE_STATE_ERROR);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
 
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
-        diskRegistry.ChangeDeviceState("uuid-2", NProto::EDeviceState::DEVICE_STATE_ONLINE);
+        DiskRegistry->ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
+        DiskRegistry->ChangeDeviceState("uuid-2", NProto::EDeviceState::DEVICE_STATE_ONLINE);
 
-        diskRegistry.AllocateDisk("vol2", 10_GB);
+        DiskRegistry->AllocateDisk("vol2", 10_GB);
     }
 
-    Y_UNIT_TEST(ShouldFailCmsRequestIfActionIsUnknown)
+    Y_UNIT_TEST_F(ShouldFailCmsRequestIfActionIsUnknown, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
         NProto::TAction action;
         action.SetHost("agent-1");
         action.SetType(NProto::TAction::UNKNOWN);
         TVector<NProto::TAction> actions { action };
 
-        auto response = diskRegistry.CmsAction(std::move(actions));
+        auto response = DiskRegistry->CmsAction(std::move(actions));
         UNIT_ASSERT_VALUES_EQUAL(
             E_ARGUMENT,
             response->Record.GetActionResults(0).GetResult().GetCode());
     }
 
-    Y_UNIT_TEST(ShouldFailCmsRequestIfAgentIsNotFound)
+    Y_UNIT_TEST_F(ShouldFailCmsRequestIfAgentIsNotFound, TFixture)
     {
-        auto runtime = TTestRuntimeBuilder()
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+        auto [error, timeout] = RemoveHost("agent-1");
 
         UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, error.GetCode());
         UNIT_ASSERT_VALUES_EQUAL(0, timeout);
     }
 
-    Y_UNIT_TEST(ShouldFailCmsRequestIfDeviceNotFound)
+    Y_UNIT_TEST_F(ShouldFailCmsRequestIfDeviceNotFound, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-2", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-2", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-10");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-10");
 
             UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
     }
 
-    Y_UNIT_TEST(ShouldRemoveDeviceUponCmsRequest)
+    Y_UNIT_TEST_F(ShouldRemoveDeviceUponCmsRequest, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
 
         ui32 cmsTimeout = 0;
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
@@ -309,10 +378,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
 
         // request will be ignored
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
+        DiskRegistry->ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
 
         {
-            auto response = diskRegistry.AllocateDisk("vol1", 10_GB);
+            auto response = DiskRegistry->AllocateDisk("vol1", 10_GB);
             const auto& msg = response->Record;
             UNIT_ASSERT_VALUES_EQUAL(1, msg.DevicesSize());
             const auto& device = msg.GetDevices(0);
@@ -323,20 +392,20 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 static_cast<ui32>(device.GetState()));
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
             UNIT_ASSERT_LT(timeout, cmsTimeout);
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
@@ -344,18 +413,18 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             cmsTimeout = timeout;
         }
 
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ERROR);
+        DiskRegistry->ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ERROR);
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
+        DiskRegistry->ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
 
         {
-            auto response = diskRegistry.AllocateDisk("vol1", 10_GB);
+            auto response = DiskRegistry->AllocateDisk("vol1", 10_GB);
             const auto& msg = response->Record;
             UNIT_ASSERT_VALUES_EQUAL(1, msg.DevicesSize());
             const auto& device = msg.GetDevices(0);
@@ -365,33 +434,31 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldRemoveMultipleDevicesUponCmsRequest)
+    Y_UNIT_TEST_F(ShouldRemoveMultipleDevicesUponCmsRequest, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("some/path", "uuid-1", "rack-1", 10_GB),
             Device("some/path", "uuid-2", "rack-1", 10_GB),
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
 
         ui32 cmsTimeout = 0;
         {
             auto [error, timeout] =
-                RemoveDevice(diskRegistry, "agent-1", "some/path");
+                RemoveDevice("agent-1", "some/path");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
@@ -399,14 +466,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             cmsTimeout = timeout;
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Seconds(cmsTimeout));
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(cmsTimeout));
 
-        diskRegistry.MarkDiskForCleanup("vol1");
-        diskRegistry.DeallocateDisk("vol1");
+        DiskRegistry->MarkDiskForCleanup("vol1");
+        DiskRegistry->DeallocateDisk("vol1");
 
         {
             auto [error, timeout] =
-                RemoveDevice(diskRegistry, "agent-1", "some/path");
+                RemoveDevice("agent-1", "some/path");
 
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
@@ -416,81 +483,83 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
 
         {
-            diskRegistry.SendAllocateDiskRequest("vol1", 10_GB);
-            auto response = diskRegistry.RecvAllocateDiskResponse();
+            DiskRegistry->SendAllocateDiskRequest("vol1", 10_GB);
+            auto response = DiskRegistry->RecvAllocateDiskResponse();
             UNIT_ASSERT_VALUES_EQUAL(
                 E_BS_DISK_ALLOCATION_FAILED,
                 response->GetStatus());
         }
     }
 
-    Y_UNIT_TEST(ShouldReturnOkIfRemovedDeviceHasNoDisks)
+    Y_UNIT_TEST_F(ShouldReturnOkIfRemovedDeviceHasNoDisks, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            diskRegistry.SendAllocateDiskRequest("vol1", 10_GB);
-            auto response = diskRegistry.RecvAllocateDiskResponse();
-            UNIT_ASSERT_VALUES_EQUAL(E_BS_DISK_ALLOCATION_FAILED, response->GetStatus());
+            DiskRegistry->SendAllocateDiskRequest("vol1", 10_GB);
+            auto response = DiskRegistry->RecvAllocateDiskResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_BS_DISK_ALLOCATION_FAILED,
+                response->GetStatus());
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error);
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ERROR);
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
+        DiskRegistry->ChangeDeviceState(
+            "uuid-1",
+            NProto::EDeviceState::DEVICE_STATE_ERROR);
+        DiskRegistry->ChangeDeviceState(
+            "uuid-1",
+            NProto::EDeviceState::DEVICE_STATE_ONLINE);
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
     }
 
-    Y_UNIT_TEST(ShouldFailCmsRequestIfDiskRegistryRestarts)
+    Y_UNIT_TEST_F(ShouldFailCmsRequestIfDiskRegistryRestarts, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
         NProto::TAction action;
         action.SetHost("agent-2");
@@ -499,214 +568,139 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         TVector<NProto::TAction> actions;
         actions.push_back(action);
 
-        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
-            switch (event->GetTypeRewrite()) {
-                case TEvDiskRegistryPrivate::EvUpdateCmsHostDeviceStateRequest: {
-                    return TTestActorRuntime::EEventAction::DROP;
+        Runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvDiskRegistryPrivate::
+                        EvUpdateCmsHostDeviceStateRequest: {
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
                 }
-            }
 
-            return TTestActorRuntime::DefaultObserverFunc(event);
-        });
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
 
-        diskRegistry.SendCmsActionRequest(std::move(actions));
+        DiskRegistry->SendCmsActionRequest(std::move(actions));
 
-        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
-        runtime->DispatchEvents({}, TDuration::MicroSeconds(40));
-        diskRegistry.RebootTablet();
-        diskRegistry.WaitReady();
+        Runtime->AdvanceCurrentTime(1s);
+        Runtime->DispatchEvents({}, 40us);
+        DiskRegistry->RebootTablet();
+        DiskRegistry->WaitReady();
 
-        auto response = diskRegistry.RecvCmsActionResponse();
+        auto response = DiskRegistry->RecvCmsActionResponse();
 
         UNIT_ASSERT_VALUES_EQUAL(
             E_REJECTED,
             response->Record.GetError().GetCode());
     }
 
-    void ShouldRestoreCMSTimeoutAfterReboot(auto removeAction)
+    Y_UNIT_TEST_F(ShouldRestoreAgentCMSTimeoutAfterReboot, TFixture)
     {
-        const auto agent = CreateAgentConfig("agent-1", {
-            Device("dev-1", "uuid-1", "rack-1", 10_GB)
-        });
-
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
-
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
-
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, { agent }));
-
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
-
-        diskRegistry.AllocateDisk("vol1", 10_GB);
-
-        ui32 cmsTimeout = 0;
-        {
-            auto [error, timeout] = removeAction(diskRegistry);
-
-            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
-            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
-
-            cmsTimeout = timeout;
-        }
-
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
-
-        {
-            auto [error, timeout] = removeAction(diskRegistry);
-
-            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
-            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
-            UNIT_ASSERT_GT(cmsTimeout, timeout);
-        }
-
-        diskRegistry.RebootTablet();
-        diskRegistry.WaitReady();
-
-        {
-            auto [error, timeout] = removeAction(diskRegistry);
-
-            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
-            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
-            UNIT_ASSERT_GT(cmsTimeout, timeout);
-        }
-
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
-
-        {
-            auto [error, timeout] = removeAction(diskRegistry);
-
-            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
-            UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
-            UNIT_ASSERT_VALUES_EQUAL(cmsTimeout, timeout);
-        }
-
-        diskRegistry.MarkDiskForCleanup("vol1");
-        diskRegistry.DeallocateDisk("vol1");
-
-        {
-            auto [error, timeout] = removeAction(diskRegistry);
-
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT_VALUES_EQUAL(0, timeout);
-        }
-    }
-
-    Y_UNIT_TEST(ShouldRestoreAgentCMSTimeoutAfterReboot)
-    {
-        ShouldRestoreCMSTimeoutAfterReboot([] (auto& diskRegistry) {
-            return RemoveHost(diskRegistry, "agent-1");
+        ShouldRestoreCMSTimeoutAfterReboot([this] {
+            return RemoveHost("agent-1");
         });
     }
 
-    Y_UNIT_TEST(ShouldRestoreDeviceCMSTimeoutAfterReboot)
+    Y_UNIT_TEST_F(ShouldRestoreDeviceCMSTimeoutAfterReboot, TFixture)
     {
-        ShouldRestoreCMSTimeoutAfterReboot([] (auto& diskRegistry) {
-            return RemoveDevice(diskRegistry, "agent-1", "dev-1");
+        ShouldRestoreCMSTimeoutAfterReboot([this] {
+            return RemoveDevice("agent-1", "dev-1");
         });
     }
 
-    Y_UNIT_TEST(ShouldReturnOkForCmsRequestIfAgentDoesnotHaveUserDisks)
+    Y_UNIT_TEST_F(ShouldReturnOkForCmsRequestIfAgentDoesnotHaveUserDisks, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            diskRegistry.SendAllocateDiskRequest("vol1", 10_GB);
-            auto response = diskRegistry.RecvAllocateDiskResponse();
+            DiskRegistry->SendAllocateDiskRequest("vol1", 10_GB);
+            auto response = DiskRegistry->RecvAllocateDiskResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_BS_DISK_ALLOCATION_FAILED, response->GetStatus());
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
     }
 
-    Y_UNIT_TEST(ShouldReturnOkForCmsRequestIfDisksWereDeallocated)
+    Y_UNIT_TEST_F(ShouldReturnOkForCmsRequestIfDisksWereDeallocated, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
-        TSSProxyClient ss(*runtime);
+        TSSProxyClient ss(*Runtime);
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
         }
 
-        diskRegistry.MarkDiskForCleanup("vol1");
-        diskRegistry.DeallocateDisk("vol1");
+        DiskRegistry->MarkDiskForCleanup("vol1");
+        DiskRegistry->DeallocateDisk("vol1");
 
-        runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
+        Runtime->AdvanceCurrentTime(TDuration::Days(1) / 2);
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_ONLINE);
     }
 
-    Y_UNIT_TEST(ShouldAllowToTakeAwayAlreadyUnavailableAgents)
+    Y_UNIT_TEST_F(ShouldAllowToTakeAwayAlreadyUnavailableAgents, TFixture)
     {
         const TVector agents {
             CreateAgentConfig("agent-1", {
@@ -717,44 +711,42 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             })
         };
 
-        auto runtime = TTestRuntimeBuilder()
+        SetUpRuntime(TTestRuntimeBuilder()
             .WithAgents(agents)
-            .Build();
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, agents));
 
-        RegisterAndWaitForAgents(*runtime, agents);
+        RegisterAndWaitForAgents(*Runtime, agents);
 
-        diskRegistry.AllocateDisk("vol1", 20_GB);
-        diskRegistry.ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
+        DiskRegistry->AllocateDisk("vol1", 20_GB);
+        DiskRegistry->ChangeAgentState("agent-1", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
 
         ui32 cmsTimeout = 0;
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
             cmsTimeout = timeout;
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Seconds(cmsTimeout / 2));
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(cmsTimeout / 2));
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
             cmsTimeout = timeout;
         }
 
-        runtime->AdvanceCurrentTime(TDuration::Seconds(cmsTimeout + 1));
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(cmsTimeout + 1));
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
@@ -762,59 +754,57 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         // Take away empty agent without timeout
 
-        diskRegistry.ChangeAgentState("agent-2", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
+        DiskRegistry->ChangeAgentState("agent-2", NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-2");
+            auto [error, timeout] = RemoveHost("agent-2");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
         }
 
-        diskRegistry.MarkDiskForCleanup("vol1");
-        diskRegistry.DeallocateDisk("vol1");
+        DiskRegistry->MarkDiskForCleanup("vol1");
+        DiskRegistry->DeallocateDisk("vol1");
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-2");
+            auto [error, timeout] = RemoveHost("agent-2");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
     }
 
-    Y_UNIT_TEST(ShouldAllowToTakeAwayAlreadyUnavailableDevice)
+    Y_UNIT_TEST_F(ShouldAllowToTakeAwayAlreadyUnavailableDevice, TFixture)
     {
         const auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB),
             Device("dev-2", "uuid-2", "rack-1", 10_GB)
         });
 
-        auto runtime = TTestRuntimeBuilder()
-            .WithAgents({ agent })
-            .Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents({agent})
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, {agent});
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, {agent});
 
-        diskRegistry.AllocateDisk("vol1", 20_GB);
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ERROR);
+        DiskRegistry->AllocateDisk("vol1", 20_GB);
+        DiskRegistry->ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ERROR);
 
-        auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+        auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
         UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
         UNIT_ASSERT_VALUES_EQUAL(0, timeout);
 
-        diskRegistry.ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
+        DiskRegistry->ChangeDeviceState("uuid-1", NProto::EDeviceState::DEVICE_STATE_ONLINE);
     }
 
-    Y_UNIT_TEST(ShouldGetDependentDisks)
+    Y_UNIT_TEST_F(ShouldGetDependentDisks, TFixture)
     {
         const TVector agents {
             CreateAgentConfig("agent-1", {
@@ -827,17 +817,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             })
         };
 
-        auto runtime = TTestRuntimeBuilder()
+        SetUpRuntime(TTestRuntimeBuilder()
             .WithAgents(agents)
-            .Build();
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, agents));
 
-        RegisterAndWaitForAgents(*runtime, agents);
+        RegisterAndWaitForAgents(*Runtime, agents);
 
         TString vol1Device;
         TString vol2Device;
@@ -847,7 +835,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         TVector<TString> agent2Disks;
 
         auto allocateDisk = [&] (const TString& diskId, TString& devName) {
-            auto response = diskRegistry.AllocateDisk(diskId, 10_GB);
+            auto response = DiskRegistry->AllocateDisk(diskId, 10_GB);
             const auto& msg = response->Record;
             UNIT_ASSERT_VALUES_EQUAL(1, msg.DevicesSize());
             devName = msg.GetDevices(0).GetDeviceName();
@@ -872,7 +860,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
 
         {
-            auto response = diskRegistry.CmsAction(actions);
+            auto response = DiskRegistry->CmsAction(actions);
             const auto& result = response->Record.GetActionResults(0);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetResult().GetCode());
             const auto& diskIds = result.GetDependentDisks();
@@ -882,7 +870,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         actions.back().SetHost("agent-2");
 
         {
-            auto response = diskRegistry.CmsAction(actions);
+            auto response = DiskRegistry->CmsAction(actions);
             const auto& result = response->Record.GetActionResults(0);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetResult().GetCode());
             const auto& diskIds = result.GetDependentDisks();
@@ -892,7 +880,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         actions.back().SetHost("agent-3");
 
         {
-            auto response = diskRegistry.CmsAction(actions);
+            auto response = DiskRegistry->CmsAction(actions);
             const auto& result = response->Record.GetActionResults(0);
             UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, result.GetResult().GetCode());
         }
@@ -901,7 +889,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         actions.back().SetDevice(vol1Device);
 
         {
-            auto response = diskRegistry.CmsAction(actions);
+            auto response = DiskRegistry->CmsAction(actions);
             const auto& result = response->Record.GetActionResults(0);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetResult().GetCode());
             const auto& diskIds = result.GetDependentDisks();
@@ -909,7 +897,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldGetDependentDisksAndIgnoreReplicated)
+    Y_UNIT_TEST_F(ShouldGetDependentDisksAndIgnoreReplicated, TFixture)
     {
         const TVector agents {
             CreateAgentConfig("agent-1", {
@@ -922,21 +910,19 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             })
         };
 
-        auto runtime = TTestRuntimeBuilder()
+        SetUpRuntime(TTestRuntimeBuilder()
             .WithAgents(agents)
-            .Build();
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.WaitReady();
-        diskRegistry.SetWritableState(true);
+        DiskRegistry->SetWritableState(true);
 
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, agents));
 
-        RegisterAndWaitForAgents(*runtime, agents);
+        RegisterAndWaitForAgents(*Runtime, agents);
 
         {
             const uint32_t replicaCount = 1;
-            auto response = diskRegistry.AllocateDisk(
+            auto response = DiskRegistry->AllocateDisk(
                 "replicated-vol", 10_GB, 4_KB, "", 0, "", "",
                 replicaCount, NProto::STORAGE_MEDIA_SSD_MIRROR2);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
@@ -945,7 +931,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
 
         {
-            auto response = diskRegistry.AllocateDisk("nonrepl-vol", 20_GB);
+            auto response = DiskRegistry->AllocateDisk("nonrepl-vol", 20_GB);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
             UNIT_ASSERT_VALUES_EQUAL(2, response->Record.DevicesSize());
         }
@@ -956,7 +942,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             action.SetType(NProto::TAction::GET_DEPENDENT_DISKS);
             TVector<NProto::TAction> actions = {action};
 
-            auto response = diskRegistry.CmsAction(actions);
+            auto response = DiskRegistry->CmsAction(actions);
             const auto& result = response->Record.GetActionResults(0);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetResult().GetCode());
 
@@ -966,7 +952,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldAddHostAndDevicesAfterRemoval)
+    Y_UNIT_TEST_F(ShouldAddHostAndDevicesAfterRemoval, TFixture)
     {
         const TVector agents {
             CreateAgentConfig("agent-1", {
@@ -974,55 +960,55 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 Device("dev-2", "uuid-2", "rack-1", 10_GB)
             })};
 
-        auto runtime = TTestRuntimeBuilder().WithAgents(agents).Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents(agents)
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.SetWritableState(true);
-        diskRegistry.WaitReady();
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+        DiskRegistry->SetWritableState(true);
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, agents));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, agents);
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, agents);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeAgentState(
+        DiskRegistry->ChangeAgentState(
             "agent-1",
             NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeAgentState(
+        DiskRegistry->ChangeAgentState(
             "agent-1",
             NProto::EAgentState::AGENT_STATE_WARNING);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
@@ -1030,62 +1016,62 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         // Check idempotency.
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.MarkDiskForCleanup("vol1");
-        diskRegistry.DeallocateDisk("vol1");
+        DiskRegistry->MarkDiskForCleanup("vol1");
+        DiskRegistry->DeallocateDisk("vol1");
 
-        diskRegistry.ChangeDeviceState(
+        DiskRegistry->ChangeDeviceState(
             "uuid-1",
             NProto::EDeviceState::DEVICE_STATE_ERROR);
 
         {
-            auto [error, timeout] = AddDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = AddDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.ChangeDeviceState(
+        DiskRegistry->ChangeDeviceState(
             "uuid-1",
             NProto::EDeviceState::DEVICE_STATE_WARNING);
 
         {
-            auto [error, timeout] = AddDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = AddDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = AddDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = AddDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
@@ -1093,64 +1079,64 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         // Check idempotency.
         {
-            auto [error, timeout] = AddDevice(diskRegistry, "agent-1", "dev-1");
+            auto [error, timeout] = AddDevice("agent-1", "dev-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        diskRegistry.AllocateDisk("vol1", 10_GB);
+        DiskRegistry->AllocateDisk("vol1", 10_GB);
 
         {
-            auto [error, timeout] = RemoveDevice(diskRegistry, "agent-1", "dev-2");
+            auto [error, timeout] = RemoveDevice("agent-1", "dev-2");
 
             UNIT_ASSERT_VALUES_EQUAL_C(E_TRY_AGAIN, error.GetCode(), error.GetMessage());
             UNIT_ASSERT_VALUES_UNEQUAL(0, timeout);
         }
 
         {
-            auto [error, timeout] = AddDevice(diskRegistry, "agent-1", "dev-2");
+            auto [error, timeout] = AddDevice("agent-1", "dev-2");
 
             UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error.GetMessage());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
     }
 
-    Y_UNIT_TEST(ShouldRejectAddHostForUnavailableAgent)
+    Y_UNIT_TEST_F(ShouldRejectAddHostForUnavailableAgent, TFixture)
     {
         const TVector agents{CreateAgentConfig(
             "agent-1",
             {Device("dev-1", "uuid-1", "rack-1", 10_GB),
              Device("dev-2", "uuid-2", "rack-1", 10_GB)})};
 
-        auto runtime = TTestRuntimeBuilder().WithAgents(agents).Build();
+        SetUpRuntime(TTestRuntimeBuilder()
+            .WithAgents(agents)
+            .Build());
 
-        TDiskRegistryClient diskRegistry(*runtime);
-        diskRegistry.SetWritableState(true);
-        diskRegistry.WaitReady();
-        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+        DiskRegistry->SetWritableState(true);
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, agents));
 
-        RegisterAgents(*runtime, 1);
-        WaitForAgents(*runtime, 1);
-        WaitForSecureErase(*runtime, agents);
+        RegisterAgents(*Runtime, 1);
+        WaitForAgents(*Runtime, 1);
+        WaitForSecureErase(*Runtime, agents);
 
         {
-            auto [error, timeout] = RemoveHost(diskRegistry, "agent-1");
+            auto [error, timeout] = RemoveHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        runtime->AdvanceCurrentTime(15min);
+        Runtime->AdvanceCurrentTime(15min);
 
-        diskRegistry.ChangeAgentState(
+        DiskRegistry->ChangeAgentState(
             "agent-1",
             NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
 
-        runtime->AdvanceCurrentTime(15min);
+        Runtime->AdvanceCurrentTime(15min);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -1158,29 +1144,29 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 TDuration::Seconds(timeout));
         }
 
-        runtime->AdvanceCurrentTime(2min);
+        Runtime->AdvanceCurrentTime(2min);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_LE(TDuration::Seconds(timeout), TDuration{3min});
             UNIT_ASSERT_GT(TDuration::Seconds(timeout), TDuration{2min});
         }
 
-        runtime->AdvanceCurrentTime(10min);
+        Runtime->AdvanceCurrentTime(10min);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);
         }
 
-        runtime->AdvanceCurrentTime(10min);
+        Runtime->AdvanceCurrentTime(10min);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -1188,16 +1174,16 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 TDuration::Seconds(timeout));
         }
 
-        runtime->AdvanceCurrentTime(1min);
+        Runtime->AdvanceCurrentTime(1min);
 
-        diskRegistry.ChangeAgentState(
+        DiskRegistry->ChangeAgentState(
             "agent-1",
             NProto::EAgentState::AGENT_STATE_WARNING);
 
-        runtime->AdvanceCurrentTime(1min);
+        Runtime->AdvanceCurrentTime(1min);
 
         {
-            auto [error, timeout] = AddHost(diskRegistry, "agent-1");
+            auto [error, timeout] = AddHost("agent-1");
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, timeout);


### PR DESCRIPTION
Local disks are deallocated synchronously: the response is sent after all the disk's devices are cleaned; REMOVE_HOST suspends local devices; Suspended devices cannot be cleaned. So if REMOVE_HOST occurs after the start of disk deallocation and before the start of secure erase, the deallocation will not be able to complete, because all local devices on the host will be suspended.