### PR TITLE
NBSNEBIUS-258: Support Zero Copy for RDMA Data Path on Disk Agent

### DIFF
--- a/cloud/blockstore/config/rdma.proto
+++ b/cloud/blockstore/config/rdma.proto
@@ -26,7 +26,7 @@ message TRdmaServer
     uint32 MaxInflightBytes = 7;           // per client
     uint64 AdaptiveWaitSleepDelay = 8;     // in microseconds
     uint64 AdaptiveWaitSleepDuration = 9;  // in microseconds
-    bool ZeroCopyEnabled = 10;
+    bool AlignedDataEnabled = 10;
 }
 
 message TRdmaClient
@@ -37,7 +37,7 @@ message TRdmaClient
     EWaitMode WaitMode = 4;
     uint64 AdaptiveWaitSleepDelay = 5;     // in microseconds
     uint64 AdaptiveWaitSleepDuration = 6;  // in microseconds
-    bool ZeroCopyEnabled = 7;
+    bool AlignedDataEnabled = 7;
 }
 
 message TRdmaTarget

--- a/cloud/blockstore/config/rdma.proto
+++ b/cloud/blockstore/config/rdma.proto
@@ -26,6 +26,7 @@ message TRdmaServer
     uint32 MaxInflightBytes = 7;           // per client
     uint64 AdaptiveWaitSleepDelay = 8;     // in microseconds
     uint64 AdaptiveWaitSleepDuration = 9;  // in microseconds
+    bool ZeroCopyEnabled = 10;
 }
 
 message TRdmaClient
@@ -36,6 +37,7 @@ message TRdmaClient
     EWaitMode WaitMode = 4;
     uint64 AdaptiveWaitSleepDelay = 5;     // in microseconds
     uint64 AdaptiveWaitSleepDuration = 6;  // in microseconds
+    bool ZeroCopyEnabled = 7;
 }
 
 message TRdmaTarget

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -110,6 +110,7 @@ public:
         return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ReadBlocksRequest,
+            0, // flags
             *Request,
             TContIOVector(nullptr, 0));
     }
@@ -211,6 +212,7 @@ public:
         return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::WriteBlocksRequest,
+            0, // flags
             *Request,
             TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
     }
@@ -284,6 +286,7 @@ public:
         return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ZeroBlocksRequest,
+            0, // flags
             *Request,
             TContIOVector(nullptr, 0));
     }

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -423,6 +423,7 @@ void TBootstrapBase::Init()
                     : FQDNHostName(),
                 Configs->ServerConfig->GetSocketAccessMode(),
                 Configs->ServerConfig->GetVhostServerTimeoutAfterParentExit(),
+                RdmaClient && RdmaClient->IsZeroCopyEnabled(),
                 std::move(vhostEndpointListener));
 
             STORAGE_INFO("VHOST External Vhost EndpointListener initialized");

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -423,7 +423,7 @@ void TBootstrapBase::Init()
                     : FQDNHostName(),
                 Configs->ServerConfig->GetSocketAccessMode(),
                 Configs->ServerConfig->GetVhostServerTimeoutAfterParentExit(),
-                RdmaClient && RdmaClient->IsZeroCopyEnabled(),
+                RdmaClient && RdmaClient->IsAlignedDataEnabled(),
                 std::move(vhostEndpointListener));
 
             STORAGE_INFO("VHOST External Vhost EndpointListener initialized");

--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
@@ -153,7 +153,9 @@ public:
             Now(),
             std::move(callContext),
             std::move(request),
-            BlockSize);
+            BlockSize,
+            {}   // no data buffer
+        );
     }
 
     TFuture<NProto::TWriteBlocksResponse> WriteBlocks(
@@ -169,7 +171,9 @@ public:
             Now(),
             std::move(callContext),
             std::move(request),
-            BlockSize);
+            BlockSize,
+            {}   // no data buffer
+        );
     }
 
     TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -208,6 +208,7 @@ NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
             size_t responseBytes = Serializer->Serialize(
                 out,
                 TBlockStoreProtocol::ReadBlocksResponse,
+                0, // flags
                 response,
                 TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
 
@@ -249,6 +250,7 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
             size_t responseBytes = Serializer->Serialize(
                 out,
                 TBlockStoreProtocol::WriteBlocksResponse,
+                0, // flags
                 response,
                 TContIOVector(nullptr, 0));
 
@@ -280,6 +282,7 @@ NProto::TError TRdmaEndpoint::HandleZeroBlocksRequest(
         size_t responseBytes = Serializer->Serialize(
             out,
             TBlockStoreProtocol::ZeroBlocksResponse,
+            0, // flags
             response,
             TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -699,7 +699,7 @@ private:
     const TExecutorPtr Executor;
     const TString LocalAgentId;
     const ui32 SocketAccessMode;
-    const bool IsZeroCopyEnabled;
+    const bool IsAlignedDataEnabled;
     const IEndpointListenerPtr FallbackListener;
     const TExternalEndpointFactory EndpointFactory;
     const TDuration VhostServerTimeoutAfterParentExit;
@@ -717,7 +717,7 @@ public:
             TString localAgentId,
             ui32 socketAccessMode,
             TDuration vhostServerTimeoutAfterParentExit,
-            bool isZeroCopyEnabled,
+            bool isAlignedDataEnabled,
             IEndpointListenerPtr fallbackListener,
             TExternalEndpointFactory endpointFactory)
         : Logging {std::move(logging)}
@@ -725,7 +725,7 @@ public:
         , Executor {std::move(executor)}
         , LocalAgentId {std::move(localAgentId)}
         , SocketAccessMode {socketAccessMode}
-        , IsZeroCopyEnabled(isZeroCopyEnabled)
+        , IsAlignedDataEnabled(isAlignedDataEnabled)
         , FallbackListener {std::move(fallbackListener)}
         , EndpointFactory {std::move(endpointFactory)}
         , VhostServerTimeoutAfterParentExit{vhostServerTimeoutAfterParentExit}
@@ -1015,8 +1015,8 @@ private:
             args.emplace_back("--block-size");
             args.emplace_back(ToString(volume.GetBlockSize()));
 
-            if (IsZeroCopyEnabled) {
-                args.emplace_back("--rdma-zero-copy");
+            if (IsAlignedDataEnabled) {
+                args.emplace_back("--rdma-aligned-data");
             }
         }
 
@@ -1168,7 +1168,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
-    bool isZeroCopyEnabled,
+    bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener)
 {
     auto defaultFactory = [=] (
@@ -1199,7 +1199,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(localAgentId),
         socketAccessMode,
         vhostServerTimeoutAfterParentExit,
-        isZeroCopyEnabled,
+        isAlignedDataEnabled,
         std::move(fallbackListener),
         std::move(defaultFactory));
 }
@@ -1211,7 +1211,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
-    bool isZeroCopyEnabled,
+    bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory)
 {
@@ -1222,7 +1222,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(localAgentId),
         socketAccessMode,
         vhostServerTimeoutAfterParentExit,
-        isZeroCopyEnabled,
+        isAlignedDataEnabled,
         std::move(fallbackListener),
         std::move(factory));
 }

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -699,6 +699,7 @@ private:
     const TExecutorPtr Executor;
     const TString LocalAgentId;
     const ui32 SocketAccessMode;
