### PR TITLE
issue-95: 1. getting rid of an accidental O(n) traversal of the Groups list in TCompactionMap::GetStats 2. limiting the number of cached handles per node in the readahead cache

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -256,4 +256,5 @@ message TStorageConfig
     optional uint32 ReadAheadCacheMaxResultsPerNode = 348;
     optional uint32 ReadAheadCacheRangeSize = 349;
     optional uint32 ReadAheadMaxGapPercentage = 350;
+    optional uint32 ReadAheadCacheMaxHandlesPerNode = 351;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -145,6 +145,7 @@ namespace {
     xxx(ReadAheadCacheMaxResultsPerNode,        ui32,       32                )\
     xxx(ReadAheadCacheRangeSize,                ui32,       0                 )\
     xxx(ReadAheadMaxGapPercentage,              ui32,       20                )\
+    xxx(ReadAheadCacheMaxHandlesPerNode,        ui32,      128                )\
     xxx(EntryTimeout,                    TDuration, TDuration::Zero()         )\
     xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\
     xxx(AttrTimeout,                     TDuration, TDuration::Zero()         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -199,6 +199,7 @@ public:
     ui32 GetReadAheadCacheMaxResultsPerNode() const;
     ui32 GetReadAheadCacheRangeSize() const;
     ui32 GetReadAheadMaxGapPercentage() const;
+    ui32 GetReadAheadCacheMaxHandlesPerNode() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead.h
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead.h
@@ -91,6 +91,7 @@ private:
     ui32 MaxResultsPerNode = 0;
     ui32 RangeSize = 0;
     ui32 MaxGapPercentage = 0;
+    ui32 MaxHandlesPerNode = 0;
 
 public:
     explicit TReadAheadCache(IAllocator* allocator);
@@ -100,7 +101,8 @@ public:
         ui32 maxNodes,
         ui32 maxResultsPerNode,
         ui32 rangeSize,
-        ui32 maxGapPercentage);
+        ui32 maxGapPercentage,
+        ui32 maxHandlesPerNode);
 
     bool TryFillResult(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -106,7 +106,8 @@ void TIndexTabletState::LoadState(
         config.GetReadAheadCacheMaxNodes(),
         config.GetReadAheadCacheMaxResultsPerNode(),
         config.GetReadAheadCacheRangeSize(),
-        config.GetReadAheadMaxGapPercentage());
+        config.GetReadAheadMaxGapPercentage(),
+        config.GetReadAheadCacheMaxHandlesPerNode());
 }
 
 void TIndexTabletState::UpdateConfig(


### PR DESCRIPTION
#95 