### PR TITLE
NBS-4665 [NBS] Add checkpoint validation method to checkpoint store

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -415,7 +415,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
     };
 
     if (checkpointId.empty()) {
-        return makeErrorInvalid("Checkpoint id should not be empty");
+        return MakeError(E_ARGUMENT, "Checkpoint id should not be empty");
     }
 
     if (checkpointType != ECheckpointType::Normal &&
@@ -425,7 +425,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
         TString message = TStringBuilder()
             << requestType
             << " request makes sense for normal checkpoints only";
-        return makeErrorInvalid(std::move(message));
+        return MakeError(E_ARGUMENT, "Checkpoint id should not be empty");
     }
 
     const auto actualCheckpointType = GetCheckpointType(checkpointId);
@@ -506,7 +506,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
     }
     STORAGE_CHECK_PRECONDITION(false);
     return MakeError(
-        E_PRECONDITION_FAILED,
+        E_INVALID_STATE,
         "Checkpoint validation should never reach this line");
 }
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -1,7 +1,7 @@
 #include "checkpoint.h"
 
 #include <cloud/storage/core/libs/common/error.h>
-#include "cloud/storage/core/libs/common/helpers.h"
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
@@ -402,14 +402,14 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
     ECheckpointRequestType requestType,
     ECheckpointType checkpointType) const
 {
-    auto makeErrorInvalid = [](TString message) -> NProto::TError
+    auto makeErrorInvalid = [](TString message)
     {
         ui32 flags = 0;
         SetProtoFlag(flags, NProto::EF_SILENT);
         return MakeError(E_PRECONDITION_FAILED, std::move(message), flags);
     };
 
-    auto makeErrorAlready = [](TString message) -> NProto::TError
+    auto makeErrorAlready = [](TString message)
     {
         return MakeError(S_ALREADY, std::move(message));
     };

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -425,7 +425,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
         TString message = TStringBuilder()
             << requestType
             << " request makes sense for normal checkpoints only";
-        return MakeError(E_ARGUMENT, "Checkpoint id should not be empty");
+        return MakeError(E_ARGUMENT, std::move(message));
     }
 
     const auto actualCheckpointType = GetCheckpointType(checkpointId);

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -423,7 +423,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
          requestType == ECheckpointRequestType::CreateWithoutData))
     {
         TString message = TStringBuilder()
-            << ToString(requestType)
+            << requestType
             << " request makes sense for normal checkpoints only";
         return makeErrorInvalid(std::move(message));
     }
@@ -433,7 +433,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
     if (actualCheckpointType && actualCheckpointType != checkpointType) {
         TString message = TStringBuilder()
             << "Checkpoint exists and has another type "
-            << ToString(*actualCheckpointType);
+            << *actualCheckpointType;
         return makeErrorInvalid(std::move(message));
     }
 
@@ -454,7 +454,8 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
                 return makeErrorInvalid("Checkpoint does not exist");
             }
         }
-    } else if (checkpointExists && checkpointDataPresent) {
+    }
+    if (checkpointExists && checkpointDataPresent) {
         // Checkpoint exists and has data.
         switch (requestType) {
             case ECheckpointRequestType::Create: {
@@ -468,7 +469,8 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
                 return makeErrorInvalid("Checkpoint exists and has data");
             }
         }
-    } else if (checkpointExists && !checkpointDataPresent) {
+    }
+    if (checkpointExists && !checkpointDataPresent) {
         // Checkpoint exists and has no data.
         switch (requestType) {
             case ECheckpointRequestType::Create: {
@@ -488,7 +490,8 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
                 return makeErrorAlready("Checkpoint exists");
             }
         }
-    } else if (!checkpointExists && checkpointDeleted) {
+    }
+    if (!checkpointExists && checkpointDeleted) {
         // Checkpoint was deleted.
         switch (requestType) {
             case ECheckpointRequestType::Create:
@@ -500,12 +503,11 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
                 return makeErrorAlready("Checkpoint is already deleted");
             }
         }
-    } else {
-        STORAGE_CHECK_PRECONDITION(false);
-        return MakeError(
-            E_PRECONDITION_FAILED,
-            "Checkpoint validation should never reach this line");
     }
+    STORAGE_CHECK_PRECONDITION(false);
+    return MakeError(
+        E_PRECONDITION_FAILED,
+        "Checkpoint validation should never reach this line");
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -423,8 +423,8 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
          requestType == ECheckpointRequestType::CreateWithoutData))
     {
         TString message = TStringBuilder()
-            << requestType
-            << " request makes sense for normal checkpoints only";
+                          << requestType
+                          << " request makes sense for normal checkpoints only";
         return MakeError(E_ARGUMENT, std::move(message));
     }
 
@@ -432,8 +432,8 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
 
     if (actualCheckpointType && actualCheckpointType != checkpointType) {
         TString message = TStringBuilder()
-            << "Checkpoint exists and has another type "
-            << *actualCheckpointType;
+                          << "Checkpoint exists and has another type "
+                          << *actualCheckpointType;
         return makeErrorInvalid(std::move(message));
     }
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "cloud/storage/core/protos/error.pb.h"
+
 #include <util/datetime/base.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/map.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
@@ -132,6 +135,7 @@ class TCheckpointStore
 private:
     TMap<ui64, TCheckpointRequest> CheckpointRequests;
     TActiveCheckpointsMap ActiveCheckpoints;
+    THashSet<TString> DeletedCheckpoints;
     ui64 LastCheckpointRequestId = 0;
     ui64 CheckpointRequestInProgress = 0;
     bool CheckpointBeingCreated = false;
