### PR TITLE
NEBDUTY-1133: add reconnect timeout option in rdma-test client

### DIFF
--- a/cloud/blockstore/tests/rdma/rdma-test/test.py
+++ b/cloud/blockstore/tests/rdma/rdma-test/test.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from cloud.blockstore.tests.python.lib.rdma import setup_rdma
 
@@ -41,14 +40,11 @@ def check_rdma_connectivity(h1, h2, rdma_port=9999, timeout=10):
         "--storage", "Rdma",
         "--verbose", "debug",
         "--test-duration", str(timeout),
+        "--connect-timeout", "120",
     ]
 
     p2 = h2.execute(target_cmd, wait=False)
-
-    # wait for target to start listening
-    time.sleep(5)
-
-    h1.execute(initiator_cmd, timeout=timeout + EXECUTE_EXTRA_TIMEOUT_SECS)
+    h1.execute(initiator_cmd)
 
     p2.terminate()
 

--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -198,7 +198,8 @@ IRunnablePtr TBootstrap::CreateTest()
             Client,
             ThreadPool,
             Options->Host,
-            Options->Port);
+            Options->Port,
+            TDuration::Seconds(Options->ConnectTimeout));
         break;
     }
 

--- a/cloud/blockstore/tools/testing/rdma-test/options.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/options.cpp
@@ -59,6 +59,11 @@ void TOptions::Parse(int argc, char** argv)
             WaitMode = FromString<EWaitMode>(s);
         });
 
+    opts.AddLongOption("connect-timeout")
+        .RequiredArgument("SEC")
+        .DefaultValue(ToString(ConnectTimeout))
+        .StoreResult(&ConnectTimeout);
+
     // device geometry
     opts.AddLongOption("storage")
         .RequiredArgument("{" + GetEnumAllNames<EStorageKind>() + "}")

--- a/cloud/blockstore/tools/testing/rdma-test/options.h
+++ b/cloud/blockstore/tools/testing/rdma-test/options.h
@@ -50,6 +50,7 @@ struct TOptions
     ui32 QueueSize = 256;
     ui32 PollerThreads = 1;
     EWaitMode WaitMode = EWaitMode::Poll;
+    ui32 ConnectTimeout = 5;
 
     // storage options
     EStorageKind StorageKind = EStorageKind::Null;

--- a/cloud/blockstore/tools/testing/rdma-test/storage.h
+++ b/cloud/blockstore/tools/testing/rdma-test/storage.h
@@ -66,7 +66,8 @@ IStoragePtr CreateRdmaStorage(
     NRdma::IClientPtr client,
     ITaskQueuePtr taskQueue,
     const TString& address,
-    ui32 port);
+    ui32 port,
+    TDuration timeout);
 
 size_t CopyMemory(const TSgList& dst, TStringBuf src);
 size_t CopyMemory(TStringBuf dst, const TSgList& src);

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -330,12 +330,13 @@ IStoragePtr CreateRdmaStorage(
     NRdma::IClientPtr client,
     ITaskQueuePtr taskQueue,
     const TString& address,
-    ui32 port)
+    ui32 port,
+    TDuration timeout)
 {
     auto storage = TRdmaStorage::Create(std::move(taskQueue));
 
     auto startEndpoint = client->StartEndpoint(address, port);
-    storage->Init(startEndpoint.GetValue(WAIT_TIMEOUT));
+    storage->Init(startEndpoint.GetValue(timeout));
 
     return storage;
 }


### PR DESCRIPTION
This allows to refactor rdma-test and avoid race between target and initiator
starting in delay. Initiator will keep trying to reconnect until much larger
timeout will pass
