### PR TITLE
blockstore client API to manage blue-green DA deploy

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -981,4 +981,8 @@ message TStorageServiceConfig
     // which is used for migration and filling of shadow disks.
     // (actual bandwidth is x2 due to the need to read and write).
     optional uint32 BackgroundOperationsTotalBandwidth = 368;
+
+    // Used inside TWaitDependentDisksToSwitchNodeActor to schedule retries.
+    // Set in ms.
+    optional uint32 WaitDependentDisksRetryRequestDelay = 369;
 }

--- a/cloud/blockstore/libs/storage/api/disk_registry.h
+++ b/cloud/blockstore/libs/storage/api/disk_registry.h
@@ -52,6 +52,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(DeallocateCheckpoint,               __VA_ARGS__)                       \
     xxx(GetCheckpointDataState,             __VA_ARGS__)                       \
     xxx(SetCheckpointDataState,             __VA_ARGS__)                       \
+    xxx(GetAgentNodeId,                     __VA_ARGS__)                       \
 // BLOCKSTORE_DISK_REGISTRY_REQUESTS_PROTO
 
 // requests forwarded from service to disk_registry
@@ -202,6 +203,9 @@ struct TEvDiskRegistry
 
         EvSetCheckpointDataStateRequest = EvBegin + 71,
         EvSetCheckpointDataStateResponse = EvBegin + 72,
+
+        EvGetAgentNodeIdRequest = EvBegin + 73,
+        EvGetAgentNodeIdResponse = EvBegin + 74,
 
         EvEnd
     };

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -483,6 +483,7 @@ TDuration MSeconds(ui32 value)
     xxx(MaxAcquireShadowDiskRetryDelayWhenNonBlocked,   TDuration, Seconds(10)   )\
     xxx(MaxAcquireShadowDiskTotalTimeoutWhenBlocked,    TDuration, Seconds(5)    )\
     xxx(MaxAcquireShadowDiskTotalTimeoutWhenNonBlocked, TDuration, Seconds(600)  )\
+    xxx(WaitDependentDisksRetryRequestDelay,            TDuration, Seconds(1)    )\
                                                                                   \
     xxx(DataScrubbingEnabled,                           bool,      false         )\
     xxx(ScrubbingInterval,                              TDuration, MSeconds(50)  )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -567,6 +567,8 @@ public:
     TDuration GetMaxAcquireShadowDiskTotalTimeoutWhenBlocked() const;
     TDuration GetMaxAcquireShadowDiskTotalTimeoutWhenNonBlocked() const;
 
+    TDuration GetWaitDependentDisksRetryRequestDelay() const;
+
     TDuration GetVolumeProxyCacheRetryDuration() const;
 
     TDuration GetServiceSelfPingInterval() const;

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -145,6 +145,7 @@ void FillDevice(
     device->SetDeviceName(deviceConfig.GetDeviceName());
     device->MutableRdmaEndpoint()->CopyFrom(deviceConfig.GetRdmaEndpoint());
     device->SetPhysicalOffset(deviceConfig.GetPhysicalOffset());
+    device->SetNodeId(deviceConfig.GetNodeId());
 }
 
 template <typename T>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_agent_node_id.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_agent_node_id.cpp
@@ -1,0 +1,43 @@
+#include "disk_registry_actor.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::HandleGetAgentNodeId(
+    const TEvDiskRegistry::TEvGetAgentNodeIdRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    BLOCKSTORE_DISK_REGISTRY_COUNTER(GetDependentDisks);
+
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "[%lu] Received GetAgentNodeId request: AgentId=%s",
+        TabletID(),
+        msg->Record.GetAgentId().c_str());
+
+    Y_DEBUG_ABORT_UNLESS(State);
+    auto response =
+        std::make_unique<TEvDiskRegistry::TEvGetAgentNodeIdResponse>();
+    const NProto::TAgentConfig* agent =
+        State->FindAgent(msg->Record.GetAgentId());
+    if (!agent) {
+        *response->Record.MutableError() = MakeError(
+            E_NOT_FOUND,
+            TStringBuilder()
+                << "Couldn't find agent with id: " << msg->Record.GetAgentId());
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return;
+    }
+
+    response->Record.SetNodeId(agent->GetNodeId());
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_dependent_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_dependent_disks.cpp
@@ -15,11 +15,6 @@ void TDiskRegistryActor::HandleGetDependentDisks(
 
     auto* msg = ev->Get();
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
-
     LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
         "[%lu] Received GetDependentDisks request: Host=%s, Path=%s",
         TabletID(),

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -641,6 +641,17 @@ public:
         return request;
     }
 
