### PR TITLE
Allow DR to work with more than one DA at once

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1000,4 +1000,8 @@ message TStorageServiceConfig
 
     // Destroy disk only with empty CloudId field
     optional bool DisableDiskWithCloudIdDestruction = 374;
+
+    // Do not send poison pill to disk agent with an AgentId that matches an
+    // already connected one. This is necessary for blue-green deployment.
+    optional bool AllowDRToManageMultipleDiskAgents = 375;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -495,6 +495,7 @@ TDuration MSeconds(ui32 value)
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(DisableDiskWithCloudIdDestruction,              bool,      false         )\
+    xxx(AllowDRToManageMultipleDiskAgents,              bool,      false         )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -584,6 +584,8 @@ public:
 
     ui32 GetVolumeHistoryCleanupItemCount() const;
     bool GetDisableDiskWithCloudIdDestruction() const;
+
+    bool GetAllowDRToManageMultipleDiskAgents() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -437,12 +437,12 @@ void TDiskRegistryActor::HandleServerDisconnected(
 
     const bool hasAnotherConnectedAgent =
         HasAnotherAgentWithSameAgentId(agentId, msg->ServerId, true);
-    if (!hasAnotherConnectedAgent) {
+    if (hasAnotherConnectedAgent) {
+        AgentRegInfo.erase(msg->ServerId);
+    } else {
         ScheduleRejectAgent(ctx, agentId, msg->ServerId);
         State->OnAgentDisconnected(ctx.Now(), agentId);
-        return;
     }
-    AgentRegInfo.erase(msg->ServerId);
 }
 
 void TDiskRegistryActor::ScheduleRejectAgent(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -253,6 +253,11 @@ private:
         const NActors::TActorContext& ctx,
         const NProto::TAgentConfig& config);
 
+    bool HasAnotherAgentWithSameAgentId(
+        const TString& agentId,
+        NActors::TActorId serverId,
+        bool requireConnected) const;
+
     void RenderHtmlInfo(TInstant now, IOutputStream& out) const;
     void RenderState(IOutputStream& out) const;
     void RenderDisks(IOutputStream& out, ui32 limit) const;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -107,7 +107,7 @@ private:
     struct TAgentRegInfo
     {
         TString AgentId;
-        TMaybe<bool> TemporaryAgent;
+        std::optional<bool> TemporaryAgent;
         bool Connected = false;
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_agent_node_id.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_agent_node_id.cpp
@@ -25,18 +25,16 @@ void TDiskRegistryActor::HandleGetAgentNodeId(
     Y_DEBUG_ABORT_UNLESS(State);
     auto response =
         std::make_unique<TEvDiskRegistry::TEvGetAgentNodeIdResponse>();
-    const NProto::TAgentConfig* agent =
-        State->FindAgent(msg->Record.GetAgentId());
-    if (!agent) {
+    if (const NProto::TAgentConfig* agent =
+            State->FindAgent(msg->Record.GetAgentId()))
+    {
+        response->Record.SetNodeId(agent->GetNodeId());
+    } else {
         *response->Record.MutableError() = MakeError(
             E_NOT_FOUND,
             TStringBuilder()
                 << "Couldn't find agent with id: " << msg->Record.GetAgentId());
-        NCloud::Reply(ctx, *ev, std::move(response));
-        return;
     }
-
-    response->Record.SetNodeId(agent->GetNodeId());
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_loadstate.cpp
@@ -196,7 +196,7 @@ void TDiskRegistryActor::CompleteLoadState(
     for (const auto& agent: args.Snapshot.Agents) {
         if (agent.GetState() != NProto::AGENT_STATE_UNAVAILABLE) {
             // this event will be scheduled using NonReplicatedAgentMaxTimeout
-            ScheduleRejectAgent(ctx, agent.GetAgentId(), 0);
+            ScheduleRejectAgent(ctx, agent.GetAgentId(), std::nullopt);
         }
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -1795,18 +1795,24 @@ void TDiskRegistryActor::RenderAgentList(
                         TABLED() {
                             DumpAgentState(out, config.GetState());
 
-                            auto it = AgentRegInfo.find(config.GetAgentId());
-
-                            const bool connected = it != AgentRegInfo.end()
-                                && it->second.Connected;
-
+                            const size_t connectedCount = CountIf(
+                                AgentRegInfo,
+                                [agentId =
+                                     config.GetAgentId()](const auto& info) {
+                                    return info.second.AgentId == agentId &&
+                                           info.second.Connected;
+                                });
                             if (config.GetState()
                                     != NProto::AGENT_STATE_UNAVAILABLE)
                             {
-                                if (!connected) {
-                                    out << " <font color=gray>disconnected</font>";
+                                if (connectedCount == 0) {
+                                    out << " <font "
+                                           "color=gray>disconnected</font>";
+                                } else if (connectedCount > 1) {
+                                    out << " <font color=DarkTurquoise>["
+                                        << connectedCount << "]</font>";
                                 }
-                            } else if (connected) {
+                            } else if (connectedCount != 0) {
                                 out << " <font color=gray>connected</font>";
                             }
                         }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_switch_agent_to_read_only.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_switch_agent_to_read_only.cpp
@@ -20,9 +20,11 @@ void TDiskRegistryActor::HandleSwitchAgentDisksToReadOnly(
 {
     auto* msg = ev->Get();
 
-    if (auto it = AgentRegInfo.find(msg->AgentId);
-        it != AgentRegInfo.end() && it->second.Connected)
-    {
+    const bool connected = AnyOf(
+        AgentRegInfo,
+        [agentId = msg->AgentId](const auto& info)
+        { return info.second.AgentId == agentId && info.second.Connected; });
+    if (connected) {
         LOG_INFO(
             ctx,
             TBlockStoreComponents::DISK_REGISTRY,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -486,13 +486,13 @@ struct TEvDiskRegistryPrivate
     struct TAgentConnectionLost
     {
         TString AgentId;
-        ui64 SeqNo;
+        std::optional<NActors::TActorId> ServerId;
 
         TAgentConnectionLost(
                 TString agentId,
-                ui64 seqNo)
+                std::optional<NActors::TActorId> serverId)
             : AgentId(std::move(agentId))
-            , SeqNo(seqNo)
+            , ServerId(serverId)
         {}
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -1958,16 +1958,16 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldKillPreviousAgentAfterRegisteringNewAgent)
-    {
+    void ShouldKillPreviousAgentAfterRegisteringNewAgent(bool shouldKill) {
         auto agent = CreateAgentConfig("agent-1", {
             Device("dev-1", "uuid-1", "rack-1", 10_GB)
         });
         agent.SetSeqNumber(0);
         agent.SetNodeId(42);
 
-        auto runtime = TTestRuntimeBuilder()
-            .Build();
+        auto config = CreateDefaultStorageConfig();
+        config.SetAllowDRToManageMultipleDiskAgents(!shouldKill);
+        auto runtime = TTestRuntimeBuilder().With(std::move(config)).Build();
 
         size_t poisonPillCount = 0;
         runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
@@ -2003,8 +2003,18 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             diskRegistry1.SendRegisterAgentRequest(agent);
             auto response = diskRegistry1.RecvRegisterAgentResponse();
             UNIT_ASSERT_C(SUCCEEDED(response->GetStatus()), response->GetErrorReason());
-            UNIT_ASSERT_VALUES_EQUAL(1, poisonPillCount);
+            UNIT_ASSERT_VALUES_EQUAL(shouldKill ? 1 : 0, poisonPillCount);
         }
+    }
+
+    Y_UNIT_TEST(ShouldKillPreviousAgentAfterRegisteringNewAgent)
+    {
+        ShouldKillPreviousAgentAfterRegisteringNewAgent(true);
+    }
+
+    Y_UNIT_TEST(ShouldIgnorePreviousAgentAfterRegisteringNewAgent)
+    {
+        ShouldKillPreviousAgentAfterRegisteringNewAgent(false);
     }
 
     Y_UNIT_TEST(ShouldMuteIOErrorsForTempUnavailableDisk)
@@ -2217,6 +2227,121 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
             UNIT_ASSERT(response->Record.HasError());
             UNIT_ASSERT_EQUAL(E_NOT_FOUND, response->Record.GetError().GetCode());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleTwoAgentsConnectedAtOnce)
+    {
+        TVector agents {
+            CreateAgentConfig("agent-1", {
+                Device("dev-1", "uuid-1", "rack-1", 10_GB),
+                Device("dev-2", "uuid-2", "rack-1", 10_GB)
+            }),
+            CreateAgentConfig("agent-2", {
+                Device("dev-3", "uuid-3", "rack-1", 10_GB),
+                Device("dev-4", "uuid-4", "rack-1", 10_GB)
+            }),
+            // Temporary agent:
+            CreateAgentConfig("agent-1", {
+                Device("dev-1", "uuid-1", "rack-1", 10_GB),
+                Device("dev-2", "uuid-2", "rack-1", 10_GB)
+            }),
+        };
+        agents[2].SetTemporaryAgent(true);
+
+        auto config = CreateDefaultStorageConfig();
+        config.SetAllowDRToManageMultipleDiskAgents(true);
+        config.SetNonReplicatedDiskSwitchToReadOnlyTimeout(
+            TDuration{5s}.MilliSeconds());
+        config.SetNonReplicatedAgentMaxTimeout(TDuration{5s}.MilliSeconds());
+
+        auto runtime =
+            TTestRuntimeBuilder().With(config).WithAgents(agents).Build();
+
+        TDiskRegistryClient diskRegistry(*runtime);
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+        diskRegistry.UpdateConfig(
+            CreateRegistryConfig(0, {agents[0], agents[1]}));
+
+        struct TPipeData
+        {
+            TActorId Sender;
+            TActorId Recipient;
+            TActorId ServerId;
+        };
+        TVector<TPipeData> pipes;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvTabletPipe::EvServerConnected: {
+                        const auto& msg =
+                            *event->Get<TEvTabletPipe::TEvServerConnected>();
+                        pipes.push_back(
+                            {event->Sender, event->Recipient, msg.ServerId});
+                        break;
+                    }
+                    case TEvTabletPipe::EvServerDisconnected: {
+                        const auto& msg =
+                            *event->Get<TEvTabletPipe::TEvServerDisconnected>();
+                        EraseIf(
+                            pipes,
+                            [&](const TPipeData& data)
+                            {
+                                return data.Sender == event->Sender &&
+                                       data.Recipient == event->Recipient &&
+                                       data.ServerId == msg.ServerId;
+                            });
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto disconnectServer = [&](const TPipeData& data)
+        {
+            auto event = std::make_unique<TEvTabletPipe::TEvServerDisconnected>(
+                TestTabletId,
+                data.ServerId,
+                data.ServerId);
+            runtime->Send(
+                new IEventHandle(data.Recipient, data.Sender, event.release()),
+                0,
+                true);
+            runtime->DispatchEvents({}, TDuration::Seconds(1));
+        };
+
+        RegisterAndWaitForAgents(*runtime, {agents[0], agents[1]});
+        // Normal agents shoul be online.
+        UNIT_ASSERT_VALUES_EQUAL(2U, pipes.size());
+        {
+            const auto response = diskRegistry.AllocateDisk("disk-1", 40_GB);
+            EXPECT_DISK_STATE(response, 4, NProto::VOLUME_IO_OK, false);
+        }
+
+        // Register temporary agent-1 and check that volume allocation returns
+        // devices with NodeId from temporary agent.
+        RegisterAgent(*runtime, 2);
+        UNIT_ASSERT_VALUES_EQUAL(3U, pipes.size());
+        {
+            auto response = diskRegistry.AllocateDisk("disk-1", 40_GB);
+            EXPECT_DISK_STATE(response, 4, NProto::VOLUME_IO_OK, false);
+            size_t tempAgenteDeviceCount = CountIf(
+                response->Record.GetDevices(),
+                [&](const NProto::TDeviceConfig& device)
+                { return device.GetNodeId() == runtime->GetNodeId(2); });
+            UNIT_ASSERT_VALUES_EQUAL(2, tempAgenteDeviceCount);
+        }
+
+        // Destroy normal agent-1.
+        KillAgent(*runtime, 0);
+        disconnectServer(pipes[0]);
+        UNIT_ASSERT_VALUES_EQUAL(2U, pipes.size());
+        {
+            auto response = diskRegistry.AllocateDisk("disk-1", 40_GB);
+            EXPECT_DISK_STATE(response, 4, NProto::VOLUME_IO_OK, false);
         }
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_session.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_session.cpp
@@ -399,18 +399,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             TDuration::MilliSeconds(10));
         UNIT_ASSERT_VALUES_EQUAL(1, agent1AcquireCallCount);
         UNIT_ASSERT_VALUES_EQUAL(0, agent2AcquireCallCount);
-        UNIT_ASSERT_VALUES_EQUAL(1, cachedAcquireDevicesRequestAmount->Val());
-
-        // Folowing register shouldn't send acquire requests since we just sent
-        // them and didn't cache fresh ones yet.
-        RegisterAgent(*runtime, 0);
-        runtime->AdvanceCurrentTime(UpdateCountersInterval);
-        runtime->DispatchEvents(
-            TDispatchOptions(),
-            TDuration::MilliSeconds(10));
-        UNIT_ASSERT_VALUES_EQUAL(1, agent1AcquireCallCount);
-        UNIT_ASSERT_VALUES_EQUAL(0, agent2AcquireCallCount);
-        UNIT_ASSERT_VALUES_EQUAL(1, cachedAcquireDevicesRequestAmount->Val());
 
         diskRegistry.AcquireDisk(
             "disk-1",
@@ -424,7 +412,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             TDuration::MilliSeconds(10));
         UNIT_ASSERT_VALUES_EQUAL(2, agent1AcquireCallCount);
         UNIT_ASSERT_VALUES_EQUAL(1, agent2AcquireCallCount);
-        UNIT_ASSERT_VALUES_EQUAL(2, cachedAcquireDevicesRequestAmount->Val());
 
         const NProto::TStorageServiceConfig storageConfig =
             CreateDefaultStorageConfig();
@@ -440,7 +427,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             TDuration::MilliSeconds(10));
         UNIT_ASSERT_VALUES_EQUAL(2, agent1AcquireCallCount);
         UNIT_ASSERT_VALUES_EQUAL(1, agent2AcquireCallCount);
-        UNIT_ASSERT_VALUES_EQUAL(1, cachedAcquireDevicesRequestAmount->Val());
 
         diskRegistry.AcquireDisk(
             "disk-1",
@@ -454,7 +440,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             TDuration::MilliSeconds(10));
         UNIT_ASSERT_VALUES_EQUAL(3, agent1AcquireCallCount);
         UNIT_ASSERT_VALUES_EQUAL(2, agent2AcquireCallCount);
-        UNIT_ASSERT_VALUES_EQUAL(2, cachedAcquireDevicesRequestAmount->Val());
 
         // Although a release event wasn't sent, agent registering shouldn't
         // send acquire because the disk is destroyed.
@@ -464,7 +449,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         runtime->DispatchEvents(
             TDispatchOptions(),
             TDuration::MilliSeconds(10));
-        UNIT_ASSERT_VALUES_EQUAL(0, cachedAcquireDevicesRequestAmount->Val());
 
         RegisterAgent(*runtime, 0);
         runtime->AdvanceCurrentTime(UpdateCountersInterval);

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -252,7 +252,7 @@ void WaitForSecureErase(
 
 void RegisterAgent(NActors::TTestActorRuntime& runtime, int nodeIdx)
 {
-    auto sender = runtime.AllocateEdgeActor();
+    auto sender = runtime.AllocateEdgeActor(nodeIdx);
     auto nodeId = runtime.GetNodeId(nodeIdx);
 
     auto request = std::make_unique<TEvRegisterAgent>();
@@ -382,6 +382,7 @@ void KillAgent(NActors::TTestActorRuntime& runtime, int nodeIdx)
         MakeDiskAgentServiceId(nodeId),
         sender,
         request.release()));
+    runtime.DispatchEvents({}, TDuration::Seconds(1));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NDiskRegistryTest

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -641,8 +641,7 @@ public:
         return request;
     }
 
-    auto CreateGetAgentNodeIdRequest(
-        const TString& agentId)
+    auto CreateGetAgentNodeIdRequest(const TString& agentId)
     {
         auto request =
             std::make_unique<TEvDiskRegistry::TEvGetAgentNodeIdRequest>();

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -1473,7 +1473,6 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
         env.GetRuntime().EnableScheduleForActor(MakeVolumeProxyServiceId());
 
         NProto::TStorageServiceConfig config;
-        // config.SetAllocationUnitNonReplicatedSSD(100);
         config.SetWaitDependentDisksRetryRequestDelay(50);  // 50 ms.
         ui32 nodeIdx = SetupTestEnv(env, config);
         TServiceClient service(env.GetRuntime(), nodeIdx);


### PR DESCRIPTION
#1255
DR tracks every connection (pipe) from disk agents. This PR slightly changes this logic to allow several connections from single host.