+    const bool IsZeroCopyEnabled;
     const IEndpointListenerPtr FallbackListener;
     const TExternalEndpointFactory EndpointFactory;
     const TDuration VhostServerTimeoutAfterParentExit;
@@ -716,6 +717,7 @@ public:
             TString localAgentId,
             ui32 socketAccessMode,
             TDuration vhostServerTimeoutAfterParentExit,
+            bool isZeroCopyEnabled,
             IEndpointListenerPtr fallbackListener,
             TExternalEndpointFactory endpointFactory)
         : Logging {std::move(logging)}
@@ -723,6 +725,7 @@ public:
         , Executor {std::move(executor)}
         , LocalAgentId {std::move(localAgentId)}
         , SocketAccessMode {socketAccessMode}
+        , IsZeroCopyEnabled(isZeroCopyEnabled)
         , FallbackListener {std::move(fallbackListener)}
         , EndpointFactory {std::move(endpointFactory)}
         , VhostServerTimeoutAfterParentExit{vhostServerTimeoutAfterParentExit}
@@ -1011,6 +1014,10 @@ private:
 
             args.emplace_back("--block-size");
             args.emplace_back(ToString(volume.GetBlockSize()));
+
+            if (IsZeroCopyEnabled) {
+                args.emplace_back("--rdma-zero-copy");
+            }
         }
 
         for (const auto& device: volume.GetDevices()) {
@@ -1161,6 +1168,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
+    bool isZeroCopyEnabled,
     IEndpointListenerPtr fallbackListener)
 {
     auto defaultFactory = [=] (
@@ -1191,6 +1199,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(localAgentId),
         socketAccessMode,
         vhostServerTimeoutAfterParentExit,
+        isZeroCopyEnabled,
         std::move(fallbackListener),
         std::move(defaultFactory));
 }
@@ -1202,6 +1211,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
+    bool isZeroCopyEnabled,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory)
 {
@@ -1212,6 +1222,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(localAgentId),
         socketAccessMode,
         vhostServerTimeoutAfterParentExit,
+        isZeroCopyEnabled,
         std::move(fallbackListener),
         std::move(factory));
 }

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -41,7 +41,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
-    bool isZeroCopyEnabled,
+    bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener);
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
@@ -51,7 +51,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
-    bool isZeroCopyEnabled,
+    bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory);
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -41,6 +41,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
+    bool isZeroCopyEnabled,
     IEndpointListenerPtr fallbackListener);
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
@@ -50,6 +51,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString localAgentId,
     ui32 socketAccessMode,
     TDuration vhostServerTimeoutAfterParentExit,
+    bool isZeroCopyEnabled,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory);
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -255,17 +255,24 @@ struct TFixture
 
     THistory History;
 
-    IEndpointListenerPtr Listener = CreateExternalVhostEndpointListener(
-        Logging,
-        ServerStats,
-        Executor,
-        LocalAgentId,
-        S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR,
-        TDuration::Seconds(30),
-        CreateFallbackListener(),
-        CreateExternalEndpointFactory());
+    IEndpointListenerPtr Listener =
+        CreateEndpointListener(false);   // no zero copy
 
 public:
+    IEndpointListenerPtr CreateEndpointListener(bool isZeroCopyEnabled)
+    {
+        return CreateExternalVhostEndpointListener(
+            Logging,
+            ServerStats,
+            Executor,
+            LocalAgentId,
+            S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR,
+            TDuration::Seconds(30),
+            isZeroCopyEnabled,
+            CreateFallbackListener(),
+            CreateExternalEndpointFactory());
+    }
+
     NProto::TStartEndpointRequest CreateDefaultStartEndpointRequest()
     {
         NProto::TStartEndpointRequest request;
@@ -364,6 +371,11 @@ TString GetArg(const TVector<TString>& args, TStringBuf name)
         return {};
     }
     return *std::next(it);
+}
+
+bool HasArg(const TVector<TString>& args, TStringBuf name)
+{
+    return Find(args, name) != args.end();
 }
 
 TVector<TString> GetArgN(const TVector<TString>& args, TStringBuf name)
@@ -564,6 +576,29 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
             UNIT_ASSERT_VALUES_EQUAL(1, History.size());
             auto* stop = std::get_if<TStopExternalEndpoint>(&History[0]);
             UNIT_ASSERT_C(stop, "actual entry: " << History[0].index());
+
+            History.clear();
+        }
+
+        {
+            auto zeroCopyListener = CreateEndpointListener(true);
+
+            auto request = CreateDefaultStartEndpointRequest();
+
+            auto error = zeroCopyListener->StartEndpoint(request, FastPathVolume, Session)
+                .GetValueSync();
+            UNIT_ASSERT_C(!HasError(error), error);
+
+            UNIT_ASSERT_VALUES_EQUAL(3, History.size());
+
+            auto* create = std::get_if<TCreateExternalEndpoint>(&History[0]);
+            UNIT_ASSERT_C(create, "actual entry: " << History[0].index());
+
+            UNIT_ASSERT_C(
+                HasArg(create->CmdArgs, "--rdma-zero-copy"),
+                "missing --rdma-zero-copy arg");
+
+            History.clear();
         }
     }
 

--- a/cloud/blockstore/libs/rdma/iface/client.cpp
+++ b/cloud/blockstore/libs/rdma/iface/client.cpp
@@ -42,6 +42,7 @@ TClientConfig::TClientConfig(const NProto::TRdmaClient& config)
     SET(PollerThreads);
     SET(AdaptiveWaitSleepDelay, TDuration::MicroSeconds);
     SET(AdaptiveWaitSleepDuration, TDuration::MicroSeconds);
+    SET(ZeroCopyEnabled);
 }
 
 #undef SET
@@ -65,6 +66,7 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(MaxResponseDelay, MaxResponseDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDelay, AdaptiveWaitSleepDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDuration, AdaptiveWaitSleepDuration.ToString());
+                ENTRY(ZeroCopyEnabled, ZeroCopyEnabled);
             }
         }
     }

--- a/cloud/blockstore/libs/rdma/iface/client.cpp
+++ b/cloud/blockstore/libs/rdma/iface/client.cpp
@@ -42,7 +42,7 @@ TClientConfig::TClientConfig(const NProto::TRdmaClient& config)
     SET(PollerThreads);
     SET(AdaptiveWaitSleepDelay, TDuration::MicroSeconds);
     SET(AdaptiveWaitSleepDuration, TDuration::MicroSeconds);
-    SET(ZeroCopyEnabled);
+    SET(AlignedDataEnabled);
 }
 
 #undef SET
@@ -66,7 +66,7 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(MaxResponseDelay, MaxResponseDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDelay, AdaptiveWaitSleepDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDuration, AdaptiveWaitSleepDuration.ToString());
-                ENTRY(ZeroCopyEnabled, ZeroCopyEnabled);
+                ENTRY(AlignedDataEnabled, AlignedDataEnabled);
             }
         }
     }

--- a/cloud/blockstore/libs/rdma/iface/client.h
+++ b/cloud/blockstore/libs/rdma/iface/client.h
@@ -29,6 +29,7 @@ struct TClientConfig
     TDuration MaxResponseDelay = TDuration::Seconds(60);
     TDuration AdaptiveWaitSleepDelay = TDuration::MilliSeconds(10);
     TDuration AdaptiveWaitSleepDuration = TDuration::MicroSeconds(100);
+    bool ZeroCopyEnabled = false;
 
     TClientConfig() = default;
 
