### PR TITLE
issue-1377: E_NOT_IMPLEMENTED errors arising from endpoint storages should not be logged by default (otherwise KeyringStorage causes a lot of useless error messages which are written upon StopEndpoint); FileStorage should catch exceptions which may happen upon various FS-related calls and return E_IO errors

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -191,6 +191,9 @@ message TServerConfig
 
     // Allow all control requests via unix socket (e.g., for CSI-driver)
     optional bool AllowAllRequestsViaUDS = 115;
+
+    // Causes E_NOT_IMPLEMENTED errors in endpoint storages to be logged.
+    optional bool EndpointStorageNotImplementedErrorIsFatal = 116;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -491,11 +491,16 @@ void TBootstrapBase::Init()
     IEndpointStoragePtr endpointStorage;
     switch (Configs->ServerConfig->GetEndpointStorageType()) {
         case NCloud::NProto::ENDPOINT_STORAGE_DEFAULT:
-        case NCloud::NProto::ENDPOINT_STORAGE_KEYRING:
+        case NCloud::NProto::ENDPOINT_STORAGE_KEYRING: {
+            const bool notImplementedErrorIsFatal = Configs->ServerConfig
+                ->GetEndpointStorageNotImplementedErrorIsFatal();
+
             endpointStorage = CreateKeyringEndpointStorage(
                 Configs->ServerConfig->GetRootKeyringName(),
-                Configs->ServerConfig->GetEndpointsKeyringName());
+                Configs->ServerConfig->GetEndpointsKeyringName(),
+                notImplementedErrorIsFatal);
             break;
+        }
         case NCloud::NProto::ENDPOINT_STORAGE_FILE:
             endpointStorage = CreateFileEndpointStorage(
                 Configs->ServerConfig->GetEndpointStorageDir());

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -636,7 +636,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, static_cast<int>(*configCounter));
 
-        auto endpointStorage = CreateKeyringEndpointStorage("nbs", "");
+        auto endpointStorage = CreateKeyringEndpointStorage("nbs", "", false);
 
         auto executor = TExecutor::Create("TestService");
         executor->Start();

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -98,6 +98,7 @@ constexpr TDuration Seconds(int s)
     xxx(NbdConnectionTimeout,        TDuration,             Seconds(86400)    )\
     xxx(EndpointProxySocketPath,     TString,               ""                )\
     xxx(AllowAllRequestsViaUDS,      bool,                  false             )\
+    xxx(EndpointStorageNotImplementedErrorIsFatal,  bool,   false             )\
 // BLOCKSTORE_SERVER_CONFIG
 
 #define BLOCKSTORE_SERVER_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -132,6 +132,7 @@ public:
     TDuration GetNbdConnectionTimeout() const;
     TString GetEndpointProxySocketPath() const;
     bool GetAllowAllRequestsViaUDS() const;
+    bool GetEndpointStorageNotImplementedErrorIsFatal() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;

--- a/cloud/filestore/config/vhost.proto
+++ b/cloud/filestore/config/vhost.proto
@@ -32,6 +32,9 @@ message TVhostServiceConfig
 
     // Access mode for endpoint socket files
     optional uint32 SocketAccessMode = 7;
+
+    // Causes E_NOT_IMPLEMENTED errors in endpoint storages to be logged.
+    optional bool EndpointStorageNotImplementedErrorIsFatal = 8;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -187,11 +187,15 @@ void TBootstrapVhost::InitComponents()
     NVhost::InitLog(Logging);
     switch (Configs->VhostServiceConfig->GetEndpointStorageType()) {
         case NCloud::NProto::ENDPOINT_STORAGE_DEFAULT:
-        case NCloud::NProto::ENDPOINT_STORAGE_KEYRING:
+        case NCloud::NProto::ENDPOINT_STORAGE_KEYRING: {
+            const bool notImplementedErrorIsFatal =
+                Configs->VhostServiceConfig->GetEndpointStorageNotImplementedErrorIsFatal();
             EndpointStorage = CreateKeyringEndpointStorage(
                 Configs->VhostServiceConfig->GetRootKeyringName(),
-                Configs->VhostServiceConfig->GetEndpointsKeyringName());
+                Configs->VhostServiceConfig->GetEndpointsKeyringName(),
+                notImplementedErrorIsFatal);
             break;
+        }
         case NCloud::NProto::ENDPOINT_STORAGE_FILE:
             EndpointStorage = CreateFileEndpointStorage(
                 Configs->VhostServiceConfig->GetEndpointStorageDir());

