### PR TITLE
issue-95: clearing deletion markers from the FreshBytes table via TxTrimBytes

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -16,7 +16,8 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using TChunkVisitor = std::function<void(const TBytes& bytes)>;
+using TChunkVisitor =
+    std::function<void(const TBytes& bytes, bool isDeletionMarker)>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -59,6 +60,7 @@ private:
     {
         TMap<TKey, TRef, TLess<TKey>, TStlAllocator> Refs;
         TDeque<TElement, TStlAllocator> Data;
+        TDeque<TBytes, TStlAllocator> DeletionMarkers;
         ui64 FirstCommitId = InvalidCommitId;
         ui64 TotalBytes = 0;
         ui64 Id = 0;
@@ -67,6 +69,7 @@ private:
         explicit TChunk(IAllocator* allocator)
             : Refs(allocator)
             , Data(allocator)
+            , DeletionMarkers(allocator)
         {}
     };
 
@@ -93,7 +96,10 @@ public:
 
     void OnCheckpoint(ui64 commitId);
 
-    TFlushBytesCleanupInfo StartCleanup(ui64 commitId, TVector<TBytes>* entries);
+    TFlushBytesCleanupInfo StartCleanup(
+        ui64 commitId,
+        TVector<TBytes>* entries,
+        TVector<TBytes>* deletionMarkers);
     void VisitTop(const TChunkVisitor& visitor);
     void FinishCleanup(ui64 chunkId);
 

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -72,6 +72,7 @@ message TFileSystemStats
     uint64 CheckpointBlobsCount = 208;
     uint64 FreshBytesCount = 209;
     uint64 AttrsUsedBytesCount = 210;
+    uint64 DeletedFreshBytesCount = 211;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -98,6 +98,7 @@ private:
 
         // Data stats
         std::atomic<i64> FreshBytesCount{0};
+        std::atomic<i64> DeletedFreshBytesCount{0};
         std::atomic<i64> MixedBytesCount{0};
         std::atomic<i64> MixedBlobsCount{0};
         std::atomic<i64> DeletionMarkersCount{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -331,7 +331,9 @@ void TIndexTabletActor::EnqueueBlobIndexOpIfNeeded(const TActorContext& ctx)
             BlobIndexOps.Push(EBlobIndexOp::Cleanup);
         }
 