@@ -113,6 +114,8 @@ struct IClient
         ui32 port) = 0;
 
     virtual void DumpHtml(IOutputStream& out) const = 0;
+
+    virtual bool IsZeroCopyEnabled() const = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/client.h
+++ b/cloud/blockstore/libs/rdma/iface/client.h
@@ -29,7 +29,7 @@ struct TClientConfig
     TDuration MaxResponseDelay = TDuration::Seconds(60);
     TDuration AdaptiveWaitSleepDelay = TDuration::MilliSeconds(10);
     TDuration AdaptiveWaitSleepDuration = TDuration::MicroSeconds(100);
-    bool ZeroCopyEnabled = false;
+    bool AlignedDataEnabled = false;
 
     TClientConfig() = default;
 
@@ -115,7 +115,7 @@ struct IClient
 
     virtual void DumpHtml(IOutputStream& out) const = 0;
 
-    virtual bool IsZeroCopyEnabled() const = 0;
+    virtual bool IsAlignedDataEnabled() const = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -64,7 +64,7 @@ size_t TProtoMessageSerializer::Serialize(
     char* ptr = const_cast<char*>(buffer.data());
     ptr += Serialize(buffer, msgId, flags, proto, dataLen);
 
-    if (flags & RDMA_PROTO_FLAG_RDATA) {
+    if (flags & RDMA_PROTO_FLAG_DATA_AT_THE_END) {
         ptr = const_cast<char*>(buffer.data()) + buffer.length() - dataLen;
     }
 
@@ -140,8 +140,9 @@ TProtoMessageSerializer::Parse(TStringBuf buffer) const
     Y_ENSURE_RETURN(succeeded, "could not parse protobuf message");
     ptr += header.ProtoLen;
 
-    if (header.Flags & RDMA_PROTO_FLAG_RDATA) {
-        ptr = const_cast<char*>(buffer.data()) + buffer.length() - header.DataLen;
+    if (header.Flags & RDMA_PROTO_FLAG_DATA_AT_THE_END) {
+        ptr =
+            const_cast<char*>(buffer.data()) + buffer.length() - header.DataLen;
     }
 
     auto data = TStringBuf(ptr, header.DataLen);

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -56,13 +56,38 @@ size_t TProtoMessageSerializer::MessageByteSize(
 size_t TProtoMessageSerializer::Serialize(
     TStringBuf buffer,
     ui32 msgId,
+    ui32 flags,
     const TProtoMessage& proto,
     TContIOVector data)
+{
+    size_t dataLen = data.Bytes();
+    char* ptr = const_cast<char*>(buffer.data());
+    ptr += Serialize(buffer, msgId, flags, proto, dataLen);
+
+    if (flags & RDMA_PROTO_FLAG_RDATA) {
+        ptr = const_cast<char*>(buffer.data()) + buffer.length() - dataLen;
+    }
+
+    for (size_t i = 0; i < data.Count(); ++i) {
+        const auto& part = data.Parts()[i];
+        memcpy(ptr, part.buf, part.len);
+        ptr += part.len;
+    }
+
+    return ptr - buffer.data();
+}
+
+// static
+size_t TProtoMessageSerializer::Serialize(
+    TStringBuf buffer,
+    ui32 msgId,
+    ui32 flags,
+    const TProtoMessage& proto,
+    size_t dataLen)
 {
     size_t protoLen = proto.ByteSizeLong();
     Y_ENSURE(protoLen < RDMA_MAX_PROTO_LEN, "protobuf message is too big");
 
-    size_t dataLen = data.Bytes();
     Y_ENSURE(dataLen < RDMA_MAX_DATA_LEN, "attached data is too big");
 
     size_t totalLen = NRdma::MessageByteSize(protoLen, dataLen);
@@ -73,6 +98,7 @@ size_t TProtoMessageSerializer::Serialize(
 
     TProtoHeader header = {
         .MsgId = msgId,
+        .Flags = flags,
         .ProtoLen = (ui32)protoLen,
         .DataLen = (ui32)dataLen,
     };
@@ -84,12 +110,6 @@ size_t TProtoMessageSerializer::Serialize(
     bool succeeded = proto.SerializeToArray(ptr, protoLen);
     Y_ENSURE(succeeded, "could not serialize protobuf message");
     ptr += protoLen;
-
-    for (size_t i = 0; i < data.Count(); ++i) {
-        const auto& part = data.Parts()[i];
-        memcpy(ptr, part.buf, part.len);
-        ptr += part.len;
-    }
 
     return ptr - buffer.data();
 }
@@ -120,10 +140,14 @@ TProtoMessageSerializer::Parse(TStringBuf buffer) const
     Y_ENSURE_RETURN(succeeded, "could not parse protobuf message");
     ptr += header.ProtoLen;
 
+    if (header.Flags & RDMA_PROTO_FLAG_RDATA) {
+        ptr = const_cast<char*>(buffer.data()) + buffer.length() - header.DataLen;
+    }
+
     auto data = TStringBuf(ptr, header.DataLen);
     ptr += header.DataLen;
 
-    return TParseResult { header.MsgId, std::move(proto), data };
+    return TParseResult { header.MsgId, header.Flags, std::move(proto), data };
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -3,6 +3,7 @@
 #include "protocol.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 
 #include <google/protobuf/message.h>
 
@@ -64,7 +65,7 @@ size_t TProtoMessageSerializer::Serialize(
     char* ptr = const_cast<char*>(buffer.data());
     ptr += Serialize(buffer, msgId, flags, proto, dataLen);
 
-    if (flags & RDMA_PROTO_FLAG_DATA_AT_THE_END) {
+    if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
         ptr = const_cast<char*>(buffer.data()) + buffer.length() - dataLen;
     }
 
@@ -140,7 +141,7 @@ TProtoMessageSerializer::Parse(TStringBuf buffer) const
     Y_ENSURE_RETURN(succeeded, "could not parse protobuf message");
     ptr += header.ProtoLen;
 
-    if (header.Flags & RDMA_PROTO_FLAG_DATA_AT_THE_END) {
+    if (HasProtoFlag(header.Flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
         ptr =
             const_cast<char*>(buffer.data()) + buffer.length() - header.DataLen;
     }

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -56,12 +56,21 @@ public:
     static size_t Serialize(
         TStringBuf buffer,
         ui32 msgId,
+        ui32 flags,
         const TProtoMessage& proto,
         TContIOVector data);
+
+    static size_t Serialize(
+        TStringBuf buffer,
+        ui32 msgId,
+        ui32 flags,
+        const TProtoMessage& proto,
+        size_t dataLen);
 
     struct TParseResult
     {
         ui32 MsgId;
+        ui32 Flags;
         TProtoMessagePtr Proto;
         TStringBuf Data;
     };

--- a/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
@@ -54,8 +54,11 @@ Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
         IOutputStream::TPart part(data.data(), data.length());
 
         size_t msgByteSize = serializer->MessageByteSize(proto, data.length());
-        TVector testedFlags{0U, RDMA_PROTO_FLAG_RDATA};
-        TVector testedBufferSizes{msgByteSize, msgByteSize + 1024, msgByteSize + 4096};
+        TVector testedFlags{0U, RDMA_PROTO_FLAG_DATA_AT_THE_END};
+        TVector testedBufferSizes{
+            msgByteSize,
+            msgByteSize + 1024,
+            msgByteSize + 4096};
 
         for (auto bufferSize : testedBufferSizes) {
             for (auto flags : testedFlags) {
@@ -68,7 +71,7 @@ Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
                     proto,
                     TContIOVector(&part, 1));
 
-                if (flags & RDMA_PROTO_FLAG_RDATA) {
+                if (flags & RDMA_PROTO_FLAG_DATA_AT_THE_END) {
                     UNIT_ASSERT_EQUAL(serializedBytes, bufferSize);
                 } else {
                     UNIT_ASSERT_EQUAL(serializedBytes, msgByteSize);

--- a/cloud/blockstore/libs/rdma/iface/protocol.h
+++ b/cloud/blockstore/libs/rdma/iface/protocol.h
@@ -38,6 +38,28 @@ enum {
     RDMA_PROTO_FAIL             = 4,
 };
 
+enum {
+    // encode data at the end of the buffer like this:
+    //
+    //              buffer
+    // |--------------+-------+--------+------|
+    // | TProtoHeader | Proto | unused | Data |
+    // |--------------+-------+--------+------|
+    //
+    // instead of:
+    //              buffer
+    // |--------------+-------+------+--------|
+    // | TProtoHeader | Proto | Data | unused |
+    // |--------------+-------+------+--------|
+    //
+    //
+    // If buffer allocated in chunks of 4k
+    // and data is allocated in multiple of block size (512, 4k)
+    // then data address is also aligned to (512, 4k)
+    RDMA_PROTO_FLAG_RDATA  = 1 << 0,
+};
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Y_PACKED TMessageHeader
@@ -122,9 +144,9 @@ static_assert(sizeof(TRejectMessage) == RDMA_PRIVATE_SIZE);
 
 struct Y_PACKED TBufferDesc
 {
-    ui64 Address;
-    ui32 Length;
-    ui32 Key;
+    ui64 Address = 0;
+    ui32 Length = 0;
+    ui32 Key = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -166,7 +188,8 @@ static_assert(sizeof(TResponseMessage) == RDMA_RESPONSE_SIZE);
 
 struct Y_PACKED TProtoHeader
 {
-    ui32 MsgId : 16;
+    ui32 MsgId : 8;
+    ui32 Flags : 8;
     ui32 ProtoLen : 16;
     ui32 DataLen;
 };

--- a/cloud/blockstore/libs/rdma/iface/protocol.h
+++ b/cloud/blockstore/libs/rdma/iface/protocol.h
@@ -39,6 +39,7 @@ enum {
 };
 
 enum {
+    RDMA_PROTO_FLAG_NONE = 0,
     // encode data at the end of the buffer like this:
     //
     //              buffer
@@ -53,12 +54,11 @@ enum {
     // |--------------+-------+------+--------|
     //
     //
-    // If buffer allocated in chunks of 4k
+    // If buffer is allocated in chunks of 4k
     // and data is allocated in multiple of block size (512, 4k)
     // then data address is also aligned to (512, 4k)
-    RDMA_PROTO_FLAG_DATA_AT_THE_END  = 1 << 0,
+    RDMA_PROTO_FLAG_DATA_AT_THE_END = 1,
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/rdma/iface/protocol.h
+++ b/cloud/blockstore/libs/rdma/iface/protocol.h
@@ -56,7 +56,7 @@ enum {
     // If buffer allocated in chunks of 4k
     // and data is allocated in multiple of block size (512, 4k)
     // then data address is also aligned to (512, 4k)
-    RDMA_PROTO_FLAG_RDATA  = 1 << 0,
+    RDMA_PROTO_FLAG_DATA_AT_THE_END  = 1 << 0,
 };
 
 

--- a/cloud/blockstore/libs/rdma/iface/server.cpp
+++ b/cloud/blockstore/libs/rdma/iface/server.cpp
@@ -45,7 +45,6 @@ TServerConfig::TServerConfig(const NProto::TRdmaServer& config)
     SET(MaxInflightBytes);
     SET(AdaptiveWaitSleepDelay, TDuration::MicroSeconds);
     SET(AdaptiveWaitSleepDuration, TDuration::MicroSeconds);
-    SET(AlignedDataEnabled);
 }
 
 #undef SET
@@ -69,7 +68,7 @@ void TServerConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(MaxInflightBytes, MaxInflightBytes);
                 ENTRY(AdaptiveWaitSleepDelay, AdaptiveWaitSleepDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDuration, AdaptiveWaitSleepDuration.ToString());
-                ENTRY(AlignedDataEnabled, AlignedDataEnabled);
+                ENTRY(AlignedDataEnabled, true);
             }
         }
     }

--- a/cloud/blockstore/libs/rdma/iface/server.cpp
+++ b/cloud/blockstore/libs/rdma/iface/server.cpp
@@ -45,7 +45,7 @@ TServerConfig::TServerConfig(const NProto::TRdmaServer& config)
     SET(MaxInflightBytes);
     SET(AdaptiveWaitSleepDelay, TDuration::MicroSeconds);
     SET(AdaptiveWaitSleepDuration, TDuration::MicroSeconds);
-    SET(ZeroCopyEnabled);
+    SET(AlignedDataEnabled);
 }
 
 #undef SET
@@ -69,7 +69,7 @@ void TServerConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(MaxInflightBytes, MaxInflightBytes);
                 ENTRY(AdaptiveWaitSleepDelay, AdaptiveWaitSleepDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDuration, AdaptiveWaitSleepDuration.ToString());
-                ENTRY(ZeroCopyEnabled, ZeroCopyEnabled);
+                ENTRY(AlignedDataEnabled, AlignedDataEnabled);
             }
         }
     }

--- a/cloud/blockstore/libs/rdma/iface/server.cpp
+++ b/cloud/blockstore/libs/rdma/iface/server.cpp
@@ -45,6 +45,7 @@ TServerConfig::TServerConfig(const NProto::TRdmaServer& config)
     SET(MaxInflightBytes);
     SET(AdaptiveWaitSleepDelay, TDuration::MicroSeconds);
     SET(AdaptiveWaitSleepDuration, TDuration::MicroSeconds);
+    SET(ZeroCopyEnabled);
 }
 
 #undef SET
@@ -68,6 +69,7 @@ void TServerConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(MaxInflightBytes, MaxInflightBytes);
                 ENTRY(AdaptiveWaitSleepDelay, AdaptiveWaitSleepDelay.ToString());
                 ENTRY(AdaptiveWaitSleepDuration, AdaptiveWaitSleepDuration.ToString());
+                ENTRY(ZeroCopyEnabled, ZeroCopyEnabled);
             }
         }
     }

--- a/cloud/blockstore/libs/rdma/iface/server.h
+++ b/cloud/blockstore/libs/rdma/iface/server.h
@@ -28,7 +28,6 @@ struct TServerConfig
     ui64 MaxInflightBytes = Max<ui64>();
     TDuration AdaptiveWaitSleepDelay = TDuration::MilliSeconds(10);
     TDuration AdaptiveWaitSleepDuration = TDuration::MicroSeconds(100);
-    bool AlignedDataEnabled = false;
 
     TServerConfig() = default;
 
@@ -73,8 +72,6 @@ struct IServer
         IServerHandlerPtr handler) = 0;
 
     virtual void DumpHtml(IOutputStream& out) const = 0;
-
-    virtual bool IsAlignedDataEnabled() const = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/server.h
+++ b/cloud/blockstore/libs/rdma/iface/server.h
@@ -28,6 +28,7 @@ struct TServerConfig
     ui64 MaxInflightBytes = Max<ui64>();
     TDuration AdaptiveWaitSleepDelay = TDuration::MilliSeconds(10);
     TDuration AdaptiveWaitSleepDuration = TDuration::MicroSeconds(100);
+    bool ZeroCopyEnabled = false;
 
     TServerConfig() = default;
 
@@ -72,6 +73,8 @@ struct IServer
         IServerHandlerPtr handler) = 0;
 
     virtual void DumpHtml(IOutputStream& out) const = 0;
+
+    virtual bool IsZeroCopyEnabled() const = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/server.h
+++ b/cloud/blockstore/libs/rdma/iface/server.h
@@ -28,7 +28,7 @@ struct TServerConfig
     ui64 MaxInflightBytes = Max<ui64>();
     TDuration AdaptiveWaitSleepDelay = TDuration::MilliSeconds(10);
     TDuration AdaptiveWaitSleepDuration = TDuration::MicroSeconds(100);
-    bool ZeroCopyEnabled = false;
+    bool AlignedDataEnabled = false;
 
     TServerConfig() = default;
 
@@ -74,7 +74,7 @@ struct IServer
 
     virtual void DumpHtml(IOutputStream& out) const = 0;
 
-    virtual bool IsZeroCopyEnabled() const = 0;
+    virtual bool IsAlignedDataEnabled() const = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -1583,7 +1583,7 @@ public:
         TString host,
         ui32 port) noexcept override;
     void DumpHtml(IOutputStream& out) const override;
