### PR TITLE
NBS-4665 [NBS] Validate checkpoint requests and reply without saving/exection when needed

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -95,8 +95,9 @@ const TCheckpointRequest& TCheckpointStore::MakeDeleteCheckpointDataRequest(
 void TCheckpointStore::RemoveCheckpointRequest(ui64 requestId)
 {
     Y_DEBUG_ABORT_UNLESS(
+        CheckpointRequests.FindPtr(requestId) &&
         CheckpointRequests.FindPtr(requestId)->State ==
-        ECheckpointRequestState::Received);
+            ECheckpointRequestState::Received);
     CheckpointRequests.erase(requestId);
 }
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -224,20 +224,20 @@ bool TCheckpointStore::DoesCheckpointHaveData(const TString& checkpointId) const
     return false;
 }
 
-bool TCheckpointStore::HasRequestToExecute(ui64* requestId) const
+TVector<ui64> TCheckpointStore::GetRequestIdsToProcess() const
 {
-    Y_DEBUG_ABORT_UNLESS(requestId);
+    TVector<ui64> requestIds(Reserve(CheckpointRequests.size()));
 
     for (const auto& [key, checkpointRequest]: CheckpointRequests) {
         if (checkpointRequest.State == ECheckpointRequestState::Received ||
             checkpointRequest.State == ECheckpointRequestState::Saved)
         {
             Y_DEBUG_ABORT_UNLESS(key == checkpointRequest.RequestId);
-            *requestId = checkpointRequest.RequestId;
-            return true;
+            requestIds.push_back(checkpointRequest.RequestId);
         }
     }
-    return false;
+
+    return requestIds;
 }
 
 std::optional<ECheckpointType> TCheckpointStore::GetCheckpointType(

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -167,8 +167,9 @@ public:
         ECheckpointRequestType requestType,
         ECheckpointType checkpointType) const;
 
+    void RemoveCheckpointRequest(ui64 requestId);
+
     void SetCheckpointRequestInProgress(ui64 requestId);
-    void UnsetCheckpointRequestInProgress();
     void SetCheckpointRequestSaved(ui64 requestId);
     void SetCheckpointRequestFinished(
         ui64 requestId,

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -167,8 +167,9 @@ public:
         ECheckpointRequestType requestType,
         ECheckpointType checkpointType) const;
 
-    void SetCheckpointRequestSaved(ui64 requestId);
     void SetCheckpointRequestInProgress(ui64 requestId);
+    void UnsetCheckpointRequestInProgress();
+    void SetCheckpointRequestSaved(ui64 requestId);
     void SetCheckpointRequestFinished(
         ui64 requestId,
         bool completed,

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -203,7 +203,7 @@ public:
     [[nodiscard]] TVector<TString> GetCheckpointsWithData() const;
     [[nodiscard]] const TActiveCheckpointsMap& GetActiveCheckpoints() const;
 
-    [[nodiscard]] bool HasRequestToExecute(ui64* requestId) const;
+    [[nodiscard]] TVector<ui64> GetRequestIdsToProcess() const;
 
     [[nodiscard]] const TCheckpointRequest& GetRequestById(
         ui64 requestId) const;

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -437,10 +437,14 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
 
         store.RemoveCheckpointRequest(requestId);
         UNIT_ASSERT_VALUES_EQUAL(false, store.HasRequestToExecute(&requestId));
-        UNIT_ASSERT_VALUES_EQUAL(false, store.DoesCheckpointBlockingWritesExist());
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
-        UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointDeleted("checkpoint"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            store.IsCheckpointDeleted("checkpoint"));
     }
 
     Y_UNIT_TEST(RepeatRequests)
@@ -705,12 +709,16 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
                 checkpointId,
                 TInstant::Now());
             ui64 requestId = 0;
-            UNIT_ASSERT_VALUES_EQUAL(true, store.HasRequestToExecute(&requestId));
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                store.HasRequestToExecute(&requestId));
             UNIT_ASSERT_VALUES_EQUAL(request.RequestId, requestId);
 
             store.RemoveCheckpointRequest(request.RequestId);
 
