### PR TITLE
NEBDUTY-1127: reduce cores consumption in disk manager tests

### DIFF
--- a/cloud/storage/core/tools/ci/runner/run_disk_manager_eternal_256_gib.sh
+++ b/cloud/storage/core/tools/ci/runner/run_disk_manager_eternal_256_gib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export instance_cores=16
+export instance_cores=6
 export instance_ram=16
 
 export disk_size_gib=256

--- a/cloud/storage/core/tools/ci/runner/run_disk_manager_eternal_8_gib.sh
+++ b/cloud/storage/core/tools/ci/runner/run_disk_manager_eternal_8_gib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export instance_cores=4
+export instance_cores=2
 export instance_ram=4
 
 export disk_size_gib=8

--- a/cloud/storage/core/tools/ci/runner/run_disk_manager_eternal_8_tib.sh
+++ b/cloud/storage/core/tools/ci/runner/run_disk_manager_eternal_8_tib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export instance_cores=32
+export instance_cores=24
 export instance_ram=32
 
 export disk_size_gib=8192


### PR DESCRIPTION
Disk limits:
https://nebius.ai/docs/overview/concepts/quotas-limits#compute-limits-vm-disks

- we have 15 MB/s max read/write bandwidth for 32G allocation unit
- we have 18 MB/s max bandwidth per vcpu
- we have 450 MB/s max bandwidth for read/write per disk

- for 8Tib disk it's enough 450/18 ~= 24 cores
- for 256GiB disk it's enough 256 / 32 * 15 / 18 ~= 6 cores
- for 8Gib disk we can reduce to 2 cores (one allocation unit 15MB/s,
  2 vcpus 2*18=36 MB/s)
