### PR TITLE
Support GetChangedBlocks for shadow disk based checkpoints

### DIFF
--- a/cloud/blockstore/libs/storage/core/forward_helpers.h
+++ b/cloud/blockstore/libs/storage/core/forward_helpers.h
@@ -25,6 +25,15 @@ constexpr bool IsWriteMethod =
     std::is_same_v<TMethod, TEvService::TZeroBlocksMethod>;
 
 template <typename TMethod>
+constexpr bool IsExactlyWriteMethod =
+    std::is_same_v<TMethod, TEvService::TWriteBlocksMethod> ||
+    std::is_same_v<TMethod, TEvService::TWriteBlocksLocalMethod>;
+
+template <typename TMethod>
+constexpr bool IsZeroMethod =
+    std::is_same_v<TMethod, TEvService::TZeroBlocksMethod>;
+
+template <typename TMethod>
 constexpr bool IsReadOrWriteMethod =
     IsReadMethod<TMethod> || IsWriteMethod<TMethod>;
 

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.cpp
@@ -10,11 +10,9 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TGetChangedBlocksCompanion::SetBehavior(
-    EBehavior behavior,
+void TGetChangedBlocksCompanion::SetDelegate(
     NActors::TActorId delegate)
 {
-    Behavior = behavior;
     Delegate = delegate;
 }
 
@@ -22,13 +20,10 @@ void TGetChangedBlocksCompanion::HandleGetChangedBlocks(
     const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
     const NActors::TActorContext& ctx) const
 {
-    switch (Behavior) {
-        case EBehavior::ReplyError: {
-            DoReplyError(ev, ctx);
-        } break;
-        case EBehavior::DelegateRequest: {
-            DoDelegateRequest(ev, ctx);
-        } break;
+    if (Delegate) {
+        DoDelegateRequest(ev, ctx);
+    } else {
+        DoReplyError(ev, ctx);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.cpp
@@ -1,0 +1,65 @@
+#include "get_changed_blocks_companion.h"
+
+#include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/storage/core/libs/actors/helpers.h>
+#include <cloud/storage/core/libs/diagnostics/critical_events.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetChangedBlocksCompanion::SetBehavior(
+    EBehavior behavior,
+    NActors::TActorId delegate)
+{
+    Behavior = behavior;
+    Delegate = delegate;
+}
+
+void TGetChangedBlocksCompanion::HandleGetChangedBlocks(
+    const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx) const
+{
+    switch (Behavior) {
+        case EBehavior::ReplyError: {
+            DoReplayError(ev, ctx);
+        } break;
+        case EBehavior::DelegateRequest: {
+            DoDelegateRequest(ev, ctx);
+        } break;
+    }
+}
+
+void TGetChangedBlocksCompanion::DoReplayError(
+    const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx) const
+{
+    auto response = std::make_unique<TEvService::TEvGetChangedBlocksResponse>(
+        MakeError(E_ARGUMENT, "GetChangedBlocks not supported"));
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+void TGetChangedBlocksCompanion::DoDelegateRequest(
+    const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx) const
+{
+    STORAGE_CHECK_PRECONDITION(Delegate);
+
+    NActors::TActorId nondeliveryActor = ev->GetForwardOnNondeliveryRecipient();
+    auto message = std::make_unique<IEventHandle>(
+        Delegate,
+        ev->Sender,
+        ev->ReleaseBase().Release(),
+        ev->Flags,
+        ev->Cookie,
+        ev->Flags & NActors::IEventHandle::FlagForwardOnNondelivery
+            ? &nondeliveryActor
+            : nullptr);
+    ctx.Send(std::move(message));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.cpp
@@ -24,7 +24,7 @@ void TGetChangedBlocksCompanion::HandleGetChangedBlocks(
 {
     switch (Behavior) {
         case EBehavior::ReplyError: {
-            DoReplayError(ev, ctx);
+            DoReplyError(ev, ctx);
         } break;
         case EBehavior::DelegateRequest: {
             DoDelegateRequest(ev, ctx);
@@ -32,7 +32,7 @@ void TGetChangedBlocksCompanion::HandleGetChangedBlocks(
     }
 }
 
-void TGetChangedBlocksCompanion::DoReplayError(
+void TGetChangedBlocksCompanion::DoReplyError(
     const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
     const NActors::TActorContext& ctx) const
 {

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
@@ -12,21 +12,13 @@ namespace NCloud::NBlockStore::NStorage {
 // respond to it with an error, or redirect it to another actor.
 class TGetChangedBlocksCompanion
 {
-public:
-    enum class EBehavior
-    {
-        ReplyError,
-        DelegateRequest,
-    };
-
 private:
-    EBehavior Behavior = EBehavior::ReplyError;
     NActors::TActorId Delegate;
 
 public:
     TGetChangedBlocksCompanion() = default;
 
-    void SetBehavior(EBehavior behavior, NActors::TActorId delegate);
+    void SetDelegate(NActors::TActorId delegate);
 
     void HandleGetChangedBlocks(
         const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cloud/blockstore/libs/storage/api/service.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TGetChangedBlocksCompanion
+{
+public:
+    enum class EBehavior
+    {
+        ReplyError,
+        DelegateRequest,
+    };
+
+private:
+    EBehavior Behavior = EBehavior::ReplyError;
+    NActors::TActorId Delegate;
+
+public:
+    TGetChangedBlocksCompanion() = default;
+
+    void SetBehavior(EBehavior behavior, NActors::TActorId delegate);
+
+    void HandleGetChangedBlocks(
+        const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+
+private:
+    void DoReplayError(
+        const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+    void DoDelegateRequest(
+        const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
@@ -33,7 +33,7 @@ public:
         const NActors::TActorContext& ctx) const;
 
 private:
-    void DoReplayError(
+    void DoReplyError(
         const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
         const NActors::TActorContext& ctx) const;
     void DoDelegateRequest(

--- a/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h
@@ -8,6 +8,8 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Helps to process the TEvGetChangedBlocksRequest message. It can either
+// respond to it with an error, or redirect it to another actor.
 class TGetChangedBlocksCompanion
 {
 public:

--- a/cloud/blockstore/libs/storage/partition_common/ya.make
+++ b/cloud/blockstore/libs/storage/partition_common/ya.make
@@ -8,6 +8,7 @@ SRCS(
     actor_loadfreshblobs.cpp
     actor_trimfreshlog.cpp
     drain_actor_companion.cpp
+    get_changed_blocks_companion.cpp
     long_running_operation_companion.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.cpp
@@ -161,6 +161,7 @@ void TCopyRangeActor::Done(const TActorContext& ctx, NProto::TError error)
             WriteStartTs,
             WriteDuration,
             std::move(AffectedBlockInfos),
+            AllZeroes,
             RequestInfo->GetExecCycles());
 
     LWTRACK(
@@ -201,6 +202,7 @@ void TCopyRangeActor::HandleReadResponse(
     }
 
     if (msg->Record.GetAllZeroes()) {
+        AllZeroes = true;
         ZeroBlocks(ctx);
     } else {
         WriteBlocks(ctx, std::move(*msg->Record.MutableBlocks()));

--- a/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h
@@ -32,6 +32,7 @@ private:
     TInstant WriteStartTs;
     TDuration WriteDuration;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
+    bool AllZeroes = false;
 
 public:
     TCopyRangeActor(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.cpp
@@ -34,7 +34,8 @@ void TChangedRangesMap::MarkNotChanged(TBlockRange64 range)
 
 TString TChangedRangesMap::GetChangedBlocks(TBlockRange64 range) const
 {
-    const auto resultSize = AlignUp<size_t>(range.Size(), 8);
+    constexpr size_t BitsInByte = 8;
+    const auto resultSize = AlignUp<size_t>(range.Size(), BitsInByte);
 
     // We know a map of changes blocks with a resolution in the RangeSize.
     // Let's convert this map to a resolution up to a block.
@@ -63,10 +64,10 @@ TString TChangedRangesMap::GetChangedBlocks(TBlockRange64 range) const
 
     // Convert the TDynBitMap to a TString.
     TString result;
-    result.resize(resultSize / 8);
+    result.resize(resultSize / BitsInByte);
     for (size_t i = 0; i < result.size(); ++i) {
         ui8 tmp = 0;
-        map.Export(i * 8, tmp);
+        map.Export(i * BitsInByte, tmp);
         result[i] = static_cast<char>(tmp);
     }
     return result;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.cpp
@@ -37,8 +37,8 @@ TString TChangedRangesMap::GetChangedBlocks(TBlockRange64 range) const
     constexpr size_t BitsInByte = 8;
     const auto resultSize = AlignUp<size_t>(range.Size(), BitsInByte);
 
-    // We know a map of changes blocks with a resolution in the RangeSize.
-    // Let's convert this map to a resolution up to a block.
+    // We know a map of changed blocks with resolution = RangeSize.
+    // Let's convert this map to resolution = BlockSize.
     TDynBitMap map;
     map.Reserve(resultSize);
     // Initially, we assume that all blocks have been changed.
@@ -85,7 +85,7 @@ void TChangedRangesMap::Mark(TBlockRange64 range, bool changed)
         ChangedRangesMap.Set(begin, end);
     } else {
         // When the part of the range is marked as clean, we mark only the
-        // ranges that completely overlaps with input range
+        // ranges that completely overlap with input range
         auto alignedStart = AlignUp<ui64>(range.Start, BlocksPerRange);
         auto alignedEnd = AlignDown<ui64>(range.End + 1, BlocksPerRange);
         if (alignedEnd > alignedStart) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.cpp
@@ -1,0 +1,105 @@
+#include "changed_ranges_map.h"
+
+#include <util/system/align.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TChangedRangesMap::TChangedRangesMap(
+        ui64 blockCount,
+        ui32 blockSize,
+        ui32 rangeSize)
+    : BlockCount(blockCount)
+    , BlockSize(blockSize)
+    , RangeSize(rangeSize)
+    , BlocksPerRange(RangeSize / BlockSize)
+{
+    Y_DEBUG_ABORT_UNLESS(RangeSize % BlockSize == 0);
+
+    const auto rangesCount = GetRangeIndex(blockCount);
+    ChangedRangesMap.Reserve(rangesCount);
+    ChangedRangesMap.Set(0, rangesCount);
+}
+
+void TChangedRangesMap::MarkChanged(TBlockRange64 range)
+{
+    Mark(range, true);
+}
+
+void TChangedRangesMap::MarkNotChanged(TBlockRange64 range)
+{
+    Mark(range, false);
+}
+
+TString TChangedRangesMap::GetChangedBlocks(TBlockRange64 range) const
+{
+    const auto resultSize = AlignUp<size_t>(range.Size(), 8);
+
+    // We know a map of changes blocks with a resolution in the RangeSize.
+    // Let's convert this map to a resolution up to a block.
+    TDynBitMap map;
+    map.Reserve(resultSize);
+    // Initially, we assume that all blocks have been changed.
+    map.Set(0, resultSize);
+
+    for (size_t i = range.Start; i <= range.End;) {
+        // We find the block index for the current range and mark many blocks at
+        // once.
+        size_t rangeIndex = GetRangeIndex(i);
+        size_t rangeStartIndex = rangeIndex * BlocksPerRange;
+        size_t rangeEndIndex = rangeStartIndex + BlocksPerRange;
+
+        size_t trimmedStart = Max(range.Start, rangeStartIndex);
+        size_t trimmedEnd = Min(range.End + 1, rangeEndIndex);
+
+        const bool isOutOfRange = rangeIndex >= BlockCount / BlocksPerRange;
+        const bool isChanged = isOutOfRange || ChangedRangesMap.Get(rangeIndex);
+        if (!isChanged) {
+            map.Reset(trimmedStart - range.Start, trimmedEnd - range.Start);
+        }
+        i = trimmedEnd;
+    }
+
+    // Convert the TDynBitMap to a TString.
+    TString result;
+    result.resize(resultSize / 8);
+    for (size_t i = 0; i < result.size(); ++i) {
+        ui8 tmp = 0;
+        map.Export(i * 8, tmp);
+        result[i] = static_cast<char>(tmp);
+    }
+    return result;
+}
+
+void TChangedRangesMap::Mark(TBlockRange64 range, bool changed)
+{
+    range.End = Min(range.End, BlockCount - 1);
+
+    if (changed) {
+        // When mark changed to a part of range occurs, we mark the entire
+        // range.
+        const auto begin = GetRangeIndex(range.Start);
+        const auto end = GetRangeIndex(range.End) + 1;
+        ChangedRangesMap.Set(begin, end);
+    } else {
+        // When the part of the range is marked as clean, we mark only the
+        // ranges that completely overlaps with input range
+        auto alignedStart = AlignUp<ui64>(range.Start, BlocksPerRange);
+        auto alignedEnd = AlignDown<ui64>(range.End + 1, BlocksPerRange);
+        if (alignedEnd > alignedStart) {
+            // Converting the indexes of the beginning and end to the indexes of
+            // the ranges.
+            const auto begin = GetRangeIndex(alignedStart);
+            const auto end = GetRangeIndex(alignedEnd);
+            ChangedRangesMap.Reset(begin, end);
+        }
+    }
+}
+
+size_t TChangedRangesMap::GetRangeIndex(ui64 blockIndex) const
+{
+    return blockIndex / BlocksPerRange;
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h
@@ -8,6 +8,9 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Stores and manages a map of changed blocks with a reduced resolution.
+// The RangeSize divided by BlockSize determines how many blocks are stored in
+// one bit.
 class TChangedRangesMap
 {
 private:
@@ -21,8 +24,14 @@ private:
 public:
     TChangedRangesMap(ui64 blockCount, ui32 blockSize, ui32 rangeSize);
 
+    // The entire region becomes changed if at least one block has been changed.
     void MarkChanged(TBlockRange64 range);
+
+    // All blocks of the range must be marked as unchanged in order to remove
+    // the mark from the region.
     void MarkNotChanged(TBlockRange64 range);
+
+    // Returns a map of modified blocks, where each bit is one block.
     [[nodiscard]] TString GetChangedBlocks(TBlockRange64 range) const;
 
 private:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cloud/blockstore/libs/common/block_range.h>
+
+#include <util/generic/bitmap.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TChangedRangesMap
+{
+private:
+    const ui64 BlockCount;
+    const ui32 BlockSize;
+    const ui32 RangeSize;
+    const ui32 BlocksPerRange;
+
+    TDynBitMap ChangedRangesMap;
+
+public:
+    TChangedRangesMap(ui64 blockCount, ui32 blockSize, ui32 rangeSize);
+
+    void MarkChanged(TBlockRange64 range);
+    void MarkNotChanged(TBlockRange64 range);
+    [[nodiscard]] TString GetChangedBlocks(TBlockRange64 range) const;
+
+private:
+    void Mark(TBlockRange64 range, bool changed);
+    [[nodiscard]] size_t GetRangeIndex(ui64 blockIndex) const;
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map_ut.cpp
@@ -1,0 +1,191 @@
+#include "changed_ranges_map.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TChangedRangesMapTest)
+{
+    Y_UNIT_TEST(ShouldAssumeThatAllBlocksInitiallyAreChanged)
+    {
+        TChangedRangesMap rangesMap(1024, 512, 4096);
+
+        auto changedBlocks =
+            rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 1024));
+        UNIT_ASSERT_VALUES_EQUAL(1024 / 8, changedBlocks.size());
+        for (auto b: changedBlocks) {
+            UNIT_ASSERT_VALUES_EQUAL(255, static_cast<ui8>(b));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldMarkCleanRangeAligned)
+    {
+        const ui32 blockSize = 2;
+        const ui32 rangeSize = 8;
+        TChangedRangesMap rangesMap(1024, blockSize, rangeSize);
+
+        // Mark second range
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(4, 4));
+        auto changed =
+            rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 32));
+        UNIT_ASSERT_VALUES_EQUAL(4, changed.size());
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[1]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[2]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[3]));
+
+        // Mark first range
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(0, 4));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 32));
+        UNIT_ASSERT_VALUES_EQUAL(4, changed.size());
+        UNIT_ASSERT_VALUES_EQUAL(0b00000000, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[1]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[2]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[3]));
+
+        // Mark two ranges at once
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(8, 8));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 32));
+        UNIT_ASSERT_VALUES_EQUAL(4, changed.size());
+        UNIT_ASSERT_VALUES_EQUAL(0b00000000, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00000000, static_cast<ui8>(changed[1]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[2]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[3]));
+    }
+
+    Y_UNIT_TEST(ShouldMarkCleanRangeUnaligned)
+    {
+        const ui32 blockSize = 2;
+        const ui32 rangeSize = blockSize * 4;
+        TChangedRangesMap rangesMap(1024, blockSize, rangeSize);
+
+        // Mark a part of range shouldn't clear range
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(0, 1));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(0, 2));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(0, 3));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 1));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 2));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 3));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 4));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 5));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 6));
+        auto changed =
+            rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 8));
+        UNIT_ASSERT_VALUES_EQUAL(1, changed.size());
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[0]));
+
+        // Unaligned range should be cut off at the beginning
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1, 7));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 16));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[1]));
+
+        // Unaligned range should be cut off at the end
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(12, 6));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 24));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[1]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[2]));
+
+        // Unaligned range should be cut off at the beginning and end.
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(17, 14));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 32));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[1]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[2]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11110000, static_cast<ui8>(changed[3]));
+    }
+
+    Y_UNIT_TEST(ShouldTrimRange)
+    {
+        const ui32 blockSize = 2;
+        const ui32 rangeSize = 4;
+        TChangedRangesMap rangesMap(16, blockSize, rangeSize);
+
+        // It is safe to pass sizes larger than the data size
+        auto changed =
+            rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 16));
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(1024, 2048));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[1]));
+
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(12, 1024));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 16));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[1]));
+    }
+
+    Y_UNIT_TEST(ShouldMarkRangeAsChanged)
+    {
+        const ui32 blockSize = 2;
+        const ui32 rangeSize = 4;
+        TChangedRangesMap rangesMap(1024, blockSize, rangeSize);
+
+        // Clean all blocks.
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(0, 1024));
+        auto changed =
+            rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 16));
+        UNIT_ASSERT_VALUES_EQUAL(0b00000000, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00000000, static_cast<ui8>(changed[1]));
+
+        // Mark as changed first block in range
+        rangesMap.MarkChanged(TBlockRange64::MakeOneBlock(0));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 8));
+        UNIT_ASSERT_VALUES_EQUAL(0b00000011, static_cast<ui8>(changed[0]));
+
+        // Mark as changed last block in range
+        rangesMap.MarkChanged(TBlockRange64::MakeOneBlock(3));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 8));
+        UNIT_ASSERT_VALUES_EQUAL(0b00001111, static_cast<ui8>(changed[0]));
+
+        // Mark as changed two ranges at once aligned
+        rangesMap.MarkChanged(TBlockRange64::WithLength(6, 4));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 16));
+        UNIT_ASSERT_VALUES_EQUAL(0b11001111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b00000011, static_cast<ui8>(changed[1]));
+
+        // Mark as changed two ranges at once unaligned
+        rangesMap.MarkChanged(TBlockRange64::WithLength(13, 2));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 16));
+        UNIT_ASSERT_VALUES_EQUAL(0b11001111, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11110011, static_cast<ui8>(changed[1]));
+    }
+
+    Y_UNIT_TEST(ShouldGetChangedBlocks)
+    {
+        const ui32 blockSize = 1;
+        const ui32 rangeSize = 1;
+        TChangedRangesMap rangesMap(16, blockSize, rangeSize);
+
+        // Mark three blocks.
+        rangesMap.MarkNotChanged(TBlockRange64::WithLength(0, 16));
+        rangesMap.MarkChanged(TBlockRange64::WithLength(3, 3));
+
+        // Get aligned blocks
+        auto changed =
+            rangesMap.GetChangedBlocks(TBlockRange64::WithLength(0, 8));
+        UNIT_ASSERT_VALUES_EQUAL(0b00111000, static_cast<ui8>(changed[0]));
+
+        // Get unaligned blocks
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(1, 8));
+        UNIT_ASSERT_VALUES_EQUAL(0b00011100, static_cast<ui8>(changed[0]));
+
+        // Get one block. Upper bits should be set.
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(1, 1));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111110, static_cast<ui8>(changed[0]));
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(3, 1));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[0]));
+
+        // Get blocks out-of-range. The out-of-range bits must be set
+        changed = rangesMap.GetChangedBlocks(TBlockRange64::WithLength(2, 32));
+        UNIT_ASSERT_VALUES_EQUAL(4, changed.size());
+        UNIT_ASSERT_VALUES_EQUAL(0b00001110, static_cast<ui8>(changed[0]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11000000, static_cast<ui8>(changed[1]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[2]));
+        UNIT_ASSERT_VALUES_EQUAL(0b11111111, static_cast<ui8>(changed[3]));
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/partition_nonrepl/model)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
+    changed_ranges_map_ut.cpp
     processing_blocks_ut.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/deny_ydb_dependency.inc)
 
 SRCS(
+    changed_ranges_map.cpp
     processing_blocks.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -431,6 +431,9 @@ STFUNC(TMirrorPartitionActor::StateWork)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(
+            TEvService::TEvGetChangedBlocksRequest,
+            GetChangedBlocksCompanion.HandleGetChangedBlocks);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, HandleGetCompactionStatus);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -4,8 +4,8 @@
 
 #include "checksum_range.h"
 #include "config.h"
