### PR TITLE
issue-1351: FreshBytesCount and DeletedFreshBytesCount should be recalculated upon FinishFlushBytes, ui64 should be used instead of ui32 for the number of the processed bytes

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -119,6 +119,8 @@ void TFreshBytes::AddDeletionMarker(
         Y_ABORT_UNLESS(commitId >= c.FirstCommitId);
     }
 
+    c.TotalDeletedBytes += len;
+
     c.DeletionMarkers.push_back({
         nodeId,
         offset,

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -63,6 +63,7 @@ private:
         TDeque<TBytes, TStlAllocator> DeletionMarkers;
         ui64 FirstCommitId = InvalidCommitId;
         ui64 TotalBytes = 0;
+        ui64 TotalDeletedBytes = 0;
         ui64 Id = 0;
         ui64 ClosingCommitId = 0;
 
@@ -82,13 +83,15 @@ public:
     TFreshBytes(IAllocator* allocator);
     ~TFreshBytes();
 
-    size_t GetTotalBytes() const
+    std::pair<size_t, size_t> GetTotalBytes() const
     {
-        ui64 bytes = 0;
+        size_t bytes = 0;
+        size_t deletedBytes = 0;
         for (const auto& c: Chunks) {
             bytes += c.TotalBytes;
+            deletedBytes += c.TotalDeletedBytes;
         }
-        return bytes;
+        return std::make_pair(bytes, deletedBytes);
     }
 
     void AddBytes(ui64 nodeId, ui64 offset, TStringBuf data, ui64 commitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -138,7 +138,7 @@ private:
             std::atomic<i64> RequestBytes{0};
             TLatHistogram Time;
 
-            void Update(ui32 requestCount, ui32 requestBytes, TDuration d)
+            void Update(ui64 requestCount, ui64 requestBytes, TDuration d)
             {
                 Count.fetch_add(requestCount, std::memory_order_relaxed);
                 RequestBytes.fetch_add(requestBytes, std::memory_order_relaxed);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -562,6 +562,8 @@ void TIndexTabletActor::HandleFlushBytes(
         if (deletionMarkers.empty()) {
             FlushState.Complete();
             BlobIndexOpState.Complete();
+            // TODO: enqueue flush and blob index op
+            // TODO: enqueue these ops upon backpressure error as well
 
             reply(ctx, *ev, MakeError(S_FALSE, "no bytes to flush"));
 
@@ -814,6 +816,7 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
 
             BlobIndexOpState.Complete();
             FlushState.Complete();
+            // TODO: enqueue flush and blob index op
 
             return;
         }
@@ -914,7 +917,7 @@ void TIndexTabletActor::CompleteTx_TrimBytes(
         ProfileLog);
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s TrimBytes completed (%lu, %u)",
+        "%s TrimBytes completed (%lu, %lu)",
         LogTag.c_str(),
         args.ChunkId,
         args.TrimmedBytes);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -31,6 +31,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CheckpointBlocksCount,  __VA_ARGS__)                                   \
     xxx(CheckpointBlobsCount,   __VA_ARGS__)                                   \
     xxx(FreshBytesCount,        __VA_ARGS__)                                   \
+    xxx(DeletedFreshBytesCount, __VA_ARGS__)                                   \
     xxx(LastCollectCommitId,    __VA_ARGS__)                                   \
 // FILESTORE_TABLET_STATS
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -696,7 +696,7 @@ public:
     TFlushBytesCleanupInfo StartFlushBytes(
         TVector<TBytes>* bytes,
         TVector<TBytes>* deletionMarkers);
-    ui32 FinishFlushBytes(
+    ui64 FinishFlushBytes(
         TIndexTabletDatabase& db,
         ui64 chunkId,
         NProto::TProfileLogRequestInfo& profileLogRequest);

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1417,7 +1417,7 @@ struct TTxIndexTablet
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 ChunkId;
-        ui32 TrimmedBytes = 0;
+        ui64 TrimmedBytes = 0;
 
         TTrimBytes(TRequestInfoPtr requestInfo, ui64 chunkId)
             : TProfileAware(EFileStoreSystemRequest::TrimBytes)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5098,6 +5098,14 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.FlushBytes();
         tablet.DestroyHandle(handle);
         tablet.UnlinkNode(RootNodeId, "test", false);
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBytesCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetDeletedFreshBytesCount(), block);
+        }
+
         tablet.FlushBytes();
 
         {
@@ -5119,6 +5127,79 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 {{
                     {"sensor", "TrimBytes.Count"},
                     {"filesystem", "test"}}, 2},
+            });
+        }
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBytesCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetDeletedFreshBytesCount(), 0);
+        }
+    }
+
+    TABLET_TEST(ShouldTrimFreshBytesDeletionMarkersForLargeFiles)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetFlushBytesThreshold(1_GB);
+
+        TTestEnv env({}, std::move(storageConfig));
+        auto registry = env.GetRegistry();
+
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        auto handle = CreateHandle(tablet, id);
+
+        tablet.ZeroRange(handle, 0, 100_GB);
+        tablet.DestroyHandle(handle);
+        tablet.UnlinkNode(RootNodeId, "test", false);
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBytesCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetDeletedFreshBytesCount(), 100_GB);
+        }
+
+        tablet.FlushBytes();
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBytesCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetDeletedFreshBytesCount(), 0);
+        }
+
+        {
+            tablet.AdvanceTime(TDuration::Seconds(15));
+            env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+            TTestRegistryVisitor visitor;
+            registry->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
+                {{
+                    {"sensor", "FlushBytes.RequestBytes"},
+                    {"filesystem", "test"}}, 0_KB},
+                {{
+                    {"sensor", "FlushBytes.Count"},
+                    {"filesystem", "test"}}, 0},
+                {{
+                    {"sensor", "TrimBytes.RequestBytes"},
+                    {"filesystem", "test"}}, 100_GB},
+                {{
+                    {"sensor", "TrimBytes.Count"},
+                    {"filesystem", "test"}}, 1},
             });
         }
     }

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -321,14 +321,14 @@ public:
             TByteRange(0, length, DefaultBlockSize));
     }
 
