### PR TITLE
issue-196: block checksums for the data read from blobstorage should be calculated over a buffer owned by NBS, not over sglist since otherwise our client can overwrite the buffer after we finish reading and before we calculate the checksum leading to false positives

### DIFF
--- a/cloud/blockstore/libs/storage/core/block_handler.cpp
+++ b/cloud/blockstore/libs/storage/core/block_handler.cpp
@@ -123,23 +123,6 @@ public:
         return SgList.Create(std::move(sglist));
     }
 
-    TGuardedSgList GetGuardedSgList(
-        const TVector<ui64>& blockIndices) const override
-    {
-        TSgList sglist(Reserve(blockIndices.size()));
-
-        for (const auto blockIndex: blockIndices) {
-            Y_ABORT_UNLESS(ReadRange.Contains(blockIndex));
-
-            size_t index = blockIndex - ReadRange.Start;
-            Y_ABORT_UNLESS(index < Blocks.BuffersSize());
-            const auto& block = Blocks.GetBuffers(index);
-            sglist.emplace_back(block.data(), BlockSize);
-        }
-
-        return SgList.Create(std::move(sglist));
-    }
-
     bool SetBlock(
         ui64 blockIndex,
         TBlockDataRef blockContent,
@@ -293,25 +276,6 @@ public:
 
                 BlockMarks[index] = true;
                 SetBitMapValue(UnencryptedBlockMask, index, baseDisk);
-            }
-
-            return GuardedSgList.Create(std::move(subset));
-        }
-
-        return GuardedSgList;
-    }
-
-    TGuardedSgList GetGuardedSgList(
-        const TVector<ui64>& blockIndices) const override
-    {
-        if (auto guard = GuardedSgList.Acquire()) {
-            const auto& src = guard.Get();
-            TSgList subset(Reserve(blockIndices.size()));
-
-            for (auto blockIndex: blockIndices) {
-                Y_ABORT_UNLESS(ReadRange.Contains(blockIndex));
-                const auto index = blockIndex - ReadRange.Start;
-                subset.push_back(src[index]);
             }
 
             return GuardedSgList.Create(std::move(subset));

--- a/cloud/blockstore/libs/storage/core/block_handler.h
+++ b/cloud/blockstore/libs/storage/core/block_handler.h
@@ -31,9 +31,6 @@ struct IReadBlocksHandler
         const TVector<ui64>& blockIndices,
         bool baseDisk) = 0;
 
-    virtual TGuardedSgList GetGuardedSgList(
-        const TVector<ui64>& blockIndices) const = 0;
-
     virtual bool SetBlock(
         ui64 blockIndex,
         TBlockDataRef blockContent,

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -973,7 +973,7 @@ void SetCounters(
 ////////////////////////////////////////////////////////////////////////////////
 
 NProto::TError VerifyBlockChecksum(
-    const TBlockDataRef& block,
+    const ui32 actualChecksum,
     const NKikimr::TLogoBlobID& blobID,
     const ui64 blockIndex,
     const ui16 blobOffset,
@@ -988,8 +988,6 @@ NProto::TError VerifyBlockChecksum(
 
         return {};
     }
-
-    const auto actualChecksum = ComputeDefaultDigest(block);
 
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob();

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -666,7 +666,7 @@ void SetCounters(
 ////////////////////////////////////////////////////////////////////////////////
 
 NProto::TError VerifyBlockChecksum(
-    const TBlockDataRef& block,
+    const ui32 actualChecksum,
     const NKikimr::TLogoBlobID& blobID,
     const ui64 blockIndex,
     const ui16 blobOffset,

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblob.cpp
@@ -50,6 +50,7 @@ void TPartitionActor::HandleReadBlob(
         VolumeActorId,
         TabletID(),
         State->GetBlockSize(),
+        msg->ShouldCalculateChecksums,
         StorageAccessMode,
         std::unique_ptr<TEvPartitionCommonPrivate::TEvReadBlobRequest>(
             msg.Release()),

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -440,8 +440,8 @@ void TReadBlocksActor::ReadBlocks(
             batch.BlobOffsets,
             ReadHandler->GetGuardedSgList(batch.Requests, baseDisk),
             batch.GroupId,
-            false,
-            TInstant::Max(),
+            false,           // async
+            TInstant::Max(), // deadline
             ChecksumsEnabled);
 
         if (!RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_scan_disk.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_scan_disk.cpp
@@ -196,7 +196,11 @@ void TScanDiskActor::SendReadBlobRequest(
         MakeBlobStorageProxyID(blobMark.BSGroupId),
         std::move(blobOffsets),
         std::move(subSgList),
-        blobMark.BSGroupId);
+        blobMark.BSGroupId,
+        false,           // async
+        TInstant::Max(), // deadline
+        false            // shouldCalculateChecksums
+    );
 
     NCloud::Send(
         ctx,

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -831,7 +831,11 @@ public:
                 MakeBlobStorageProxyID(bSGroupId),
                 blobOffsets,
                 TGuardedSgList(std::move(sglist)),
-                bSGroupId);
+                bSGroupId,
+                false,           // async
+                TInstant::Max(), // deadline
+                false            // shouldCalculateChecksums
+            );
         return request;
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -10655,6 +10655,47 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             true);
     }
 
+    void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
     Y_UNIT_TEST(ShouldDetectBlockCorruptionInBlobs)
     {
         constexpr ui32 blockCount = 1024 * 1024;
@@ -10668,49 +10709,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         const auto range = TBlockRange32::WithLength(0, 1024);
         partition.WriteBlocks(range, 1);
 
-        TGuardedSgList sgList;
-        TVector<ui16> blobOffsets;
-        ui32 corruptedOffset = 0;
-        int corruptValue = 0;
-        auto corruptData = [&] () {
-            auto g = sgList.Acquire();
-            UNIT_ASSERT(g);
-            ui32 i = 0;
-            while (i < blobOffsets.size()) {
-                if (blobOffsets[i] == corruptedOffset) {
-                    break;
-                }
-
-                ++i;
-            }
-
-            if (i == blobOffsets.size()) {
-                return;
-            }
-
-            const char* block = g.Get()[i].Data();
-            memset(const_cast<char*>(block), corruptValue, DefaultBlockSize);
-        };
-
-        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
-                switch (event->GetTypeRewrite()) {
-                    case TEvPartitionCommonPrivate::EvReadBlobRequest: {
-                        using TEv =
-                            TEvPartitionCommonPrivate::TEvReadBlobRequest;
-                        auto* msg = event->Get<TEv>();
-                        blobOffsets = msg->BlobOffsets;
-                        sgList = msg->Sglist;
-
-                        break;
-                    }
-                    case TEvPartitionCommonPrivate::EvReadBlobResponse: {
-                        corruptData();
-                        break;
-                    }
-                }
-                return TTestActorRuntime::DefaultObserverFunc(event);
-            }
-        );
+        EnableReadBlobCorruption(*runtime, 0);
 
         // direct read should fail
         {
@@ -10763,40 +10762,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 response->GetStatus(),
                 response->GetErrorReason());
         }
-    }
-
-    void EnableReadBlobCorruption(TTestActorRuntime& runtime)
-    {
-        std::shared_ptr<TGuardedSgList> sgList;
-
-        runtime.SetEventFilter([=] (
-            TTestActorRuntimeBase& runtime,
-            TAutoPtr<IEventHandle>& event) mutable
-        {
-            Y_UNUSED(runtime);
-
-            switch (event->GetTypeRewrite()) {
-                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
-                    using TEv =
-                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
-                    auto* msg = event->Get<TEv>();
-                    sgList = std::make_shared<TGuardedSgList>(msg->Sglist);
-
-                    break;
-                }
-                case TEvPartitionCommonPrivate::EvReadBlobResponse: {
-                    auto g = sgList->Acquire();
-                    UNIT_ASSERT(g);
-                    UNIT_ASSERT_VALUES_UNEQUAL(0, g.Get().size());
-
-                    const char* block = g.Get()[0].Data();
-                    memset(const_cast<char*>(block), '0', DefaultBlockSize);
-                    break;
-                }
-            }
-            return false;
-        });
-
     }
 
     Y_UNIT_TEST(ShouldDetectBlockCorruptionInBlobsWhenAddingUnconfirmedBlobs)

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_compaction.cpp
@@ -283,7 +283,10 @@ void TCompactionActor::ReadBlocks(const TActorContext& ctx)
                 req.Proxy,
                 std::move(req.DataBlobOffsets),
                 req.BlobContent.GetGuardedSgList(),
