### PR TITLE
NBS-4665, NBS-4262 [nbs] save checkpoint request just before execution, i.e. after setting it in progress

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -101,6 +101,7 @@ void TCheckpointStore::SetCheckpointRequestInProgress(ui64 requestId)
 {
     auto& checkpointRequest = GetRequest(requestId);
     Y_DEBUG_ABORT_UNLESS(
+        checkpointRequest.State == ECheckpointRequestState::Received ||
         checkpointRequest.State == ECheckpointRequestState::Saved);
 
     CheckpointRequestInProgress = requestId;
@@ -211,9 +212,13 @@ bool TCheckpointStore::HasRequestToExecute(ui64* requestId) const
     Y_DEBUG_ABORT_UNLESS(requestId);
 
     for (const auto& [key, checkpointRequest]: CheckpointRequests) {
-        if (checkpointRequest.State != ECheckpointRequestState::Saved) {
+        if (
+            checkpointRequest.State != ECheckpointRequestState::Received &&
+            checkpointRequest.State != ECheckpointRequestState::Saved)
+        {
             continue;
         }
+
         Y_DEBUG_ABORT_UNLESS(key == checkpointRequest.RequestId);
         if (requestId) {
             *requestId = checkpointRequest.RequestId;

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -212,18 +212,15 @@ bool TCheckpointStore::HasRequestToExecute(ui64* requestId) const
     Y_DEBUG_ABORT_UNLESS(requestId);
 
     for (const auto& [key, checkpointRequest]: CheckpointRequests) {
-        if (
-            checkpointRequest.State != ECheckpointRequestState::Received &&
-            checkpointRequest.State != ECheckpointRequestState::Saved)
+        if (checkpointRequest.State == ECheckpointRequestState::Received ||
+            checkpointRequest.State == ECheckpointRequestState::Saved)
         {
-            continue;
+            Y_DEBUG_ABORT_UNLESS(key == checkpointRequest.RequestId);
+            if (requestId) {
+                *requestId = checkpointRequest.RequestId;
+            }
+            return true;
         }
-
-        Y_DEBUG_ABORT_UNLESS(key == checkpointRequest.RequestId);
-        if (requestId) {
-            *requestId = checkpointRequest.RequestId;
-        }
-        return true;
     }
     return false;
 }

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -216,9 +216,7 @@ bool TCheckpointStore::HasRequestToExecute(ui64* requestId) const
             checkpointRequest.State == ECheckpointRequestState::Saved)
         {
             Y_DEBUG_ABORT_UNLESS(key == checkpointRequest.RequestId);
-            if (requestId) {
-                *requestId = checkpointRequest.RequestId;
-            }
+            *requestId = checkpointRequest.RequestId;
             return true;
         }
     }

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -353,7 +353,8 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(store.HasShadowActor(checkpointId), false);
     }
 
-    Y_UNIT_TEST(SetInProgressBeforeSave) {
+    Y_UNIT_TEST(SetInProgressBeforeSave)
+    {
         TCheckpointStore store({}, "disk-1");
 
         const auto& request = store.MakeCreateCheckpointRequest(

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -367,14 +367,18 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         ui64 requestId = request.RequestId;
 
         store.SetCheckpointRequestInProgress(requestId);
-        UNIT_ASSERT_VALUES_EQUAL(true, store.DoesCheckpointBlockingWritesExist());
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(true, store.IsCheckpointBeingCreated());
         UNIT_ASSERT_VALUES_EQUAL(true, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(true, store.HasRequestToExecute(&requestId));
         UNIT_ASSERT_VALUES_EQUAL(request.RequestId, requestId);
 
         store.SetCheckpointRequestSaved(request.RequestId);
-        UNIT_ASSERT_VALUES_EQUAL(true, store.DoesCheckpointBlockingWritesExist());
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(true, store.IsCheckpointBeingCreated());
         UNIT_ASSERT_VALUES_EQUAL(true, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(true, store.HasRequestToExecute(&requestId));
@@ -387,7 +391,9 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
             EShadowDiskState::None);
         auto checkpoints = store.GetActiveCheckpoints();
         UNIT_ASSERT_VALUES_EQUAL(1, checkpoints.size());
-        UNIT_ASSERT_VALUES_EQUAL(true, store.DoesCheckpointBlockingWritesExist());
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(false, store.HasRequestToExecute(&requestId));

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -653,6 +653,10 @@ private:
 
     void ProcessNextCheckpointRequest(const NActors::TActorContext& ctx);
 
+    void ProcessCheckpointRequest(
+        const NActors::TActorContext& ctx,
+        ui64 requestId);
+
     void HandleUpdateShadowDiskStateRequest(
         const TEvVolumePrivate::TEvUpdateShadowDiskStateRequest::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1114,10 +1114,10 @@ void TVolumeActor::ProcessNextCheckpointRequest(const TActorContext& ctx)
     State->GetCheckpointStore().SetCheckpointRequestInProgress(
         readyToExecuteRequestId);
 
-    auto checkpointRequestCopy =
+    const TCheckpointRequest& request =
         State->GetCheckpointStore().GetRequestById(readyToExecuteRequestId);
 
-    if (checkpointRequestCopy.State == ECheckpointRequestState::Received) {
+    if (request.State == ECheckpointRequestState::Received) {
         const TCheckpointRequestInfo* requestInfo =
             CheckpointRequests.FindPtr(readyToExecuteRequestId);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1176,8 +1176,7 @@ void TVolumeActor::ProcessCheckpointRequest(const TActorContext& ctx, ui64 reque
             ToString(actorId).c_str());
     }
 
-    State->GetCheckpointStore().SetCheckpointRequestInProgress(
-        requestId);
+    State->GetCheckpointStore().SetCheckpointRequestInProgress(requestId);
 
     TActorId actorId;
     switch (request.ReqType) {

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -397,18 +397,12 @@ struct TTxVolume
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 RequestId;
-        const bool IsTraced;
-        const ui64 TraceTs;
 
         TSaveCheckpointRequest(
                 TRequestInfoPtr requestInfo,
-                ui64 requestId,
-                bool isTraced,
-                ui64 traceTs)
+                ui64 requestId)
             : RequestInfo(std::move(requestInfo))
             , RequestId(requestId)
-            , IsTraced(isTraced)
-            , TraceTs(traceTs)
         {}
 
         void Clear()


### PR DESCRIPTION
In this pr some changes in processing checkpoint requests are made. Before, we saved a request to database immediately after receiving the request. Now we save a request later -- just before executing it.

In particular, we call SetCheckpointRequestInProgress method before saving the request. Consequently, there is always at most one uncompleted saved request.

This change will help to simplify this https://github.com/ydb-platform/nbs/pull/239. Namely, there will be no need in in-memory queue of postponed requests: all 'waiting' requests are already in memory. By the moment when we save the request, we will already have all the information required to take decision to save or not to save the request.