### PR TITLE
issue-95: tracking BlobsCount and DeletionsCount in TCompactionMap and exposing this data as tablet counters

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.h
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.h
@@ -33,6 +33,8 @@ struct TCompactionMapStats
 {
     ui64 UsedRangesCount = 0;
     ui64 AllocatedRangesCount = 0;
+    ui64 TotalBlobsCount = 0;
+    ui64 TotalDeletionsCount = 0;
 
     TVector<TCompactionRangeInfo> TopRangesByCleanupScore;
     TVector<TCompactionRangeInfo> TopRangesByCompactionScore;

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
@@ -311,6 +311,20 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[1].Stats.DeletionsCount, 444);
         }
     }
+
+    Y_UNIT_TEST(ShouldTrackTotalBlobsCountAndDeletionsCount)
+    {
+        TCompactionMap compactionMap(TDefaultAllocator::Instance());
+
+        compactionMap.Update(1, 10, 20);
+        compactionMap.Update(2, 5, 40);
+        compactionMap.Update(2, 15, 50);
+        compactionMap.Update(100, 7, 100);
+
+        auto stats = compactionMap.GetStats(1);
+        UNIT_ASSERT_VALUES_EQUAL(32, stats.TotalBlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(170, stats.TotalDeletionsCount);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -105,6 +105,8 @@ private:
         std::atomic<i64> GarbageQueueSize{0};
         std::atomic<i64> GarbageBytesCount{0};
         std::atomic<i64> FreshBlocksCount{0};
+        std::atomic<i64> CMMixedBlobsCount{0};
+        std::atomic<i64> CMDeletionMarkersCount{0};
 
         // Throttling
         std::atomic<i64> MaxReadBandwidth{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -116,6 +116,8 @@ void TIndexTabletActor::TMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(GarbageQueueSize, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(GarbageBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(FreshBlocksCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(CMMixedBlobsCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(CMDeletionMarkersCount, EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(IdleTime, EMetricType::MT_DERIVATIVE);
     REGISTER_AGGREGATABLE_SUM(BusyTime, EMetricType::MT_DERIVATIVE);
@@ -213,6 +215,8 @@ void TIndexTabletActor::TMetrics::Update(
     Store(GarbageQueueSize, stats.GetGarbageQueueSize());
     Store(GarbageBytesCount, stats.GetGarbageBlocksCount() * blockSize);
     Store(FreshBlocksCount, stats.GetFreshBlocksCount());
+    Store(CMMixedBlobsCount, compactionStats.TotalBlobsCount);
+    Store(CMDeletionMarkersCount, compactionStats.TotalDeletionsCount);
 
     Store(MaxReadIops, performanceProfile.GetMaxReadIops());
     Store(MaxWriteIops, performanceProfile.GetMaxWriteIops());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -601,6 +601,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             {{{"sensor", "FreshBytesCount"}, {"filesystem", "test"}},   DefaultBlockSize - 1},
             {{{"sensor", "FreshBlocksCount"}, {"filesystem", "test"}},  1},
             {{{"sensor", "MixedBlobsCount"}, {"filesystem", "test"}}, 1},
+            {{{"sensor", "CMMixedBlobsCount"}, {"filesystem", "test"}}, 1},
+            {{{"sensor", "DeletionMarkersCount"}, {"filesystem", "test"}}, 64},
+            {{{"sensor", "CMDeletionMarkersCount"}, {"filesystem", "test"}}, 64},
             {{{"sensor", "MixedBytesCount"}, {"filesystem", "test"}}, sz},
         });
         // clang-format on


### PR DESCRIPTION
Needed to check that tablet actor-based MixedBlobsCount and DeletionMarkersCount counters are in sync with the state of the compaction map

#95 