### PR TITLE
should mount proxy overlay disk locally

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -1181,6 +1181,36 @@ func (c *client) MountRO(
 	)
 }
 
+func (c *client) MountLocalRO(
+	ctx context.Context,
+	diskID string,
+	encryption *types.EncryptionDesc,
+) (session *Session, err error) {
+
+	defer c.metrics.StatRequest("MountLocalRO")(&err)
+
+	mountFlags, err := c.getMountFlags(ctx, diskID)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptionSpec, err := getEncryptionSpec(encryption)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewLocalROSession(
+		ctx,
+		c.nbs,
+		c.sessionMetricsRegistry,
+		diskID,
+		mountFlags,
+		encryptionSpec,
+		c.sessionRediscoverPeriodMin,
+		c.sessionRediscoverPeriodMax,
+	)
+}
+
 func (c *client) MountRW(
 	ctx context.Context,
 	diskID string,

--- a/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
@@ -231,6 +231,12 @@ type Client interface {
 		encryption *types.EncryptionDesc,
 	) (*Session, error)
 
+	MountLocalRO(
+		ctx context.Context,
+		diskID string,
+		encryption *types.EncryptionDesc,
+	) (*Session, error)
+
 	MountRW(
 		ctx context.Context,
 		diskID string,

--- a/cloud/disk_manager/internal/pkg/clients/nbs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/mocks/client_mock.go
@@ -240,6 +240,16 @@ func (c *ClientMock) MountRO(
 	return args.Get(0).(*nbs.Session), args.Error(1)
 }
 
+func (c *ClientMock) MountLocalRO(
+	ctx context.Context,
+	diskID string,
+	encryption *types.EncryptionDesc,
+) (*nbs.Session, error) {
+
+	args := c.Called(ctx, diskID, encryption)
+	return args.Get(0).(*nbs.Session), args.Error(1)
+}
+
 func (c *ClientMock) MountRW(
 	ctx context.Context,
 	diskID string,

--- a/cloud/disk_manager/internal/pkg/clients/nbs/session.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/session.go
@@ -110,6 +110,34 @@ func NewROSession(
 	)
 }
 
+func NewLocalROSession(
+	ctx context.Context,
+	nbs *nbs_client.DiscoveryClient,
+	metricsRegistry metrics.Registry,
+	diskID string,
+	mountFlags uint32,
+	encryptionSpec *protos.TEncryptionSpec,
+	rediscoverPeriodMin time.Duration,
+	rediscoverPeriodMax time.Duration,
+) (*Session, error) {
+
+	mountOpts := nbs_client.MountVolumeOpts{
+		MountFlags:     mountFlags,
+		EncryptionSpec: encryptionSpec,
+		AccessMode:     protos.EVolumeAccessMode_VOLUME_ACCESS_READ_ONLY,
+		MountMode:      protos.EVolumeMountMode_VOLUME_MOUNT_LOCAL,
+	}
+	return newSession(
+		ctx,
+		nbs,
+		metricsRegistry,
+		diskID,
+		mountOpts,
+		rediscoverPeriodMin,
+		rediscoverPeriodMax,
+	)
+}
+
 func NewRWSession(
 	ctx context.Context,
 	nbs *nbs_client.DiscoveryClient,

--- a/cloud/disk_manager/internal/pkg/dataplane/nbs/source.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/nbs/source.go
@@ -249,11 +249,14 @@ func NewDiskSource(
 	dontReadFromCheckpoint bool,
 ) (dataplane_common.Source, error) {
 
-	if len(proxyDiskID) == 0 {
-		proxyDiskID = diskID
+	var session *nbs.Session
+	var err error
+	if len(proxyDiskID) != 0 {
+		session, err = client.MountLocalRO(ctx, proxyDiskID, encryption)
+	} else {
+		session, err = client.MountRO(ctx, diskID, encryption)
 	}
 
-	session, err := client.MountRO(ctx, proxyDiskID, encryption)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/transfer_from_disk_to_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/transfer_from_disk_to_disk_task.go
@@ -56,7 +56,7 @@ func (t *transferFromDiskToDiskTask) Run(
 		ctx,
 		client,
 		t.request.SrcDisk.DiskId,
-		t.request.SrcDisk.DiskId, // proxyDiskID
+		"", // proxyDiskID
 		t.request.SrcDiskBaseCheckpointId,
 		t.request.SrcDiskCheckpointId,
 		diskParams.EncryptionDesc,


### PR DESCRIPTION
We do not use optimization that provided by proxy overlay disks because of remote mounting 

data path was:
Snapshot ->  nbs control -> nbs control where disk is mounted -> nbs control -> snapshot 

now it will be: 
snapshot -> nbs control (proxy overlay disk will be mounted on it locally) -> snapshot 

Also we can probably improve load balancing on the nbs control using this approach 