-#include "part_nonrepl_events_private.h"
 #include "part_mirror_state.h"
+#include "part_nonrepl_events_private.h"
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
@@ -17,6 +17,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -53,6 +54,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         DiskId};
+    TGetChangedBlocksCompanion GetChangedBlocksCompanion;
 
     TRequestInfoPtr Poisoner;
     size_t AliveReplicas = 0;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
@@ -110,6 +110,10 @@ void TMirrorPartitionResyncActor::SetupPartitions(const TActorContext& ctx)
             SelfId(),
             SelfId()));
 
+    GetChangedBlocksCompanion.SetBehavior(
+        TGetChangedBlocksCompanion::EBehavior::DelegateRequest,
+        MirrorActorId);
+
     const auto& replicaInfos = State.GetReplicaInfos();
     for (ui32 i = 0; i < replicaInfos.size(); i++) {
         IActorPtr actor = CreateNonreplicatedPartition(
@@ -253,6 +257,9 @@ STFUNC(TMirrorPartitionResyncActor::StateWork)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(
+            TEvService::TEvGetChangedBlocksRequest,
+            GetChangedBlocksCompanion.HandleGetChangedBlocks);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, HandleGetCompactionStatus);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
@@ -110,9 +110,7 @@ void TMirrorPartitionResyncActor::SetupPartitions(const TActorContext& ctx)
             SelfId(),
             SelfId()));
 
