### PR TITLE
issue-1320: Query agents info

### DIFF
--- a/cloud/blockstore/apps/client/lib/factory.cpp
+++ b/cloud/blockstore/apps/client/lib/factory.cpp
@@ -9,6 +9,7 @@
 #include "create_volume.h"
 #include "create_volume_from_device.h"
 #include "delete_checkpoint.h"
+#include "query_agents_info.h"
 #include "describe_disk_registry_config.h"
 #include "describe_endpoint.h"
 #include "describe_placement_group.h"
@@ -79,6 +80,7 @@ struct THandlerFactory
         { "listplacementgroups", NewListPlacementGroupsCommand },
         { "listvolumes", NewListVolumesCommand },
         { "ping", NewPingCommand },
+        { "queryagentsinfo", NewQueryAgentsInfoCommand },
         { "queryavailablestorage", NewQueryAvailableStorageCommand },
         { "readblocks", NewReadBlocksCommand },
         { "refreshendpoint", NewRefreshEndpointCommand },

--- a/cloud/blockstore/apps/client/lib/query_agents_info.cpp
+++ b/cloud/blockstore/apps/client/lib/query_agents_info.cpp
@@ -1,0 +1,65 @@
+#include "query_agents_info.h"
+
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/service.h>
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+
+namespace NCloud::NBlockStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TQueryAgentsInfoCommand final: public TCommand
+{
+public:
+    explicit TQueryAgentsInfoCommand(IBlockStorePtr client)
+        : TCommand(std::move(client))
+    {}
+
+protected:
+    bool DoExecute() override
+    {
+        auto& input = GetInputStream();
+        auto& output = GetOutputStream();
+
+        STORAGE_DEBUG("Reading QueryAgentsInfo request");
+        auto request = std::make_shared<NProto::TQueryAgentsInfoRequest>();
+        if (Proto) {
+            ParseFromTextFormat(input, *request);
+        }
+
+        STORAGE_DEBUG("Sending QueryAgentsInfo request");
+        auto result = WaitFor(ClientEndpoint->QueryAgentsInfo(
+            MakeIntrusive<TCallContext>(),
+            std::move(request)));
+
+        STORAGE_DEBUG("Received QueryAgentsInfo response");
+        if (Proto) {
+            SerializeToTextFormat(result, output);
+            return true;
+        }
+
+        if (HasError(result)) {
+            output << FormatError(result.GetError()) << Endl;
+            return false;
+        }
+
+        output << result << Endl;
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewQueryAgentsInfoCommand(IBlockStorePtr client)
+{
+    return MakeIntrusive<TQueryAgentsInfoCommand>(std::move(client));
+}
+
+}   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/apps/client/lib/query_agents_info.h
+++ b/cloud/blockstore/apps/client/lib/query_agents_info.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "command.h"
+
+namespace NCloud::NBlockStore::NClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewQueryAgentsInfoCommand(IBlockStorePtr client);
+
+}   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/apps/client/lib/ya.make
+++ b/cloud/blockstore/apps/client/lib/ya.make
@@ -34,6 +34,7 @@ SRCS(
     list_placement_groups.cpp
     list_volumes.cpp
     ping.cpp
+    query_agents_info.cpp
     query_available_storage.cpp
     read_blocks.cpp
     refresh_endpoint.cpp

--- a/cloud/blockstore/libs/service/auth_scheme.cpp
+++ b/cloud/blockstore/libs/service/auth_scheme.cpp
@@ -58,11 +58,12 @@ TPermissionList GetRequestPermissions(EBlockStoreRequest requestType)
     switch (requestType) {
         case EBlockStoreRequest::CmsAction:
             return CreatePermissionList({EPermission::Update});
-        // The following 4 don't deal with user data.
+        // The following 5 don't deal with user data.
         case EBlockStoreRequest::Ping:
         case EBlockStoreRequest::UploadClientMetrics:
         case EBlockStoreRequest::DiscoverInstances:
         case EBlockStoreRequest::QueryAvailableStorage:
+        case EBlockStoreRequest::QueryAgentsInfo:
             return CreatePermissionList({});
         // UnmountVolume can't expose or corrupt any user data.
         case EBlockStoreRequest::UnmountVolume:

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -88,6 +88,7 @@ using TWriteBlocksLocalResponse = TWriteBlocksResponse;
     xxx(QueryAvailableStorage,              __VA_ARGS__)                       \
     xxx(CreateVolumeFromDevice,             __VA_ARGS__)                       \
     xxx(ResumeDevice,                       __VA_ARGS__)                       \
+    xxx(QueryAgentsInfo,                    __VA_ARGS__)                       \
 // BLOCKSTORE_GRPC_STORAGE_SERVICE
 
 #define BLOCKSTORE_ENDPOINT_SERVICE(xxx, ...)                                  \

--- a/cloud/blockstore/libs/service/request_helpers.h
+++ b/cloud/blockstore/libs/service/request_helpers.h
@@ -313,6 +313,7 @@ constexpr bool IsControlRequest(EBlockStoreRequest requestType)
         case EBlockStoreRequest::ListKeyrings:
         case EBlockStoreRequest::DescribeEndpoint:
         case EBlockStoreRequest::RefreshEndpoint:
+        case EBlockStoreRequest::QueryAgentsInfo:
             return true;
         case EBlockStoreRequest::MAX:
             Y_DEBUG_ABORT_UNLESS(false);

--- a/cloud/blockstore/libs/storage/api/disk_registry.h
+++ b/cloud/blockstore/libs/storage/api/disk_registry.h
@@ -65,6 +65,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(CmsAction,                      __VA_ARGS__)                           \
     xxx(QueryAvailableStorage,          __VA_ARGS__)                           \
     xxx(ResumeDevice,                   __VA_ARGS__)                           \
+    xxx(QueryAgentsInfo,                __VA_ARGS__)                           \
 // BLOCKSTORE_DISK_REGISTRY_REQUESTS_FWD_SERVICE
 
 #define BLOCKSTORE_DISK_REGISTRY_REQUESTS(xxx, ...)                            \
@@ -206,6 +207,9 @@ struct TEvDiskRegistry
 
         EvGetAgentNodeIdRequest = EvBegin + 73,
         EvGetAgentNodeIdResponse = EvBegin + 74,
+
+        EvQueryAgentsInfoRequest = EvBegin + 75,
+        EvQueryAgentsInfoResponse = EvBegin + 76,
 
         EvEnd
     };

--- a/cloud/blockstore/libs/storage/api/service.h
+++ b/cloud/blockstore/libs/storage/api/service.h
@@ -314,6 +314,9 @@ struct TEvService
 
         EvVolumeMountStateChanged = EvBegin + 88,
 
+        EvQueryAgentsInfoRequest = EvBegin + 89,
+        EvQueryAgentsInfoResponse = EvBegin + 90,
+
         EvEnd
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_query_agents_info.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_query_agents_info.cpp
@@ -1,0 +1,31 @@
+#include "disk_registry_actor.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::HandleQueryAgentsInfo(
+    const TEvService::TEvQueryAgentsInfoRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "[%lu] Received QueryAgentsInfo request",
+        TabletID());
+
+    auto response = std::make_unique<TEvService::TEvQueryAgentsInfoResponse>(
+        MakeError(S_OK));
+    for (auto& agentInfo: State->QueryAgentsInfo()) {
+        *response->Record.AddAgents() = std::move(agentInfo);
+    }
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -832,6 +832,8 @@ public:
 
     const NProto::TDeviceConfig* FindDevice(const TDeviceId& uuid) const;
 
