### PR TITLE
loop shutdown should not call CancelRequest for inflight requests because it causes a race with the code that's executing those requests, we should simply wait until those requests complete by themselves

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -123,16 +123,20 @@ public:
         bool haveInflight = false;
         with_lock (RequestsLock) {
             if (!Requests.erase(req)) {
+                Cerr << "req NOT FOUND" << Endl;
                 return 0;
             }
             CompletingCount.Add(1);
             haveInflight = !Requests.empty();
+            Cerr << "REQUESTS: " << Requests.size() << Endl;
+            Cerr << "COMPLETING: " << CompletingCount.Val() << Endl;
         }
 
         int ret = cb(req);
         bool haveCompleting = CompletingCount.Dec() > 0;
 
         if (!haveInflight && !haveCompleting && ShouldStop) {
+            Cerr << "SETTING StopPromise IN Complete" << Endl;
             StopPromise.TrySetValue();
         }
 
@@ -148,9 +152,12 @@ public:
 
         with_lock (RequestsLock) {
             canStop = Requests.empty() && CompletingCount.Val() == 0;
+            Cerr << "REQUESTS: " << Requests.size() << Endl;
+            Cerr << "COMPLETING: " << CompletingCount.Val() << Endl;
         }
 
         if (canStop) {
+            Cerr << "SETTING StopPromise IN StopAsync" << Endl;
             StopPromise.TrySetValue();
         }
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -134,9 +134,12 @@ public:
             bool noInflight = false;
             with_lock (RequestsLock) {
                 noInflight = Requests.empty();
+                // double-checking needed because inflight count and completing
+                // count should be checked together atomically
+                noCompleting = CompletingCount.Val() == 0;
             }
 
-            if (noInflight) {
+            if (noInflight && noCompleting) {
                 StopPromise.TrySetValue();
             }
         }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -132,7 +132,9 @@ public:
             Cerr << "COMPLETING: " << CompletingCount.Val() << Endl;
         }
 
+        Cerr << "STARTED CB FOR " << req->unique << Endl;
         int ret = cb(req);
+        Cerr << "FINISHED CB FOR " << req->unique << Endl;
         bool haveCompleting = CompletingCount.Dec() > 0;
 
         if (!haveInflight && !haveCompleting && ShouldStop) {

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -132,9 +132,9 @@ public:
             Cerr << "COMPLETING: " << CompletingCount.Val() << Endl;
         }
 
-        Cerr << "STARTED CB FOR " << req->unique << Endl;
+        Cerr << "STARTED CB FOR " << reinterpret_cast<ui64>(req) << Endl;
         int ret = cb(req);