@@ -158,6 +162,11 @@ public:
         const TString& checkpointId,
         TInstant timestamp);
 
+    [[nodiscard]] std::optional<NProto::TError> ValidateCheckpointRequest(
+        const TString& checkpointId,
+        ECheckpointRequestType requestType,
+        ECheckpointType checkpointType);
+
     void SetCheckpointRequestSaved(ui64 requestId);
     void SetCheckpointRequestInProgress(ui64 requestId);
     void SetCheckpointRequestFinished(
@@ -177,6 +186,8 @@ public:
     [[nodiscard]] bool IsRequestInProgress() const;
     [[nodiscard]] bool IsCheckpointBeingCreated() const;
     [[nodiscard]] bool DoesCheckpointBlockingWritesExist() const;
+
+    [[nodiscard]] bool IsCheckpointDeleted(const TString& checkpointId) const;
     [[nodiscard]] bool DoesCheckpointHaveData(
         const TString& checkpointId) const;
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "cloud/storage/core/protos/error.pb.h"
+#include <cloud/storage/core/protos/error.pb.h>
 
 #include <util/datetime/base.h>
 #include <util/generic/hash_set.h>

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -165,7 +165,7 @@ public:
     [[nodiscard]] std::optional<NProto::TError> ValidateCheckpointRequest(
         const TString& checkpointId,
         ECheckpointRequestType requestType,
-        ECheckpointType checkpointType);
+        ECheckpointType checkpointType) const;
 
     void SetCheckpointRequestSaved(ui64 requestId);
     void SetCheckpointRequestInProgress(ui64 requestId);

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -809,11 +809,13 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
 
         int checkpointIndex = 0;
 
-        auto executeRequests = [&](ECheckpointType checkpointType, const TVector<TStep>& steps)
+        auto executeRequests =
+            [&](ECheckpointType checkpointType, const TVector<TStep>& steps)
         {
-            TString checkpointId = TStringBuilder() << "checkpoint_" << checkpointIndex++;
+            TString checkpointId = TStringBuilder()
+                                   << "checkpoint_" << checkpointIndex++;
 
-            for (const TStep& step : steps) {
+            for (const TStep& step: steps) {
                 executeRequest(
                     checkpointId,
                     step.RequestType,

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -743,7 +743,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         auto makeCheckpointRequest =
             [&] (const TString& checkpointId,
                 ECheckpointRequestType requestType,
-                ECheckpointType checkpointType) -> TCheckpointRequest
+                ECheckpointType checkpointType)
         {
             switch (requestType) {
                 case ECheckpointRequestType::Create:
@@ -770,7 +770,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
             [&](const TString& checkpointId,
                 ECheckpointRequestType requestType,
                 ECheckpointType checkpointType,
-                std::optional<EWellKnownResultCodes> expectedErrorCode) -> void
+                std::optional<EWellKnownResultCodes> expectedErrorCode)
         {
             auto request = makeCheckpointRequest(
                 checkpointId,

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -759,12 +759,10 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
                     return store.MakeDeleteCheckpointDataRequest(
                         checkpointId,
                         TInstant::Now());
-                    break;
                 case ECheckpointRequestType::Delete:
                     return store.MakeDeleteCheckpointRequest(
                         checkpointId,
                         TInstant::Now());
-                    break;
             }
         };
 
@@ -803,7 +801,8 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
             }
         };
 
-        struct TStep {
+        struct TStep
+        {
             ECheckpointRequestType RequestType;
             std::optional<EWellKnownResultCodes> ExpectedErrorCode;
         };

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -870,29 +870,29 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         }
 
         executeRequests(ECheckpointType::Light, TVector<TStep>{
-            {ECheckpointRequestType::DeleteData, E_PRECONDITION_FAILED},
+            {ECheckpointRequestType::DeleteData, E_ARGUMENT},
             {ECheckpointRequestType::Create, std::nullopt},
-            {ECheckpointRequestType::DeleteData, E_PRECONDITION_FAILED},
+            {ECheckpointRequestType::DeleteData, E_ARGUMENT},
             {ECheckpointRequestType::Delete, std::nullopt},
-            {ECheckpointRequestType::DeleteData, E_PRECONDITION_FAILED},
+            {ECheckpointRequestType::DeleteData, E_ARGUMENT},
         });
 
         executeRequests(ECheckpointType::Light, TVector<TStep>{
-            {ECheckpointRequestType::CreateWithoutData, E_PRECONDITION_FAILED},
+            {ECheckpointRequestType::CreateWithoutData, E_ARGUMENT},
             {ECheckpointRequestType::Create, std::nullopt},
-            {ECheckpointRequestType::CreateWithoutData, E_PRECONDITION_FAILED},
+            {ECheckpointRequestType::CreateWithoutData, E_ARGUMENT},
         });
 
         executeRequest(
             "",
             ECheckpointRequestType::Create,
             ECheckpointType::Normal,
-            E_PRECONDITION_FAILED);
+            E_ARGUMENT);
         executeRequest(
             "",
             ECheckpointRequestType::Create,
             ECheckpointType::Light,
-            E_PRECONDITION_FAILED);
+            E_ARGUMENT);
     }
 }
 


### PR DESCRIPTION
Added ValidateCheckpointRequest to checkpoint store. For each checkpoint request, it chooses one of three possible options:
1) Request is invalid and must return error
2) Request is duplicate and should do nothing
3) Request should be saved to database and executed as usual.

This method should be called before saving and executing checkpoint request. We are going to do this in another pull request. These two pull requests are supposed to replace #239, which is going to be discarded. I took in account all comments by reviewers from #239.