### PR TITLE
small trace processor refactoring

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -278,3 +278,4 @@ WhitespaceSensitiveMacros:
   - PP_STRINGIZE
   - STRINGIZE
 ...
+

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -87,7 +87,8 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
-#include <cloud/storage/core/libs/diagnostics/trace_reader.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor_mon.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor.h>
 #include <cloud/storage/core/libs/diagnostics/trace_serializer.h>
 #include <cloud/storage/core/libs/grpc/logging.h>
 #include <cloud/storage/core/libs/grpc/threadpool.h>
@@ -238,14 +239,15 @@ void TBootstrapBase::Init()
 
     auto diagnosticsConfig = Configs->DiagnosticsConfig;
     if (TraceReaders.size()) {
-        TraceProcessor = CreateTraceProcessor(
-            Timer,
-            BackgroundScheduler,
-            Logging,
+        TraceProcessor = CreateTraceProcessorMon(
             Monitoring,
-            "BLOCKSTORE_TRACE",
-            NLwTraceMonPage::TraceManager(diagnosticsConfig->GetUnsafeLWTrace()),
-            TraceReaders);
+            CreateTraceProcessor(
+                Timer,
+                BackgroundScheduler,
+                Logging,
+                "BLOCKSTORE_TRACE",
+                NLwTraceMonPage::TraceManager(diagnosticsConfig->GetUnsafeLWTrace()),
+                TraceReaders));
 
         STORAGE_INFO("TraceProcessor initialized");
     }

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -40,7 +40,8 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
-#include <cloud/storage/core/libs/diagnostics/trace_reader.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor_mon.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor.h>
 #include <cloud/storage/core/libs/diagnostics/trace_serializer.h>
 #include <cloud/storage/core/libs/features/features_config.h>
 #include <cloud/storage/core/libs/kikimr/actorsystem.h>
@@ -212,14 +213,15 @@ void TBootstrap::Init()
 
     auto diagnosticsConfig = Configs->DiagnosticsConfig;
     if (TraceReaders.size()) {
-        TraceProcessor = CreateTraceProcessor(
-            Timer,
-            Scheduler,
-            Logging,
+        TraceProcessor = CreateTraceProcessorMon(
             Monitoring,
-            "BLOCKSTORE_TRACE",
-            NLwTraceMonPage::TraceManager(diagnosticsConfig->GetUnsafeLWTrace()),
-            TraceReaders);
+            CreateTraceProcessor(
+                Timer,
+                Scheduler,
+                Logging,
+                "BLOCKSTORE_TRACE",
+                NLwTraceMonPage::TraceManager(diagnosticsConfig->GetUnsafeLWTrace()),
+                TraceReaders));
 
         STORAGE_INFO("TraceProcessor initialized");
     }

--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -17,6 +17,8 @@
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor_mon.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor.h>
 #include <cloud/storage/core/libs/diagnostics/trace_reader.h>
 
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
@@ -122,14 +124,15 @@ void TBootstrap::InitTracing()
     }
 
     if (traceReaders) {
-        TraceProcessor = CreateTraceProcessor(
-            Timer,
-            Scheduler,
-            Logging,
+        TraceProcessor = CreateTraceProcessorMon(
             Monitoring,
-            "BLOCKSTORE_TRACE",
-            traceManager,
-            std::move(traceReaders));
+            CreateTraceProcessor(
+                Timer,
+                Scheduler,
+                Logging,
+                "BLOCKSTORE_TRACE",
+                traceManager,
+                std::move(traceReaders)));
     }
 }
 

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -21,7 +21,8 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
-#include <cloud/storage/core/libs/diagnostics/trace_reader.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor_mon.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor.h>
 #include <cloud/storage/core/libs/kikimr/actorsystem.h>
 #include <cloud/storage/core/libs/kikimr/node.h>
 #include <cloud/storage/core/libs/kikimr/proxy.h>
