### PR TITLE
issue-1373: cancelled requests should not trigger fatal errors during nfs-vhost restart

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs.cpp
@@ -363,7 +363,9 @@ void CancelRequest(
     requestStats.RequestCompleted(
         log,
         callContext,
-        MakeError(E_CANCELLED, "Driver is stopping"));
+        MakeError(
+            MAKE_FILESTORE_ERROR(E_CANCELLED),
+            "Driver is stopping"));
 
     const ui64 now = GetCycleCount();
     const auto ts = callContext.CalcRequestTime(now);

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_lock.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_lock.cpp
@@ -214,11 +214,7 @@ void TFileSystem::AcquireLock(
                     // error code shouldn't really matter for the guest since
                     // if we are in FUSE_SUSPEND mode we won't respond to
                     // the guest anyway
-                    self->ReplyError(
-                        *callContext,
-                        MakeError(MAKE_FILESTORE_ERROR(E_CANCELLED)),
-                        req,
-                        EINTR);
+                    CancelRequest(std::move(callContext), req);
                 } else {
                     // locks should be acquired synchronously if asked so retry attempt
                     self->ScheduleAcquireLock(

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_lock.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_lock.cpp
@@ -216,7 +216,7 @@ void TFileSystem::AcquireLock(
                     // the guest anyway
                     self->ReplyError(
                         *callContext,
-                        MakeError(E_CANCELLED),
+                        MakeError(MAKE_FILESTORE_ERROR(E_CANCELLED)),
                         req,
                         EINTR);
                 } else {

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -1292,9 +1292,6 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         auto future =
             bootstrap.Fuse->SendRequest<TAcquireLockRequest>(0, F_RDLCK);
-        UNIT_ASSERT_C(
-            !future.HasValue(),
-            "TAcquireLockRequest future should not be set");
 
         bootstrap.Stop(); // wait till all requests are done writing their stats
 


### PR DESCRIPTION
#1373 