--- a/cloud/filestore/libs/endpoint_vhost/config.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/config.cpp
@@ -24,6 +24,7 @@ static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
         NCloud::NProto::ENDPOINT_STORAGE_KEYRING                              )\
     xxx(EndpointStorageDir,         TString,                {}                )\
     xxx(SocketAccessMode,           ui32,                   MODE0660          )\
+    xxx(EndpointStorageNotImplementedErrorIsFatal,  bool,   false             )\
 // VHOST_SERVICE_CONFIG
 
 #define VHOST_SERVICE_DECLARE_CONFIG(name, type, value)                        \

--- a/cloud/filestore/libs/endpoint_vhost/config.h
+++ b/cloud/filestore/libs/endpoint_vhost/config.h
@@ -28,6 +28,7 @@ public:
     NCloud::NProto::EEndpointStorageType GetEndpointStorageType() const;
     TString GetEndpointStorageDir() const;
     ui32 GetSocketAccessMode() const;
+    bool GetEndpointStorageNotImplementedErrorIsFatal() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/storage/core/libs/keyring/endpoints.h
+++ b/cloud/storage/core/libs/keyring/endpoints.h
@@ -31,7 +31,8 @@ struct IEndpointStorage
 
 IEndpointStoragePtr CreateKeyringEndpointStorage(
     TString rootKeyringDesc,
-    TString endpointsKeyringDesc);
+    TString endpointsKeyringDesc,
+    bool notImplementedErrorIsFatal);
 
 IEndpointStoragePtr CreateFileEndpointStorage(TString dirPath);
 

--- a/cloud/storage/core/libs/keyring/endpoints_ut.cpp
+++ b/cloud/storage/core/libs/keyring/endpoints_ut.cpp
@@ -48,7 +48,8 @@ TStorages InitKeyringStorages()
 
     auto endpointStorage = CreateKeyringEndpointStorage(
         nbsDesc,
-        endpointsDesc);
+        endpointsDesc,
+        true /* notImplementedErrorIsFatal */);
 
     auto mutableEndpointStorage = CreateKeyringMutableEndpointStorage(
         nbsDesc,
@@ -221,6 +222,11 @@ Y_UNIT_TEST_SUITE(TEndpointsTest)
     Y_UNIT_TEST(ShouldNotGetStoredEndpointByWrongIdFromFiles)
     {
         ShouldNotGetStoredEndpointByWrongId(InitFileStorages());
+    }
+
+    Y_UNIT_TEST(FileStorageShouldNotThrow)
+    {
+        auto s = CreateFileEndpointStorage("nonexistent_dir");
     }
 }
 

--- a/cloud/storage/core/libs/keyring/endpoints_ut.cpp
+++ b/cloud/storage/core/libs/keyring/endpoints_ut.cpp
@@ -223,11 +223,6 @@ Y_UNIT_TEST_SUITE(TEndpointsTest)
     {
         ShouldNotGetStoredEndpointByWrongId(InitFileStorages());
     }
-
-    Y_UNIT_TEST(FileStorageShouldNotThrow)
-    {
-        auto s = CreateFileEndpointStorage("nonexistent_dir");
-    }
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
Proper uts will be added in #1377 - right now https://github.com/ydb-platform/nbs/tree/main/cloud/storage/core/libs/keyring/ut uts can't be launched