### PR TITLE
[NBS] do not add devices with non-standard size to the free device pool

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -59,6 +59,7 @@ namespace NCloud::NBlockStore {
     xxx(DiskAgentIoDuringSecureErase)                                          \
     xxx(BlockDigestMismatchInBlob)                                             \
     xxx(DiskRegistryResumeDeviceFailed)                                        \
+    xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -320,7 +320,7 @@ private:
 
     TReplicaTable ReplicaTable{&DeviceList};
 
-    THashMap<TString, NProto::TDevicePoolConfig> DevicePoolConfigs;
+    TDevicePoolConfigs DevicePoolConfigs;
 
     TPendingCleanup PendingCleanup;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -2505,6 +2505,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
 
         NProto::TStorageServiceConfig proto;
         proto.SetMaxAutomaticDeviceReplacementsPerHour(10);
+        proto.SetAllocationUnitNonReplicatedSSD(10);
         auto storageConfig = CreateStorageConfig(proto);
 
         TDiskRegistryState state = TDiskRegistryStateBuilder()

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
@@ -814,6 +814,141 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             }
         });
     }
+
+    Y_UNIT_TEST(ShouldEnforceAllocationUnitSize)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto rootGroup = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore");
+
+        auto serverGroup = rootGroup->GetSubgroup("component", "server");
+        InitCriticalEventsCounter(serverGroup);
+
+        auto criticalEvents = serverGroup->FindCounter(
+            "AppCriticalEvents/DiskRegistryAgentDevicePoolConfigMismatch");
+
+        UNIT_ASSERT_VALUES_EQUAL(0, criticalEvents->Val());
+
+        TTestExecutor executor;
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            db.InitSchema();
+        });
+
+        constexpr ui64 allocationUnitSize = 10_GB;
+
+        auto device = [] (TString uuid, ui64 size, TString rack) {
+            TDeviceConfig config;
+
+            config.SetDeviceName("path-" + uuid);
+            config.SetDeviceUUID(std::move(uuid));
+            config.SetRack(std::move(rack));
+            config.SetBlockSize(DefaultLogicalBlockSize);
+            config.SetBlocksCount(size / DefaultLogicalBlockSize);
+            config.SetUnadjustedBlockCount(size / DefaultLogicalBlockSize + 5);
+
+            return config;
+        };
+
+        const TVector agents {
+            AgentConfig(1, {
+                device("uuid-1.1", allocationUnitSize, "rack-1"),
+                device("uuid-1.2", allocationUnitSize, "rack-1"),
+            }),
+            AgentConfig(2, {
+                // uuid-2.1 has a non-standard size
+                device("uuid-2.1", 2 * allocationUnitSize, "rack-2"),
+                device("uuid-2.2", allocationUnitSize, "rack-2"),
+            }),
+            AgentConfig(3, {
+                device("uuid-3.1", allocationUnitSize, "rack-3"),
+                device("uuid-3.2", allocationUnitSize, "rack-3"),
+            })
+        };
+
+        TDiskRegistryState state = TDiskRegistryStateBuilder()
+            .WithStorageConfig([] {
+                auto config = CreateDefaultStorageConfigProto();
+                config.SetAllocationUnitNonReplicatedSSD(
+                    static_cast<ui32>(allocationUnitSize / 1_GB));
+                return config;
+            }())
+            .WithKnownAgents(agents)
+            .Build();
+
+        // uuid-2.1 was detected as a non-standart size device.
+        UNIT_ASSERT_VALUES_EQUAL(1, criticalEvents->Val());
+
+        auto allocate = [&] (auto db) {
+            TDiskRegistryState::TAllocateDiskResult result;
+
+            // Try allocating a mirrored disk with 2 devices per replica.
+            auto error = state.AllocateDisk(
+                Now(),
+                db,
+                TDiskRegistryState::TAllocateDiskParams{
+                    .DiskId = "m3",
+                    .BlockSize = DefaultLogicalBlockSize,
+                    .BlocksCount =
+                        2 * allocationUnitSize / DefaultLogicalBlockSize,
+                    .ReplicaCount = 2,
+                    .PoolName = {},
+                    .MediaKind = NProto::STORAGE_MEDIA_SSD_MIRROR3},
+                &result);
+
+            return std::make_pair(result, error);
+        };
+
+        // The allocation should fail because uuid-2.1 hasn't been added to
+        // the free pool and there is no enough space.
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            auto [_, error] = allocate(db);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_BS_DISK_ALLOCATION_FAILED,
+                error.GetCode(),
+                error);
+        });
+
+        // cleaning devices after an unsuccessful allocation
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                UNIT_ASSERT_VALUES_EQUAL(4, state.GetDirtyDevices().size());
+
+                state.MarkDeviceAsClean(Now(), db, "uuid-1.1");
+                state.MarkDeviceAsClean(Now(), db, "uuid-1.2");
+                state.MarkDeviceAsClean(Now(), db, "uuid-3.1");
+                state.MarkDeviceAsClean(Now(), db, "uuid-3.2");
+
+                UNIT_ASSERT_VALUES_EQUAL(0, state.GetDirtyDevices().size());
+            });
+
+        // fix uuid-2.1
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                auto fixedConfig = agents[1];
+                auto& uuid21 = *fixedConfig.MutableDevices(0);
+
+                UNIT_ASSERT_VALUES_EQUAL("uuid-2.1", uuid21.GetDeviceUUID());
+
+                uuid21.SetBlocksCount(allocationUnitSize);
+
+                auto error = RegisterAgent(state, db, fixedConfig, Now());
+                UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error);
+            });
+
+        // Now the free pool has enough space.
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            auto [result, error] = allocate(db);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error);
+            UNIT_ASSERT_VALUES_EQUAL(2, result.Devices.size());
+            UNIT_ASSERT_VALUES_EQUAL(2, result.Replicas.size());
+            UNIT_ASSERT_VALUES_EQUAL(2, result.Replicas[0].size());
+            UNIT_ASSERT_VALUES_EQUAL(2, result.Replicas[1].size());
+        });
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
@@ -15,6 +15,10 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TDevicePoolConfigs = THashMap<TString, NProto::TDevicePoolConfig>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TDeviceList
 {
     using TDeviceId = TString;
@@ -94,8 +98,15 @@ public:
         return PoolName2DeviceCount;
     }
 
-    void UpdateDevices(const NProto::TAgentConfig& agent, TNodeId prevNodeId);
-    void UpdateDevices(const NProto::TAgentConfig& agent);
+    void UpdateDevices(
+        const NProto::TAgentConfig& agent,
+        const TDevicePoolConfigs& poolConfigs,
+        TNodeId prevNodeId);
+
+    void UpdateDevices(
+        const NProto::TAgentConfig& agent,
+        const TDevicePoolConfigs& poolConfigs);
+
     void RemoveDevices(const NProto::TAgentConfig& agent);
 
     TNodeId FindNodeId(const TDeviceId& id) const;


### PR DESCRIPTION
#1369

The free device pool could include devices with non-standard size. This could have caused the non-consistent size of replicas of mirrored disks. For example, if there is a 186 GiB device in the pool (twice the standard allocation unit) and DR allocate a 186 GiB mirror disk. Then we can get 2 replicas with two 93 GiB devices and one replica with one 186 GiB device. This situation can lead to unexpected consequences (such as nbs crash).