### PR TITLE
issue-95: Compaction.DudCount metric + enqueueing BlobIndexOp upon dud compactions

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -142,6 +142,11 @@ private:
             }
         };
 
+        struct TCompactionMetrics: TRequestMetrics
+        {
+            std::atomic<i64> DudCount{0};
+        };
+
         TRequestMetrics ReadBlob;
         TRequestMetrics WriteBlob;
         TRequestMetrics PatchBlob;
@@ -150,7 +155,7 @@ private:
         TRequestMetrics WriteData;
         TRequestMetrics AddData;
         TRequestMetrics GenerateBlobIds;
-        TRequestMetrics Compaction;
+        TCompactionMetrics Compaction;
         TRequestMetrics Cleanup;
         TRequestMetrics Flush;
         TRequestMetrics FlushBytes;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -555,6 +555,12 @@ void TIndexTabletActor::CompleteTx_Compaction(
         replyError(ctx, args, MakeError(S_FALSE, "nothing to do"));
 
         BlobIndexOpState.Complete();
+        EnqueueBlobIndexOpIfNeeded(ctx);
+        Metrics.Compaction.Update(
+            1,  // count
+            0,  // requestBytes
+            ctx.Now() - args.RequestInfo->StartedTs);
+        Metrics.Compaction.DudCount.fetch_add(1, std::memory_order_relaxed);
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -167,6 +167,7 @@ void TIndexTabletActor::TMetrics::Register(
     REGISTER_REQUEST(AddData);
     REGISTER_REQUEST(GenerateBlobIds);
     REGISTER_REQUEST(Compaction);
+    REGISTER_AGGREGATABLE_SUM(Compaction.DudCount, EMetricType::MT_DERIVATIVE);
     REGISTER_REQUEST(Cleanup);
     REGISTER_REQUEST(Flush);
     REGISTER_REQUEST(FlushBytes);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5083,6 +5083,53 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
     }
 
+    TABLET_TEST(ShouldCountDudCompactions)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        auto handle = CreateHandle(tablet, id);
+
+        ui32 rangeId = GetMixedRangeIndex(id, 0);
+        tablet.Compaction(rangeId);
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+        }
+
+        tablet.DestroyHandle(handle);
+
+        auto registry = env.GetRegistry();
+
+        TTestRegistryVisitor visitor;
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{
+                {"sensor", "Compaction.RequestBytes"},
+                {"filesystem", "test"}}, 0},
+            {{
+                {"sensor", "Compaction.Count"},
+                {"filesystem", "test"}}, 1},
+            {{
+                {"sensor", "Compaction.DudCount"},
+                {"filesystem", "test"}}, 1},
+        });
+    }
+
 #undef TABLET_TEST
 }
 


### PR DESCRIPTION
If Compaction doesn't have any blobs to read or write it exits prematurely without re-enqueueing another BlobIndexOp - fixed it. It's hard to write a ut for this thing so I decided to skip it this time. Added a Compaction.DudCount metric as well.

#95 