### PR TITLE
issue-95: fixed BlobIndexOps status codes for the case when another op is running - correct response code is E_TRY_AGAIN

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -51,7 +51,7 @@ void TIndexTabletActor::HandleCleanup(
 
     if (!BlobIndexOpState.Start()) {
         replyError(
-            MakeError(S_ALREADY, "cleanup/compaction is in progress"));
+            MakeError(E_TRY_AGAIN, "cleanup/compaction is in progress"));
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -302,7 +302,7 @@ void TIndexTabletActor::HandleFlush(
             ctx,
             *ev,
             std::move(profileLogRequest),
-            MakeError(S_ALREADY, "flush is in progress"));
+            MakeError(E_TRY_AGAIN, "flush is in progress"));
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -528,7 +528,7 @@ void TIndexTabletActor::HandleFlushBytes(
         reply(
             ctx,
             *ev,
-            MakeError(S_FALSE, "cleanup/compaction is in progress")
+            MakeError(E_TRY_AGAIN, "cleanup/compaction is in progress")
         );
 
         return;
@@ -537,7 +537,7 @@ void TIndexTabletActor::HandleFlushBytes(
     if (!FlushState.Start()) {
         BlobIndexOpState.Complete();
 
-        reply(ctx, *ev, MakeError(S_FALSE, "flush is in progress"));
+        reply(ctx, *ev, MakeError(E_TRY_AGAIN, "flush is in progress"));
 
         return;
     }
@@ -563,7 +563,7 @@ void TIndexTabletActor::HandleFlushBytes(
             FlushState.Complete();
             BlobIndexOpState.Complete();
 
-            reply(ctx, *ev, MakeError(S_ALREADY, "no bytes to flush"));
+            reply(ctx, *ev, MakeError(S_FALSE, "no bytes to flush"));
 
             return;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1120,7 +1120,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.InitSession("client", "session");
 
         auto response = tablet.FlushBytes();
-        UNIT_ASSERT(response->Error.GetCode() == S_ALREADY);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_FALSE,
+            response->Error.GetCode(),
+            response->Error.GetMessage());
 
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         auto handle = CreateHandle(tablet, id);
@@ -2780,7 +2783,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.InitSession("client", "session");
 
         auto response = tablet.FlushBytes();
-        UNIT_ASSERT(response->Error.GetCode() == S_ALREADY);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_FALSE,
+            response->Error.GetCode(),
+            response->Error.GetMessage());
 
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         auto handle = CreateHandle(tablet, id);
@@ -5128,6 +5134,119 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 {"sensor", "Compaction.DudCount"},
                 {"filesystem", "test"}}, 1},
         });
+    }
+
+    TABLET_TEST(ShouldRejectBlobIndexOpsWithProperErrorCodeIfAnotherOpIsRunning)
+    {
+        const auto block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        TTestEnv env({}, std::move(storageConfig));
+
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+        tablet.WriteData(handle, 0, 256_KB, '0');
+
+        ui32 rangeId = GetMixedRangeIndex(id, 0);
+        tablet.SendCompactionRequest(rangeId);
+        tablet.SendCleanupRequest(rangeId);
+
+        {
+            auto response = tablet.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            auto response = tablet.RecvCleanupResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        tablet.WriteData(handle, 0, 256_KB, '0');
+        tablet.SendCleanupRequest(rangeId);
+        tablet.SendCompactionRequest(rangeId);
+
+        {
+            auto response = tablet.RecvCleanupResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            auto response = tablet.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        tablet.WriteData(handle, 0, block, '0');
+        tablet.SendFlushRequest();
+        tablet.SendFlushBytesRequest();
+
+        {
+            auto response = tablet.RecvFlushResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            auto response = tablet.RecvFlushBytesResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        tablet.WriteData(handle, 0, 1_KB, '0');
+        tablet.SendFlushBytesRequest();
+        tablet.SendCompactionRequest(rangeId);
+        tablet.SendCleanupRequest(rangeId);
+
+        {
+            auto response = tablet.RecvFlushBytesResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            auto response = tablet.RecvCleanupResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            auto response = tablet.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
     }
 
 #undef TABLET_TEST

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5141,6 +5141,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto block = tabletConfig.BlockSize;
 
         NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(2 * block);
         TTestEnv env({}, std::move(storageConfig));
 
         env.CreateSubDomain("nfs");


### PR DESCRIPTION
Affects forced Cleanup - it skips most of the ranges if some other ops are running concurrently (which is a bug fixed in this PR).

#95 