-    GetChangedBlocksCompanion.SetBehavior(
-        TGetChangedBlocksCompanion::EBehavior::DelegateRequest,
-        MirrorActorId);
+    GetChangedBlocksCompanion.SetDelegate(MirrorActorId);
 
     const auto& replicaInfos = State.GetReplicaInfos();
     for (ui32 i = 0; i < replicaInfos.size(); i++) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
@@ -17,6 +17,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -62,6 +63,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         PartConfig->GetName()};
+    TGetChangedBlocksCompanion GetChangedBlocksCompanion;
 
     TRequestInfoPtr Poisoner;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -432,6 +432,9 @@ STFUNC(TNonreplicatedPartitionActor::StateWork)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(
+            TEvService::TEvGetChangedBlocksRequest,
+            GetChangedBlocksCompanion.HandleGetChangedBlocks);
 
         HFunc(TEvNonreplPartitionPrivate::TEvReadBlocksCompleted, HandleReadBlocksCompleted);
         HFunc(TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted, HandleWriteBlocksCompleted);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -12,11 +12,13 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
 #include <contrib/ydb/library/actors/core/hfunc.h>
 #include <contrib/ydb/library/actors/core/mon.h>
+
 #include <library/cpp/containers/ring_buffer/ring_buffer.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
@@ -57,6 +59,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
+    TGetChangedBlocksCompanion GetChangedBlocksCompanion;
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -43,6 +43,7 @@ struct TEvNonreplPartitionPrivate
         TInstant WriteStartTs;
         TDuration WriteDuration;
         TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
