### PR TITLE
issue-1164: endpoint-proxy - implemented nbd proxying

### DIFF
--- a/cloud/blockstore/apps/client/lib/endpoint_proxy.cpp
+++ b/cloud/blockstore/apps/client/lib/endpoint_proxy.cpp
@@ -17,6 +17,8 @@ class TStartProxyEndpointCommand final: public TCommand
 private:
     TString UnixSocketPath;
     TString NbdDeviceFile;
+    ui32 BlockSize = 0;
+    ui64 BlocksCount = 0;
 
 public:
     explicit TStartProxyEndpointCommand(IBlockStorePtr client)
@@ -29,6 +31,14 @@ public:
         Opts.AddLongOption("nbd-device", "nbd device file")
             .RequiredArgument("STR")
             .StoreResult(&NbdDeviceFile);
+
+        Opts.AddLongOption("block-size", "nbd options: block size")
+            .RequiredArgument("STR")
+            .StoreResult(&BlockSize);
+
+        Opts.AddLongOption("blocks-count", "nbd options: blocks count")
+            .RequiredArgument("STR")
+            .StoreResult(&BlocksCount);
     }
 
 protected:
@@ -48,6 +58,8 @@ protected:
         } else {
             request->SetUnixSocketPath(UnixSocketPath);
             request->SetNbdDevice(NbdDeviceFile);
+            request->SetBlockSize(BlockSize);
+            request->SetBlocksCount(BlocksCount);
         }
 
         STORAGE_DEBUG("Sending StartProxyEndpoint request");
@@ -79,6 +91,16 @@ private:
 
         if (!NbdDeviceFile) {
             STORAGE_ERROR("NbdDeviceFile is required");
+            return false;
+        }
+
+        if (!BlockSize) {
+            STORAGE_ERROR("BlockSize is required");
+            return false;
+        }
+
+        if (!BlocksCount) {
+            STORAGE_ERROR("BlocksCount is required");
             return false;
         }
 

