### PR TITLE
fix: empty files produced after running setup script, fixed by running sync + fix for setting github user password

### DIFF
--- a/.github/scripts/github-runner.sh
+++ b/.github/scripts/github-runner.sh
@@ -26,7 +26,7 @@ function on_exit() {
     sudo rm -rf "/home/${USER_TO_CREATE}/.aws" /root/.aws/
     sudo rm -rf /var/lib/apt/lists/*
     sync
-    exit $exit_code
+    exit "$exit_code"
 }
 trap on_exit EXIT
 
@@ -201,7 +201,7 @@ sudo test -s "/home/${USER_TO_CREATE}/.ssh/authorized_keys" || {
     sudo ls -lsha "/home/${USER_TO_CREATE}/.ssh/authorized_keys"
     healthchecks_exit_code=1
 }
-sudo grep 'github:\$' /etc/shadow >/dev/null 2>/dev/null || {
+sudo grep 'github:\$' /etc/shadow > /dev/null 2> /dev/null || {
     echo "User github either do not exist or has wrong hash"
     healthchecks_exit_code=1
 }

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -186,7 +186,7 @@ jobs:
         cat << EOF > $VARIABLES_FILE
         RUNNER_VERSION="${RUNNER_VERSION}"
         USER_TO_CREATE="${USER_NAME}"
-        PASSWORD_HASH="${{ secrets.VM_USER_PASSWD }}"
+        PASSWORD_HASH="${PASSWORD_HASH}"
         ${YA_ARCHIVE_PARAMETER}
         FOLDER_ID="${FOLDER_ID}"
         ZONE="${ZONE}"
@@ -209,6 +209,7 @@ jobs:
         SUBNET_ID: f8uh0ml4rhb45nde9p75
         USER_NAME: github
         GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        PASSWORD_HASH: ${{ secrets.VM_USER_PASSWD }}
         ORG: "ydb-platform"
         TEAM: "nbs"
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Turns out VMs were shutting down too fast to sync changes to disks and without sync it produced _sometimes_ inconsistent results, like not writing authorized_keys or, in recent example, not writing part of python library.

Also added few healthchecks to test whether we have everything we need to debug this issue faster (maybe later we will add some other checks too).