### PR TITLE
issue-1196: return E_BS_THROTTLED instead of E_REJECTED(Throttled)

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -165,8 +165,7 @@ NProto::TError TVolumeActor::Throttle(
     bool throttlingDisabled)
 {
     static const auto ok = MakeError(S_OK);
-    static const auto err
-        = MakeError(E_REJECTED, "Throttled");  // TODO: E_BS_THROTTLED;
+    static const auto err = MakeError(E_BS_THROTTLED, "Throttled");
 
     if (!RequiresThrottling<TMethod>
             || throttlingDisabled

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -3419,10 +3419,10 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         // 2. testing that we start rejecting requests after our postponed limit saturates
         volume.SendReadBlocksRequest(twoBlocks, clientInfo.GetClientId());
-        TEST_QUICK_RESPONSE(runtime, ReadBlocks, E_REJECTED);
+        TEST_QUICK_RESPONSE(runtime, ReadBlocks, E_BS_THROTTLED);
 
         volume.SendDescribeBlocksRequest(oneBlock, clientInfo.GetClientId(), 1);
-        TEST_QUICK_RESPONSE_VOLUME_EVENT(runtime, DescribeBlocks, E_REJECTED);
+        TEST_QUICK_RESPONSE_VOLUME_EVENT(runtime, DescribeBlocks, E_BS_THROTTLED);
         // testing that DescribeBlocks requests with zero BlocksCountToRead are
         // not affected by limits
         volume.SendDescribeBlocksRequest(oneBlock, clientInfo.GetClientId(), 0);
@@ -3911,7 +3911,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         // TODO test that the second request gets rejected, not just any one of
         // the two requests
-        TEST_RESPONSE(volume, ReadBlocks, E_REJECTED, TDuration::Seconds(1));
+        TEST_RESPONSE(volume, ReadBlocks, E_BS_THROTTLED, TDuration::Seconds(1));
         TEST_RESPONSE(volume, ReadBlocks, S_OK, WaitTimeout);
     }
 


### PR DESCRIPTION
#1196

Also fixes issue with local-overflow[version1-throttled] test https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/9072536131/1/nebius-x86-64/summary/ya-test.html#FAIL
```
--- /actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-overflow/canondata/test.test_load_version1-throttled_/stats_overflow-version1-throttled.txt	2024-05-14 01:58:40.817442973 +0000
+++ /home/github/.ya/build/build_root/0k9p/001d62/canon_tmp7gbhff_m/stats_overflow-version1-throttled.txt	2024-05-14 04:39:40.438115267 +0000
@@ -1,3 +1 @@
 component:server/sensor:AppCriticalEvents/ReassignTablet=False
-component:service/sensor:ThrottlerRejectedRequests=True
-component:service/sensor:ThrottlerRejectedRequests/type:hdd=True
```