+        bool AllZeroes;
         ui64 ExecCycles;
 
         TRangeMigrated(
@@ -52,13 +53,15 @@ struct TEvNonreplPartitionPrivate
                 TInstant writeStartTs,
                 TDuration writeDuration,
                 TVector<IProfileLog::TBlockInfo> affectedBlockInfos,
+                bool allZeroes,
                 ui64 execCycles)
-            : Range(std::move(range))
+            : Range(range)
             , ReadStartTs(readStartTs)
             , ReadDuration(readDuration)
             , WriteStartTs(writeStartTs)
             , WriteDuration(writeDuration)
             , AffectedBlockInfos(std::move(affectedBlockInfos))
+            , AllZeroes(allZeroes)
             , ExecCycles(execCycles)
         {
         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -86,11 +86,8 @@ TDuration TNonreplicatedPartitionMigrationActor::CalculateMigrationTimeout(
 }
 
 void TNonreplicatedPartitionMigrationActor::OnMigrationFinished(
-    const NActors::TActorContext& ctx,
-    const TDynBitMap& voidRangesMap)
+    const NActors::TActorContext& ctx)
 {
-    Y_UNUSED(voidRangesMap);
-
     MigrationFinished = true;
     FinishMigration(ctx, false);
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -86,8 +86,11 @@ TDuration TNonreplicatedPartitionMigrationActor::CalculateMigrationTimeout(
 }
 
 void TNonreplicatedPartitionMigrationActor::OnMigrationFinished(
-    const NActors::TActorContext& ctx)
+    const NActors::TActorContext& ctx,
+    const TDynBitMap& voidRangesMap)
 {
+    Y_UNUSED(voidRangesMap);
+
     MigrationFinished = true;
     FinishMigration(ctx, false);
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -43,9 +43,7 @@ public:
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;
-    void OnMigrationFinished(
-        const NActors::TActorContext& ctx,
-        const TDynBitMap& voidRangesMap) override;
+    void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
 
 private:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -43,7 +43,9 @@ public:
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;
-    void OnMigrationFinished(const NActors::TActorContext& ctx) override;
+    void OnMigrationFinished(
+        const NActors::TActorContext& ctx,
+        const TDynBitMap& voidRangesMap) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
 
 private:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -40,7 +40,7 @@ TNonreplicatedPartitionMigrationCommonActor::
     , StatActorId(statActorId)
     , PoisonPillHelper(this)
 {
-    const auto rangesCount = GetRangeIndex(blockCount);
+    const auto rangesCount = GetMigratingRangeIndex(blockCount);
     VoidRangesMap.Reserve(rangesCount);
     VoidRangesMap.Reset(0, rangesCount);
 }
@@ -151,6 +151,9 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateWork)
         HFunc(
             NPartition::TEvPartition::TEvDrainRequest,
             DrainActorCompanion.HandleDrain);
