### PR TITLE
Change default spaceship operator to operator<

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -92,9 +92,16 @@ struct TCachedAcquireKey
     TString DiskId;
     TString ClientId;
 
-    friend std::strong_ordering operator<=>(
-        const TCachedAcquireKey&,
-        const TCachedAcquireKey&) = default;
+    friend bool operator<(
+        const TCachedAcquireKey& lhs,
+        const TCachedAcquireKey& rhs)
+    {
+        auto tie = [](const TCachedAcquireKey& arg)
+        {
+            return std::tie(arg.DiskId, arg.ClientId);
+        };
+        return tie(lhs) < tie(rhs);
+    }
 };
 
 using TCachedAcquireRequests =


### PR DESCRIPTION
Build для запуска фаззера падает 

Крэшится llvm на spaceship
```
/home/sdimanx91/arcadia/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h:95:33: Generating code for declaration 'NCloud::NBlockStore::NStorage::operator<=>'
...
clang++: error: clang frontend command failed with exit code 70 (use -v to see invocation)
```