### PR TITLE
Get rid macros for counters

### DIFF
--- a/cloud/blockstore/libs/storage/core/disk_counters.cpp
+++ b/cloud/blockstore/libs/storage/core/disk_counters.cpp
@@ -223,20 +223,15 @@ void TVolumeSelfCounters::AggregateWith(const TVolumeSelfCounters& source)
         counter.AggregateWith(source.Simple.*counterPtr);
     }
 
+    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+        auto& counter = Cumulative.*counterPtr;
+        counter.AggregateWith(source.Cumulative.*counterPtr);
+    }
 
-#define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
-    Cumulative.name.AggregateWith(source.Cumulative.name);                     \
-//  BLOCKSTORE_CUMULATIVE_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-#undef BLOCKSTORE_CUMULATIVE_COUNTER
-
-#define BLOCKSTORE_REQUEST_COUNTER(name, ...)                                  \
-    RequestCounters.name.AggregateWith(source.RequestCounters.name);           \
-// BLOCKSTORE_REQUEST_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_REQUEST_COUNTERS(BLOCKSTORE_REQUEST_COUNTER)
-#undef BLOCKSTORE_REQUEST_COUNTER
+    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+        auto& counter = RequestCounters.*counterPtr;
+        counter.AggregateWith(source.RequestCounters.*counterPtr);
+    }
 }
 
 void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
@@ -246,20 +241,15 @@ void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
         counter.Add(source.Simple.*counterPtr);
     }
 
+    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+        auto& counter = Cumulative.*counterPtr;
+        counter.Add(source.Cumulative.*counterPtr);
+    }
 
-#define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
-    Cumulative.name.Add(source.Cumulative.name);                              \
-//  BLOCKSTORE_CUMULATIVE_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-#undef BLOCKSTORE_CUMULATIVE_COUNTER
-
-#define BLOCKSTORE_REQUEST_COUNTER(name, ...)                                 \
-    RequestCounters.name.Add(source.RequestCounters.name);                    \
-// BLOCKSTORE_REQUEST_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_REQUEST_COUNTERS(BLOCKSTORE_REQUEST_COUNTER)
-#undef BLOCKSTORE_REQUEST_COUNTER
+    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+        auto& counter = RequestCounters.*counterPtr;
+        counter.Add(source.RequestCounters.*counterPtr);
+    }
 }
 
 void TVolumeSelfCounters::Reset()
@@ -269,20 +259,15 @@ void TVolumeSelfCounters::Reset()
         counter.Reset();
     }
 
+    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+        auto& counter = Cumulative.*counterPtr;
+        counter.Reset();
+    }
 
-#define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
-    Cumulative.name.Reset();                                                  \
-// BLOCKSTORE_CUMULATIVE_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-#undef BLOCKSTORE_CUMULATIVE_COUNTER
-
-#define BLOCKSTORE_REQUEST_COUNTER(name, ...)                                 \
-    RequestCounters.name.Reset();                                             \
-// BLOCKSTORE_REQUEST_COUNTER
-
-        BLOCKSTORE_VOLUME_SELF_COMMON_REQUEST_COUNTERS(BLOCKSTORE_REQUEST_COUNTER)
-#undef BLOCKSTORE_REQUEST_COUNTER
+    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+        auto& counter = RequestCounters.*counterPtr;
+        counter.Reset();
+    }
 }
 
 void TVolumeSelfCounters::Register(
@@ -299,22 +284,28 @@ void TVolumeSelfCounters::Register(
         }
     }
 
-#define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
-    Cumulative.name.Register(counters, #name);                                \
-// BLOCKSTORE_CUMULATIVE_COUNTER
+    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+        auto& counter = Cumulative.*counterPtr;
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Register(counters, counter.Name);
+        }
+    }
 
-    BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-#undef BLOCKSTORE_CUMULATIVE_COUNTER
-
-#define BLOCKSTORE_REQUEST_COUNTER(name, ...)                                 \
-    RequestCounters.name.ForceRegister(                                       \
-        counters->GetSubgroup("request", #name),                              \
-        "ThrottlerDelay",                                                     \
-        aggregate);                                                           \
-// BLOCKSTORE_REQUEST_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_REQUEST_COUNTERS(BLOCKSTORE_REQUEST_COUNTER)
-#undef BLOCKSTORE_REQUEST_COUNTER
+    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+        auto& counter = RequestCounters.*counterPtr;
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.ForceRegister(
+                counters->GetSubgroup("request", counter.Name),
+                "ThrottlerDelay",
+                aggregate);
+        }
+    }
 }
 
 void TVolumeSelfCounters::Publish(TInstant now)
@@ -329,21 +320,25 @@ void TVolumeSelfCounters::Publish(TInstant now)
         }
     }
 
-#define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
-    Cumulative.name.Publish(now);                                             \
-// BLOCKSTORE_CUMULATIVE_COUNTER
+    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+        auto& counter = Cumulative.*counterPtr;
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Publish(now);
+        }
+    }
 
-    BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-#undef BLOCKSTORE_CUMULATIVE_COUNTER
-
-#define BLOCKSTORE_REQUEST_COUNTER(name, ...)                                 \
-    RequestCounters.name.Publish();                                           \
-// BLOCKSTORE_REQUEST_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_REQUEST_COUNTERS(BLOCKSTORE_REQUEST_COUNTER)
-#undef BLOCKSTORE_REQUEST_COUNTER
-
-    Reset();
+    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+        auto& counter = RequestCounters.*counterPtr;
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Publish();
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/disk_counters.cpp
+++ b/cloud/blockstore/libs/storage/core/disk_counters.cpp
@@ -218,14 +218,11 @@ void TPartitionDiskCounters::Reset()
 
 void TVolumeSelfCounters::AggregateWith(const TVolumeSelfCounters& source)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.AggregateWith(source.Simple.name);                             \
-// BLOCKSTORE_SIMPLE_COUNTER
+    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        counter.AggregateWith(source.Simple.*counterPtr);
+    }
 
-    BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
     Cumulative.name.AggregateWith(source.Cumulative.name);                     \
@@ -244,14 +241,11 @@ void TVolumeSelfCounters::AggregateWith(const TVolumeSelfCounters& source)
 
 void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.Add(source.Simple.name);                                       \
-// BLOCKSTORE_SIMPLE_COUNTER
+    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        counter.Add(source.Simple.*counterPtr);
+    }
 
-    BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
     Cumulative.name.Add(source.Cumulative.name);                              \
@@ -270,14 +264,11 @@ void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
 
 void TVolumeSelfCounters::Reset()
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                  \
-    Simple.name.Reset();                                                      \
-// BLOCKSTORE_SIMPLE_COUNTER
+    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        counter.Reset();
+    }
 
-    BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
     Cumulative.name.Reset();                                                  \
@@ -298,20 +289,15 @@ void TVolumeSelfCounters::Register(
     NMonitoring::TDynamicCountersPtr counters,
     bool aggregate)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                  \
-    Simple.name.Register(counters, #name);                                    \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    if (Policy == EPublishingPolicy::All || Policy == EPublishingPolicy::Repl) {
-        BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
+    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Register(counters, counter.Name);
+        }
     }
