### PR TITLE
configure ttl for stat and archive stats ydb tables

### DIFF
--- a/cloud/blockstore/config/ydbstats.proto
+++ b/cloud/blockstore/config/ydbstats.proto
@@ -37,4 +37,10 @@ message TYdbStatsConfig
 
     // use secure connection to YDB.
     optional bool UseSsl = 10;
+
+    // Stats table ttl.
+    optional uint32 StatsTableTtl = 11;
+
+    // Archive stats table ttl.
+    optional uint32 ArchiveStatsTableTtl = 12;
 }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -310,9 +310,9 @@ void TBootstrapYdb::InitKikimrService()
             statsConfig,
             logging,
             YdbStorage,
-            NYdbStats::CreateStatsTableScheme(),
+            NYdbStats::CreateStatsTableScheme(statsConfig->GetStatsTableTtl()),
             NYdbStats::CreateHistoryTableScheme(),
-            NYdbStats::CreateArchiveStatsTableScheme(),
+            NYdbStats::CreateArchiveStatsTableScheme(statsConfig->GetArchiveStatsTableTtl()),
             NYdbStats::CreateBlobLoadMetricsTableScheme());
     } else {
         StatsUploader = NYdbStats::CreateVolumesStatsUploaderStub();

--- a/cloud/blockstore/libs/ydbstats/config.cpp
+++ b/cloud/blockstore/libs/ydbstats/config.cpp
@@ -8,6 +8,13 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TDuration Seconds(ui32 value)
+{
+    return TDuration::Seconds(value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 #define BLOCKSTORE_YDBSTATS_CONFIG(xxx)                                        \
     xxx(StatsTableName,                   TString,          ""                )\
     xxx(HistoryTablePrefix,               TString,          ""                )\
@@ -19,6 +26,9 @@ namespace {
     xxx(ArchiveStatsTableName,            TString,          ""                )\
     xxx(BlobLoadMetricsTableName,         TString,          ""                )\
     xxx(UseSsl,                           bool,             false             )\
+    xxx(StatsTableTtl,                    TDuration,        Seconds(0)        )\
+    xxx(ArchiveStatsTableTtl,             TDuration,        Seconds(0)        )\
+
 // BLOCKSTORE_YDBSTATS_CONFIG
 
 #define BLOCKSTORE_YDBSTATS_DECLARE_CONFIG(name, type, value)                  \
@@ -35,6 +45,12 @@ template <typename TTarget, typename TSource>
 TTarget ConvertValue(TSource value)
 {
     return static_cast<TTarget>(std::move(value));
+}
+
+template <>
+TDuration ConvertValue<TDuration, ui32>(ui32 value)
+{
+    return TDuration::MilliSeconds(value);
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/ydbstats/config.h
+++ b/cloud/blockstore/libs/ydbstats/config.h
@@ -32,6 +32,8 @@ public:
     ui32 GetHistoryTableLifetimeDays() const;
     ui32 GetStatsTableRotationAfterDays() const;
     bool GetUseSsl() const;
+    TDuration GetStatsTableTtl() const;
+    TDuration GetArchiveStatsTableTtl() const;
 };
 
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
@@ -1,5 +1,6 @@
-#include "config.h"
 #include "ydbscheme.h"
+
+#include "config.h"
 #include "ydbrow.h"
 
 #include <cloud/storage/core/libs/common/verify.h>

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "ydbscheme.h"
 #include "ydbrow.h"
 
@@ -59,7 +60,7 @@ TStatsTableSchemeBuilder BuildListOfColumns()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TStatsTableSchemePtr CreateStatsTableScheme()
+TStatsTableSchemePtr CreateStatsTableScheme(TDuration ttl)
 {
     auto out = BuildListOfColumns();
     STORAGE_VERIFY_C(
@@ -67,6 +68,12 @@ TStatsTableSchemePtr CreateStatsTableScheme()
         TWellKnownEntityTypes::YDB_TABLE,
         "stats table",
         "unable to set key fields");
+    if (ttl) {
+        out.SetTtl(NTable::TTtlSettings{
+            "Timestamp",
+            NTable::TTtlSettings::EUnit::MilliSeconds,
+            ttl});
+    }
     return out.Finish();
 }
 
@@ -81,7 +88,7 @@ TStatsTableSchemePtr CreateHistoryTableScheme()
     return out.Finish();
 }
 
-TStatsTableSchemePtr CreateArchiveStatsTableScheme()
+TStatsTableSchemePtr CreateArchiveStatsTableScheme(TDuration ttl)
 {
     auto out = BuildListOfColumns();
     STORAGE_VERIFY_C(
@@ -89,6 +96,12 @@ TStatsTableSchemePtr CreateArchiveStatsTableScheme()
         TWellKnownEntityTypes::YDB_TABLE,
         "archive table",
         "unable to setup key fields");
+    if (ttl) {
+        out.SetTtl(NTable::TTtlSettings{
+            "Timestamp",
+            NTable::TTtlSettings::EUnit::MilliSeconds,
+            ttl});
+    }
     return out.Finish();
 }
 

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.h
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.h
@@ -21,27 +21,9 @@ struct TStatsTableScheme
 {
     const TVector<NYdb::TColumn> Columns;
     const TVector<TString> KeyColumns;
-    const std::optional<NYdb::NTable::TTtlSettings> Ttl;
+    const TMaybe<NYdb::NTable::TTtlSettings> Ttl;
 
     TStatsTableScheme() = default;
-
-    TStatsTableScheme(
-            TVector<NYdb::TColumn> columns,
-            TVector<TString> keyColumns,
-            NYdb::NTable::TTtlSettings ttl)
-        : Columns(std::move(columns))
-        , KeyColumns(std::move(keyColumns))
-        , Ttl(std::move(ttl))
-    {}
-
-    TStatsTableScheme(
-            TVector<NYdb::TColumn> columns,
-            TVector<TString> keyColumns,
-            std::optional<NYdb::NTable::TTtlSettings> ttl)
-        : Columns(std::move(columns))
-        , KeyColumns(std::move(keyColumns))
-        , Ttl(std::move(ttl))
-    {}
 
     TStatsTableScheme(
             TVector<NYdb::TColumn> columns,
@@ -49,7 +31,7 @@ struct TStatsTableScheme
             TMaybe<NYdb::NTable::TTtlSettings> ttl)
         : Columns(std::move(columns))
         , KeyColumns(std::move(keyColumns))
-        , Ttl(ttl.Empty() ? decltype(Ttl){} : *ttl)
+        , Ttl(std::move(ttl))
     {}
 };
 
@@ -61,7 +43,7 @@ private:
     THashSet<TString> Names;
     TVector<NYdb::TColumn> Columns;
     TVector<TString> KeyColumns;
-    std::optional<NYdb::NTable::TTtlSettings> Ttl;
+    TMaybe<NYdb::NTable::TTtlSettings> Ttl;
 
 public:
     bool AddColumns(

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.h
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.h
@@ -28,10 +28,28 @@ struct TStatsTableScheme
     TStatsTableScheme(
             TVector<NYdb::TColumn> columns,
             TVector<TString> keyColumns,
-            std::optional<NYdb::NTable::TTtlSettings> ttl = {})
+            NYdb::NTable::TTtlSettings ttl)
         : Columns(std::move(columns))
         , KeyColumns(std::move(keyColumns))
         , Ttl(std::move(ttl))
+    {}
+
+    TStatsTableScheme(
+            TVector<NYdb::TColumn> columns,
+            TVector<TString> keyColumns,
+            std::optional<NYdb::NTable::TTtlSettings> ttl)
+        : Columns(std::move(columns))
+        , KeyColumns(std::move(keyColumns))
+        , Ttl(std::move(ttl))
+    {}
+
+    TStatsTableScheme(
+            TVector<NYdb::TColumn> columns,
+            TVector<TString> keyColumns,
+            TMaybe<NYdb::NTable::TTtlSettings> ttl)
+        : Columns(std::move(columns))
+        , KeyColumns(std::move(keyColumns))
+        , Ttl(ttl.Empty() ? decltype(Ttl){} : *ttl)
     {}
 };
 
@@ -107,9 +125,9 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TStatsTableSchemePtr CreateStatsTableScheme();
+TStatsTableSchemePtr CreateStatsTableScheme(TDuration ttl);
 TStatsTableSchemePtr CreateHistoryTableScheme();
-TStatsTableSchemePtr CreateArchiveStatsTableScheme();
+TStatsTableSchemePtr CreateArchiveStatsTableScheme(TDuration ttl);
 TStatsTableSchemePtr CreateBlobLoadMetricsTableScheme();
 
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
@@ -383,7 +383,7 @@ public:
                     origColumns,
                     origKeyColumns,
                     settings.GetAlterTtlSettings().Empty()
-                        ? std::optional<TTtlSettings>{}
+                        ? TMaybe<TTtlSettings>{}
                         : settings.GetAlterTtlSettings()->GetTtlSettings())});
             return MakeFuture(MakeError(S_OK));
         }