-    auto CreateTruncateRangeRequest(ui64 node, ui64 offset, ui32 length)
+    auto CreateTruncateRangeRequest(ui64 node, ui64 offset, ui64 length)
     {
         return std::make_unique<TEvIndexTabletPrivate::TEvTruncateRangeRequest>(
             node,
             TByteRange(offset, length, DefaultBlockSize));
     }
 
-    auto CreateZeroRangeRequest(ui64 node, ui64 offset, ui32 length)
+    auto CreateZeroRangeRequest(ui64 node, ui64 offset, ui64 length)
     {
         return std::make_unique<TEvIndexTabletPrivate::TEvZeroRangeRequest>(
             node,
@@ -530,7 +530,7 @@ public:
         return request;
     }
 
-    auto CreateWriteDataRequest(ui64 handle, ui64 offset, ui32 len, char fill)
+    auto CreateWriteDataRequest(ui64 handle, ui64 offset, ui64 len, char fill)
     {
         auto request = CreateSessionRequest<TEvService::TEvWriteDataRequest>();
         request->Record.SetHandle(handle);
@@ -539,7 +539,7 @@ public:
         return request;
     }
 
-    auto CreateWriteDataRequest(ui64 handle, ui64 offset, ui32 len, const char* data)
+    auto CreateWriteDataRequest(ui64 handle, ui64 offset, ui64 len, const char* data)
     {
         auto request = CreateSessionRequest<TEvService::TEvWriteDataRequest>();
         request->Record.SetHandle(handle);
@@ -548,7 +548,7 @@ public:
         return request;
     }
 
-    auto CreateReadDataRequest(ui64 handle, ui64 offset, ui32 len)
+    auto CreateReadDataRequest(ui64 handle, ui64 offset, ui64 len)
     {
         auto request = CreateSessionRequest<TEvService::TEvReadDataRequest>();
         request->Record.SetHandle(handle);
@@ -557,7 +557,7 @@ public:
         return request;
     }
 
-    auto CreateDescribeDataRequest(ui64 handle, ui64 offset, ui32 len)
+    auto CreateDescribeDataRequest(ui64 handle, ui64 offset, ui64 len)
     {
         auto request =
             CreateSessionRequest<TEvIndexTablet::TEvDescribeDataRequest>();
@@ -586,7 +586,7 @@ public:
         ui64 nodeId,
         ui64 handle,
         ui64 offset,
-        ui32 length,
+        ui64 length,
         const TVector<NKikimr::TLogoBlobID>& blobIds,
         ui64 commitId)
     {
@@ -609,7 +609,7 @@ public:
         ui64 handle,
         ui64 owner,
         ui64 offset,
-        ui32 len,
+        ui64 len,
         i32 pid = DefaultPid,
         NProto::ELockType type = NProto::E_EXCLUSIVE,
         NProto::ELockOrigin origin = NProto::E_FCNTL)
@@ -630,7 +630,7 @@ public:
         ui64 handle,
         ui64 owner,
         ui64 offset,
-        ui32 len,
+        ui64 len,
         i32 pid = DefaultPid,
         NProto::ELockOrigin origin = NProto::E_FCNTL)
     {
@@ -649,7 +649,7 @@ public:
         ui64 handle,
         ui64 owner,
         ui64 offset,
-        ui32 len,
+        ui64 len,
         i32 pid = DefaultPid,
         NProto::ELockType type = NProto::E_EXCLUSIVE,
         NProto::ELockOrigin origin = NProto::E_FCNTL)

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -118,6 +118,7 @@ message TStorageStats
     uint64 AllocatedCompactionRanges = 110;
     uint64 UsedCompactionRanges = 111;
     uint64 LastCollectCommitId = 112;
+    uint64 DeletedFreshBytesCount = 113;
 
     // channel stats
     uint64 TabletChannelCount = 1000;


### PR DESCRIPTION
#1351 