### PR TITLE
issue-1164: support for uds in blockstore-endpoint-proxy

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -600,6 +600,7 @@ void TCommand::Init()
             {
                 TDuration::Seconds(1),
                 TDuration::Minutes(5),
+                TDuration::Seconds(5),
             },
         }, Scheduler, Timer, Logging);
     }

--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -164,6 +164,10 @@ TCommand::TCommand(IBlockStorePtr client)
         .RequiredArgument("NUM")
         .StoreResult(&EndpointProxySecurePort);
 
+    Opts.AddLongOption("endpoint-proxy-unix-socket-path", "endpoint proxy unix socket path")
+        .RequiredArgument("FILE")
+        .StoreResult(&EndpointProxyUnixSocketPath);
+
     Opts.AddLongOption("mon-file")
         .RequiredArgument("STR")
         .StoreResult(&MonitoringConfig);
@@ -586,12 +590,13 @@ void TCommand::Init()
 
     }
 
-    if (EndpointProxyHost) {
+    if (EndpointProxyHost || EndpointProxyUnixSocketPath) {
         EndpointProxyClient = CreateClient(TEndpointProxyClientConfig{
             EndpointProxyHost,
             static_cast<ui16>(EndpointProxyInsecurePort),
             static_cast<ui16>(EndpointProxySecurePort),
             {}, // rootCertsFile
+            EndpointProxyUnixSocketPath,
             {
                 TDuration::Seconds(1),
                 TDuration::Minutes(5),

--- a/cloud/blockstore/apps/client/lib/command.h
+++ b/cloud/blockstore/apps/client/lib/command.h
@@ -50,6 +50,7 @@ protected:
     TString EndpointProxyHost;
     ui32 EndpointProxyInsecurePort = 0;
     ui32 EndpointProxySecurePort = 0;
+    TString EndpointProxyUnixSocketPath;
 
     TString MonitoringConfig;
     TString MonitoringAddress;

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.h
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.h
@@ -43,6 +43,7 @@ struct TEndpointProxyClientConfig
     ui16 Port;
     ui16 SecurePort;
     TString RootCertsFile;
+    TString UnixSocketPath;
     TRetryPolicy RetryPolicy;
 };
 

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.h
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.h
@@ -37,6 +37,7 @@ struct TEndpointProxyClientConfig
     {
         TDuration Backoff;
         TDuration TotalTimeout;
+        TDuration UnixSocketConnectTimeout;
     };
 
     TString Host;

--- a/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
@@ -25,6 +25,7 @@ void TBootstrap::Init()
         Options.RootCertsFile,
         Options.KeyFile,
         Options.CertFile,
+        Options.UnixSocketPath,
         Options.Netlink,
     },
     CreateWallClockTimer(),

--- a/cloud/blockstore/libs/endpoint_proxy/server/options.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/options.cpp
@@ -20,6 +20,10 @@ TOptions::TOptions()
         .RequiredArgument("FILE")
         .StoreResult(&CertFile);
 
+    Opts.AddLongOption("unix-socket-path")
+        .RequiredArgument("FILE")
+        .StoreResult(&UnixSocketPath);
+
     Opts.AddLongOption("netlink")
         .NoArgument()
         .SetFlag(&Netlink);

--- a/cloud/blockstore/libs/endpoint_proxy/server/options.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/options.h
@@ -13,6 +13,7 @@ struct TOptions final: TOptionsBase
     TString RootCertsFile;
     TString KeyFile;
     TString CertFile;
+    TString UnixSocketPath;
     bool Netlink = false;
 
     TOptions();

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.h
@@ -24,6 +24,7 @@ struct TEndpointProxyServerConfig
     TString RootCertsFile;
     TString KeyFile;
     TString CertFile;
+    TString UnixSocketPath;
     bool Netlink;
 
     TEndpointProxyServerConfig(
@@ -32,12 +33,14 @@ struct TEndpointProxyServerConfig
             TString rootCertsFile,
             TString keyFile,
             TString certFile,
+            TString unixSocketPath,
             bool netlink)
         : Port(port)
         , SecurePort(securePort)
         , RootCertsFile(std::move(rootCertsFile))
         , KeyFile(std::move(keyFile))
         , CertFile(std::move(certFile))
+        , UnixSocketPath(std::move(unixSocketPath))
         , Netlink(netlink)
     {
     }

--- a/cloud/blockstore/libs/endpoint_proxy/server/ya.make
+++ b/cloud/blockstore/libs/endpoint_proxy/server/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     cloud/storage/core/libs/common
     cloud/storage/core/libs/diagnostics
     cloud/storage/core/libs/grpc
+    cloud/storage/core/libs/uds
 
     library/cpp/getopt/small
     library/cpp/logger

--- a/cloud/blockstore/tests/client/canondata/result.json
+++ b/cloud/blockstore/tests/client/canondata/result.json
@@ -11,6 +11,9 @@
     "test_with_client.test_endpoint_proxy": {
         "uri": "file://test_with_client.test_endpoint_proxy/results.txt"
     },
+    "test_with_client.test_endpoint_proxy_uds": {
+        "uri": "file://test_with_client.test_endpoint_proxy_uds/results.txt"
+    },
     "test_with_client.test_successive_remounts_and_writes": {
         "uri": "file://test_with_client.test_successive_remounts_and_writes/results.txt"
     }

--- a/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy_uds/results.txt
+++ b/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy_uds/results.txt
@@ -1,0 +1,11 @@
+InternalUnixSocketPath: "TODO-nbs-socket.proxy"
+
+Endpoints {
+  UnixSocketPath: "TODO-nbs-socket"
+  InternalUnixSocketPath: "TODO-nbs-socket.proxy"
+  BlockSize: 4096
+  BlocksCount: 1024
+}
+
+InternalUnixSocketPath: "TODO-nbs-socket.proxy"
+

--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -989,3 +989,38 @@ def test_endpoint_proxy():
     ret = common.canonical_file(env.results_path, local=True)
     tear_down(env)
     return ret
+
+
+# it's a smoke test right now - it doesn't test nbd proxying logic
+def test_endpoint_proxy_uds():
+    env, run = setup()
+
+    endpoint_proxy_path = common.binary_path(
+        "cloud/blockstore/apps/endpoint_proxy/blockstore-endpoint-proxy")
+
+    run_async(
+        [
+            endpoint_proxy_path, "--unix-socket-path", "ep.sock",
+        ],
+        "endpoint-proxy.out",
+        "endpoint-proxy.err",
+    )
+
+    run("startproxyendpoint",
+        "--endpoint-proxy-unix-socket-path", "ep.sock",
+        "--socket", "TODO-nbs-socket",
+        # can't use modprobe nbd in tests
+        # "--nbd-device", "TODO-nbd-device",
+        "--block-size", "4096",
+        "--blocks-count", "1024")
+
+    run("listproxyendpoints",
+        "--endpoint-proxy-unix-socket-path", "ep.sock")
+
+    run("stopproxyendpoint",
+        "--endpoint-proxy-unix-socket-path", "ep.sock",
+        "--socket", "TODO-nbs-socket")
+
+    ret = common.canonical_file(env.results_path, local=True)
+    tear_down(env)
+    return ret


### PR DESCRIPTION
blockstore-server <-> blockstore-endpoint-proxy communication will most probably be local to the host so a unix socket channel is preferable 

#1164 