### PR TITLE
[Filestore]: fix localdb-compaction-test: do not consider `E_FS_NOENT` and `E_FS_EXIST` fatal because of the filestore restarts

### DIFF
--- a/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/create-remove.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/create-remove.txt
@@ -20,5 +20,9 @@ Tests {
         }
         IODepth: 64
         TestDuration: 120
+        # E_FS_NOENT and E_FS_EXIST: we ignore these errors, as they might have
+        # occured due to the filestore restart
+        SuccessOnError: 2147942402
+        SuccessOnError: 2147942405
     }
 }

--- a/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/ya.make
@@ -11,7 +11,7 @@ DEPENDS(
 )
 
 DATA(
-    arcadia/cloud/filestore/tests/loadtes/service-kikimr-localdb-compaction-test
+    arcadia/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test
 )
 
 PEERDIR(

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -604,11 +604,20 @@ private:
 
             auto code = request->Error.GetCode();
             if (FAILED(code)) {
-                STORAGE_ERROR("%s failing test due to: %s",
-                    MakeTestTag().c_str(),
-                    FormatError(request->Error).c_str());
+                bool expectedErrorCode = false;
+                for (auto code: Config.GetSuccessOnError()) {
+                    if (code == request->Error.GetCode()) {
+                        expectedErrorCode = true;
+                        break;
+                    }
+                }
+                if (!expectedErrorCode) {
+                    STORAGE_ERROR("%s failing test due to: %s",
+                        MakeTestTag().c_str(),
+                        FormatError(request->Error).c_str());
 
-                TestStats.Success = false;
+                    TestStats.Success = false;
+                }
             }
 
             auto& stats = TestStats.ActionStats[request->Action];

--- a/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
@@ -89,6 +89,9 @@ message TLoadTest
 
     // disables destruction of the filestore created via CreateFileStoreRequest
     bool KeepFileStore = 16;
+
+    // Specific Errors we are waiting for.
+    repeated uint32 SuccessOnError = 17;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There have been some executions of `localdb-compaction-test` failing due to `E_FS_NOENT` and `E_FS_EXIST` errors. Those errors should be valid for this case because the filestore is constantly restarting.

https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/9040226739/1/nebius-x86-64/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk5/testing_out_stuff/