### PR TITLE
fix: git config flags in rebase

### DIFF
--- a/.github/workflows/build_and_test_cmake.yaml
+++ b/.github/workflows/build_and_test_cmake.yaml
@@ -58,8 +58,8 @@ jobs:
       if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
       run: |
-        git config --global user.email "librarian@nebius.com"
-        git config --global user.name "Rebase Robotovich"
+        git config user.email "librarian@nebius.com"
+        git config user.name "Rebase Robotovich"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git rebase origin/${{ github.event.pull_request.base.ref }}
     - name: Checkout

--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -141,8 +141,8 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          git config --global user.email "librarian@nebius.com"
-          git config --global user.name "Rebase Robotovich"
+          git config user.email "librarian@nebius.com"
+          git config user.name "Rebase Robotovich"
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git rebase origin/${{ github.event.pull_request.base.ref }}
       - name: checkout

--- a/.github/workflows/build_and_test_on_demand_cmake.yaml
+++ b/.github/workflows/build_and_test_on_demand_cmake.yaml
@@ -67,8 +67,8 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          git config --global user.email "librarian@nebius.com"
-          git config --global user.name "Rebase Robotovich"
+          git config user.email "librarian@nebius.com"
+          git config user.name "Rebase Robotovich"
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git rebase origin/${{ github.event.pull_request.base.ref }}
       - name: checkout

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -102,8 +102,8 @@ jobs:
       if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
       run: |
-        git config --global user.email "librarian@nebius.com"
-        git config --global user.name "Rebase Robotovich"
+        git config user.email "librarian@nebius.com"
+        git config user.name "Rebase Robotovich"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git rebase origin/${{ github.event.pull_request.base.ref }}
     - name: Checkout

--- a/.github/workflows/github_actions_scripts.yaml
+++ b/.github/workflows/github_actions_scripts.yaml
@@ -66,8 +66,8 @@ jobs:
         set -x
         # git config is needed for some reason, idk why it works without
         # it on self-hosted runners
-        git config --global user.email "librarian@nebius.com"
-        git config --global user.name "Rebase Robotovich"
+        git config user.email "librarian@nebius.com"
+        git config user.name "Rebase Robotovich"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git rebase origin/${{ github.event.pull_request.base.ref }}
     - name: Checkout

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -11,6 +11,11 @@ on:
       - main
     paths:
     - ".github/**"
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'labeled'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
problem was, that when you use --global flag it writes to ~/.gitconfig and for that it needs to know $HOME, and for some reason $HOME is not set.