### PR TITLE
[Filestore] issue-652: use `currentCommitId-1` instead of `currentCommitId` for `CollectGarbage`

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -1,7 +1,6 @@
 #include "tablet_actor.h"
 
 #include "profile_log_events.h"
-#include "tablet_schema.h"
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 
@@ -409,7 +408,7 @@ void TIndexTabletActor::HandleCollectGarbage(
         return;
     }
 
-    ui64 collectCommitId = GetCollectCommitId();
+    ui64 collectCommitId = GetCollectCommitId(msg->ConsiderCurrentCommitId);
 
     auto newBlobs = GetNewBlobs(collectCommitId);
     auto garbageBlobs = GetGarbageBlobs(collectCommitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -408,7 +408,7 @@ void TIndexTabletActor::HandleCollectGarbage(
         return;
     }
 
-    ui64 collectCommitId = GetCollectCommitId(msg->ConsiderCurrentCommitId);
+    ui64 collectCommitId = GetCollectCommitId();
 
     auto newBlobs = GetNewBlobs(collectCommitId);
     auto garbageBlobs = GetGarbageBlobs(collectCommitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_generatecommitid.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_generatecommitid.cpp
@@ -21,7 +21,7 @@ void TIndexTabletActor::HandleGenerateCommitId(
     auto response = std::make_unique<TEvIndexTabletPrivate::TEvGenerateCommitIdResponse>();
     response->CommitId = GenerateCommitId();
     if (response->CommitId == InvalidCommitId) {
-        return RebootTabletOnCommitOverflow(ctx, "CreateHandle");
+        return RebootTabletOnCommitOverflow(ctx, "GenerateCommitId");
     }
 
     NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_generatecommitid.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_generatecommitid.cpp
@@ -1,0 +1,30 @@
+#include "tablet_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Used only for testing
+void TIndexTabletActor::HandleGenerateCommitId(
+    const TEvIndexTabletPrivate::TEvGenerateCommitIdRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s GenerateCommitId",
+        LogTag.c_str());
+
+    auto response = std::make_unique<TEvIndexTabletPrivate::TEvGenerateCommitIdResponse>();
+    response->CommitId = GenerateCommitId();
+    if (response->CommitId == InvalidCommitId) {
+        return RebootTabletOnCommitOverflow(ctx, "CreateHandle");
+    }
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -527,6 +527,16 @@ struct TEvIndexTabletPrivate
 
     struct TCollectGarbageRequest
     {
+        // If set to false, will not consider data associated with the current
+        // commitId. By default, is set to false. Is set to true only for
+        // testing purposes, when there is a guarantee that no other concurrent
+        // operations may need to access the data associated with the current
+        // commitId.
+        const bool ConsiderCurrentCommitId = false;
+
+        explicit TCollectGarbageRequest(bool considerCurrentCommitId = false)
+            : ConsiderCurrentCommitId(considerCurrentCommitId)
+        {}
     };
 
     struct TCollectGarbageResponse

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -685,7 +685,7 @@ struct TEvIndexTabletPrivate
 
     struct TGenerateCommitIdResponse
     {
-        ui64 CommitId;
+        ui64 CommitId = InvalidCommitId;
     };
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -44,6 +44,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(TruncateRange,                          __VA_ARGS__)                   \
     xxx(ZeroRange,                              __VA_ARGS__)                   \
     xxx(FilterAliveNodes,                       __VA_ARGS__)                   \
+    xxx(GenerateCommitId,                       __VA_ARGS__)                   \
 // FILESTORE_TABLET_REQUESTS_PRIVATE
 
 #define FILESTORE_TABLET_REQUESTS_PRIVATE(xxx, ...)                            \
@@ -525,23 +526,9 @@ struct TEvIndexTabletPrivate
     // CollectGarbage
     //
 
-    struct TCollectGarbageRequest
-    {
-        // If set to false, will not consider data associated with the current
-        // commitId. By default, is set to false. Is set to true only for
-        // testing purposes, when there is a guarantee that no other concurrent
-        // operations may need to access the data associated with the current
-        // commitId.
-        const bool ConsiderCurrentCommitId = false;
+    using TCollectGarbageRequest = TEmpty;
 
-        explicit TCollectGarbageRequest(bool considerCurrentCommitId = false)
-            : ConsiderCurrentCommitId(considerCurrentCommitId)
-        {}
-    };
-
-    struct TCollectGarbageResponse
-    {
-    };
+    using TCollectGarbageResponse = TEmpty;
 
     using TCollectGarbageCompleted = TDataOperationCompleted;
 
@@ -688,6 +675,17 @@ struct TEvIndexTabletPrivate
             : CommitId(commitId)
             , Count(count)
         {}
+    };
+
+    //
+    // Generate commit id
+    //
+
+    using TGenerateCommitIdRequest = TEmpty;
+
+    struct TGenerateCommitIdResponse
+    {
+        ui64 CommitId;
     };
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -843,7 +843,7 @@ public:
     bool TryReleaseCollectBarrier(ui64 commitId);
     bool IsCollectBarrierAcquired(ui64 commitId) const;
 
-    ui64 GetCollectCommitId(bool considerCurrentCommitId) const;
+    ui64 GetCollectCommitId() const;
 
     void LoadGarbage(
         const TVector<TPartialBlobId>& newBlobs,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -843,7 +843,7 @@ public:
     bool TryReleaseCollectBarrier(ui64 commitId);
     bool IsCollectBarrierAcquired(ui64 commitId) const;
 
-    ui64 GetCollectCommitId() const;
+    ui64 GetCollectCommitId(bool considerCurrentCommitId) const;
 
     void LoadGarbage(
         const TVector<TPartialBlobId>& newBlobs,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -994,10 +994,12 @@ bool TIndexTabletState::IsCollectBarrierAcquired(ui64 commitId) const
     return Impl->GarbageQueue.IsCollectBarrierAcquired(commitId);
 }
 
-ui64 TIndexTabletState::GetCollectCommitId() const
+ui64 TIndexTabletState::GetCollectCommitId(bool considerCurrentCommitId) const
 {
     // should not collect after any barrier
-    return Min(GetCurrentCommitId(), Impl->GarbageQueue.GetCollectCommitId());
+    return Min(
+        GetCurrentCommitId() - 1 + considerCurrentCommitId,
+        Impl->GarbageQueue.GetCollectCommitId());
 }
 
 void TIndexTabletState::AddNewBlob(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -994,11 +994,11 @@ bool TIndexTabletState::IsCollectBarrierAcquired(ui64 commitId) const
     return Impl->GarbageQueue.IsCollectBarrierAcquired(commitId);
 }
 
-ui64 TIndexTabletState::GetCollectCommitId(bool considerCurrentCommitId) const
+ui64 TIndexTabletState::GetCollectCommitId() const
 {
     // should not collect after any barrier
     return Min(
-        GetCurrentCommitId() - 1 + considerCurrentCommitId,
+        GetCurrentCommitId() - 1,
         Impl->GarbageQueue.GetCollectCommitId());
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5164,14 +5164,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         });
     }
 
-    TABLET_TEST(CleanupShouldNotInterferwWithCollectGarbage)
+    TABLET_TEST(CleanupShouldNotInterfereWithCollectGarbage)
     {
         const auto block = tabletConfig.BlockSize;
         tabletConfig.BlockCount = 1'000'000;
 
         NProto::TStorageConfig storageConfig;
 
-        storageConfig.SetWriteBlobThreshold(0);
         storageConfig.SetCompactionThreshold(999'999);
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetCollectGarbageThreshold(1_GB);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5295,6 +5295,21 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetCollectGarbageThreshold(1_GB);
 
+        TTestEnv env({}, std::move(storageConfig));
+
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+
         auto handle = CreateHandle(tablet, id);
 
         for (int i = 0; i < 2; i++) {

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -38,6 +38,7 @@ SRCS(
     tablet_actor_filteralivenodes.cpp
     tablet_actor_flush.cpp
     tablet_actor_flush_bytes.cpp
+    tablet_actor_generatecommitid.cpp
     tablet_actor_getnodeattr.cpp
     tablet_actor_getnodexattr.cpp
     tablet_actor_initschema.cpp

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -309,9 +309,11 @@ public:
             mode);
     }
 
-    auto CreateCollectGarbageRequest()
+    auto CreateCollectGarbageRequest(bool considerCurrentCommitId = false)
     {
-        return std::make_unique<TEvIndexTabletPrivate::TEvCollectGarbageRequest>();
+        return std::make_unique<
+            TEvIndexTabletPrivate::TEvCollectGarbageRequest>(
+            considerCurrentCommitId);
     }
 
     auto CreateTruncateRequest(ui64 node, ui64 length)

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -309,11 +309,9 @@ public:
             mode);
     }
 
-    auto CreateCollectGarbageRequest(bool considerCurrentCommitId = false)
+    auto CreateCollectGarbageRequest()
     {
-        return std::make_unique<
-            TEvIndexTabletPrivate::TEvCollectGarbageRequest>(
-            considerCurrentCommitId);
+        return std::make_unique<TEvIndexTabletPrivate::TEvCollectGarbageRequest>();
     }
 
     auto CreateTruncateRequest(ui64 node, ui64 length)
@@ -352,6 +350,11 @@ public:
     {
         return std::make_unique<TEvIndexTabletPrivate::TEvFilterAliveNodesRequest>(
             std::move(nodes));
+    }
+
+    auto CreateGenerateCommitIdRequest()
+    {
+        return std::make_unique<TEvIndexTabletPrivate::TEvGenerateCommitIdRequest>();
     }
 
     auto CreateDumpCompactionRangeRequest(ui32 rangeId)


### PR DESCRIPTION
References #652

Cleanup operation acquires a collect barrier with the current commitId to protect the data with the current commitId (or greater) from being tampered with.

Thus, it will be more logical to modify the CollectGarbage operation not to use the `currentCommitId`, but use `currentCommitId - 1`, if no barriers are present.