-    bool IsZeroCopyEnabled() const override;
+    bool IsAlignedDataEnabled() const override;
 
 private:
     // called from external thread
@@ -2070,9 +2070,9 @@ void TClient::DumpHtml(IOutputStream& out) const
     }
 }
 
-bool TClient::IsZeroCopyEnabled() const
+bool TClient::IsAlignedDataEnabled() const
 {
-    return Config->ZeroCopyEnabled;
+    return Config->AlignedDataEnabled;
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -737,11 +737,11 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
 
     req->RequestBuffer = TStringBuf {
         reinterpret_cast<char*>(req->InBuffer.Address),
-        requestBytes,
+        req->InBuffer.Length,
     };
     req->ResponseBuffer = TStringBuf {
         reinterpret_cast<char*>(req->OutBuffer.Address),
-        responseBytes,
+        req->OutBuffer.Length,
     };
 
     return TClientRequestPtr(std::move(req));
@@ -1583,6 +1583,7 @@ public:
         TString host,
         ui32 port) noexcept override;
     void DumpHtml(IOutputStream& out) const override;
+    bool IsZeroCopyEnabled() const override;
 
 private:
     // called from external thread
@@ -2067,6 +2068,11 @@ void TClient::DumpHtml(IOutputStream& out) const
             }
         }
     }
