### PR TITLE
NBS-4763: fix incorrect chmod result processing

### DIFF
--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -153,12 +153,14 @@ void TServer::Start(const TOptions& options)
     Y_ABORT_UNLESS(Handler, "vhd_register_blockdev: Can't register device");
 
     if (!options.NoChmod) {
-        if (int err = Chmod(SocketPath.c_str(), options.SocketAccessMode)) {
+        if (Chmod(
+                SocketPath.c_str(),
+                static_cast<int>(options.SocketAccessMode)) < 0)
+        {
             Y_ABORT(
                 "failed to chmod socket %s: %s",
                 SocketPath.c_str(),
-                strerror(err)
-            );
+                strerror(errno));
         }
     }
 


### PR DESCRIPTION
chmod return only 0 (success) or -1 (failure) 
https://devdoc.net/linux/POSIXstandard/functions/chmod.html

error will be cached on global variable 'errno'