### PR TITLE
merge to stable-23-3: issue-1161: hiding DupCache implementation details inside TSession, getting rid of unneeded TIntrusiveList usage for DupCacheEntries (the most important effect of this will be getting rid of TIntrusiveList::Size() calls which are O(n)) (#1162)

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -725,7 +725,7 @@ void TIndexTabletState::AddDupCacheEntry(                                      \
                                                                                \
     NProto::TDupCacheEntry entry;                                              \
     entry.SetSessionId(session->GetSessionId());                               \
-    entry.SetEntryId(session->LastDupCacheEntryId++);                          \
+    entry.SetEntryId(session->GenerateDupCacheEntryId());                      \
     entry.SetRequestId(requestId);                                             \
     *entry.Mutable##name() = response;                                         \
                                                                                \


### PR DESCRIPTION
afd1cf8556492826a8c50adbeef40457eec0ddeb