### PR TITLE
issue-1236: update DR config w/o triggering STORAGE_VERIFY

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1220,6 +1220,10 @@ private:
         const THashMap<TDeviceId, NProto::TDeviceConfig>& oldConfigs) const;
 
     void ResetMigrationStartTsIfNeeded(TDiskState& disk);
+
+    struct TConfigUpdateEffect;
+    TResultOrError<TConfigUpdateEffect> CalcConfigUpdateEffect(
+        const NProto::TDiskRegistryConfig& newConfig) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -737,6 +737,11 @@ public:
         bool isReplacement);
 
     NProto::TError SuspendDevice(TDiskRegistryDatabase& db, const TDeviceId& id);
+
+    void SuspendDeviceIfNeeded(
+        TDiskRegistryDatabase& db,
+        NProto::TDeviceConfig& device);
+
     void ResumeDevice(
         TInstant now,
         TDiskRegistryDatabase& db,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -280,6 +280,171 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             UNIT_ASSERT_VALUES_EQUAL(4, devices.size());
         });
     }
+
+    Y_UNIT_TEST(ShouldAddUnknownHost)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            db.InitSchema();
+        });
+
+        const auto lostAgentConfig = AgentConfig(1, "agent-1", {});
+
+        const auto agentConfig = AgentConfig(1, "agent-2", {
+            Device("NVMENBS01", "uuid-1.1", "rack-1"),
+            Device("NVMENBS02", "uuid-1.2", "rack-1"),
+            Device("NVMENBS03", "uuid-1.3", "rack-1"),
+            Device("NVMENBS04", "uuid-1.4", "rack-1"),
+        });
+
+        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+
+        // prepare agent-1
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetConfig().KnownAgentsSize());
+
+            NProto::TDiskRegistryConfig config;
+            config.AddKnownAgents()->SetAgentId(lostAgentConfig.GetAgentId());
+
+            TVector<TString> affectedDisks;
+            UNIT_ASSERT_SUCCESS(
+                state.UpdateConfig(db, config, true, affectedDisks));
+
+            UNIT_ASSERT_SUCCESS(
+                RegisterAgent(state, db, lostAgentConfig, Now()));
+
+            UNIT_ASSERT_SUCCESS(state.UpdateConfig(
+                db,
+                NProto::TDiskRegistryConfig{},
+                true,
+                affectedDisks));
+
+            UNIT_ASSERT_SUCCESS(state.UpdateAgentState(
+                db,
+                lostAgentConfig.GetAgentId(),
+                NProto::AGENT_STATE_UNAVAILABLE,
+                Now(),
+                "lost",
+                affectedDisks));
+
+            UNIT_ASSERT_VALUES_EQUAL(1, state.GetAgents().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                lostAgentConfig.GetNodeId(),
+                state.GetAgents()[0].GetNodeId());
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetSuspendedDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetDirtyDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(1, state.GetAgents().size());
+        });
+
+        // prepare agent-2
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            UNIT_ASSERT_SUCCESS(RegisterAgent(state, db, agentConfig, Now()));
+
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetSuspendedDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetDirtyDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
+
+            UNIT_ASSERT_VALUES_EQUAL(2, state.GetAgents().size());
+
+            auto agents = state.GetAgents();
+            SortBy(
+                agents,
+                [](const auto& agent) { return agent.GetAgentId(); });
+
+            UNIT_ASSERT_VALUES_EQUAL(2, agents.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                lostAgentConfig.GetAgentId(),
+                agents[0].GetAgentId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0, // agent-1 lost his nodeId
+                agents[0].GetNodeId());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[0].DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[0].UnknownDevicesSize());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.GetAgentId(),
+                agents[1].GetAgentId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.GetNodeId(),
+                agents[1].GetNodeId());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[1].DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.DevicesSize(),
+                agents[1].UnknownDevicesSize());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetConfig().KnownAgentsSize());
+            UNIT_ASSERT_VALUES_EQUAL(2, state.GetConfigVersion());
+        });
+
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            TVector<TString> affectedDisks;
+            TDuration timeout;
+            UNIT_ASSERT_SUCCESS(state.UpdateCmsHostState(
+                db,
+                agentConfig.GetAgentId(),
+                NProto::AGENT_STATE_ONLINE,
+                Now(),
+                false, // dryRun
+                affectedDisks,
+                timeout));
+
+            auto knownAgents = state.GetConfig().GetKnownAgents();
+
+            UNIT_ASSERT_VALUES_EQUAL(1, knownAgents.size());
+            UNIT_ASSERT_VALUES_EQUAL(3, state.GetConfigVersion());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.DevicesSize(),
+                knownAgents.Get(0).DevicesSize());
+
+            SortBy(
+                *knownAgents.Mutable(0)->MutableDevices(),
+                [](const auto& d) {
+                    return d.GetDeviceUUID();
+                });
+            for (size_t i = 0; i != agentConfig.DevicesSize(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    agentConfig.GetDevices(i).GetDeviceUUID(),
+                    knownAgents.Get(0).GetDevices(i).GetDeviceUUID());
+            }
+
+            ASSERT_VECTORS_EQUAL(TVector<TString>{}, affectedDisks);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration {}, timeout);
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetSuspendedDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.DevicesSize(),
+                state.GetDirtyDevices().size());
+            UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
+
+            UNIT_ASSERT_VALUES_EQUAL(2, state.GetAgents().size());
+
+            auto agents = state.GetAgents();
+            SortBy(
+                agents,
+                [](const auto& agent) { return agent.GetAgentId(); });
+
+            UNIT_ASSERT_VALUES_EQUAL(2, agents.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                lostAgentConfig.GetAgentId(),
+                agents[0].GetAgentId());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[0].GetNodeId());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[0].DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[0].UnknownDevicesSize());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.GetAgentId(),
+                agents[1].GetAgentId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.GetNodeId(),
+                agents[1].GetNodeId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig.DevicesSize(),
+                agents[1].DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(0, agents[1].UnknownDevicesSize());
+        });
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/agent_list.h
@@ -96,6 +96,18 @@ public:
         TInstant timestamp,
         const TKnownAgent& knownAgent);
 
+    struct TUpdateAgentDevicesResult
+    {
+        NProto::TAgentConfig* Agent = nullptr;
+        TVector<TDeviceId> NewDevices;
+    };
+
+    // If agent with agentId exists, split devices between Devices &
+    // UnknownDevices according to knownAgent.
+    TUpdateAgentDevicesResult TryUpdateAgentDevices(
+        const TString& agentId,
+        const TKnownAgent& knownAgent);
+
     bool RemoveAgent(TNodeId nodeId);
     bool RemoveAgent(const TAgentId& agentId);
 
@@ -165,6 +177,8 @@ private:
         NProto::TDeviceConfig device);
 
     TString FindAgentRack(const TString& agentId) const;
+
+    void RegisterCounters(const NProto::TAgentConfig& agent);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
Now UpdateConfig doesn't invoke RegisterAgent and therefore STORAGE_VERIFY will not be called.

#1236