+}
+
+bool TClient::IsZeroCopyEnabled() const
+{
+    return Config->ZeroCopyEnabled;
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -1444,6 +1444,7 @@ public:
         ui32 port,
         IServerHandlerPtr handler) override;
     void DumpHtml(IOutputStream& out) const override;
+    bool IsZeroCopyEnabled() const override;
 
 private:
     // called from external thread
@@ -1675,6 +1676,11 @@ void TServer::DumpHtml(IOutputStream& out) const
             }
         }
     }
+}
+
+bool TServer::IsZeroCopyEnabled() const
+{
+    return Config->ZeroCopyEnabled;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -1444,7 +1444,6 @@ public:
         ui32 port,
         IServerHandlerPtr handler) override;
     void DumpHtml(IOutputStream& out) const override;
-    bool IsAlignedDataEnabled() const override;
 
 private:
     // called from external thread
@@ -1676,11 +1675,6 @@ void TServer::DumpHtml(IOutputStream& out) const
             }
         }
     }
-}
-
-bool TServer::IsAlignedDataEnabled() const
-{
-    return Config->AlignedDataEnabled;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -1444,7 +1444,7 @@ public:
         ui32 port,
         IServerHandlerPtr handler) override;
     void DumpHtml(IOutputStream& out) const override;
-    bool IsZeroCopyEnabled() const override;
+    bool IsAlignedDataEnabled() const override;
 
 private:
     // called from external thread
@@ -1678,9 +1678,9 @@ void TServer::DumpHtml(IOutputStream& out) const
     }
 }
 
-bool TServer::IsZeroCopyEnabled() const
+bool TServer::IsAlignedDataEnabled() const
 {
-    return Config->ZeroCopyEnabled;
+    return Config->AlignedDataEnabled;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -131,6 +131,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                 responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ReadDeviceBlocksResponse,
+                    0, // flags
                     response,
                     TContIOVector(
                         (IOutputStream::TPart*)sglist.begin(),
@@ -168,6 +169,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                 responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::WriteDeviceBlocksResponse,
+                    0, // flags
                     response,
                     TContIOVector(nullptr, 0));
 
@@ -198,6 +200,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                 responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ZeroDeviceBlocksResponse,
+                    0, // flags
                     response,
                     TContIOVector(nullptr, 0));
 
@@ -231,6 +234,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                 responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
+                    0, // flags
                     response,
                     TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/libs/rdma_test/client_test.h
+++ b/cloud/blockstore/libs/rdma_test/client_test.h
@@ -46,7 +46,7 @@ struct TRdmaClientTest: NRdma::IClient
         Y_UNUSED(out);
     }
 
-    bool IsZeroCopyEnabled() const override
+    bool IsAlignedDataEnabled() const override
     {
         return false;
     }

--- a/cloud/blockstore/libs/rdma_test/client_test.h
+++ b/cloud/blockstore/libs/rdma_test/client_test.h
@@ -46,6 +46,11 @@ struct TRdmaClientTest: NRdma::IClient
         Y_UNUSED(out);
     }
 
+    bool IsZeroCopyEnabled() const override
+    {
+        return false;
+    }
+
     void InjectErrors(
         NProto::TError allocationError,
         NProto::TError rdmaResponseError,

--- a/cloud/blockstore/libs/rdma_test/server_test_async.cpp
+++ b/cloud/blockstore/libs/rdma_test/server_test_async.cpp
@@ -141,6 +141,7 @@ public:
         const size_t serializedSize = Serializer->Serialize(
             wrapper->Serialized,
             messageType,
+            0, // flags
             request,
             ioVector);
         UNIT_ASSERT(expectedSerializedSize >= serializedSize);

--- a/cloud/blockstore/libs/rdma_test/server_test_async.h
+++ b/cloud/blockstore/libs/rdma_test/server_test_async.h
@@ -35,7 +35,7 @@ public:
         Y_UNUSED(out);
     }
 
-    bool IsZeroCopyEnabled() const override
+    bool IsAlignedDataEnabled() const override
     {
         return false;
     }

--- a/cloud/blockstore/libs/rdma_test/server_test_async.h
+++ b/cloud/blockstore/libs/rdma_test/server_test_async.h
@@ -35,6 +35,11 @@ public:
         Y_UNUSED(out);
     }
 
