### PR TITLE
issue-1164: implemented endpoint metrics in blockstore-endpoint-proxy, moved proxy storage to a separate module, added proxy storage uts

### DIFF
--- a/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage.cpp
@@ -1,0 +1,340 @@
+#include "proxy_storage.h"
+
+#include <cloud/blockstore/libs/service/service.h>
+#include <cloud/blockstore/libs/service/storage.h>
+#include <cloud/blockstore/public/api/protos/io.pb.h>
+
+#include <cloud/storage/core/protos/media.pb.h>
+
+#include <util/datetime/base.h>
+#include <util/datetime/cputimer.h>
+
+#include <atomic>
+
+namespace NCloud::NBlockStore::NServer {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRequestStats: public IProxyRequestStats
+{
+private:
+    TRequestTypeStatsArray RequestType2Stats;
+
+    TRequestTypeStats& S(EBlockStoreRequest requestType)
+    {
+        return RequestType2Stats[static_cast<ui32>(requestType)];
+    }
+
+public:
+    const TRequestTypeStatsArray& GetInternalStats() const override
+    {
+        return RequestType2Stats;
+    }
+
+    ui64 RequestStarted(
+        NCloud::NProto::EStorageMediaKind mediaKind,
+        EBlockStoreRequest requestType,
+        ui32 requestBytes) override
+    {
+        Y_UNUSED(mediaKind);
+
+        auto& s = S(requestType);
+        s.Count.fetch_add(1, std::memory_order_relaxed);
+        s.RequestBytes.fetch_add(requestBytes, std::memory_order_relaxed);
+        s.Inflight.fetch_add(1, std::memory_order_relaxed);
+        s.InflightBytes.fetch_add(requestBytes, std::memory_order_relaxed);
+
+        return GetCycleCount();
+    }
+
+    TDuration RequestCompleted(
+        NCloud::NProto::EStorageMediaKind mediaKind,
+        EBlockStoreRequest requestType,
+        ui64 requestStarted,
+        TDuration postponedTime,
+        ui32 requestBytes,
+        EDiagnosticsErrorKind errorKind,
+        ui32 errorFlags,
+        bool unaligned,
+        ECalcMaxTime calcMaxTime,
+        ui64 responseSent) override
+    {
+        Y_UNUSED(mediaKind);
+        Y_UNUSED(postponedTime);
+        Y_UNUSED(errorFlags);
+        Y_UNUSED(unaligned);
+        Y_UNUSED(calcMaxTime);
+
+        auto& s = S(requestType);
+        s.Inflight.fetch_sub(1, std::memory_order_relaxed);
+        s.InflightBytes.fetch_sub(requestBytes, std::memory_order_relaxed);
+        s.E(errorKind).fetch_add(1, std::memory_order_relaxed);
+
+        return CyclesToDurationSafe(responseSent - requestStarted);
+    }
+
+    void AddIncompleteStats(
+        NCloud::NProto::EStorageMediaKind mediaKind,
+        EBlockStoreRequest requestType,
+        TRequestTime requestTime,
+        ECalcMaxTime calcMaxTime) override
+    {
+        Y_UNUSED(mediaKind);
+        Y_UNUSED(requestType);
+        Y_UNUSED(requestTime);
+        Y_UNUSED(calcMaxTime);
+    }
+
+    void AddRetryStats(
+        NCloud::NProto::EStorageMediaKind mediaKind,
+        EBlockStoreRequest requestType,
+        EDiagnosticsErrorKind errorKind,
+        ui32 errorFlags) override
+    {
+        Y_UNUSED(mediaKind);
+        Y_UNUSED(requestType);
+        Y_UNUSED(errorKind);
+        Y_UNUSED(errorFlags);
+    }
+
+    void RequestPostponed(EBlockStoreRequest requestType) override
+    {
+        Y_UNUSED(requestType);
+    }
+
+    void RequestPostponedServer(EBlockStoreRequest requestType) override
+    {
+        Y_UNUSED(requestType);
+    }
+
+    void RequestAdvanced(EBlockStoreRequest requestType) override
+    {
+        Y_UNUSED(requestType);
+    }
+
+    void RequestAdvancedServer(EBlockStoreRequest requestType) override
+    {
+        Y_UNUSED(requestType);
+    }
+
+    void RequestFastPathHit(EBlockStoreRequest requestType) override
+    {
+        Y_UNUSED(requestType);
+    }
+
+    void BatchCompleted(
+        NCloud::NProto::EStorageMediaKind mediaKind,
+        EBlockStoreRequest requestType,
+        ui64 count,
+        ui64 bytes,
+        ui64 errors,
+        std::span<TTimeBucket> timeHist,
+        std::span<TSizeBucket> sizeHist) override
+    {
+        Y_UNUSED(mediaKind);
+        Y_UNUSED(requestType);
+        Y_UNUSED(count);
+        Y_UNUSED(bytes);
+        Y_UNUSED(errors);
+        Y_UNUSED(timeHist);
+        Y_UNUSED(sizeHist);
+    }
+
+    void UpdateStats(bool updateIntervalFinished) override
+    {
+        Y_UNUSED(updateIntervalFinished);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TProxyStorage final: public IStorage
+{
+private:
+    const IBlockStorePtr Service;
+    const IRequestStatsPtr RequestStats;
+    const ui32 BlockSize;
+
+public:
+    explicit TProxyStorage(
+            IBlockStorePtr service,
+            IRequestStatsPtr requestStats,
+            ui32 blockSize)
+        : Service(std::move(service))
+        , RequestStats(std::move(requestStats))
+        , BlockSize(blockSize)
+    {}
+
+    NThreading::TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TZeroBlocksRequest> request) override
+    {
+        const auto requestBytes = request->GetBlocksCount() * BlockSize;
+        const auto requestStarted = RequestStats->RequestStarted(
+            NProto::STORAGE_MEDIA_DEFAULT,
+            EBlockStoreRequest::ZeroBlocks,
+            requestBytes);
+
+        auto f = Service->ZeroBlocks(
+            std::move(callContext),
+            std::move(request));
+
+        f.Subscribe([=, rs = RequestStats] (const auto& f) {
+            auto errorKind = EDiagnosticsErrorKind::ErrorFatal;
+            try {
+                const auto& result = f.GetValue();
+                errorKind = GetDiagnosticsErrorKind(result.GetError());
+            } catch (...) {
+                Cerr << "unexpected exception in ZeroBlocks result: "
+                    << CurrentExceptionMessage() << Endl;
+                Y_DEBUG_ABORT_UNLESS(0);
+            }
+
+            rs->RequestCompleted(
+                NProto::STORAGE_MEDIA_DEFAULT,
+                EBlockStoreRequest::ZeroBlocks,
+                requestStarted,
+                TDuration::Zero(),
+                requestBytes,
+                errorKind,
+                0,
+                false,
+                ECalcMaxTime::DISABLE,
+                GetCycleCount());
+        });
+
+        return f;
+    }
+
+    NThreading::TFuture<NProto::TReadBlocksLocalResponse> ReadBlocksLocal(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TReadBlocksLocalRequest> request) override
+    {
+        ui64 requestBytes = 0;
+        if (auto g = request->Sglist.Acquire()) {
+            for (const auto& block: g.Get()) {
+                requestBytes += block.Size();
+            }
+        }
+        const auto requestStarted = RequestStats->RequestStarted(
+            NProto::STORAGE_MEDIA_DEFAULT,
+            EBlockStoreRequest::ReadBlocks,
+            requestBytes);
+
+        auto f = Service->ReadBlocksLocal(
+            std::move(callContext),
+            std::move(request));
+
+        f.Subscribe([=, rs = RequestStats] (const auto& f) {
+            auto errorKind = EDiagnosticsErrorKind::ErrorFatal;
+            try {
+                const auto& result = f.GetValue();
+                errorKind = GetDiagnosticsErrorKind(result.GetError());
+            } catch (...) {
+                Cerr << "unexpected exception in ReadBlocksLocal result: "
+                    << CurrentExceptionMessage() << Endl;
+                Y_DEBUG_ABORT_UNLESS(0);
+            }
+
+            rs->RequestCompleted(
+                NProto::STORAGE_MEDIA_DEFAULT,
+                EBlockStoreRequest::ReadBlocks,
+                requestStarted,
+                TDuration::Zero(),
+                requestBytes,
+                errorKind,
+                0,
+                false,
+                ECalcMaxTime::DISABLE,
+                GetCycleCount());
+        });
+
+        return f;
+    }
+
+    NThreading::TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteBlocksLocalRequest> request) override
+    {
+        ui64 requestBytes = 0;
+        if (auto g = request->Sglist.Acquire()) {
+            for (const auto& block: g.Get()) {
+                requestBytes += block.Size();
+            }
+        }
+        const auto requestStarted = RequestStats->RequestStarted(
+            NProto::STORAGE_MEDIA_DEFAULT,
+            EBlockStoreRequest::WriteBlocks,
+            requestBytes);
+
+        auto f = Service->WriteBlocksLocal(
+            std::move(callContext),
+            std::move(request));
+
+        f.Subscribe([=, rs = RequestStats] (const auto& f) {
+            auto errorKind = EDiagnosticsErrorKind::ErrorFatal;
+            try {
+                const auto& result = f.GetValue();
+                errorKind = GetDiagnosticsErrorKind(result.GetError());
+            } catch (...) {
+                Cerr << "unexpected exception in WriteBlocksLocal result: "
+                    << CurrentExceptionMessage() << Endl;
+                Y_DEBUG_ABORT_UNLESS(0);
+            }
+
+            rs->RequestCompleted(
+                NProto::STORAGE_MEDIA_DEFAULT,
+                EBlockStoreRequest::WriteBlocks,
+                requestStarted,
+                TDuration::Zero(),
+                requestBytes,
+                errorKind,
+                0,
+                false,
+                ECalcMaxTime::DISABLE,
+                GetCycleCount());
+        });
+
+        return f;
+    }
+
+    NThreading::TFuture<NProto::TError> EraseDevice(
+        NProto::EDeviceEraseMethod method) override
+    {
+        Y_UNUSED(method);
+        return NThreading::MakeFuture(MakeError(E_NOT_IMPLEMENTED));
+    }
+
+    TStorageBuffer AllocateBuffer(size_t bytesCount) override
+    {
+        Y_UNUSED(bytesCount);
+        return nullptr;
+    }
+
+    void ReportIOError() override
+    {}
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IProxyRequestStatsPtr CreateProxyRequestStats()
+{
+    return std::make_shared<TRequestStats>();
+}
+
+IStoragePtr CreateProxyStorage(
+    IBlockStorePtr blockStore,
+    IRequestStatsPtr requestStats,
+    ui32 blockSize)
+{
+    return std::make_shared<TProxyStorage>(
+        std::move(blockStore),
+        std::move(requestStats),
+        blockSize);
+}
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cloud/blockstore/libs/diagnostics/request_stats.h>
+#include <cloud/blockstore/libs/service/public.h>
+#include <cloud/blockstore/libs/service/request.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <array>
+
+namespace NCloud::NBlockStore::NServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TRequestTypeStats
+{
+    std::atomic<ui64> Count = 0;
+    std::atomic<ui64> RequestBytes = 0;
+    std::atomic<ui32> Inflight = 0;
+    std::atomic<ui32> InflightBytes = 0;
+    std::array<
+        std::atomic<ui64>,
+        static_cast<ui32>(EDiagnosticsErrorKind::Max)
+    > ErrorKind2Count = {};
+
+    std::atomic<ui64>& E(EDiagnosticsErrorKind errorKind)
+    {
+        return ErrorKind2Count[static_cast<ui32>(errorKind)];
+    }
+
+    ui64 E(EDiagnosticsErrorKind errorKind) const
+    {
+        return const_cast<TRequestTypeStats*>(this)->E(errorKind);
+    }
+};
+
+using TRequestTypeStatsArray = std::array<
+    TRequestTypeStats,
+    static_cast<ui32>(EBlockStoreRequest::MAX)>;
+
+struct IProxyRequestStats: IRequestStats
+{
+    [[nodiscard]]
+    virtual const TRequestTypeStatsArray& GetInternalStats() const = 0;
+};
+
+using IProxyRequestStatsPtr = std::shared_ptr<IProxyRequestStats>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+IProxyRequestStatsPtr CreateProxyRequestStats();
+IStoragePtr CreateProxyStorage(
+    IBlockStorePtr blockStore,
+    IRequestStatsPtr requestStats,
+    ui32 blockSize);
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage_ut.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage_ut.cpp
@@ -1,0 +1,263 @@
+#include "proxy_storage.h"
+
+#include <cloud/blockstore/libs/service/service_test.h>
+#include <cloud/blockstore/libs/service/storage.h>
+#include <cloud/blockstore/public/api/protos/io.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/core/future.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TProxyStorageTest)
+{
+    Y_UNIT_TEST(ShouldProxyRequestsAndTrackStats)
+    {
+        using TZero = std::shared_ptr<NProto::TZeroBlocksRequest>;
+        using TRead = std::shared_ptr<NProto::TReadBlocksLocalRequest>;
+        using TWrite = std::shared_ptr<NProto::TWriteBlocksLocalRequest>;
+
+        auto service = std::make_shared<TTestService>();
+        auto zeroPromise = NThreading::NewPromise<NProto::TZeroBlocksResponse>();
+        service->ZeroBlocksHandler = [&] (TZero) {
+            return zeroPromise.GetFuture();
+        };
+        auto readPromise =
+            NThreading::NewPromise<NProto::TReadBlocksLocalResponse>();
+        service->ReadBlocksLocalHandler = [&] (TRead) {
+            return readPromise.GetFuture();
+        };
+        auto writePromise =
+            NThreading::NewPromise<NProto::TWriteBlocksLocalResponse>();
+        service->WriteBlocksLocalHandler = [&] (TWrite) {
+            return writePromise.GetFuture();
+        };
+        auto requestStats = CreateProxyRequestStats();
+        auto proxyStorage = CreateProxyStorage(service, requestStats, 4_KB);
+
+        const auto& stats = requestStats->GetInternalStats();
+        const auto& zeroStats =
+            stats[static_cast<ui32>(EBlockStoreRequest::ZeroBlocks)];
+        const auto& readStats =
+            stats[static_cast<ui32>(EBlockStoreRequest::ReadBlocks)];
+        const auto& writeStats =
+            stats[static_cast<ui32>(EBlockStoreRequest::WriteBlocks)];
+
+        // ZeroBlocks Success
+
+        {
+            auto zeroBlocks = std::make_shared<NProto::TZeroBlocksRequest>();
+            zeroBlocks->SetStartIndex(1024);
+            zeroBlocks->SetBlocksCount(128);
+            auto f = proxyStorage->ZeroBlocks(
+                MakeIntrusive<TCallContext>(),
+                zeroBlocks);
+            UNIT_ASSERT(!f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, zeroStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(512_KB, zeroStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(1, zeroStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(512_KB, zeroStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                zeroStats.E(EDiagnosticsErrorKind::Success));
+
+            zeroPromise.SetValue({});
+            UNIT_ASSERT(f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, zeroStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(512_KB, zeroStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, zeroStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, zeroStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                zeroStats.E(EDiagnosticsErrorKind::Success));
+        }
+
+        // ZeroBlocks Error
+
+        {
+            zeroPromise = NThreading::NewPromise<NProto::TZeroBlocksResponse>();
+            auto zeroBlocks = std::make_shared<NProto::TZeroBlocksRequest>();
+            zeroBlocks->SetStartIndex(1024);
+            zeroBlocks->SetBlocksCount(128);
+            auto f = proxyStorage->ZeroBlocks(
+                MakeIntrusive<TCallContext>(),
+                zeroBlocks);
+            UNIT_ASSERT(!f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(2, zeroStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(1_MB, zeroStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(1, zeroStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(512_KB, zeroStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                zeroStats.E(EDiagnosticsErrorKind::Success));
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                zeroStats.E(EDiagnosticsErrorKind::ErrorRetriable));
+
+            NProto::TZeroBlocksResponse result;
+            result.MutableError()->SetCode(E_REJECTED);
+            zeroPromise.SetValue(result);
+            UNIT_ASSERT(f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(2, zeroStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(1_MB, zeroStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, zeroStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, zeroStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                zeroStats.E(EDiagnosticsErrorKind::Success));
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                zeroStats.E(EDiagnosticsErrorKind::ErrorRetriable));
+        }
+
+        // ReadBlocks Success
+
+        {
+            auto readBlocks =
+                std::make_shared<NProto::TReadBlocksLocalRequest>();
+            TGuardedBuffer<TString> buffer(TString(4_KB, 0));
+            readBlocks->Sglist = buffer.GetGuardedSgList();
+            readBlocks->SetStartIndex(1024);
+            auto f = proxyStorage->ReadBlocksLocal(
+                MakeIntrusive<TCallContext>(),
+                readBlocks);
+            UNIT_ASSERT(!f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, readStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, readStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(1, readStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, readStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                readStats.E(EDiagnosticsErrorKind::Success));
+
+            readPromise.SetValue({});
+            UNIT_ASSERT(f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, readStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, readStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, readStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, readStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                readStats.E(EDiagnosticsErrorKind::Success));
+        }
+
+        // ReadBlocks Error
+
+        {
+            readPromise =
+                NThreading::NewPromise<NProto::TReadBlocksLocalResponse>();
+            auto readBlocks =
+                std::make_shared<NProto::TReadBlocksLocalRequest>();
+            TGuardedBuffer<TString> buffer(TString(4_KB, 0));
+            readBlocks->Sglist = buffer.GetGuardedSgList();
+            readBlocks->SetStartIndex(1024);
+            auto f = proxyStorage->ReadBlocksLocal(
+                MakeIntrusive<TCallContext>(),
+                readBlocks);
+            UNIT_ASSERT(!f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(2, readStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(8_KB, readStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(1, readStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, readStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                readStats.E(EDiagnosticsErrorKind::Success));
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                readStats.E(EDiagnosticsErrorKind::ErrorRetriable));
+
+            NProto::TReadBlocksLocalResponse result;
+            result.MutableError()->SetCode(E_REJECTED);
+            readPromise.SetValue(result);
+            UNIT_ASSERT(f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(2, readStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(8_KB, readStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, readStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, readStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                readStats.E(EDiagnosticsErrorKind::Success));
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                readStats.E(EDiagnosticsErrorKind::ErrorRetriable));
+        }
+
+        // WriteBlocks Success
+
+        {
+            auto writeBlocks =
+                std::make_shared<NProto::TWriteBlocksLocalRequest>();
+            TGuardedBuffer<TString> buffer(TString(4_KB, 0));
+            writeBlocks->Sglist = buffer.GetGuardedSgList();
+            writeBlocks->SetStartIndex(1024);
+            auto f = proxyStorage->WriteBlocksLocal(
+                MakeIntrusive<TCallContext>(),
+                writeBlocks);
+            UNIT_ASSERT(!f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, writeStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, writeStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(1, writeStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, writeStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                writeStats.E(EDiagnosticsErrorKind::Success));
+
+            writePromise.SetValue({});
+            UNIT_ASSERT(f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, writeStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, writeStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, writeStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, writeStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                writeStats.E(EDiagnosticsErrorKind::Success));
+        }
+
+        // WriteBlocks Error
+
+        {
+            writePromise =
+                NThreading::NewPromise<NProto::TWriteBlocksLocalResponse>();
+            auto writeBlocks =
+                std::make_shared<NProto::TWriteBlocksLocalRequest>();
+            TGuardedBuffer<TString> buffer(TString(4_KB, 0));
+            writeBlocks->Sglist = buffer.GetGuardedSgList();
+            writeBlocks->SetStartIndex(1024);
+            auto f = proxyStorage->WriteBlocksLocal(
+                MakeIntrusive<TCallContext>(),
+                writeBlocks);
+            UNIT_ASSERT(!f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(2, writeStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(8_KB, writeStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(1, writeStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, writeStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                writeStats.E(EDiagnosticsErrorKind::Success));
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                writeStats.E(EDiagnosticsErrorKind::ErrorRetriable));
+
+            NProto::TWriteBlocksLocalResponse result;
+            result.MutableError()->SetCode(E_REJECTED);
+            writePromise.SetValue(result);
+            UNIT_ASSERT(f.HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(2, writeStats.Count.load());
+            UNIT_ASSERT_VALUES_EQUAL(8_KB, writeStats.RequestBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, writeStats.Inflight.load());
+            UNIT_ASSERT_VALUES_EQUAL(0, writeStats.InflightBytes.load());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                writeStats.E(EDiagnosticsErrorKind::Success));
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                writeStats.E(EDiagnosticsErrorKind::ErrorRetriable));
+        }
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoint_proxy/server/ut/ya.make
+++ b/cloud/blockstore/libs/endpoint_proxy/server/ut/ya.make
@@ -1,0 +1,12 @@
+UNITTEST_FOR(cloud/blockstore/libs/endpoint_proxy/server)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    proxy_storage_ut.cpp
+)
+
+PEERDIR(
+)
+
+END()

--- a/cloud/blockstore/libs/endpoint_proxy/server/ya.make
+++ b/cloud/blockstore/libs/endpoint_proxy/server/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     bootstrap.cpp
     options.cpp
+    proxy_storage.cpp
     server.cpp
 )
 
@@ -17,6 +18,7 @@ PEERDIR(
     cloud/storage/core/libs/diagnostics
     cloud/storage/core/libs/grpc
     cloud/storage/core/libs/uds
+    cloud/storage/core/protos
 
     library/cpp/getopt/small
     library/cpp/logger
@@ -32,3 +34,5 @@ IF(NETLINK)
 ENDIF()
 
 END()
+
+RECURSE_FOR_TESTS(ut)

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -286,6 +286,27 @@ message TListProxyEndpointsRequest
 
 message TListProxyEndpointsResponse
 {
+    message TErrorKindStats
+    {
+        string ErrorKindName = 1;
+        uint64 Count = 2;
+    }
+
+    message TRequestTypeStats
+    {
+        string RequestName = 1;
+        uint64 Count = 2;
+        uint64 RequestBytes = 3;
+        uint64 Inflight = 4;
+        uint64 InflightBytes = 5;
+        repeated TErrorKindStats ErrorKindStats = 6;
+    }
+
+    message TProxyEndpointStats
+    {
+        repeated TRequestTypeStats RequestTypeStats = 1;
+    }
+
     message TProxyEndpoint
     {
         // BlockStore unix-socket path.
@@ -300,6 +321,9 @@ message TListProxyEndpointsResponse
         // NBD StorageOptions.
         uint32 BlockSize = 4;
         uint64 BlocksCount = 5;
+
+        // Stats.
+        TProxyEndpointStats Stats = 6;
     }
 
     // Optional error, set only if error happened.

--- a/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy/results.txt
+++ b/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy/results.txt
@@ -5,6 +5,8 @@ Endpoints {
   InternalUnixSocketPath: "TODO-nbs-socket.proxy"
   BlockSize: 4096
   BlocksCount: 1024
+  Stats {
+  }
 }
 
 InternalUnixSocketPath: "TODO-nbs-socket.proxy"

--- a/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy_uds/results.txt
+++ b/cloud/blockstore/tests/client/canondata/test_with_client.test_endpoint_proxy_uds/results.txt
@@ -5,6 +5,8 @@ Endpoints {
   InternalUnixSocketPath: "TODO-nbs-socket.proxy"
   BlockSize: 4096
   BlocksCount: 1024
+  Stats {
+  }
 }
 
 Endpoints {
@@ -12,6 +14,8 @@ Endpoints {
   InternalUnixSocketPath: "TODO-nbs-socket.proxy"
   BlockSize: 4096
   BlocksCount: 1024
+  Stats {
+  }
 }
 
 InternalUnixSocketPath: "TODO-nbs-socket.proxy"

--- a/cloud/storage/core/libs/common/error.h
+++ b/cloud/storage/core/libs/common/error.h
@@ -201,6 +201,7 @@ enum class EDiagnosticsErrorKind
     ErrorWriteRejectedByCheckpoint,
     ErrorSession,
     ErrorSilent,
+    Max,
 };
 
 EDiagnosticsErrorKind GetDiagnosticsErrorKind(const NProto::TError& e);

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -466,6 +466,9 @@ struct TRequestCounters::TStatCounters
                     ErrorsSilent->Inc();
                 }
                 break;
+            case EDiagnosticsErrorKind::Max:
+                Y_DEBUG_ABORT_UNLESS(false);
+                return;
         }
 
         const auto time = requestTime - requestCompletionTime;
@@ -564,6 +567,9 @@ struct TRequestCounters::TStatCounters
             case EDiagnosticsErrorKind::ErrorAborted:
             case EDiagnosticsErrorKind::ErrorFatal:
             case EDiagnosticsErrorKind::ErrorSilent:
+                Y_DEBUG_ABORT_UNLESS(false);
+                return;
+            case EDiagnosticsErrorKind::Max:
                 Y_DEBUG_ABORT_UNLESS(false);
                 return;
         }


### PR DESCRIPTION
Metrics can be retrieved via the ListProxyEndpoints API call

#1164 