--- a/cloud/blockstore/apps/client/lib/endpoint_proxy.cpp
+++ b/cloud/blockstore/apps/client/lib/endpoint_proxy.cpp
@@ -90,8 +90,8 @@ private:
         }
 
         if (!NbdDeviceFile) {
-            STORAGE_ERROR("NbdDeviceFile is required");
-            return false;
+            STORAGE_WARN("NbdDeviceFile missing, no nbd connection with the"
+                " kernel will be established");
         }
 
         if (!BlockSize) {

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
@@ -155,9 +155,9 @@ struct TEndpointProxyClient
         , Timer(std::move(timer))
         , Log(logging->CreateLog("ENDPOINT_PROXY_CLIENT"))
     {
-        if (config.SecurePort) {
+        if (Config.SecurePort) {
             ChannelCredentials = grpc::SslCredentials({
-                .pem_root_certs = ReadFile(config.RootCertsFile)
+                .pem_root_certs = ReadFile(Config.RootCertsFile)
             });
         } else {
             ChannelCredentials = grpc::InsecureChannelCredentials();

--- a/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
@@ -19,16 +19,16 @@ void TBootstrap::Init()
     TLogSettings logSettings;
     Scheduler = CreateScheduler();
     logSettings.UseLocalTimestamps = true;
-Server = CreateServer({
-            static_cast<ui16>(Options.ServerPort),
-            static_cast<ui16>(Options.SecureServerPort),
-            Options.RootCertsFile,
-            Options.KeyFile,
-            Options.CertFile
-        },
-        CreateWallClockTimer(),
-        Scheduler,
-        CreateLoggingService("console", logSettings));
+    Server = CreateServer({
+        static_cast<ui16>(Options.ServerPort),
+        static_cast<ui16>(Options.SecureServerPort),
+        Options.RootCertsFile,
+        Options.KeyFile,
+        Options.CertFile
+    },
+    CreateWallClockTimer(),
+    Scheduler,
+    CreateLoggingService("console", logSettings));
 }
 
 void TBootstrap::Start()

--- a/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.h
@@ -3,6 +3,8 @@
 #include "public.h"
 #include "options.h"
 
+#include <cloud/storage/core/libs/common/public.h>
+
 #include <contrib/ydb/library/actors/util/should_continue.h>
 
 namespace NCloud::NBlockStore::NServer {
@@ -13,6 +15,7 @@ class TBootstrap
 {
 private:
     TOptions Options;
+    ISchedulerPtr Scheduler;
     IEndpointProxyServerPtr Server;
     TProgramShouldContinue ShouldContinue;
 

--- a/cloud/blockstore/libs/endpoint_proxy/server/options.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/options.cpp
@@ -8,10 +8,6 @@ using namespace NLastGetopt;
 
 TOptions::TOptions()
 {
-    Opts.AddLongOption("sockets-dir")
-        .RequiredArgument("FILE")
-        .StoreResult(&SocketsDir);
-
     Opts.AddLongOption("root-certs-file")
         .RequiredArgument("FILE")
         .StoreResult(&RootCertsFile);

--- a/cloud/blockstore/libs/endpoint_proxy/server/options.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/options.h
@@ -10,7 +10,6 @@ namespace NCloud::NBlockStore::NServer {
 
 struct TOptions final: TOptionsBase
 {
-    TString SocketsDir;
     TString RootCertsFile;
     TString KeyFile;
     TString CertFile;

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 
+#include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/common/startable.h>
 
 namespace NCloud::NBlockStore::NServer {
@@ -23,21 +24,18 @@ struct TEndpointProxyServerConfig
     TString RootCertsFile;
     TString KeyFile;
     TString CertFile;
-    TString SocketsDir;
 
     TEndpointProxyServerConfig(
             ui16 port,
             ui16 securePort,
             TString rootCertsFile,
             TString keyFile,
-            TString certFile,
-            TString socketsDir)
+            TString certFile)
         : Port(port)
         , SecurePort(securePort)
         , RootCertsFile(std::move(rootCertsFile))
         , KeyFile(std::move(keyFile))
         , CertFile(std::move(certFile))
-        , SocketsDir(std::move(socketsDir))
     {
     }
 };
@@ -46,6 +44,8 @@ struct TEndpointProxyServerConfig
 
 IEndpointProxyServerPtr CreateServer(
     TEndpointProxyServerConfig config,
+    ITimerPtr timer,
+    ISchedulerPtr scheduler,
     ILoggingServicePtr logging);
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoint_proxy/server/ya.make
+++ b/cloud/blockstore/libs/endpoint_proxy/server/ya.make
@@ -8,9 +8,19 @@ SRCS(
 
 PEERDIR(
     cloud/blockstore/libs/daemon/common
+    cloud/blockstore/libs/nbd
+    cloud/blockstore/libs/service
+    cloud/blockstore/public/api/grpc
+    cloud/blockstore/public/api/protos
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/libs/diagnostics
+    cloud/storage/core/libs/grpc
 
     library/cpp/getopt/small
+    library/cpp/logger
 
+    contrib/libs/grpc
     contrib/ydb/library/actors/util
 )
 

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -242,6 +242,10 @@ message TStartProxyEndpointRequest
 
     // NBD device to proxy requests from.
     string NbdDevice = 3;
+
+    // NBD StorageOptions.
+    uint32 BlockSize = 4;
+    uint64 BlocksCount = 5;
 }
 
 message TStartProxyEndpointResponse

--- a/cloud/blockstore/tests/client/canondata/result.json
+++ b/cloud/blockstore/tests/client/canondata/result.json
@@ -2,11 +2,11 @@
     "test_with_client.test_destroy_volume": {
         "uri": "file://test_with_client.test_destroy_volume/results.txt"
     },
-    "test_with_client.test_enabled_configs_dispatcher": {
-        "uri": "file://test_with_client.test_enabled_configs_dispatcher/results.txt"
-    },
     "test_with_client.test_disabled_configs_dispatcher": {
         "uri": "file://test_with_client.test_disabled_configs_dispatcher/results.txt"
+    },
+    "test_with_client.test_enabled_configs_dispatcher": {
+        "uri": "file://test_with_client.test_enabled_configs_dispatcher/results.txt"
     },
     "test_with_client.test_endpoint_proxy": {
         "uri": "file://test_with_client.test_endpoint_proxy/results.txt"

--- a/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy/results.txt
+++ b/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy/results.txt
@@ -1,5 +1,4 @@
-InternalUnixSocketPath: "TODO-internal-socket"
+InternalUnixSocketPath: "TODO-nbs-socket.proxy"
 
-InternalUnixSocketPath: "TODO-internal-socket"
-NbdDevice: "TODO-nbd-device"
+InternalUnixSocketPath: "TODO-nbs-socket.proxy"
 

--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -958,12 +958,10 @@ def test_endpoint_proxy():
 
     port_manager = network.PortManager()
     port = port_manager.get_port()
-    sockets_dir = tempfile.TemporaryDirectory()
 
     run_async(
         [
             endpoint_proxy_path, "--server-port", str(port),
-            "--sockets-dir", sockets_dir.name
         ],
         "endpoint-proxy-%s.out" % port,
         "endpoint-proxy-%s.err" % port
@@ -982,5 +980,4 @@ def test_endpoint_proxy():
 
     ret = common.canonical_file(env.results_path, local=True)
     tear_down(env)
-    sockets_dir.cleanup()
     return ret

--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -950,6 +950,7 @@ def test_enabled_configs_dispatcher():
     return ret
 
 
+# it's a smoke test right now - it doesn't test nbd proxying logic
 def test_endpoint_proxy():
     env, run = setup()
 
@@ -971,7 +972,10 @@ def test_endpoint_proxy():
         "--endpoint-proxy-host", "localhost",
         "--endpoint-proxy-port", str(port),
         "--socket", "TODO-nbs-socket",
-        "--nbd-device", "TODO-nbd-device")
+        # can't use modprobe nbd in tests
+        # "--nbd-device", "TODO-nbd-device",
+        "--block-size", "4096",
+        "--blocks-count", "1024")
 
     run("stopproxyendpoint",
         "--endpoint-proxy-host", "localhost",


### PR DESCRIPTION
Fixed nbd client Start/StopEndpoint race as well. Can't properly test proxy<->kernel nbd logic in autotests now. Tested manually using the following scripts:
```
root@ubuntu:~/github/blockstore/nbs_setup/example# LD_LIBRARY_PATH=../cloud/blockstore/buildall/cloud/blockstore/apps/client/ ../cloud/blockstore/buildall/cloud/blockstore/apps/client/blockstore-client startendpoint --socket sockets/vol0.sock --disk-id vol0 --ipc-type nbd --mount-mode local
root@ubuntu:~/github/blockstore/nbs_setup/example# LD_LIBRARY_PATH=../cloud/blockstore/buildall/cloud/blockstore/apps/client/ ../cloud/blockstore/buildall/cloud/blockstore/apps/client/blockstore-client startendpoint --socket sockets/vol1.sock --disk-id vol1 --ipc-type nbd --mount-mode local

root@ubuntu:~/github/blockstore/nbs/cloud/blockstore/apps/client# cat startstop.sh 
#!/usr/bin/env bash
./blockstore-client startproxyendpoint --endpoint-proxy-host localhost --endpoint-proxy-port 9780 --socket /root/github/blockstore/nbs_setup/example/sockets/vol0.sock --nbd-device /dev/nbd0 --block-size 4096 --blocks-count 1024
./blockstore-client startproxyendpoint --endpoint-proxy-host localhost --endpoint-proxy-port 9780 --socket /root/github/blockstore/nbs_setup/example/sockets/vol1.sock --nbd-device /dev/nbd1 --block-size 4096 --blocks-count 1024
./blockstore-client stopproxyendpoint --endpoint-proxy-host localhost --endpoint-proxy-port 9780 --socket /root/github/blockstore/nbs_setup/example/sockets/vol0.sock
./blockstore-client stopproxyendpoint --endpoint-proxy-host localhost --endpoint-proxy-port 9780 --socket /root/github/blockstore/nbs_setup/example/sockets/vol1.sock

root@ubuntu:~/github/blockstore/nbs/cloud/blockstore/apps/client# while true; do ./startstop.sh ; done
...
```
and in a separate session in parallel with start/stop:
```
while true
do
    dd oflag=direct if=../../apps/client/block.txt of=/dev/nbd0 count=1 bs=4k
    dd iflag=direct if=/dev/nbd0 of=/dev/stdout count=1 bs=4k
    dd oflag=direct if=../../apps/client/block1.txt of=/dev/nbd1 count=1 bs=4k
    dd iflag=direct if=/dev/nbd1 of=/dev/stdout count=1 bs=4k
done
``` 

#1164 