+    TVector<NProto::TAgentInfo> QueryAgentsInfo() const;
+
 private:
     void ProcessConfig(const NProto::TDiskRegistryConfig& config);
     void ProcessDisks(TVector<NProto::TDiskConfig> disks);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
@@ -1,0 +1,255 @@
+#include "disk_registry_state.h"
+
+#include "disk_registry_database.h"
+
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
+#include <cloud/blockstore/libs/storage/testlib/test_executor.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/guid.h>
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NDiskRegistryStateTest;
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
+{
+    Y_UNIT_TEST(QueryAgentsInfo)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        const TVector agents{
+            AgentConfig(
+                1,
+                {Device("dev-1", "uuid-1.1"),
+                 Device("dev-2", "uuid-1.2") |
+                     WithPool("local-ssd", NProto::DEVICE_POOL_KIND_LOCAL),
+                 Device("dev-3", "uuid-1.3"),
+                 Device("dev-4", "uuid-1.4")}),
+            AgentConfig(
+                2,
+                {Device("dev-1", "uuid-2.1") |
+                     WithPool("local-ssd", NProto::DEVICE_POOL_KIND_LOCAL),
+                 Device("dev-2", "uuid-2.2"),
+                 Device("dev-3", "uuid-2.3"),
+                 Device("dev-4", "uuid-2.4")})};
+
+        TDiskRegistryState state =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
+
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
+
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .Build();
+
+        auto agentsInfo = state.QueryAgentsInfo();
+        UNIT_ASSERT_VALUES_EQUAL(2, agentsInfo.size());
+        const auto& agentInfo = agentsInfo[0];
+        const auto& agent = agents[0];
+        const auto& device = agent.GetDevices(0);
+        UNIT_ASSERT_VALUES_EQUAL(agent.GetAgentId(), agentInfo.GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(agent.DevicesSize(), agentInfo.DevicesSize());
+
+        const auto& deviceInfo = agentInfo.GetDevices(0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            device.GetDeviceName(),
+            deviceInfo.GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            device.GetSerialNumber(),
+            deviceInfo.GetDeviceSerialNumber());
+
+        const auto deviceSpaceInBytes =
+            device.GetBlockSize() * device.GetBlocksCount();
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceTotalSpaceInBytes());
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceFreeSpaceInBytes());
+    }
+
+    Y_UNIT_TEST(QueryAgentsInfoWithDirtyDevices)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        const TVector agents{AgentConfig(
+            1,
+            {Device("dev-1", "uuid-1.1"), Device("dev-2", "uuid-1.2")})};
+
+        TDiskRegistryState state =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
+
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
+
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .WithDirtyDevices({"uuid-1.1"})
+                .Build();
+
+        auto agentsInfo = state.QueryAgentsInfo();
+        UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
+        const auto& agentInfo = agentsInfo[0];
+        const auto& agent = agents[0];
+        const auto& device = agent.GetDevices(0);
+        UNIT_ASSERT_VALUES_EQUAL(agent.DevicesSize(), agentInfo.DevicesSize());
+        const auto& deviceInfo = agentInfo.GetDevices(0);
+        const auto deviceSpaceInBytes =
+            device.GetBlockSize() * device.GetBlocksCount();
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceTotalSpaceInBytes());
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceDirtySpaceInBytes());
+    }
+
+    Y_UNIT_TEST(QueryAgentsInfoWithSuspendedDevice)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        const TVector agents{AgentConfig(
+            1,
+            {Device("dev-1", "uuid-1.1"), Device("dev-2", "uuid-1.2")})};
+
+        TDiskRegistryState state =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
+
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
+
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .WithSuspendedDevices({"uuid-1.1"})
+                .Build();
+
+        auto agentsInfo = state.QueryAgentsInfo();
+        UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
+        const auto& agentInfo = agentsInfo[0];
+        const auto& agent = agents[0];
+        const auto& device = agent.GetDevices(0);
+        UNIT_ASSERT_VALUES_EQUAL(agent.DevicesSize(), agentInfo.DevicesSize());
+        const auto& deviceInfo = agentInfo.GetDevices(0);
+        const auto deviceSpaceInBytes =
+            device.GetBlockSize() * device.GetBlocksCount();
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceTotalSpaceInBytes());
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceSuspendedSpaceInBytes());
+    }
+
+    Y_UNIT_TEST(QueryAgentsInfoWithAllocatedDevice)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        const TVector agents{AgentConfig(
+            1,
+            {Device("dev-1", "uuid-1.1"), Device("dev-2", "uuid-1.2")})};
+
+        TDiskRegistryState state =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
+
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
+
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .Build();
+
+        auto allocate = [&](auto db,
+                            TString agentId,
+                            TString diskId,
+                            ui32 blockSize,
+                            ui32 blockCount)
+        {
+            TDiskRegistryState::TAllocateDiskResult result;
+
+            auto error = state.AllocateDisk(
+                TInstant::Zero(),
+                db,
+                TDiskRegistryState::TAllocateDiskParams{
+                    .DiskId = std::move(diskId),
+                    .BlockSize = blockSize,
+                    .BlocksCount = blockCount,
+                    .AgentIds = {agentId}},
+                &result);
+
+            return std::make_pair(std::move(result), error);
+        };
+
+        const auto& agent = agents[0];
+        const auto& device = agent.GetDevices(0);
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                auto [result, error] = allocate(
+                    db,
+                    agent.GetAgentId(),
+                    device.GetDeviceName(),
+                    device.GetBlockSize(),
+                    device.GetBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+            });
+
+        auto agentsInfo = state.QueryAgentsInfo();
+        UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
+        const auto& agentInfo = agentsInfo[0];
+
+        UNIT_ASSERT_VALUES_EQUAL(agent.DevicesSize(), agentInfo.DevicesSize());
+        const auto& deviceInfo = agentInfo.GetDevices(0);
+        const auto deviceSpaceInBytes =
+            device.GetBlockSize() * device.GetBlocksCount();
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceTotalSpaceInBytes());
+        UNIT_ASSERT_VALUES_EQUAL(
+            deviceSpaceInBytes,
+            deviceInfo.GetDeviceAllocatedSpaceInBytes());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
@@ -574,6 +574,19 @@ TDiskRegistryStateBuilder& TDiskRegistryStateBuilder::WithDirtyDevices(
     return *this;
 }
 