-    if (Policy == EPublishingPolicy::All
-            || Policy == EPublishingPolicy::DiskRegistryBased)
-    {
-        BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    }
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
     Cumulative.name.Register(counters, #name);                                \
@@ -333,20 +319,15 @@ void TVolumeSelfCounters::Register(
 
 void TVolumeSelfCounters::Publish(TInstant now)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                  \
-    Simple.name.Publish(now);                                                 \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    if (Policy == EPublishingPolicy::All || Policy == EPublishingPolicy::Repl) {
-        BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
+    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Publish(now);
+        }
     }
-    if (Policy == EPublishingPolicy::All
-            || Policy == EPublishingPolicy::DiskRegistryBased)
-    {
-        BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    }
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                              \
     Cumulative.name.Publish(now);                                             \

--- a/cloud/blockstore/libs/storage/core/disk_counters.cpp
+++ b/cloud/blockstore/libs/storage/core/disk_counters.cpp
@@ -10,12 +10,12 @@ using namespace NKikimr;
 
 void TPartitionDiskCounters::Add(const TPartitionDiskCounters& source)
 {
-    for (auto counterPtr: TSimpleDiskCounters::All) {
+    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         counter.Add(source.Simple.*counterPtr);
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::All) {
+    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         counter.Add(source.Cumulative.*counterPtr);
     }
@@ -30,7 +30,7 @@ void TPartitionDiskCounters::Add(const TPartitionDiskCounters& source)
         counter.Add(source.RequestCounters.*counterPtr);
     }
 
-    for (auto counterPtr: THistogramCounters::All) {
+    for (auto counterPtr: THistogramCounters::AllCounters) {
         auto& counter = Histogram.*counterPtr;
         counter.Add(source.Histogram.*counterPtr);
     }
@@ -38,12 +38,12 @@ void TPartitionDiskCounters::Add(const TPartitionDiskCounters& source)
 
 void TPartitionDiskCounters::AggregateWith(const TPartitionDiskCounters& source)
 {
-    for (auto counterPtr: TSimpleDiskCounters::All) {
+    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         counter.AggregateWith(source.Simple.*counterPtr);
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::All) {
+    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         counter.AggregateWith(source.Cumulative.*counterPtr);
     }
@@ -58,7 +58,7 @@ void TPartitionDiskCounters::AggregateWith(const TPartitionDiskCounters& source)
         counter.AggregateWith(source.RequestCounters.*counterPtr);
     }
 
-    for (auto counterPtr: THistogramCounters::All) {
+    for (auto counterPtr: THistogramCounters::AllCounters) {
         auto& counter = Histogram.*counterPtr;
         counter.AggregateWith(source.Histogram.*counterPtr);
     }
@@ -66,7 +66,7 @@ void TPartitionDiskCounters::AggregateWith(const TPartitionDiskCounters& source)
 
 void TPartitionDiskCounters::Publish(TInstant now)
 {
-    for (auto counterPtr: TSimpleDiskCounters::All) {
+    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
         auto& counter = (Simple.*counterPtr);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -76,7 +76,7 @@ void TPartitionDiskCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::All) {
+    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
         auto& counter = (Cumulative.*counterPtr);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -106,7 +106,7 @@ void TPartitionDiskCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: THistogramCounters::All) {
+    for (auto counterPtr: THistogramCounters::AllCounters) {
         auto& counter = Histogram.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -129,7 +129,7 @@ void TPartitionDiskCounters::Register(
             requestCounterOptions | ERequestCounterOption::ReportHistogram;
     }
 
-    for (auto counterPtr: TSimpleDiskCounters::All) {
+    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
         auto& counter = (Simple.*counterPtr);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -139,7 +139,7 @@ void TPartitionDiskCounters::Register(
         }
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::All) {
+    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
         auto& counter = (Cumulative.*counterPtr);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -173,7 +173,7 @@ void TPartitionDiskCounters::Register(
         }
     }
 
-    for (auto counterPtr: THistogramCounters::All) {
+    for (auto counterPtr: THistogramCounters::AllCounters) {
         auto& counter = Histogram.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -188,12 +188,12 @@ void TPartitionDiskCounters::Register(
 
 void TPartitionDiskCounters::Reset()
 {
-    for (auto counterPtr: TSimpleDiskCounters::All) {
+    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
         auto& counter = (Simple.*counterPtr);
         counter.Reset();
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::All) {
+    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
         auto& counter = (Cumulative.*counterPtr);
         counter.Reset();
     }
@@ -208,7 +208,7 @@ void TPartitionDiskCounters::Reset()
         counter.Reset();
     }
 
-    for (auto counterPtr: THistogramCounters::All) {
+    for (auto counterPtr: THistogramCounters::AllCounters) {
         auto& counter = Histogram.*counterPtr;
         counter.Reset();
     }
@@ -218,17 +218,17 @@ void TPartitionDiskCounters::Reset()
 
 void TVolumeSelfCounters::AggregateWith(const TVolumeSelfCounters& source)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         counter.AggregateWith(source.Simple.*counterPtr);
     }
 
-    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         counter.AggregateWith(source.Cumulative.*counterPtr);
     }
 
-    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
         auto& counter = RequestCounters.*counterPtr;
         counter.AggregateWith(source.RequestCounters.*counterPtr);
     }
@@ -236,17 +236,17 @@ void TVolumeSelfCounters::AggregateWith(const TVolumeSelfCounters& source)
 
 void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         counter.Add(source.Simple.*counterPtr);
     }
 
-    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         counter.Add(source.Cumulative.*counterPtr);
     }
 
-    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
         auto& counter = RequestCounters.*counterPtr;
         counter.Add(source.RequestCounters.*counterPtr);
     }
@@ -254,17 +254,17 @@ void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
 
 void TVolumeSelfCounters::Reset()
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         counter.Reset();
     }
 
-    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         counter.Reset();
     }
 
-    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
         auto& counter = RequestCounters.*counterPtr;
         counter.Reset();
     }
@@ -274,7 +274,7 @@ void TVolumeSelfCounters::Register(
     NMonitoring::TDynamicCountersPtr counters,
     bool aggregate)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -284,7 +284,7 @@ void TVolumeSelfCounters::Register(
         }
     }
 
-    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -294,7 +294,7 @@ void TVolumeSelfCounters::Register(
         }
     }
 
