### PR TITLE
(sync 23-3) fix: client backupvolume command (#1036)

### DIFF
--- a/cloud/blockstore/apps/client/lib/backup_volume.cpp
+++ b/cloud/blockstore/apps/client/lib/backup_volume.cpp
@@ -33,7 +33,7 @@ protected:
 
     ui32 BatchSize = 4 * 1024 * 1024;
     ui32 BatchBlocksCount = 0;
-    ui32 ChangedBlocksCount = CHAR_BIT * 1024 * 1024;
+    ui32 ChangedBlocksCount = 1024 * 1024;
 
     ui32 TabletVersion = 0;
     ui32 BlockSize = 0;

--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -417,6 +417,13 @@ def test_backup():
         "--backup-disk-id", "volume-1",
         "--checkpoint-id", "checkpoint-0",
         "--io-depth", "16",
+        "--verbose")
+
+    run("backupvolume",
+        "--disk-id", "volume-0",
+        "--backup-disk-id", "volume-1",
+        "--checkpoint-id", "checkpoint-0",
+        "--io-depth", "16",
         "--changed-blocks-count", str(CHANGED_BLOCKS_COUNT),
         "--verbose")
 


### PR DESCRIPTION
* fix: client backupvolume command

* fix: add test for backupvolume command without changed-blocks-count parameter