### PR TITLE
filestore-vhost: 1. extracted IEndpointManager::Drain phase and calling it before Stop 2. callbacks which need to be called when StopPromise is set should be called in a separate thread to avoid a deadlock occurring because Join gets called from the same thread on which it is called 3. explicitly cancelling AcquireLock request retries

### DIFF
--- a/cloud/filestore/libs/client/client.cpp
+++ b/cloud/filestore/libs/client/client.cpp
@@ -849,6 +849,9 @@ class TEndpointManagerClient final
 public:
     using TBase::TBase;
 
+    void Drain() override
+    {}
+
     void InitService(std::shared_ptr<::grpc::Channel> channel) override
     {
         TBase::AppCtx.Service = NProto::TEndpointManagerService::NewStub(std::move(channel));

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -268,7 +268,9 @@ class TDurableEndpointManagerClient final
     using TDurableClientBase::TDurableClientBase;
 
     void Drain() override
-    {}
+    {
+        Client->Drain();
+    }
 
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \
     TFuture<NProto::T##name##Response> name(                                   \

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -267,6 +267,9 @@ class TDurableEndpointManagerClient final
 {
     using TDurableClientBase::TDurableClientBase;
 
+    void Drain() override
+    {}
+
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \
     TFuture<NProto::T##name##Response> name(                                   \
         TCallContextPtr callContext,                                           \

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -137,6 +137,8 @@ void TBootstrapCommon::Start()
 
 void TBootstrapCommon::Stop()
 {
+    Drain();
+
     // stopping scheduler before all other components to avoid races between
     // scheduled tasks and shutting down of component dependencies
     FILESTORE_LOG_STOP_COMPONENT(BackgroundScheduler);

--- a/cloud/filestore/libs/daemon/common/bootstrap.h
+++ b/cloud/filestore/libs/daemon/common/bootstrap.h
@@ -93,6 +93,7 @@ protected:
 
     virtual void InitComponents() = 0;
     virtual void StartComponents() = 0;
+    virtual void Drain() = 0;
     virtual void StopComponents() = 0;
 
     void RegisterServer(NServer::IServerPtr server);

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -61,6 +61,9 @@ void TBootstrapServer::StartComponents()
     FILESTORE_LOG_START_COMPONENT(Server);
 }
 
+void TBootstrapServer::Drain()
+{}
+
 void TBootstrapServer::StopComponents()
 {
     FILESTORE_LOG_STOP_COMPONENT(Server);

--- a/cloud/filestore/libs/daemon/server/bootstrap.h
+++ b/cloud/filestore/libs/daemon/server/bootstrap.h
@@ -33,6 +33,7 @@ public:
 protected:
     void InitComponents() override;
     void StartComponents() override;
+    void Drain() override;
     void StopComponents() override;
 
 private:

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -326,6 +326,13 @@ void TBootstrapVhost::StopComponents()
     NVhost::StopServer();
 }
 
+void TBootstrapVhost::Drain()
+{
+    if (EndpointManager) {
+        EndpointManager->Drain();
+    }
+}
+
 void TBootstrapVhost::RestoreKeyringEndpoints()
 {
     auto idsOrError = EndpointStorage->GetEndpointIds();

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.h
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.h
@@ -55,6 +55,7 @@ private:
     void InitComponents() override;
     void StartComponents() override;
     void StopComponents() override;
+    void Drain() override;
 
 private:
     void InitLWTrace();

--- a/cloud/filestore/libs/endpoint/service.cpp
+++ b/cloud/filestore/libs/endpoint/service.cpp
@@ -127,7 +127,10 @@ public:
     void Stop() override
     {
         Executor->Stop();
+    }
 
+    void Drain() override
+    {
         TVector<TFuture<void>> futures;
         for (auto&& [_, endpoint]: Endpoints) {
             futures.push_back(endpoint.Endpoint->SuspendAsync());
@@ -399,6 +402,9 @@ class TNullEndpointManager final
     {}
 
     void Stop() override
+    {}
+
+    void Drain() override
     {}
 
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \

--- a/cloud/filestore/libs/endpoint/service_auth.cpp
+++ b/cloud/filestore/libs/endpoint/service_auth.cpp
@@ -42,6 +42,11 @@ public:
         Service->Stop();
     }
 
+    void Drain() override
+    {
+        Service->Drain();
+    }
+
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \
     TFuture<NProto::T##name##Response> name(                                   \
         TCallContextPtr ctx,                                                   \

--- a/cloud/filestore/libs/endpoint/service_ut.cpp
+++ b/cloud/filestore/libs/endpoint/service_ut.cpp
@@ -222,6 +222,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         endpoint->Stop.SetValue();
 
+        UNIT_ASSERT_NO_EXCEPTION(service->Drain());
         UNIT_ASSERT_NO_EXCEPTION(service->Stop());
     }
 
@@ -341,6 +342,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         endpoint->Stop.SetValue();
 
+        UNIT_ASSERT_NO_EXCEPTION(service->Drain());
         UNIT_ASSERT_NO_EXCEPTION(service->Stop());
     }
 
@@ -387,6 +389,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         Y_DEFER {
             endpoint->Stop.SetValue();
+            UNIT_ASSERT_NO_EXCEPTION(service->Drain());
             UNIT_ASSERT_NO_EXCEPTION(service->Stop());
         };
 

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -6,6 +6,8 @@
 #include <cloud/storage/core/libs/common/context.h>
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <atomic>
+
 namespace NCloud::NFileStore {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -19,6 +21,8 @@ public:
     EFileStoreRequest RequestType = EFileStoreRequest::MAX;
     ui64 RequestSize = 0;
     bool Unaligned = false;
+
+    std::atomic<bool> Cancelled = false;
 
     explicit TCallContext(ui64 requestId = 0);
     TCallContext(TString fileSystemId, ui64 requestId = 0);

--- a/cloud/filestore/libs/service/endpoint.h
+++ b/cloud/filestore/libs/service/endpoint.h
@@ -30,6 +30,8 @@ struct IEndpointManager
     FILESTORE_ENDPOINT_SERVICE(FILESTORE_DECLARE_METHOD)
 
 #undef FILESTORE_DECLARE_METHOD
+
+    virtual void Drain() = 0;
 };
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service/endpoint_test.h
+++ b/cloud/filestore/libs/service/endpoint_test.h
@@ -39,6 +39,9 @@ struct TEndpointManagerTest
 
     void Stop() override
     {}
+
+    void Drain() override
+    {}
 };
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -29,6 +29,7 @@
 #include <util/system/info.h>
 #include <util/system/rwlock.h>
 #include <util/system/thread.h>
+#include <util/thread/factory.h>
 
 #include <errno.h>
 #include <pthread.h>
@@ -570,47 +571,59 @@ public:
 
         auto w = weak_from_this();
         auto s = NewPromise<void>();
-        CompletionQueue->StopAsync(FUSE_ERROR).Subscribe(
-            [w = std::move(w), s] (const auto& f) mutable {
-                f.GetValue();
 
-                auto p = w.lock();
-                if (!p) {
-                    return;
-                }
+        auto onStop = [w = std::move(w), s] (const TFuture<void>& f) mutable {
+            f.GetValue();
 
-                p->SessionThread->Unmount();
-                p->SessionThread = nullptr;
+            auto p = w.lock();
+            if (!p) {
+                return;
+            }
 
-                auto callContext = MakeIntrusive<TCallContext>(
-                    p->Config->GetFileSystemId(),
-                    CreateRequestId());
-                callContext->RequestType = EFileStoreRequest::DestroySession;
-                p->RequestStats->RequestStarted(p->Log, *callContext);
+            p->SessionThread->Unmount();
+            p->SessionThread = nullptr;
 
-                p->Session->DestroySession()
-                    .Subscribe([
-                        w = std::move(w),
-                        s = std::move(s),
-                        callContext = std::move(callContext)
-                    ] (const auto& f) mutable {
-                        auto p = w.lock();
-                        if (!p) {
-                            s.SetValue();
-                            return;
-                        }
+            auto callContext = MakeIntrusive<TCallContext>(
+                p->Config->GetFileSystemId(),
+                CreateRequestId());
+            callContext->RequestType = EFileStoreRequest::DestroySession;
+            p->RequestStats->RequestStarted(p->Log, *callContext);
 
-                        const auto& response = f.GetValue();
-                        p->RequestStats->RequestCompleted(
-                            p->Log,
-                            *callContext,
-                            response.GetError());
-
-                        p->StatsRegistry->Unregister(
-                            p->Config->GetFileSystemId(),
-                            p->Config->GetClientId());
-
+            p->Session->DestroySession()
+                .Subscribe([
+                    w = std::move(w),
+                    s = std::move(s),
+                    callContext = std::move(callContext)
+                ] (const auto& f) mutable {
+                    auto p = w.lock();
+                    if (!p) {
                         s.SetValue();
+                        return;
+                    }
+
+                    const auto& response = f.GetValue();
+                    p->RequestStats->RequestCompleted(
+                        p->Log,
+                        *callContext,
+                        response.GetError());
+
+                    p->StatsRegistry->Unregister(
+                        p->Config->GetFileSystemId(),
+                        p->Config->GetClientId());
+
+                    s.SetValue();
+                });
+        };
+
+        CompletionQueue->StopAsync(FUSE_ERROR).Subscribe(
+            [onStop = std::move(onStop)] (TFuture<void> f) mutable {
+                // this callback may be called from the same thread where the
+                // returned future is set => we shouldn't call onStop inside
+                // this callback directly to avoid a deadlock caused by the
+                // Join call which is done by SessionThread->Unmount()
+                SystemThreadFactory()->Run(
+                    [onStop = std::move(onStop), f = std::move(f)] () mutable {
+                        onStop(f);
                     });
             });
 
@@ -625,26 +638,37 @@ public:
 
         auto w = weak_from_this();
         auto s = NewPromise<void>();
-        CompletionQueue->StopAsync(FUSE_SUSPEND).Subscribe(
-            [w = std::move(w), s] (const auto& f) mutable {
-                f.GetValue();
+        auto onStop = [w = std::move(w), s] (const auto& f) mutable {
+            f.GetValue();
 
-                auto p = w.lock();
-                if (!p) {
-                    s.SetValue();
-                    return;
-                }
-
-                // just stop loop, leave connection
-                p->SessionThread->StopThread();
-                p->SessionThread->Suspend();
-                p->SessionThread = nullptr;
-
-                p->StatsRegistry->Unregister(
-                    p->Config->GetFileSystemId(),
-                    p->Config->GetClientId());
-
+            auto p = w.lock();
+            if (!p) {
                 s.SetValue();
+                return;
+            }
+
+            // just stop loop, leave connection
+            p->SessionThread->StopThread();
+            p->SessionThread->Suspend();
+            p->SessionThread = nullptr;
+
+            p->StatsRegistry->Unregister(
+                p->Config->GetFileSystemId(),
+                p->Config->GetClientId());
+
+            s.SetValue();
+        };
+
+        CompletionQueue->StopAsync(FUSE_SUSPEND).Subscribe(
+            [onStop = std::move(onStop)] (TFuture<void> f) mutable {
+                // this callback may be called from the same thread where the
+                // returned future is set => we shouldn't call onStop inside
+                // this callback directly to avoid a deadlock caused by the
+                // Join call which is done by SessionThread->StopThread()
+                SystemThreadFactory()->Run(
+                    [onStop = std::move(onStop), f = std::move(f)] () mutable {
+                        onStop(f);
+                    });
             });
 
         return s;


### PR DESCRIPTION
followup fixes after https://github.com/ydb-platform/nbs/commit/075bd0d9d62e6b01f20a6cde3f205fc90d819e21 and https://github.com/ydb-platform/nbs/commit/d712c8432373dbededaf79272736d013e1162e4b

motivation:
https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/9247766212/1/nebius-x86-64-tsan/summary/ya-test.html#FAIL
> cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-nemesis-test/test.py.test_posix_compliance[flock]

зависает из-за того, что в некоторых ситуациях AcquireLock-запрос может зашедулить асинхронное действие: https://github.com/ydb-platform/nbs/blob/d67a0ff439d193fcb3610a2842ef318b2dc12aad/cloud/filestore/libs/vfs_fuse/fs_impl_lock.cpp#L213 

при этом Scheduler сейчас стопается до вызова SuspendAsync у TFileSystemLoop

также есть вторая проблема - некоторые AcquireLock-запросы мы должны ретраить до победного конца - сейчас из-за этого filestore-vhost зависает на остановке, надо таким запросам взводить какой-нибудь Cancelled-флаг, на очередном ретрае его проверять и не делать ретрай, если флаг взведен

https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(asan)/9248043976/1/nebius-x86-64-asan/summary/ya-test.html#FAIL
> cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-nemesis-test/test.py.test_posix_compliance[rmdir]

тут мы, кажется, позвали TCompletionQueue::Complete из того же треда, который делает fuse_session_loop

соответственно, Complete стриггерил StopFuture.TrySetValue, тот позвал колбек, повешенный на результат в TFileSystemLoop::SuspendAsync, тот вызвал Join у треда, в котором сам же и выполняется, все зависло: https://github.com/ydb-platform/nbs/blob/d67a0ff439d193fcb3610a2842ef318b2dc12aad/cloud/filestore/libs/vfs_fuse/loop.cpp#L639