### PR TITLE
Parallelize migration and shadow disk fill

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -959,4 +959,10 @@ message TStorageServiceConfig
     // Service actor self ping measurement interval. Used to evaluate
     // service actor load. Set in ms.
     optional uint32 ServiceSelfPingInterval = 361;
+
+    // Max migration io depth.
+    optional uint32 MaxMigrationIoDepth = 362;
+
+    // Max shadow disk fill io depth.
+    optional uint32 MaxShadowDiskFillIoDepth = 363;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -387,6 +387,7 @@ TDuration MSeconds(ui32 value)
     xxx(NonReplicatedVolumeMigrationDisabled,      bool,      false           )\
     xxx(MigrationIndexCachingInterval,             ui32,      65536           )\
     xxx(MaxMigrationBandwidth,                     ui32,      100             )\
+    xxx(MaxMigrationIoDepth,                       ui32,      1               )\
     xxx(ExpectedDiskAgentSize,                     ui32,      15              )\
     /* 75 devices = 5 agents */                                                \
     xxx(MaxNonReplicatedDeviceMigrationsInProgress,             ui32,      75 )\
@@ -474,6 +475,7 @@ TDuration MSeconds(ui32 value)
     xxx(VolumeProxyCacheRetryDuration,             TDuration, Seconds(15)     )\
                                                                                \
     xxx(MaxShadowDiskFillBandwidth,                     ui32,      500           )\
+    xxx(MaxShadowDiskFillIoDepth,                       ui32,      1             )\
     xxx(MinAcquireShadowDiskRetryDelayWhenBlocked,      TDuration, MSeconds(250) )\
     xxx(MaxAcquireShadowDiskRetryDelayWhenBlocked,      TDuration, Seconds(1)    )\
     xxx(MinAcquireShadowDiskRetryDelayWhenNonBlocked,   TDuration, Seconds(1)    )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -417,6 +417,7 @@ public:
     bool GetNonReplicatedVolumeMigrationDisabled() const;
     ui32 GetMigrationIndexCachingInterval() const;
     ui32 GetMaxMigrationBandwidth() const;
+    ui32 GetMaxMigrationIoDepth() const;
     ui32 GetExpectedDiskAgentSize() const;
     ui32 GetMaxNonReplicatedDeviceMigrationsInProgress() const;
     ui32 GetMaxNonReplicatedDeviceMigrationPercentageInProgress() const;
@@ -556,6 +557,8 @@ public:
     TString GetCachedDiskAgentSessionsPath() const;
 
     ui32 GetMaxShadowDiskFillBandwidth() const;
+    ui32 GetMaxShadowDiskFillIoDepth() const;
+
     TDuration GetMinAcquireShadowDiskRetryDelayWhenBlocked() const;
     TDuration GetMaxAcquireShadowDiskRetryDelayWhenBlocked() const;
     TDuration GetMinAcquireShadowDiskRetryDelayWhenNonBlocked() const;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
@@ -29,7 +29,7 @@ void TProcessingBlocks::AbortProcessing()
     NextProcessingIndex = 0;
 }
 
