### PR TITLE
[Filestore] issue-1289: rework ExtendedBlockSizeEnabled flag + increase vhost-side logging

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -278,7 +278,7 @@ message TStorageConfig
 
     // By default, the blocksize, provided by the GetNodeAttr request, is set to
     // the filestore blocksize. Due to the fact that every 64 blocks are stored in
-    // the same range, it may be beneficial to increase the reported blocksize 64-fold.
-    // This flag enables this feature.
-    optional bool ExtendedBlockSizeEnabled = 354;
+    // the same range, it may be beneficial to increase the reported blocksize x-fold.
+    // This numeric value is that x.
+    optional uint32 PreferredBlockSizeMultiplier = 354;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -158,7 +158,7 @@ namespace {
     xxx(GenerateBlobIdsReleaseCollectBarrierTimeout,                           \
         TDuration,                                                             \
         TDuration::Seconds(10)                                                )\
-    xxx(ExtendedBlockSizeEnabled,                       bool,      false      )\
+    xxx(PreferredBlockSizeMultiplier,                   ui32,      1          )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_DECLARE_CONFIG(name, type, value)                            \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -186,7 +186,7 @@ public:
     TDuration GetEntryTimeout() const;
     TDuration GetNegativeEntryTimeout() const;
     TDuration GetAttrTimeout() const;
-    bool GetExtendedBlockSizeEnabled() const;
+    ui32 GetPreferredBlockSizeMultiplier() const;
 
     ui32 GetMaxOutOfOrderCompactionMapLoadRequestsInQueue() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -22,8 +22,12 @@ void FillFeatures(const TStorageConfig& config, NProto::TFileStore& fileStore)
     features->SetAttrTimeout(config.GetAttrTimeout().MilliSeconds());
     features->SetThreeStageWriteEnabled(config.GetThreeStageWriteEnabled());
     features->SetThreeStageWriteThreshold(config.GetThreeStageWriteThreshold());
-    if (config.GetExtendedBlockSizeEnabled()) {
-        features->SetPreferredBlockSize(BlockGroupSize * fileStore.GetBlockSize());
+
+    auto preferredBlockSizeMultiplier =
+        config.GetPreferredBlockSizeMultiplier();
+    if (preferredBlockSizeMultiplier) {
+        features->SetPreferredBlockSize(
+            fileStore.GetBlockSize() * preferredBlockSizeMultiplier);
     } else {
         features->SetPreferredBlockSize(fileStore.GetBlockSize());
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -835,7 +835,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
         config.SetNegativeEntryTimeout(TDuration::Seconds(1).MilliSeconds());
         config.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
-        config.SetExtendedBlockSizeEnabled(true);
+        config.SetPreferredBlockSizeMultiplier(2);
 
         features.SetTwoStageReadEnabled(true);
         features.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
@@ -843,7 +843,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
         features.SetThreeStageWriteEnabled(true);
         features.SetThreeStageWriteThreshold(10_MB);
-        features.SetPreferredBlockSize(4_KB * 64);
+        features.SetPreferredBlockSize(4_KB * 2);
 
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
     }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -758,12 +758,13 @@ private:
                 RequestStats,
                 Log,
                 StorageMediaKind);
+            auto filestoreConfig = MakeFileSystemConfig(filestore);
             FileSystem = CreateFileSystem(
                 Logging,
                 ProfileLog,
                 Scheduler,
                 Timer,
-                MakeFileSystemConfig(filestore),
+                filestoreConfig,
                 Session,
                 RequestStats,
                 CompletionQueue);
@@ -778,6 +779,14 @@ private:
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str(),
                 SessionState.empty() ? "new" : "existing");
+
+            TStringStream filestoreConfigDump;
+            filestoreConfig->Dump(filestoreConfigDump);
+            STORAGE_INFO(
+                "[f:%s][c:%s] new session filestore config: %s",
+                Config->GetFileSystemId().Quote().c_str(),
+                Config->GetClientId().Quote().c_str(),
+                filestoreConfigDump.Str().Quote().c_str());
 
             SessionThread = std::make_unique<TSessionThread>(
                 Log,

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
@@ -4,4 +4,4 @@ NewCleanupEnabled: true
 ThreeStageWriteEnabled: true
 ReadAheadCacheRangeSize: 1048576
 NodeIndexCacheMaxNodes: 128
-ExtendedBlockSizeEnabled: true
+PreferredBlockSizeMultiplier: 64


### PR DESCRIPTION
Replacement of ExtendedBlockSizeEnabled(bool) with PreferredBlockSizeMultiplier(ui32) should be safe, according to protobuf documentation.

References #1289