### PR TITLE
[Disk Manager] accept core metrics registry in Run function of disk manager app

### DIFF
--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -15,9 +15,9 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/health"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring"
-	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/util"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/pkg/auth"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/tasks"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
@@ -29,7 +29,7 @@ import (
 func Run(
 	appName string,
 	defaultConfigFilePath string,
-	newMetricsRegistry metrics.NewRegistryFunc,
+	newMetricsRegistry metrics.NewCoreRegistryFunc,
 	newAuthorizer auth.NewAuthorizer,
 ) {
 
@@ -62,7 +62,7 @@ func Run(
 
 func run(
 	config *server_config.ServerConfig,
-	newMetricsRegistry metrics.NewRegistryFunc,
+	newMetricsRegistry metrics.NewCoreRegistryFunc,
 	newAuthorizer auth.NewAuthorizer,
 ) error {
 
@@ -102,7 +102,10 @@ func run(
 	}
 
 	logging.Info(ctx, "Starting monitoring")
-	mon := monitoring.NewMonitoring(config.MonitoringConfig, newMetricsRegistry)
+	mon := monitoring.NewMonitoring(
+		config.MonitoringConfig,
+		metrics.WithWrapper(newMetricsRegistry),
+	)
 	mon.Start(ctx)
 
 	accounting.Init(mon.NewRegistry("accounting"))

--- a/cloud/disk_manager/pkg/monitoring/metrics/prometheus.go
+++ b/cloud/disk_manager/pkg/monitoring/metrics/prometheus.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	clientmodel "github.com/prometheus/client_model/go"
 
-	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
+	core_metrics "github.com/ydb-platform/nbs/library/go/core/metrics"
 	"github.com/ydb-platform/nbs/library/go/core/metrics/prometheus"
 )
 
@@ -55,7 +55,7 @@ func sanitizeName(name string) string {
 
 var newRegistryOnce sync.Once
 
-func NewPrometheusRegistry(mux *http.ServeMux, path string) metrics.Registry {
+func NewPrometheusRegistry(mux *http.ServeMux, path string) core_metrics.Registry {
 	registry := prometheus.NewRegistry(
 		prometheus.NewRegistryOpts().SetNameSanitizer(
 			sanitizeName,
@@ -78,5 +78,5 @@ func NewPrometheusRegistry(mux *http.ServeMux, path string) metrics.Registry {
 			)
 		},
 	)
-	return WrapRegistry(registry)
+	return registry
 }

--- a/cloud/disk_manager/pkg/monitoring/metrics/registry_wrapper.go
+++ b/cloud/disk_manager/pkg/monitoring/metrics/registry_wrapper.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
@@ -402,4 +403,14 @@ func (v *histogramVec) With(kv map[string]string) metrics.Histogram {
 
 func (v *histogramVec) Reset() {
 	v.histogramVec.Reset()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type NewCoreRegistryFunc = func(mux *http.ServeMux, path string) core_metrics.Registry
+
+func WithWrapper(coreRegistryFunc NewCoreRegistryFunc) metrics.NewRegistryFunc {
+	return func(mux *http.ServeMux, path string) Registry {
+		return WrapRegistry(coreRegistryFunc(mux, path))
+	}
 }


### PR DESCRIPTION
Commit https://github.com/ydb-platform/nbs/pull/1247 makes the caller of Run function from cloud/disk_manager/pkg/app to provide a function of type NewRegistryFunc.
https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/pkg/app/run.go#L32
https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/monitoring/metrics/interface.go#L11

It breaks code compilation for users of cloud/disk_manager/pkg/app. Also it makes it difficult to call Run function from outside nbs/cloud/disk-manager folder because NewRegistryFunc is defined in internal folder.

This pr is supposed to fix this problem.