### PR TITLE
NBSNEBIUS-5: BytesCount is now Max(CalculateVBytesCount(), BytesCount) - preparing to get rid of VBytesCount

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -325,6 +325,11 @@ void TVolumeActor::DoSendPartStatsToService(
         return;
     }
     stats->Simple.ChannelHistorySize.Set(channelsHistorySize);
+    // having 2 metrics with the same meaning is pointless - will need to get
+    // rid of one of them
+    const auto vbytesCount = GetBlocksCount() * State->GetBlockSize();
+    stats->Simple.BytesCount.Set(
+        Max(stats->Simple.BytesCount.Value, vbytesCount));
 
     auto blobLoadMetrics = NBlobMetrics::MakeBlobLoadMetrics(
         State->GetMeta().GetVolumeConfig().GetVolumeExplicitChannelProfiles(),


### PR DESCRIPTION
VBytesCount is 0 for STORAGE_MEDIA_SSD_* media kinds, BytesCount can be 0 for STORAGE_MEDIA_SSD media kinds which have never been mounted for at least somewhere around 30-60 seconds. Fixing this problem in a very simple way. Will get rid of VBytesCount later - when we are sure that noone uses it anymore.