### PR TITLE
Speed up checks

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -25,22 +25,39 @@ inputs:
     required: false
     default: "8"
     description: "link threads count"
+  clean_ya_dir:
+    required: false
+    default: "no"
+    description: "clean ya dir"
+  use_network_cache:
+    required: false
+    default: "yes"
+    description: "use network cache"
+
 
 runs:
   using: composite
   steps:
     - name: Init
       id: init
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        echo "SHELLOPTS=xtrace" >> $GITHUB_ENV
         export TMP_DIR=/home/github/tmp_build
         echo "TMP_DIR=$TMP_DIR" >> $GITHUB_ENV
         rm -rf $TMP_DIR && mkdir $TMP_DIR && chown -R github:github $TMP_DIR $GITHUB_WORKSPACE
 
+        if [ "${{ inputs.clean_ya_dir }}" == "yes" ] && [ -d /home/github/.ya/ ]; then
+          echo "Cleaning ya dir"
+          rm -rf /home/github/.ya/
+        fi
+
     - name: build
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
+        function grep_ya_tc() {
+          ps aux | grep [y]a-tc || true
+        }
+
         extra_params=()
 
         if [ ! -z "${{ inputs.build_target }}" ]; then
@@ -50,19 +67,21 @@ runs:
           done
         fi
 
-        if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
-          extra_params+=(--bazel-remote-store)
-          extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
-        fi
+        if [ "${{ inputs.use_network_cache }}" == "yes" ]; then
+          if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
+            extra_params+=(--bazel-remote-store)
+            extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
+          fi
 
-        if [ ! -z "${{ inputs.bazel_remote_username }}" ]; then
-          extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
-          extra_params+=(--bazel-remote-password "${{ inputs.bazel_remote_password }}")
-          extra_params+=(--add-result .o)
-        fi
+          if [ ! -z "${{ inputs.bazel_remote_username }}" ]; then
+            extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
+            extra_params+=(--bazel-remote-password "${{ inputs.bazel_remote_password }}")
+            extra_params+=(--add-result .o)
+          fi
 
-        if [ "${{ inputs.cache_update }}" == "true" ]; then
-          extra_params+=(--bazel-remote-put --dist-cache-evict-bins)
+          if [ "${{ inputs.cache_update }}" == "true" ]; then
+            extra_params+=(--bazel-remote-put)
+          fi
         fi
 
         case "${{ inputs.build_preset }}" in
@@ -88,11 +107,59 @@ runs:
             ;;
         esac
 
-        sudo -E -H -u github ./ya make -k --build "${build_type}" --force-build-depends -D'BUILD_LANGUAGES=CPP PY3 PY2 GO' -T --stat  \
+
+        if [ -d /home/github/.ya/tools/ ]; then
+          ya_bin_path=$(find /home/github/.ya/tools/ -type f -name "ya-bin")
+          if [ ! -s "$ya_bin_path" ]; then
+            echo "ya-bin exists but is empty, lets look for ya-tc process and kill it if it's running somehow."
+            ps auxf | grep -vE "]$"
+            ls -lsha "$ya_bin_path"
+            du -h -d 1 /home/github/.ya/
+
+            process_name="ya-tc"
+            # by default ya-tc should terminate within 5 minutes
+            timeout=360
+            start_time=$(date +%s)
+
+            while true; do
+              pgrep -x "ya-tc" && {
+                  echo "ya-tc is still running."
+                  grep_ya_tc
+              } || {
+                  echo "ya-tc is not running."
+                  grep_ya_tc
+                  break
+              }
+
+              current_time=$(date +%s)
+              elapsed_time=$((current_time - start_time))
+
+              if [ "$elapsed_time" -ge "$timeout" ]; then
+                  echo "Timeout reached. ya-tc is still running. killing it"
+                  grep_ya_tc
+                  pkill -f ya-tc || true
+                  grep_ya_tc
+                  break
+              fi
+
+              sleep 5
+            done
+
+            echo "ya-bin exists but is empty, recovering by removing it."
+            ls -lsha "$ya_bin_path"
+            ps auxf | grep -vE "]$"
+            rm -rf $ya_bin_path
+          fi
+        else
+          echo "/home/github/.ya/tools/ not found"
+        fi
+        date
+        sudo -E -H -u github ./ya make -k -j60 --build "${build_type}" --force-build-depends -D'BUILD_LANGUAGES=CPP PY3 PY2 GO' -T --stat  \
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --dump-graph --dump-graph-to-file "$TMP_DIR/ya_graph.json" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
           "${extra_params[@]}"
+        date
 
     - name: Sync logs to S3
       if: always()

--- a/.github/actions/build_cmake/action.yaml
+++ b/.github/actions/build_cmake/action.yaml
@@ -19,8 +19,8 @@ runs:
   using: composite
   steps:
     - name: Init
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       id: init
-      shell: bash
       run: |
         export TMP_DIR=$(pwd)/tmp_build
         export ROOT_PATH=$(pwd)
@@ -37,7 +37,7 @@ runs:
         echo "CCACHE_REMOTE_STORAGE=http://${{ inputs.bazel_remote_username }}:${{ inputs.bazel_remote_password }}@195.242.17.155:9090|layout=bazel" >> $GITHUB_ENV
 
     - name: build
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         cd $TMP_DIR
         export

--- a/.github/actions/ncp/action.yaml
+++ b/.github/actions/ncp/action.yaml
@@ -11,6 +11,7 @@ outputs:
   runner_ipv4:
     value: ${{ steps.result.outputs.runner_ipv4 }}
     description: "runner ipv4"
+
 runs:
   using: composite
   steps:

--- a/.github/actions/prepare/action.yaml
+++ b/.github/actions/prepare/action.yaml
@@ -16,9 +16,11 @@ runs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends git wget gnupg lsb-release curl xz-utils tzdata cmake \
           python3-dev python3-pip ninja-build antlr3 m4 libidn11-dev libaio1 libaio-dev make clang-14 lld-14 llvm-14 file \
-          distcc strace qemu-kvm qemu-utils dpkg-dev atop
+          distcc strace qemu-kvm qemu-utils dpkg-dev atop pigz pbzip2 xz-utils pixz
         sudo apt-get remove -y unattended-upgrades
-        sudo pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 grpcio grpcio-tools PyHamcrest tornado xmltodict pyarrow boto3 moto[server] psutil pygithub==1.59.1 pyinstaller==5.13.2 cryptography packaging six pyyaml
+        sudo pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 grpcio grpcio-tools \
+             PyHamcrest tornado xmltodict pyarrow boto3 moto[server] psutil yandexcloud==0.258.0 PyGithub==2.2.0 pyinstaller==5.13.2 \
+             cryptography packaging six pyyaml rapidgzip
     - name: install ccache
       shell: bash
       run: |

--- a/.github/actions/runner_create/action.yaml
+++ b/.github/actions/runner_create/action.yaml
@@ -2,10 +2,10 @@ name: Create runner VM
 description: Create runner VM using manage-vm.py
 inputs:
   org:
-    required: true
+    required: false
     description: "org name"
   team:
-    required: true
+    required: false
     description: "team slug name"
   repo_owner:
     required: true
@@ -77,6 +77,7 @@ outputs:
       The address is used to connect to the runner via SSH.
     value: ${{ steps.create-vm.outputs.external-ipv4 || '0.0.0.0' }}
 
+
 runs:
   using: composite
   steps:
@@ -96,9 +97,7 @@ runs:
       id: create-vm
       shell: bash
       run: |
-        python .github/scripts/manage-vm.py create \
-          --github-org "${ORG}" \
-          --github-team-slug "${TEAM}" \
+        python .github/scripts/manage-vm.py create ${ORG} ${TEAM} \
           --github-repo-owner "${REPO_OWNER}" \
           --github-repo "${REPO}" \
           --service-account-key "${SERVICE_ACCOUNT_KEY}" \
@@ -113,8 +112,8 @@ runs:
           --apply
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-        ORG: ${{ inputs.org }}
-        TEAM: ${{ inputs.team }}
+        ORG: ${{ inputs.org && format('--github-org {0}', inputs.org) || ''}}
+        TEAM: ${{ inputs.team && format('--github-team-slug {0}', inputs.team) || ''}}
         REPO_OWNER: ${{ inputs.repo_owner }}
         REPO: ${{ inputs.repo }}
         VM_NAME: ${{ inputs.vm_name }}

--- a/.github/actions/runner_remove/action.yaml
+++ b/.github/actions/runner_remove/action.yaml
@@ -17,7 +17,6 @@ inputs:
     required: true
     description: "vm id"
 
-
 runs:
   using: composite
   steps:

--- a/.github/actions/s3cmd/action.yaml
+++ b/.github/actions/s3cmd/action.yaml
@@ -25,16 +25,22 @@ inputs:
   user:
     required: false
     description: "github user"
+  install:
+    required: false
+    default: true
+    description: "install s3cmd and awscli"
+
 runs:
   using: composite
   steps:
     - name: install s3cmd
+      if: inputs.install == 'true'
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends s3cmd
+        sudo apt-get install -y --no-install-recommends s3cmd awscli
     - name: configure s3cmd
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         export S3CMD_CONFIG=$(sudo -E -H -u $user mktemp -p /home/$user)
         sudo chown $user: $S3CMD_CONFIG
@@ -59,6 +65,10 @@ runs:
         [default]
         region = eu-north1
         endpoint_url=https://storage.ai.nebius.cloud/
+        s3 =
+          max_concurrent_requests = 32
+          multipart_chunksize = 32MB
+          max_queue_size = 10240
         EOF
 
         sudo mkdir -p /root/.aws/
@@ -71,6 +81,10 @@ runs:
         [default]
         region = eu-north1
         endpoint_url=https://storage.ai.nebius.cloud/
+        s3 =
+          max_concurrent_requests = 32
+          multipart_chunksize = 32MB
+          max_queue_size = 10240
         EOF
 
         folder="${{ runner.arch == 'X64' && 'x86-64' || runner.arch == 'ARM64' && 'arm64' || 'unknown' }}"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -40,14 +40,26 @@ inputs:
     required: false
     default: 'false'
     description: 'Sync failed tests folders to s3'
+  upload_ya_dir:
+    required: false
+    default: 'no'
+    description: 'Upload ya dir to s3'
+  clean_ya_dir:
+    required: false
+    default: 'no'
+    description: 'Clean ya dir'
+  use_network_cache:
+    required: false
+    default: 'yes'
+    description: 'Use network cache'
+
 runs:
   using: composite
   steps:
     - name: Init
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       id: init
-      shell: bash
       run: |
-        echo "SHELLOPTS=xtrace" >> $GITHUB_ENV
         export TMP_DIR=/home/github/tmp
         echo "TMP_DIR=$TMP_DIR" >> $GITHUB_ENV
         echo "LOG_DIR=$TMP_DIR/logs" >> $GITHUB_ENV
@@ -60,15 +72,19 @@ runs:
         echo "SUMMARY_LINKS=$(mktemp -p /home/github)" >> $GITHUB_ENV
 
     - name: prepare
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         rm -rf $TMP_DIR $JUNIT_REPORT_XML $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR $TESTS_DATA_DIR
         mkdir -p $TMP_DIR $OUT_DIR $ARTIFACTS_DIR $LOG_DIR $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR $TESTS_DATA_DIR
         chown -R github:github $TMP_DIR $OUT_DIR $ARTIFACTS_DIR $LOG_DIR $JUNIT_REPORT_PARTS \
                                $REPORTS_ARTIFACTS_DIR $SUMMARY_LINKS $GITHUB_WORKSPACE \
                                $GITHUB_STEP_SUMMARY $TESTS_DATA_DIR