+TDiskRegistryStateBuilder& TDiskRegistryStateBuilder::WithSuspendedDevices(
+    TVector<TString> suspendedDevices)
+{
+    SuspendedDevices.clear();
+    SuspendedDevices.reserve(suspendedDevices.size());
+    for (auto& uuid: suspendedDevices) {
+        NProto::TSuspendedDevice suspendedDevice;
+        suspendedDevice.SetId(uuid);
+        SuspendedDevices.push_back(std::move(suspendedDevice));
+    }
+    return *this;
+}
+
 TDiskRegistryStateBuilder& TDiskRegistryStateBuilder::WithSpreadPlacementGroups(
     TVector<TString> groupIds)
 {

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h
@@ -278,6 +278,9 @@ struct TDiskRegistryStateBuilder
 
     TDiskRegistryStateBuilder& WithDirtyDevices(TVector<TString> dirtyDevices);
 
+    TDiskRegistryStateBuilder& WithSuspendedDevices(
+        TVector<TString> suspendedDevices);
+
     TDiskRegistryStateBuilder& WithSpreadPlacementGroups(
         TVector<TString> groupIds);
 

--- a/cloud/blockstore/libs/storage/disk_registry/ut/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ut/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
     disk_registry_database_ut.cpp
+    disk_registry_state_ut_agents_info.cpp
     disk_registry_state_ut_checkpoint.cpp
     disk_registry_state_ut_cms.cpp
     disk_registry_state_ut_config.cpp

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -28,6 +28,7 @@ SRCS(
     disk_registry_actor_placement.cpp
     disk_registry_actor_publish_disk_state.cpp
     disk_registry_actor_writable_state.cpp
+    disk_registry_actor_query_agents_info.cpp
     disk_registry_actor_query_available_storage.cpp
     disk_registry_actor_register.cpp
     disk_registry_actor_regular.cpp

--- a/cloud/blockstore/public/api/grpc/service.proto
+++ b/cloud/blockstore/public/api/grpc/service.proto
@@ -273,6 +273,16 @@ service TBlockStoreService
     }
 
     //
+    // Agents info
+    //
+    rpc QueryAgentsInfo(TQueryAgentsInfoRequest) returns (TQueryAgentsInfoResponse) {
+        option (google.api.http) = {
+            post: "/query_agents_info"
+            body: "*"
+        };
+    }
+
+    //
     // Local SSD
     //
 

--- a/cloud/blockstore/public/api/protos/disk.proto
+++ b/cloud/blockstore/public/api/protos/disk.proto
@@ -162,6 +162,61 @@ message TDescribeDiskRegistryConfigResponse
     repeated TKnownDevicePool KnownDevicePools = 5;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+// Device Info
+
+message TDeviceInfo
+{
+    // Device  name.
+    string DeviceName = 1;
+
+    // Serial number.
+    string DeviceSerialNumber = 2;
+
+    // Total space in bytes.
+    uint64 DeviceTotalSpaceInBytes = 3;
+
+    // Allocated space in bytes.
+    uint64 DeviceAllocatedSpaceInBytes = 4;
+
+    // Free space in bytes.
+    uint64 DeviceFreeSpaceInBytes = 5;
+
+    // Dirty space in bytes.
+    uint64 DeviceDirtySpaceInBytes = 6;
+
+    // Suspended space in bytes.
+    uint64 DeviceSuspendedSpaceInBytes = 7;
+}
+
+message TAgentInfo {
+    // Agent  id.
+    string AgentId = 1;
+
+    // List of device info
+    repeated TDeviceInfo Devices = 2;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Query agents info
+
+message TQueryAgentsInfoRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+}
+
+message TQueryAgentsInfoResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // List of agent info
+    repeated TAgentInfo Agents = 2;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Volume create from device request/response.
 

--- a/cloud/blockstore/tools/http_proxy/main_test.go
+++ b/cloud/blockstore/tools/http_proxy/main_test.go
@@ -511,6 +511,16 @@ func (s *mockBlockstoreServer) CmsAction(
 	return res, args.Error(1)
 }
 
+func (s *mockBlockstoreServer) QueryAgentsInfo(
+	ctx context.Context,
+	req *blockstore_protos.TQueryAgentsInfoRequest,
+) (*blockstore_protos.TQueryAgentsInfoResponse, error) {
+
+	args := s.Called(ctx, req)
+	res, _ := args.Get(0).(*blockstore_protos.TQueryAgentsInfoResponse)
+	return res, args.Error(1)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func runMockBlockstoreServer(

--- a/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
+++ b/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
@@ -312,6 +312,14 @@ func (n nbsService) ResumeDevice(
 	panic("implement me")
 }
 
+func (n nbsService) QueryAgentsInfo(
+	ctx context.Context,
+	request *protos.TQueryAgentsInfoRequest,
+) (*protos.TQueryAgentsInfoResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (n nbsService) ExecuteAction(
 	ctx context.Context,
 	request *protos.TExecuteActionRequest,


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1320

Adding new handle 'QueryAgentsInfo' to grpc/blockstore-client to query information about agents/disks

Current output: list of agent ids with device info: total space, allocated space, suspended space, dirty space

Out of scope for this pull request as a diff is too big already:
1. python mock test: blockstore/tests/client/test_with_client.py
2. Broken space
3. Decommission space