### PR TITLE
filestore-vhost: 1. extracted IEndpointManager::Drain phase and calling it before Stop 2. callbacks which need to be called when StopPromise is set should be called in a separate thread to avoid a deadlock occurring because Join gets called from the same thread on which it is called 3. explicitly cancelling AcquireLock request retries (#1278)

### DIFF
--- a/cloud/filestore/libs/client/client.cpp
+++ b/cloud/filestore/libs/client/client.cpp
@@ -849,6 +849,9 @@ class TEndpointManagerClient final
 public:
     using TBase::TBase;
 
+    void Drain() override
+    {}
+
     void InitService(std::shared_ptr<::grpc::Channel> channel) override
     {
         TBase::AppCtx.Service = NProto::TEndpointManagerService::NewStub(std::move(channel));

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -267,6 +267,11 @@ class TDurableEndpointManagerClient final
 {
     using TDurableClientBase::TDurableClientBase;
 
+    void Drain() override
+    {
+        Client->Drain();
+    }
+
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \
     TFuture<NProto::T##name##Response> name(                                   \
         TCallContextPtr callContext,                                           \

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -135,6 +135,8 @@ void TBootstrapCommon::Start()
 
 void TBootstrapCommon::Stop()
 {
+    Drain();
+
     // stopping scheduler before all other components to avoid races between
     // scheduled tasks and shutting down of component dependencies
     FILESTORE_LOG_STOP_COMPONENT(BackgroundScheduler);

--- a/cloud/filestore/libs/daemon/common/bootstrap.h
+++ b/cloud/filestore/libs/daemon/common/bootstrap.h
@@ -93,6 +93,7 @@ protected:
 
     virtual void InitComponents() = 0;
     virtual void StartComponents() = 0;
+    virtual void Drain() = 0;
     virtual void StopComponents() = 0;
 
     void RegisterServer(NServer::IServerPtr server);

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -61,6 +61,9 @@ void TBootstrapServer::StartComponents()
     FILESTORE_LOG_START_COMPONENT(Server);
 }
 
+void TBootstrapServer::Drain()
+{}
+
 void TBootstrapServer::StopComponents()
 {
     FILESTORE_LOG_STOP_COMPONENT(Server);

--- a/cloud/filestore/libs/daemon/server/bootstrap.h
+++ b/cloud/filestore/libs/daemon/server/bootstrap.h
@@ -33,6 +33,7 @@ public:
 protected:
     void InitComponents() override;
     void StartComponents() override;
+    void Drain() override;
     void StopComponents() override;
 
 private:

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -326,6 +326,13 @@ void TBootstrapVhost::StopComponents()
     NVhost::StopServer();
 }
 
+void TBootstrapVhost::Drain()
+{
+    if (EndpointManager) {
+        EndpointManager->Drain();
+    }
+}
+
 void TBootstrapVhost::RestoreKeyringEndpoints()
 {
     auto idsOrError = EndpointStorage->GetEndpointIds();

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.h
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.h
@@ -55,6 +55,7 @@ private:
     void InitComponents() override;
     void StartComponents() override;
     void StopComponents() override;
+    void Drain() override;
 
 private:
     void InitLWTrace();

--- a/cloud/filestore/libs/endpoint/service.cpp
+++ b/cloud/filestore/libs/endpoint/service.cpp
@@ -127,7 +127,10 @@ public:
     void Stop() override
     {
         Executor->Stop();
+    }
 
+    void Drain() override
+    {
         TVector<TFuture<void>> futures;
         for (auto&& [_, endpoint]: Endpoints) {
             futures.push_back(endpoint.Endpoint->SuspendAsync());
@@ -399,6 +402,9 @@ class TNullEndpointManager final
     {}
 
     void Stop() override
+    {}
+
+    void Drain() override
     {}
 
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \

--- a/cloud/filestore/libs/endpoint/service_auth.cpp
+++ b/cloud/filestore/libs/endpoint/service_auth.cpp
@@ -42,6 +42,11 @@ public:
         Service->Stop();
     }
 
+    void Drain() override
+    {
+        Service->Drain();
+    }
+
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \
     TFuture<NProto::T##name##Response> name(                                   \
         TCallContextPtr ctx,                                                   \

--- a/cloud/filestore/libs/endpoint/service_ut.cpp
+++ b/cloud/filestore/libs/endpoint/service_ut.cpp
@@ -222,6 +222,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         endpoint->Stop.SetValue();
 
+        UNIT_ASSERT_NO_EXCEPTION(service->Drain());
         UNIT_ASSERT_NO_EXCEPTION(service->Stop());
     }
 
@@ -341,6 +342,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         endpoint->Stop.SetValue();
 
+        UNIT_ASSERT_NO_EXCEPTION(service->Drain());
         UNIT_ASSERT_NO_EXCEPTION(service->Stop());
     }
 
@@ -387,6 +389,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         Y_DEFER {
             endpoint->Stop.SetValue();
+            UNIT_ASSERT_NO_EXCEPTION(service->Drain());
             UNIT_ASSERT_NO_EXCEPTION(service->Stop());
         };
 

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -6,6 +6,8 @@
 #include <cloud/storage/core/libs/common/context.h>
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <atomic>
+
 namespace NCloud::NFileStore {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -19,6 +21,8 @@ public:
     EFileStoreRequest RequestType = EFileStoreRequest::MAX;
     ui64 RequestSize = 0;
     bool Unaligned = false;
+
+    std::atomic<bool> Cancelled = false;
 
     explicit TCallContext(ui64 requestId = 0);
     TCallContext(TString fileSystemId, ui64 requestId = 0);

--- a/cloud/filestore/libs/service/endpoint.h
+++ b/cloud/filestore/libs/service/endpoint.h
@@ -30,6 +30,8 @@ struct IEndpointManager
     FILESTORE_ENDPOINT_SERVICE(FILESTORE_DECLARE_METHOD)
 
 #undef FILESTORE_DECLARE_METHOD
+
+    virtual void Drain() = 0;
 };
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service/endpoint_test.h
+++ b/cloud/filestore/libs/service/endpoint_test.h
@@ -39,6 +39,9 @@ struct TEndpointManagerTest
 
     void Stop() override
     {}
+
+    void Drain() override
+    {}
 };
 
 }   // namespace NCloud::NFileStore


### PR DESCRIPTION
5c37adf56693d5cdea19944fadd5707ee7f9a595