### PR TITLE
issue-1351: enqueueing Flush and BlobIndexOps upon backpressure error and upon FlushBytes shortcut

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -145,8 +145,8 @@ private:
             Logging,
             Timer,
             Scheduler,
-            NClient::CreateRetryPolicy(clientConfig),
-            filestore);
+            NClient::CreateRetryPolicy(std::move(clientConfig)),
+            std::move(filestore));
 
         Endpoints.emplace(name, std::move(client));
         return true;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -339,6 +339,9 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
 
     TString message;
     if (!IsWriteAllowed(BuildBackpressureThresholds(), &message)) {
+        EnqueueFlushIfNeeded(ctx);
+        EnqueueBlobIndexOpIfNeeded(ctx);
+
         if (CompactionStateLoadStatus.Finished &&
             ++BackpressureErrorCount >=
                 Config->GetMaxBackpressureErrorsBeforeSuicide())

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -562,8 +562,8 @@ void TIndexTabletActor::HandleFlushBytes(
         if (deletionMarkers.empty()) {
             FlushState.Complete();
             BlobIndexOpState.Complete();
-            // TODO: enqueue flush and blob index op
-            // TODO: enqueue these ops upon backpressure error as well
+            EnqueueBlobIndexOpIfNeeded(ctx);
+            EnqueueFlushIfNeeded(ctx);
 
             reply(ctx, *ev, MakeError(S_FALSE, "no bytes to flush"));
 
@@ -816,7 +816,8 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
 
             BlobIndexOpState.Complete();
             FlushState.Complete();
-            // TODO: enqueue flush and blob index op
+            EnqueueBlobIndexOpIfNeeded(ctx);
+            EnqueueFlushIfNeeded(ctx);
 
             return;
         }


### PR DESCRIPTION
#1351 