+    bool IsZeroCopyEnabled() const override
+    {
+        return false;
+    }
+
     NThreading::TFuture<NProto::TWriteDeviceBlocksResponse> Run(
         TString host,
         ui32 port,

--- a/cloud/blockstore/libs/rdma_test/server_test_async.h
+++ b/cloud/blockstore/libs/rdma_test/server_test_async.h
@@ -35,11 +35,6 @@ public:
         Y_UNUSED(out);
     }
 
-    bool IsAlignedDataEnabled() const override
-    {
-        return false;
-    }
-
     NThreading::TFuture<NProto::TWriteDeviceBlocksResponse> Run(
         TString host,
         ui32 port,

--- a/cloud/blockstore/libs/service/storage.cpp
+++ b/cloud/blockstore/libs/service/storage.cpp
@@ -339,6 +339,7 @@ TFuture<NProto::TReadBlocksResponse> TStorageAdapter::TImpl::ReadBlocks(
          promise,
          response = std::move(response),
          buffer = std::move(buffer),
+         dataBuffer,
          guardedSgList = std::move(guardedSgList),
          requestBlocksCount = request->GetBlocksCount(),
          requestBlockSize,
@@ -376,8 +377,9 @@ TFuture<NProto::TReadBlocksResponse> TStorageAdapter::TImpl::ReadBlocks(
                     Y_ABORT_UNLESS(bytesCopied == bytesCount);
                 }
             } else {
-                if (optimizeNetworkTransfer ==
-                    NProto::EOptimizeNetworkTransfer::SKIP_VOID_BLOCKS)
+                if (!dataBuffer.size() &&
+                    optimizeNetworkTransfer ==
+                        NProto::EOptimizeNetworkTransfer::SKIP_VOID_BLOCKS)
                 {
                     // If we read the data directly to the final destination,
                     // then we clean out the void buffers where the data

--- a/cloud/blockstore/libs/service/storage.cpp
+++ b/cloud/blockstore/libs/service/storage.cpp
@@ -288,7 +288,7 @@ TFuture<NProto::TReadBlocksResponse> TStorageAdapter::TImpl::ReadBlocks(
     TSgList sgList;
     TStorageBuffer buffer;
 
-    if (dataBuffer.size()) {
+    if (dataBuffer) {
         sgList = {{dataBuffer.data(), dataBuffer.size()}};
     } else {
         // We are trying to allocate memory for request using Storage. If the memory
@@ -308,7 +308,7 @@ TFuture<NProto::TReadBlocksResponse> TStorageAdapter::TImpl::ReadBlocks(
     }
 
     if (Normalize) {
-        if (dataBuffer.size() || buffer || requestBlockSize != StorageBlockSize) {
+        if (dataBuffer || buffer || requestBlockSize != StorageBlockSize) {
             // not normalized yet
             auto sgListOrError =
                 SgListNormalize(std::move(sgList), StorageBlockSize);
@@ -377,7 +377,7 @@ TFuture<NProto::TReadBlocksResponse> TStorageAdapter::TImpl::ReadBlocks(
                     Y_ABORT_UNLESS(bytesCopied == bytesCount);
                 }
             } else {
-                if (!dataBuffer.size() &&
+                if (dataBuffer.empty() &&
                     optimizeNetworkTransfer ==
                         NProto::EOptimizeNetworkTransfer::SKIP_VOID_BLOCKS)
                 {
@@ -405,7 +405,7 @@ TFuture<NProto::TWriteBlocksResponse> TStorageAdapter::TImpl::WriteBlocks(
     VerifyBlockSize(requestBlockSize);
 
     ui32 bytesCount = 0;
-    if (dataBuffer.size()) {
+    if (dataBuffer) {
         bytesCount = VerifyRequestSize(dataBuffer.size());
     } else {
         bytesCount = VerifyRequestSize(request->GetBlocks());
@@ -428,7 +428,7 @@ TFuture<NProto::TWriteBlocksResponse> TStorageAdapter::TImpl::WriteBlocks(
     TStorageBuffer buffer;
     TSgList sgList;
 
-    if (dataBuffer.size()) {
+    if (dataBuffer) {
         sgList = TSgList{{dataBuffer.data(), dataBuffer.size()}};
     } else {
         sgList = GetSgList(*request);

--- a/cloud/blockstore/libs/service/storage.h
+++ b/cloud/blockstore/libs/service/storage.h
@@ -67,13 +67,15 @@ public:
         TInstant now,
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadBlocksRequest> request,
-        ui32 requestBlockSize) const;
+        ui32 requestBlockSize,
+        TStringBuf dataBuffer) const;
 
     NThreading::TFuture<NProto::TWriteBlocksResponse> WriteBlocks(
         TInstant now,
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TWriteBlocksRequest> request,
-        ui32 requestBlockSize) const;
+        ui32 requestBlockSize,
+        TStringBuf dataBuffer) const;
 
     NThreading::TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
         TInstant now,

--- a/cloud/blockstore/libs/service/storage.h
+++ b/cloud/blockstore/libs/service/storage.h
@@ -68,14 +68,20 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadBlocksRequest> request,
         ui32 requestBlockSize,
-        TStringBuf dataBuffer) const;
+        TStringBuf dataBuffer   // if non empty,
+                                // response data is written into the buffer
+                                // instead of TReadBlocksResponse
+    ) const;
 
     NThreading::TFuture<NProto::TWriteBlocksResponse> WriteBlocks(
         TInstant now,
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TWriteBlocksRequest> request,
         ui32 requestBlockSize,
-        TStringBuf dataBuffer) const;
+        TStringBuf dataBuffer   // if non empty,
+                                // data is read from the buffer
+                                // instead of TWriteBlocksRequest
+    ) const;
 
     NThreading::TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
         TInstant now,

--- a/cloud/blockstore/libs/service/storage_ut.cpp
+++ b/cloud/blockstore/libs/service/storage_ut.cpp
@@ -84,15 +84,15 @@ Y_UNIT_TEST_SUITE(TStorageTest)
         TString data;
         TStringBuf dataBuffer;
 
-        if (!useDataBuffer) {
+        if (useDataBuffer) {
+            data = TString(1_MB, 'X');
+            dataBuffer = TStringBuf(data);
+        } else {
             auto& iov = *request->MutableBlocks();
             auto& buffers = *iov.MutableBuffers();
             auto& buffer = *buffers.Add();
             buffer.ReserveAndResize(1_MB);
             memset(const_cast<char*>(buffer.data()), 'X', buffer.size());
-        } else {
-            data = TString(1_MB, 'X');
-            dataBuffer = TStringBuf(data);
         }
 
         auto future = adapter->WriteBlocks(

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -670,7 +670,9 @@ TFuture<NProto::TReadBlocksResponse> TLocalService::ReadBlocks(
             Now(),
             std::move(ctx),
             std::move(request),
-            volume->Volume.GetBlockSize());
+            volume->Volume.GetBlockSize(),
+            {} // no data buffer
+        );
     });
 }
 
@@ -727,7 +729,9 @@ TFuture<NProto::TWriteBlocksResponse> TLocalService::WriteBlocks(
             Now(),
             std::move(ctx),
             std::move(request),
-            volume->Volume.GetBlockSize());
+            volume->Volume.GetBlockSize(),
+            {} // no data buffer
+        );
     });
 }
 

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -90,7 +90,7 @@ public:
         return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
-            isZeroCopyEnabled ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
+            isZeroCopyEnabled ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END : 0,
             Proto,
             TContIOVector(nullptr, 0));
     }
@@ -202,7 +202,7 @@ public:
         return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            isZeroCopyEnabled ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
+            isZeroCopyEnabled ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END : 0,
             Proto,
             TContIOVector((IOutputStream::TPart*)sglist.data(), sglist.size()));
     }

--- a/cloud/blockstore/libs/service_local/storage_rdma_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma_ut.cpp
@@ -68,6 +68,11 @@ public:
     {
         Y_UNUSED(out);
     }
+
+    bool IsZeroCopyEnabled() const override
+    {
+        return false;
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/service_local/storage_rdma_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma_ut.cpp
@@ -69,7 +69,7 @@ public:
         Y_UNUSED(out);
     }
 
-    bool IsZeroCopyEnabled() const override
+    bool IsAlignedDataEnabled() const override
     {
         return false;
     }

--- a/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
@@ -670,7 +670,9 @@ Y_UNIT_TEST_SUITE(TSpdkStorageTest)
                 Now(),
                 MakeIntrusive<TCallContext>(),
                 std::move(request),
-                blockSize);
+                blockSize,
+                {}   // no data buffer
+            );
 
             const auto& response = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT(!HasError(response));
