### PR TITLE
[Disk Manager] add ConfigurePoolsByDefault flag to images config

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/images/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/images/config/config.proto
@@ -21,4 +21,5 @@ message ImagesConfig {
     repeated DiskPoolConfig DefaultDiskPoolConfigs = 5;
     repeated string UseS3ForFolder = 6;
     optional uint32 UseS3Percentage = 7;
+    optional bool ConfigurePoolsByDefault = 8;
 }

--- a/cloud/disk_manager/internal/pkg/services/images/service.go
+++ b/cloud/disk_manager/internal/pkg/services/images/service.go
@@ -31,7 +31,7 @@ func (s *service) CreateImage(
 		rand.Uint32()%100 < s.config.GetUseS3Percentage()
 
 	pools := make([]*types.DiskPool, 0)
-	if req.Pooled {
+	if req.Pooled || s.config.GetConfigurePoolsByDefault() {
 		for _, c := range s.config.GetDefaultDiskPoolConfigs() {
 			pools = append(pools, &types.DiskPool{
 				ZoneId:   c.GetZoneId(),


### PR DESCRIPTION
Enable ability to create pooled images by default