--- a/cloud/blockstore/libs/ydbstats/ydbstorage.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstorage.cpp
@@ -250,7 +250,8 @@ TFuture<NYdbStats::TDescribeTableResponse> TYdbNativeStorage::DescribeTable(
                 const auto& description = future.GetValue().GetTableDescription();
                 result.SetValue(TDescribeTableResponse(
                     description.GetColumns(),
-                    description.GetPrimaryKeyColumns()));
+                    description.GetPrimaryKeyColumns(),
+                    description.GetTtlSettings()));
             }
             return MakeFuture<NYdb::TStatus>(future.GetValue());
         });

--- a/cloud/blockstore/libs/ydbstats/ydbstorage.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstorage.h
@@ -59,18 +59,6 @@ struct TDescribeTableResponse
         : TableScheme(
             std::move(columns),
             std::move(keyColumns),
-            ttlSettings.Empty()
-                ? std::optional<NYdb::NTable::TTtlSettings>()
-                : std::move(*ttlSettings))
-    {}
-
-    TDescribeTableResponse(
-            TVector<NYdb::TColumn> columns,
-            TVector<TString> keyColumns,
-            std::optional<NYdb::NTable::TTtlSettings> ttlSettings )
-        : TableScheme(
-            std::move(columns),
-            std::move(keyColumns),
             std::move(ttlSettings))
     {}
 };

