### PR TITLE
NBSNEBIUS-281: don't report critical event when BackgroundOps client reads during secure erase (#1121)

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -193,7 +193,9 @@ void TDiskAgentActor::PerformIO(
     if (SecureErasePendingRequests.contains(deviceUUID)) {
         const bool isHealthCheckRead =
             IsReadDeviceMethod<TMethod> && clientId == CheckHealthClientId;
-        if (!isHealthCheckRead) {
+        const bool isBackgroundOpsRead =
+            IsReadDeviceMethod<TMethod> && clientId == BackgroundOpsClientId;
+        if (!isHealthCheckRead && !isBackgroundOpsRead) {
             ReportDiskAgentIoDuringSecureErase(
                 TStringBuilder()
                 << " Device=" << deviceUUID

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -3236,6 +3236,21 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                     .GetCode());
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
 
+        // Read during secure erase from BackgroundOps client doesn't generate
+        // critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            ReadDeviceBlocks(
+                runtime,
+                diskAgent,
+                "uuid",
+                0,
+                1,
+                TString(BackgroundOpsClientId))
+                    ->Record.GetError()
+                    .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 3);
+
         // Write zero during secure erase from HealthCheck client generates
         // critical event
         UNIT_ASSERT_VALUES_EQUAL(
@@ -3250,6 +3265,21 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                     ->Record.GetError()
                     .GetCode());
         UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 4);
+
+        // Write zero during secure erase from BackgroundOps client generates
+        // critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            ZeroDeviceBlocks(
+                runtime,
+                diskAgent,
+                "uuid",
+                0,
+                1,
+                TString(BackgroundOpsClientId))
+                    ->Record.GetError()
+                    .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), 5);
 
         spdk->SecureEraseResult.SetValue(NProto::TError());
         runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(10));


### PR DESCRIPTION
related to issue #975