@@ -685,7 +687,9 @@ Y_UNIT_TEST_SUITE(TSpdkStorageTest)
                 Now(),
                 MakeIntrusive<TCallContext>(),
                 std::move(request),
-                blockSize);
+                blockSize,
+                {}   // no data buffer
+            );
 
             const auto& response = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT(!HasError(response));

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -613,7 +613,8 @@ TFuture<NProto::TWriteDeviceBlocksResponse> TDiskAgentState::Write(
         MakeIntrusive<TCallContext>(),
         std::move(writeRequest),
         request.GetBlockSize(),
-        {});
+        {} // no data buffer
+    );
 
     return result.Apply(
         [] (const auto& future) {

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -547,7 +547,9 @@ TFuture<NProto::TReadDeviceBlocksResponse> TDiskAgentState::Read(
         now,
         MakeIntrusive<TCallContext>(),
         std::move(readRequest),
-        request.GetBlockSize());
+        request.GetBlockSize(),
+        {} // no data buffer
+    );
 
     return result.Apply(
         [] (auto future) {
@@ -610,7 +612,8 @@ TFuture<NProto::TWriteDeviceBlocksResponse> TDiskAgentState::Write(
         now,
         MakeIntrusive<TCallContext>(),
         std::move(writeRequest),
-        request.GetBlockSize());
+        request.GetBlockSize(),
+        {});
 
     return result.Apply(
         [] (const auto& future) {
@@ -727,7 +730,9 @@ TFuture<NProto::TChecksumDeviceBlocksResponse> TDiskAgentState::Checksum(
         now,
         MakeIntrusive<TCallContext>(),
         std::move(readRequest),
-        request.GetBlockSize());
+        request.GetBlockSize(),
+        {} // no data buffer
+    );
 
     return result.Apply(
         [] (auto future) {

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -251,9 +251,12 @@ private:
 
         const auto& request = resultOrError.GetResult();
 
-        bool isZeroCopyDataSupported = request.Flags & NRdma::RDMA_PROTO_FLAG_RDATA;
-        if (Y_UNLIKELY(isZeroCopyDataSupported && !ZeroCopyEnabled)) {
-            return MakeError(E_NOT_IMPLEMENTED, "Zero copy is disabled on disk agent");
+        const bool isZeroCopyDataSupported =
+            request.Flags & NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END;
+        if (isZeroCopyDataSupported && !ZeroCopyEnabled) {
+            return MakeError(
+                E_NOT_IMPLEMENTED,
+                "Zero copy is disabled on disk agent");
         }
 
         switch (request.MsgId) {
@@ -601,7 +604,7 @@ private:
             NRdma::TProtoMessageSerializer::Serialize(
                 requestDetails.Out,
                 TBlockStoreProtocol::ReadDeviceBlocksResponse,
-                NRdma::RDMA_PROTO_FLAG_RDATA,
+                NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END,
                 proto,
                 requestDetails.DataBuffer.size());
             bytes = requestDetails.Out.size();

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -145,7 +145,7 @@ private:
         TBlockStoreProtocol::Serializer();
 
     const bool RejectLateRequestsAtDiskAgentEnabled;
-    const bool ZeroCopyEnabled;
+    const bool AlignedDataEnabled;
 
 public:
     TRequestHandler(
@@ -153,13 +153,13 @@ public:
             ITaskQueuePtr taskQueue,
             TDeviceClientPtr deviceClient,
             TRdmaTargetConfig rdmaTargetConfig,
-            bool zeroCopyEnabled)
+            bool alignedDataEnabled)
         : Devices(MakeDevices(std::move(devices), rdmaTargetConfig))
         , TaskQueue(std::move(taskQueue))
         , DeviceClient(std::move(deviceClient))
         , RejectLateRequestsAtDiskAgentEnabled(
               rdmaTargetConfig.RejectLateRequestsAtDiskAgentEnabled)
-        , ZeroCopyEnabled(zeroCopyEnabled)
+        , AlignedDataEnabled(alignedDataEnabled)
     {}
 
     void Init(NRdma::IServerEndpointPtr endpoint, TLog log)
@@ -253,7 +253,7 @@ private:
 
         const bool isZeroCopyDataSupported =
             request.Flags & NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END;
-        if (isZeroCopyDataSupported && !ZeroCopyEnabled) {
+        if (isZeroCopyDataSupported && !AlignedDataEnabled) {
             return MakeError(
                 E_NOT_IMPLEMENTED,
                 "Zero copy is disabled on disk agent");
@@ -997,7 +997,7 @@ public:
             std::move(taskQueue),
             std::move(deviceClient),
             std::move(rdmaTargetConfig),
-            Server->IsZeroCopyEnabled());
+            Server->IsAlignedDataEnabled());
     }
 
     void Start() override

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -280,12 +280,15 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
             return err;
         }
 
+        ui32 flags = 0;
+        if (RdmaClient->IsAlignedDataEnabled()) {
+            SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
+        }
+
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
-            RdmaClient->IsAlignedDataEnabled()
-                ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
-                : 0,
+            flags,
             deviceRequest,
             TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -283,7 +283,7 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
-            RdmaClient->IsZeroCopyEnabled()
+            RdmaClient->IsAlignedDataEnabled()
                 ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
                 : 0,
             deviceRequest,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/rdma/iface/protobuf.h>
+#include <cloud/blockstore/libs/rdma/iface/protocol.h>
 #include <cloud/blockstore/libs/service_local/rdma_protocol.h>
 #include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
@@ -282,6 +283,7 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
+            RdmaClient->IsZeroCopyEnabled() ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
             deviceRequest,
             TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -283,7 +283,9 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
-            RdmaClient->IsZeroCopyEnabled() ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
+            RdmaClient->IsZeroCopyEnabled()
+                ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
+                : 0,
             deviceRequest,
             TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -258,6 +258,7 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
         serializer->Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ChecksumDeviceBlocksRequest,
+            0, // flags
             deviceRequest,
             TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -285,7 +285,9 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            RdmaClient->IsZeroCopyEnabled() ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
+            RdmaClient->IsZeroCopyEnabled()
+                ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
+                : 0,
             deviceRequest,
             TContIOVector(parts.data(), parts.size()));
 
@@ -428,16 +430,16 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            RdmaClient->IsZeroCopyEnabled() ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
+            RdmaClient->IsZeroCopyEnabled()
+                ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
+                : 0,
             deviceRequest,
             // XXX (cast)
             TContIOVector(
                 const_cast<IOutputStream::TPart*>(
                     reinterpret_cast<const IOutputStream::TPart*>(
-                        sglist.begin() + blocks
-                )),
-                r.DeviceBlockRange.Size()
-            ));
+                        sglist.begin() + blocks)),
+                r.DeviceBlockRange.Size()));
 
         blocks += r.DeviceBlockRange.Size();
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -285,6 +285,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
+            RdmaClient->IsZeroCopyEnabled() ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
             deviceRequest,
             TContIOVector(parts.data(), parts.size()));
 