--- a/cloud/blockstore/libs/ydbstats/ydbstorage.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstorage.h
@@ -18,6 +18,7 @@
 #include <util/generic/vector.h>
 #include <util/datetime/base.h>
 
+#include <optional>
 #include <utility>
 
 namespace NCloud::NBlockStore::NYdbStats {
@@ -53,8 +54,24 @@ struct TDescribeTableResponse
 
     TDescribeTableResponse(
             TVector<NYdb::TColumn> columns,
-            TVector<TString> keyColumns)
-        : TableScheme(std::move(columns), std::move(keyColumns))
+            TVector<TString> keyColumns,
+            TMaybe<NYdb::NTable::TTtlSettings> ttlSettings )
+        : TableScheme(
+            std::move(columns),
+            std::move(keyColumns),
+            ttlSettings.Empty()
+                ? std::optional<NYdb::NTable::TTtlSettings>()
+                : std::move(*ttlSettings))
+    {}
+
+    TDescribeTableResponse(
+            TVector<NYdb::TColumn> columns,
+            TVector<TString> keyColumns,
+            std::optional<NYdb::NTable::TTtlSettings> ttlSettings )
+        : TableScheme(
+            std::move(columns),
+            std::move(keyColumns),
+            std::move(ttlSettings))
     {}
 };
 


### PR DESCRIPTION
Right now we limit the size of ydb stats table by setting ttl in a cloud console. It better to have an option to specify ttl in config files.
Ttl as a duration is set in milliseconds as usual. 0 means "do not update ttl for table"

#1412 