+        HFunc(
+            TEvService::TEvGetChangedBlocksRequest,
+            GetChangedBlocksCompanion.HandleGetChangedBlocks);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocks);
         HFunc(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -37,13 +37,10 @@ TNonreplicatedPartitionMigrationCommonActor::
     , MaxIoDepth(maxIoDepth)
     , RWClientId(std::move(rwClientId))
     , ProcessingBlocks(blockCount, blockSize, initialMigrationIndex)
+    , ChangedRangesMap(blockCount, blockSize, ProcessingRangeSize)
     , StatActorId(statActorId)
     , PoisonPillHelper(this)
-{
-    const auto rangesCount = GetMigratingRangeIndex(blockCount);
-    VoidRangesMap.Reserve(rangesCount);
-    VoidRangesMap.Reset(0, rangesCount);
-}
+{}
 
 TNonreplicatedPartitionMigrationCommonActor::
     ~TNonreplicatedPartitionMigrationCommonActor() = default;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -32,13 +32,18 @@ TNonreplicatedPartitionMigrationCommonActor::
     , ProfileLog(std::move(profileLog))
     , DiskId(std::move(diskId))
     , BlockSize(blockSize)
+    , BlockCount(blockCount)
     , BlockDigestGenerator(std::move(digestGenerator))
     , MaxIoDepth(maxIoDepth)
     , RWClientId(std::move(rwClientId))
     , ProcessingBlocks(blockCount, blockSize, initialMigrationIndex)
     , StatActorId(statActorId)
     , PoisonPillHelper(this)
-{}
+{
+    const auto rangesCount = GetRangeIndex(blockCount);
+    VoidRangesMap.Reserve(rangesCount);
+    VoidRangesMap.Reset(0, rangesCount);
+}
 
 TNonreplicatedPartitionMigrationCommonActor::
     ~TNonreplicatedPartitionMigrationCommonActor() = default;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -14,6 +14,7 @@
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
 #include <cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
 #include <cloud/storage/core/libs/actors/poison_pill_helper.h>
@@ -103,7 +104,7 @@ private:
     TMap<ui64, TBlockRange64> MigrationsInProgress;
     TMap<ui64, TBlockRange64> DeferredMigrations;
 
-    TDynBitMap VoidRangesMap;
+    TChangedRangesMap ChangedRangesMap;
 
     // When we migrated a block whose range contains or exceeds a persistently
     // stored offset of the progress of the entire migration, we remember this
@@ -197,10 +198,6 @@ private:
         const NActors::TActorContext& ctx,
         TBlockRange64 migratedRange);
     void NotifyMigrationFinishedIfNeeded(const NActors::TActorContext& ctx);
