### PR TITLE
filestore-vhost loop shutdown logging

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -148,7 +148,8 @@ public:
                     requestsSize = Requests.size();
                     // double-checking needed because inflight count and completing
                     // count should be checked together atomically
-                    noCompleting = CompletingCount.Val() == 0;
+                    completingCount = CompletingCount.Val();
+                    noCompleting = completingCount == 0;
                 }
 
                 STORAGE_INFO("[f:%s] completing left: %ld, requests left: %u",


### PR DESCRIPTION
there are still some races happening during shutdown - they don't lead to crashes but lead to hangups in rare cases

can't reproduce it locally - running large tests in a loop for several days in a row fails to detect the problem => decided to commit some logging to have the required debug info in nightly builds