### PR TITLE
[Disk Manager] add baseDiskStatusCreationFailed

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -57,11 +57,12 @@ func (s *baseDiskStatus) UnmarshalYDB(res persistence.RawValue) error {
 
 // NOTE: These values are stored in DB, do not shuffle them around.
 const (
-	baseDiskStatusScheduling baseDiskStatus = iota
-	baseDiskStatusCreating   baseDiskStatus = iota
-	baseDiskStatusReady      baseDiskStatus = iota
-	baseDiskStatusDeleting   baseDiskStatus = iota
-	baseDiskStatusDeleted    baseDiskStatus = iota
+	baseDiskStatusScheduling     baseDiskStatus = iota
+	baseDiskStatusCreating       baseDiskStatus = iota
+	baseDiskStatusReady          baseDiskStatus = iota
+	baseDiskStatusDeleting       baseDiskStatus = iota
+	baseDiskStatusDeleted        baseDiskStatus = iota
+	baseDiskStatusCreationFailed baseDiskStatus = iota
 )
 
 func baseDiskStatusToString(status baseDiskStatus) string {
@@ -76,6 +77,8 @@ func baseDiskStatusToString(status baseDiskStatus) string {
 		return "deleting"
 	case baseDiskStatusDeleted:
 		return "deleted"
+	case baseDiskStatusCreationFailed:
+		return "creation_failed"
 	}
 
 	return fmt.Sprintf("unknown_%v", status)
@@ -137,7 +140,9 @@ func (d *baseDisk) isDoomed() bool {
 }
 
 func (d *baseDisk) applyInvariants() {
-	if !d.isDoomed() && !d.fromPool && d.activeSlots == 0 {
+	if (!d.isDoomed() || d.status == baseDiskStatusCreationFailed) &&
+		!d.fromPool && d.activeSlots == 0 {
+
 		d.status = baseDiskStatusDeleting
 	}
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -140,10 +140,17 @@ func (d *baseDisk) isDoomed() bool {
 }
 
 func (d *baseDisk) applyInvariants() {
-	if (!d.isDoomed() || d.status == baseDiskStatusCreationFailed) &&
-		!d.fromPool && d.activeSlots == 0 {
+	if d.activeUnits == 0 {
+		if d.status == baseDiskStatusCreationFailed {
+			d.status = baseDiskStatusDeleting
+			return
+		}
 
-		d.status = baseDiskStatusDeleting
+		// If base disk is not from pool and it does not have active units then
+		// it should be deleted.
+		if !d.isDoomed() && !d.fromPool {
+			d.status = baseDiskStatusDeleting
+		}
 	}
 }
 

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -146,7 +146,7 @@ func (d *baseDisk) applyInvariants() {
 			return
 		}
 
-		// If base disk is not from pool and it does not have active units then
+		// If base disk is not from pool and it does not have active slots then
 		// it should be deleted.
 		if !d.isDoomed() && !d.fromPool {
 			d.status = baseDiskStatusDeleting

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
@@ -654,37 +654,48 @@ func (s *storageYDB) applyBaseDiskInvariants(
 
 	for _, baseDiskTransition := range baseDiskTransitions {
 		baseDisk := baseDiskTransition.state
-		action := computePoolAction(baseDiskTransition)
 
-		if action.hasChanges() {
-			imageID := baseDisk.imageID
-			zoneID := baseDisk.zoneID
-			key := imageID + zoneID
+		imageID := baseDisk.imageID
+		zoneID := baseDisk.zoneID
+		key := imageID + zoneID
 
-			t, ok := poolTransitions[key]
-			if !ok {
-				p, err := s.getPoolOrDefault(ctx, tx, imageID, zoneID)
-				if err != nil {
-					return nil, err
-				}
-
-				t = poolTransition{
-					oldState: p,
-					state:    p,
-				}
+		t, ok := poolTransitions[key]
+		if !ok {
+			p, err := s.getPoolOrDefault(ctx, tx, imageID, zoneID)
+			if err != nil {
+				return nil, err
 			}
 
-			if t.state.status == poolStatusDeleted {
-				// Remove from deleted pool.
-				baseDisk.fromPool = false
-			} else {
-				action.apply(&t.state)
+			t = poolTransition{
+				oldState: p,
+				state:    p,
 			}
+		}
 
-			poolTransitions[key] = t
+		if t.state.status == poolStatusDeleted {
+			// Remove from deleted pool.
+			baseDisk.fromPool = false
 		}
 
 		baseDisk.applyInvariants()
+
+		logging.Debug(
+			ctx,
+			"applying base disk transition from %+v to %+v",
+			baseDiskTransition.oldState,
+			baseDiskTransition.state,
+		)
+
+		action := computePoolAction(baseDiskTransition)
+		logging.Debug(
+			ctx,
+			"computed pool action is %+v",
+			action,
+		)
+
+		action.apply(&t.state)
+
+		poolTransitions[key] = t
 	}
 
 	var res []poolTransition
@@ -1840,7 +1851,8 @@ func (s *storageYDB) baseDiskCreationFailed(
 	}
 
 	updated := found
-	updated.status = baseDiskStatusDeleting
+	updated.fromPool = false
+	updated.status = baseDiskStatusCreationFailed
 
 	err = s.updateBaseDisk(ctx, tx, baseDiskTransition{
 		oldState: &found,

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
@@ -1851,7 +1851,6 @@ func (s *storageYDB) baseDiskCreationFailed(
 	}
 
 	updated := found
-	updated.fromPool = false
 	updated.status = baseDiskStatusCreationFailed
 
 	err = s.updateBaseDisk(ctx, tx, baseDiskTransition{


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1306

we can not mark base disk as deleted if creation failed because we violate `d.activeSlots == 0` invariant in that case 

https://github.com/ydb-platform/nbs/blob/0aef3171f800ec3989ef1bbedf094c0a55a9f3c8/cloud/disk_manager/internal/pkg/services/pools/storage/common.go#L141

added baseDiskStatusCreationFailed - it `isDoomed`, but active_slots may not be equal to 0