+        if [ "${{ inputs.clean_ya_dir }}" == "yes" ] && [ -d /home/github/.ya/ ]; then
+          echo "Cleaning ya dir"
+          rm -rf /home/github/.ya/
+        fi
     - name: ya test
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         set -x
         extra_params=()
@@ -105,24 +121,36 @@ runs:
           done
         fi
 
-        if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
-          extra_params+=(--bazel-remote-store)
-          extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
-        fi
+        if [ "${{ inputs.use_network_cache }}" == "yes" ]; then
+          if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
+            extra_params+=(--bazel-remote-store)
+            extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
+          fi
 
-        if [ ! -z "${{ inputs.bazel_remote_username }}" ]; then
-          extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
-          extra_params+=(--bazel-remote-password "${{ inputs.bazel_remote_password }}")
-        fi
+          if [ ! -z "${{ inputs.bazel_remote_username }}" ]; then
+            extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
+            extra_params+=(--bazel-remote-password "${{ inputs.bazel_remote_password }}")
+          fi
 
-        if [ "${{ inputs.cache_update }}" = "true" ]; then
-          extra_params+=(--cache-tests)
-          extra_params+=(--bazel-remote-put --dist-cache-evict-bins)
+          if [ "${{ inputs.cache_update }}" = "true" ]; then
+            extra_params+=(--bazel-remote-put)
+          fi
         fi
 
         readarray -d ',' -t test_size < <(printf "%s" "${{ inputs.test_size }}")
         readarray -d ',' -t test_type < <(printf "%s" "${{ inputs.test_type }}")
 
+        echo "::group::empty-files"
+        [ -d  /home/github/.ya/tools/ ] && {
+          find /home/github/.ya/tools/ -type f -exec file {} \; | grep empty;
+          ya_bin_path=$(find /home/github/.ya/tools/ -type f -name "ya-bin")
+          if [ ! -s "$ya_bin_path" ]; then
+            echo "ya-bin exists but is empty, recovering by removing ya-bin"
+            rm -rf $ya_bin_path
+          fi
+        }
+        echo "::endgroup::"
+        date
         echo "::group::ya-make-test"
         sudo -E -H -u github ./ya test -k --build "${build_type}" \
           ${test_size[@]/#/--test-size=} ${test_type[@]/#/--test-type=} \
@@ -137,23 +165,27 @@ runs:
               if [ -s "$JUNIT_REPORT_XML" ]; then
                 echo "$JUNIT_REPORT_XML exists"
                 ls -la "$JUNIT_REPORT_XML"
+                echo "::endgroup::"
+                date
               else
                 echo "$JUNIT_REPORT_XML doesn't exist or has zero size"
                 ls -la "$JUNIT_REPORT_XML" || true
+                echo "::endgroup::"
+                date
                 exit $RC
               fi
             fi
         )
-        echo "::endgroup::"
 
     - name: archive unitest reports (orig)
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         sudo -E -H -u github gzip -c $JUNIT_REPORT_XML > $REPORTS_ARTIFACTS_DIR/orig_junit.xml.gz
 
     - name: postprocess junit report
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
+        echo "::group::postprocess-junit"
         sudo -E -H -u github .github/scripts/tests/transform-ya-junit.py -i \
           -m .github/config/muted_ya.txt \
           --ya-out "$OUT_DIR" \
@@ -163,17 +195,19 @@ runs:
           "$JUNIT_REPORT_XML"
 
         sudo -E -H -u github .github/scripts/tests/split-junit.py -o "$JUNIT_REPORT_PARTS" "$JUNIT_REPORT_XML"
+        echo "::endgroup::"
 
     - name: archive unitest reports (transformed)
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         sudo -E -H -u github tar -C $JUNIT_REPORT_PARTS/.. -czf $REPORTS_ARTIFACTS_DIR/junit_parts.xml.tar.gz $(basename $JUNIT_REPORT_PARTS) $JUNIT_REPORT_XML
 
     - name: write tests summary
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
+        echo "::group::write-summary"
         sudo -E -H -u github mkdir $ARTIFACTS_DIR/summary/
 
         cat $SUMMARY_LINKS | python3 -c 'import sys; print(" | ".join([v for _, v in sorted([l.strip().split(" ", 1) for l in sys.stdin], key=lambda a: (int(a[0]), a))]))' >> $GITHUB_STEP_SUMMARY
@@ -190,11 +224,11 @@ runs:
           "Tests" ya-test.html "$JUNIT_REPORT_XML"
 
         cat $SUMMARY_OUT_ENV_PATH | tee -a $GITHUB_STEP_SUMMARY
+        echo "::endgroup::"
 
     - name: check test results
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        set -x
         sudo -E -H -u github .github/scripts/tests/fail-checker.py "$JUNIT_REPORT_XML" || {
           RC=$?
 
@@ -258,6 +292,82 @@ runs:
         echo ${S3_WEBSITE_PREFIX}/summary/ya-test.html
         echo "::endgroup::"
 
+    - name: upload ya dir to s3 on success
+      id: upload_ya_dir
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      if: success() && inputs.upload_ya_dir == 'yes'
+      run: |
+        function grep_ya_tc() {
+          ps aux | grep [y]a-tc || true
+        }
+        process_name="ya-tc"
+        # by default ya-tc should terminate within 5 minutes
+        timeout=360
+        start_time=$(date +%s)
+        while true; do
+            pgrep -x "ya-tc" && {
+                echo "ya-tc is still running."
+                grep_ya_tc
+            } || {
+                echo "ya-tc is not running."
+                grep_ya_tc
+                break
+            }
+
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            if [ "$elapsed_time" -ge "$timeout" ]; then
+                echo "Timeout reached. ya-tc is still running. killing it"
+                grep_ya_tc
+                pkill -f ya-tc || true
+                grep_ya_tc
+                break
+            fi
+
+            sleep 5
+        done
+
+        ps aux | grep ya
+        # checking if files are not corrupted
+        echo "::group::ya-files-empty"
+        find /home/github/.ya/tools/ -type f -exec file {} \; | grep empty
+        echo "::endgroup::"
+        ya_bin_path=$(find /home/github/.ya/tools/ -type f -name "ya-bin")
+        if [ ! -s "$ya_bin_path" ]; then
+          echo "ya-bin exists but is empty"
+          echo "empty_ya_bin=yes" >> $GITHUB_OUTPUT
+        else
+          echo "empty_ya_bin=no" >> $GITHUB_OUTPUT
+          echo "::group::upload-ya-dir"
+
+          df -h
+          EXTENSION=tar.xz
+          if [ "$EXTENSION" = "tar.zst" ] || [ "$EXTENSION" = "tar.zstd" ]; then COMPRESS_ARGS='zstd -16 -T60'; fi
+          if [ "$EXTENSION" = "tar.xz" ]; then COMPRESS_ARGS='pixz -1'; fi
+          if [ "$EXTENSION" = "tar.bz2" ]; then COMPRESS_ARGS=pbzip2; fi
+          if [ "$EXTENSION" = "tar.gz" ]; then COMPRESS_ARGS=pigz; fi
+          sudo -E -H -u github time tar -S -C /home/github -I "$COMPRESS_ARGS" -c -f  /home/github/tmp/ya.${EXTENSION} /home/github/.ya
+          ls -lsha /home/github/tmp/ya.${EXTENSION}
+          sudo -E -H -u github time aws s3 cp --no-progress  /home/github/tmp/ya.${EXTENSION} "$S3_BUCKET_PATH/ya_archive/ya.${EXTENSION}"
+          echo "${S3_WEBSITE_PREFIX}/ya_archive/ya.${EXTENSION}" > /home/github/ya_web_url.txt
+          echo "${S3_BUCKET_PATH}/ya_archive/ya.${EXTENSION}" > /home/github/ya_s3_url.txt
+          df -h
+          echo "::endgroup::"
+        fi
+
+    - name: upload ya url to s3 on success
+      if: success() && inputs.upload_ya_dir == 'yes' && steps.upload_ya_dir.outputs.empty_ya_bin != 'yes'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ya_web_url_file
+        path: /home/github/ya_web_url.txt
+    - name: upload ya url to s3 on success
+      if: success() && inputs.upload_ya_dir == 'yes' && steps.upload_ya_dir.outputs.empty_ya_bin != 'yes'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ya_s3_url_file
+        path: /home/github/ya_s3_url.txt
     - name: Create directory listing on s3
       if: always()
       shell: bash
@@ -265,7 +375,6 @@ runs:
         echo "::group::generate-listing"
         sudo -E -H -u github python3 .github/scripts/index.py "$S3_BUCKET_PATH" --generate-indexes --apply
         echo "::endgroup::"
-
     - name: show free space
       if: always()
       shell: bash

--- a/.github/actions/test_cmake/action.yaml
+++ b/.github/actions/test_cmake/action.yaml
@@ -1,10 +1,11 @@
 name: Run tests with cmake
 description: Run tests using cmake infrastructure
+
 runs:
   using: composite
   steps:
     - name: prepare
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         echo "SHELLOPTS=$SHELLOPTS:xtrace" >> $GITHUB_ENV
         echo "ARTIFACTS_DIR=${TMP_DIR}/artifacts" >> $GITHUB_ENV
@@ -12,11 +13,11 @@ runs:
         echo "SUMMARY_LINKS=$(mktemp)" >> $GITHUB_ENV
 
     - name: create dirs
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         mkdir -p "$ARTIFACTS_DIR" "$SUMMARY_DIR"
     - name: ctest
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         cd $TMP_DIR
 
@@ -26,7 +27,7 @@ runs:
 
     - name: Generate summary
       if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
@@ -47,7 +48,7 @@ runs:
 
     - name: Sync logs to S3
       if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         echo "::group::s3-sync"
         [ -f "${TMP_DIR}/ctest.log" ] && {

--- a/.github/scripts/github-runner.sh
+++ b/.github/scripts/github-runner.sh
@@ -3,7 +3,7 @@ set -x
 set -e
 set -o pipefail
 
-function on_exit () {
+function on_exit() {
     local exit_code=$?
     echo "Caught signal $exit_code, exiting..."
     df -h
@@ -34,9 +34,9 @@ sudo tar xzf ./runner.tar.gz
 # we do not have v6 connectivity on vms
 echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo apt-key add -
-echo "deb https://apt.kitware.com/ubuntu/ ${LSB_RELEASE} main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+echo "deb https://apt.kitware.com/ubuntu/ ${LSB_RELEASE} main" | sudo tee /etc/apt/sources.list.d/kitware.list > /dev/null
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-echo "deb https://apt.llvm.org/${LSB_RELEASE}/ llvm-toolchain-${LSB_RELEASE}-14 main" | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+echo "deb https://apt.llvm.org/${LSB_RELEASE}/ llvm-toolchain-${LSB_RELEASE}-14 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 sudo chmod a+r /etc/apt/keyrings/docker.asc
@@ -44,16 +44,16 @@ echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.d
 echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 sudo apt-get update
 sudo apt-get -y upgrade
-sudo apt-get install -y --no-install-recommends                 \
-             git wget gnupg lsb-release curl tzdata             \
-             cmake python3-dev python3-pip ninja-build antlr3   \
-             m4 libidn11-dev libaio1 libaio-dev make clang-14   \
+sudo apt-get install -y --no-install-recommends \
+             git wget gnupg lsb-release curl tzdata \
+             cmake python3-dev python3-pip ninja-build antlr3 \
+             m4 libidn11-dev libaio1 libaio-dev make clang-14 \
              lld-14 llvm-14 file distcc s3cmd qemu-kvm dpkg-dev \
-             docker-ce docker-ce-cli containerd.io              \
-             docker-buildx-plugin docker-compose-plugin jq      \
-             aria2 jq tree tmux atop awscli iftop htop          \
+             docker-ce docker-ce-cli containerd.io \
+             docker-buildx-plugin docker-compose-plugin jq \
+             aria2 jq tree tmux atop awscli iftop htop \
              pixz pigz pbzip2 xz-utils
-cat <<EOF > /tmp/requirements.txt
+cat << EOF > /tmp/requirements.txt
 conan==1.59
 pytest==7.1.3
 pyinstaller==5.13.2
@@ -90,7 +90,7 @@ set -x
 sudo sed -i -e 's/\\\$/$/g' /etc/shadow
 sudo usermod -a -G kvm "${USER_TO_CREATE}"
 sudo usermod -a -G docker "${USER_TO_CREATE}"
-sudo echo "${USER_TO_CREATE} ALL=(ALL) NOPASSWD:ALL" | sudo tee "/etc/sudoers.d/99-${USER_TO_CREATE}" >/dev/null
+sudo echo "${USER_TO_CREATE} ALL=(ALL) NOPASSWD:ALL" | sudo tee "/etc/sudoers.d/99-${USER_TO_CREATE}" > /dev/null
 sudo chmod 0440 "/etc/sudoers.d/99-${USER_TO_CREATE}"
 
 if [ -n "$GITHUB_TOKEN" ] && [ -n "$ORG" ] && [ -n "$TEAM" ]; then
@@ -108,13 +108,13 @@ if [ -n "$GITHUB_TOKEN" ] && [ -n "$ORG" ] && [ -n "$TEAM" ]; then
 
     # Get members ssh keys
     while read -r login; do
-        curl  -s -L \
+        curl -s -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/users/${login}/keys" | jq -r '.[].key' | while read -r key; do
             echo "$key $login" | tee -a "$KEYS_FILE"
-        done;
+        done
     done < "$LOGINS_FILE"
 fi
 
@@ -138,38 +138,39 @@ if [ -n "${YA_ARCHIVE_URL}" ]; then
     case "$EXTENSION" in
         gz)
             COMPRESS_ARGS=rapidgzip
-        ;;
+            ;;
         xz)
             COMPRESS_ARGS='pixz'
-        ;;
+            ;;
         bz2)
             COMPRESS_ARGS=pbzip2
-        ;;
-        zst|zstd)
+            ;;
+        zst | zstd)
             COMPRESS_ARGS=zstd