-bool TProcessingBlocks::IsProcessingStarted() const
+bool TProcessingBlocks::IsProcessing() const
 {
     return !!BlockMap;
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
@@ -30,7 +30,7 @@ public:
 
 public:
     void AbortProcessing();
-    bool IsProcessingStarted() const;
+    bool IsProcessing() const;
     bool IsProcessed(TBlockRange64 range) const;
     void MarkProcessed(TBlockRange64 range);
     bool SkipProcessedRanges();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks_ut.cpp
@@ -34,25 +34,25 @@ Y_UNIT_TEST_SUITE(TProcessingBlocksTest)
         blocks.MarkProcessed(TBlockRange64::WithLength(0, 1024));
         blocks.SkipProcessedRanges();
 
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         auto range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(1024, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(2047, range.End);
 
         UNIT_ASSERT(blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(2048, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(3071, range.End);
 
         UNIT_ASSERT(blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(3072, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(4095, range.End);
 
         UNIT_ASSERT(!blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(!blocks.IsProcessingStarted());
+        UNIT_ASSERT(!blocks.IsProcessing());
     }
 
     Y_UNIT_TEST(ShouldTestIfRangeProcessed)
@@ -87,37 +87,37 @@ Y_UNIT_TEST_SUITE(TProcessingBlocksTest)
             TBlockRange64::MakeHalfOpenInterval(35048, 1024 * 1024));
         blocks.SkipProcessedRanges();
 
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         auto range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(0, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(1023, range.End);
 
         UNIT_ASSERT(blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(1500, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(2523, range.End);
 
         UNIT_ASSERT(blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(2524, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(3547, range.End);
 
         UNIT_ASSERT(blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(33000, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(34023, range.End);
 
         UNIT_ASSERT(blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(blocks.IsProcessingStarted());
+        UNIT_ASSERT(blocks.IsProcessing());
         range = blocks.BuildProcessingRange();
         UNIT_ASSERT_VALUES_EQUAL(34024, range.Start);
         UNIT_ASSERT_VALUES_EQUAL(35047, range.End);
 
         UNIT_ASSERT(!blocks.AdvanceProcessingIndex());
-        UNIT_ASSERT(!blocks.IsProcessingStarted());
+        UNIT_ASSERT(!blocks.IsProcessing());
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_state.cpp
@@ -33,7 +33,7 @@ TMirrorPartitionResyncState::TMirrorPartitionResyncState(
 
 bool TMirrorPartitionResyncState::IsResynced(TBlockRange64 range) const
 {
-    return ProcessingBlocks.IsProcessingStarted() &&
+    return ProcessingBlocks.IsProcessing() &&
         ProcessingBlocks.IsProcessed(range);
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -35,7 +35,8 @@ TNonreplicatedPartitionMigrationActor::TNonreplicatedPartitionMigrationActor(
           std::move(digestGenerator),
           initialMigrationIndex,
           std::move(rwClientId),
-          statActorId)
+          statActorId,
+          config->GetMaxMigrationIoDepth())
     , Config(std::move(config))
     , SrcConfig(std::move(srcConfig))
     , Migrations(std::move(migrations))
@@ -78,9 +79,10 @@ bool TNonreplicatedPartitionMigrationActor::OnMessage(
     return true;
 }
 
-TDuration TNonreplicatedPartitionMigrationActor::CalculateMigrationTimeout()
+TDuration TNonreplicatedPartitionMigrationActor::CalculateMigrationTimeout(
+    TBlockRange64 range)
 {
-    return TimeoutCalculator.CalculateTimeout(GetNextProcessingRange());
+    return TimeoutCalculator.CalculateTimeout(range);
 }
 
 void TNonreplicatedPartitionMigrationActor::OnMigrationFinished(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -39,7 +39,7 @@ public:
     void OnBootstrap(const NActors::TActorContext& ctx) override;
     bool OnMessage(const NActors::TActorContext& ctx,
         TAutoPtr<NActors::IEventHandle>& ev) override;
-    TDuration CalculateMigrationTimeout() override;
+    TDuration CalculateMigrationTimeout(TBlockRange64 range) override;
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -25,13 +25,15 @@ TNonreplicatedPartitionMigrationCommonActor::
         IBlockDigestGeneratorPtr digestGenerator,
         ui64 initialMigrationIndex,
         TString rwClientId,
-        NActors::TActorId statActorId)
+        NActors::TActorId statActorId,
+        ui32 maxIoDepth)
     : MigrationOwner(migrationOwner)
     , Config(std::move(config))
     , ProfileLog(std::move(profileLog))
     , DiskId(std::move(diskId))
     , BlockSize(blockSize)
     , BlockDigestGenerator(std::move(digestGenerator))
+    , MaxIoDepth(maxIoDepth)
     , RWClientId(std::move(rwClientId))
     , ProcessingBlocks(blockCount, blockSize, initialMigrationIndex)
     , StatActorId(statActorId)
@@ -55,12 +57,6 @@ void TNonreplicatedPartitionMigrationCommonActor::MarkMigratedBlocks(
     TBlockRange64 range)
 {
     ProcessingBlocks.MarkProcessed(range);
-}
-
-TBlockRange64 TNonreplicatedPartitionMigrationCommonActor::
-    GetNextProcessingRange() const
-{
-    return ProcessingBlocks.BuildProcessingRange();
 }
 
 ui64 TNonreplicatedPartitionMigrationCommonActor::

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -43,7 +43,8 @@ public:
         TAutoPtr<NActors::IEventHandle>& ev) = 0;
 
     // Calculates the time during which a 4MB block should migrate.
-    [[nodiscard]] virtual TDuration CalculateMigrationTimeout() = 0;
+    [[nodiscard]] virtual TDuration
+    CalculateMigrationTimeout(TBlockRange64 range) = 0;
 
     // Notifies that a sufficiently large block of data has been migrated. The
     // size is determined by the settings.
@@ -87,22 +88,26 @@ private:
     const TString DiskId;
     const ui64 BlockSize;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
+    const ui32 MaxIoDepth;
     TString RWClientId;
 
     NActors::TActorId SrcActorId;
     NActors::TActorId DstActorId;
 
     TProcessingBlocks ProcessingBlocks;
-    bool MigrationInProgress = false;
-    bool MigrationStarted = false;
+    bool MigrationEnabled = false;
+    bool MigrateRangeScheduled = false;
+    TInstant LastRangeMigrationStartTs;
+    TDuration LastUsedDelay;
+    TMap<ui64, TBlockRange64> MigrationsInProgress;
+    TMap<ui64, TBlockRange64> DeferredMigrations;
+    std::optional<ui64> CachedMigrationProgressAchieved;
 
     TRequestsInProgress<ui64, TBlockRange64> WriteAndZeroRequestsInProgress{
         EAllowedRequests::WriteOnly};
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         DiskId};
-
-    TInstant LastRangeMigrationStartTs = {};
 
     // Statistics
     const NActors::TActorId StatActorId;
@@ -129,7 +134,8 @@ public:
         IBlockDigestGeneratorPtr digestGenerator,
         ui64 initialMigrationIndex,
         TString rwClientId,
-        NActors::TActorId statActorId);
+        NActors::TActorId statActorId,
+        ui32 maxIoDepth);
 
     ~TNonreplicatedPartitionMigrationCommonActor() override;
 
@@ -148,9 +154,6 @@ public:
     // processed.
     void MarkMigratedBlocks(TBlockRange64 range);
 
-    // Called from the inheritor to get the next processing range.
-    TBlockRange64 GetNextProcessingRange() const;
-
     // Called from the inheritor to get the number of blocks that need to be
     // processed.
     ui64 GetBlockCountNeedToBeProcessed() const;
@@ -162,12 +165,22 @@ public:
     }
 
 private:
+    bool IsMigrationAllowed() const;
+    bool IsIoDepthLimitReached() const;
+    bool IsOverlapsWithInflightWriteAndZero(TBlockRange64 range) const;
+
     void ScheduleCountersUpdate(const NActors::TActorContext& ctx);
     void SendStats(const NActors::TActorContext& ctx);
 
-    void ScheduleMigrateNextRange(const NActors::TActorContext& ctx);
-    void MigrateNextRange(const NActors::TActorContext& ctx);
-    void ContinueMigrationIfNeeded(const NActors::TActorContext& ctx);
+    void ScheduleRangeMigration(const NActors::TActorContext& ctx);
+    void StartRangeMigration(const NActors::TActorContext& ctx);
+    bool StartDeferredMigration(const NActors::TActorContext& ctx);
+    void MigrateRange(const NActors::TActorContext& ctx, TBlockRange64 range);
+
+    void NotifyMigrationProgressIfNeeded(
+        const NActors::TActorContext& ctx,
+        TBlockRange64 migratedRange);
+    void NotifyMigrationFinishedIfNeeded(const NActors::TActorContext& ctx);
 
 private:
     STFUNC(StateWork);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -96,11 +96,17 @@ private:
 
     TProcessingBlocks ProcessingBlocks;
     bool MigrationEnabled = false;
-    bool MigrateRangeScheduled = false;
+    bool MigrationRangeScheduled = false;
     TInstant LastRangeMigrationStartTs;
     TDuration LastUsedDelay;
     TMap<ui64, TBlockRange64> MigrationsInProgress;
     TMap<ui64, TBlockRange64> DeferredMigrations;
+
+    // When we migrated a block whose range contains or exceeds a persistently
+    // stored offset of the progress of the entire migration, we remember this
+    // offset and wait for all blocks with addresses less than this offset to
+    // migrate. After that, we save the execution progress persistently by
+    // calling MigrationOwner->OnMigrationProgress().
     std::optional<ui64> CachedMigrationProgressAchieved;
 
     TRequestsInProgress<ui64, TBlockRange64> WriteAndZeroRequestsInProgress{
@@ -167,7 +173,7 @@ public:
 private:
     bool IsMigrationAllowed() const;
     bool IsIoDepthLimitReached() const;
-    bool IsOverlapsWithInflightWriteAndZero(TBlockRange64 range) const;
+    bool OverlapsWithInflightWriteAndZero(TBlockRange64 range) const;
 
     void ScheduleCountersUpdate(const NActors::TActorContext& ctx);
     void SendStats(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -96,9 +96,8 @@ private:
 
     TProcessingBlocks ProcessingBlocks;
     bool MigrationEnabled = false;
-    bool MigrationRangeScheduled = false;
+    bool RangeMigrationScheduled = false;
     TInstant LastRangeMigrationStartTs;
-    TDuration LastUsedDelay;
     TMap<ui64, TBlockRange64> MigrationsInProgress;
     TMap<ui64, TBlockRange64> DeferredMigrations;
 
@@ -175,12 +174,15 @@ private:
     bool IsIoDepthLimitReached() const;
     bool OverlapsWithInflightWriteAndZero(TBlockRange64 range) const;
 
+    std::optional<TBlockRange64> GetNextMigrationRange() const;
+    std::optional<TBlockRange64>
+    TakeNextMigrationRange(const NActors::TActorContext& ctx);
+
     void ScheduleCountersUpdate(const NActors::TActorContext& ctx);
     void SendStats(const NActors::TActorContext& ctx);
 
     void ScheduleRangeMigration(const NActors::TActorContext& ctx);
     void StartRangeMigration(const NActors::TActorContext& ctx);
-    bool StartDeferredMigration(const NActors::TActorContext& ctx);
     void MigrateRange(const NActors::TActorContext& ctx, TBlockRange64 range);
 
     void NotifyMigrationProgressIfNeeded(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -70,7 +70,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
 
     LastRangeMigrationStartTs = ctx.Now();
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
         "[%s] Migrating range: %s",
@@ -236,7 +236,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleRangeMigrated(
     Y_DEBUG_ABORT_UNLESS(erasedCount == 1);
 
     if (HasError(msg->GetError())) {
-        LOG_ERROR(ctx, TBlockStoreComponents::PARTITION,
+        LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
             "[%s] Range migration failed: %s, error: %s",
             DiskId.c_str(),
             DescribeRange(msg->Range).c_str(),
@@ -255,7 +255,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleRangeMigrated(
         return;
     }
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
         "[%s] Range %s migrated",
@@ -341,7 +341,7 @@ void TNonreplicatedPartitionMigrationCommonActor::ScheduleRangeMigration(
         return;
     }
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
         "[%s] Schedule migrating next range after %s",

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -77,13 +77,16 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
     }
 
     // Check overlapping with a range that will be migrated next.
+    // We need to ensure priority for the migration process, otherwise if the
+    // client continuously writes to one block, the migration progress will
+    // stall on this block.
     if (MigrationsInProgress.empty() && !DeferredMigrations.empty()) {
         if (checkOverlapsWithMigration(DeferredMigrations.begin()->second)) {
             return;
         }
     } else if (
         MigrationsInProgress.empty() && IsMigrationAllowed() &&
-        ProcessingBlocks.IsProcessingStarted())
+        ProcessingBlocks.IsProcessing())
     {
         if (checkOverlapsWithMigration(ProcessingBlocks.BuildProcessingRange()))
         {

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -130,7 +130,7 @@ public:
     bool OnMessage(
         const NActors::TActorContext& ctx,
         TAutoPtr<NActors::IEventHandle>& ev) override;
-    TDuration CalculateMigrationTimeout() override;
+    TDuration CalculateMigrationTimeout(TBlockRange64 range) override;
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -392,9 +392,12 @@ void TVolumeActor::SendSelfStatsToService(const TActorContext& ctx)
 
     if (isMigrationIndexValid) {
         simple.MigrationStarted.Set(true);
+        ui64 migratedBlockCount =
+            State->GetBlockCountToMigrate()
+                ? GetBlocksCount() - *State->GetBlockCountToMigrate()
+                : State->GetMeta().GetMigrationIndex();
         simple.MigrationProgress.Set(
-            100 * State->GetMeta().GetMigrationIndex() / GetBlocksCount()
-        );
+            100 * migratedBlockCount / GetBlocksCount());
     }
 
     simple.ResyncStarted.Set(State->IsMirrorResyncNeeded());

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -392,12 +392,9 @@ void TVolumeActor::SendSelfStatsToService(const TActorContext& ctx)
 
     if (isMigrationIndexValid) {
         simple.MigrationStarted.Set(true);
-        ui64 migratedBlockCount =
-            State->GetBlockCountToMigrate()
-                ? GetBlocksCount() - *State->GetBlockCountToMigrate()
-                : State->GetMeta().GetMigrationIndex();
         simple.MigrationProgress.Set(
-            100 * migratedBlockCount / GetBlocksCount());
+            100 * State->GetMeta().GetMigrationIndex() / GetBlocksCount()
+        );
     }
 
     simple.ResyncStarted.Set(State->IsMirrorResyncNeeded());

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1089,10 +1089,15 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
     }
 
     Y_UNIT_TEST(
-        ShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests)
+        ShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests_1)
     {
         DoShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests(
             1);
+    }
+
+    Y_UNIT_TEST(
+        ShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests_8)
+    {
         DoShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests(
             8);
     }
@@ -1323,7 +1328,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         );
         runtime->DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT_VALUES_EQUAL(1, migrationStartedCounter);
-        UNIT_ASSERT_VALUES_EQUAL(60, migrationProgressCounter);
+        UNIT_ASSERT_VALUES_EQUAL(39, migrationProgressCounter);
 
         volume.RebootTablet();
         volume.AddClient(clientInfo);

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/partition_common/events_private.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h>
 
 #include <util/system/hostname.h>
 
@@ -925,11 +926,12 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(0, migratedRanges);
     }
 
-    Y_UNIT_TEST(ShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests)
+    void DoShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests(ui32 ioDepth)
     {
         NProto::TStorageServiceConfig config;
         config.SetAcquireNonReplicatedDevices(true);
         config.SetMaxMigrationBandwidth(999'999'999);
+        config.SetMaxMigrationIoDepth(ioDepth);
         auto state = MakeIntrusive<TDiskRegistryState>();
         auto runtime = PrepareTestActorRuntime(config, state);
 
@@ -1084,6 +1086,15 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         const auto& bufs = resp->Record.GetBlocks().GetBuffers();
         UNIT_ASSERT_VALUES_EQUAL(1, bufs.size());
         UNIT_ASSERT_VALUES_EQUAL(GetBlockContent('a'), bufs[0]);
+    }
+
+    Y_UNIT_TEST(
+        ShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests)
+    {
+        DoShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests(
+            1);
+        DoShouldEnsureMutualExclusionOfIntersectingWritesAndMigrationRequests(
+            8);
     }
 
     Y_UNIT_TEST(ShouldRunMigrationForVolumesWithoutClients)
@@ -1312,7 +1323,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         );
         runtime->DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT_VALUES_EQUAL(1, migrationStartedCounter);
-        UNIT_ASSERT_VALUES_EQUAL(80, migrationProgressCounter);
+        UNIT_ASSERT_VALUES_EQUAL(60, migrationProgressCounter);
 
         volume.RebootTablet();
         volume.AddClient(clientInfo);
@@ -1455,6 +1466,222 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         runtime->DispatchEvents({}, TDuration::MilliSeconds(1));
         UNIT_ASSERT_VALUES_EQUAL(3, migratedRanges);
         UNIT_ASSERT_VALUES_EQUAL(2048, lastMigratedRange.Start);
+    }
+
+    void DoShouldMigrateAllBlocks(ui32 ioDepth, ui32 bandwidth)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetAcquireNonReplicatedDevices(true);
+        config.SetMaxMigrationBandwidth(bandwidth);
+        config.SetMaxMigrationIoDepth(ioDepth);
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(config, state);
+
+        TVolumeClient volume(*runtime);
+
+        const auto blocksPerDevice =
+            DefaultDeviceBlockCount * DefaultDeviceBlockSize / DefaultBlockSize;
+        const auto volumeBlockCount = blocksPerDevice * 2.5;
+        // We will migrate only the first and third devices.
+        const auto migrationRangesPerDevice =
+            blocksPerDevice * DefaultBlockSize / ProcessingRangeSize;
+        const auto rangesToMigrateCount = migrationRangesPerDevice * 2;
+        const auto totalRangesInVolume = migrationRangesPerDevice * 3;
+        auto getDeviceBlocks = [&](ui32 deviceIndex) -> TBlockRange64
+        {
+            return TBlockRange64::WithLength(
+                blocksPerDevice * deviceIndex,
+                blocksPerDevice);
+        };
+        auto getMigrationRangeIndexByBlockStart = [&](ui64 start) -> ui32 {
+            return start * DefaultBlockSize / ProcessingRangeSize;
+        };
+
+        // creating a nonreplicated disk
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            volumeBlockCount);
+
+        volume.WaitReady();
+
+        state->MigrationMode = EMigrationMode::InProgress;
+        TVector<bool> migratedRanges(totalRangesInVolume);
+        ui32 totalMigratedRangesCount = 0;
+
+        auto countMigratedRanges = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TMigratedEvent = TEvNonreplPartitionPrivate::TEvRangeMigrated;
+
+            const auto migratedEvent =
+                TEvNonreplPartitionPrivate::EvRangeMigrated;
+
+            if (event->GetTypeRewrite() == migratedEvent) {
+                auto migratedRange = event->Get<TMigratedEvent>()->Range;
+                migratedRanges[getMigrationRangeIndexByBlockStart(
+                    migratedRange.Start)] = true;
+                ++totalMigratedRangesCount;
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        runtime->SetObserverFunc(countMigratedRanges);
+
+        // reallocating disk
+        volume.ReallocateDisk();
+        volume.ReconnectPipe();
+        volume.WaitReady();
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvDiskRegistry::EvFinishMigrationRequest);
+        runtime->DispatchEvents(options);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            rangesToMigrateCount,
+            totalMigratedRangesCount);
+
+        // Check that all blocks of the first and third device have been
+        // migrated.
+        auto checkAllBlockOfDeviceMigrated = [&](ui32 deviceIndex)
+        {
+            auto deviceBlocks = getDeviceBlocks(deviceIndex);
+            ui32 start = getMigrationRangeIndexByBlockStart(deviceBlocks.Start);
+            ui32 end = start + migrationRangesPerDevice;
+            for (ui32 i = start; i != end; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    true,
+                    migratedRanges[i],
+                    TString("Range #") + i + " should be migrated");
+            }
+        };
+        checkAllBlockOfDeviceMigrated(0);
+        checkAllBlockOfDeviceMigrated(2);
+    }
+
+    Y_UNIT_TEST(ShouldMigrateWithDifferentioDepth)
+    {
+        DoShouldMigrateAllBlocks(1, 80);
+        DoShouldMigrateAllBlocks(8, 80);
+        DoShouldMigrateAllBlocks(16, 80);
+
+        DoShouldMigrateAllBlocks(1, 1000000);
+        DoShouldMigrateAllBlocks(8, 1000000);
+        DoShouldMigrateAllBlocks(16, 1000000);
+    }
+
+    void DoShouldMigrateWhenErrorHappens(ui32 ioDepth, ui32 bandwidth)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetAcquireNonReplicatedDevices(true);
+        config.SetMaxMigrationBandwidth(bandwidth);
+        config.SetMaxMigrationIoDepth(ioDepth);
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(config, state);
+
+        TVolumeClient volume(*runtime);
+
+        const auto blocksPerDevice =
+            DefaultDeviceBlockCount * DefaultDeviceBlockSize / DefaultBlockSize;
+        const auto volumeBlockCount = blocksPerDevice * 2.5;
+        // We will migrate only the first and third devices.
+        const auto migrationRangesPerDevice =
+            blocksPerDevice * DefaultBlockSize / ProcessingRangeSize;
+        const auto totalRangesInVolume = migrationRangesPerDevice * 3;
+        auto getDeviceBlocks = [&](ui32 deviceIndex) -> TBlockRange64
+        {
+            return TBlockRange64::WithLength(
+                blocksPerDevice * deviceIndex,
+                blocksPerDevice);
+        };
+        auto getMigrationRangeIndexByBlockStart = [&](ui64 start) -> ui32 {
+            return start * DefaultBlockSize / ProcessingRangeSize;
+        };
+
+        // creating a nonreplicated disk
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            volumeBlockCount);
+
+        volume.WaitReady();
+
+        state->MigrationMode = EMigrationMode::InProgress;
+        TVector<bool> migratedRanges(totalRangesInVolume);
+        ui32 failOnMigratedRangeWithIndex = 0;
+
+        auto countMigratedRanges = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TMigratedEvent = TEvNonreplPartitionPrivate::TEvRangeMigrated;
+
+            const auto migratedEvent =
+                TEvNonreplPartitionPrivate::EvRangeMigrated;
+
+            if (event->GetTypeRewrite() == migratedEvent) {
+                auto* msg = event->Get<TMigratedEvent>();
+                auto migratedRangeIndex =
+                    getMigrationRangeIndexByBlockStart(msg->Range.Start);
+                if (migratedRangeIndex == failOnMigratedRangeWithIndex) {
+                    failOnMigratedRangeWithIndex += 3;
+                    const_cast<NProto::TError&>(msg->Error).SetCode(E_REJECTED);
+                } else {
+                    migratedRanges[migratedRangeIndex] = true;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        runtime->SetObserverFunc(countMigratedRanges);
+
+        // reallocating disk
+        volume.ReallocateDisk();
+        volume.ReconnectPipe();
+        volume.WaitReady();
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvDiskRegistry::EvFinishMigrationRequest);
+        runtime->DispatchEvents(options);
+
+        // Check that all blocks of the first and third device have been
+        // migrated.
+        auto checkAllBlockOfDeviceMigrated = [&](ui32 deviceIndex)
+        {
+            auto deviceBlocks = getDeviceBlocks(deviceIndex);
+            ui32 start = getMigrationRangeIndexByBlockStart(deviceBlocks.Start);
+            ui32 end = start + migrationRangesPerDevice;
+            for (ui32 i = start; i != end; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    true,
+                    migratedRanges[i],
+                    TString("Range #") + i + " should be migrated");
+            }
+        };
+        checkAllBlockOfDeviceMigrated(0);
+        checkAllBlockOfDeviceMigrated(2);
+    }
+
+    Y_UNIT_TEST(ShouldMigrateWhenErrorHappens)
+    {
+        DoShouldMigrateWhenErrorHappens(1, 80);
+        DoShouldMigrateWhenErrorHappens(8, 80);
+        DoShouldMigrateWhenErrorHappens(16, 80);
+
+        DoShouldMigrateWhenErrorHappens(1, 1000000);
+        DoShouldMigrateWhenErrorHappens(8, 1000000);
+        DoShouldMigrateWhenErrorHappens(16, 1000000);
     }
 
     Y_UNIT_TEST(ShouldRegularlyReacquireNonreplicatedDisks)
