### PR TITLE
NBSNEBIUS-228: deduplicate names of the filestore clients on the same host for csi driver

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -408,7 +408,7 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 		Endpoint: &nfsapi.TEndpointConfig{
 			SocketPath:       socketPath,
 			FileSystemId:     req.VolumeId,
-			ClientId:         s.clientID,
+			ClientId:         fmt.Sprintf("%s-%s", s.clientID, s.getPodId(req)),
 			VhostQueuesCount: 8,
 			Persistent:       true,
 		},

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -32,6 +32,7 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string) {
 	ctx := context.Background()
 	clientID := "testClientId"
 	podID := "test-pod-id-13"
+	nfsClientId := "testClientId-test-pod-id-13"
 	diskID := "test-disk-id-42"
 	podSocketsDir := filepath.Join(tempDir, "sockets")
 	nbsSocketsDir := "/test/sockets/folder"
@@ -88,7 +89,7 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string) {
 			Endpoint: &nfs.TEndpointConfig{
 				SocketPath:       nfsSocketPath,
 				FileSystemId:     diskID,
-				ClientId:         clientID,
+				ClientId:         nfsClientId,
 				VhostQueuesCount: 8,
 				Persistent:       true,
 			},


### PR DESCRIPTION
Right now if two pods try to mount the same filestore, they will use the same clientId. this PR fixes it