### PR TITLE
[nbs] fix client backup test

### DIFF
--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -513,7 +513,7 @@ def test_backup():
     run("backupvolume",
         "--disk-id", "volume-0",
         "--backup-disk-id", "volume-1",
-        "--checkpoint-id", "checkpoint-0",
+        "--checkpoint-id", "checkpoint-1",
         "--io-depth", "16",
         "--changed-blocks-count", str(CHANGED_BLOCKS_COUNT),
         "--verbose")


### PR DESCRIPTION
Fix test https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/9311158788/1/nebius-x86-64/summary/ya-test.html#FAIL. Change checkpoint name for second backup in this test because now one can not create checkpoint if checkpoint with the same id was deleted.