-        ;;
+            ;;
         *)
             echo "Unsupported archive extension: $EXTENSION"
             exit 1
-        ;;
+            ;;
     esac
 
     # wget -nv -O - "${YA_ARCHIVE_URL}" | sudo -E -H -u github time tar -S -I "$COMPRESS_ARGS" -C "/home/${USER_TO_CREATE}" --strip-components=2 -x -f -
     case "$PROTOCOL" in
-        http|https)
+        http | https)
             sudo -E -H -u "$USER_TO_CREATE" time aria2c -x 8 -d "/home/${USER_TO_CREATE}" "${YA_ARCHIVE_URL}" -d "/home/${USER_TO_CREATE}" -o "${FILENAME}"
-        ;;
+            ;;
         s3)
             if [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-                echo "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set"; exit 1;
+                echo "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set"
+                exit 1
             fi
             sudo -E -H -u "$USER_TO_CREATE" mkdir -p "/home/$USER_TO_CREATE/.aws"
-            cat <<EOF | sudo -E -H -u "$USER_TO_CREATE" tee "/home/$USER_TO_CREATE/.aws/config"
+            cat << EOF | sudo -E -H -u "$USER_TO_CREATE" tee "/home/$USER_TO_CREATE/.aws/config"
 [default]
 aws_access_key_id = $AWS_ACCESS_KEY_ID
 aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
 EOF
-            cat <<EOF | sudo -E -H -u "$USER_TO_CREATE" tee "/home/$USER_TO_CREATE/.aws/credentials"
+            cat << EOF | sudo -E -H -u "$USER_TO_CREATE" tee "/home/$USER_TO_CREATE/.aws/credentials"
 [default]
 region = eu-north1
 endpoint_url=https://storage.ai.nebius.cloud/
@@ -179,11 +180,11 @@ s3 =
     max_queue_size = 10240
 EOF
             sudo -E -H -u github time aws s3 cp "${YA_ARCHIVE_URL}" "/home/${USER_TO_CREATE}/${FILENAME}"
-        ;;
+            ;;
         *)
             echo "Unsupported protocol: $PROTOCOL"
             exit 1
-        ;;
+            ;;
     esac
     sudo -E -H -u "$USER_TO_CREATE" time tar -S -I "$COMPRESS_ARGS" -C "/home/${USER_TO_CREATE}" --strip-components=2 -x -f "/home/${USER_TO_CREATE}/${FILENAME}"
 fi

--- a/.github/scripts/github-runner.sh
+++ b/.github/scripts/github-runner.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -x
+set -e
+set -o pipefail
+
+function on_exit () {
+    local exit_code=$?
+    echo "Caught signal $exit_code, exiting..."
+    df -h
+    mount
+    [ "$exit_code" -eq 1 ] && sleep 1800
+    # shellcheck disable=SC2009
+    ps auxf | grep -vE "]$"
+    sudo ls -lsha "/home/${USER_TO_CREATE}/"
+    [ -d "/home/${USER_TO_CREATE}/.ya" ] && {
+        sudo ls -lsha "/home/${USER_TO_CREATE}/.ya"
+        sudo du -h -d 1 "/home/${USER_TO_CREATE}/.ya"
+    }
+    if [ -n "$FILENAME" ] && [ -f "/home/${USER_TO_CREATE}/${FILENAME}" ]; then
+        sudo rm -f "/home/${USER_TO_CREATE}/${FILENAME}"
+    fi
+    sudo rm -rf "/home/${USER_TO_CREATE}/.aws" /root/.aws/
+
+    sudo rm -rf "/home/${USER_TO_CREATE}/.aws" /root/.aws/
+    sudo rm -rf /var/lib/apt/lists/*
+    exit $exit_code
+}
+trap on_exit EXIT
+
+# Download github runner
+sudo mkdir -p /actions-runner && cd /actions-runner || exit
+sudo curl -o runner.tar.gz -L "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+sudo tar xzf ./runner.tar.gz
+# we do not have v6 connectivity on vms
+echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo apt-key add -
+echo "deb https://apt.kitware.com/ubuntu/ ${LSB_RELEASE} main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+echo "deb https://apt.llvm.org/${LSB_RELEASE}/ llvm-toolchain-${LSB_RELEASE}-14 main" | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu jammy stable' | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+sudo apt-get update
+sudo apt-get -y upgrade
+sudo apt-get install -y --no-install-recommends                 \
+             git wget gnupg lsb-release curl tzdata             \
+             cmake python3-dev python3-pip ninja-build antlr3   \
+             m4 libidn11-dev libaio1 libaio-dev make clang-14   \
+             lld-14 llvm-14 file distcc s3cmd qemu-kvm dpkg-dev \
+             docker-ce docker-ce-cli containerd.io              \
+             docker-buildx-plugin docker-compose-plugin jq      \
+             aria2 jq tree tmux atop awscli iftop htop          \
+             pixz pigz pbzip2 xz-utils
+cat <<EOF > /tmp/requirements.txt
+conan==1.59
+pytest==7.1.3
+pyinstaller==5.13.2
+pytest-timeout
+pytest-xdist==3.3.1
+setproctitle==1.3.2
+six
+pyyaml
+packaging
+cryptography
+grpcio
+grpcio-tools
+PyHamcrest
+tornado
+xmltodict
+pyarrow
+boto3
+moto[server]
+psutil
+yandexcloud==0.258.0
+PyGithub==2.2.0
+cryptography
+packaging
+rapidgzip
+EOF
+sudo pip3 install -r /tmp/requirements.txt
+curl -L "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-${OS_ARCH}.tar.xz" | sudo tar -xJ -C /usr/local/bin/ --strip-components=1 --no-same-owner "ccache-${CCACHE_VERSION}-linux-${OS_ARCH}/ccache"
+sudo apt-get remove -y unattended-upgrades
+
+sudo adduser --gecos "" --disabled-password --shell /bin/bash "${USER_TO_CREATE}"
+set +x
+sudo usermod --password "${PASSWORD_HASH//$/\\$}" "${USER_TO_CREATE}"
+set -x
+sudo sed -i -e 's/\\\$/$/g' /etc/shadow
+sudo usermod -a -G kvm "${USER_TO_CREATE}"
+sudo usermod -a -G docker "${USER_TO_CREATE}"
+sudo echo "${USER_TO_CREATE} ALL=(ALL) NOPASSWD:ALL" | sudo tee "/etc/sudoers.d/99-${USER_TO_CREATE}" >/dev/null
+sudo chmod 0440 "/etc/sudoers.d/99-${USER_TO_CREATE}"
+
+if [ -n "$GITHUB_TOKEN" ] && [ -n "$ORG" ] && [ -n "$TEAM" ]; then
+    export LOGINS_FILE
+    export KEYS_FILE
+    LOGINS_FILE=$(mktemp)
+    KEYS_FILE=$(mktemp)
+
+    # Get team members
+    curl -s -L \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/orgs/${ORG}/teams/${TEAM}/members?per_page=100&page=1" | jq -r '.[].login' | tee -a "$LOGINS_FILE"
+
+    # Get members ssh keys
+    while read -r login; do
+        curl  -s -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/users/${login}/keys" | jq -r '.[].key' | while read -r key; do
+            echo "$key $login" | tee -a "$KEYS_FILE"
+        done;
+    done < "$LOGINS_FILE"
+fi
+
+if [ -f "$KEYS_FILE" ]; then
+    sudo mkdir -p "/home/${USER_TO_CREATE}/.ssh"
+    sudo chown -R "${USER_TO_CREATE}:${USER_TO_CREATE}" "/home/${USER_TO_CREATE}/.ssh"
+    sudo chmod 0700 "/home/${USER_TO_CREATE}/.ssh"
+    sudo cp "${KEYS_FILE}" "/home/${USER_TO_CREATE}/.ssh/authorized_keys"
+    sudo chown "${USER_TO_CREATE}:${USER_TO_CREATE}" "/home/${USER_TO_CREATE}/.ssh/authorized_keys"
+    sudo chmod 0600 "/home/${USER_TO_CREATE}/.ssh/authorized_keys"
+    sudo cat "/home/${USER_TO_CREATE}/.ssh/authorized_keys"
+fi
+
+# add .ya cache
+sudo ls -lsha "/home/${USER_TO_CREATE}/"
+df -h
+if [ -n "${YA_ARCHIVE_URL}" ]; then
+    FILENAME="${YA_ARCHIVE_URL##*/}"
+    EXTENSION="${FILENAME##*.}"
+    PROTOCOL="${YA_ARCHIVE_URL%%://*}"
+    case "$EXTENSION" in
+        gz)
+            COMPRESS_ARGS=rapidgzip
+        ;;
+        xz)
+            COMPRESS_ARGS='pixz'
+        ;;
+        bz2)
+            COMPRESS_ARGS=pbzip2
+        ;;
+        zst|zstd)
+            COMPRESS_ARGS=zstd
+        ;;
+        *)
+            echo "Unsupported archive extension: $EXTENSION"
+            exit 1
+        ;;
+    esac
+
+    # wget -nv -O - "${YA_ARCHIVE_URL}" | sudo -E -H -u github time tar -S -I "$COMPRESS_ARGS" -C "/home/${USER_TO_CREATE}" --strip-components=2 -x -f -
+    case "$PROTOCOL" in
+        http|https)
+            sudo -E -H -u "$USER_TO_CREATE" time aria2c -x 8 -d "/home/${USER_TO_CREATE}" "${YA_ARCHIVE_URL}" -d "/home/${USER_TO_CREATE}" -o "${FILENAME}"
+        ;;
+        s3)
+            if [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+                echo "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set"; exit 1;
+            fi
+            sudo -E -H -u "$USER_TO_CREATE" mkdir -p "/home/$USER_TO_CREATE/.aws"
+            cat <<EOF | sudo -E -H -u "$USER_TO_CREATE" tee "/home/$USER_TO_CREATE/.aws/config"
+[default]
+aws_access_key_id = $AWS_ACCESS_KEY_ID
+aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+EOF
+            cat <<EOF | sudo -E -H -u "$USER_TO_CREATE" tee "/home/$USER_TO_CREATE/.aws/credentials"
+[default]
+region = eu-north1
+endpoint_url=https://storage.ai.nebius.cloud/
+s3 =
+    max_concurrent_requests = 32
+    multipart_chunksize = 32MB
+    max_queue_size = 10240
+EOF
+            sudo -E -H -u github time aws s3 cp "${YA_ARCHIVE_URL}" "/home/${USER_TO_CREATE}/${FILENAME}"
+        ;;
+        *)
+            echo "Unsupported protocol: $PROTOCOL"
+            exit 1
+        ;;
+    esac
+    sudo -E -H -u "$USER_TO_CREATE" time tar -S -I "$COMPRESS_ARGS" -C "/home/${USER_TO_CREATE}" --strip-components=2 -x -f "/home/${USER_TO_CREATE}/${FILENAME}"
+fi

