### PR TITLE
issue-1307: calling fuse_cancel_request instead of fuse_reply_err for cancelled AcquireLock requests

### DIFF
--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -22,6 +22,7 @@ public:
     ui64 RequestSize = 0;
     bool Unaligned = false;
 
+    int CancellationCode = 0;
     std::atomic<bool> Cancelled = false;
 
     explicit TCallContext(ui64 requestId = 0);

--- a/cloud/filestore/libs/vfs_fuse/fs.h
+++ b/cloud/filestore/libs/vfs_fuse/fs.h
@@ -131,6 +131,11 @@ int ReplyLock(
     const NCloud::NProto::TError& error,
     fuse_req_t req,
     const struct flock *lock);
+void CancelRequest(
+    TLog& log,
+    IRequestStats& requestStats,
+    TCallContext& callContext,
+    fuse_req_t req);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -219,4 +219,13 @@ void TFileSystem::ReplyAttr(
         Config->GetAttrTimeout().Seconds());
 }
 
+void TFileSystem::CancelRequest(TCallContextPtr callContext, fuse_req_t req)
+{
+    NFuse::CancelRequest(
+        Log,
+        *RequestStats,
+        *callContext,
+        req);
+}
+
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -419,6 +419,8 @@ private:
 
 #undef FILESYSTEM_REPLY_IMPL
 
+    void CancelRequest(TCallContextPtr callContext, fuse_req_t req);
+
     void HandleLock(
         TCallContextPtr callContext,
         fuse_req_t req,


### PR DESCRIPTION
#1307 