-                req.GroupId);
+                req.GroupId,
+                true,           // async
+                TInstant::Max() // deadline
+            );
 
             if (!RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {
                 LWTRACK(

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblocks.cpp
@@ -517,7 +517,10 @@ void TReadBlocksActor::ReadBlocks(
             batch.Proxy,
             std::move(batch.BlobOffsets),
             ReadHandler->GetGuardedSgList(batch.Requests, baseDisk),
-            batch.GroupId);
+            batch.GroupId,
+            false,          // async
+            TInstant::Max() // deadline
+        );
 
         if (!RequestInfo->CallContext->LWOrbit.Fork(request->CallContext->LWOrbit)) {
             LWTRACK(

--- a/cloud/blockstore/libs/storage/partition2/part2_events_private.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_events_private.h
@@ -98,8 +98,8 @@ struct TEvPartitionPrivate
                 TVector<ui16> blobOffsets,
                 TGuardedSgList sglist,
                 ui32 groupId,
-                bool async = false,
-                TInstant deadline = TInstant::Max())
+                bool async,
+                TInstant deadline)
             : BlobId(blobId)
             , Proxy(proxy)
             , BlobOffsets(std::move(blobOffsets))

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -771,7 +771,10 @@ public:
                 MakeBlobStorageProxyID(bSGroupId),
                 blobOffsets,
                 std::move(sglist),
-                bSGroupId);
+                bSGroupId,
+                false,          // async
+                TInstant::Max() // deadline
+            );
         return request;
     }
 

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
@@ -240,7 +240,7 @@ void TReadBlobActor::HandleGetResult(
                 void* to = const_cast<char*>(sglist[sglistIndex].Data());
                 if (ShouldCalculateChecksums) {
                     auto block = TString::Uninitialized(BlockSize);
-                    iter.ExtractPlainDataAndAdvance(to, BlockSize);
+                    iter.ExtractPlainDataAndAdvance(block.begin(), BlockSize);
                     blockChecksums.push_back(
                         ComputeDefaultDigest({block.Data(), BlockSize}));
 

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob.h
@@ -28,6 +28,7 @@ private:
     const NActors::TActorId PartitionActorId;
     const ui64 PartitionTabletId;
     const ui32 BlockSize;
+    const bool ShouldCalculateChecksums;
     const EStorageAccessMode StorageAccessMode;
     const std::unique_ptr<TRequest> Request;
 
@@ -41,6 +42,7 @@ public:
         const NActors::TActorId& volumeActorId,
         ui64 partitionTabletId,
         ui32 blockSize,
+        bool shouldCalculateChecksums,
         const EStorageAccessMode storageAccessMode,
         std::unique_ptr<TRequest> request,
         TDuration longRunningThreshold);

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob_ut.cpp
@@ -43,7 +43,6 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
     {
         const ui32 groupId = 12;
         const ui32 blockSize = 512;
-        const ui32 blockSizeForChecksums = 0;
         const NKikimr::TLogoBlobID logoBlobID(142, 143, 0x8000);  //blob size 2028
         const TVector<ui16> blobOffsets{0 , 2, 3};
 
@@ -72,7 +71,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 NActors::TActorId(),
                 0,
                 blockSize,
-                blockSizeForChecksums,
+                false, // shouldCalculateChecksums
                 EStorageAccessMode::Default,
                 std::move(request),
                 TDuration()));