--- a/.github/scripts/index.py
+++ b/.github/scripts/index.py
@@ -373,9 +373,10 @@ if __name__ == "__main__":
         "logs",
         "build_logs",
         "artifacts",
+        "ya_archive",
     }
 
-    ttl_config = {"default": "30d", "test_data": "7d"}
+    ttl_config = {"default": "30d", "test_data": "7d", "ya_archive": "7d"}
     for ttl_setting in args.ttl:
         key, value = ttl_setting.split("=")
         ttl_config[key] = value

--- a/.github/scripts/manage-images.py
+++ b/.github/scripts/manage-images.py
@@ -36,9 +36,9 @@ def status_to_string(image: Image) -> str:
 
 def convert_size(size_bytes):
     if size_bytes == 0:
-        return "0B"
-    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
-    i = int(math.floor(math.log(size_bytes, 1024)))
+        return "0 B"
+    size_name = ("B", "KB", "MB", "GB", "TB")
+    i = math.floor(math.log(size_bytes, 1024))
     p = math.pow(1024, i)
     s = round(size_bytes / p, 2)
     return f"{s} {size_name[i]}"
@@ -71,9 +71,9 @@ def main(
 
     if update_image_id:
         variable.edit(value=new_image_id)
-        logger.info("%s (new) = %s" % (image_variable_name, new_image_id))
+        logger.info("%s (new) = %s", image_variable_name, new_image_id)
     else:
-        logger.info("Would set %s (new) = %s" % (image_variable_name, new_image_id))
+        logger.info("Would set %s (new) = %s", image_variable_name, new_image_id)
 
     request = ListImagesRequest(
         folder_id=folder_id,
@@ -104,24 +104,22 @@ def main(
             candidate_images.append(image)
 
         logger.info(
-            "Found image%s: %s %s %s %s %s %s %s %s"
-            % (
-                # fmt: off
-                prefix, image.id, image.name, status, created_at,
-                image.family, storage_size, min_disk_size,
-                ', '.join(f"{k}={v}" for k, v in image.labels.items())
-                # fmt: on
-            )
+            "Found image%s: %s %s %s %s %s %s %s %s",
+            # fmt: off
+            prefix, image.id, image.name, status, created_at,
+            image.family, storage_size, min_disk_size,
+            ', '.join(f"{k}={v}" for k, v in image.labels.items())
+            # fmt: on
         )
-    logger.info(f"Total images: {len(response.images)}")
+    logger.info("Total images: %d", len(response.images))
 
     for image in candidate_images[images_to_keep:]:
         if remove_old_images:
-            logger.info(f"Removing image {image.id}")
+            logger.info("Removing image %s", image.id)
             client.Delete(DeleteImageRequest(image_id=image.id))
-            logger.info(f"Image {image.id} removed")
+            logger.info("Image %s removed", image.id)
         else:
-            logger.info(f"Would remove image {image.id}")
+            logger.info("Would remove image %s", image.id)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/manage-images.py
+++ b/.github/scripts/manage-images.py
@@ -91,16 +91,17 @@ def main(
         min_disk_size = convert_size(image.min_disk_size)
         prefix = " (PROTECTED)"
         postfix = ""
+
+        if image.id == new_image_id:
+            postfix = " (NEW)"
+
         if (
             image.id not in PROTECTED_IMAGE_IDS
             and image.family == image_family_name  # noqa: W503
             and image.id != new_image_id  # noqa: W503
         ):
             prefix = ""
-            if image.id == new_image_id:
-                postfix = " (NEW)"
-            if image.family == image_family_name:
-                postfix += " (SELECTED)"
+            postfix += " (SELECTED)"
             candidate_images.append(image)
 
         logger.info(

--- a/.github/scripts/manage-images.py
+++ b/.github/scripts/manage-images.py
@@ -1,0 +1,209 @@
+import os
+import json
+import grpc
+import math
+import logging
+import argparse
+from github import Github
+from datetime import datetime, timezone
+from yandex.cloud.compute.v1.image_pb2 import Image
+from yandex.cloud.compute.v1.image_service_pb2 import (
+    DeleteImageRequest,
+    ListImagesRequest,
+)
+from yandex.cloud.compute.v1.image_service_pb2_grpc import ImageServiceStub
+from yandexcloud import SDK, RetryInterceptor, backoff_linear_with_jitter
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s: %(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# they won't appear in the list of images
+# but they will be protected from deletion anyway
+PROTECTED_IMAGE_IDS = [
+    "arl2kdkt7j8aorb1ib1h",
+    "arlf5b2mm2k1s4b71u4t",
+    "arlhviu5hj9aj6uqq6l3",
+    "arlpgqq65s5p13srj592",
+    "arl7p6s8d25e8m83kvi3",
+]
+
+
+def status_to_string(image: Image) -> str:
+    return Image.Status.Name(image.status)
+
+
+def convert_size(size_bytes):
+    if size_bytes == 0:
+        return "0B"
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    i = int(math.floor(math.log(size_bytes, 1024)))
+    p = math.pow(1024, i)
+    s = round(size_bytes / p, 2)
+    return f"{s} {size_name[i]}"
+
+
+def main(
+    sdk: SDK,
+    github_token: str,
+    github_repository: str,
+    new_image_id: str,
+    image_variable_name: str,
+    update_image_id: bool,
+    images_to_keep: int,
+    remove_old_images: bool,
+    folder_id: str,
+) -> None:
+    github = Github(github_token)
+    repo = github.get_repo(github_repository)
+    github_repository_owner, github_repository_name = github_repository.split("/")
+    image_family_name = (
+        f"github-runner-{github_repository_owner}-{github_repository_name}"
+    )
+
+    variable = repo.get_variable(image_variable_name)
+
+    logger.info("%s (old) = %s" % (image_variable_name, variable.value))
+
+    if new_image_id is None:
+        new_image_id = variable.value
+
+    if update_image_id:
+        variable.edit(value=new_image_id)
+        logger.info("%s (new) = %s" % (image_variable_name, new_image_id))
+    else:
+        logger.info("Would set %s (new) = %s" % (image_variable_name, new_image_id))
+
+    request = ListImagesRequest(
+        folder_id=folder_id,
+        order_by="created_at desc",
+        filter=f"family IN ('{image_family_name}') AND status = 'READY'",
+    )
+
+    client = sdk.client(ImageServiceStub)
+    response = client.List(request)
+    candidate_images = []
+    for image in response.images:
+        status = status_to_string(image)
+        created_at = datetime.fromtimestamp(image.created_at.seconds, tz=timezone.utc)
+        storage_size = convert_size(image.storage_size)
+        min_disk_size = convert_size(image.min_disk_size)
+        prefix = " (PROTECTED)"
+        postfix = ""
+        if (
+            image.id not in PROTECTED_IMAGE_IDS
+            and image.family == image_family_name  # noqa: W503
+            and image.id != new_image_id  # noqa: W503
+        ):
+            prefix = ""
+            if image.id == new_image_id:
+                postfix = " (NEW)"
+            if image.family == image_family_name:
+                postfix += " (SELECTED)"
+            candidate_images.append(image)
+
+        logger.info(
+            "Found image%s: %s %s %s %s %s %s %s %s"
+            % (
+                # fmt: off
+                prefix, image.id, image.name, status, created_at,
+                image.family, storage_size, min_disk_size,
+                ', '.join(f"{k}={v}" for k, v in image.labels.items())
+                # fmt: on
+            )
+        )
+    logger.info(f"Total images: {len(response.images)}")
+
+    for image in candidate_images[images_to_keep:]:
+        if remove_old_images:
+            logger.info(f"Removing image {image.id}")
+            client.Delete(DeleteImageRequest(image_id=image.id))
+            logger.info(f"Image {image.id} removed")
+        else:
+            logger.info(f"Would remove image {image.id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download and process GitHub Actions artifact."
+    )
+    parser.add_argument(
+        "--github-token",
+        default=os.getenv("GITHUB_TOKEN"),
+        help="GitHub Token for authentication",
+    )
+    parser.add_argument(
+        "--github-repo",
+        default=os.getenv("GITHUB_REPOSITORY"),
+        help='GitHub repository in the format "owner/repo"',
+    )
+    parser.add_argument(
+        "--api-endpoint",
+        default="api.ai.nebius.cloud",
+        help="Cloud API Endpoint",
+    )
+    parser.add_argument(
+        "--folder-id",
+        default="bjeuq5o166dq4ukv3eec",
+        help="Folder ID where the VM will be created",
+    )
+    parser.add_argument(
+        "--service-account-key",
+        required=True,
+        help="Path to the service account key file",
+    )
+    parser.add_argument(
+        "--new-image-id",
+        default=os.getenv("NEW_IMAGE_ID"),
+        help="Name of the artifact to download and extract",
+    )
+    parser.add_argument(
+        "--image-variable-name",
+        default="IMAGE_ID_2204",
+        help="Name of the variable to update in GitHub Actions",
+    )
+    parser.add_argument(
+        "--update-image-id",
+        default=False,
+        action="store_true",
+        help="Update the image id in Github Actions variables",
+    )
+    parser.add_argument(
+        "--images-to-keep", default=7, type=int, help="Workflow file name"
+    )
+
+    parser.add_argument(
+        "--remove-old-images",
+        default=False,
+        action="store_true",
+        help="Remove old images",
+    )
+
+    args = parser.parse_args()
+    logger.info(args)
+
+    interceptor = RetryInterceptor(
+        max_retry_count=30,
+        retriable_codes=[grpc.StatusCode.UNAVAILABLE],
+        back_off_func=backoff_linear_with_jitter(5, 0),
+    )
+
+    with open(args.service_account_key, "r") as fp:
+        sdk = SDK(
+            service_account_key=json.load(fp),
+            endpoint=args.api_endpoint,
+            interceptor=interceptor,
+        )
+
+    main(
+        sdk=sdk,
+        github_token=args.github_token,
+        github_repository=args.github_repo,
+        new_image_id=args.new_image_id,
+        image_variable_name=args.image_variable_name,
+        update_image_id=args.update_image_id,
+        images_to_keep=args.images_to_keep,
+        remove_old_images=args.remove_old_images,
+        folder_id=args.folder_id,
+    )

--- a/.github/scripts/manage-vm.py
+++ b/.github/scripts/manage-vm.py
@@ -146,7 +146,7 @@ done
 ./run.sh || exit 0
 """
 
-    cloud_init = {}
+    cloud_init = {"runcmd": [script]}
     # cloud_init["ssh_pwauth"] = False
     cloud_init["users"] = [
         {
@@ -161,7 +161,6 @@ done
         logger.info("Adding SSH keys to cloud-init")
         cloud_init["users"][0]["ssh_authorized_keys"] = ssh_keys
 
-    cloud_init["runcmd"] = [script]
     logger.info(
         f"Cloud-init: \n{yaml.safe_dump(cloud_init, default_flow_style=False, width=math.inf)}".replace(
             token, "****"

--- a/.github/scripts/manage-vm.py
+++ b/.github/scripts/manage-vm.py
@@ -98,36 +98,70 @@ def generate_cloud_init_script(
             f",GITHUB_REPOSITORY_{os.environ['GITHUB_REPOSITORY'].replace('/', '_')}"
         )
 
-    for item in ["GITHUB_SHA", "GITHUB_REF", "GITHUB_RUN_ID", "GITHUB_RUN_NUMBER"]:
+    for item in ["GITHUB_SHA", "GITHUB_REF", "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT"]:
         if os.environ.get(item):
             label += f",{item}_{os.environ[item]}"
 
-    script = [
-        "#!/bin/bash",
-        "set -x",
-        "mkdir -p /actions-runner && cd /actions-runner",
-        'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64";; esac',
-        f"export FILENAME=actions-runner-linux-${{ARCH}}-{version}.tar.gz",
-        # https://github.com/actions/runner/releases/download/v2.314.1/actions-runner-linux-x64-2.314.1.tar.gz
-        f'[ -f "$FILENAME" ] || curl -O -L "https://github.com/actions/runner/releases/download/v{version}/$FILENAME"',
-        'tar xzf "./$FILENAME"',
-        "export RUNNER_ALLOW_RUNASROOT=1",
-        f"./config.sh  --labels {label} --url https://github.com/{owner}/{repo} --token {token}",
-        "./run.sh",
-    ]
+    script = f"""
+set -x
+[ -d /actions-runner ] && {{
+    echo "Runner already installed"
+    cd /actions-runner
+}} || {{
+    mkdir -p /actions-runner && cd /actions-runner
+    case $(uname -m) in
+        aarch64) ARCH="arm64" ;;
+        amd64|x86_64) ARCH="x64";;
+    esac
+    export FILENAME=runner.tar.gz
+    # https://github.com/actions/runner/releases/download/v2.314.1/actions-runner-linux-x64-2.314.1.tar.gz
+    exit_code=1
+    i=0
+    url="https://github.com/actions/runner/releases/download/v{version}/actions-runner-linux-${{ARCH}}-{version}.tar.gz"
+    until [ $exit_code -eq 0 ] || [ $i -gt 3 ]; do
+        [ -f "$FILENAME" ] || curl --connect-timeout 5 -O -L "$url" -o "$FILENAME"
+        exit_code=$?
+        i=$((i+1))
+        [ $exit_code -eq 0 ] || rm -f "$FILENAME"
+        echo "$((date)) [$i] curl exited (or timed-out) with code $exit_code"
+    done
+    tar xzf "./$FILENAME" || exit 0
+}}
+export RUNNER_ALLOW_RUNASROOT=1
+
+# trying to catch registration error
+exit_code=1
+i=0
+until [ $exit_code -eq 0 ] || [ $i -gt 3 ]; do
+    echo ./config.sh --labels {label} --url https://github.com/{owner}/{repo} --token XXX --unattended
+    set +x
+    timeout 60 ./config.sh --labels {label} --url https://github.com/{owner}/{repo} --token {token} --unattended
+    set -x
+    exit_code=$?
+    i=$((i+1))
+    echo "$((date)) [$i] config.sh exited (or timed-out) with code $exit_code"
+    [ $exit_code -eq 0 ] || find /actions-runner -name *.log -print -exec cat {{}} \; # noqa: W605
+done
+# exit code 0 to skip the error and to boot vm correctly
+./run.sh || exit 0
+"""
 
     cloud_init = {}
-    cloud_init["ssh_pwauth"] = False
+    # cloud_init["ssh_pwauth"] = False
     cloud_init["users"] = [
         {
             "name": user,
             "sudo": "ALL=(ALL) NOPASSWD:ALL",
             "passwd": os.environ["VM_USER_PASSWD"],
+            "lock_passwd": False,
             "shell": "/bin/bash",
-            "ssh_authorized_keys": ssh_keys,
         }
     ]
-    cloud_init["runcmd"] = ["\n".join(script)]
+    if ssh_keys:
+        logger.info("Adding SSH keys to cloud-init")
+        cloud_init["users"][0]["ssh_authorized_keys"] = ssh_keys
+
+    cloud_init["runcmd"] = [script]
     logger.info(
         f"Cloud-init: \n{yaml.safe_dump(cloud_init, default_flow_style=False, width=math.inf)}".replace(
             token, "****"
@@ -155,10 +189,13 @@ def get_runner_token(
     ).json()
 
     token = result.get("token")
+    expires_at = result.get("expires_at")
     if token:
         # Mask the token in the logs
         print(f"::add-mask::{token}")
-        logger.debug("Got runner registration token: %s", token)
+        logger.debug(
+            "Got runner registration token: %s (valid till: %s)", (token, expires_at)
+        )
         return token
     else:
         raise ValueError(f"Failed to get runner registration token: {result}")
@@ -218,7 +255,15 @@ def create_vm(sdk: SDK, args: argparse.Namespace):
         args.github_repo_owner, args.github_repo, GITHUB_TOKEN
     )
 
-    ssh_keys = fetch_github_team_public_keys(gh, args.github_org, args.github_team_slug)
+    ssh_keys = []
+    if args.github_org and args.github_team_slug:
+        ssh_keys = fetch_github_team_public_keys(
+            gh, args.github_org, args.github_team_slug
+        )
+    else:
+        logger.info(
+            "No GitHub organization or team specified, skipping SSH key fetching"
+        )
 
     # fmt: off
     standard_v2_cpu = [
@@ -257,6 +302,14 @@ def create_vm(sdk: SDK, args: argparse.Namespace):
     labels = args.labels
     labels["runner-label"] = runner_github_label
 
+    metadata = {
+        "user-data": user_data,
+        "serial-port-enable": "1",
+    }
+    if ssh_keys:
+        logger.info("Adding SSH keys to metadata")
+        metadata["ssh-keys"] = "\n".join([f"{args.user}:{key}" for key in ssh_keys])
+
     request = CreateInstanceRequest(
         name=args.name,
         folder_id=args.folder_id,
@@ -283,11 +336,7 @@ def create_vm(sdk: SDK, args: argparse.Namespace):
                 ),
             )
         ],
-        metadata={
-            "user-data": user_data,
-            "ssh-keys": "\n".join([f"{args.user}:{key}" for key in ssh_keys]),
-            "serial-port-enable": "1",
-        },
+        metadata=metadata,
     )
 
     # Create the VM
@@ -407,15 +456,15 @@ if __name__ == "__main__":
     create = subparsers.add_parser("create", help="Create a new VM")
     create.add_argument(
         "--github-org",
-        required=True,
-        default="ydb-platform",
+        required=False,
+        default="",
         help="GitHub organization name (we will fetch SSH keys from this org to allow access to the VM)",
     )
 
     create.add_argument(
         "--github-team-slug",
-        required=True,
-        default="NBS",
+        required=False,
+        default="",
         help="Slug of the GitHub team within the organization",
     )
 
@@ -434,7 +483,7 @@ if __name__ == "__main__":
 
     create.add_argument(
         "--github-runner-version",
-        default="2.308.0",
+        default="2.316.1",
         help="GitHub Runner version",
     )
 
@@ -488,7 +537,7 @@ if __name__ == "__main__":
 
     create.add_argument("--retry-time", default=10, help="How often to retry (seconds)")
     create.add_argument(
-        "--timeout", default=600, help="How long to wait for creation (seconds)"
+        "--timeout", default=1200, help="How long to wait for creation (seconds)"
     )
     create.add_argument("--apply", action="store_true", help="Apply the changes")
 

--- a/.github/scripts/tests/transform-ya-junit.py
+++ b/.github/scripts/tests/transform-ya-junit.py
@@ -169,25 +169,34 @@ class YTestReportTrace:
         return result
 
     def get_log_dir(self, class_event, name) -> str | None:
-        logs_dir = self.traces.get(
-            (class_event, name),
-            {},
-        ).get("logs", {}).get("logsdir")
+        logs_dir = (
+            self.traces.get(
+                (class_event, name),
+                {},
+            )
+            .get("logs", {})
+            .get("logsdir")
+        )
 
         if logs_dir is None:
             return None
 
-        return logs_dir.replace("$(BUILD_ROOT)", '').lstrip('/')
+        return logs_dir.replace("$(BUILD_ROOT)", "").lstrip("/")
 
     def get_log_dir_chunk(self, suite, idx, total):
-        logs_dir = self.traces.get(
-            (suite, idx, total), {},
-        ).get("logs", {}).get("logsdir")
+        logs_dir = (
+            self.traces.get(
+                (suite, idx, total),
+                {},
+            )
+            .get("logs", {})
+            .get("logsdir")
+        )
 
         if logs_dir is None:
             return None
 
-        return logs_dir.replace("$(BUILD_ROOT)", '').lstrip('/')
+        return logs_dir.replace("$(BUILD_ROOT)", "").lstrip("/")
 
 
 def filter_empty_logs(logs):
@@ -292,9 +301,8 @@ def transform(
                     )
                     add_junit_link_property(
                         case,
-                        'logs_directory',
-                        f'{data_url_prefix}/'
-                        f'{urllib.parse.quote(logs_directory)}',
+                        "logs_directory",
+                        f"{data_url_prefix}/" f"{urllib.parse.quote(logs_directory)}",
                     )
 
                 if logs:
@@ -339,7 +347,7 @@ def main():
     parser.add_argument("--log-url-prefix", default="./", help="url prefix for logs")
     parser.add_argument(
         "--data-url-prefix",
-        dest='data_url_prefix',
+        dest="data_url_prefix",
         default="./",
         help="Url prefix for test data, which stores all the additional logs",
     )

--- a/.github/scripts/ttl-watcher.py
+++ b/.github/scripts/ttl-watcher.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
 
     bucket_name, base_prefix = parse_s3_path(args.s3_path)
 
-    ttl_config = {"default": "30d", "test_data": "7d"}
+    ttl_config = {"default": "30d", "test_data": "7d", "ya_archive": "7d"}
     for ttl_setting in args.ttl:
         key, value = ttl_setting.split("=")
         ttl_config[key] = value
@@ -177,6 +177,7 @@ if __name__ == "__main__":
         "logs",
         "build_logs",
         "artifacts",
+        "ya_archive",
     }
 
     s3_client = boto3.client("s3")

--- a/.github/scripts/workflow-artifact-download.py
+++ b/.github/scripts/workflow-artifact-download.py
@@ -1,0 +1,175 @@
+import os
+import logging
+import requests
+import zipfile
+import io
+from github import Github
+from typing import List, Optional
+import argparse
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s: %(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def download_and_extract_artifact(
+    artifact_url: str, headers: dict, files_to_extract: List[str], output_path: str
+) -> List[str]:
+    extracted_files = []
+    response = requests.get(artifact_url, headers=headers, stream=True)
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zip_file:
+        if files_to_extract:
+            for file_name in files_to_extract:
+                try:
+                    zip_file.extract(file_name, path=output_path)
+                    extracted_files.append(file_name)
+                    log_file_extraction(file_name, output_path)
+                except KeyError:
+                    logger.error("File '%s' not found within the artifact.", file_name)
+        else:
+            zip_file.extractall(path=output_path)
+            extracted_files = zip_file.namelist()
+            for file_name in extracted_files:
+                log_file_extraction(file_name, output_path)
+    return extracted_files
+
+
+def log_file_extraction(file_name: str, output_path: str) -> None:
+    file_path = os.path.join(output_path, file_name)
+    logger.info("Extracted '%s' to '%s'", file_name, file_path)
+
+
+def write_contents_to_output(
+    output_file_path: str, output_path: str, files: List[str], run_id: int = 0
+) -> None:
+    with open(output_file_path, "a") as output_file:  # 'a' to append to the file
+        for file_name in files:
+            file_path = os.path.join(output_path, file_name)
+            try:
+                with open(file_path, "r") as f:
+                    content = f.read()
+                    normalized_file_name = file_name.replace(".", "_").replace("-", "_")
+                    # Here we use the filename as the variable name for simplicity
+                    logger.info(
+                        "Writing %s=%s to %s",
+                        normalized_file_name,
+                        content,
+                        output_file_path,
+                    )
+                    output_file.write(f"{normalized_file_name}={content}\n")
+                    output_file.write(f"latest_url={content}\n")
+                    if run_id != 0:
+                        output_file.write(f"run_id={run_id}\n")
+            except FileNotFoundError:
+                logger.error(
+                    "File '%s' was not found in the extracted files.", file_name
+                )
+
+
+def main(
+    github_token: str,
+    github_repository: str,
+    output_path: str,
+    artifact_name: str,
+    workflow_name: str,
+    workflow_run_id: int,
+    branch: str,
+    files_to_extract: Optional[List[str]],
+    github_output: str,
+) -> None:
+    g = Github(github_token)
+    repo = g.get_repo(github_repository)
+    if workflow_run_id != 0:
+        workflow_runs = [repo.get_workflow_run(workflow_run_id)]
+    else:
+        workflow = repo.get_workflow(workflow_name)
+        workflow_runs = workflow.get_runs(branch=branch, status="success")
+
+    for run in workflow_runs:
+        artifacts = run.get_artifacts()
+        for artifact in artifacts:
+            if artifact.name == artifact_name:
+                logger.info("Found artifact '%s' in run %d", artifact_name, run.id)
+                headers = {"Authorization": f"token {github_token}"}
+                extracted_files = download_and_extract_artifact(
+                    artifact.archive_download_url,
+                    headers,
+                    files_to_extract,
+                    output_path,
+                )
+
+                if files_to_extract is None:
+                    # If no specific files were requested, write all extracted files' contents
+                    files_to_extract = extracted_files
+
+                write_contents_to_output(
+                    github_output, output_path, files_to_extract, run.id
+                )
+                logger.info("Artifact contents written to '%s'", github_output)
+                return
+    logger.info(
+        "Artifact named '%s' not found in any workflow runs on branch '%s'.",
+        artifact_name,
+        branch,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download and process GitHub Actions artifact."
+    )
+    parser.add_argument(
+        "--github-token",
+        default=os.getenv("GITHUB_TOKEN"),
+        help="GitHub Token for authentication",
+    )
+    parser.add_argument(
+        "--github-repo",
+        default=os.getenv("GITHUB_REPOSITORY"),
+        help='GitHub repository in the format "owner/repo"',
+    )
+    parser.add_argument(
+        "--output",
+        default=os.getenv("GITHUB_WORKSPACE", "."),
+        help="Output path for the extracted files",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.getenv("GITHUB_OUTPUT"),
+        help="File path for writing output variables for GitHub Actions",
+    )
+    parser.add_argument(
+        "--artifact",
+        default="ya_web_url_file",
+        help="Name of the artifact to download and extract",
+    )
+    parser.add_argument("--workflow", default="nightly.yaml", help="Workflow file name")
+    parser.add_argument(
+        "--workflow-run-id",
+        default=0,
+        type=int,
+        help="Workflow run id (if we want specific run)",
+    )
+    parser.add_argument("--branch", default="main", help="Repository branch")
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        help="List of files to extract from the artifact. If not specified, all files are extracted.",
+    )
+
+    args = parser.parse_args()
+
+    logger.info(args)
+
+    main(
+        github_token=args.github_token,
+        github_repository=args.github_repo,
+        output_path=args.output,
+        artifact_name=args.artifact,
+        workflow_name=args.workflow,
+        workflow_run_id=args.workflow_run_id,
+        branch=args.branch,
+        files_to_extract=args.files,
+        github_output=args.github_output,
+    )

--- a/.github/scripts/workflow-artifact-download.py
+++ b/.github/scripts/workflow-artifact-download.py
@@ -43,7 +43,7 @@ def log_file_extraction(file_name: str, output_path: str) -> None:
 def write_contents_to_output(
     output_file_path: str, output_path: str, files: List[str], run_id: int = 0
 ) -> None:
-    with open(output_file_path, "a") as output_file:  # 'a' to append to the file
+    with open(output_file_path, "a") as output_file:
         for file_name in files:
             file_path = os.path.join(output_path, file_name)
             try:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,10 +1,10 @@
-You can use [act](https://github.com/nektos/act) as debugging tool for pipelines it acts as github runner of some sort, using docker.
+You can use [act](https://github.com/nektos/act) as a debugging tool for pipelines it acts as a GitHub runner of some sort, using docker.
 
-It is not 100% replacement for github actions altogether (i.e. you can't run self-hosted github runners), but you can use it to debug your changes before committing
+It is not 100% replacement for GitHub actions altogether (i.e. you can't run self-hosted GitHub runners), but you can use it to debug your changes before committing
 
-To set it up follow instructions on gihtub page and
+To set it up follow the instructions on the GitHub page and
 
-To use it you need to set up few files in separate directory, from where you will call `act`:
+To use it you need to set up a few files in separate directories, from where you will call `act`:
 
 * `.secrets` - get it here https://console.nebius.ai/folders/yc.nbs.nbs-secrets/lockbox/secret/cd4pqp4a1mt3hcshllf6/overview
 * `.vars` - example below:
@@ -16,16 +16,9 @@ REMOTE_CACHE_URL_YA=http://195.242.17.155:9090
 AWS_WEBSITE_SUFFIX=website.nemax.nebius.cloud
 ```
 
-Also you will need `~/.actrc`:
+Also, you will need `~/.actrc`:
 
-```bash
--P ubuntu-latest=catthehacker/ubuntu:act-latest
--P ubuntu-22.04=catthehacker/ubuntu:act-22.04
--P ubuntu-20.04=catthehacker/ubuntu:act-20.04
--P ubuntu-18.04=catthehacker/ubuntu:act-18.04
-```
-
-Here is few examples how to use it:
+Here are a few examples of how to use it:
 
 ```bash
 act -W .github/workflows/pr-github-actions.yaml workflow_dispatch

--- a/.github/workflows/build_and_test_cmake.yaml
+++ b/.github/workflows/build_and_test_cmake.yaml
@@ -75,6 +75,7 @@ jobs:
         s3_key_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         folder_prefix: nebius-
         build_preset: ${{ inputs.build_preset }}
+        install: false
 
     - name: Build
       uses: ./.github/actions/build_cmake

--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -99,8 +99,24 @@ on:
         description: "--link-threads in ya make"
       test_threads:
         type: string
-        default: "12"
+        default: "32"
         description: "--test-threads in ya test"
+      upload_ya_dir:
+        type: string
+        default: "no"
+        description: "Upload ya dir to s3"
+      clean_ya_dir:
+        type: string
+        default: "no"
+        description: "Clean ya dir from image before building"
+      use_network_cache:
+        type: string
+        default: "yes"
+        description: "Use network cache"
+      disk_type:
+        type: string
+        default: "network-ssd-nonreplicated"
+        description: "Disk type for VM"
 
 jobs:
   provide-runner:
@@ -138,8 +154,6 @@ jobs:
         uses: ./.github/actions/runner_create
         timeout-minutes: 60
         with:
-          org: ydb-platform
-          team: NBS
           repo_owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           service_account_key: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
@@ -148,47 +162,19 @@ jobs:
           vm_name: ${{ github.event.pull_request.number && format('pr-{0}{1}-{2}-{3}', github.event.pull_request.number, inputs.vm_name_suffix, github.run_id, github.run_attempt) || format('run-{0}-{1}', github.run_id, github.run_attempt) }}
           vm_zone: eu-north1-c
           vm_cpu: 60
-          vm_memory: 240
-          vm_disk_type: network-ssd-nonreplicated
+          vm_memory: 420
+          vm_disk_type: ${{ inputs.disk_type || 'network-ssd-nonreplicated' }}
           vm_disk_size: 1023
           vm_subnet: f8uh0ml4rhb45nde9p75
           vm_image: ${{ vars.IMAGE_ID_2204 }}
-          vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2},repo={3}', github.event.pull_request.number, github.run_id, github.run_attempt, github.event.repository.name) || format('run={0}-{1},repo={2}', github.run_id, github.run_attempt, github.event.repository.name) }}
+          vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2},repo={3},owner={4}', github.event.pull_request.number, github.run_id, github.run_attempt, github.event.repository.name, github.repository_owner) || format('run={0}-{1},repo={2},owner={3}', github.run_id, github.run_attempt, github.event.repository.name, github.repository_owner) }}
           vm_user_passwd: ${{ secrets.VM_USER_PASSWD }}
-
-
-  prepare-vm:
-    name: Prepare runner (${{ inputs.build_preset }}) [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
-    needs: provide-runner
-    runs-on: [ self-hosted, "${{ needs.provide-runner.outputs.label }}" ]
-    steps:
-      - name: Checkout PR
-        uses: actions/checkout@v4
-        if: github.event.pull_request.head.sha != ''
-        with:
-          submodules: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: Rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: Checkout
-        uses: actions/checkout@v4
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: true
-      - name: Prepare VM
-        uses: ./.github/actions/prepare
 
   build-and-test:
     name: Build and test NBS (${{ inputs.build_preset }}) [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     uses: ./.github/workflows/build_and_test_ya.yaml
     needs:
       - provide-runner
-      - prepare-vm
     with:
       runner_kind: self-hosted
       runner_label: ${{ needs.provide-runner.outputs.label }}
@@ -206,6 +192,9 @@ jobs:
       sleep_after_tests: ${{ inputs.sleep_after_tests }}
       cache_update_build: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('{0}', inputs.cache_update) || format('{0}', inputs.cache_update_build)) }}
       cache_update_tests: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('{0}', inputs.cache_update) || format('{0}', inputs.cache_update_tests)) }}
+      upload_ya_dir: ${{ github.event == 'workflow_dispatch' && 'no' || inputs.upload_ya_dir}}
+      clean_ya_dir: ${{ github.event == 'workflow_dispatch' && 'no' || inputs.clean_ya_dir }}
+      use_network_cache: ${{ github.event == 'workflow_dispatch' && 'yes'|| inputs.use_network_cache }}
     secrets: inherit
 
   sleep-if-needed:
@@ -219,7 +208,11 @@ jobs:
       - name: Sleep ${{ needs.build-and-test.outputs.sleep_after_tests  || '0' }}s if build failed
         shell: bash
         if: ${{ needs.build-and-test.outputs.sleep_after_tests && needs.build-and-test.outputs.sleep_after_tests != '0'  }}
-        run: sleep ${{ needs.build-and-test.outputs.sleep_after_tests }}
+        # we need to use binary because builting doesn't produce process
+        # which we can kill to stop the vm before it's done
+        run: |
+          echo "sleeping ${{ needs.build-and-test.outputs.sleep_after_tests }}s"
+          /usr/bin/sleep ${{ needs.build-and-test.outputs.sleep_after_tests }}
 
   release-runner:
     name: Release self-hosted runner (${{ inputs.build_preset }}) [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]

--- a/.github/workflows/build_and_test_on_demand_cmake.yaml
+++ b/.github/workflows/build_and_test_on_demand_cmake.yaml
@@ -39,6 +39,10 @@ on:
         type: string
         default: "0"
         description: "Amount of seconds to sleep after tests"
+      disk_type:
+        type: string
+        default: "network-ssd-nonreplicated"
+        description: "Disk type for VM"
 
 jobs:
   provide-runner:
@@ -76,8 +80,6 @@ jobs:
         uses: ./.github/actions/runner_create
         timeout-minutes: 60
         with:
-          org: ydb-platform
-          team: NBS
           repo_owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           service_account_key: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
@@ -86,46 +88,19 @@ jobs:
           vm_name: ${{ github.event.pull_request.number && format('pr-{0}-{1}-{2}', github.event.pull_request.number, github.run_id, github.run_attempt) || format('run-{0}-{1}', github.run_id, github.run_attempt) }}
           vm_zone: eu-north1-c
           vm_cpu: 60
-          vm_memory: 240
-          vm_disk_type: network-ssd-nonreplicated
+          vm_memory: 420
+          vm_disk_type: ${{ inputs.disk_type || 'network-ssd-nonreplicated' }}
           vm_disk_size: 1023
           vm_subnet: f8uh0ml4rhb45nde9p75
           vm_image: ${{ vars.IMAGE_ID_2204 }}
-          vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2},repo={3}', github.event.pull_request.number, github.run_id, github.run_attempt, github.event.repository.name) || format('run={0}-{1},repo={2}', github.run_id, github.run_attempt, github.event.repository.name) }}
+          vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2},repo={3},owner={4}', github.event.pull_request.number, github.run_id, github.run_attempt, github.event.repository.name, github.repository_owner) || format('run={0}-{1},repo={2},owner={3}', github.run_id, github.run_attempt, github.event.repository.name, github.repository_owner) }}
           vm_user_passwd: ${{ secrets.VM_USER_PASSWD }}
-
-  prepare-vm:
-    name: Prepare runner [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
-    needs: provide-runner
-    runs-on: [ self-hosted, "${{ needs.provide-runner.outputs.label }}" ]
-    steps:
-      - name: Checkout PR
-        uses: actions/checkout@v4
-        if: github.event.pull_request.head.sha != ''
-        with:
-          submodules: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: Rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: Checkout
-        uses: actions/checkout@v4
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: true
-      - name: Prepare VM
-        uses: ./.github/actions/prepare
 
   build-and-test:
     name: Build and test NBS [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]
     uses: ./.github/workflows/build_and_test_cmake.yaml
     needs:
       - provide-runner
-      - prepare-vm
     with:
       runner_kind: self-hosted
       runner_label: ${{ needs.provide-runner.outputs.label }}
@@ -148,7 +123,9 @@ jobs:
       - name: Sleep ${{ needs.build-and-test.outputs.sleep_after_tests || '0' }}s if build failed
         shell: bash
         if: ${{ needs.build-and-test.outputs.sleep_after_tests && needs.build-and-test.outputs.sleep_after_tests != '0'  }}
-        run: sleep ${{ needs.build-and-test.outputs.sleep_after_tests }}
+        run: |
+          echo "sleeping ${{ needs.build-and-test.outputs.sleep_after_tests }}s"
+          /usr/bin/sleep  ${{ needs.build-and-test.outputs.sleep_after_tests }}
 
   release-runner:
     name: Release self-hosted runner [id=${{ needs.provide-runner.outputs.instance-id }} local_ip=${{ needs.provide-runner.outputs.runner_local_ipv4 }} ip=${{ needs.provide-runner.outputs.runner_ipv4 }}]

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -66,6 +66,18 @@ on:
         type: boolean
         default: false
         description: "Update remote build cache"
+      upload_ya_dir:
+        type: string
+        default: "no"
+        description: "Upload ya dir to s3"
+      clean_ya_dir:
+        type: string
+        default: "no"
+        description: "Clean ya dir from image before building"
+      use_network_cache:
+        type: string
+        default: "yes"
+        description: "Use network cache"
     outputs:
       sleep_after_tests:
         description: "sleep_after_tests"
@@ -108,6 +120,7 @@ jobs:
         s3_key_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         folder_prefix: nebius-
         build_preset: ${{ inputs.build_preset }}
+        install: false
 
     - name: Build
       uses: ./.github/actions/build
@@ -120,6 +133,8 @@ jobs:
         bazel_remote_username: ${{ secrets.REMOTE_CACHE_USERNAME }}
         bazel_remote_password: ${{ secrets.REMOTE_CACHE_PASSWORD }}
         link_threads: ${{ inputs.link_threads }}
+        clean_ya_dir: ${{ inputs.clean_ya_dir }}
+        use_network_cache: ${{ inputs.use_network_cache }}
 
     - name: Run tests
       uses: ./.github/actions/test
@@ -136,6 +151,9 @@ jobs:
         link_threads: ${{ inputs.link_threads }}
         test_threads: ${{ inputs.test_threads }}
         sync_to_s3: ${{ vars.SYNC_TO_S3 }}
+        upload_ya_dir: ${{ inputs.upload_ya_dir }}
+        clean_ya_dir: ${{ inputs.run_build && 'no' || inputs.clean_ya_dir }}
+        use_network_cache: ${{ inputs.use_network_cache }}
 
     - id: failure
       name: set sleep_after_tests in case of failure

--- a/.github/workflows/github_actions_scripts.yaml
+++ b/.github/workflows/github_actions_scripts.yaml
@@ -110,6 +110,8 @@ jobs:
       shell: bash
       run: |
         set -x
+        # you can't override GITHUB_* vars (except token) in step env
+        export GITHUB_REPOSITORY="ydb-platform/nbs"
         echo "::group::generate-summary"
         python3 .github/scripts/tests/generate-summary.py \
           --summary-out-path "$TMP_DIR" \
@@ -120,7 +122,7 @@ jobs:
         echo "::endgroup::"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_REPOSITORY: "ydb-platform/nbs"
+
 
     - name: Launch fail-checker.py
       shell: bash

--- a/.github/workflows/nightly-index-rebuild.yaml
+++ b/.github/workflows/nightly-index-rebuild.yaml
@@ -43,7 +43,7 @@ jobs:
       run: |
         set -x
         echo "::group::generate-listing"
-        python3 .github/scripts/index.py s3://${S3_BUCKET}/${GITHUB_REPOSITORY}/ --ttl default=7d --generate-indexes --remove-expired --apply
+        python3 .github/scripts/index.py s3://${S3_BUCKET}/${GITHUB_REPOSITORY}/ --ttl default=7d --ttl ya_archive=1d --generate-indexes --remove-expired --apply
         echo "::endgroup::"
       env:
         S3_BUCKET: ${{ vars.AWS_BUCKET }}

--- a/.github/workflows/nightly-packer.yaml
+++ b/.github/workflows/nightly-packer.yaml
@@ -1,0 +1,22 @@
+name: Build VM image after nightly build
+run-name: Build VM image after nightly build ${{ github.event.workflow_run.event}} ${{ github.event.workflow_run.id }}
+on:
+  workflow_run:
+    workflows: ["Nightly build"]
+    types:
+      - completed
+    branches: [main]
+jobs:
+  build_vm_image:
+    name: Run packer to build VM image
+    uses: ./.github/workflows/packer.yaml
+    secrets: inherit
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'schedule'
+    with:
+      build: true
+      file: 'ya_web_url_file'
+      images_to_keep: ${{ github.repository == 'ydb-platform/nbs' && 7 || 3 }}
+      remove_old_images: true
+      update_image_id: false
+      image_prefix: 'gh-2204-auto'
+      workflow_run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,16 +1,95 @@
 name: Nightly build
+run-name: |
+  ${{ github.event_name == 'workflow_dispatch'
+      && format(
+          'Nightly build (manual) use_network_cache:{0} clean_ya_dir:{1} upload_ya_dir:{2}, disk_type:{3}, build_target:{4} test_target:{5}',
+          inputs.use_network_cache, inputs.clean_ya_dir, inputs.upload_ya_dir, inputs.disk_type, inputs.build_target, inputs.test_target
+        )
+      || format('Nightly build (schedule) schedule:"{0}"', github.event.schedule)
+    }}
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      clean_ya_dir:
+        description: 'Clean ya dir'
+        type: choice
+        required: false
+        default: 'no'
+        options:
+          - 'yes'
+          - 'no'
+      upload_ya_dir:
+        description: 'Upload ya dir'
+        type: choice
+        required: false
+        default: 'no'
+        options:
+          - 'yes'
+          - 'no'
+      use_network_cache:
+        description: 'Use network cache'
+        type: choice
+        required: false
+        default: 'yes'
+        options:
+          - 'yes'
+          - 'no'
+      disk_type:
+        description: 'Disk type'
+        type: choice
+        required: false
+        default: 'network-ssd-nonreplicated'
+        options:
+          - 'network-ssd'
+          - 'network-ssd-nonreplicated'
+      build_target:
+        description: 'Build target'
+        type: string
+        required: false
+        #default: 'cloud/tasks/'
+        default: 'cloud/blockstore/apps/,cloud/filestore/apps/,cloud/disk_manager/,cloud/tasks/'
+      test_target:
+        description: 'Test target'
+        type: string
+        required: false
+        #default: 'cloud/tasks/'
+        default: 'cloud/blockstore/,cloud/filestore/,cloud/disk_manager/,cloud/tasks/'
+
 
 jobs:
-  build:
-    name: Build/test x86_64 using YA (relwithdebinfo)
+  build_dispatch:
+    name: Build/test x86_64 using YA (relwithdebinfo) (dispatch)
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build_and_test_on_demand.yaml
     secrets: inherit
     with:
+      build_target: ${{ inputs.build_target }}
+      test_target: ${{ inputs.test_target }}
       build_preset: relwithdebinfo
       cache_update_build: true
       cache_update_tests: false
-      test_threads: 6
+      sleep_after_tests: 1
+      test_threads: 32
+      disk_type: ${{ inputs.disk_type }}
+      use_network_cache: ${{ inputs.use_network_cache }}
+      upload_ya_dir: ${{ inputs.upload_ya_dir }}
+      clean_ya_dir: ${{ inputs.clean_ya_dir }}
+  build_schedule:
+    name: Build/test x86_64 using YA (relwithdebinfo) (schedule)
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/build_and_test_on_demand.yaml
+    secrets: inherit
+    with:
+      build_target: 'cloud/blockstore/apps/,cloud/filestore/apps/,cloud/disk_manager/,cloud/tasks/'
+      test_target: 'cloud/blockstore/,cloud/filestore/,cloud/disk_manager/,cloud/tasks/'
+      build_preset: relwithdebinfo
+      cache_update_build: true
+      cache_update_tests: false
+      sleep_after_tests: 1
+      test_threads: 32
+      disk_type: 'network-ssd-nonreplicated'
+      use_network_cache: "yes"
+      upload_ya_dir: "yes"
+      clean_ya_dir: "yes"

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -1,0 +1,262 @@
+name: Build VM Image
+run-name: Build VM Image ${{ github.event.workflow_run.event }} workflow_run_id:${{ inputs.workflow_run_id }} download_ya_archive:${{ inputs.download_ya_archive }} remove_old_images:${{ inputs.remove_old_images }} update_image_id:${{ inputs.update_image_id }}
+on:
+  # schedule:
+  #   - cron: "0 5 * * *"
+  workflow_call:
+    inputs:
+      build:
+        description: "Build VM image"
+        required: false
+        default: true
+        type: boolean
+      download_ya_archive:
+        description: "Download .ya archive to resulting image"
+        required: false
+        default: true
+        type: boolean
+      workflow_run_id:
+        description: "Workflow run id (optional)"
+        required: false
+        default: 0
+        type: number
+      file:
+        description: "File to download"
+        required: false
+        default: "ya_web_url_file"
+        type: string
+      images_to_keep:
+        description: "Number of images to keep"
+        required: false
+        default: 3
+        type: number
+      remove_old_images:
+        description: "Delete old images"
+        required: false
+        default: false
+        type: boolean
+      update_image_id:
+        description: "Update image id"
+        required: false
+        default: false
+        type: boolean
+      image_prefix:
+        description: "Image prefix"
+        required: false
+        default: "gh-2204-auto"
+        type: string
+  workflow_dispatch:
+    inputs:
+      build:
+        description: "Build VM image"
+        required: false
+        default: true
+        type: boolean
+      download_ya_archive:
+        description: "Download .ya archive to resulting image"
+        required: false
+        default: true
+        type: boolean
+      workflow_run_id:
+        description: "Workflow run id (optional)"
+        required: false
+        default: 0
+        type: number
+      file:
+        description: "File to download"
+        required: false
+        default: "ya_web_url_file"
+        type: string
+      images_to_keep:
+        description: "Number of images to keep"
+        required: false
+        default: 3
+        type: number
+      remove_old_images:
+        description: "Delete old images"
+        required: false
+        default: false
+        type: boolean
+      update_image_id:
+        description: "Update image id"
+        required: false
+        default: false
+        type: boolean
+      image_prefix:
+        description: "Image prefix"
+        required: false
+        default: "gh-2204-auto"
+        type: string
+
+env:
+  build: ${{ github.event_name == 'schedule' && 'true' || inputs.build }}
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout PR
+      uses: actions/checkout@v4
+
+    - name: Set up Packer
+      uses: hashicorp/setup-packer@v3
+      with:
+        version: 1.10.2
+    - name: install dependencies
+      run: |
+        pip install PyGithub==2.2.0 grpcio grpcio-tools yandexcloud==0.258.0
+        echo "PATH=$PATH:$HOME/nebius-cloud/bin" >> $GITHUB_ENV
+
+    - name: Set up NCP
+      run: |
+        curl -sSL https://storage.ai.nebius.cloud/ncp/install.sh | bash
+        cat <<EOF > sa.json
+        ${sa_json}
+        EOF
+
+        ncp config profile create nbs-github-user-sa
+        ncp config set service-account-key sa.json
+        ncp config set endpoint api.ai.nebius.cloud:443
+      env:
+        sa_json: ${{ secrets.NEBIUS_SA_JSON_CREDENTIALS }}
+
+    - name: Get IAM token
+      id: get-iam-token
+      run: |
+        YC_TOKEN=$(ncp --profile=nbs-github-user-sa iam create-token --format=json | jq -r .iam_token)
+        echo "::add-mask::$YC_TOKEN"
+        echo "YC_TOKEN=$YC_TOKEN" >> $GITHUB_ENV
+
+    - name: Get .ya archive url
+      if: inputs.download_ya_archive == true
+      id: get-ya-archive-url
+      run: |
+        python .github/scripts/workflow-artifact-download.py \
+          --artifact "${ARTIFACT_NAME}" \
+          --workflow-run-id "${WORKFLOW_RUN_ID}"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        ARTIFACT_NAME: ${{ inputs.file }}
+        WORKFLOW_RUN_ID: ${{ inputs.workflow_run_id }}
+
+
+    - name: Check whether we have image with this workflow_run_id
+      if: inputs.download_ya_archive == true
+      id: check-image
+      run: |
+        ncp --profile=nbs-github-user-sa compute images list --folder-id "${FOLDER_ID}" --format=json | tee -a images.txt
+        exit_code=0
+        jq  -r 'first(
+          .[].name |
+          if .== "${{ inputs.image_prefix }}-${{ steps.get-ya-archive-url.outputs.run_id }}"
+          then
+            halt_error(1)
+          else
+            empty
+          end
+        )' < images.txt || {
+          exit_code=$?
+        }
+        if [ "$exit_code" -eq 1 ]; then
+          echo "Image with this run_id already exists, if you want to overwrite it, rename old one"
+
+          echo "image_already_exists=true" >> $GITHUB_OUTPUT
+
+        else
+          echo "Image with this run_id doesn't exist"
+          echo "image_already_exists=false" >> $GITHUB_OUTPUT
+
+        fi
+      env:
+        FOLDER_ID: bjeuq5o166dq4ukv3eec
+
+    - name: Run `packer init` and create variables file
+      if: steps.check-image.outputs.image_already_exists != 'true'
+      id: init
+      run: |
+        VARIABLES_FILE=$(mktemp XXXXXXX.hcl)
+        IMAGE_FAMILY_NAME=${GITHUB_REPOSITORY//\//-}
+        echo "VARIABLES_FILE=$VARIABLES_FILE" >> $GITHUB_ENV
+        packer init .github/packer/config.pkr.hcl
+
+        cat << EOF > $VARIABLES_FILE
+        RUNNER_VERSION="${RUNNER_VERSION}"
+        USER_TO_CREATE="${USER_NAME}"
+        PASSWORD_HASH="${{ secrets.VM_USER_PASSWD }}"
+        ${YA_ARCHIVE_PARAMETER}
+        FOLDER_ID="${FOLDER_ID}"
+        ZONE="${ZONE}"
+        SUBNET_ID="${SUBNET_ID}"
+        ORG="${ORG}"
+        TEAM="${TEAM}"
+        GITHUB_TOKEN="${GITHUB_TOKEN}"
+        AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+        AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+        REPOSITORY="${GITHUB_REPOSITORY}"
+        IMAGE_FAMILY_NAME="${IMAGE_FAMILY_NAME}"
+        IMAGE_PREFIX="${IMAGE_PREFIX}"
+        BUILD_RUN_ID="${BUILD_RUN_ID}"
+        EOF
+        cat $VARIABLES_FILE
+      env:
+        RUNNER_VERSION: ${{ vars.RUNNER_VERSION || '2.308.0' }}
+        FOLDER_ID: bjeuq5o166dq4ukv3eec
+        ZONE: eu-north1-c
+        SUBNET_ID: f8uh0ml4rhb45nde9p75
+        USER_NAME: github
+        GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        ORG: "ydb-platform"
+        TEAM: "nbs"
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        IMAGE_PREFIX: ${{ inputs.image_prefix }}
+        BUILD_RUN_ID: ${{ github.run_id }}
+        YA_ARCHIVE_PARAMETER: |
+          ${{ (inputs.download_ya_archive && steps.get-ya-archive-url.outputs.latest_url != '')
+              && format(
+                'YA_ARCHIVE_URL="{0}"
+                NIGHTLY_RUN_ID="{1}"',
+                steps.get-ya-archive-url.outputs.latest_url, steps.get-ya-archive-url.outputs.run_id
+              ) || ''
+          }}
+
+    - name: Run `packer validate`
+      if: steps.check-image.outputs.image_already_exists != 'true'
+      id: validate
+      run: |
+        packer validate -var-file=$VARIABLES_FILE .github/packer/github-runner.pkr.hcl
+
+    - name: Run `packer build`
+      id: build
+      if: env.build == 'true' && steps.check-image.outputs.image_already_exists != 'true'
+      timeout-minutes: 120
+      # IMPORTANT: PASSWORD_HASH is in '' and with in-place variable to prevent need to escape $ in variable name
+      run: |
+        packer build -timestamp-ui -var-file=$VARIABLES_FILE .github/packer/github-runner.pkr.hcl
+
+        echo "IMAGE_ID_2204=$(jq -r '.builds[0].artifact_id' manifest.json)" >> $GITHUB_OUTPUT
+
+
+    - name: Print IMAGE_ID_2204
+      if: env.build == 'true' && steps.check-image.outputs.image_already_exists != 'true'
+      run: echo ${{ steps.build.outputs.IMAGE_ID_2204 }}
+
+    - name: Set new image id
+      if: env.build == 'true' && steps.check-image.outputs.image_already_exists != 'true'
+      run: |
+        python ./.github/scripts/manage-images.py \
+          --service-account-key sa.json \
+          --new-image-id ${NEW_IMAGE_ID} \
+          --image-variable-name ${IMAGE_VARIABLE_NAME} \
+          --images-to-keep ${IMAGES_TO_KEEP} ${UPDATE_IMAGE_ID} ${REMOVE_OLD_IMAGES}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        IMAGE_VARIABLE_NAME: IMAGE_ID_2204
+        NEW_IMAGE_ID: ${{ steps.build.outputs.IMAGE_ID_2204 }}
+        IMAGES_TO_KEEP: ${{ inputs.images_to_keep }}
+        UPDATE_IMAGE_ID: ${{ inputs.update_image_id && '--update-image-id' || '' }}
+        REMOVE_OLD_IMAGES: ${{ inputs.remove_old_images && '--remove-old-images' || '' }}

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -46,7 +46,6 @@ jobs:
           reporter: ${{ steps.reporter.outputs.value }}
           path: |
             .github/
-            cloud/storage/core/tools/ci/
           pattern: "*.sh"
 
       - name: shfmt

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workdir: .github/
+          shfmt_flags: "-i 4 -ci -kp -bn -sr"
 
   python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Overview of what has been done:
1. Increased quotas for our cloud and since we have allocated hosts I increased VM memory to its limit and therefore we can increase number of test threads. This gave biggest performance boost: for nightly build, _build_ time decreased by 1hr. But if we upload .ya dir it takes this time back (archiving and uploading takes ~ 1hr)
2. Added task to build VM image on schedule. In result we shave off approximately 2-3 minutes each time, saving on creating VM (before we needed to unpack and update github runner software) and installing necessary packages (or checking that we installed them).
3. Said VM image can contain .ya dir with built code and downloaded artifacts. If we use network-ssd with overlayed VM image we usually shave off 1-2m. But we use network-ssd-nonreplicated which don't have this feature yet, so it is temporarily disabled. It is mostly limited by host network. And it is basically the same as using network cache machine (which we use by default). Additional benefit that we still will have this bonus if cache machine will die for some reason
