### PR TITLE
Fix unaligned access to memory

### DIFF
--- a/cloud/blockstore/libs/common/iovector.cpp
+++ b/cloud/blockstore/libs/common/iovector.cpp
@@ -173,7 +173,7 @@ ui32 CountVoidBuffers(const NProto::TIOVector& iov)
 
 bool IsAllZeroes(const char* src, size_t size)
 {
-    using TBigNumber = ui64;
+    using TBigNumber = ui32;
 
     if (size < sizeof(TBigNumber)) {
         return false;


### PR DESCRIPTION
```
[crashed] TIOVectorTest::ShouldTrimVoidBuffers [default-linux-x86_64-release-usan] (0.00s)
Test crashed (return code: 100)
/place/sandbox-data/tasks/3/8/2357407883/__FUSE/mount_path_19fadc74-2bdf-4619-8912-39cad0885237/cloud/blockstore/libs/common/iovector.cpp:183:9: runtime error: load of misaligned address 0x000003371019 for type 'const TBigNumber' (aka 'const unsigned long'), which requires 8 byte alignment
0x000003371019: note: pointer points here
 00 00 00  10 00 00 00 00 00 00 00  00 00 55 45 53 54 45 44  00 fd 36 03 00 00 00 00  30 00 00 00 00
              ^ 
    #0 0x1562ca5 in NCloud::NBlockStore::IsAllZeroes /-S/cloud/blockstore/libs/common/iovector.cpp:183:9
    #1 0x1562ca5 in NCloud::NBlockStore::TrimVoidBuffers(NCloud::NBlockStore::NProto::TIOVector&) /-S/cloud/blockstore/libs/common/iovector.cpp:127:13
    #2 0x9e4ec8 in NCloud::NBlockStore::NTestSuiteTIOVectorTest::TTestCaseShouldTrimVoidBuffers::Execute_(NUnitTest::TTestContext&) /-S/cloud/blockstore/libs/common/iovector_ut.cpp:199:9
    #3 0x9e76b6 in NCloud::NBlockStore::NTestSuiteTIOVectorTest::TCurrentTest::Execute()::'lambda'()::operator()() const /-S/cloud/blockstore/libs/common/iovector_ut.cpp:56:1
    #4 0xcad28d in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char> > const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:374:18
    #5 0x9e5fb9 in NCloud::NBlockStore::NTestSuiteTIOVectorTest::TCurrentTest::Execute() /-S/cloud/blockstore/libs/common/iovector_ut.cpp:56:1
    #6 0xcade88 in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:495:19
    #7 0xccc32c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:877:44
    #8 0x7f8ee7bad082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #9 0x9a2788 in _start (http://proxy.sandbox.yandex-team.ru/6411376263/cloud/blockstore/libs/common/ut/cloud-blockstore-libs-common-ut+0x9a2788) (BuildId: ae16c9996cfb017ed89d0a2c0219e93213c2d99f)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /place/sandbox-data/tasks/3/8/2357407883/__FUSE/mount_path_19fadc74-2bdf-4619-8912-39cad0885237/cloud/blockstore/libs/common/iovector.cpp:183:9 in

```