@@ -131,7 +130,6 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
     {
         const ui32 groupId = 12;
         const ui32 blockSize = 512;
-        const ui32 blockSizeForChecksums = 0;
         const NKikimr::TLogoBlobID logoBlobID(142, 143, 0x8000);  //blob size 2028
         const TVector<ui16> blobOffsets{0 , 2, 3};
 
@@ -160,7 +158,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 NActors::TActorId(),
                 0,
                 blockSize,
-                blockSizeForChecksums,
+                false, // shouldCalculateChecksums
                 EStorageAccessMode::Default,
                 std::move(request),
                 TDuration()));
@@ -203,7 +201,6 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
     {
         const ui32 groupId = 12;
         const ui32 blockSize = 512;
-        const ui32 blockSizeForChecksums = 0;
         const NKikimr::TLogoBlobID logoBlobID(142, 143, 0x8000);  //blob size 2028
         const TVector<ui16> blobOffsets{0 , 2, 3};
 
@@ -232,7 +229,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 NActors::TActorId(),
                 0,
                 blockSize,
-                blockSizeForChecksums,
+                false, // shouldCalculateChecksums
                 EStorageAccessMode::Default,
                 std::move(request),
                 TDuration()));

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob_ut.cpp
@@ -43,6 +43,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
     {
         const ui32 groupId = 12;
         const ui32 blockSize = 512;
+        const ui32 blockSizeForChecksums = 0;
         const NKikimr::TLogoBlobID logoBlobID(142, 143, 0x8000);  //blob size 2028
         const TVector<ui16> blobOffsets{0 , 2, 3};
 
@@ -71,6 +72,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 NActors::TActorId(),
                 0,
                 blockSize,
+                blockSizeForChecksums,
                 EStorageAccessMode::Default,
                 std::move(request),
                 TDuration()));