@@ -379,14 +380,15 @@ void TBootstrapCommon::InitLWTrace(
     }
 
     if (traceReaders.size()) {
-        TraceProcessor = CreateTraceProcessor(
-            Timer,
-            BackgroundScheduler,
-            Logging,
+        TraceProcessor = CreateTraceProcessorMon(
             Monitoring,
-            "NFS_TRACE",
-            NLwTraceMonPage::TraceManager(false),
-            std::move(traceReaders));
+            CreateTraceProcessor(
+                Timer,
+                BackgroundScheduler,
+                Logging,
+                "NFS_TRACE",
+                NLwTraceMonPage::TraceManager(false),
+                std::move(traceReaders)));
 
         STORAGE_INFO("TraceProcessor initialized");
     } else {

--- a/cloud/storage/core/libs/diagnostics/trace_processor.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor.cpp
@@ -1,0 +1,143 @@
+#include "trace_processor.h"
+
+#include "trace_reader.h"
+
+#include <cloud/storage/core/libs/common/scheduler.h>
+#include <cloud/storage/core/libs/common/timer.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/lwtrace/control.h>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTraceProcessor
+    : public ITraceProcessor
+    , public std::enable_shared_from_this<TTraceProcessor>
+{
+private:
+    const ITimerPtr Timer;
+    const ISchedulerPtr Scheduler;
+    const ILoggingServicePtr Logging;
+    const TString ComponentName;
+    NLWTrace::TManager& LWManager;
+    TVector<ITraceReaderPtr> Readers;
+
+    TLog Log;
+    TAtomic ShouldStop = 0;
+
+public:
+    TTraceProcessor(
+        ITimerPtr timer,
+        ISchedulerPtr scheduler,
+        ILoggingServicePtr logging,
+        TString componentName,
+        NLWTrace::TManager& lwManager,
+        TVector<ITraceReaderPtr> readers)
+        : Timer(std::move(timer))
+        , Scheduler(std::move(scheduler))
+        , Logging(std::move(logging))
+        , ComponentName(std::move(componentName))
+        , LWManager(lwManager)
+        , Readers(std::move(readers))
+    {}
+
+    void Start() override
+    {
+        Log = Logging->CreateLog(ComponentName);
+        ScheduleProcessLWDepot();
+    }
+
+    void Stop() override
+    {
+        AtomicSet(ShouldStop, 1);
+    }
+
+    void ForEach(std::function<void(ITraceReaderPtr)> fn) override
+    {
+        for (ITraceReaderPtr& keeper: Readers) {
+            fn(keeper);
+        }
+    }
+
+private:
+    void ScheduleProcessLWDepot()
+    {
+        if (AtomicGet(ShouldStop)) {
+            return;
+        }
+
+        auto weak_ptr = weak_from_this();
+
+        Scheduler->Schedule(
+            Timer->Now() + DumpTracksInterval,
+            [weak_ptr = std::move(weak_ptr)]
+            {
+                if (auto p = weak_ptr.lock()) {
+                    p->ProcessLWDepot();
+                    p->ScheduleProcessLWDepot();
+                }
+            });
+    }
+
+    void ProcessLWDepot()
+    {
+        for (auto& reader: Readers) {
+            try {
+                reader->Reset();
+                LWManager.ExtractItemsFromCyclicDepot(reader->Id, *reader);
+            } catch (...) {
+                STORAGE_ERROR("Tracing error: " << CurrentExceptionMessage());
+                Y_DEBUG_ABORT_UNLESS(0);
+            }
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTraceProcessorStub final
+    : public ITraceProcessor
+{
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
+    void ForEach(std::function<void(ITraceReaderPtr)> fn) override
+    {
+        Y_UNUSED(fn);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceProcessorPtr CreateTraceProcessor(
+    ITimerPtr timer,
+    ISchedulerPtr scheduler,
+    ILoggingServicePtr logging,
+    TString componentName,
+    NLWTrace::TManager& lwManager,
+    TVector<ITraceReaderPtr> readers)
+{
+    return std::make_shared<TTraceProcessor>(
+        std::move(timer),
+        std::move(scheduler),
+        std::move(logging),
+        std::move(componentName),
+        lwManager,
+        std::move(readers));
+}
+
+ITraceProcessorPtr CreateTraceProcessorStub()
+{
+    return std::make_shared<TTraceProcessorStub>();
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/trace_processor.h
+++ b/cloud/storage/core/libs/diagnostics/trace_processor.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/startable.h>
+
+#include <util/generic/function.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+namespace NLWTrace {
+class TManager;
+}   // namespace NLWTrace
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ITraceProcessor
+    : public IStartable
+{
+    virtual ~ITraceProcessor() = default;
+
+    virtual void ForEach(std::function<void(ITraceReaderPtr)> fn) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceProcessorPtr CreateTraceProcessor(
+    ITimerPtr timer,
+    ISchedulerPtr scheduler,
+    ILoggingServicePtr logging,
+    TString componentName,
+    NLWTrace::TManager& lwManager,
+    TVector<ITraceReaderPtr> keepers);
+
+ITraceProcessorPtr CreateTraceProcessorStub();
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon.cpp
@@ -1,0 +1,353 @@
+#include "trace_processor_mon.h"
+
+#include "trace_processor.h"
+#include "trace_reader.h"
+
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
+
+#include <library/cpp/json/writer/json.h>
+#include <library/cpp/monlib/service/pages/html_mon_page.h>
+#include <library/cpp/monlib/service/pages/index_mon_page.h>
+#include <library/cpp/monlib/service/pages/templates.h>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TTraceKey = std::pair<TStringBuf, TStringBuf>;
+using TTraceLog = std::pair<TStringBuf, TEntry>;
+
+const TStringBuf slowName = "slow";
+const TStringBuf randomName = "random";
+const TStringBuf jsonName = "json";
+
+const TTraceKey TRACE_TYPE_SLOW{slowName, "st_slow_requests_filter"};
+const TTraceKey TRACE_TYPE_RANDOM{randomName, "st_trace_logger"};
+
+using namespace NMonitoring;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void SerializeTraceToJson(
+    const NLWTrace::TTrackLog& tl,
+    ui64 minSeenTimestamp,
+    const TString& tag,
+    NJsonWriter::TBuf& writer)
+{
+    TString paramValues[LWTRACE_MAX_PARAMS];
+
+    writer.BeginList();
+    for (const auto& item: tl.Items) {
+        if (!item.Probe) {
+            // NBS-492#5d45b57d701665001d0e946e
+            continue;
+        }
+
+        const auto spanLength =
+            CyclesToDurationSafe(item.TimestampCycles - minSeenTimestamp);
+
+        item.Probe->Event.Signature.SerializeParams(
+            item.Params,
+            paramValues);
+
+        writer.BeginList();
+        {
+            writer.WriteString(item.Probe->Event.Name);
+            writer.WriteULongLong(spanLength.MicroSeconds());
+            for (size_t i = 0; i < item.SavedParamsCount; ++i) {
+                writer.WriteString(paramValues[i]);
+            }
+        }
+        writer.EndList();
+    }
+    writer.BeginList();
+    writer.WriteString(tag);
+    writer.EndList();
+    writer.EndList();
+}
+
+TString SerializeTraceToString(
+    const NLWTrace::TTrackLog& tl,
+    ui64 minSeenTimestamp,
+    const TString& tag)
+{
+    TStringStream ss;
+    NJsonWriter::TBuf writer(NJsonWriter::HEM_UNSAFE, &ss);
+
+    SerializeTraceToJson(tl, minSeenTimestamp, tag, writer);
+
+    return ss.Str();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+const NLWTrace::TParam* FindParam(
+    const NLWTrace::TLogItem& logItem,
+    const TStringBuf name)
+{
+    if (const auto* probe = logItem.Probe) {
+        for (ui32 i = 0; i < probe->Event.Signature.ParamCount; ++i) {
+            if (probe->Event.Signature.ParamNames[i] == name) {
+                return &logItem.Params.Param[i];
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+template <typename TResult>
+    requires std::is_default_constructible_v<TResult>
+TResult GetIdParam(const NLWTrace::TTrackLog::TItem& ringItem)
+{
+    if (const auto* diskId = FindParam(ringItem, NProbeParam::DiskId); diskId) {
+        return diskId->Get<TResult>();
+    }
+
+    if (const auto* fsId = FindParam(ringItem, NProbeParam::FsId); fsId) {
+        return fsId->Get<TResult>();
+    }
+
+    return TResult{};
+}
+
+template <typename TResult>
+    requires std::is_default_constructible_v<TResult>
+TResult GetIdParam(const TCgiParameters& cgiParams)
+{
+    if (auto diskId = cgiParams.Get(NProbeParam::DiskId); !diskId.empty()) {
+        return diskId;
+    }
+
+    if (auto fsId = cgiParams.Get(NProbeParam::FsId); !fsId.empty()) {
+        return fsId;
+    }
+
+    return TResult{};
+}
+
+void DisplayJsonErrorMessage(IOutputStream& out, const TString& message)
+{
+    out << "HTTP/1.1 400 Invalid Request\r\n"
+           "Content-Type: application/json\r\n"
+           "Connection: Close\r\n\r\n";
+    out << "{\"status\": \"error\", \"message\": \"" << message << "\"}";
+}
+
+bool ReaderIdMatch(const TString& traceType, const TString& readerId)
+{
+    const TTraceKey key{traceType, readerId};
+    return traceType.empty() ||
+        key == TRACE_TYPE_SLOW ||
+        key == TRACE_TYPE_RANDOM;
+}
+
+TVector<TTraceLog> PrepareTraceLogDump(
+    ITraceProcessorPtr processor,
+    const TString& traceType,
+    const TString& id)
+{
+    TVector<TTraceLog> traceLogDump;
+
+    processor->ForEach(
+        [&traceType, &id, &traceLogDump](ITraceReaderPtr reader)
+        {
+            const auto& readerId = reader->Id;
+
+            if (traceType && !ReaderIdMatch(traceType, readerId)) {
+                return;
+            }
+
+            reader->ForEach(
+                [&traceLogDump, &id, &readerId](const TEntry& item)
+                {
+                    const auto traceId =
+                        GetIdParam<TString>(item.TrackLog.Items.front());
+
+                    if (!traceId.empty() && (id.empty() || traceId == id)) {
+                        traceLogDump.emplace_back(readerId, item);
+                    }
+                });
+        });
+
+    return traceLogDump;
+}
+
+
+void DumpTraceLogHtml(
+    IOutputStream& out,
+    const TVector<TTraceLog>& traceLogDump)
+{
+    HTML(out) {
+        TABLE_SORTABLE() {
+            TABLEHEAD() {
+                TABLER() {
+                    TABLED() { out << "Date"; }
+                    TABLED() { out << "Id"; }
+                    TABLED() { out << "Trace"; }
+                    TABLED() { out << "Actions"; }
+                }
+            }
+            TABLEBODY() {
+                for (auto& [requestId, entry]: traceLogDump) {
+                    TABLER() {
+                        TABLED() { out << entry.Ts.ToStringLocalUpToSeconds(); }
+                        TABLED() { out << requestId; }
+                        TABLED() { out << SerializeTraceToString(entry.TrackLog, entry.Date, entry.Tag); }
+                        TABLED() { out << ""; }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void DumpTraceLogJson(
+    IOutputStream& out,
+    const TVector<TTraceLog>& traceLogDump)
+{
+    TStringStream ss;
+    NJsonWriter::TBuf writer(NJsonWriter::HEM_UNSAFE, &ss);
+
+    writer.BeginList();
+    for (const auto& [requestId, entry]: traceLogDump) {
+        writer.BeginList();
+        writer.WriteString(entry.Ts.ToStringLocalUpToSeconds());
+        writer.WriteString(requestId);
+        SerializeTraceToJson(entry.TrackLog, entry.Date, entry.Tag, writer);
+        writer.EndList();
+    }
+    writer.EndList();
+
+    out << ss.Str();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTraceProcessorMon
+    : public ITraceProcessor
+{
+private:
+    class TMonPageHtml final
+        : public THtmlMonPage
+    {
+    private:
+        TTraceProcessorMon& TraceProcessor;
+        const TString TraceType;
+
+    public:
+        TMonPageHtml(
+                TTraceProcessorMon& traceProcessor,
+                const TString& traceType,
+                const TString& traceName)
+            : THtmlMonPage(traceType, traceName, true)
+            , TraceProcessor(traceProcessor)
+            , TraceType(traceType)
+        {}
+
+        void OutputContent(IMonHttpRequest& request) override
+        {
+            TraceProcessor.OutputHtml(request.Output(), request, TraceType);
+        }
+    };
+
+    class TMonPageJson final
+        : public IMonPage
+    {
+    public:
+        TTraceProcessorMon& TraceProcessor;
+
+        TMonPageJson(TTraceProcessorMon& traceProcessor, const TString& path)
+            : IMonPage(path)
+            , TraceProcessor(traceProcessor)
+        {}
+
+        void Output(IMonHttpRequest& request) override
+        {
+            return TraceProcessor.OutputJson(request.Output(), request);
+        }
+    };
+
+private:
+    ITraceProcessorPtr Impl;
+
+public:
+    TTraceProcessorMon(
+            IMonitoringServicePtr monitoring,
+            ITraceProcessorPtr impl)
+        : Impl(std::move(impl))
+    {
+        auto rootPage =
+            monitoring->RegisterIndexPage("tracelogs", "Traces Logs");
+        auto& index = static_cast<TIndexMonPage&>(*rootPage);
+        index.Register(
+            new TMonPageHtml(*this, randomName.Data(), "Random samples"));
+        index.Register(
+            new TMonPageHtml(*this, slowName.Data(), "Slow samples"));
+        index.Register(new TMonPageJson(*this, jsonName.Data()));
+    }
+
+    void Start() override
+    {
+        return Impl->Start();
+    }
+
+    void Stop() override
+    {
+        return Impl->Stop();
+    }
+
+    void ForEach(std::function<void(ITraceReaderPtr)> fn) override
+    {
+        return Impl->ForEach(std::move(fn));
+    }
+
+    void OutputHtml(
+        IOutputStream& out,
+        IMonHttpRequest& request,
+        const TString& traceType)
+    {
+        const auto traceLogDump = PrepareTraceLogDump(
+            Impl,
+            traceType,
+            GetIdParam<TString>(request.GetParams()));
+        DumpTraceLogHtml(out, traceLogDump);
+    }
+
+    void OutputJson(IOutputStream& out, IMonHttpRequest& request)
+    {
+        const TString traceType = request.GetParams().Get("traceType");
+        if (slowName != traceType && randomName != traceType &&
+            !traceType.empty())
+        {
+            DisplayJsonErrorMessage(
+                out,
+                "Invalid traceType set '" + traceType + "'");
+        }
+
+        const auto traceLogDump = PrepareTraceLogDump(
+            Impl,
+            traceType,
+            GetIdParam<TString>(request.GetParams()));
+
+        out << HTTPOKJSON;
+        DumpTraceLogJson(out, traceLogDump);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceProcessorPtr CreateTraceProcessorMon(
+    IMonitoringServicePtr monitoring,
+    ITraceProcessorPtr impl)
+{
+    return std::make_shared<TTraceProcessorMon>(
+        std::move(monitoring),
+        std::move(impl));
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon.h
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "public.h"
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceProcessorPtr CreateTraceProcessorMon(
+    IMonitoringServicePtr monitoring,
+    ITraceProcessorPtr impl);
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
@@ -1,3 +1,5 @@
+#include "trace_processor_mon.h"
+#include "trace_processor.h"
 #include "trace_reader.h"
 
 #include <cloud/storage/core/protos/media.pb.h>
@@ -5,6 +7,7 @@
 #include <cloud/storage/core/libs/common/scheduler_test.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/logger/backend.h>
@@ -115,14 +118,15 @@ struct TEnv
                 "STORAGE_TRACE",
                 requestThresholds
         )};
-        return NCloud::CreateTraceProcessor(
-            Timer,
-            Scheduler,
-            logging,
+        return NCloud::CreateTraceProcessorMon(
             monitoring,
-            "STORAGE_TRACE",
-            *LWManager,
-            std::move(readers)
+            NCloud::CreateTraceProcessor(
+                Timer,
+                Scheduler,
+                logging,
+                "STORAGE_TRACE",
+                *LWManager,
+                std::move(readers))
         );
     }
 };

--- a/cloud/storage/core/libs/diagnostics/ut/ya.make
+++ b/cloud/storage/core/libs/diagnostics/ut/ya.make
@@ -17,7 +17,7 @@ SRCS(
     postpone_time_predictor_ut.cpp
     request_counters_ut.cpp
     solomon_counters_ut.cpp
-    trace_processor_ut.cpp
+    trace_processor_mon_ut.cpp
     trace_serializer_ut.cpp
     weighted_percentile_ut.cpp
 )

--- a/cloud/storage/core/libs/diagnostics/ya.make
+++ b/cloud/storage/core/libs/diagnostics/ya.make
@@ -16,6 +16,8 @@ SRCS(
     request_counters.cpp
     solomon_counters.cpp
     stats_updater.cpp
+    trace_processor_mon.cpp
+    trace_processor.cpp
     trace_reader.cpp
     trace_serializer.cpp
     weighted_percentile.cpp

--- a/cloud/vm/blockstore/bootstrap.cpp
+++ b/cloud/vm/blockstore/bootstrap.cpp
@@ -25,7 +25,8 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
-#include <cloud/storage/core/libs/diagnostics/trace_reader.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor_mon.h>
+#include <cloud/storage/core/libs/diagnostics/trace_processor.h>
 #include <cloud/storage/core/libs/grpc/logging.h>
 #include <cloud/storage/core/libs/grpc/threadpool.h>
 #include <cloud/storage/core/libs/grpc/utils.h>
@@ -139,14 +140,15 @@ void TBootstrap::Init()
     }
 
     if (TraceReaders.size()) {
-        TraceProcessor = CreateTraceProcessor(
-            Timer,
-            Scheduler,
-            Logging,
+        TraceProcessor = CreateTraceProcessorMon(
             Monitoring,
-            "BLOCKSTORE_TRACE",
-            TLWTraceSafeManager::Instance(),
-            TraceReaders);
+            CreateTraceProcessor(
+                Timer,
+                Scheduler,
+                Logging,
+                "BLOCKSTORE_TRACE",
+                TLWTraceSafeManager::Instance(),
+                TraceReaders));
     }
 
     auto rootGroup = Monitoring->GetCounters()


### PR DESCRIPTION
Разбил trace_processor на 3 отдельные части:
- trace_processor - отвечает за то, что бы периодически "сбрасывать" трейсы
- trace_processor_mon - декоратор предыдущего класса, добавляет возможность отображать трейсы на mon странице
- trace_reader - ридеры для трейсов (просто вынес в отдельный файл)