### PR TITLE
Removed assert on metrics without sensor label (prometheus format)

### DIFF
--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder.cpp
@@ -368,9 +368,9 @@ namespace NMonitoring {
                 }
 
                 TMaybe<TLabel> nameLabel = MetricState_.Labels.Extract(MetricNameLabel_);
-                Y_ENSURE(nameLabel,
-                         "labels " << MetricState_.Labels <<
-                         " does not contain label '" << MetricNameLabel_ << '\'');
+                if (!nameLabel) {
+                    return;
+                }
 
                 const TString& metricName = ToString(nameLabel->Value());
                 if (MetricState_.Type != EMetricType::DSUMMARY) {

--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
@@ -496,4 +496,22 @@ _99_9 99.9
 
 )");
     }
+
+    Y_UNIT_TEST(ShouldNotFailOnMetricWithoutSensorLabel) {
+        auto result = EncodeToString([](IMetricEncoder* e) {
+            e->OnStreamBegin();
+            e->OnStreamEnd();
+            { // no values
+                e->OnMetricBegin(EMetricType::GAUGE);
+                {
+                    e->OnLabelsBegin();
+                    e->OnLabel("name", "cpuUsage");
+                    e->OnLabelsEnd();
+                }
+                e->OnInt64(TInstant::Zero(), 0);
+                e->OnMetricEnd();
+            }
+        });
+        UNIT_ASSERT_STRINGS_EQUAL(result, "\n");
+    }
 }

--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
@@ -412,8 +412,7 @@ two{labels="l2", project="solomon", } 42 1500000000000
 )");
     }
 
-    Y_UNIT_TEST(FirstCharacterShouldNotBeReplaced) 
-    {
+    Y_UNIT_TEST(FirstCharacterShouldNotBeReplaced) {
         auto result = EncodeToString([](IMetricEncoder* e) {
             e->OnStreamBegin();
             const TVector<std::pair<TString, double>> sensors = {
@@ -461,8 +460,7 @@ _0123abc 123
 )");
     }
 
-    Y_UNIT_TEST(InvalidCharactersShouldBeReplaced)
-    {
+    Y_UNIT_TEST(InvalidCharactersShouldBeReplaced) {
         auto result = EncodeToString([](IMetricEncoder* e) {
             e->OnStreamBegin();
             const TVector<std::pair<TString, double>> sensors = {


### PR DESCRIPTION
### Problem
If metric has no "sensor" label the assert is triggered causing crash. 

### Solution
This has been already fixed in ydb repo: https://github.com/ydb-platform/ydb/commit/d7c2d188d2464ce858465870a39220c4dfbb5509 Applying the same in NBS