@@ -427,6 +428,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
+            RdmaClient->IsZeroCopyEnabled() ? NRdma::RDMA_PROTO_FLAG_RDATA : 0,
             deviceRequest,
             // XXX (cast)
             TContIOVector(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -282,12 +282,15 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
         TVector<IOutputStream::TPart> parts;
         builder.BuildNextRequest(&parts);
 
+        ui32 flags = 0;
+        if (RdmaClient->IsAlignedDataEnabled()) {
+            SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
+        }
+
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            RdmaClient->IsAlignedDataEnabled()
-                ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
-                : 0,
+            flags,
             deviceRequest,
             TContIOVector(parts.data(), parts.size()));
 
@@ -427,12 +430,15 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
             return;
         }
 
+        ui32 flags = 0;
+        if (RdmaClient->IsAlignedDataEnabled()) {
+            SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
+        }
+
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            RdmaClient->IsAlignedDataEnabled()
-                ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
-                : 0,
+            flags,
             deviceRequest,
             // XXX (cast)
             TContIOVector(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -285,7 +285,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            RdmaClient->IsZeroCopyEnabled()
+            RdmaClient->IsAlignedDataEnabled()
                 ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
                 : 0,
             deviceRequest,
@@ -430,7 +430,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
         NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
-            RdmaClient->IsZeroCopyEnabled()
+            RdmaClient->IsAlignedDataEnabled()
                 ? NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END
                 : 0,
             deviceRequest,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -229,6 +229,7 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         serializer->Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
+            0, // flags
             deviceRequest,
             TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -85,6 +85,7 @@ public:
         Serializer->Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadBlocksRequest,
+            0, // flags
             *Request,
             TContIOVector(nullptr, 0));
 
@@ -176,6 +177,7 @@ public:
         Serializer->Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteBlocksRequest,
+            0, // flags
             *Request,
             TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
 

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -160,6 +160,7 @@ private:
                 size_t responseBytes = Serializer->Serialize(
                     out,
                     TBlockStoreProtocol::ReadBlocksResponse,
+                    0, // flags
                     response,
                     TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
 
@@ -199,6 +200,7 @@ private:
                 size_t responseBytes = Serializer->Serialize(
                     out,
                     TBlockStoreProtocol::WriteBlocksResponse,
+                    0, // flags
                     response,
                     TContIOVector(nullptr, 0));
 

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -185,6 +185,7 @@ vhd_bdev_info TRdmaBackend::Init(const TOptions& options)
     auto rdmaClientConfig = std::make_shared<NRdma::TClientConfig>();
     rdmaClientConfig->QueueSize = options.RdmaClient.QueueSize;
     rdmaClientConfig->MaxBufferSize = options.RdmaClient.MaxBufferSize;
+    rdmaClientConfig->ZeroCopyEnabled = options.RdmaClient.ZeroCopy;
 
     RdmaClient = NRdma::CreateClient(
         NRdma::NVerbs::CreateVerbs(),

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -185,7 +185,7 @@ vhd_bdev_info TRdmaBackend::Init(const TOptions& options)
     auto rdmaClientConfig = std::make_shared<NRdma::TClientConfig>();
     rdmaClientConfig->QueueSize = options.RdmaClient.QueueSize;
     rdmaClientConfig->MaxBufferSize = options.RdmaClient.MaxBufferSize;
-    rdmaClientConfig->ZeroCopyEnabled = options.RdmaClient.ZeroCopy;
+    rdmaClientConfig->AlignedDataEnabled = options.RdmaClient.AlignedData;
 
     RdmaClient = NRdma::CreateClient(
         NRdma::NVerbs::CreateVerbs(),

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -132,6 +132,10 @@ void TOptions::Parse(int argc, char** argv)
             [this](const auto& timeout)
             { WaitAfterParentExit = TDuration::Seconds(timeout); });
 
+    opts.AddLongOption("rdma-zero-copy", "enable rdma zero copy")
+        .NoArgument()
+        .SetFlag(&RdmaClient.ZeroCopy);
+
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.FindLongOptParseResult("verbose") && VerboseLevel.empty()) {

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -132,9 +132,9 @@ void TOptions::Parse(int argc, char** argv)
             [this](const auto& timeout)
             { WaitAfterParentExit = TDuration::Seconds(timeout); });
 
-    opts.AddLongOption("rdma-zero-copy", "enable rdma zero copy")
+    opts.AddLongOption("rdma-aligned-data", "enable rdma aligned data")
         .NoArgument()
-        .SetFlag(&RdmaClient.ZeroCopy);
+        .SetFlag(&RdmaClient.AlignedData);
 
     TOptsParseResultException res(&opts, argc, argv);
 

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -44,7 +44,7 @@ struct TOptions
     {
         ui32 QueueSize = 256;
         ui32 MaxBufferSize = 4_MB + 4_KB;
-        bool ZeroCopy = false;
+        bool AlignedData = false;
     } RdmaClient;
 
     void Parse(int argc, char** argv);

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -44,6 +44,7 @@ struct TOptions
     {
         ui32 QueueSize = 256;
         ui32 MaxBufferSize = 4_MB + 4_KB;
+        bool ZeroCopy = false;
     } RdmaClient;
 
     void Parse(int argc, char** argv);


### PR DESCRIPTION
The Disk Agent currently copies data buffers multiple times for READ/WRITE
requests received using RDMA transport.

For WRITE requests, the RDMA data buffer is first copied into the memory of
TWriteBlocksRequest and then into a disk block-aligned buffer allocated by
Storage.

For READ requests, disk data is first read into a disk block-aligned buffer
allocated by Storage and then copied into the TReadBlocksResponse message. This
message is then serialized into the RDMA buffer.

To avoid these expensive copies and maintain compatibility with older clients,
we introduce the RDMA_PROTO_FLAG_RDATA flag, which signals the data layout
relative to the allocated RDMA buffer.

Previously, the data layout was:

```
             buffer
|--------------+-------+------+--------|
| TProtoHeader | Proto | Data | unused |
|--------------+-------+------+--------|
```

This layout allows the data offset in memory to be unaligned to 512/4096 bytes,
even though the RDMA buffer is allocated in 4096-byte chunks. Libaio requires
block-aligned memory buffers for writing to the underlying block device with
O_DIRECT, necessitating a different data layout.

With RDMA_PROTO_FLAG_RDATA, the data layout becomes:

```
|--------------+-------+--------+------|
| TProtoHeader | Proto | unused | Data |
|--------------+-------+--------+------|
```

Since the Data buffer size is a multiple of 512/4096 bytes (depending on the
device block size) and the buffer is a multiple of 4096-byte chunks, the data
offset in memory will be 512/4096 bytes aligned, allowing its use with libaio.
