### PR TITLE
[Filestore] Add CpuWaitFilename field for filestore diagnostics config, analogous to the one in blockstore

### DIFF
--- a/cloud/filestore/config/diagnostics.proto
+++ b/cloud/filestore/config/diagnostics.proto
@@ -71,6 +71,11 @@ message TDiagnosticsConfig
     // Used to form path to file with cpu wait counters
     optional string CpuWaitServiceName = 15;
 
+    // Alternatively to CpuWaitServiceName, can be used to explicitly specify
+    // the filename of the file with cpu wait counters. If both are specified,
+    // CpuWaitFilename is used.
+    optional string CpuWaitFilename = 23;
+
     // Aggregate and write metrics values in Metrics service to monlib counters
     // every MetricsUpdateInterval ms.
     optional uint32 MetricsUpdateInterval = 16;

--- a/cloud/filestore/libs/diagnostics/config.cpp
+++ b/cloud/filestore/libs/diagnostics/config.cpp
@@ -24,6 +24,7 @@ namespace {
     xxx(LWTraceShuttleCount,        ui32,       2000                          )\
                                                                                \
     xxx(CpuWaitServiceName,         TString,    ""                            )\
+    xxx(CpuWaitFilename,            TString,    ""                            )\
                                                                                \
     xxx(MetricsUpdateInterval,      TDuration,  TDuration::Seconds(5)         )\
                                                                                \

--- a/cloud/filestore/libs/diagnostics/config.h
+++ b/cloud/filestore/libs/diagnostics/config.h
@@ -53,6 +53,7 @@ public:
     ui32 GetLWTraceShuttleCount() const;
 
     TString GetCpuWaitServiceName() const;
+    TString GetCpuWaitFilename() const;
 
     TDuration GetMetricsUpdateInterval() const;
 


### PR DESCRIPTION
Right now the filename for cpuWait is equal to `/sys/fs/cgroup/cpu/system.slice/%s.service/cpuacct.wait`, where `%s` is the service name, which can be defined at the `nfs-diagnostics.txt` config as `CpuWaitServiceName`. Analogous to blockstore, we may need to overwrite this statFile path to something custom. This is what `CpuWaitFilename` option in `nfs-diagnostics.txt` does. If not set, `CpuWaitServiceName` will be used in the same manner, as usual