### PR TITLE
issue-1268: show preempted volumes at nbs-control monitoring page

### DIFF
--- a/cloud/blockstore/libs/storage/api/service.h
+++ b/cloud/blockstore/libs/storage/api/service.h
@@ -160,7 +160,9 @@ struct TEvService
         {}
     };
 
+    //
     // VolumeMountStateChanged
+    //
 
     struct TVolumeMountStateChanged
     {

--- a/cloud/blockstore/libs/storage/api/service.h
+++ b/cloud/blockstore/libs/storage/api/service.h
@@ -160,6 +160,21 @@ struct TEvService
         {}
     };
 
+    // VolumeMountStateChanged
+
+    struct TVolumeMountStateChanged
+    {
+        const TString DiskId;
+        const bool HasLocalMount = false;
+
+        explicit TVolumeMountStateChanged(
+                TString diskId,
+                bool value)
+            : DiskId(std::move(diskId))
+            , HasLocalMount(value)
+        {}
+    };
+
     //
     // Events declaration
     //
@@ -295,6 +310,8 @@ struct TEvService
         EvGetCheckpointStatusRequest = EvBegin + 86,
         EvGetCheckpointStatusResponse = EvBegin + 87,
 
+        EvVolumeMountStateChanged = EvBegin + 88,
+
         EvEnd
     };
 
@@ -317,6 +334,11 @@ struct TEvService
     using TEvVolumeConfigUpdated = TRequestEvent<
         TVolumeConfigUpdated,
         EvVolumeConfigUpdated
+    >;
+
+    using TEvVolumeMountStateChanged = TRequestEvent<
+        TVolumeMountStateChanged,
+        EvVolumeMountStateChanged
     >;
 };
 

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -154,6 +154,18 @@ void TServiceActor::UpdateActorStats(const TActorContext& ctx)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TServiceActor::HandleVolumeMountStateChanged(
+    const TEvService::TEvVolumeMountStateChanged::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ctx);
+    const auto& msg = ev->Get();
+
+    auto volume = State.GetOrAddVolume(msg->DiskId);
+    volume->SetTabletReportedLocalMount(msg->HasLocalMount);
+}
+
+
 void TServiceActor::HandleRegisterVolume(
     const TEvService::TEvRegisterVolume::TPtr& ev,
     const TActorContext& ctx)
@@ -282,6 +294,7 @@ STFUNC(TServiceActor::StateWork)
 
         HFunc(NMon::TEvHttpInfo, HandleHttpInfo);
 
+        HFunc(TEvService::TEvVolumeMountStateChanged, HandleVolumeMountStateChanged);
         HFunc(TEvService::TEvRegisterVolume, HandleRegisterVolume);
         HFunc(TEvService::TEvUnregisterVolume, HandleUnregisterVolume);
         HFunc(TEvService::TEvVolumeConfigUpdated, HandleVolumeConfigUpdated);

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -161,8 +161,10 @@ void TServiceActor::HandleVolumeMountStateChanged(
     Y_UNUSED(ctx);
     const auto& msg = ev->Get();
 
-    auto volume = State.GetOrAddVolume(msg->DiskId);
-    volume->SetTabletReportedLocalMount(msg->HasLocalMount);
+    auto volume = State.GetVolume(msg->DiskId);
+    if (volume) {
+        volume->SetTabletReportedLocalMount(msg->HasLocalMount);
+    }
 }
 
 

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -161,8 +161,7 @@ void TServiceActor::HandleVolumeMountStateChanged(
     Y_UNUSED(ctx);
     const auto& msg = ev->Get();
 
-    auto volume = State.GetVolume(msg->DiskId);
-    if (volume) {
+    if (auto volume = State.GetVolume(msg->DiskId)) {
         volume->SetTabletReportedLocalMount(msg->HasLocalMount);
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -173,6 +173,10 @@ private:
         TRequestInfo& requestInfo,
         TString message);
 
+    void HandleVolumeMountStateChanged(
+        const TEvService::TEvVolumeMountStateChanged::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleRegisterVolume(
         const TEvService::TEvRegisterVolume::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/service/service_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_monitoring.cpp
@@ -310,6 +310,8 @@ void TServiceActor::RenderVolumeList(IOutputStream& out) const
                             cssClass = "label-success";
                         } else if (volume.IsMounted()) {
                             statusText = "Mounted (remote)";
+                        } else if (volume.IsLocallyMounted()) {
+                            statusText = "Mounted (preempted)";
                         }
 
                         SPAN_CLASS("label " + cssClass) {

--- a/cloud/blockstore/libs/storage/service/service_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_monitoring.cpp
@@ -310,7 +310,7 @@ void TServiceActor::RenderVolumeList(IOutputStream& out) const
                             cssClass = "label-success";
                         } else if (volume.IsMounted()) {
                             statusText = "Mounted (remote)";
-                        } else if (volume.IsLocallyMounted()) {
+                        } else if (volume.GetTabletReportedLocalMount()) {
                             statusText = "Mounted (preempted)";
                         }
 

--- a/cloud/blockstore/libs/storage/service/service_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_state.cpp
@@ -165,7 +165,7 @@ bool TVolumeInfo::IsLocallyMounted() const
         }
     }
 
-    return TabletReportedLocalMount;
+    return false;
 }
 
 void TVolumeInfo::SetTabletReportedLocalMount(bool value)