-
-    // Finds which migration range the block index belongs to.
-    [[nodiscard]] size_t GetMigratingRangeIndex(ui64 blockIndex) const;
-    void MarkVoidRange(TBlockRange64 range, bool isVoid);
 
 private:
     STFUNC(StateWork);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -53,7 +53,9 @@ public:
         ui64 migrationIndex) = 0;
 
     // Notifies that the data migration was completed successfully.
-    virtual void OnMigrationFinished(const NActors::TActorContext& ctx) = 0;
+    virtual void OnMigrationFinished(
+        const NActors::TActorContext& ctx,
+        const TDynBitMap& voidRangesMap) = 0;
 
     // Notifies that an non-retriable error occurred during the migration.
     // And the migration was stopped.
@@ -87,6 +89,7 @@ private:
     const IProfileLogPtr ProfileLog;
     const TString DiskId;
     const ui64 BlockSize;
+    const ui64 BlockCount;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const ui32 MaxIoDepth;
     TString RWClientId;
@@ -100,6 +103,8 @@ private:
     TInstant LastRangeMigrationStartTs;
     TMap<ui64, TBlockRange64> MigrationsInProgress;
     TMap<ui64, TBlockRange64> DeferredMigrations;
+
+    TDynBitMap VoidRangesMap;
 
     // When we migrated a block whose range contains or exceeds a persistently
     // stored offset of the progress of the entire migration, we remember this
@@ -189,6 +194,9 @@ private:
         const NActors::TActorContext& ctx,
         TBlockRange64 migratedRange);
     void NotifyMigrationFinishedIfNeeded(const NActors::TActorContext& ctx);
+
+    [[nodiscard]] size_t GetRangeIndex(ui64 blockIndex) const;
+    void MarkZeroRange(TBlockRange64 range, bool zero);
 
 private:
     STFUNC(StateWork);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -176,7 +176,7 @@ public:
     }
 
 protected:
-    void GetChangedBlocks(TBlockRange64 range, TString* result) const;
+    [[nodiscard]] TString GetChangedBlocks(TBlockRange64 range) const;
 
 private:
     bool IsMigrationAllowed() const;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -263,7 +263,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleRangeMigrated(
         DescribeRange(msg->Range).c_str());
 
     if (msg->AllZeroes) {
-        MarkZeroRange(msg->Range, true);
+        MarkVoidRange(msg->Range, true);
     }
     NotifyMigrationProgressIfNeeded(ctx, msg->Range);
     NotifyMigrationFinishedIfNeeded(ctx);
@@ -315,33 +315,82 @@ void TNonreplicatedPartitionMigrationCommonActor::
         return;
     }
 
-    MigrationOwner->OnMigrationFinished(ctx, VoidRangesMap);
+    MigrationOwner->OnMigrationFinished(ctx);
 }
 
