### PR TITLE
[Filestore] decrease iodepth of nemesis tests because of dup cache limitations

### DIFF
--- a/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/create-remove.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/create-remove.txt
@@ -18,7 +18,7 @@ Tests {
                 Rate: 33
             }
         }
-        IODepth: 64
+        IODepth: 32
         TestDuration: 120
     }
 }

--- a/cloud/filestore/tests/loadtest/service-kikimr-nemesis-test/create-remove.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-nemesis-test/create-remove.txt
@@ -18,7 +18,7 @@ Tests {
                 Rate: 33
             }
         }
-        IODepth: 64
+        IODepth: 32
         TestDuration: 60
     }
 }


### PR DESCRIPTION
The mentioned tests are running some load during constant filestore restarts.

Sometimes the request is processed by the server, yet the response is not sent back to the client due to the server restart. To mitigate this issue, a DupCache is used to store the latest requests and their responses. The DupCache is used to match non-idempotent requests with their responses and resend the responses to the client after the server restart.

By its nature, the DupCache is limited in size and by default stores only 1024 entries.

In the latest test failure (https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/PR-check/9228148116/1/nebius-x86-64/summary/ya-test.html#FAIL) there have been >1100 requests between two retries of the same `UnlinkNode` request. This caused the DupCache to evict the response of the first request and resulted in the second retry getting
`E_FS_NOENT` instead of `OK`, as expected.

Lowering the `IODepth` of these tests should make such failures much less likely to happen.