+    auto CreateGetAgentNodeIdRequest(
+        const TString& agentId)
+    {
+        auto request =
+            std::make_unique<TEvDiskRegistry::TEvGetAgentNodeIdRequest>();
+
+        request->Record.SetAgentId(agentId);
+
+        return request;
+    }
+
     auto CreateAcquireDiskRequest(
         const TString& diskId,
         const TString& clientId,

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -12,6 +12,7 @@ SRCS(
     disk_registry_actor_create_disk_from_devices.cpp
     disk_registry_actor_describe.cpp
     disk_registry_actor_destroy.cpp
+    disk_registry_actor_get_agent_node_id.cpp
     disk_registry_actor_get_dependent_disks.cpp
     disk_registry_actor_initiate_realloc.cpp
     disk_registry_actor_initschema.cpp

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1609,7 +1609,7 @@ message TGetAgentNodeIdResponse
 
 message TWaitDependentDisksToSwitchNodeRequest
 {
-    // Agent hostname to search for dependent disks.
+    // Target agent.
     string AgentId = 1;
 
     // Wait for this Disk Agent node id to disappear from dependent volume
@@ -1634,7 +1634,7 @@ message TWaitDependentDisksToSwitchNodeResponse
         // The volume is ready.
         DISK_STATE_READY = 2;
 
-        // An error is occured during waiting.
+        // An error occured during waiting.
         DISK_STATE_ERROR = 3;
     }
 

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1582,3 +1582,72 @@ message TSetCheckpointDataStateResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Get disk agent node id by agent id.
+
+message TGetAgentNodeIdRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Target agent.
+    string AgentId = 2;
+}
+
+message TGetAgentNodeIdResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // Node that agent is running on.
+    uint32 NodeId = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Get dependent disks
+
+message TWaitDependentDisksToSwitchNodeRequest
+{
+    // Agent hostname to search for dependent disks.
+    string AgentId = 1;
+
+    // Wait for this Disk Agent node id to disappear from dependent volume
+    // configs.
+    uint32 OldNodeId = 2;
+}
+
+message TWaitDependentDisksToSwitchNodeResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // Possible disk states during switching.
+    enum EDiskState
+    {
+        // Initial state.
+        DISK_STATE_INITIAL = 0;
+
+        // Disk has switched its node id.
+        DISK_STATE_SWITCHED = 1;
+
+        // The volume is ready.
+        DISK_STATE_READY = 2;
+
+        // An error is occured during waiting.
+        DISK_STATE_ERROR = 3;
+    }
+
+    message TDependentDiskState
+    {
+        // Disk id.
+        string DiskId = 1;
+
+        // Disk state.
+        EDiskState DiskState = 2;
+    }
+
+    // List of disks with their corresponding states at the time of the actor's
+    // shutdown.
+    repeated TDependentDiskState DependentDiskStates = 2;
+}

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -387,6 +387,14 @@ private:
     TResultOrError<NActors::IActorPtr> CreateFlushProfileLogActor(
         TRequestInfoPtr requestInfo,
         TString input);
+
+    TResultOrError<NActors::IActorPtr> CreateGetDiskAgentNodeIdActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    TResultOrError<NActors::IActorPtr> CreateWaitDependentDisksToSwitchNodeActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
@@ -82,6 +82,8 @@ void TServiceActor::HandleExecuteAction(
         {"getnameservernodes",                &TServiceActor::CreateGetNameserverNodesActionActor          },
         {"cms",                               &TServiceActor::CreateCmsActionActor                         },
         {"flushprofilelog",                   &TServiceActor::CreateFlushProfileLogActor                   },
+        {"getdiskagentnodeid",                &TServiceActor::CreateGetDiskAgentNodeIdActor                },
+        {"waitdependentdiskstoswitchnode",    &TServiceActor::CreateWaitDependentDisksToSwitchNodeActor    },
     };
 
     NProto::TError error;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_flush_profile_log.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_flush_profile_log.cpp