@@ -2508,6 +2735,8 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         TVolumeClient volume(*runtime);
 
         state->ReplicaCount = 1;
+        const ui64 volumeBlockCount = 1024;
+        const ui64 migratedBlockCount = 512;
 
         volume.UpdateVolumeConfig(
             0,
@@ -2517,7 +2746,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             false,
             1,
             NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2,
-            1024
+            volumeBlockCount
         );
 
         volume.WaitReady();
@@ -2537,8 +2766,9 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             }
         );
 
-        volume.SendToPipe(
-            std::make_unique<TEvVolume::TEvUpdateMigrationState>(512, 1024));
+        volume.SendToPipe(std::make_unique<TEvVolume::TEvUpdateMigrationState>(
+            migratedBlockCount,
+            volumeBlockCount - migratedBlockCount));
         runtime->DispatchEvents({}, TDuration::Seconds(1));
 
         volume.SendToPipe(
@@ -2553,8 +2783,9 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         volume.ReconnectPipe();
         volume.WaitReady();
 
-        volume.SendToPipe(
-            std::make_unique<TEvVolume::TEvUpdateMigrationState>(512, 1024));
+        volume.SendToPipe(std::make_unique<TEvVolume::TEvUpdateMigrationState>(
+            migratedBlockCount,
+            volumeBlockCount - migratedBlockCount));
         runtime->DispatchEvents({}, TDuration::Seconds(1));
 
         volume.SendToPipe(

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -3304,10 +3304,12 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
     }
 
     void DoShouldCreateCheckpointWithShadowDisk(
-        NProto::EStorageMediaKind mediaKind)
+        NProto::EStorageMediaKind mediaKind,
+        ui32 ioDepth)
     {
         NProto::TStorageServiceConfig config;
         config.SetUseShadowDisksForNonreplDiskCheckpoints(true);
+        config.SetMaxShadowDiskFillIoDepth(ioDepth);
         auto runtime = PrepareTestActorRuntime(config);
 
         int allocateRequestCount = 0;
@@ -3521,25 +3523,42 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
     Y_UNIT_TEST(ShouldCreateCheckpointWithShadowDiskNonrepl)
     {
         DoShouldCreateCheckpointWithShadowDisk(
-            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            1);
+        DoShouldCreateCheckpointWithShadowDisk(
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            8);
     }
 
     Y_UNIT_TEST(ShouldCreateCheckpointWithShadowDiskMirror2)
     {
         DoShouldCreateCheckpointWithShadowDisk(
-            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2);
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2,
+            1);
+        DoShouldCreateCheckpointWithShadowDisk(
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2,
+            8);
     }
 
     Y_UNIT_TEST(ShouldCreateCheckpointWithShadowDiskMirror3)
     {
         DoShouldCreateCheckpointWithShadowDisk(
-            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3);
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3,
+            1);
+
+        DoShouldCreateCheckpointWithShadowDisk(
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3,
+            8);
     }
 
     Y_UNIT_TEST(ShouldCreateCheckpointWithShadowDiskHddNonrepl)
     {
         DoShouldCreateCheckpointWithShadowDisk(
-            NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED);
+            NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED,
+            1);
+        DoShouldCreateCheckpointWithShadowDisk(
+            NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED,
+            8);
     }
 
     void ShouldRetryWhenAcquiringShadowDisk(ui32 responseMessage)


### PR DESCRIPTION
Столкнулись с тем что попыки увеличения скорости миграции и наливки теневых дисков ничего не дают. Скорость не поднимается выше 150 МБ/с.
Скорее всего упираемся в то что делаем все в один поток.
В этом ПР добавляю настройку, которой можно управлять количеством одновременно выполняемых запросов миграции.