### PR TITLE
issue-1307: accessing Endpoints map under a lock

### DIFF
--- a/cloud/filestore/libs/endpoint/service.cpp
+++ b/cloud/filestore/libs/endpoint/service.cpp
@@ -134,14 +134,13 @@ public:
     void Drain() override
     {
         auto g = Guard(EndpointsLock);
+        DrainingStarted = true;
 
         TVector<TFuture<void>> futures;
         for (auto&& [_, endpoint]: Endpoints) {
             futures.push_back(endpoint.Endpoint->SuspendAsync());
         }
         WaitAll(futures).GetValueSync();
-
-        DrainingStarted = true;
     }
 
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=224360)
  Read of size 8 at 0x7b44000095c0 by main thread:
    #0 NCloud::NFileStore::(anonymous namespace)::TEndpointManager::Drain() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service.cpp:135:34 (filestore-vhost+0x26c5935b) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #1 NCloud::NFileStore::(anonymous namespace)::TAuthService::Drain() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service_auth.cpp:47:18 (filestore-vhost+0x26c8cf1f) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #2 NCloud::NFileStore::NDaemon::TBootstrapVhost::Drain() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/vhost/bootstrap.cpp:332:26 (filestore-vhost+0x26c2273a) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #3 NCloud::NFileStore::NDaemon::TBootstrapCommon::Stop() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/common/bootstrap.cpp:140:5 (filestore-vhost+0x1b93636b) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #4 int NCloud::DoMain<NCloud::NFileStore::NDaemon::TBootstrapVhost>(NCloud::NFileStore::NDaemon::TBootstrapVhost&, int, char**) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/daemon/app.h:47:23 (filestore-vhost+0xf4c5d4e) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #5 main /actions-runner/_work/nbs/nbs/cloud/filestore/apps/vhost/main.cpp:22:12 (filestore-vhost+0xf4c5b14) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)

  Previous write of size 8 at 0x7b44000095c0 by thread T67:
    #0 std::__y1::__tree<std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo>, std::__y1::__map_value_compare<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo>, TLess<TBasicString<char, std::__y1::char_traits<char> > >, true>, std::__y1::allocator<std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> > >::__insert_node_at /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__tree:2078:24 (filestore-vhost+0x26c5e9db) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #1 std::__y1::__tree<std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo>, std::__y1::__map_value_compare<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo>, TLess<TBasicString<char, std::__y1::char_traits<char> > >, true>, std::__y1::allocator<std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> > >::__emplace_unique_key_args<TBasicString<char, std::__y1::char_traits<char> >, const TBasicString<char, std::__y1::char_traits<char> > &, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__tree:2095:9 (filestore-vhost+0x26c5e9db)
    #2 std::__y1::__tree<std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo>, std::__y1::__map_value_compare<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo>, TLess<TBasicString<char, std::__y1::char_traits<char> > >, true>, std::__y1::allocator<std::__y1::__value_type<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> > >::__emplace_unique<const TBasicString<char, std::__y1::char_traits<char> > &, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__tree:1178:16 (filestore-vhost+0x26c5e9db)
    #3 std::__y1::map<TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo, TLess<TBasicString<char, std::__y1::char_traits<char> > >, std::__y1::allocator<std::__y1::pair<const TBasicString<char, std::__y1::char_traits<char> >, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> > >::emplace<const TBasicString<char, std::__y1::char_traits<char> > &, NCloud::NFileStore::(anonymous namespace)::TEndpointInfo> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/map:1221:24 (filestore-vhost+0x26c5e9db)
    #4 NCloud::NFileStore::(anonymous namespace)::TEndpointManager::DoStartEndpoint(NCloud::NFileStore::NProto::TStartEndpointRequest const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service.cpp:302:19 (filestore-vhost+0x26c5e9db)
    #5 TCont::Switch() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:76:17 (filestore-vhost+0x1be77bd3) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #6 NCoro::(anonymous namespace)::DoExecuteEvent<TTimerEvent> /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/cont_poller.cpp:15:19 (filestore-vhost+0x1be7dc09) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #7 ExecuteEvent(TTimerEvent*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/cont_poller.cpp:69:12 (filestore-vhost+0x1be7dc09)
    #8 TCont::SleepD /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:72:12 (filestore-vhost+0x1be780e7) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #9 TCont::Yield() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:80:9 (filestore-vhost+0x1be780e7)
    #10 NCloud::(anonymous namespace)::TDispatcher::DoDispatch /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:104:16 (filestore-vhost+0x26c7169a) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #11 NCloud::(anonymous namespace)::TDispatcher::Dispatch /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:83:13 (filestore-vhost+0x26c7169a)
    #12 void ContHelperMemberFunc<NCloud::(anonymous namespace)::TDispatcher, &NCloud::(anonymous namespace)::TDispatcher::Dispatch(TCont*)>(TCont*, void*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.h:151:5 (filestore-vhost+0x26c7169a)
    #13 NCloud::TExecutor::WaitFor<NCloud::NFileStore::NProto::TStartEndpointResponse> /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.h:53:36 (filestore-vhost+0x26c5e1f6) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #14 NCloud::NFileStore::(anonymous namespace)::TEndpointManager::DoStartEndpoint(NCloud::NFileStore::NProto::TStartEndpointRequest const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service.cpp:296:15 (filestore-vhost+0x26c5e1f6)
    #15 NCloud::NFileStore::(anonymous namespace)::TEndpointManager::StartEndpoint(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TStartEndpointRequest>)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service.cpp:157:5 (filestore-vhost+0x26c5b556) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #16 NThreading::NImpl::SetValue<NCloud::NFileStore::NProto::TStartEndpointResponse, (lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/endpoint/service.cpp:157:5) &> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (filestore-vhost+0x26c5b556)
    #17 NCloud::TFutureTask<NCloud::NFileStore::(anonymous namespace)::TEndpointManager::StartEndpoint(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TStartEndpointRequest>)::'lambda'()>::Execute() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/task_queue.h:41:9 (filestore-vhost+0x26c5b556)
    #18 NCloud::(anonymous namespace)::TWorker::Execute /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:43:19 (filestore-vhost+0x26c722c8) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #19 void ContHelperMemberFunc<NCloud::(anonymous namespace)::TWorker, &NCloud::(anonymous namespace)::TWorker::Execute(TCont*)>(TCont*, void*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.h:151:5 (filestore-vhost+0x26c722c8)
    #20 TContExecutor::Create(void (*)(TCont *, void *), void *, const char *, TMaybe<unsigned int, NMaybe::TPolicyUndefinedExcept>)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:249:9 (filestore-vhost+0x1be7ca53) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #21 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24) &, TCont *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (filestore-vhost+0x1be7ca53)
    #22 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24) &, TCont *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (filestore-vhost+0x1be7ca53)
    #23 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24)>, void (TCont *)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (filestore-vhost+0x1be7ca53)
    #24 std::__y1::__function::__func<TContExecutor::Create(void (*)(TCont*, void*), void*, char const*, TMaybe<unsigned int, NMaybe::TPolicyUndefinedExcept>)::$_0, std::__y1::allocator<TContExecutor::Create(void (*)(TCont*, void*), void*, char const*, TMaybe<unsigned int, NMaybe::TPolicyUndefinedExcept>)::$_0>, void (TCont*)>::operator()(TCont*&&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (filestore-vhost+0x1be7ca53)
    #25 std::__y1::__function::__value_func<void (TCont *)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (filestore-vhost+0x1be7cd82) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #26 std::__y1::function<void (TCont *)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (filestore-vhost+0x1be7cd82)
    #27 NCoro::TTrampoline::DoRun() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/trampoline.cpp:30:17 (filestore-vhost+0x1be7cd82)
    #28 NCoro::TTrampoline::DoRunNaked() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/trampoline.cpp:46:9 (filestore-vhost+0x1be7ce82) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #29 Run /actions-runner/_work/nbs/nbs/util/system/context.cpp:47:26 (filestore-vhost+0xf6d6b62) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #30 ContextTrampoLine(void*) /actions-runner/_work/nbs/nbs/util/system/context.cpp:215:5 (filestore-vhost+0xf6d6b62)
    #31 <null> <null> (libc.so.6+0x5a12f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #32 TContExecutor::RunScheduler() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:348:22 (filestore-vhost+0x1be77e74) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #33 TCont::Switch() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:76:17 (filestore-vhost+0x1be77bd3) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #34 NCoro::(anonymous namespace)::DoExecuteEvent<TTimerEvent> /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/cont_poller.cpp:15:19 (filestore-vhost+0x1be7dc09) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #35 ExecuteEvent(TTimerEvent*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/cont_poller.cpp:69:12 (filestore-vhost+0x1be7dc09)
    #36 TCont::SleepD /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:72:12 (filestore-vhost+0x1be780e7) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #37 TCont::Yield() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:80:9 (filestore-vhost+0x1be780e7)
    #38 NCloud::(anonymous namespace)::TDispatcher::DoDispatch /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:104:16 (filestore-vhost+0x26c7169a) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #39 NCloud::(anonymous namespace)::TDispatcher::Dispatch /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:83:13 (filestore-vhost+0x26c7169a)
    #40 void ContHelperMemberFunc<NCloud::(anonymous namespace)::TDispatcher, &NCloud::(anonymous namespace)::TDispatcher::Dispatch(TCont*)>(TCont*, void*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.h:151:5 (filestore-vhost+0x26c7169a)
    #41 <null> <null> (libc.so.6+0x5a12f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #42 TContExecutor::RunScheduler() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:348:22 (filestore-vhost+0x1be77e74) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #43 TCont::Switch() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:76:17 (filestore-vhost+0x1be77bd3) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #44 NCoro::(anonymous namespace)::DoExecuteEvent<TFdEvent> /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/cont_poller.cpp:15:19 (filestore-vhost+0x1be7dad7) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #45 ExecuteEvent(TFdEvent*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/cont_poller.cpp:65:12 (filestore-vhost+0x1be7dad7)
    #46 NCoro::PollD /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/network.cpp:100:16 (filestore-vhost+0x1be859e9) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #47 NCoro::ReadVectorD(TCont*, int, TContIOVector*, TInstant) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/network.cpp:128:24 (filestore-vhost+0x1be859e9)
    #48 NCoro::ReadD /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/network.cpp:146:16 (filestore-vhost+0x1be85d01) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #49 NCoro::ReadI(TCont*, int, void*, unsigned long) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/network.cpp:154:16 (filestore-vhost+0x1be85d01)
    #50 NCloud::TContPipeEvent::WaitI /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/queue.h:102:16 (filestore-vhost+0x26c7177f) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #51 NCloud::TContQueue<NCloud::ITask *, TLockFreeQueue<NCloud::ITask *, TDefaultLFCounter>, NCloud::TContPipeEvent>::Dequeue /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/queue.h:132:24 (filestore-vhost+0x26c7177f)
    #52 NCloud::(anonymous namespace)::TDispatcher::DoDispatch /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:94:22 (filestore-vhost+0x26c7177f)
    #53 NCloud::(anonymous namespace)::TDispatcher::Dispatch /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:83:13 (filestore-vhost+0x26c7177f)
    #54 void ContHelperMemberFunc<NCloud::(anonymous namespace)::TDispatcher, &NCloud::(anonymous namespace)::TDispatcher::Dispatch(TCont*)>(TCont*, void*) /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.h:151:5 (filestore-vhost+0x26c7177f)
    #55 TContExecutor::Create(void (*)(TCont *, void *), void *, const char *, TMaybe<unsigned int, NMaybe::TPolicyUndefinedExcept>)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:249:9 (filestore-vhost+0x1be7ca53) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #56 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24) &, TCont *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (filestore-vhost+0x1be7ca53)
    #57 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24) &, TCont *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (filestore-vhost+0x1be7ca53)
    #58 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:248:24)>, void (TCont *)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (filestore-vhost+0x1be7ca53)
    #59 std::__y1::__function::__func<TContExecutor::Create(void (*)(TCont*, void*), void*, char const*, TMaybe<unsigned int, NMaybe::TPolicyUndefinedExcept>)::$_0, std::__y1::allocator<TContExecutor::Create(void (*)(TCont*, void*), void*, char const*, TMaybe<unsigned int, NMaybe::TPolicyUndefinedExcept>)::$_0>, void (TCont*)>::operator()(TCont*&&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (filestore-vhost+0x1be7ca53)
    #60 std::__y1::__function::__value_func<void (TCont *)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (filestore-vhost+0x1be7cd82) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #61 std::__y1::function<void (TCont *)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (filestore-vhost+0x1be7cd82)
    #62 NCoro::TTrampoline::DoRun() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/trampoline.cpp:30:17 (filestore-vhost+0x1be7cd82)
    #63 NCoro::TTrampoline::DoRunNaked() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/trampoline.cpp:46:9 (filestore-vhost+0x1be7ce82) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #64 Run /actions-runner/_work/nbs/nbs/util/system/context.cpp:47:26 (filestore-vhost+0xf6d6b62) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #65 ContextTrampoLine(void*) /actions-runner/_work/nbs/nbs/util/system/context.cpp:215:5 (filestore-vhost+0xf6d6b62)
    #66 <null> <null> (libc.so.6+0x5a12f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #67 TContExecutor::RunScheduler() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:348:22 (filestore-vhost+0x1be77e74) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #68 TContExecutor::Execute /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:161:5 (filestore-vhost+0x1be797b8) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #69 TContExecutor::Execute<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:153:16)> /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.h:189:9 (filestore-vhost+0x1be797b8)
    #70 TContExecutor::Execute() /actions-runner/_work/nbs/nbs/library/cpp/coroutine/engine/impl.cpp:154:5 (filestore-vhost+0x1be797b8)
    #71 NCloud::TExecutor::TThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/coroutine/executor.cpp:153:19 (filestore-vhost+0x26c71133) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #72 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-vhost+0xf72d782) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
    #73 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-vhost+0xf73111c) (BuildId: 636bcafcca3e067b10e7765df584d9849a883dc8)
```

#1307 