### PR TITLE
issue-1128: entries in the CompactionMap table should be deleted instead of updating of both BlobCount and DeletionCount are 0

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1589,10 +1589,14 @@ void TIndexTabletDatabase::WriteCompactionMap(
 {
     using TTable = TIndexTabletSchema::CompactionMap;
 
-    Table<TTable>()
-        .Key(rangeId)
-        .Update(NIceDb::TUpdate<TTable::BlobsCount>(blobsCount))
-        .Update(NIceDb::TUpdate<TTable::DeletionsCount>(deletionsCount));
+    if (blobsCount || deletionsCount) {
+        Table<TTable>()
+            .Key(rangeId)
+            .Update(NIceDb::TUpdate<TTable::BlobsCount>(blobsCount))
+            .Update(NIceDb::TUpdate<TTable::DeletionsCount>(deletionsCount));
+    } else {
+        Table<TTable>().Key(rangeId).Delete();
+    }
 }
 
 bool TIndexTabletDatabase::ReadCompactionMap(


### PR DESCRIPTION
Otherwise we end up with gigabytes of zero ranges in the CompactionMap tables of big filesystems.