### PR TITLE
[NBS] bugfix: device's BlocksCount is not adjusted when DevicePool changes

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -823,9 +823,7 @@ void TDiskRegistryState::AdjustDeviceIfNeeded(
         return;
     }
 
-    if (deviceSize > unit) {
-        device.SetBlocksCount(unit / device.GetBlockSize());
-    }
+    device.SetBlocksCount(unit / device.GetBlockSize());
 }
 
 void TDiskRegistryState::RemoveAgentFromNode(


### PR DESCRIPTION
#1369 

How to reproduce: change the non-standard layout (with BlocksCount != 24379392) to the standard layout. Then on the DR's monpage we will see that all other device parameters will be as expected, but BlocksCount will remain the same.
In this PR was added [unit test](https://github.com/ydb-platform/nbs/pull/1364/files#diff-e634cc966228e6d782a5547e872bab6c32d5d7ca1352d2ff1e626b00d5227019R666) in which the above situation is reproduced: an agent is configured with two devices of different sizes, then the configuration is changed to the standard one. Without the fix, both devices will get the old BlocksCount (262144 and 26214400 respectively, instead of 24379392).