-size_t TNonreplicatedPartitionMigrationCommonActor::GetRangeIndex(
+size_t TNonreplicatedPartitionMigrationCommonActor::GetMigratingRangeIndex(
     ui64 blockIndex) const
 {
     return blockIndex * BlockSize / ProcessingRangeSize;
 }
 
-void TNonreplicatedPartitionMigrationCommonActor::MarkZeroRange(
+void TNonreplicatedPartitionMigrationCommonActor::GetChangedBlocks(
     TBlockRange64 range,
-    bool zero)
+    TString* result) const
 {
-    const auto begin = GetRangeIndex(range.Start);
-    const auto end = GetRangeIndex(range.End) + 1;
-    if (zero) {
+    // We know a map of void blocks with a resolution in the size of the
+    // ProcessingRangeSize.
+    // Let's convert this map to a resolution up to a block.
+    TDynBitMap map;
+    map.Reserve(range.Size());
+    // Initially, we assume that all blocks have been changed.
+    map.Set(0, range.Size());
+
+    for (size_t i = range.Start; i <= range.End;) {
+        // We find the block index for the current migration range and mark
+        // many blocks at once.
+        size_t rangeIndex = GetMigratingRangeIndex(i);
+        size_t blockStartIndex = rangeIndex * ProcessingRangeSize / BlockSize;
+        size_t blockEndIndex =
+            (rangeIndex + 1) * ProcessingRangeSize / BlockSize;
+
+        size_t trimmedStart = Max(range.Start, blockStartIndex);
+        size_t trimmedEnd = Min(range.End + 1, blockEndIndex);
+
+        bool isVoid = VoidRangesMap.Get(rangeIndex);
+        if (isVoid) {
+            map.Reset(trimmedStart - range.Start, trimmedEnd - range.Start);
+        }
+        i = trimmedEnd;
+    }
+
+    // Convert the TDynBitMap to a TString.
+    result->resize(map.Size() / 8);
+    for (size_t i = 0; i < result->size(); ++i) {
+        ui8 tmp = 0;
+        map.Export(i * 8, tmp);
+        (*result)[i] = static_cast<char>(tmp);
+    }
+}
+
+void TNonreplicatedPartitionMigrationCommonActor::MarkVoidRange(
+    TBlockRange64 range,
+    bool isVoid)
+{
+    // Converting the indexes of the beginning and end of the range to the
+    // indexes of the migrated ranges of 4 MiB each.
+    const auto begin = GetMigratingRangeIndex(range.Start);
+    const auto end = GetMigratingRangeIndex(range.End) + 1;
+    if (isVoid) {
+        // When we find out that the migration block consists entirely of zeros,
+        // just in case, we check that this block completely covers the
+        // migration range of 4 MiB.
         const bool alignedWithTheSizeOfTheProcessingBlock =
             (range.Start * BlockSize % ProcessingRangeSize) == 0;
         const bool processedLastRange = range.End == BlockCount - 1;
         const bool processedOneRange =
             range.Size() * BlockSize == ProcessingRangeSize;
-        STORAGE_CHECK_PRECONDITION(
+        const bool completelyCoversTheMigrationRange =
             alignedWithTheSizeOfTheProcessingBlock &&
-            (processedLastRange || processedOneRange));
+            (processedLastRange || processedOneRange);
 
-        VoidRangesMap.Set(begin, end);
+        STORAGE_CHECK_PRECONDITION(completelyCoversTheMigrationRange);
+
+        if (completelyCoversTheMigrationRange) {
+            VoidRangesMap.Set(begin, end);
+        }
     } else {
+        // When writing to a block occurs, we mark the entire migration range.
         VoidRangesMap.Reset(begin, end);
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -318,11 +318,10 @@ void TNonreplicatedPartitionMigrationCommonActor::
     MigrationOwner->OnMigrationFinished(ctx);
 }
 
-void TNonreplicatedPartitionMigrationCommonActor::GetChangedBlocks(
-    TBlockRange64 range,
-    TString* result) const
+TString TNonreplicatedPartitionMigrationCommonActor::GetChangedBlocks(
+    TBlockRange64 range) const
 {
-    *result = ChangedRangesMap.GetChangedBlocks(range);
+    return ChangedRangesMap.GetChangedBlocks(range);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/storage/api/undelivered.h>
+#include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h>
@@ -104,7 +105,9 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         false // shouldProcessError
     );
 
-    MarkVoidRange(range, false);
+    if constexpr (IsExactlyWriteMethod<TMethod>) {
+        ChangedRangesMap.MarkChanged(range);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -103,6 +103,8 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         WriteAndZeroRequestsInProgress.AddWriteRequest(range),
         false // shouldProcessError
     );
+
+    MarkZeroRange(range, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -104,7 +104,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         false // shouldProcessError
     );
 
-    MarkZeroRange(range, false);
+    MarkVoidRange(range, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -520,6 +520,9 @@ STFUNC(TNonreplicatedPartitionRdmaActor::StateWork)
         HFunc(TEvService::TEvZeroBlocksRequest, HandleZeroBlocks);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(
+            TEvService::TEvGetChangedBlocksRequest,
+            GetChangedBlocksCompanion.HandleGetChangedBlocks);
 
         HFunc(TEvService::TEvReadBlocksLocalRequest, HandleReadBlocksLocal);
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -13,11 +13,13 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
 #include <contrib/ydb/library/actors/core/hfunc.h>
 #include <contrib/ydb/library/actors/core/mon.h>
+
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -53,6 +55,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
+    TGetChangedBlocksCompanion GetChangedBlocksCompanion;
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -631,6 +631,7 @@ bool TShadowDiskActor::OnMessage(
         HFunc(
             TEvVolumePrivate::TEvUpdateShadowDiskStateResponse,
             HandleUpdateShadowDiskStateResponse);
+        HFunc(TEvService::TEvGetChangedBlocksRequest, HandleGetChangedBlocks);
 
         // Read request.
         HFunc(
@@ -703,14 +704,11 @@ void TShadowDiskActor::OnMigrationProgress(
     NCloud::Send(ctx, VolumeActorId, std::move(request));
 }
 
-void TShadowDiskActor::OnMigrationFinished(
-    const NActors::TActorContext& ctx,
-    const TDynBitMap& voidRangesMap)
+void TShadowDiskActor::OnMigrationFinished(const NActors::TActorContext& ctx)
 {
     using EReason = TEvVolumePrivate::TUpdateShadowDiskStateRequest::EReason;
 
     ProcessedBlockCount = SrcConfig->GetBlockCount();
-    VoidRangesMap = voidRangesMap;
 
     auto request =
         std::make_unique<TEvVolumePrivate::TEvUpdateShadowDiskStateRequest>(
@@ -1215,6 +1213,50 @@ bool TShadowDiskActor::HandleRWClientIdChanged(
     ev->Get()->RWClientId =
         MakeShadowDiskClientId(SourceDiskClientId, ReadOnlyMount());
     return false;
+}
+
+void TShadowDiskActor::HandleGetChangedBlocks(
+    const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (msg->Record.GetHighCheckpointId() != CheckpointId) {
+        ForwardMessageToActor(ev, ctx, SrcActorId);
+        return;
+    }
+
+    LOG_INFO_S(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "GetChangedBlocks for shadow disk " << ShadowDiskId.Quote());
+
+    if (State != EActorState::CheckpointReady) {
+        LOG_ERROR_S(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "Shadow disk: "
+                << ShadowDiskId.Quote()
+                << " Can't GetChangedBlocks when shadow disk is not ready.");
+
+        auto response =
+            std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
+        *response->Record.MutableError() = MakeError(
+            E_ARGUMENT,
+            "Can't GetChangedBlocks when shadow disk is not ready.");
+
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return;
+    }
+
+    auto response = std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
+    GetChangedBlocks(
+        TBlockRange64::WithLength(
+            msg->Record.GetStartIndex(),
+            msg->Record.GetBlocksCount()),
+        response->Record.MutableMask());
+
+    NCloud::Reply(ctx, *ev, std::move(response));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -1250,11 +1250,10 @@ void TShadowDiskActor::HandleGetChangedBlocks(
     }
 
     auto response = std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
-    GetChangedBlocks(
-        TBlockRange64::WithLength(
-            msg->Record.GetStartIndex(),
-            msg->Record.GetBlocksCount()),
-        response->Record.MutableMask());
+    auto range = TBlockRange64::WithLength(
+        msg->Record.GetStartIndex(),
+        msg->Record.GetBlocksCount());
+    response->Record.SetMask(GetChangedBlocks(range));
 
     NCloud::Reply(ctx, *ev, std::move(response));
 }

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -1242,7 +1242,7 @@ void TShadowDiskActor::HandleGetChangedBlocks(
         auto response =
             std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
         *response->Record.MutableError() = MakeError(
-            E_ARGUMENT,
+            E_REJECTED,
             "Can't GetChangedBlocks when shadow disk is not ready.");
 
         NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -703,11 +703,14 @@ void TShadowDiskActor::OnMigrationProgress(
     NCloud::Send(ctx, VolumeActorId, std::move(request));
 }
 
-void TShadowDiskActor::OnMigrationFinished(const NActors::TActorContext& ctx)
+void TShadowDiskActor::OnMigrationFinished(
+    const NActors::TActorContext& ctx,
+    const TDynBitMap& voidRangesMap)
 {
     using EReason = TEvVolumePrivate::TUpdateShadowDiskStateRequest::EReason;
 
     ProcessedBlockCount = SrcConfig->GetBlockCount();
+    VoidRangesMap = voidRangesMap;
 
     auto request =
         std::make_unique<TEvVolumePrivate::TEvUpdateShadowDiskStateRequest>(

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -109,6 +109,8 @@ private:
 
     bool ForcedReAcquireInProgress = false;
 
+    TDynBitMap VoidRangesMap;
+
 public:
     TShadowDiskActor(
         TStorageConfigPtr config,
@@ -134,7 +136,9 @@ public:
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;
-    void OnMigrationFinished(const NActors::TActorContext& ctx) override;
+    void OnMigrationFinished(
+        const NActors::TActorContext& ctx,
+        const TDynBitMap& voidRangesMap) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
 
 private:

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -109,8 +109,6 @@ private:
 
     bool ForcedReAcquireInProgress = false;
 
-    TDynBitMap VoidRangesMap;
-
 public:
     TShadowDiskActor(
         TStorageConfigPtr config,
@@ -136,9 +134,7 @@ public:
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;
-    void OnMigrationFinished(
-        const NActors::TActorContext& ctx,
-        const TDynBitMap& voidRangesMap) override;
+    void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
 
 private:
@@ -222,6 +218,10 @@ private:
 
     [[nodiscard]] bool HandleRWClientIdChanged(
         const TEvVolume::TEvRWClientIdChanged::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleGetChangedBlocks(
+        const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -898,24 +898,24 @@ void TVolumeActor::ReplyErrorOnNormalGetChangedBlocksRequestForDiskRegistryBased
 {
     const auto* msg = ev->Get();
 
-    auto response = std::make_unique<TGetChangedBlocksMethod::TResponse>();
-    auto requestInfo =
-            CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
-
-    TString errorMsg = TStringBuilder()
-        << "[%lu] %s: " << "Disk registry based disks can not handle"
-        << " GetChangedBlocks requests for normal checkpoints,"
-        << " Checkpoints requested:"
-        << " LowCheckpointId: " << msg->Record.GetLowCheckpointId() << ","
-        << " HighCheckpointId: " << msg->Record.GetHighCheckpointId();
+    TString errorMsg =
+        TStringBuilder()
+        << "Disk registry based disks can not handle GetChangedBlocks requests "
+           "for normal checkpoints, DiskId: "
+        << State->GetDiskId().Quote()
+        << ", LowCheckpointId: " << msg->Record.GetLowCheckpointId().Quote()
+        << ", HighCheckpointId: " << msg->Record.GetHighCheckpointId().Quote();
 
     LOG_ERROR(ctx, TBlockStoreComponents::VOLUME,
-        errorMsg.c_str(),
+        "[%lu] %s %s",
         TabletID(),
-        TGetChangedBlocksMethod::Name);
+        TGetChangedBlocksMethod::Name,
+        errorMsg.c_str());
 
+    auto response = std::make_unique<TGetChangedBlocksMethod::TResponse>();
     *response->Record.MutableError() = MakeError(E_ARGUMENT, errorMsg);
-    NCloud::Reply(ctx, *requestInfo, std::move(response));
+
+    NCloud::Reply(ctx, *ev, std::move(response));
 }
 
 template <>

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -129,6 +129,8 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking<
     Y_UNUSED(volumeRequestId);
 
     if (!State->IsDiskRegistryMediaKind()) {
+        // For BlobStorage-based disks, we return false to process the request
+        // in the partition actor.
         return false;
     }
 
@@ -139,8 +141,8 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking<
     const auto lowCheckpoint = State->GetCheckpointStore().GetCheckpoint(
         msg->Record.GetLowCheckpointId());
 
-    if ((msg->Record.GetHighCheckpointId() == "" &&
-         msg->Record.GetLowCheckpointId() == "") ||
+    if ((msg->Record.GetHighCheckpointId().empty() &&
+         msg->Record.GetLowCheckpointId().empty()) ||
         highCheckpoint && highCheckpoint->Type == ECheckpointType::Light ||
         lowCheckpoint && lowCheckpoint->Type == ECheckpointType::Light)
     {


### PR DESCRIPTION
При наливке теневого диска формируем в памяти битовую карту регионов по 4МБ, в которых нет данных. Эта карта используется для ответов на запросы  GetChangedBlocks. 