--- a/cloud/blockstore/libs/storage/service/service_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_state.cpp
@@ -165,7 +165,12 @@ bool TVolumeInfo::IsLocallyMounted() const
         }
     }
 
-    return false;
+    return TabletReportedLocalMount;
+}
+
+void TVolumeInfo::SetTabletReportedLocalMount(bool value)
+{
+    TabletReportedLocalMount = value;
 }
 
 bool TVolumeInfo::IsDiskRegistryVolume() const

--- a/cloud/blockstore/libs/storage/service/service_state.h
+++ b/cloud/blockstore/libs/storage/service/service_state.h
@@ -108,6 +108,8 @@ struct TVolumeInfo
 
     bool SyncManuallyPreemptedVolumesRequired = false;
 
+    bool TabletReportedLocalMount = false;
+
     TVolumeInfo(TString diskId);
 
     //
@@ -120,6 +122,7 @@ struct TVolumeInfo
     TClientInfo* AddClientInfo(const TString& clientId);
     void RemoveClientInfo(TClientInfo* info);
     void RemoveClientInfo(const TString& clientId);
+    void SetTabletReportedLocalMount(bool value);
 
     bool IsMounted() const;
     bool IsReadWriteMounted() const;

--- a/cloud/blockstore/libs/storage/service/service_state.h
+++ b/cloud/blockstore/libs/storage/service/service_state.h
@@ -123,6 +123,10 @@ struct TVolumeInfo
     void RemoveClientInfo(TClientInfo* info);
     void RemoveClientInfo(const TString& clientId);
     void SetTabletReportedLocalMount(bool value);
+    bool GetTabletReportedLocalMount() const
+    {
+        return TabletReportedLocalMount;
+    }
 
     bool IsMounted() const;
     bool IsReadWriteMounted() const;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -355,13 +355,13 @@ TString TVolumeActor::GetVolumeStatusString(TVolumeActor::EStatus status) const
     {
         case TVolumeActor::STATUS_ONLINE: {
             if (!State->GetLocalMountClientId().Empty()) {
-                return "online(preempted)";
+                return "Online (preempted)";
             }
-            return "online";
+            return "Online";
         }
-        case TVolumeActor::STATUS_INACTIVE: return "inactive";
-        case TVolumeActor::STATUS_MOUNTED: return "mounted";
-        default: return "offline";
+        case TVolumeActor::STATUS_INACTIVE: return "Inactive";
+        case TVolumeActor::STATUS_MOUNTED: return "Mounted";
+        default: return "Offline";
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -349,11 +349,16 @@ void TVolumeActor::ReleaseTransactions()
     }
 }
 
-TString TVolumeActor::GetVolumeStatusString(TVolumeActor::EStatus status)
+TString TVolumeActor::GetVolumeStatusString(TVolumeActor::EStatus status) const
 {
     switch (status)
     {
-        case TVolumeActor::STATUS_ONLINE: return "online";
+        case TVolumeActor::STATUS_ONLINE: {
+            if (!State->GetLocalMountClientId().Empty()) {
+                return "online(preempted)";
+            }
+            return "online";
+        }
         case TVolumeActor::STATUS_INACTIVE: return "inactive";
         case TVolumeActor::STATUS_MOUNTED: return "mounted";
         default: return "offline";

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -354,10 +354,9 @@ TString TVolumeActor::GetVolumeStatusString(TVolumeActor::EStatus status) const
     switch (status)
     {
         case TVolumeActor::STATUS_ONLINE: {
-            if (!State->GetLocalMountClientId().Empty()) {
-                return "Online (preempted)";
-            }
-            return "Online";
+            return State->GetLocalMountClientId().Empty() ?
+                "Online":
+                "Online (preempted)";
         }
         case TVolumeActor::STATUS_INACTIVE: return "Inactive";
         case TVolumeActor::STATUS_MOUNTED: return "Mounted";

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -457,7 +457,7 @@ private:
         const NActors::TActorContext& ctx,
         TVolumeActor::EStatus status);
 
-    static TString GetVolumeStatusString(EStatus status);
+    TString GetVolumeStatusString(EStatus status) const;
     EStatus GetVolumeStatus() const;
 
     NRdma::IClientPtr GetRdmaClient() const;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -527,6 +527,13 @@ void TVolumeActor::OnClientListUpdate(const NActors::TActorContext& ctx)
             std::make_unique<TEvVolume::TEvRWClientIdChanged>(
                 State->GetReadWriteAccessClientId()));
     }
+
+    if (StartMode != EVolumeStartMode::MOUNTED) {
+        auto request = std::make_unique<TEvService::TEvVolumeMountStateChanged>(
+            State->GetDiskId(),
+            !State->GetLocalMountClientId().Empty());
+        NCloud::Send(ctx, MakeStorageServiceId(), std::move(request));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#1268 

Сделал чтобы на контролах в мониторинге сервиса контрола были видны отселенные на него диски. Ну и на мон. страничку таблетки вывел что таблетка была отселена. Коллеги просили