### PR TITLE
[stable-23-3][Backport] Make interconnect proxy retry timeout parameters configurable

### DIFF
--- a/library/cpp/actors/interconnect/interconnect_common.h
+++ b/library/cpp/actors/interconnect/interconnect_common.h
@@ -51,6 +51,9 @@ namespace NActors {
         bool EnableExternalDataChannel = false;
         bool ValidateIncomingPeerViaDirectLookup = false;
         ui32 SocketBacklogSize = 0; // SOMAXCONN if zero
+        TDuration FirstErrorSleep = TDuration::MilliSeconds(10);
+        TDuration MaxErrorSleep = TDuration::Seconds(1);
+        double ErrorSleepRetryMultiplier = 4.0;
 
         ui32 GetSendBufferSize() const {
             ui32 res = 512 * 1024; // 512 kb is the default value for send buffer

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -581,6 +581,16 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
     }
     result.SocketBacklogSize = config.GetSocketBacklogSize();
 
+    if (config.HasFirstErrorSleep()) {
+        result.FirstErrorSleep = DurationFromProto(config.GetFirstErrorSleep());
+    }
+    if (config.HasMaxErrorSleep()) {
+        result.MaxErrorSleep = DurationFromProto(config.GetMaxErrorSleep());
+    }
+    if (config.HasErrorSleepRetryMultiplier()) {
+        result.ErrorSleepRetryMultiplier = config.GetErrorSleepRetryMultiplier();
+    }
+
     return result;
 }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -462,6 +462,10 @@ message TInterconnectConfig {
     optional NKikimrConfigUnits.TDuration LostConnectionDuration = 28;
     optional NKikimrConfigUnits.TDuration BatchPeriodDuration = 29;
 
+    optional NKikimrConfigUnits.TDuration FirstErrorSleep = 46;
+    optional NKikimrConfigUnits.TDuration MaxErrorSleep = 47;
+    optional double ErrorSleepRetryMultiplier = 48;
+
     optional uint32 OutgoingHandshakeInflightLimit = 43;
 }
 


### PR DESCRIPTION
Бекпорт изменений в YDB: https://github.com/ydb-platform/ydb/pull/3748

Самое важное изменение для нас - снижение максимального времени "сна" интерконнекта с 10 до 1 секунды.
Логика там примерно следующая:

Пытаемся отправить сообщение на ноду которая лежит
Интерконнект пытается установить соединение, но у него не получается
Впадает в "сон" на 10мс.
Во сне любые сообщение до ноды не пытаются отправляться и происходит синхроный undelivery.
Интерконнект просыпается, ждёт посылку сообщения
Повторяем отправку сообщения
Соединение опять не установлено, теперь спим уже 40мс
и т.д.

До этой правки, из-за backoff коэффициента в 4, мы довольно быстро дорастали до 10 секунд. При рестартах диск агента, это означало, что если он не поднимется достаточно быстро, мы попадём в этот десятисекудный сон. Но что ещё хуже, партишн подумаеет что DA всё еще недоступен и свой backoff на перезапрос тоже умножит на 2.