@@ -129,6 +131,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
     {
         const ui32 groupId = 12;
         const ui32 blockSize = 512;
+        const ui32 blockSizeForChecksums = 0;
         const NKikimr::TLogoBlobID logoBlobID(142, 143, 0x8000);  //blob size 2028
         const TVector<ui16> blobOffsets{0 , 2, 3};
 
@@ -157,6 +160,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 NActors::TActorId(),
                 0,
                 blockSize,
+                blockSizeForChecksums,
                 EStorageAccessMode::Default,
                 std::move(request),
                 TDuration()));
@@ -199,6 +203,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
     {
         const ui32 groupId = 12;
         const ui32 blockSize = 512;
+        const ui32 blockSizeForChecksums = 0;
         const NKikimr::TLogoBlobID logoBlobID(142, 143, 0x8000);  //blob size 2028
         const TVector<ui16> blobOffsets{0 , 2, 3};
 
@@ -227,6 +232,7 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 NActors::TActorId(),
                 0,
                 blockSize,
+                blockSizeForChecksums,
                 EStorageAccessMode::Default,
                 std::move(request),
                 TDuration()));

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob_ut.cpp
@@ -59,7 +59,11 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 EdgeActor,
                 blobOffsets,
                 guardedSglist,
-                groupId);
+                groupId,
+                false,           // async
+                TInstant::Max(), // deadline
+                false            // shouldCalculateChecksums
+            );
 
         auto readActor = ActorSystem.Register(
             new TReadBlobActor(
@@ -146,7 +150,11 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 EdgeActor,
                 blobOffsets,
                 guardedSglist,
-                groupId);
+                groupId,
+                false,           // async
+                TInstant::Max(), // deadline
+                false            // shouldCalculateChecksums
+            );
 
         auto readActor = ActorSystem.Register(
             new TReadBlobActor(
@@ -217,7 +225,11 @@ Y_UNIT_TEST_SUITE(TReadBlobTests)
                 EdgeActor,
                 blobOffsets,
                 guardedSglist,
-                groupId);
+                groupId,
+                false,           // async
+                TInstant::Max(), // deadline
+                false            // shouldCalculateChecksums
+            );
 
         auto readActor = ActorSystem.Register(
             new TReadBlobActor(

--- a/cloud/blockstore/libs/storage/partition_common/events_private.h
+++ b/cloud/blockstore/libs/storage/partition_common/events_private.h
@@ -72,6 +72,7 @@ struct TEvPartitionCommonPrivate
         ui32 GroupId = 0;
         bool Async = false;
         TInstant Deadline;
+        bool ShouldCalculateChecksums = false;
 
         TReadBlobRequest() = default;
 
@@ -81,8 +82,9 @@ struct TEvPartitionCommonPrivate
                 TVector<ui16> blobOffsets,
                 TGuardedSgList sglist,
                 ui32 groupId,
-                bool async = false,
-                TInstant deadline = TInstant::Max())
+                bool async,
+                TInstant deadline,
+                bool shouldCalculateChecksums)
             : BlobId(blobId)
             , Proxy(proxy)
             , BlobOffsets(std::move(blobOffsets))
@@ -90,14 +92,14 @@ struct TEvPartitionCommonPrivate
             , GroupId(groupId)
             , Async(async)
             , Deadline(deadline)
+            , ShouldCalculateChecksums(shouldCalculateChecksums)
         {}
     };
 
     struct TReadBlobResponse
     {
+        TVector<ui32> BlockChecksums;
         ui64 ExecCycles = 0;
-
-        TReadBlobResponse() = default;
     };
 
     // TReadBlobCompleted

--- a/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay.cpp
@@ -371,6 +371,7 @@ void TReadDiskRegistryBasedOverlayActor<TMethod>::HandleDescribeBlocksCompleted(
                     VolumeActorId,
                     VolumeTabletId,
                     BlockSize,
+                    false, // shouldCalculateChecksums
                     Mode,
                     std::move(currentRequest),
                     LongRunningThreshold);
@@ -397,6 +398,7 @@ void TReadDiskRegistryBasedOverlayActor<TMethod>::HandleDescribeBlocksCompleted(
             VolumeActorId,
             VolumeTabletId,
             BlockSize,
+            false, // shouldCalculateChecksums
             EStorageAccessMode::Default,
             std::move(currentRequest),
             LongRunningThreshold);


### PR DESCRIPTION
The problem is similar to the one described here for write requests: https://github.com/ydb-platform/nbs/pull/825

#196 