@@ -20,7 +20,6 @@ class TFlushProfileLogActor final
 {
 private:
     const TRequestInfoPtr RequestInfo;
-    const TString Input;
     IProfileLogPtr ProfileLog;
 
 public:

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
@@ -89,6 +89,8 @@ void TGetDependentDisksActor::Bootstrap(const TActorContext& ctx)
     NProto::TGetDependentDisksRequest request;
     request.SetHost(input["Host"].GetString());
     request.SetPath(input["Path"].GetStringSafe({}));
+    request.SetIgnoreReplicatedDisks(
+        input["IgnoreReplicatedDisks"].GetBooleanSafe(false));
     GetDependentDisks(ctx, std::move(request));
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_disk_agent_node_id.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_disk_agent_node_id.cpp
@@ -1,0 +1,128 @@
+#include "service_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <google/protobuf/util/json_util.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TGetDiskAgentNodeIdActor final
+    : public TActorBootstrapped<TGetDiskAgentNodeIdActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString Input;
+
+public:
+    TGetDiskAgentNodeIdActor(TRequestInfoPtr requestInfo, TString input);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        std::unique_ptr<TEvService::TEvExecuteActionResponse> response);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleGetAgentNodeIdResponse(
+        const TEvDiskRegistry::TEvGetAgentNodeIdResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TGetDiskAgentNodeIdActor::TGetDiskAgentNodeIdActor(
+        TRequestInfoPtr requestInfo,
+        TString input)
+    : RequestInfo(std::move(requestInfo))
+    , Input(std::move(input))
+{}
+
+void TGetDiskAgentNodeIdActor::Bootstrap(const TActorContext& ctx)
+{
+    auto request =
+        std::make_unique<TEvDiskRegistry::TEvGetAgentNodeIdRequest>();
+    if (!google::protobuf::util::JsonStringToMessage(Input, &request->Record)
+             .ok())
+    {
+        auto response = std::make_unique<TEvService::TEvExecuteActionResponse>(
+            MakeError(E_ARGUMENT, "Failed to parse input"));
+        ReplyAndDie(ctx, std::move(response));
+        return;
+    }
+
+    Become(&TThis::StateWork);
+    NCloud::Send(ctx, MakeDiskRegistryProxyServiceId(), std::move(request));
+}
+
+void TGetDiskAgentNodeIdActor::ReplyAndDie(
+    const TActorContext& ctx,
+    std::unique_ptr<TEvService::TEvExecuteActionResponse> response)
+{
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetDiskAgentNodeIdActor::HandleGetAgentNodeIdResponse(
+    const TEvDiskRegistry::TEvGetAgentNodeIdResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    auto response =
+        std::make_unique<TEvService::TEvExecuteActionResponse>(msg->GetError());
+    google::protobuf::util::MessageToJsonString(
+        msg->Record,
+        response->Record.MutableOutput());
+
+    ReplyAndDie(ctx, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TGetDiskAgentNodeIdActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvDiskRegistry::TEvGetAgentNodeIdResponse,
+            HandleGetAgentNodeIdResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TResultOrError<IActorPtr> TServiceActor::CreateGetDiskAgentNodeIdActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    return {std::make_unique<TGetDiskAgentNodeIdActor>(
+        std::move(requestInfo),
+        std::move(input))};
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
@@ -1,0 +1,414 @@
+#include "service_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/api/volume_proxy.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <library/cpp/json/json_reader.h>
+
+#include <google/protobuf/util/json_util.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+using NProto::TWaitDependentDisksToSwitchNodeResponse;
+using EDiskState = TWaitDependentDisksToSwitchNodeResponse::EDiskState;
+using TDependentDiskState =
+    TWaitDependentDisksToSwitchNodeResponse::TDependentDiskState;
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+bool VolumeUsesNode(const NProto::TVolume& volume, ui32 nodeId)
+{
+    auto containsNodeIdPred = [nodeId](const NProto::TDevice& device)
+    {
+        return device.GetNodeId() == nodeId;
+    };
+
+    bool foundNodeId = AnyOf(volume.GetDevices(), containsNodeIdPred);
+    if (foundNodeId) {
+        return true;
+    }
+
+    for (const auto& replica: volume.GetReplicas()) {
+        foundNodeId = AnyOf(replica.GetDevices(), containsNodeIdPred);
+        if (foundNodeId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TWaitDependentDisksToSwitchNodeActor final
+    : public TActorBootstrapped<TWaitDependentDisksToSwitchNodeActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString Input;
+    const TDuration RetryTimeout;
+
+    NProto::TWaitDependentDisksToSwitchNodeRequest Request;
+
+    THashMap<ui64, TDependentDiskState> DependentDiskStates;
+
+public:
+    TWaitDependentDisksToSwitchNodeActor(
+        TRequestInfoPtr requestInfo,
+        TString input,
+        TDuration retryTimeout);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void HandleSuccess(const TActorContext& ctx);
+    void HandleError(const TActorContext& ctx, const NProto::TError& error);
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        std::unique_ptr<TEvService::TEvExecuteActionResponse> response);
+
+    void ScheduleGetVolumeInfoRequest(const TActorContext& ctx, ui64 cookie);
+
+    void CheckAllVolumesAreSwitched(const TActorContext& ctx);
+    void CheckAllVolumesAreReady(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleGetDependentDisksResponse(
+        const TEvDiskRegistry::TEvGetDependentDisksResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleGetVolumeInfoResponse(
+        const TEvVolume::TEvGetVolumeInfoResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleWaitReadyResponse(
+        const TEvVolume::TEvWaitReadyResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TWaitDependentDisksToSwitchNodeActor::TWaitDependentDisksToSwitchNodeActor(
+    TRequestInfoPtr requestInfo,
+    TString input,
+    TDuration retryTimeout)
+    : RequestInfo(std::move(requestInfo))
+    , Input(std::move(input))
+    , RetryTimeout(retryTimeout)
+{}
+
+void TWaitDependentDisksToSwitchNodeActor::Bootstrap(const TActorContext& ctx)
+{
+    if (!google::protobuf::util::JsonStringToMessage(Input, &Request).ok()) {
+        HandleError(ctx, MakeError(E_ARGUMENT, "Failed to parse input"));
+        return;
+    }
+
+    if (Request.GetAgentId().Empty()) {
+        HandleError(ctx, MakeError(E_ARGUMENT, "Empty AgentId"));
+        return;
+    }
+
+    if (Request.GetOldNodeId() == 0) {
+        HandleError(ctx, MakeError(E_ARGUMENT, "Empty OldNodeId"));
+        return;
+    }
+
+    Become(&TThis::StateWork);
+
+    auto request =
+        std::make_unique<TEvDiskRegistry::TEvGetDependentDisksRequest>();
+    request->Record.SetHost(Request.GetAgentId());
+    NCloud::Send(ctx, MakeDiskRegistryProxyServiceId(), std::move(request));
+}
+
+void TWaitDependentDisksToSwitchNodeActor::HandleError(
+    const TActorContext& ctx,
+    const NProto::TError& error)
+{
+    ReplyAndDie(
+        ctx,
+        std::make_unique<TEvService::TEvExecuteActionResponse>(error));
+}
+
+void TWaitDependentDisksToSwitchNodeActor::HandleSuccess(
+    const TActorContext& ctx)
+{
+    ReplyAndDie(ctx, std::make_unique<TEvService::TEvExecuteActionResponse>());
+}
+
+void TWaitDependentDisksToSwitchNodeActor::ReplyAndDie(
+    const TActorContext& ctx,
+    std::unique_ptr<TEvService::TEvExecuteActionResponse> response)
+{
+    NProto::TWaitDependentDisksToSwitchNodeResponse result;
+    for (auto& kv: DependentDiskStates) {
+        result.MutableDependentDiskStates()->Add(std::move(kv.second));
+    }
+    google::protobuf::util::MessageToJsonString(
+        result,
+        response->Record.MutableOutput());
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+void TWaitDependentDisksToSwitchNodeActor::ScheduleGetVolumeInfoRequest(
+    const TActorContext& ctx,
+    ui64 cookie)
+{
+    Y_DEBUG_ABORT_UNLESS(DependentDiskStates.contains(cookie));
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "Schedule GetVolumeInfoRequest for volume: %s, timeout: %s",
+        "Schedule GetVolumeInfoRequest for volume: %s, timeout: %s",
+        DependentDiskStates[cookie].GetDiskId().c_str(),
+        RetryTimeout.ToString().c_str());
+
+    auto request = std::make_unique<TEvVolume::TEvGetVolumeInfoRequest>();
+    request->Record.SetDiskId(DependentDiskStates[cookie].GetDiskId());
+    ctx.ExecutorThread.Schedule(
+        RetryTimeout,
+        new IEventHandle(
+            MakeVolumeProxyServiceId(),
+            SelfId(),
+            request.release(),
+            TEventFlags{0},
+            cookie));
+}
+
+void TWaitDependentDisksToSwitchNodeActor::CheckAllVolumesAreSwitched(
+    const TActorContext& ctx)
+{
+    if (DependentDiskStates.empty()) {
+        HandleSuccess(ctx);
+        return;
+    }
+
+    const bool allVolumesAreSwitched = AllOf(
+        DependentDiskStates,
+        [](const auto& pr)
+        {
+            return pr.second.GetDiskState() >
+                   TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_INITIAL;
+        });
+    if (!allVolumesAreSwitched) {
+        return;
+    }
+
+    for (const auto& pr: DependentDiskStates) {
+        auto request = std::make_unique<TEvVolume::TEvWaitReadyRequest>();
+        request->Record.SetDiskId(pr.second.GetDiskId());
+        NCloud::Send(
+            ctx,
+            MakeVolumeProxyServiceId(),
+            std::move(request),
+            pr.first);
+    }
+}
+
+void TWaitDependentDisksToSwitchNodeActor::CheckAllVolumesAreReady(
+    const TActorContext& ctx)
+{
+    if (DependentDiskStates.empty()) {
+        HandleSuccess(ctx);
+        return;
+    }
+
+    const bool allVolumesAreReady = AllOf(
+        DependentDiskStates,
+        [](const auto& pr)
+        {
+            return pr.second.GetDiskState() >
+                   TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_SWITCHED;
+        });
+    if (!allVolumesAreReady) {
+        return;
+    }
+
+    HandleSuccess(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TWaitDependentDisksToSwitchNodeActor::HandleGetDependentDisksResponse(
+    const TEvDiskRegistry::TEvGetDependentDisksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Dependent disks listing failed with error: %s",
+            FormatError(msg->GetError()).c_str());
+
+        if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            auto request = std::make_unique<
+                TEvDiskRegistry::TEvGetDependentDisksRequest>();
+            request->Record.SetHost(Request.GetAgentId());
+
+            ctx.ExecutorThread.Schedule(
+                RetryTimeout,
+                new IEventHandle(
+                    MakeDiskRegistryProxyServiceId(),
+                    SelfId(),
+                    request.release()));
+            return;
+        }
+
+        HandleError(
+            ctx,
+            MakeError(
+                E_FAIL,
+                TStringBuilder() << "Couldn't list dependent disks with error: "
+                                 << FormatError(msg->GetError())));
+        return;
+    }
+
+    if (msg->Record.GetDependentDiskIds().empty()) {
+        HandleSuccess(ctx);
+        return;
+    }
+
+    ui64 cookie = 0;
+    for (auto& diskId: *msg->Record.MutableDependentDiskIds()) {
+        TDependentDiskState state;
+        state.SetDiskId(std::move(diskId));
+        state.SetDiskState(
+            TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_INITIAL);
+        auto result = DependentDiskStates.emplace(cookie, std::move(state));
+        Y_DEBUG_ABORT_UNLESS(result.second);
+
+        auto request = std::make_unique<TEvVolume::TEvGetVolumeInfoRequest>();
+        request->Record.SetDiskId(result.first->second.GetDiskId());
+        NCloud::Send(
+            ctx,
+            MakeVolumeProxyServiceId(),
+            std::move(request),
+            cookie++);
+    }
+}
+
+void TWaitDependentDisksToSwitchNodeActor::HandleGetVolumeInfoResponse(
+    const TEvVolume::TEvGetVolumeInfoResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    Y_DEBUG_ABORT_UNLESS(DependentDiskStates.contains(ev->Cookie));
+
+    if (HasError(msg->GetError())) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Volume [%s] info request responded with error: %s",
+            DependentDiskStates[ev->Cookie].GetDiskId().c_str(),
+            FormatError(msg->GetError()).c_str());
+
+        if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            ScheduleGetVolumeInfoRequest(ctx, ev->Cookie);
+            return;
+        }
+
+        DependentDiskStates[ev->Cookie].SetDiskState(
+            TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_ERROR);
+        CheckAllVolumesAreSwitched(ctx);
+        return;
+    }
+
+    const bool oldNodeIdPresent =
+        VolumeUsesNode(msg->Record.GetVolume(), Request.GetOldNodeId());
+    if (oldNodeIdPresent) {
+        ScheduleGetVolumeInfoRequest(ctx, ev->Cookie);
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "Volume %s has switched its node",
+        DependentDiskStates[ev->Cookie].GetDiskId().c_str());
+
+    DependentDiskStates[ev->Cookie].SetDiskState(
+        TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_SWITCHED);
+    CheckAllVolumesAreSwitched(ctx);
+}
+
+void TWaitDependentDisksToSwitchNodeActor::HandleWaitReadyResponse(
+    const TEvVolume::TEvWaitReadyResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    Y_DEBUG_ABORT_UNLESS(DependentDiskStates.contains(ev->Cookie));
+
+    if (HasError(msg->GetError())) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Volume [%s] wait ready request responded with error: %s",
+            DependentDiskStates[ev->Cookie].GetDiskId().c_str(),
+            FormatError(msg->GetError()).c_str());
+
+        DependentDiskStates[ev->Cookie].SetDiskState(
+            TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_ERROR);
+    } else {
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Volume %s is ready",
+            DependentDiskStates[ev->Cookie].GetDiskId().c_str());
+
+        DependentDiskStates[ev->Cookie].SetDiskState(
+            TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_READY);
+    }
+
+    CheckAllVolumesAreReady(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TWaitDependentDisksToSwitchNodeActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvDiskRegistry::TEvGetDependentDisksResponse,
+            HandleGetDependentDisksResponse);
+        HFunc(TEvVolume::TEvGetVolumeInfoResponse, HandleGetVolumeInfoResponse);
+        HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TResultOrError<IActorPtr>
+TServiceActor::CreateWaitDependentDisksToSwitchNodeActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    return {std::make_unique<TWaitDependentDisksToSwitchNodeActor>(
+        std::move(requestInfo),
+        std::move(input),
+        Config->GetWaitDependentDisksRetryRequestDelay())};
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
+#include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -103,9 +104,9 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TWaitDependentDisksToSwitchNodeActor::TWaitDependentDisksToSwitchNodeActor(
-    TRequestInfoPtr requestInfo,
-    TString input,
-    TDuration retryTimeout)
+        TRequestInfoPtr requestInfo,
+        TString input,
+        TDuration retryTimeout)
     : RequestInfo(std::move(requestInfo))
     , Input(std::move(input))
     , RetryTimeout(retryTimeout)
@@ -170,11 +171,10 @@ void TWaitDependentDisksToSwitchNodeActor::ScheduleGetVolumeInfoRequest(
     const TActorContext& ctx,
     ui64 cookie)
 {
-    Y_DEBUG_ABORT_UNLESS(DependentDiskStates.contains(cookie));
+    STORAGE_CHECK_PRECONDITION(DependentDiskStates.contains(cookie));
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::SERVICE,
-        "Schedule GetVolumeInfoRequest for volume: %s, timeout: %s",
         "Schedule GetVolumeInfoRequest for volume: %s, timeout: %s",
         DependentDiskStates[cookie].GetDiskId().c_str(),
         RetryTimeout.ToString().c_str());
@@ -274,7 +274,7 @@ void TWaitDependentDisksToSwitchNodeActor::HandleGetDependentDisksResponse(
         HandleError(
             ctx,
             MakeError(
-                E_FAIL,
+                msg->GetError().GetCode(),
                 TStringBuilder() << "Couldn't list dependent disks with error: "
                                  << FormatError(msg->GetError())));
         return;
@@ -292,7 +292,7 @@ void TWaitDependentDisksToSwitchNodeActor::HandleGetDependentDisksResponse(
         state.SetDiskState(
             TWaitDependentDisksToSwitchNodeResponse::DISK_STATE_INITIAL);
         auto result = DependentDiskStates.emplace(cookie, std::move(state));
-        Y_DEBUG_ABORT_UNLESS(result.second);
+        STORAGE_CHECK_PRECONDITION(result.second);
 
         auto request = std::make_unique<TEvVolume::TEvGetVolumeInfoRequest>();
         request->Record.SetDiskId(result.first->second.GetDiskId());
@@ -309,7 +309,14 @@ void TWaitDependentDisksToSwitchNodeActor::HandleGetVolumeInfoResponse(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
-    Y_DEBUG_ABORT_UNLESS(DependentDiskStates.contains(ev->Cookie));
+    STORAGE_CHECK_PRECONDITION(DependentDiskStates.contains(ev->Cookie));
+    STORAGE_CHECK_PRECONDITION_C(
+        DependentDiskStates[ev->Cookie].GetDiskId() ==
+            msg->Record.GetVolume().GetDiskId(),
+        TStringBuilder() << "Stored disk id: "
+                         << DependentDiskStates[ev->Cookie].GetDiskId()
+                         << "; incoming disk id: "
+                         << msg->Record.GetVolume().GetDiskId());
 
     if (HasError(msg->GetError())) {
         LOG_WARN(
@@ -353,7 +360,14 @@ void TWaitDependentDisksToSwitchNodeActor::HandleWaitReadyResponse(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
-    Y_DEBUG_ABORT_UNLESS(DependentDiskStates.contains(ev->Cookie));
+    STORAGE_CHECK_PRECONDITION(DependentDiskStates.contains(ev->Cookie));
+    STORAGE_CHECK_PRECONDITION_C(
+        DependentDiskStates[ev->Cookie].GetDiskId() ==
+            msg->Record.GetVolume().GetDiskId(),
+        TStringBuilder() << "Stored disk id: "
+                         << DependentDiskStates[ev->Cookie].GetDiskId()
+                         << "; incoming disk id: "
+                         << msg->Record.GetVolume().GetDiskId());
 
     if (HasError(msg->GetError())) {
         LOG_WARN(

--- a/cloud/blockstore/libs/storage/service/ya.make
+++ b/cloud/blockstore/libs/storage/service/ya.make
@@ -20,6 +20,7 @@ SRCS(
     service_actor_actions_flush_profile_log.cpp
     service_actor_actions_get_dependent_disks.cpp
     service_actor_actions_get_compaction_status.cpp
+    service_actor_actions_get_disk_agent_node_id.cpp
     service_actor_actions_get_diskregistry_tablet_info.cpp
     service_actor_actions_get_nameservice_config.cpp
     service_actor_actions_get_partition_info.cpp
@@ -44,6 +45,7 @@ SRCS(
     service_actor_actions_update_placement_group_settings.cpp
     service_actor_actions_update_used_blocks.cpp
     service_actor_actions_update_volume_params.cpp
+    service_actor_actions_wait_dependent_disks_switched_node.cpp
     service_actor_actions_writable_state.cpp
     service_actor_actions.cpp
     service_actor_alter.cpp

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -132,6 +132,8 @@ message TDevice
     TRdmaEndpoint RdmaEndpoint = 7;
     // Physical offset in bytes.
     uint64 PhysicalOffset = 8;
+    // Node that agent is running on.
+    uint32 NodeId = 9;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tests/client/test_with_multiple_agents.py
+++ b/cloud/blockstore/tests/client/test_with_multiple_agents.py
@@ -1,0 +1,229 @@
+import json
+import logging
+import os
+from subprocess import TimeoutExpired
+
+from cloud.blockstore.config.server_pb2 import TServerConfig, \
+    TServerAppConfig, TKikimrServiceConfig
+from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
+
+from cloud.blockstore.tests.python.lib.client import NbsClient
+from cloud.blockstore.tests.python.lib.disk_agent_runner import LocalDiskAgent
+from cloud.blockstore.tests.python.lib.nbs_runner import LocalNbs
+from cloud.blockstore.tests.python.lib.test_base import thread_count, \
+    wait_for_nbs_server, wait_for_disk_agent, wait_for_secure_erase
+from cloud.blockstore.tests.python.lib.nonreplicated_setup import setup_nonreplicated, \
+    create_devices, setup_disk_registry_config, \
+    enable_writable_state, make_agent_node_type, make_agent_id, AgentInfo, DeviceInfo
+
+from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+import yatest.common as yatest_common
+
+DEFAULT_BLOCK_SIZE = 4096
+DEFAULT_DEVICE_COUNT = 3
+DEFAULT_AGENT_COUNT = 1
+DEFAULT_ALLOCATION_UNIT_SIZE = 1
+DEFAULT_BLOCK_COUNT_PER_DEVICE = 262144
+NBD_SOCKET_SUFFIX = "_nbd"
+NRD_BLOCKS_COUNT = 1024**3
+
+
+class TestWithMultipleAgents(object):
+
+    def __init__(
+            self,
+            device_count=DEFAULT_DEVICE_COUNT,
+            block_count_per_device=DEFAULT_BLOCK_COUNT_PER_DEVICE,
+            allocation_unit_size=DEFAULT_ALLOCATION_UNIT_SIZE,
+            agent_count=DEFAULT_AGENT_COUNT):
+        self.device_count = device_count
+        self.block_count_per_device = block_count_per_device
+        self.allocation_unit_size = allocation_unit_size
+        self.agent_count = agent_count
+        self.__disk_agents = []
+
+        self.kikimr_binary_path = yatest_common.binary_path(
+            "contrib/ydb/apps/ydbd/ydbd")
+        self.nbs_binary_path = yatest_common.binary_path(
+            "cloud/blockstore/apps/server/nbsd")
+        self.disk_agent_binary_path = yatest_common.binary_path(
+            "cloud/blockstore/apps/disk_agent/diskagentd")
+        self.nbs_client_binary_path = yatest_common.binary_path(
+            "cloud/blockstore/apps/client/blockstore-client")
+
+        self.server_app_config = TServerAppConfig()
+        self.server_app_config.ServerConfig.CopyFrom(TServerConfig())
+        self.server_app_config.ServerConfig.ThreadsCount = thread_count()
+        self.server_app_config.ServerConfig.StrictContractValidation = False
+        self.server_app_config.ServerConfig.NodeType = 'main'
+        self.server_app_config.ServerConfig.NbdEnabled = True
+        self.server_app_config.ServerConfig.NbdSocketSuffix = NBD_SOCKET_SUFFIX
+        self.server_app_config.KikimrServiceConfig.CopyFrom(TKikimrServiceConfig())
+
+        self.storage_config = TStorageServiceConfig()
+        self.storage_config.AllocationUnitNonReplicatedSSD = self.allocation_unit_size
+        self.storage_config.AllocationUnitMirror2SSD = self.allocation_unit_size
+        self.storage_config.AllocationUnitMirror3SSD = self.allocation_unit_size
+        self.storage_config.AcquireNonReplicatedDevices = True
+        self.storage_config.ClientRemountPeriod = 1000
+        self.storage_config.NonReplicatedMigrationStartAllowed = True
+        self.storage_config.DisableLocalService = False
+        self.storage_config.InactiveClientsTimeout = 60000  # 1 min
+        self.storage_config.AgentRequestTimeout = 5000      # 5 sec
+        self.storage_config.MaxMigrationBandwidth = 1024 * 1024 * 1024
+        self.storage_config.UseMirrorResync = True
+        self.storage_config.MirroredMigrationStartAllowed = True
+
+    def run_disk_agent(self, index):
+        storage = TStorageServiceConfig()
+        storage.CopyFrom(self.storage_config)
+        storage.DisableLocalService = True
+
+        disk_agent = LocalDiskAgent(
+            self.__kikimr_port,
+            self.__configurator.domains_txt,
+            server_app_config=self.server_app_config,
+            storage_config_patches=[storage],
+            config_sub_folder="disk_agent_configs_%s" % index,
+            log_sub_folder="disk_agent_logs_%s" % index,
+            kikimr_binary_path=self.kikimr_binary_path,
+            disk_agent_binary_path=self.disk_agent_binary_path,
+            rack="rack-%s" % index,
+            node_type=make_agent_node_type(index))
+
+        disk_agent.start()
+        wait_for_disk_agent(disk_agent.mon_port)
+        self.__disk_agents.append(disk_agent)
+        return disk_agent
+
+    def setup(self):
+        self.__configurator = KikimrConfigGenerator(
+            erasure=None,
+            binary_path=self.kikimr_binary_path,
+            has_cluster_uuid=False,
+            use_in_memory_pdisks=True,
+            dynamic_storage_pools=[
+                dict(name="dynamic_storage_pool:1",
+                     kind="hdd",
+                     pdisk_user_kind=0),
+                dict(name="dynamic_storage_pool:2",
+                     kind="ssd",
+                     pdisk_user_kind=0)
+            ])
+
+        self.__kikimr_cluster = kikimr_cluster_factory(
+            configurator=self.__configurator)
+        self.__kikimr_cluster.start()
+        self.__kikimr_port = list(self.__kikimr_cluster.nodes.values())[0].port
+
+        self.__devices = create_devices(
+            False,  # use_memory_devices
+            self.device_count * self.agent_count,
+            DEFAULT_BLOCK_SIZE,
+            self.block_count_per_device,
+            yatest_common.ram_drive_path())
+        devices_per_agent = []
+        agent_infos = []
+        device_idx = 0
+        for i in range(self.agent_count):
+            device_infos = []
+            agent_devices = []
+            for _ in range(self.device_count):
+                device_infos.append(DeviceInfo(self.__devices[device_idx].uuid))
+                agent_devices.append(self.__devices[device_idx])
+                device_idx += 1
+            agent_infos.append(AgentInfo(make_agent_id(i), device_infos))
+            devices_per_agent.append(agent_devices)
+
+        setup_nonreplicated(
+            self.__kikimr_cluster.client,
+            devices_per_agent,
+            dedicated_disk_agent=True,
+            agent_count=self.agent_count,
+        )
+
+        self.nbs = LocalNbs(
+            self.__kikimr_port,
+            self.__configurator.domains_txt,
+            server_app_config=self.server_app_config,
+            storage_config_patches=[self.storage_config],
+            kikimr_binary_path=self.kikimr_binary_path,
+            nbs_binary_path=self.nbs_binary_path)
+
+        self.nbs.start()
+        wait_for_nbs_server(self.nbs.nbs_port)
+
+        enable_writable_state(self.nbs.nbs_port, self.nbs_client_binary_path)
+        setup_disk_registry_config(
+            agent_infos,
+            self.nbs.nbs_port,
+            self.nbs_client_binary_path
+        )
+
+    def cleanup_file_devices(self):
+        logging.info("Remove temporary device files")
+        for d in self.__devices:
+            if d.path is not None:
+                logging.info("unlink %s (%s)" % (d.uuid, d.path))
+                assert d.handle is not None
+                d.handle.close()
+                os.unlink(d.path)
+
+    @property
+    def disk_agents(self):
+        return self.__disk_agents
+
+
+def test_wait_dependent_disks_to_switch_node_timeout():
+    env = TestWithMultipleAgents()
+    try:
+        env.setup()
+        env.run_disk_agent(0)
+        wait_for_secure_erase(env.nbs.mon_port)
+
+        client = NbsClient(env.nbs.nbs_port)
+        client.create_volume("nrd0", "nonreplicated", str(DEFAULT_BLOCK_COUNT_PER_DEVICE))
+
+        agent_id = make_agent_id(0)
+        node_id_response = json.loads(client.get_disk_agent_node_id(agent_id))
+        assert node_id_response["NodeId"] > 50000
+
+        # This should return immediately.
+        wait_response = client.wait_dependent_disks_to_switch_node(
+            agent_id, node_id_response["NodeId"] + 1)
+        assert json.loads(wait_response) == {
+            "DependentDiskStates": [
+                {
+                    "DiskId": "nrd0",
+                    "DiskState": "DISK_STATE_READY"
+                }
+            ]
+        }, f"wait_response = {wait_response}"
+
+        # This should return after 40s timeout in the wait actor.
+        process = client.wait_dependent_disks_to_switch_node_async(
+            agent_id, node_id_response["NodeId"], timeout=40)
+        try:
+            out, err = process.communicate(timeout=60)
+        except TimeoutExpired:
+            process.kill()
+            out, err = process.communicate()
+            assert False, "blockstore-client should have exited after 30s."\
+                " stdout: {}\nstderr: {}".format(out, err)
+
+        # This should return after 25s communicate() timeout.
+        process = client.wait_dependent_disks_to_switch_node_async(
+            agent_id, node_id_response["NodeId"])
+        try:
+            out, err = process.communicate(timeout=25)
+        except TimeoutExpired:
+            process.kill()
+            out, err = process.communicate()
+        else:
+            assert False, "blockstore-client shouldn't have exited."\
+                " stdout: {}\nstderr: {}".format(out, err)
+
+    finally:
+        env.cleanup_file_devices()

--- a/cloud/blockstore/tests/client/ya.make
+++ b/cloud/blockstore/tests/client/ya.make
@@ -5,10 +5,12 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/large.inc)
 TEST_SRCS(
     keepalive.py
     test_with_client.py
+    test_with_multiple_agents.py
 )
 
 DEPENDS(
     cloud/blockstore/apps/client
+    cloud/blockstore/apps/disk_agent
     cloud/blockstore/apps/endpoint_proxy
     cloud/blockstore/apps/server
 

--- a/cloud/storage/core/libs/diagnostics/critical_events.cpp
+++ b/cloud/storage/core/libs/diagnostics/critical_events.cpp
@@ -94,14 +94,15 @@ void ReportPreconditionFailed(
     TStringBuf file,
     int line,
     TStringBuf func,
-    TStringBuf expr)
+    TStringBuf expr,
+    TStringBuf message)
 {
     ReportCriticalEvent(
         "PreconditionFailed",
         TStringBuilder()
             << file << ":" << line
             << " " << func << "(): requirement " << expr
-            << " failed",
+            << " failed. " << message,
         true    // verifyDebug
     );
 }

--- a/cloud/storage/core/libs/diagnostics/critical_events.h
+++ b/cloud/storage/core/libs/diagnostics/critical_events.h
@@ -35,17 +35,21 @@ void ReportPreconditionFailed(
     TStringBuf file,
     int line,
     TStringBuf func,
-    TStringBuf expr);
+    TStringBuf expr,
+    TStringBuf message);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define STORAGE_CHECK_PRECONDITION(expr)                                             \
-    if (!(expr)) {                                                             \
+#define STORAGE_CHECK_PRECONDITION_C(expr, message)                            \
+    if (Y_UNLIKELY(!(expr))) {                                                 \
         ReportPreconditionFailed(                                              \
             __SOURCE_FILE_IMPL__,                                              \
             __LINE__,                                                          \
             __FUNCTION__,                                                      \
-            #expr);                                                            \
+            #expr,                                                             \
+            message);                                                          \
     }                                                                          \
+
+#define STORAGE_CHECK_PRECONDITION(expr) STORAGE_CHECK_PRECONDITION_C(expr, "")
 
 }   // namespace NCloud


### PR DESCRIPTION
Сделал 2 ручки в blockstore-client:
1) `GetDiskAgentNodeId` - тут всё понятно думаю. Просто получаем численный nodeId
2) `WaitDependentDisksToSwitchNode` - ручка, которая будет дожидаться пока все зависимые диски сменят NodeId

Вкратце логика blue-green скрипта будет такая:
1) Получаем NodeId первого DA
2) Стартуем DA2
3) Ждем с `WaitDependentDisksToSwitchNode` пока диски переедут на DA2
4) Получаем NodeId DA2
5) Рестартуем DA1
6) Ждем с `WaitDependentDisksToSwitchNode` пока диски переедут на DA1