-        if (GetFreshBytesCount() >= Config->GetFlushBytesThreshold()) {
+        if (GetFreshBytesCount() >= Config->GetFlushBytesThreshold()
+                || GetDeletedFreshBytesCount() >= Config->GetFlushBytesThreshold())
+        {
             BlobIndexOps.Push(EBlobIndexOp::FlushBytes);
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -109,6 +109,7 @@ void TIndexTabletActor::TMetrics::Register(
         EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(FreshBytesCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(DeletedFreshBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(MixedBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(MixedBlobsCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(DeletionMarkersCount, EMetricType::MT_ABSOLUTE);
@@ -205,6 +206,7 @@ void TIndexTabletActor::TMetrics::Update(
     Store(UsedLocksCount, stats.GetUsedLocksCount());
 
     Store(FreshBytesCount, stats.GetFreshBytesCount());
+    Store(DeletedFreshBytesCount, stats.GetDeletedFreshBytesCount());
     Store(MixedBytesCount, stats.GetMixedBlocksCount() * blockSize);
     Store(MixedBlobsCount, stats.GetMixedBlobsCount());
     Store(DeletionMarkersCount, stats.GetDeletionMarkersCount());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -552,6 +552,9 @@ void TIndexTabletActor::HandleFlushBytes(
         msg->CallContext);
 
     TVector<TBytes> bytes;
+    // deletionMarkers won't be needed in the transactions - the actual localdb
+    // cleanup will use the markers stored in TFreshBytes via the FinishCleanup
+    // call which uses TFreshBytes::VisitTop
     TVector<TBytes> deletionMarkers;
     auto cleanupInfo = StartFlushBytes(&bytes, &deletionMarkers);
 
@@ -584,8 +587,7 @@ void TIndexTabletActor::HandleFlushBytes(
         std::move(requestInfo),
         cleanupInfo.ClosingCommitId,
         cleanupInfo.ChunkId,
-        std::move(bytes),
-        std::move(deletionMarkers)
+        std::move(bytes)
     );
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -482,7 +482,7 @@ void TIndexTabletActor::HandleFlushBytes(
         msg->CallContext->FileSystemId,
         GetFileSystem().GetStorageMediaKind());
 
-    auto replyError = [] (
+    auto reply = [] (
         const TActorContext& ctx,
         auto& ev,
         const NProto::TError& error)
@@ -511,7 +511,7 @@ void TIndexTabletActor::HandleFlushBytes(
             FlushState.Complete();
         }
 
-        replyError(
+        reply(
             ctx,
             *ev,
             MakeError(E_TRY_AGAIN, "compaction state not loaded yet")
@@ -525,7 +525,7 @@ void TIndexTabletActor::HandleFlushBytes(
             FlushState.Complete();
         }
 
-        replyError(
+        reply(
             ctx,
             *ev,
             MakeError(S_FALSE, "cleanup/compaction is in progress")
@@ -537,11 +537,7 @@ void TIndexTabletActor::HandleFlushBytes(
     if (!FlushState.Start()) {
         BlobIndexOpState.Complete();
 
-        replyError(
-            ctx,
-            *ev,
-            MakeError(S_FALSE, "flush is in progress")
-        );
+        reply(ctx, *ev, MakeError(S_FALSE, "flush is in progress"));
 
         return;
     }
@@ -556,17 +552,29 @@ void TIndexTabletActor::HandleFlushBytes(
         msg->CallContext);
 
     TVector<TBytes> bytes;
-    auto cleanupInfo = StartFlushBytes(&bytes);
+    TVector<TBytes> deletionMarkers;
+    auto cleanupInfo = StartFlushBytes(&bytes, &deletionMarkers);
 
     if (bytes.empty()) {
-        FlushState.Complete();
-        BlobIndexOpState.Complete();
+        if (deletionMarkers.empty()) {
+            FlushState.Complete();
+            BlobIndexOpState.Complete();
 
-        replyError(
+            reply(ctx, *ev, MakeError(S_ALREADY, "no bytes to flush"));
+
+            return;
+        }
+
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+            "%s FlushBytes: only deletion markers found, trimming",
+            LogTag.c_str());
+
+        reply(ctx, *ev, {});
+
+        ExecuteTx<TTrimBytes>(
             ctx,
-            *ev,
-            MakeError(S_ALREADY, "no bytes to flush")
-        );
+            std::move(requestInfo),
+            cleanupInfo.ChunkId);
 
         return;
     }
@@ -576,7 +584,8 @@ void TIndexTabletActor::HandleFlushBytes(
         std::move(requestInfo),
         cleanupInfo.ClosingCommitId,
         cleanupInfo.ChunkId,
-        std::move(bytes)
+        std::move(bytes),
+        std::move(deletionMarkers)
     );
 }
 
@@ -836,7 +845,6 @@ void TIndexTabletActor::HandleFlushBytesCompleted(
     const TEvIndexTabletPrivate::TEvFlushBytesCompleted::TPtr& ev,
     const TActorContext& ctx)
 {
-    // RECEIVED FROM TFlushBytesActor!
     const auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
@@ -904,9 +912,10 @@ void TIndexTabletActor::CompleteTx_TrimBytes(
         ProfileLog);
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s TrimBytes completed (%lu)",
+        "%s TrimBytes completed (%lu, %u)",
         LogTag.c_str(),
-        args.ChunkId);
+        args.ChunkId,
+        args.TrimmedBytes);
 
     FILESTORE_TRACK(
         ResponseSent_Tablet,

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -45,6 +45,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CheckpointBlobsCount,   __VA_ARGS__)                                   \
     xxx(FreshBytesCount,        __VA_ARGS__)                                   \
     xxx(AttrsUsedBytesCount,    __VA_ARGS__)                                   \
+    xxx(DeletedFreshBytesCount, __VA_ARGS__)                                   \
 // FILESTORE_FILESYSTEM_STATS
 
 #define FILESTORE_DUPCACHE_REQUESTS(xxx, ...)                                  \

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -57,6 +57,9 @@ struct TIndexTabletSchema
 
         struct StorageConfig        : ProtoColumn<23, NProto::TStorageConfig> {};
 
+        struct DeletedFreshBytesCount
+            : Column<24, NKikimr::NScheme::NTypeIds::Uint64> {};
+
         using TKey = TableKey<Id>;
 
         using TColumns = TableColumns<
@@ -82,7 +85,8 @@ struct TIndexTabletSchema
             FreshBytesCount,
             UsedBlocksCount,
             AttrsUsedBytesCount,
-            StorageConfig
+            StorageConfig,
+            DeletedFreshBytesCount
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -692,7 +692,9 @@ public:
         ui64 offset,
         ui64 len);
 
-    TFlushBytesCleanupInfo StartFlushBytes(TVector<TBytes>* bytes);
+    TFlushBytesCleanupInfo StartFlushBytes(
+        TVector<TBytes>* bytes,
+        TVector<TBytes>* deletionMarkers);
     ui32 FinishFlushBytes(
         TIndexTabletDatabase& db,
         ui64 chunkId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -388,6 +388,8 @@ ui32 TIndexTabletState::FinishFlushBytes(
     });
 
     DecrementFreshBytesCount(db, sz);
+    // Min() needed for backwards compat
+    deletedSz = Min<ui32>(deletedSz, GetDeletedFreshBytesCount());
     DecrementDeletedFreshBytesCount(db, deletedSz);
 
     Impl->FreshBytes.FinishCleanup(chunkId);

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1383,6 +1383,7 @@ struct TTxIndexTablet
         const ui64 ReadCommitId;
         const ui64 ChunkId;
         const TVector<TBytes> Bytes;
+        const TVector<TBytes> DeletionMarkers;
 
         ui64 CollectCommitId = InvalidCommitId;
 
@@ -1393,12 +1394,14 @@ struct TTxIndexTablet
                 TRequestInfoPtr requestInfo,
                 ui64 readCommitId,
                 ui64 chunkId,
-                TVector<TBytes> bytes)
+                TVector<TBytes> bytes,
+                TVector<TBytes> deletionMarkers)
             : TProfileAware(EFileStoreSystemRequest::FlushBytes)
             , RequestInfo(std::move(requestInfo))
             , ReadCommitId(readCommitId)
             , ChunkId(chunkId)
             , Bytes(std::move(bytes))
+            , DeletionMarkers(std::move(deletionMarkers))
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1383,7 +1383,6 @@ struct TTxIndexTablet
         const ui64 ReadCommitId;
         const ui64 ChunkId;
         const TVector<TBytes> Bytes;
-        const TVector<TBytes> DeletionMarkers;
 
         ui64 CollectCommitId = InvalidCommitId;
 
@@ -1394,14 +1393,12 @@ struct TTxIndexTablet
                 TRequestInfoPtr requestInfo,
                 ui64 readCommitId,
                 ui64 chunkId,
-                TVector<TBytes> bytes,
-                TVector<TBytes> deletionMarkers)
+                TVector<TBytes> bytes)
             : TProfileAware(EFileStoreSystemRequest::FlushBytes)
             , RequestInfo(std::move(requestInfo))
             , ReadCommitId(readCommitId)
             , ChunkId(chunkId)
             , Bytes(std::move(bytes))
-            , DeletionMarkers(std::move(deletionMarkers))
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5027,6 +5027,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldTrimFreshBytesDeletionMarkers)
     {
+        const auto block = tabletConfig.BlockSize;
+
         NProto::TStorageConfig storageConfig;
         storageConfig.SetFlushBytesThreshold(1_GB);
 
@@ -5051,7 +5053,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // initializing the first block to write fresh bytes then
         // otherwise those 1_KB of fresh bytes would be extended to a whole
         // block
-        tablet.WriteData(handle, 0, 4_KB, 'a');
+        tablet.WriteData(handle, 0, block, 'a');
         tablet.WriteData(handle, 0, 1_KB, 'a');
         tablet.FlushBytes();
         tablet.DestroyHandle(handle);
@@ -5073,7 +5075,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                     {"filesystem", "test"}}, 1},
                 {{
                     {"sensor", "TrimBytes.RequestBytes"},
-                    {"filesystem", "test"}}, 5_KB},
+                    {"filesystem", "test"}}, block + 1_KB},
                 {{
                     {"sensor", "TrimBytes.Count"},
                     {"filesystem", "test"}}, 2},


### PR DESCRIPTION
See #95 
Deletion markers are not cleared from the FreshBytes table and stay there forever. This PR fixes it.