-    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
         auto& counter = RequestCounters.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -310,7 +310,7 @@ void TVolumeSelfCounters::Register(
 
 void TVolumeSelfCounters::Publish(TInstant now)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::All) {
+    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
         auto& counter = Simple.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -320,7 +320,7 @@ void TVolumeSelfCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: TVolumeSelfCommonCumulativeCounters::All) {
+    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
         auto& counter = Cumulative.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
@@ -330,7 +330,7 @@ void TVolumeSelfCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: TVolumeSelfCommonRequestCounters::All) {
+    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
         auto& counter = RequestCounters.*counterPtr;
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||

--- a/cloud/blockstore/libs/storage/core/disk_counters.cpp
+++ b/cloud/blockstore/libs/storage/core/disk_counters.cpp
@@ -10,64 +10,64 @@ using namespace NKikimr;
 
 void TPartitionDiskCounters::Add(const TPartitionDiskCounters& source)
 {
-    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
-        counter.Add(source.Simple.*counterPtr);
+    for (auto meta: TSimpleDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
+        counter.Add(meta.GetValue(source.Simple));
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
-        counter.Add(source.Cumulative.*counterPtr);
+    for (auto meta: TCumulativeDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
+        counter.Add(meta.GetValue(source.Cumulative));
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllLowResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
-        counter.Add(source.RequestCounters.*counterPtr);
+    for (auto meta: THistogramRequestCounters::AllLowResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
+        counter.Add(meta.GetValue(source.RequestCounters));
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllHighResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
-        counter.Add(source.RequestCounters.*counterPtr);
+    for (auto meta: THistogramRequestCounters::AllHighResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
+        counter.Add(meta.GetValue(source.RequestCounters));
     }
 
-    for (auto counterPtr: THistogramCounters::AllCounters) {
-        auto& counter = Histogram.*counterPtr;
-        counter.Add(source.Histogram.*counterPtr);
+    for (auto meta: THistogramCounters::AllCounters) {
+        auto& counter = meta.GetValue(Histogram);
+        counter.Add(meta.GetValue(source.Histogram));
     }
 }
 
 void TPartitionDiskCounters::AggregateWith(const TPartitionDiskCounters& source)
 {
-    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
-        counter.AggregateWith(source.Simple.*counterPtr);
+    for (auto meta: TSimpleDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
+        counter.AggregateWith(meta.GetValue(source.Simple));
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
-        counter.AggregateWith(source.Cumulative.*counterPtr);
+    for (auto meta: TCumulativeDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
+        counter.AggregateWith(meta.GetValue(source.Cumulative));
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllLowResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
-        counter.AggregateWith(source.RequestCounters.*counterPtr);
+    for (auto meta: THistogramRequestCounters::AllLowResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
+        counter.AggregateWith(meta.GetValue(source.RequestCounters));
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllHighResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
-        counter.AggregateWith(source.RequestCounters.*counterPtr);
+    for (auto meta: THistogramRequestCounters::AllHighResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
+        counter.AggregateWith(meta.GetValue(source.RequestCounters));
     }
 
-    for (auto counterPtr: THistogramCounters::AllCounters) {
-        auto& counter = Histogram.*counterPtr;
-        counter.AggregateWith(source.Histogram.*counterPtr);
+    for (auto meta: THistogramCounters::AllCounters) {
+        auto& counter = meta.GetValue(Histogram);
+        counter.AggregateWith(meta.GetValue(source.Histogram));
     }
 }
 
 void TPartitionDiskCounters::Publish(TInstant now)
 {
-    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
-        auto& counter = (Simple.*counterPtr);
+    for (auto meta: TSimpleDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -76,8 +76,8 @@ void TPartitionDiskCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
-        auto& counter = (Cumulative.*counterPtr);
+    for (auto meta: TCumulativeDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -86,8 +86,8 @@ void TPartitionDiskCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllLowResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: THistogramRequestCounters::AllLowResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -96,8 +96,8 @@ void TPartitionDiskCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllHighResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: THistogramRequestCounters::AllHighResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -106,8 +106,8 @@ void TPartitionDiskCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: THistogramCounters::AllCounters) {
-        auto& counter = Histogram.*counterPtr;
+    for (auto meta: THistogramCounters::AllCounters) {
+        auto& counter = meta.GetValue(Histogram);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -129,58 +129,58 @@ void TPartitionDiskCounters::Register(
             requestCounterOptions | ERequestCounterOption::ReportHistogram;
     }
 
-    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
-        auto& counter = (Simple.*counterPtr);
+    for (auto meta: TSimpleDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
-            counter.Register(counters, counter.Name);
+            counter.Register(counters, TString(meta.Name));
         }
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
-        auto& counter = (Cumulative.*counterPtr);
+    for (auto meta: TCumulativeDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
-            counter.Register(counters, counter.Name);
+            counter.Register(counters, TString(meta.Name));
         }
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllLowResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: THistogramRequestCounters::AllLowResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
             counter.Register(
-                counters->GetSubgroup("request", counter.Name),
+                counters->GetSubgroup("request", TString(meta.Name)),
                 requestCounterOptions | counter.CounterOption);
         }
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllHighResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: THistogramRequestCounters::AllHighResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
             counter.Register(
-                counters->GetSubgroup("request", counter.Name),
+                counters->GetSubgroup("request", TString(meta.Name)),
                 requestCounterOptions | counter.CounterOption);
         }
     }
 
-    for (auto counterPtr: THistogramCounters::AllCounters) {
-        auto& counter = Histogram.*counterPtr;
+    for (auto meta: THistogramCounters::AllCounters) {
+        auto& counter = meta.GetValue(Histogram);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
             counter.Register(
-                counters->GetSubgroup("queue", counter.Name),
+                counters->GetSubgroup("queue", TString(meta.Name)),
                 aggregate);
         }
     }
@@ -188,28 +188,28 @@ void TPartitionDiskCounters::Register(
 
 void TPartitionDiskCounters::Reset()
 {
-    for (auto counterPtr: TSimpleDiskCounters::AllCounters) {
-        auto& counter = (Simple.*counterPtr);
+    for (auto meta: TSimpleDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
         counter.Reset();
     }
 
-    for (auto counterPtr: TCumulativeDiskCounters::AllCounters) {
-        auto& counter = (Cumulative.*counterPtr);
+    for (auto meta: TCumulativeDiskCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
         counter.Reset();
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllLowResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: THistogramRequestCounters::AllLowResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         counter.Reset();
     }
 
-    for (auto counterPtr: THistogramRequestCounters::AllHighResCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: THistogramRequestCounters::AllHighResCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         counter.Reset();
     }
 
-    for (auto counterPtr: THistogramCounters::AllCounters) {
-        auto& counter = Histogram.*counterPtr;
+    for (auto meta: THistogramCounters::AllCounters) {
+        auto& counter = meta.GetValue(Histogram);
         counter.Reset();
     }
 }
@@ -218,54 +218,54 @@ void TPartitionDiskCounters::Reset()
 
 void TVolumeSelfCounters::AggregateWith(const TVolumeSelfCounters& source)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
-        counter.AggregateWith(source.Simple.*counterPtr);
+    for (auto meta: TVolumeSelfSimpleCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
+        counter.AggregateWith(meta.GetValue(source.Simple));
     }
 
-    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
-        counter.AggregateWith(source.Cumulative.*counterPtr);
+    for (auto meta: TVolumeSelfCumulativeCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
+        counter.AggregateWith(meta.GetValue(source.Cumulative));
     }
 
-    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
-        auto& counter = RequestCounters.*counterPtr;
-        counter.AggregateWith(source.RequestCounters.*counterPtr);
+    for (auto meta: TVolumeSelfRequestCounters::AllCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
+        counter.AggregateWith(meta.GetValue(source.RequestCounters));
     }
 }
 
 void TVolumeSelfCounters::Add(const TVolumeSelfCounters& source)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
-        counter.Add(source.Simple.*counterPtr);
+    for (auto meta: TVolumeSelfSimpleCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
+        counter.Add(meta.GetValue(source.Simple));
     }
 
-    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
-        counter.Add(source.Cumulative.*counterPtr);
+    for (auto meta: TVolumeSelfCumulativeCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
+        counter.Add(meta.GetValue(source.Cumulative));
     }
 
-    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
-        auto& counter = RequestCounters.*counterPtr;
-        counter.Add(source.RequestCounters.*counterPtr);
+    for (auto meta: TVolumeSelfRequestCounters::AllCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
+        counter.Add(meta.GetValue(source.RequestCounters));
     }
 }
 
 void TVolumeSelfCounters::Reset()
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
+    for (auto meta: TVolumeSelfSimpleCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
         counter.Reset();
     }
 
-    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
+    for (auto meta: TVolumeSelfCumulativeCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
         counter.Reset();
     }
 
-    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: TVolumeSelfRequestCounters::AllCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         counter.Reset();
     }
 }
@@ -274,34 +274,34 @@ void TVolumeSelfCounters::Register(
     NMonitoring::TDynamicCountersPtr counters,
     bool aggregate)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
+    for (auto meta: TVolumeSelfSimpleCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
-            counter.Register(counters, counter.Name);
+            counter.Register(counters, TString(meta.Name));
         }
     }
 
-    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
+    for (auto meta: TVolumeSelfCumulativeCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
-            counter.Register(counters, counter.Name);
+            counter.Register(counters, TString(meta.Name));
         }
     }
 
-    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: TVolumeSelfRequestCounters::AllCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
         {
             counter.ForceRegister(
-                counters->GetSubgroup("request", counter.Name),
+                counters->GetSubgroup("request", TString(meta.Name)),
                 "ThrottlerDelay",
                 aggregate);
         }
@@ -310,8 +310,8 @@ void TVolumeSelfCounters::Register(
 
 void TVolumeSelfCounters::Publish(TInstant now)
 {
-    for (auto counterPtr: TVolumeSelfSimpleCounters::AllCounters) {
-        auto& counter = Simple.*counterPtr;
+    for (auto meta: TVolumeSelfSimpleCounters::AllCounters) {
+        auto& counter = meta.GetValue(Simple);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -320,8 +320,8 @@ void TVolumeSelfCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: TVolumeSelfCumulativeCounters::AllCounters) {
-        auto& counter = Cumulative.*counterPtr;
+    for (auto meta: TVolumeSelfCumulativeCounters::AllCounters) {
+        auto& counter = meta.GetValue(Cumulative);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)
@@ -330,8 +330,8 @@ void TVolumeSelfCounters::Publish(TInstant now)
         }
     }
 
-    for (auto counterPtr: TVolumeSelfRequestCounters::AllCounters) {
-        auto& counter = RequestCounters.*counterPtr;
+    for (auto meta: TVolumeSelfRequestCounters::AllCounters) {
+        auto& counter = meta.GetValue(RequestCounters);
         if (Policy == EPublishingPolicy::All ||
             counter.PublishingPolicy == EPublishingPolicy::All ||
             Policy == counter.PublishingPolicy)

--- a/cloud/blockstore/libs/storage/core/disk_counters.cpp
+++ b/cloud/blockstore/libs/storage/core/disk_counters.cpp
@@ -10,14 +10,10 @@ using namespace NKikimr;
 
 void TPartitionDiskCounters::Add(const TPartitionDiskCounters& source)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.Add(source.Simple.name);                                       \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
+    for (auto counterPtr: TSimpleDiskCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        counter.Add(source.Simple.*counterPtr);
+    }
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
     Cumulative.name.Add(source.Cumulative.name);                               \
@@ -46,14 +42,10 @@ void TPartitionDiskCounters::Add(const TPartitionDiskCounters& source)
 
 void TPartitionDiskCounters::AggregateWith(const TPartitionDiskCounters& source)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.AggregateWith(source.Simple.name);                             \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
+    for (auto counterPtr: TSimpleDiskCounters::All) {
+        auto& counter = Simple.*counterPtr;
+        counter.AggregateWith(source.Simple.*counterPtr);
+    }
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
     Cumulative.name.AggregateWith(source.Cumulative.name);                     \
@@ -82,20 +74,15 @@ void TPartitionDiskCounters::AggregateWith(const TPartitionDiskCounters& source)
 
 void TPartitionDiskCounters::Publish(TInstant now)
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.Publish(now);                                                  \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    if (Policy == EPublishingPolicy::All || Policy == EPublishingPolicy::Repl) {
-        BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
+    for (auto counterPtr: TSimpleDiskCounters::All) {
+        auto& counter = (Simple.*counterPtr);
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Publish(now);
+        }
     }
-    if (Policy == EPublishingPolicy::All
-            || Policy == EPublishingPolicy::DiskRegistryBased)
-    {
-        BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    }
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
     Cumulative.name.Publish(now);                                              \
@@ -148,20 +135,15 @@ void TPartitionDiskCounters::Register(
         requestCounterOptions |
         ERequestCounterOption::HasKind;
 
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.Register(counters, #name);                                     \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    if (Policy == EPublishingPolicy::All || Policy == EPublishingPolicy::Repl) {
-        BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
+    for (auto counterPtr: TSimpleDiskCounters::All) {
+        auto& counter = (Simple.*counterPtr);
+        if (Policy == EPublishingPolicy::All ||
+            counter.PublishingPolicy == EPublishingPolicy::All ||
+            Policy == counter.PublishingPolicy)
+        {
+            counter.Register(counters, counter.Name);
+        }
     }
-    if (Policy == EPublishingPolicy::All
-            || Policy == EPublishingPolicy::DiskRegistryBased)
-    {
-        BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    }
-#undef BLOCKSTORE_SIMPLE_COUNTER
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
 Cumulative.name.Register(counters, #name);                                     \
@@ -218,14 +200,10 @@ Cumulative.name.Register(counters, #name);                                     \
 
 void TPartitionDiskCounters::Reset()
 {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, ...)                                   \
-    Simple.name.Reset();                                                       \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-    BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-    BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
+    for (auto counterPtr: TSimpleDiskCounters::All) {
+        auto& counter = (Simple.*counterPtr);
+        counter.Reset();
+    }
 
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, ...)                               \
     Cumulative.name.Reset();                                                   \

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -477,19 +477,164 @@ static_assert(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(xxx, ...)                \
-    xxx(MaxReadBandwidth,           Generic, Permanent,            __VA_ARGS__)\
-    xxx(MaxWriteBandwidth,          Generic, Permanent,            __VA_ARGS__)\
-    xxx(MaxReadIops,                Generic, Permanent,            __VA_ARGS__)\
-    xxx(MaxWriteIops,               Generic, Permanent,            __VA_ARGS__)\
-    xxx(MaxUsedQuota,               Generic, Permanent,            __VA_ARGS__)\
-    xxx(LastVolumeLoadTime,         Max,     Permanent,            __VA_ARGS__)\
-    xxx(LastVolumeStartTime,        Max,     Permanent,            __VA_ARGS__)\
-    xxx(HasStorageConfigPatch,      Generic, Permanent,            __VA_ARGS__)\
-    xxx(LongRunningReadBlob,        Generic, Expiring,             __VA_ARGS__)\
-    xxx(LongRunningWriteBlob,       Generic, Expiring,             __VA_ARGS__)\
-    xxx(UseFastPath,                Generic, Permanent,            __VA_ARGS__)\
+struct TVolumeSelfSimpleCounters
+{
+    using TCounter = TMemberWithMeta<TSimpleCounter>;
+    using TCounterPtr = TCounter TVolumeSelfSimpleCounters::*;
 
+    // Common
+    TCounter MaxReadBandwidth{
+        "MaxReadBandwidth",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MaxWriteBandwidth{
+        "MaxWriteBandwidth",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MaxReadIops{
+        "MaxReadIops",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MaxWriteIops{
+        "MaxWriteIops",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MaxUsedQuota{
+        "MaxUsedQuota",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter LastVolumeLoadTime{
+        "LastVolumeLoadTime",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Max,
+        ECounterExpirationPolicy::Permanent};
+    TCounter LastVolumeStartTime{
+        "LastVolumeStartTime",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Max,
+        ECounterExpirationPolicy::Permanent};
+    TCounter HasStorageConfigPatch{
+        "HasStorageConfigPatch",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter LongRunningReadBlob{
+        "LongRunningReadBlob",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter LongRunningWriteBlob{
+        "LongRunningWriteBlob",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter UseFastPath{
+        "UseFastPath",
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    // BlobStorage-based
+    TCounter RealMaxWriteBandwidth{
+        "RealMaxWriteBandwidth",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter PostponedQueueWeight{
+        "PostponedQueueWeight",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter BPFreshIndexScore{
+        "BPFreshIndexScore",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter BPCompactionScore{
+        "BPCompactionScore",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter BPDiskSpaceScore{
+        "BPDiskSpaceScore",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter BPCleanupScore{
+        "BPCleanupScore",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter VBytesCount{
+        "VBytesCount",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter PartitionCount{
+        "PartitionCount",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    // DiskRegistry-based
+    TCounter MigrationStarted{
+        "MigrationStarted",
+        EPublishingPolicy::DiskRegistryBased,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MigrationProgress{
+        "MigrationProgress",
+        EPublishingPolicy::DiskRegistryBased,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter ResyncStarted{
+        "ResyncStarted",
+        EPublishingPolicy::DiskRegistryBased,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter ResyncProgress{
+        "ResyncProgress",
+        EPublishingPolicy::DiskRegistryBased,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    static constexpr TCounterPtr All[] = {
+        &TVolumeSelfSimpleCounters::MaxReadBandwidth,
+        &TVolumeSelfSimpleCounters::MaxWriteBandwidth,
+        &TVolumeSelfSimpleCounters::MaxReadIops,
+        &TVolumeSelfSimpleCounters::MaxWriteIops,
+        &TVolumeSelfSimpleCounters::MaxUsedQuota,
+        &TVolumeSelfSimpleCounters::LastVolumeLoadTime,
+        &TVolumeSelfSimpleCounters::LastVolumeStartTime,
+        &TVolumeSelfSimpleCounters::HasStorageConfigPatch,
+        &TVolumeSelfSimpleCounters::LongRunningReadBlob,
+        &TVolumeSelfSimpleCounters::LongRunningWriteBlob,
+        &TVolumeSelfSimpleCounters::UseFastPath,
+
+        &TVolumeSelfSimpleCounters::RealMaxWriteBandwidth,
+        &TVolumeSelfSimpleCounters::PostponedQueueWeight,
+        &TVolumeSelfSimpleCounters::BPFreshIndexScore,
+        &TVolumeSelfSimpleCounters::BPCompactionScore,
+        &TVolumeSelfSimpleCounters::BPDiskSpaceScore,
+        &TVolumeSelfSimpleCounters::BPCleanupScore,
+        &TVolumeSelfSimpleCounters::VBytesCount,
+        &TVolumeSelfSimpleCounters::PartitionCount,
+
+        &TVolumeSelfSimpleCounters::MigrationStarted,
+        &TVolumeSelfSimpleCounters::MigrationProgress,
+        &TVolumeSelfSimpleCounters::ResyncStarted,
+        &TVolumeSelfSimpleCounters::ResyncProgress,
+    };
+};
+static_assert(
+    sizeof(TVolumeSelfSimpleCounters) ==
+    sizeof(TVolumeSelfSimpleCounters::TCounter) *
+        std::size(TVolumeSelfSimpleCounters::All));
 
 #define BLOCKSTORE_VOLUME_SELF_COMMON_CUMULATIVE_COUNTERS(xxx, ...)            \
     xxx(ThrottlerRejectedRequests,  Generic, Expiring,             __VA_ARGS__)\
@@ -507,27 +652,6 @@ static_assert(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(xxx, ...)                  \
-    xxx(RealMaxWriteBandwidth,      Generic, Permanent,            __VA_ARGS__)\
-    xxx(PostponedQueueWeight,       Generic, Expiring,             __VA_ARGS__)\
-    xxx(BPFreshIndexScore,          Generic, Expiring,             __VA_ARGS__)\
-    xxx(BPCompactionScore,          Generic, Expiring,             __VA_ARGS__)\
-    xxx(BPDiskSpaceScore,           Generic, Expiring,             __VA_ARGS__)\
-    xxx(BPCleanupScore,             Generic, Expiring,             __VA_ARGS__)\
-    xxx(VBytesCount,                Generic, Permanent,            __VA_ARGS__)\
-    xxx(PartitionCount,             Generic, Permanent,            __VA_ARGS__)\
-// BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS
-
-////////////////////////////////////////////////////////////////////////////////
-
-#define BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(xxx, ...)               \
-    xxx(MigrationStarted,           Generic, Permanent,            __VA_ARGS__)\
-    xxx(MigrationProgress,          Generic, Permanent,            __VA_ARGS__)\
-    xxx(ResyncStarted,              Generic, Permanent,            __VA_ARGS__)\
-    xxx(ResyncProgress,             Generic, Permanent,            __VA_ARGS__)\
-// BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS
-
-////////////////////////////////////////////////////////////////////////////////
 
 struct TPartitionDiskCounters
 {
@@ -553,20 +677,7 @@ struct TPartitionDiskCounters
 
 struct TVolumeSelfCounters
 {
-    struct
-    {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, type, policy, ...)                    \
-    TSimpleCounter name{                                                      \
-        TSimpleCounter::ECounterType::type,                                   \
-        ECounterExpirationPolicy::policy                                      \
-    };                                                                        \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-        BLOCKSTORE_VOLUME_SELF_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-        BLOCKSTORE_REPL_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-        BLOCKSTORE_DRBASED_VOLUME_SELF_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
-    } Simple;
+    TVolumeSelfSimpleCounters Simple;
 
     struct
     {

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -416,23 +416,23 @@ struct THistogramRequestCounters
 
     THighResCounter ReadBlocks{
         "ReadBlocks",
-        EPublishingPolicy::Repl,
+        EPublishingPolicy::All,
         ERequestCounterOption::HasVoidBytes};
     THighResCounter WriteBlocks{
         "WriteBlocks",
-        EPublishingPolicy::Repl,
+        EPublishingPolicy::All,
         ERequestCounterOption{}};
     THighResCounter ZeroBlocks{
         "ZeroBlocks",
-        EPublishingPolicy::Repl,
+        EPublishingPolicy::All,
         ERequestCounterOption{}};
     THighResCounter DescribeBlocks{
         "DescribeBlocks",
-        EPublishingPolicy::Repl,
+        EPublishingPolicy::All,
         ERequestCounterOption{}};
     THighResCounter ChecksumBlocks{
         "ChecksumBlocks",
-        EPublishingPolicy::Repl,
+        EPublishingPolicy::All,
         ERequestCounterOption{}};
 
     static constexpr THighResCounterPtr AllHighResCounters[] = {

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -199,6 +199,10 @@ struct TSimpleDiskCounters
         EPublishingPolicy::DiskRegistryBased,
         TSimpleCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
+    TCounter ScrubbingProgress{
+        EPublishingPolicy::DiskRegistryBased,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
 
     static constexpr TMeta AllCounters[] = {
         MakeMeta<&TSimpleDiskCounters::BytesCount>(),
@@ -228,6 +232,7 @@ struct TSimpleDiskCounters
 
         MakeMeta<&TSimpleDiskCounters::HasBrokenDevice>(),
         MakeMeta<&TSimpleDiskCounters::HasBrokenDeviceSilent>(),
+        MakeMeta<&TSimpleDiskCounters::ScrubbingProgress>(),
     };
 };
 static_assert(

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -50,7 +50,7 @@ struct TMemberWithMeta: public TBase
 template <typename TMemberPtr>
 struct TMemberMeta
 {
-    std::string_view Name;
+    TStringBuf Name;
     TMemberPtr MemberPtr{};
 
     auto& GetValue(auto& object)

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -16,46 +16,212 @@ enum class EPublishingPolicy
     DiskRegistryBased,
 };
 
-////////////////////////////////////////////////////////////////////////////////
+template <typename TBase>
+struct TMemberWithMeta: public TBase
+{
+    const char* Name = {};
+    EPublishingPolicy PublishingPolicy = {};
+    ERequestCounterOption CounterOption = {};
 
-#define BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(xxx, ...)                       \
-    xxx(BytesCount,             Generic, Permanent,                __VA_ARGS__)\
-    xxx(IORequestsInFlight,     Generic, Permanent,                __VA_ARGS__)\
-// BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS
+    TMemberWithMeta() = default;
 
-////////////////////////////////////////////////////////////////////////////////
+    template <typename... TArgs>
+    TMemberWithMeta(
+            const char* name,
+            EPublishingPolicy publishingPolicy,
+            TArgs&&... args)
+        : TBase(std::forward<TArgs>(args)...)
+        , Name(name)
+        , PublishingPolicy(publishingPolicy)
+    {}
 
-#define BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(xxx, ...)                         \
-    xxx(MixedBytesCount,        Generic, Permanent,                __VA_ARGS__)\
-    xxx(MergedBytesCount,       Generic, Permanent,                __VA_ARGS__)\
-    xxx(FreshBytesCount,        Generic, Permanent,                __VA_ARGS__)\
-    xxx(UntrimmedFreshBlobBytesCount,    Generic, Permanent        __VA_ARGS__)\
-    xxx(UsedBytesCount,         Generic, Permanent,                __VA_ARGS__)\
-    xxx(LogicalUsedBytesCount,  Generic, Permanent,                __VA_ARGS__)\
-    xxx(IORequestsQueued,       Generic, Expiring,                 __VA_ARGS__)\
-    xxx(UsedBlocksMapMemSize,   Generic, Expiring,                 __VA_ARGS__)\
-    xxx(MixedIndexCacheMemSize, Generic, Expiring,                 __VA_ARGS__)\
-    xxx(CheckpointBytes,        Generic, Permanent,                __VA_ARGS__)\
-    xxx(AlmostFullChannelCount, Generic, Expiring,                 __VA_ARGS__)\
-    xxx(FreshBlocksInFlight,    Generic, Expiring,                 __VA_ARGS__)\
-    xxx(FreshBlocksQueued,      Generic, Expiring,                 __VA_ARGS__)\
-    xxx(CleanupQueueBytes,      Generic, Permanent,                __VA_ARGS__)\
-    xxx(GarbageQueueBytes,      Generic, Permanent,                __VA_ARGS__)\
-    xxx(CompactionScore,        Max,     Permanent,                __VA_ARGS__)\
-    xxx(CompactionGarbageScore, Max,     Permanent,                __VA_ARGS__)\
-    xxx(ChannelHistorySize,     Max,     Permanent,                __VA_ARGS__)\
-    xxx(CompactionRangeCountPerRun, Max, Permanent,                __VA_ARGS__)\
-    xxx(UnconfirmedBlobCount,   Generic, Permanent,                __VA_ARGS__)\
-    xxx(ConfirmedBlobCount,     Generic, Permanent,                __VA_ARGS__)\
-// BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS
+    TMemberWithMeta(
+            const char* name,
+            EPublishingPolicy publishingPolicy,
+            ERequestCounterOption counterOption = ERequestCounterOption())
+        : TBase()
+        , Name(name)
+        , PublishingPolicy(publishingPolicy)
+        , CounterOption(counterOption)
+    {}
 
-////////////////////////////////////////////////////////////////////////////////
+    TMemberWithMeta(const TMemberWithMeta& rh) = default;
+    TMemberWithMeta(TMemberWithMeta&& rh) = default;
 
-#define BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(xxx, ...)                      \
-    xxx(HasBrokenDevice,        Generic, Permanent,                __VA_ARGS__)\
-    xxx(HasBrokenDeviceSilent,  Generic, Permanent,                __VA_ARGS__)\
-    xxx(ScrubbingProgress,      Generic, Permanent,                __VA_ARGS__)\
-// BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS
+    TMemberWithMeta& operator=(const TMemberWithMeta& rh) = default;
+    TMemberWithMeta& operator=(TMemberWithMeta&& rh) = default;
+};
+
+struct TSimpleDiskCounters
+{
+    using TCounter = TMemberWithMeta<TSimpleCounter>;
+    using TCounterPtr = TCounter TSimpleDiskCounters::*;
+
+    // Common
+    TCounter BytesCount{
+        "BytesCount",
+        EPublishingPolicy::All,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter IORequestsInFlight{
+        "IORequestsInFlight",
+        EPublishingPolicy::All,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    // BlobStorage based
+    TCounter MixedBytesCount{
+        "MixedBytesCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MergedBytesCount{
+        "MergedBytesCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter FreshBytesCount{
+        "FreshBytesCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter UntrimmedFreshBlobBytesCount{
+        "UntrimmedFreshBlobBytesCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter UsedBytesCount{
+        "UsedBytesCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter LogicalUsedBytesCount{
+        "LogicalUsedBytesCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter IORequestsQueued{
+        "IORequestsQueued",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter UsedBlocksMapMemSize{
+        "UsedBlocksMapMemSize",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter MixedIndexCacheMemSize{
+        "MixedIndexCacheMemSize",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter CheckpointBytes{
+        "CheckpointBytes",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter AlmostFullChannelCount{
+        "AlmostFullChannelCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter FreshBlocksInFlight{
+        "FreshBlocksInFlight",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter FreshBlocksQueued{
+        "FreshBlocksQueued",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Expiring};
+    TCounter CleanupQueueBytes{
+        "CleanupQueueBytes",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter GarbageQueueBytes{
+        "GarbageQueueBytes",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionScore{
+        "CompactionScore",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Max,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionGarbageScore{
+        "CompactionGarbageScore",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Max,
+        ECounterExpirationPolicy::Permanent};
+    TCounter ChannelHistorySize{
+        "ChannelHistorySize",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Max,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionRangeCountPerRun{
+        "CompactionRangeCountPerRun",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Max,
+        ECounterExpirationPolicy::Permanent};
+    TCounter UnconfirmedBlobCount{
+        "UnconfirmedBlobCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter ConfirmedBlobCount{
+        "ConfirmedBlobCount",
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    // DiskRegistry based
+    TCounter HasBrokenDevice{
+        "HasBrokenDevice",
+        EPublishingPolicy::DiskRegistryBased,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter HasBrokenDeviceSilent{
+        "HasBrokenDeviceSilent",
+        EPublishingPolicy::DiskRegistryBased,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    static constexpr TCounterPtr All[] = {
+        &TSimpleDiskCounters::BytesCount,
+        &TSimpleDiskCounters::IORequestsInFlight,
+
+        &TSimpleDiskCounters::MixedBytesCount,
+        &TSimpleDiskCounters::MergedBytesCount,
+        &TSimpleDiskCounters::FreshBytesCount,
+        &TSimpleDiskCounters::UntrimmedFreshBlobBytesCount,
+        &TSimpleDiskCounters::UsedBytesCount,
+        &TSimpleDiskCounters::LogicalUsedBytesCount,
+        &TSimpleDiskCounters::IORequestsQueued,
+        &TSimpleDiskCounters::UsedBlocksMapMemSize,
+        &TSimpleDiskCounters::MixedIndexCacheMemSize,
+        &TSimpleDiskCounters::CheckpointBytes,
+        &TSimpleDiskCounters::AlmostFullChannelCount,
+        &TSimpleDiskCounters::FreshBlocksInFlight,
+        &TSimpleDiskCounters::FreshBlocksQueued,
+        &TSimpleDiskCounters::CleanupQueueBytes,
+        &TSimpleDiskCounters::GarbageQueueBytes,
+        &TSimpleDiskCounters::CompactionScore,
+        &TSimpleDiskCounters::CompactionGarbageScore,
+        &TSimpleDiskCounters::ChannelHistorySize,
+        &TSimpleDiskCounters::CompactionRangeCountPerRun,
+        &TSimpleDiskCounters::UnconfirmedBlobCount,
+        &TSimpleDiskCounters::ConfirmedBlobCount,
+
+        &TSimpleDiskCounters::HasBrokenDevice,
+        &TSimpleDiskCounters::HasBrokenDeviceSilent,
+    };
+    static constexpr size_t MemberCount = std::size(All);
+};
+static_assert(
+    sizeof(TSimpleDiskCounters) ==
+    sizeof(TSimpleDiskCounters::TCounter) * TSimpleDiskCounters::MemberCount);
 
 #define BLOCKSTORE_DRBASED_PART_CUMULATIVE_COUNTERS(xxx, ...)                  \
     xxx(ScrubbingThroughput, Generic, Permanent,                   __VA_ARGS__)\
@@ -173,19 +339,7 @@ enum class EPublishingPolicy
 
 struct TPartitionDiskCounters
 {
-    struct {
-#define BLOCKSTORE_SIMPLE_COUNTER(name, type, policy, ...)                     \
-    TSimpleCounter name{                                                       \
-        TSimpleCounter::ECounterType::type,                                    \
-        ECounterExpirationPolicy::policy                                       \
-    };                                                                         \
-// BLOCKSTORE_SIMPLE_COUNTER
-
-        BLOCKSTORE_PART_COMMON_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-        BLOCKSTORE_REPL_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-        BLOCKSTORE_DRBASED_PART_SIMPLE_COUNTERS(BLOCKSTORE_SIMPLE_COUNTER)
-#undef BLOCKSTORE_SIMPLE_COUNTER
-    } Simple;
+    TSimpleDiskCounters Simple;
 
     struct {
 #define BLOCKSTORE_CUMULATIVE_COUNTER(name, type, policy, ...)                 \

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -217,34 +217,118 @@ struct TSimpleDiskCounters
         &TSimpleDiskCounters::HasBrokenDevice,
         &TSimpleDiskCounters::HasBrokenDeviceSilent,
     };
-    static constexpr size_t MemberCount = std::size(All);
 };
 static_assert(
-    sizeof(TSimpleDiskCounters) ==
-    sizeof(TSimpleDiskCounters::TCounter) * TSimpleDiskCounters::MemberCount);
+    sizeof(TSimpleDiskCounters) == sizeof(TSimpleDiskCounters::TCounter) *
+                                       std::size(TSimpleDiskCounters::All));
 
-#define BLOCKSTORE_DRBASED_PART_CUMULATIVE_COUNTERS(xxx, ...)                  \
-    xxx(ScrubbingThroughput, Generic, Permanent,                   __VA_ARGS__)\
-// BLOCKSTORE_DRBASED_PART_CUMULATIVE_COUNTERS
+struct TCumulativeDiskCounters
+{
+    using TCounter = TMemberWithMeta<TCumulativeCounter>;
+    using TCounterPtr = TCounter TCumulativeDiskCounters::*;
 
-////////////////////////////////////////////////////////////////////////////////
+    // BlobStorage based
+    TCounter BytesWritten{
+        "BytesWritten",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter BytesRead{
+        "BytesRead",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter SysBytesWritten{
+        "SysBytesWritten",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter SysBytesRead{
+        "SysBytesRead",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter RealSysBytesWritten{
+        "RealSysBytesWritten",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter RealSysBytesRead{
+        "RealSysBytesRead",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter BatchCount{
+        "BatchCount",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter UncompressedBytesWritten{
+        "UncompressedBytesWritten",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompressedBytesWritten{
+        "CompressedBytesWritten",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionByReadStats{
+        "CompactionByReadStats",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionByBlobCountPerRange{
+        "CompactionByBlobCountPerRange",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionByBlobCountPerDisk{
+        "CompactionByBlobCountPerDisk",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionByGarbageBlocksPerRange{
+        "CompactionByGarbageBlocksPerRange",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter CompactionByGarbageBlocksPerDisk{
+        "CompactionByGarbageBlocksPerDisk",
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
 
-#define BLOCKSTORE_REPL_PART_CUMULATIVE_COUNTERS(xxx, ...)                     \
-    xxx(BytesWritten,               Generic, Permanent,            __VA_ARGS__)\
-    xxx(BytesRead,                  Generic, Permanent,            __VA_ARGS__)\
-    xxx(SysBytesWritten,            Generic, Permanent,            __VA_ARGS__)\
-    xxx(SysBytesRead,               Generic, Permanent,            __VA_ARGS__)\
-    xxx(RealSysBytesWritten,        Generic, Permanent,            __VA_ARGS__)\
-    xxx(RealSysBytesRead,           Generic, Permanent,            __VA_ARGS__)\
-    xxx(BatchCount,                 Generic, Permanent,            __VA_ARGS__)\
-    xxx(UncompressedBytesWritten,   Generic, Permanent,            __VA_ARGS__)\
-    xxx(CompressedBytesWritten,     Generic, Permanent,            __VA_ARGS__)\
-    xxx(CompactionByReadStats,      Generic, Permanent,            __VA_ARGS__)\
-    xxx(CompactionByBlobCountPerRange,     Generic, Permanent,     __VA_ARGS__)\
-    xxx(CompactionByBlobCountPerDisk,      Generic, Permanent,     __VA_ARGS__)\
-    xxx(CompactionByGarbageBlocksPerRange, Generic, Permanent,     __VA_ARGS__)\
-    xxx(CompactionByGarbageBlocksPerDisk,  Generic, Permanent,     __VA_ARGS__)\
-// BLOCKSTORE_REPL_PART_CUMULATIVE_COUNTERS
+    // DiskRegistry based
+    TCounter ScrubbingThroughput{
+        "ScrubbingThroughput",
+        EPublishingPolicy::DiskRegistryBased,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+
+    static constexpr TCounterPtr All[] = {
+        &TCumulativeDiskCounters::BytesWritten,
+        &TCumulativeDiskCounters::BytesRead,
+        &TCumulativeDiskCounters::SysBytesWritten,
+        &TCumulativeDiskCounters::SysBytesRead,
+        &TCumulativeDiskCounters::RealSysBytesWritten,
+        &TCumulativeDiskCounters::RealSysBytesRead,
+        &TCumulativeDiskCounters::BatchCount,
+        &TCumulativeDiskCounters::UncompressedBytesWritten,
+        &TCumulativeDiskCounters::CompressedBytesWritten,
+        &TCumulativeDiskCounters::CompactionByReadStats,
+        &TCumulativeDiskCounters::CompactionByBlobCountPerRange,
+        &TCumulativeDiskCounters::CompactionByBlobCountPerDisk,
+        &TCumulativeDiskCounters::CompactionByGarbageBlocksPerRange,
+        &TCumulativeDiskCounters::CompactionByGarbageBlocksPerDisk,
+
+        &TCumulativeDiskCounters::ScrubbingThroughput,
+    };
+};
+static_assert(
+    sizeof(TCumulativeDiskCounters) ==
+    sizeof(TCumulativeDiskCounters::TCounter) *
+        std::size(TCumulativeDiskCounters::All));
 
 #define BLOCKSTORE_REPL_PART_REQUEST_COUNTERS(xxx, ...)                        \
     xxx(Flush,                                                     __VA_ARGS__)\
@@ -340,19 +424,7 @@ static_assert(
 struct TPartitionDiskCounters
 {
     TSimpleDiskCounters Simple;
-
-    struct {
-#define BLOCKSTORE_CUMULATIVE_COUNTER(name, type, policy, ...)                 \
-    TCumulativeCounter name{                                                   \
-        TCumulativeCounter::ECounterType::type,                                \
-        ECounterExpirationPolicy::policy                                       \
-    };                                                                         \
-// BLOCKSTORE_CUMULATIVE_COUNTER
-
-        BLOCKSTORE_REPL_PART_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-        BLOCKSTORE_DRBASED_PART_CUMULATIVE_COUNTERS(BLOCKSTORE_CUMULATIVE_COUNTER)
-#undef BLOCKSTORE_CUMULATIVE_COUNTER
-    } Cumulative;
+    TCumulativeDiskCounters Cumulative;
 
     struct {
 #define BLOCKSTORE_REQUEST_LOW_RESOLUTION_COUNTER(name, ...)                  \

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -61,18 +61,18 @@ struct TMemberMeta
 
 namespace NDetail {
 
-template <auto T>
+template <auto TMemberPtr>
 consteval auto ExtractMemberPtr()
 {
-    return T;
+    return TMemberPtr;
 }
 
 }   // namespace NDetail
 
-template <auto T>
+template <auto TMemberPtr>
 consteval auto MakeMeta()
 {
-    TMemberMeta<decltype(NDetail::ExtractMemberPtr<T>())> result;
+    TMemberMeta<decltype(NDetail::ExtractMemberPtr<TMemberPtr>())> result;
 
     // Extract member name from __PRETTY_FUNCTION__.
     // __PRETTY_FUNCTION__ looks like
@@ -85,7 +85,7 @@ consteval auto MakeMeta()
     result.Name = raw.substr(start + left.size(), end - start - left.size());
 
     // Store member ptr.
-    result.MemberPtr = NDetail::ExtractMemberPtr<T>();
+    result.MemberPtr = NDetail::ExtractMemberPtr<TMemberPtr>();
     return result;
 }
 

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -188,7 +188,7 @@ struct TSimpleDiskCounters
         TSimpleCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
 
-    static constexpr TCounterPtr All[] = {
+    static constexpr TCounterPtr AllCounters[] = {
         &TSimpleDiskCounters::BytesCount,
         &TSimpleDiskCounters::IORequestsInFlight,
 
@@ -219,8 +219,9 @@ struct TSimpleDiskCounters
     };
 };
 static_assert(
-    sizeof(TSimpleDiskCounters) == sizeof(TSimpleDiskCounters::TCounter) *
-                                       std::size(TSimpleDiskCounters::All));
+    sizeof(TSimpleDiskCounters) ==
+    sizeof(TSimpleDiskCounters::TCounter) *
+        std::size(TSimpleDiskCounters::AllCounters));
 
 struct TCumulativeDiskCounters
 {
@@ -306,7 +307,7 @@ struct TCumulativeDiskCounters
         TCumulativeCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
 
-    static constexpr TCounterPtr All[] = {
+    static constexpr TCounterPtr AllCounters[] = {
         &TCumulativeDiskCounters::BytesWritten,
         &TCumulativeDiskCounters::BytesRead,
         &TCumulativeDiskCounters::SysBytesWritten,
@@ -328,7 +329,7 @@ struct TCumulativeDiskCounters
 static_assert(
     sizeof(TCumulativeDiskCounters) ==
     sizeof(TCumulativeDiskCounters::TCounter) *
-        std::size(TCumulativeDiskCounters::All));
+        std::size(TCumulativeDiskCounters::AllCounters));
 
 struct THistogramRequestCounters
 {
@@ -465,7 +466,7 @@ struct THistogramCounters
         EPublishingPolicy::Repl,
         ERequestCounterOption{}};
 
-    static constexpr TCounterPtr All[] = {
+    static constexpr TCounterPtr AllCounters[] = {
         &THistogramCounters::ActorQueue,
         &THistogramCounters::MailboxQueue,
     };
@@ -473,7 +474,8 @@ struct THistogramCounters
 
 static_assert(
     sizeof(THistogramCounters) ==
-    sizeof(THistogramCounters::TCounter) * std::size(THistogramCounters::All));
+    sizeof(THistogramCounters::TCounter) *
+        std::size(THistogramCounters::AllCounters));
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -603,7 +605,7 @@ struct TVolumeSelfSimpleCounters
         TCumulativeCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
 
-    static constexpr TCounterPtr All[] = {
+    static constexpr TCounterPtr AllCounters[] = {
         &TVolumeSelfSimpleCounters::MaxReadBandwidth,
         &TVolumeSelfSimpleCounters::MaxWriteBandwidth,
         &TVolumeSelfSimpleCounters::MaxReadIops,
@@ -634,12 +636,12 @@ struct TVolumeSelfSimpleCounters
 static_assert(
     sizeof(TVolumeSelfSimpleCounters) ==
     sizeof(TVolumeSelfSimpleCounters::TCounter) *
-        std::size(TVolumeSelfSimpleCounters::All));
+        std::size(TVolumeSelfSimpleCounters::AllCounters));
 
-struct TVolumeSelfCommonCumulativeCounters
+struct TVolumeSelfCumulativeCounters
 {
     using TCounter = TMemberWithMeta<TCumulativeCounter>;
-    using TCounterPtr = TCounter TVolumeSelfCommonCumulativeCounters::*;
+    using TCounterPtr = TCounter TVolumeSelfCumulativeCounters::*;
 
     // Common
     TCounter ThrottlerRejectedRequests{
@@ -663,22 +665,22 @@ struct TVolumeSelfCommonCumulativeCounters
         TCumulativeCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
 
-    static constexpr TCounterPtr All[] = {
-        &TVolumeSelfCommonCumulativeCounters::ThrottlerRejectedRequests,
-        &TVolumeSelfCommonCumulativeCounters::ThrottlerPostponedRequests,
-        &TVolumeSelfCommonCumulativeCounters::ThrottlerSkippedRequests,
-        &TVolumeSelfCommonCumulativeCounters::UsedQuota,
+    static constexpr TCounterPtr AllCounters[] = {
+        &TVolumeSelfCumulativeCounters::ThrottlerRejectedRequests,
+        &TVolumeSelfCumulativeCounters::ThrottlerPostponedRequests,
+        &TVolumeSelfCumulativeCounters::ThrottlerSkippedRequests,
+        &TVolumeSelfCumulativeCounters::UsedQuota,
     };
 };
 static_assert(
-    sizeof(TVolumeSelfCommonCumulativeCounters) ==
-    sizeof(TVolumeSelfCommonCumulativeCounters::TCounter) *
-        std::size(TVolumeSelfCommonCumulativeCounters::All));
+    sizeof(TVolumeSelfCumulativeCounters) ==
+    sizeof(TVolumeSelfCumulativeCounters::TCounter) *
+        std::size(TVolumeSelfCumulativeCounters::AllCounters));
 
-struct TVolumeSelfCommonRequestCounters
+struct TVolumeSelfRequestCounters
 {
     using TCounter = TMemberWithMeta<THistogram<TRequestUsTimeBuckets>>;
-    using TCounterPtr = TCounter TVolumeSelfCommonRequestCounters::*;
+    using TCounterPtr = TCounter TVolumeSelfRequestCounters::*;
 
     // Common
     TCounter ReadBlocks{
@@ -698,20 +700,19 @@ struct TVolumeSelfCommonRequestCounters
         EPublishingPolicy::All,
         ERequestCounterOption{}};
 
-    static constexpr TCounterPtr All[] = {
-        &TVolumeSelfCommonRequestCounters::ReadBlocks,
-        &TVolumeSelfCommonRequestCounters::WriteBlocks,
-        &TVolumeSelfCommonRequestCounters::ZeroBlocks,
-        &TVolumeSelfCommonRequestCounters::DescribeBlocks,
+    static constexpr TCounterPtr AllCounters[] = {
+        &TVolumeSelfRequestCounters::ReadBlocks,
+        &TVolumeSelfRequestCounters::WriteBlocks,
+        &TVolumeSelfRequestCounters::ZeroBlocks,
+        &TVolumeSelfRequestCounters::DescribeBlocks,
     };
 };
 static_assert(
-    sizeof(TVolumeSelfCommonRequestCounters) ==
-    sizeof(TVolumeSelfCommonRequestCounters::TCounter) *
-        std::size(TVolumeSelfCommonRequestCounters::All));
+    sizeof(TVolumeSelfRequestCounters) ==
+    sizeof(TVolumeSelfRequestCounters::TCounter) *
+        std::size(TVolumeSelfRequestCounters::AllCounters));
 
 ////////////////////////////////////////////////////////////////////////////////
-
 
 struct TPartitionDiskCounters
 {
@@ -738,8 +739,8 @@ struct TPartitionDiskCounters
 struct TVolumeSelfCounters
 {
     TVolumeSelfSimpleCounters Simple;
-    TVolumeSelfCommonCumulativeCounters Cumulative;
-    TVolumeSelfCommonRequestCounters RequestCounters;
+    TVolumeSelfCumulativeCounters Cumulative;
+    TVolumeSelfRequestCounters RequestCounters;
 
     EPublishingPolicy Policy;
 


### PR DESCRIPTION
Убираю макросы в счетчиках. При таком подходе объявление счетчика чуть сложнее, его нужно прописать в двух местах, но код при этом становится читаемым.
Есть защита от дурака, если не прописать новый счетчик в общем списке всех счетчиков, сломается static_assert.