-            UNIT_ASSERT_VALUES_EQUAL(false, store.HasRequestToExecute(&requestId));
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                store.HasRequestToExecute(&requestId));
         };
 
         {
@@ -727,7 +735,9 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
             addAndRemoveCheckpointRequest("checkpoint-not-executed");
             UNIT_ASSERT_VALUES_EQUAL(3, store.GetCheckpointsWithData().size());
             UNIT_ASSERT_VALUES_EQUAL(3, store.GetActiveCheckpoints().size());
-            UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointDeleted("checkpoint-not-executed"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                store.IsCheckpointDeleted("checkpoint-not-executed"));
 
             deleteCheckpointData("checkpoint-1");
             UNIT_ASSERT_VALUES_EQUAL(true, store.DoesCheckpointBlockingWritesExist());
@@ -778,7 +788,9 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
             addAndRemoveCheckpointRequest("checkpoint-1");
             UNIT_ASSERT_VALUES_EQUAL(0, store.GetCheckpointsWithData().size());
             UNIT_ASSERT_VALUES_EQUAL(0, store.GetActiveCheckpoints().size());
-            UNIT_ASSERT_VALUES_EQUAL(true, store.IsCheckpointDeleted("checkpoint-1"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                store.IsCheckpointDeleted("checkpoint-1"));
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -17,9 +17,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(false, store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
-        ui64 requestId = 0;
         UNIT_ASSERT_VALUES_EQUAL(0, store.GetRequestIdsToProcess().size());
-        UNIT_ASSERT_VALUES_EQUAL(0, requestId);
     }
 
     Y_UNIT_TEST(HasPersistentState)
@@ -165,7 +163,6 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
 
         auto requestsToProcess = store.GetRequestIdsToProcess();
         UNIT_ASSERT_VALUES_EQUAL(2, requestsToProcess.size());
-        std::sort(requestsToProcess.begin(), requestsToProcess.end());
         UNIT_ASSERT_VALUES_EQUAL(10, requestsToProcess[0]);
         UNIT_ASSERT_VALUES_EQUAL(11, requestsToProcess[1]);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -651,7 +651,9 @@ private:
         const TEvVolumePrivate::TEvRemoveExpiredVolumeParams::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    void ProcessNextCheckpointRequest(const NActors::TActorContext& ctx);
+    void ProcessCheckpointRequests(const NActors::TActorContext& ctx);
+
+    bool ProcessCheckpointRequest(const NActors::TActorContext& ctx, ui64 requestId);
 
     void ReplyToCheckpointRequestWithoutSaving(
         const NActors::TActorContext& ctx,
@@ -659,7 +661,7 @@ private:
         const TCheckpointRequestInfo* requestInfo,
         const NProto::TError& error);
 
-    void ProcessCheckpointRequest(
+    void ExecuteCheckpointRequest(
         const NActors::TActorContext& ctx,
         ui64 requestId);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -317,6 +317,15 @@ private:
             , IsTraced(isTraced)
             , TraceTs(traceTs)
         {}
+
+        explicit TCheckpointRequestInfo(const NActors::TActorId& actorId)
+            : RequestInfo(CreateRequestInfo(
+                  actorId,
+                  0,   // cookie
+                  MakeIntrusive<TCallContext>()))
+            , IsTraced(false)
+            , TraceTs(GetCycleCount())
+        {}
     };
     TMap<ui64, TCheckpointRequestInfo> CheckpointRequests;
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -653,6 +653,12 @@ private:
 
     void ProcessNextCheckpointRequest(const NActors::TActorContext& ctx);
 
+    void ReplyToCheckpointRequestWithoutSaving(
+        const NActors::TActorContext& ctx,
+        ECheckpointRequestType requestType,
+        const TCheckpointRequestInfo* requestInfo,
+        const NProto::TError& error);
+
     void ProcessCheckpointRequest(
         const NActors::TActorContext& ctx,
         ui64 requestId);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1106,7 +1106,7 @@ void TVolumeActor::ProcessCheckpointRequests(const NActors::TActorContext& ctx)
     }
 
     auto readyToProcessRequestIds = checkpointStore.GetRequestIdsToProcess();
-    for (auto requestId : readyToProcessRequestIds) {
+    for (auto requestId: readyToProcessRequestIds) {
         if (ProcessCheckpointRequest(ctx, requestId)) {
             // Execution of the request has started, should return now.
             return;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1105,9 +1105,9 @@ void TVolumeActor::ProcessCheckpointRequests(const NActors::TActorContext& ctx)
         return;
     }
 
-    ui64 readyToExecuteRequestId = 0;
-    while (checkpointStore.HasRequestToExecute(&readyToExecuteRequestId)) {
-        if (ProcessCheckpointRequest(ctx, readyToExecuteRequestId)) {
+    auto readyToProcessRequestIds = checkpointStore.GetRequestIdsToProcess();
+    for (auto requestId : readyToProcessRequestIds) {
+        if (ProcessCheckpointRequest(ctx, requestId)) {
             // Execution of the request has started, should return now.
             return;
         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1108,7 +1108,7 @@ void TVolumeActor::ProcessCheckpointRequests(const NActors::TActorContext& ctx)
     ui64 readyToExecuteRequestId = 0;
     while (checkpointStore.HasRequestToExecute(&readyToExecuteRequestId)) {
         if (ProcessCheckpointRequest(ctx, readyToExecuteRequestId)) {
-            // Execution of the request started, should return now.
+            // Execution of the request has started, should return now.
             return;
         }
     }
@@ -1144,8 +1144,7 @@ bool TVolumeActor::ProcessCheckpointRequest(const TActorContext& ctx, ui64 reque
         }
     }
 
-    checkpointStore.SetCheckpointRequestInProgress(
-        requestId);
+    checkpointStore.SetCheckpointRequestInProgress(requestId);
 
     if (request.State == ECheckpointRequestState::Received) {
         AddTransaction(*requestInfo->RequestInfo);
@@ -1162,10 +1161,10 @@ bool TVolumeActor::ProcessCheckpointRequest(const TActorContext& ctx, ui64 reque
 }
 
 void TVolumeActor::ReplyToCheckpointRequestWithoutSaving(
-        const NActors::TActorContext& ctx,
-        ECheckpointRequestType requestType,
-        const TCheckpointRequestInfo* requestInfo,
-        const NProto::TError& error)
+    const NActors::TActorContext& ctx,
+    ECheckpointRequestType requestType,
+    const TCheckpointRequestInfo* requestInfo,
+    const NProto::TError& error)
 {
     NActors::IEventBasePtr response;
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -423,7 +423,7 @@ void TVolumeActor::HandleMultipartitionWriteOrZeroCompleted(
 
     Y_DEBUG_ABORT_UNLESS(MultipartitionWriteAndZeroRequestsInProgress > 0);
     --MultipartitionWriteAndZeroRequestsInProgress;
-    ProcessNextCheckpointRequest(ctx);
+    ProcessCheckpointRequests(ctx);
 }
 
 void TVolumeActor::HandleWriteOrZeroCompleted(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -107,7 +107,7 @@ void TVolumeActor::OnStarted(const TActorContext& ctx)
         PendingRequests.pop_front();
     }
 
-    ProcessNextCheckpointRequest(ctx);
+    ProcessCheckpointRequests(ctx);
 }
 
 void TVolumeActor::StartPartitionsIfNeeded(const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -4685,11 +4685,6 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         );
         volume.WaitReady();
 
-        TVector<bool> isLightCases{true};  // light checkpoint
-        if (!IsDiskRegistryMediaKind(mediaKind)) {
-            isLightCases.push_back(false);  // normal checkpoint
-        }
-
         std::vector<std::pair<NProto::ECheckpointType, TString>> testCases{
             {NProto::ECheckpointType::NORMAL, "checkpoint_normal"},
             {NProto::ECheckpointType::LIGHT, "checkpoint_light"},
@@ -4701,7 +4696,9 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
             volume.DeleteCheckpoint(checkpointId);
 
             volume.SendCreateCheckpointRequest(checkpointId, checkpointType);
-            UNIT_ASSERT_VALUES_UNEQUAL(S_OK, volume.RecvCreateCheckpointResponse()->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_PRECONDITION_FAILED,
+                volume.RecvCreateCheckpointResponse()->GetStatus());
         }
     }
 
@@ -4747,7 +4744,9 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         volume.DeleteCheckpointData(checkpointId);
 
         volume.SendCreateCheckpointRequest(checkpointId);
-        UNIT_ASSERT_VALUES_UNEQUAL(S_OK, volume.RecvCreateCheckpointResponse()->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_PRECONDITION_FAILED,
+            volume.RecvCreateCheckpointResponse()->GetStatus());
     }
 }
 


### PR DESCRIPTION
This pr is to replace #239.

When we start to process a checkpoint request, we should call ValidateCheckpointRequest method added in #1134. Depending on the result of validation, we either reply to the request immediately or save the request to the database and execute it as usual.