-        Cerr << "FINISHED CB FOR " << req->unique << Endl;
+        Cerr << "FINISHED CB FOR " << reinterpret_cast<ui64>(req) << Endl;
         bool haveCompleting = CompletingCount.Dec() > 0;
 
         if (!haveInflight && !haveCompleting && ShouldStop) {


### PR DESCRIPTION
Data race example:
```
WARNING: ThreadSanitizer: data race (pid=238490)
  Atomic write of size 8 at 0x7b20001f2c50 by main thread (mutexes: write M0):
    #0 AtomicCas /actions-runner/_work/nbs/nbs/library/cpp/deprecated/atomic/atomic_gcc.h:67:12 (filestore-vhost+0x10cf2eb8) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #1 std::__y1::invoke_result<NLWTrace::TOrbit::AddProbe(NLWTrace::TProbe*, NLWTrace::TParams const&, unsigned long)::'lambda'(TIntrusivePtr<NLWTrace::IShuttle, TDefaultIntrusivePtrOps<NLWTrace::IShuttle>>&), TIntrusivePtr<NLWTrace::IShuttle, TDefaultIntrusivePtrOps<NLWTrace::IShuttle>>&>::type NLWTrace::TOrbit::NotConcurrent<NLWTrace::TOrbit::AddProbe(NLWTrace::TProbe*, NLWTrace::TParams const&, unsigned long)::'lambda'(TIntrusivePtr<NLWTrace::IShuttle, TDefaultIntrusivePtrOps<NLWTrace::IShuttle>>&)>(NLWTrace::TOrbit::AddProbe(NLWTrace::TProbe*, NLWTrace::TParams const&, unsigned long)::'lambda'(TIntrusivePtr<NLWTrace::IShuttle, TDefaultIntrusivePtrOps<NLWTrace::IShuttle>>&)) /actions-runner/_work/nbs/nbs/library/cpp/lwtrace/shuttle.h:337:39 (filestore-vhost+0x10cf2eb8)
    #2 NLWTrace::TOrbit::AddProbe /actions-runner/_work/nbs/nbs/library/cpp/lwtrace/shuttle.h:232:13 (filestore-vhost+0x26b7a698) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #3 NLWTrace::TProbe::RunShuttles /actions-runner/_work/nbs/nbs/library/cpp/lwtrace/probe.h:164:19 (filestore-vhost+0x26b7a698)
    #4 NLWTrace::TUserProbe<TBasicString<char, std::__y1::char_traits<char> >, unsigned long, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil, NLWTrace::TNil>::RunShuttles /actions-runner/_work/nbs/nbs/library/cpp/lwtrace/probe.h:257:19 (filestore-vhost+0x26b7a698)
    #5 NCloud::NFileStore::NFuse::(anonymous namespace)::CancelRequest(TLog&, NCloud::NFileStore::IRequestStats&, NCloud::NFileStore::TCallContext&, fuse_req*, fuse_cancelation_code) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:55:5 (filestore-vhost+0x26b7a698)
    #6 NCloud::NFileStore::NFuse::(anonymous namespace)::TCompletionQueue::Stop(fuse_cancelation_code) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:142:13 (filestore-vhost+0x26b95705) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #7 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::SuspendAsync() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:572:26 (filestore-vhost+0x26b70447) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #8 NCloud::NFileStore::NVhost::(anonymous namespace)::TEndpoint::SuspendAsync() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint_vhost/listener.cpp:46:22 (filestore-vhost+0x270e7271) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #9 NCloud::NFileStore::(anonymous namespace)::TEndpointManager::Stop() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service.cpp:133:50 (filestore-vhost+0x26c47f9e) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #10 NCloud::NFileStore::(anonymous namespace)::TAuthService::Stop() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service_auth.cpp:42:18 (filestore-vhost+0x26c7821f) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #11 NCloud::NFileStore::NDaemon::TBootstrapVhost::StopComponents() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/vhost/bootstrap.cpp:323:5 (filestore-vhost+0x26c12097) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #12 NCloud::NFileStore::NDaemon::TBootstrapCommon::Stop() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/common/bootstrap.cpp:144:5 (filestore-vhost+0x1b932593) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #13 int NCloud::DoMain<NCloud::NFileStore::NDaemon::TBootstrapVhost>(NCloud::NFileStore::NDaemon::TBootstrapVhost&, int, char**) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/daemon/app.h:47:23 (filestore-vhost+0xf4c1d4e) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #14 main /actions-runner/_work/nbs/nbs/cloud/filestore/apps/vhost/main.cpp:22:12 (filestore-vhost+0xf4c1b14) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)

  Previous read of size 8 at 0x7b20001f2c50 by thread T50:
    #0 TIntrusivePtr<NLWTrace::IShuttle, TDefaultIntrusivePtrOps<NLWTrace::IShuttle> >::Get /actions-runner/_work/nbs/nbs/util/generic/ptr.h:560:16 (filestore-vhost+0x1bd8c96d) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #1 NLWTrace::TOrbit::HasShuttles /actions-runner/_work/nbs/nbs/library/cpp/lwtrace/shuttle.h:203:31 (filestore-vhost+0x1bd8c96d)
    #2 NLWTrace::TManager::CreateTraceRequest(NLWTrace::TTraceRequest&, NLWTrace::TOrbit&) /actions-runner/_work/nbs/nbs/library/cpp/lwtrace/control.cpp:37:27 (filestore-vhost+0x1bd8c96d)
    #3 NCloud::(anonymous namespace)::TTraceSerializer::BuildTraceRequest(NLWTrace::TTraceRequest&, NLWTrace::TOrbit&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/trace_serializer.cpp:105:19 (filestore-vhost+0x1bd8bf03) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #4 void NCloud::NFileStore::NStorage::TStorageServiceActor::ForwardRequest<NCloud::NFileStore::NStorage::TEvService::TWriteDataMethod>(NActors::TActorContext const&, NCloud::NFileStore::NStorage::TEvService::TWriteDataMethod::TRequest::TPtr const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/service/service_actor_forward.cpp:49:22 (filestore-vhost+0x266fcc46) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #5 NCloud::NFileStore::NStorage::TStorageServiceActor::HandleWriteData(TAutoPtr<NActors::TEventHandle<NCloud::NFileStore::NStorage::TProtoRequestEvent<NCloud::NFileStore::NProto::TWriteDataRequest, 275054747u>>, TDelete> const&, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/service/service_actor_writedata.cpp:411:9 (filestore-vhost+0x26776c88) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #6 NCloud::NFileStore::NStorage::TStorageServiceActor::HandleRequests(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/service/service_actor.cpp:128:9 (filestore-vhost+0x26585c1b) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #7 NCloud::NFileStore::NStorage::TStorageServiceActor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/service/service_actor.cpp:152:18 (filestore-vhost+0x265831c0) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #8 NActors::TActorCallbackBehaviour::Receive(NActors::IActor*, TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.cpp:232:9 (filestore-vhost+0x10c30133) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #9 NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.h:526:23 (filestore-vhost+0x10cf3a22) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #10 NActors::TExecutorThread::TProcessingResult NActors::TExecutorThread::Execute<NActors::TMailboxTable::TRevolvingMailbox>(NActors::TMailboxTable::TRevolvingMailbox*, unsigned int, bool) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:236:28 (filestore-vhost+0x10ce0d33) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #11 NActors::TExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:416:25 (filestore-vhost+0x10cd9132) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #12 NActors::TExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:470:13 (filestore-vhost+0x10cd874e) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #13 NActors::TExecutorThread::ThreadProc() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:515:13 (filestore-vhost+0x10cdaa43) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #14 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-vhost+0xf729782) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
    #15 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-vhost+0xf72d11c) (BuildId: ba951d02e6e461eddf1019ce03d1fdf7c3ddcc51)
```

Current code calls CancelRequest for each inflight request upon loop shutdown/suspend. But inflight requests are flying all over the system and are being accessed by other threads. We have to wait till those requests complete, we can't cancel them with our current code architecture.