### PR TITLE
issue-1350: multitablet filesystems api, follower configuration code, automatic session creation in followers, node creation in followers via requests to leader, service uts

### DIFF
--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -28,6 +28,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(AddData,                    __VA_ARGS__)                               \
     xxx(ForcedOperation,            __VA_ARGS__)                               \
     xxx(ConfigureFollowers,         __VA_ARGS__)                               \
+    xxx(ConfigureAsFollower,        __VA_ARGS__)                               \
 // FILESTORE_TABLET_REQUESTS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,6 +81,9 @@ struct TEvIndexTablet
 
         EvConfigureFollowersRequest = EvBegin + 25,
         EvConfigureFollowersResponse,
+
+        EvConfigureAsFollowerRequest = EvBegin + 27,
+        EvConfigureAsFollowerResponse,
 
         EvEnd
     };

--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -27,6 +27,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(GenerateBlobIds,            __VA_ARGS__)                               \
     xxx(AddData,                    __VA_ARGS__)                               \
     xxx(ForcedOperation,            __VA_ARGS__)                               \
+    xxx(ConfigureFollowers,         __VA_ARGS__)                               \
 // FILESTORE_TABLET_REQUESTS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -76,6 +77,9 @@ struct TEvIndexTablet
 
         EvForcedOperationRequest = EvBegin + 23,
         EvForcedOperationResponse,
+
+        EvConfigureFollowersRequest = EvBegin + 25,
+        EvConfigureFollowersResponse,
 
         EvEnd
     };

--- a/cloud/filestore/libs/storage/model/utils.h
+++ b/cloud/filestore/libs/storage/model/utils.h
@@ -12,4 +12,11 @@ inline bool IsAligned(size_t len, size_t align) noexcept
     return (len & (align - 1)) == 0;
 }
 
+inline ui64 ShardedId(ui64 id, ui32 shardNo)
+{
+    const auto realBits = 56U;
+    const auto realMask = Max<ui64>() >> (64 - realBits);
+    return (static_cast<ui64>(shardNo) << realBits) | (realMask & id);
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/model/utils.h
+++ b/cloud/filestore/libs/storage/model/utils.h
@@ -16,6 +16,7 @@ inline ui64 ShardedId(ui64 id, ui32 shardNo)
 {
     const auto realBits = 56U;
     const auto realMask = Max<ui64>() >> (64 - realBits);
+    Y_DEBUG_ABORT_UNLESS(shardNo < (1UL << (64 - realBits)));
     return (static_cast<ui64>(shardNo) << realBits) | (realMask & id);
 }
 

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -161,6 +161,10 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateConfigureAsFollowerActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
 private:
     void RenderSessions(IOutputStream& out);
     void RenderLocalFileStores(IOutputStream& out);

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -157,6 +157,10 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateConfigureFollowersActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
 private:
     void RenderSessions(IOutputStream& out);
     void RenderLocalFileStores(IOutputStream& out);

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -60,6 +60,10 @@ void TStorageServiceActor::HandleExecuteAction(
             "configurefollowers",
             &TStorageServiceActor::CreateConfigureFollowersActionActor
         },
+        {
+            "configureasfollower",
+            &TStorageServiceActor::CreateConfigureAsFollowerActionActor
+        },
     };
 
     auto it = actions.find(action);

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -56,6 +56,10 @@ void TStorageServiceActor::HandleExecuteAction(
             "reassigntablet",
             &TStorageServiceActor::CreateReassignTabletActionActor
         },
+        {
+            "configurefollowers",
+            &TStorageServiceActor::CreateConfigureFollowersActionActor
+        },
     };
 
     auto it = actions.find(action);

--- a/cloud/filestore/libs/storage/service/service_actor_actions_configure_as_follower.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_configure_as_follower.cpp
@@ -1,0 +1,139 @@
+#include "service_actor.h"
+
+#include <cloud/filestore/libs/storage/api/service.h>
+#include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/public.h>
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <google/protobuf/util/json_util.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TConfigureAsFollowerActionActor final
+    : public TActorBootstrapped<TConfigureAsFollowerActionActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString Input;
+
+public:
+    TConfigureAsFollowerActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        const NProtoPrivate::TConfigureAsFollowerResponse& response);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleConfigureAsFollowerResponse(
+        const TEvIndexTablet::TEvConfigureAsFollowerResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TConfigureAsFollowerActionActor::TConfigureAsFollowerActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input)
+    : RequestInfo(std::move(requestInfo))
+    , Input(std::move(input))
+{}
+
+void TConfigureAsFollowerActionActor::Bootstrap(const TActorContext& ctx)
+{
+    NProtoPrivate::TConfigureAsFollowerRequest request;
+    if (!google::protobuf::util::JsonStringToMessage(Input, &request).ok()) {
+        ReplyAndDie(
+            ctx,
+            TErrorResponse(E_ARGUMENT, "Failed to parse input"));
+        return;
+    }
+
+    if (!request.GetFileSystemId()) {
+        ReplyAndDie(
+            ctx,
+            TErrorResponse(E_ARGUMENT, "FileSystem id should be supplied"));
+        return;
+    }
+
+    auto requestToTablet =
+        std::make_unique<TEvIndexTablet::TEvConfigureAsFollowerRequest>();
+
+    requestToTablet->Record = std::move(request);
+
+    NCloud::Send(
+        ctx,
+        MakeIndexTabletProxyServiceId(),
+        std::move(requestToTablet));
+
+    Become(&TThis::StateWork);
+}
+
+void TConfigureAsFollowerActionActor::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProtoPrivate::TConfigureAsFollowerResponse& response)
+{
+    auto msg = std::make_unique<TEvService::TEvExecuteActionResponse>(
+        response.GetError());
+
+    google::protobuf::util::MessageToJsonString(
+        response,
+        msg->Record.MutableOutput());
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(msg));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TConfigureAsFollowerActionActor::HandleConfigureAsFollowerResponse(
+    const TEvIndexTablet::TEvConfigureAsFollowerResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ReplyAndDie(ctx, ev->Get()->Record);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TConfigureAsFollowerActionActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvIndexTablet::TEvConfigureAsFollowerResponse,
+            HandleConfigureAsFollowerResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            break;
+    }
+}
+
+} // namespace
+
+IActorPtr TStorageServiceActor::CreateConfigureAsFollowerActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    return std::make_unique<TConfigureAsFollowerActionActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_actions_configure_followers.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_configure_followers.cpp
@@ -1,0 +1,139 @@
+#include "service_actor.h"
+
+#include <cloud/filestore/libs/storage/api/service.h>
+#include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/public.h>
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <google/protobuf/util/json_util.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TConfigureFollowersActionActor final
+    : public TActorBootstrapped<TConfigureFollowersActionActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString Input;
+
+public:
+    TConfigureFollowersActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        const NProtoPrivate::TConfigureFollowersResponse& response);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleConfigureFollowersResponse(
+        const TEvIndexTablet::TEvConfigureFollowersResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TConfigureFollowersActionActor::TConfigureFollowersActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input)
+    : RequestInfo(std::move(requestInfo))
+    , Input(std::move(input))
+{}
+
+void TConfigureFollowersActionActor::Bootstrap(const TActorContext& ctx)
+{
+    NProtoPrivate::TConfigureFollowersRequest request;
+    if (!google::protobuf::util::JsonStringToMessage(Input, &request).ok()) {
+        ReplyAndDie(
+            ctx,
+            TErrorResponse(E_ARGUMENT, "Failed to parse input"));
+        return;
+    }
+
+    if (!request.GetFileSystemId()) {
+        ReplyAndDie(
+            ctx,
+            TErrorResponse(E_ARGUMENT, "FileSystem id should be supplied"));
+        return;
+    }
+
+    auto requestToTablet =
+        std::make_unique<TEvIndexTablet::TEvConfigureFollowersRequest>();
+
+    requestToTablet->Record = std::move(request);
+
+    NCloud::Send(
+        ctx,
+        MakeIndexTabletProxyServiceId(),
+        std::move(requestToTablet));
+
+    Become(&TThis::StateWork);
+}
+
+void TConfigureFollowersActionActor::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProtoPrivate::TConfigureFollowersResponse& response)
+{
+    auto msg = std::make_unique<TEvService::TEvExecuteActionResponse>(
+        response.GetError());
+
+    google::protobuf::util::MessageToJsonString(
+        response,
+        msg->Record.MutableOutput());
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(msg));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TConfigureFollowersActionActor::HandleConfigureFollowersResponse(
+    const TEvIndexTablet::TEvConfigureFollowersResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ReplyAndDie(ctx, ev->Get()->Record);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TConfigureFollowersActionActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvIndexTablet::TEvConfigureFollowersResponse,
+            HandleConfigureFollowersResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            break;
+    }
+}
+
+} // namespace
+
+IActorPtr TStorageServiceActor::CreateConfigureFollowersActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    return std::make_unique<TConfigureFollowersActionActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -5,6 +5,7 @@ SRCS(
     service.cpp
     service_actor.cpp
     service_actor_actions_change_storage_config.cpp
+    service_actor_actions_configure_followers.cpp
     service_actor_actions_describe_sessions.cpp
     service_actor_actions_drain_tablets.cpp
     service_actor_actions_forced_operation.cpp

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -5,6 +5,7 @@ SRCS(
     service.cpp
     service_actor.cpp
     service_actor_actions_change_storage_config.cpp
+    service_actor_actions_configure_as_follower.cpp
     service_actor_actions_configure_followers.cpp
     service_actor_actions_describe_sessions.cpp
     service_actor_actions_drain_tablets.cpp

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -43,6 +43,7 @@ message TFileSystem
     TFileStorePerformanceProfile PerformanceProfile = 12;
 
     repeated string FollowerFileSystemIds = 13;
+    uint32 ShardNo = 14;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -41,6 +41,8 @@ message TFileSystem
 
     // Performance profile, used for throttling.
     TFileStorePerformanceProfile PerformanceProfile = 12;
+
+    repeated string FollowerFileSystemIds = 13;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -740,6 +740,12 @@ STFUNC(TIndexTabletActor::StateInit)
         HFunc(
             TEvIndexTabletPrivate::TEvForcedRangeOperationProgress,
             HandleForcedRangeOperationProgress);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollower,
+            HandleNodeCreatedInFollower);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle,
+            HandleNodeCreatedInFollowerUponCreateHandle);
 
         FILESTORE_HANDLE_REQUEST(WaitReady, TEvIndexTablet)
 
@@ -772,6 +778,12 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(
             TEvIndexTabletPrivate::TEvForcedRangeOperationProgress,
             HandleForcedRangeOperationProgress);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollower,
+            HandleNodeCreatedInFollower);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle,
+            HandleNodeCreatedInFollowerUponCreateHandle);
 
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -463,6 +463,14 @@ private:
         const TEvIndexTabletPrivate::TEvForcedRangeOperationProgress::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleNodeCreatedInFollower(
+        const TEvIndexTabletPrivate::TEvNodeCreatedInFollower::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleNodeCreatedInFollowerUponCreateHandle(
+        const TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     bool HandleRequests(STFUNC_SIG);
     bool RejectRequests(STFUNC_SIG);
     bool RejectRequestsByBrokenTablet(STFUNC_SIG);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -2,6 +2,10 @@
 
 #include "helpers.h"
 
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+
+#include <util/generic/guid.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
@@ -36,6 +40,172 @@ NProto::TError ValidateRequest(const NProto::TCreateHandleRequest& request)
     return {};
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+class TCreateNodeInFollowerUponCreateHandleActor final
+    : public TActorBootstrapped<TCreateNodeInFollowerUponCreateHandleActor>
+{
+private:
+    const TString LogTag;
+    TRequestInfoPtr RequestInfo;
+    const TString FollowerId;
+    const TString FollowerName;
+    const TActorId ParentId;
+    const NProto::TNode Attrs;
+    NProto::TCreateHandleResponse Response;
+    NProto::TCreateNodeResponse FollowerResponse;
+
+public:
+    TCreateNodeInFollowerUponCreateHandleActor(
+        TString logTag,
+        TRequestInfoPtr requestInfo,
+        TString followerId,
+        TString followerName,
+        const TActorId& parentId,
+        NProto::TNode attrs,
+        NProto::TCreateHandleResponse response);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void SendRequest(const TActorContext& ctx);
+
+    void HandleCreateNodeResponse(
+        const TEvService::TEvCreateNodeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(const TActorContext& ctx, NProto::TError error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCreateNodeInFollowerUponCreateHandleActor::TCreateNodeInFollowerUponCreateHandleActor(
+        TString logTag,
+        TRequestInfoPtr requestInfo,
+        TString followerId,
+        TString followerName,
+        const TActorId& parentId,
+        NProto::TNode attrs,
+        NProto::TCreateHandleResponse response)
+    : LogTag(std::move(logTag))
+    , RequestInfo(std::move(requestInfo))
+    , FollowerId(std::move(followerId))
+    , FollowerName(std::move(followerName))
+    , ParentId(parentId)
+    , Attrs(std::move(attrs))
+    , Response(std::move(response))
+{}
+
+void TCreateNodeInFollowerUponCreateHandleActor::Bootstrap(const TActorContext& ctx)
+{
+    SendRequest(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TCreateNodeInFollowerUponCreateHandleActor::SendRequest(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
+    request->Record.MutableFile()->SetMode(Attrs.GetMode());
+    request->Record.SetUid(Attrs.GetUid());
+    request->Record.SetGid(Attrs.GetGid());
+    request->Record.SetFileSystemId(FollowerId);
+    request->Record.SetNodeId(RootNodeId);
+    request->Record.SetName(FollowerName);
+    request->Record.ClearFollowerFileSystemId();
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s Sending CreateNodeRequest to follower %s, %s",
+        LogTag.c_str(),
+        FollowerId.c_str(),
+        FollowerName.c_str());
+
+    ctx.Send(
+        MakeIndexTabletProxyServiceId(),
+        request.release());
+}
+
+void TCreateNodeInFollowerUponCreateHandleActor::HandleCreateNodeResponse(
+    const TEvService::TEvCreateNodeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        LOG_ERROR(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s Follower node creation failed for %s, %s with error %s",
+            LogTag.c_str(),
+            FollowerId.c_str(),
+            FollowerName.c_str(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        ReplyAndDie(ctx, msg->GetError());
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s Follower node created for %s, %s",
+        LogTag.c_str(),
+        FollowerId.c_str(),
+        FollowerName.c_str());
+
+    FollowerResponse = std::move(msg->Record);
+
+    ReplyAndDie(ctx, {});
+}
+
+void TCreateNodeInFollowerUponCreateHandleActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
+}
+
+void TCreateNodeInFollowerUponCreateHandleActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TError error)
+{
+    if (HasError(error)) {
+        // TODO(#1350): properly retry node creation via the leader fs
+        *Response.MutableError() = std::move(error);
+    }
+
+    using TResponse =
+        TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle;
+    ctx.Send(ParentId, std::make_unique<TResponse>(
+        std::move(RequestInfo),
+        std::move(FollowerResponse),
+        std::move(Response)
+    ));
+
+    Die(ctx);
+}
+
+STFUNC(TCreateNodeInFollowerUponCreateHandleActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(TEvService::TEvCreateNodeResponse, HandleCreateNodeResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            break;
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,9 +221,9 @@ void TIndexTabletActor::HandleCreateHandle(
     }
 
     auto* msg = ev->Get();
-    if (auto entry = session->LookupDupEntry(GetRequestId(msg->Record))) {
+    if (const auto* e = session->LookupDupEntry(GetRequestId(msg->Record))) {
         auto response = std::make_unique<TEvService::TEvCreateHandleResponse>();
-        GetDupCacheEntry(entry, response->Record);
+        GetDupCacheEntry(e, response->Record);
         return NCloud::Reply(ctx, *ev, std::move(response));
     }
 
@@ -128,6 +298,12 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
                 args.Error = ErrorNoSpaceLeft();
                 return true;
             }
+
+            if (args.RequestFollowerId) {
+                args.FollowerId = args.RequestFollowerId;
+                args.FollowerName = CreateGuidAsString();
+                args.IsNewFollowerNode = true;
+            }
         } else {
             // if yes check whether O_EXCL was specified, assume O_CREAT is also specified
             if (HasFlag(args.Flags, NProto::TCreateHandleRequest::E_EXCLUSIVE)) {
@@ -136,17 +312,22 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
             }
 
             args.TargetNodeId = ref->ChildNodeId;
+            args.FollowerId = ref->FollowerId;
+            args.FollowerName = ref->FollowerName;
         }
     } else {
         args.TargetNodeId = args.NodeId;
+        args.FollowerId = args.RequestFollowerId;
     }
 
-    if (args.TargetNodeId != InvalidNodeId) {
+    // TODO(#1350): proper validity checks for external node requests
+    if (args.TargetNodeId != InvalidNodeId && args.FollowerId.Empty()) {
         if (!ReadNode(db, args.TargetNodeId, args.ReadCommitId, args.TargetNode)) {
             return false;   // not ready
         }
 
         if (!args.TargetNode) {
+            // TODO(#1350): try to extract shardNo from TargetNodeId?
             args.Error = ErrorInvalidTarget(args.TargetNodeId);
             return true;
         }
@@ -182,22 +363,27 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
 
     TIndexTabletDatabase db(tx.DB);
 
-    if (args.TargetNodeId == InvalidNodeId) {
+    if (args.TargetNodeId == InvalidNodeId
+            && (args.FollowerId.Empty() || args.IsNewFollowerNode))
+    {
         TABLET_VERIFY(!args.TargetNode);
         TABLET_VERIFY(args.ParentNode);
 
-        NProto::TNode attrs = CreateRegularAttrs(args.Mode, args.Uid, args.Gid);
-        args.TargetNodeId = CreateNode(
-            db,
-            args.WriteCommitId,
-            attrs);
+        if (args.FollowerId.Empty()) {
+            NProto::TNode attrs =
+                CreateRegularAttrs(args.Mode, args.Uid, args.Gid);
+            args.TargetNodeId = CreateNode(
+                db,
+                args.WriteCommitId,
+                attrs);
 
-        args.TargetNode = TIndexTabletDatabase::TNode {
-            args.TargetNodeId,
-            attrs,
-            args.WriteCommitId,
-            InvalidCommitId
-        };
+            args.TargetNode = TIndexTabletDatabase::TNode {
+                args.TargetNodeId,
+                attrs,
+                args.WriteCommitId,
+                InvalidCommitId
+            };
+        }
 
         // TODO: support for O_TMPFILE
         CreateNodeRef(
@@ -205,7 +391,9 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             args.NodeId,
             args.WriteCommitId,
             args.Name,
-            args.TargetNodeId);
+            args.TargetNodeId,
+            args.FollowerId,
+            args.FollowerName);
 
         // update parent cmtime as we created a new entry
         auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
@@ -217,7 +405,9 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             parent,
             args.ParentNode->Attrs);
 
-    } else if (HasFlag(args.Flags, NProto::TCreateHandleRequest::E_TRUNCATE)) {
+    } else if (args.FollowerId.Empty()
+        && HasFlag(args.Flags, NProto::TCreateHandleRequest::E_TRUNCATE))
+    {
         Truncate(
             db,
             args.TargetNodeId,
@@ -237,17 +427,22 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             args.TargetNode->Attrs);
     }
 
-    auto* handle = CreateHandle(
-        db,
-        session,
-        args.TargetNodeId,
-        session->GetCheckpointId() ? args.ReadCommitId : InvalidCommitId,
-        args.Flags);
+    if (args.FollowerId.Empty()) {
+        auto* handle = CreateHandle(
+            db,
+            session,
+            args.TargetNodeId,
+            session->GetCheckpointId() ? args.ReadCommitId : InvalidCommitId,
+            args.Flags);
 
-    TABLET_VERIFY(handle);
-    args.Response.SetHandle(handle->GetHandle());
-    auto* node = args.Response.MutableNodeAttr();
-    ConvertNodeFromAttrs(*node, args.TargetNodeId, args.TargetNode->Attrs);
+        TABLET_VERIFY(handle);
+        args.Response.SetHandle(handle->GetHandle());
+        auto* node = args.Response.MutableNodeAttr();
+        ConvertNodeFromAttrs(*node, args.TargetNodeId, args.TargetNode->Attrs);
+    } else {
+        args.Response.SetFollowerFileSystemId(args.FollowerId);
+        args.Response.SetFollowerNodeName(args.FollowerName);
+    }
 
     AddDupCacheEntry(
         db,
@@ -265,8 +460,32 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
 {
     RemoveTransaction(*args.RequestInfo);
 
-    auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(args.Error);
-    if (SUCCEEDED(args.Error.GetCode())) {
+    if (args.IsNewFollowerNode && !HasError(args.Error)) {
+        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+            "%s Creating node in follower upon CreateHandle: %s, %s",
+            LogTag.c_str(),
+            args.FollowerId.c_str(),
+            args.FollowerName.c_str());
+
+        auto actor = std::make_unique<TCreateNodeInFollowerUponCreateHandleActor>(
+            LogTag,
+            args.RequestInfo,
+            args.FollowerId,
+            args.FollowerName,
+            ctx.SelfID,
+            CreateRegularAttrs(args.Mode, args.Uid, args.Gid),
+            std::move(args.Response));
+
+        auto actorId = NCloud::Register(ctx, std::move(actor));
+        WorkerActors.insert(actorId);
+
+        return;
+    }
+
+    auto response =
+        std::make_unique<TEvService::TEvCreateHandleResponse>(args.Error);
+
+    if (!HasError(args.Error)) {
         CommitDupCacheEntry(args.SessionId, args.RequestId);
         response->Record = std::move(args.Response);
     }
@@ -277,6 +496,31 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleNodeCreatedInFollowerUponCreateHandle(
+    const TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(
+        msg->FollowerCreateNodeResponse.GetError());
+
+    if (!HasError(response->GetError())) {
+        response->Record = std::move(msg->CreateHandleResponse);
+    }
+
+    CompleteResponse<TEvService::TCreateHandleMethod>(
+        response->Record,
+        msg->RequestInfo->CallContext,
+        ctx);
+
+    NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+
+    WorkerActors.erase(ev->Sender);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -2,6 +2,8 @@
 
 #include "helpers.h"
 
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
@@ -63,6 +65,169 @@ void InitAttrs(NProto::TNode& attrs, const NProto::TCreateNodeRequest& request)
             sock.GetMode(),
             request.GetUid(),
             request.GetGid());
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TCreateNodeInFollowerActor final
+    : public TActorBootstrapped<TCreateNodeInFollowerActor>
+{
+private:
+    const TString LogTag;
+    TRequestInfoPtr RequestInfo;
+    const TString FollowerId;
+    const TString FollowerName;
+    const TActorId ParentId;
+    NProto::TCreateNodeRequest Request;
+    NProto::TCreateNodeResponse Response;
+    NProto::TCreateNodeResponse FollowerResponse;
+
+public:
+    TCreateNodeInFollowerActor(
+        TString logTag,
+        TRequestInfoPtr requestInfo,
+        TString followerId,
+        TString followerName,
+        const TActorId& parentId,
+        NProto::TCreateNodeRequest request,
+        NProto::TCreateNodeResponse response);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void SendRequest(const TActorContext& ctx);
+
+    void HandleCreateNodeResponse(
+        const TEvService::TEvCreateNodeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(const TActorContext& ctx, NProto::TError error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCreateNodeInFollowerActor::TCreateNodeInFollowerActor(
+        TString logTag,
+        TRequestInfoPtr requestInfo,
+        TString followerId,
+        TString followerName,
+        const TActorId& parentId,
+        NProto::TCreateNodeRequest request,
+        NProto::TCreateNodeResponse response)
+    : LogTag(std::move(logTag))
+    , RequestInfo(std::move(requestInfo))
+    , FollowerId(std::move(followerId))
+    , FollowerName(std::move(followerName))
+    , ParentId(parentId)
+    , Request(std::move(request))
+    , Response(std::move(response))
+{}
+
+void TCreateNodeInFollowerActor::Bootstrap(const TActorContext& ctx)
+{
+    SendRequest(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TCreateNodeInFollowerActor::SendRequest(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
+    request->Record = std::move(Request);
+    request->Record.SetFileSystemId(FollowerId);
+    request->Record.SetNodeId(RootNodeId);
+    request->Record.SetName(FollowerName);
+    request->Record.ClearFollowerFileSystemId();
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s Sending CreateNodeRequest to follower %s, %s",
+        LogTag.c_str(),
+        FollowerId.c_str(),
+        FollowerName.c_str());
+
+    ctx.Send(
+        MakeIndexTabletProxyServiceId(),
+        request.release());
+}
+
+void TCreateNodeInFollowerActor::HandleCreateNodeResponse(
+    const TEvService::TEvCreateNodeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        LOG_ERROR(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s Follower node creation failed for %s, %s with error %s",
+            LogTag.c_str(),
+            FollowerId.c_str(),
+            FollowerName.c_str(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        ReplyAndDie(ctx, msg->GetError());
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s Follower node created for %s, %s",
+        LogTag.c_str(),
+        FollowerId.c_str(),
+        FollowerName.c_str());
+
+    FollowerResponse = std::move(msg->Record);
+
+    ReplyAndDie(ctx, {});
+}
+
+void TCreateNodeInFollowerActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
+}
+
+void TCreateNodeInFollowerActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TError error)
+{
+    if (HasError(error)) {
+        // TODO(#1350): properly retry node creation via the leader fs
+        *Response.MutableError() = std::move(error);
+    }
+
+    using TResponse = TEvIndexTabletPrivate::TEvNodeCreatedInFollower;
+    ctx.Send(ParentId, std::make_unique<TResponse>(
+        std::move(RequestInfo),
+        std::move(FollowerResponse),
+        std::move(Response)
+    ));
+
+    Die(ctx);
+}
+
+STFUNC(TCreateNodeInFollowerActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(TEvService::TEvCreateNodeResponse, HandleCreateNodeResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            break;
     }
 }
 
@@ -175,12 +340,16 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
             // should exist
             args.Error = ErrorInvalidTarget(args.ChildNodeId);
             return true;
-        } else if (args.ChildNode->Attrs.GetType() == NProto::E_DIRECTORY_NODE) {
+        }
+
+        if (args.ChildNode->Attrs.GetType() == NProto::E_DIRECTORY_NODE) {
             // should not be a directory
             args.Error = ErrorIsDirectory(args.ChildNodeId);
             return true;
-        } else if (args.ChildNode->Attrs.GetLinks() + 1 > MaxLink) {
-            // should not have too much links
+        }
+
+        if (args.ChildNode->Attrs.GetLinks() + 1 > MaxLink) {
+            // should not have too many links
             args.Error = ErrorMaxLink(args.ChildNodeId);
             return true;
         }
@@ -210,18 +379,19 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
     }
 
     if (!args.ChildNode) {
-        // new node
-        args.ChildNodeId = CreateNode(
-            db,
-            args.CommitId,
-            args.Attrs);
+        if (args.FollowerId.Empty()) {
+            args.ChildNodeId = CreateNode(
+                db,
+                args.CommitId,
+                args.Attrs);
 
-        args.ChildNode = TIndexTabletDatabase::TNode {
-            args.ChildNodeId,
-            args.Attrs,
-            args.CommitId,
-            InvalidCommitId
-        };
+            args.ChildNode = TIndexTabletDatabase::TNode {
+                args.ChildNodeId,
+                args.Attrs,
+                args.CommitId,
+                InvalidCommitId
+            };
+        }
     } else {
         // hard link
         auto attrs = CopyAttrs(args.ChildNode->Attrs, E_CM_CMTIME | E_CM_REF);
@@ -246,22 +416,32 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         parent,
         args.ParentNode->Attrs);
 
-    TABLET_VERIFY(args.ChildNodeId != InvalidNodeId);
     CreateNodeRef(
         db,
         args.ParentNodeId,
         args.CommitId,
         args.Name,
-        args.ChildNodeId);
+        args.ChildNodeId,
+        args.FollowerId,
+        args.FollowerName);
 
-    ConvertNodeFromAttrs(*args.Response.MutableNode(), args.ChildNodeId, args.ChildNode->Attrs);
+    if (args.FollowerId.Empty()) {
+        TABLET_VERIFY(args.ChildNodeId != InvalidNodeId);
 
-    AddDupCacheEntry(
-        db,
-        session,
-        args.RequestId,
-        args.Response,
-        Config->GetDupCacheEntryCount());
+        ConvertNodeFromAttrs(
+            *args.Response.MutableNode(),
+            args.ChildNodeId,
+            args.ChildNode->Attrs);
+
+        AddDupCacheEntry(
+            db,
+            session,
+            args.RequestId,
+            args.Response,
+            Config->GetDupCacheEntryCount());
+    }
+
+    // TODO(#1350): support DupCache for external nodes
 }
 
 void TIndexTabletActor::CompleteTx_CreateNode(
@@ -270,8 +450,31 @@ void TIndexTabletActor::CompleteTx_CreateNode(
 {
     RemoveTransaction(*args.RequestInfo);
 
-    auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(args.Error);
-    if (SUCCEEDED(args.Error.GetCode())) {
+    if (args.FollowerId && !HasError(args.Error)) {
+        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+            "%s Creating node in follower upon CreateNode: %s, %s",
+            LogTag.c_str(),
+            args.FollowerId.c_str(),
+            args.FollowerName.c_str());
+
+        auto actor = std::make_unique<TCreateNodeInFollowerActor>(
+            LogTag,
+            args.RequestInfo,
+            args.FollowerId,
+            args.FollowerName,
+            ctx.SelfID,
+            std::move(args.Request),
+            std::move(args.Response));
+
+        auto actorId = NCloud::Register(ctx, std::move(actor));
+        WorkerActors.insert(actorId);
+
+        return;
+    }
+
+    auto response =
+        std::make_unique<TEvService::TEvCreateNodeResponse>(args.Error);
+    if (!HasError(args.Error)) {
         CommitDupCacheEntry(args.SessionId, args.RequestId);
 
         TABLET_VERIFY(args.ChildNode);
@@ -294,6 +497,33 @@ void TIndexTabletActor::CompleteTx_CreateNode(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleNodeCreatedInFollower(
+    const TEvIndexTabletPrivate::TEvNodeCreatedInFollower::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
+        msg->FollowerCreateNodeResponse.GetError());
+
+    if (!HasError(response->GetError())) {
+        response->Record = std::move(msg->CreateNodeResponse);
+        *response->Record.MutableNode() =
+            std::move(*msg->FollowerCreateNodeResponse.MutableNode());
+    }
+
+    CompleteResponse<TEvService::TCreateNodeMethod>(
+        response->Record,
+        msg->RequestInfo->CallContext,
+        ctx);
+
+    NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+
+    WorkerActors.erase(ev->Sender);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -81,9 +81,9 @@ void TIndexTabletActor::HandleCreateNode(
     }
 
     auto* msg = ev->Get();
-    if (auto entry = session->LookupDupEntry(GetRequestId(msg->Record))) {
+    if (const auto* e = session->LookupDupEntry(GetRequestId(msg->Record))) {
         auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
-        GetDupCacheEntry(entry, response->Record);
+        GetDupCacheEntry(e, response->Record);
         return NCloud::Reply(ctx, *ev, std::move(response));
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -202,7 +202,9 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
                     ref.MinCommitId,
                     ref.MaxCommitId,
                     ref.Name,
-                    ref.ChildNodeId);
+                    ref.ChildNodeId,
+                    ref.FollowerId,
+                    ref.FollowerName);
             }
 
             RemoveCheckpointNodes(db, checkpoint, args.NodeIds);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -48,9 +48,9 @@ void TIndexTabletActor::HandleUnlinkNode(
     }
 
     auto* msg = ev->Get();
-    if (auto entry = session->LookupDupEntry(GetRequestId(msg->Record))) {
+    if (const auto* e = session->LookupDupEntry(GetRequestId(msg->Record))) {
         auto response = std::make_unique<TEvService::TEvUnlinkNodeResponse>();
-        GetDupCacheEntry(entry, response->Record);
+        GetDupCacheEntry(e, response->Record);
         return NCloud::Reply(ctx, *ev, std::move(response));
     }
 
@@ -150,6 +150,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
         return RebootTabletOnCommitOverflow(ctx, "UnlinkNode");
     }
 
+    // TODO(#1350): unlink external nodes
     UnlinkNode(
         db,
         args.ParentNodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -2,6 +2,8 @@
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 
+#include <util/string/join.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
@@ -231,6 +233,72 @@ void TIndexTabletActor::CompleteTx_UpdateConfig(
     response->Record.SetTxId(args.TxId);
     response->Record.SetOrigin(TabletID());
     response->Record.SetStatus(NKikimrFileStore::OK);
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleConfigureFollowers(
+    const TEvIndexTablet::TEvConfigureFollowersRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        // external event
+        MakeIntrusive<TCallContext>(GetFileSystemId()));
+
+    ExecuteTx<TConfigureFollowers>(
+        ctx,
+        std::move(requestInfo),
+        std::move(msg->Record));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_ConfigureFollowers(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TConfigureFollowers& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_ConfigureFollowers(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TConfigureFollowers& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabase db(tx.DB);
+
+    auto config = GetFileSystem();
+    // TODO(#1350): properly process follower removal
+    *config.MutableFollowerFileSystemIds() =
+        std::move(*args.Request.MutableFollowerFileSystemIds());
+
+    UpdateConfig(db, config, GetThrottlingConfig());
+}
+
+void TIndexTabletActor::CompleteTx_ConfigureFollowers(
+    const TActorContext& ctx,
+    TTxIndexTablet::TConfigureFollowers& args)
+{
+    LOG_INFO(ctx, TFileStoreComponents::TABLET,
+        "%s Configured followers, new follower list: %s",
+        LogTag.c_str(),
+        JoinSeq(",", GetFileSystem().GetFollowerFileSystemIds()).c_str());
+
+    auto response =
+        std::make_unique<TEvIndexTablet::TEvConfigureFollowersResponse>();
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -482,7 +482,9 @@ void TIndexTabletDatabase::WriteNodeRef(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
-    ui64 childNodeId)
+    ui64 childNodeId,
+    const TString& followerId,
+    const TString& followerName)
 {
     using TTable = TIndexTabletSchema::NodeRefs;
 
@@ -490,7 +492,9 @@ void TIndexTabletDatabase::WriteNodeRef(
         .Key(nodeId, name)
         .Update(
             NIceDb::TUpdate<TTable::CommitId>(commitId),
-            NIceDb::TUpdate<TTable::ChildId>(childNodeId)
+            NIceDb::TUpdate<TTable::ChildId>(childNodeId),
+            NIceDb::TUpdate<TTable::FollowerId>(followerId),
+            NIceDb::TUpdate<TTable::FollowerName>(followerName)
         );
 }
 
@@ -528,6 +532,8 @@ bool TIndexTabletDatabase::ReadNodeRef(
                 nodeId,
                 name,
                 it.GetValue<TTable::ChildId>(),
+                it.GetValue<TTable::FollowerId>(),
+                it.GetValue<TTable::FollowerName>(),
                 minCommitId,
                 maxCommitId
             };
@@ -566,6 +572,8 @@ bool TIndexTabletDatabase::ReadNodeRefs(
                 nodeId,
                 it.GetValue<TTable::Name>(),
                 it.GetValue<TTable::ChildId>(),
+                it.GetValue<TTable::FollowerId>(),
+                it.GetValue<TTable::FollowerName>(),
                 minCommitId,
                 maxCommitId
             });
@@ -612,7 +620,9 @@ void TIndexTabletDatabase::WriteNodeRefVer(
     ui64 minCommitId,
     ui64 maxCommitId,
     const TString& name,
-    ui64 childNodeId)
+    ui64 childNodeId,
+    const TString& followerId,
+    const TString& followerName)
 {
     using TTable = TIndexTabletSchema::NodeRefs_Ver;
 
@@ -620,7 +630,9 @@ void TIndexTabletDatabase::WriteNodeRefVer(
         .Key(nodeId, name, ReverseCommitId(minCommitId))
         .Update(
             NIceDb::TUpdate<TTable::MaxCommitId>(maxCommitId),
-            NIceDb::TUpdate<TTable::ChildId>(childNodeId)
+            NIceDb::TUpdate<TTable::ChildId>(childNodeId),
+            NIceDb::TUpdate<TTable::FollowerId>(followerId),
+            NIceDb::TUpdate<TTable::FollowerName>(followerName)
         );
 }
 
@@ -668,6 +680,8 @@ bool TIndexTabletDatabase::ReadNodeRefVer(
                 nodeId,
                 name,
                 it.GetValue<TTable::ChildId>(),
+                it.GetValue<TTable::FollowerId>(),
+                it.GetValue<TTable::FollowerName>(),
                 minCommitId,
                 maxCommitId
             };
@@ -706,6 +720,8 @@ bool TIndexTabletDatabase::ReadNodeRefVers(
                 nodeId,
                 it.GetValue<TTable::Name>(),
                 it.GetValue<TTable::ChildId>(),
+                it.GetValue<TTable::FollowerId>(),
+                it.GetValue<TTable::FollowerName>(),
                 minCommitId,
                 maxCommitId
             });

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -186,7 +186,9 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        ui64 childNode);
+        ui64 childNode,
+        const TString& followerId,
+        const TString& followerName);
 
     void DeleteNodeRef(ui64 nodeId, const TString& name);
 
@@ -195,6 +197,8 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 NodeId;
         TString Name;
         ui64 ChildNodeId;
+        TString FollowerId;
+        TString FollowerName;
         ui64 MinCommitId;
         ui64 MaxCommitId;
     };
@@ -227,7 +231,9 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 minCommitId,
         ui64 maxCommitId,
         const TString& name,
-        ui64 childNode);
+        ui64 childNode,
+        const TString& followerId,
+        const TString& followerName);
 
     void DeleteNodeRefVer(ui64 nodeId, ui64 commitId, const TString& name);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -135,18 +135,28 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
             db.WriteNode(nodeId, commitId, attrs);
             db.WriteNode(childNodeId1, commitId, attrs);
             db.WriteNode(childNodeId2, commitId, attrs);
-            db.WriteNodeRef(nodeId, commitId, "child1", childNodeId1);
-            db.WriteNodeRef(nodeId, commitId, "child2", childNodeId2);
+            db.WriteNodeRef(nodeId, commitId, "child1", childNodeId1, "", "");
+            db.WriteNodeRef(
+                nodeId,
+                commitId,
+                "child2",
+                childNodeId2,
+                "follower",
+                "name");
         });
 
         executor.ReadTx([&] (TIndexTabletDatabase db) {
             TMaybe<TIndexTabletDatabase::TNodeRef> ref1;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child1", ref1));
             UNIT_ASSERT_EQUAL(ref1->ChildNodeId, childNodeId1);
+            UNIT_ASSERT_EQUAL(ref1->FollowerId, "");
+            UNIT_ASSERT_EQUAL(ref1->FollowerName, "");
 
             TMaybe<TIndexTabletDatabase::TNodeRef> ref2;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child2", ref2));
             UNIT_ASSERT_EQUAL(ref2->ChildNodeId, childNodeId2);
+            UNIT_ASSERT_EQUAL(ref2->FollowerId, "follower");
+            UNIT_ASSERT_EQUAL(ref2->FollowerName, "name");
 
             TMaybe<TIndexTabletDatabase::TNodeRef> ref3;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child3", ref3));

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -6,6 +6,7 @@
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/api/components.h>
 #include <cloud/filestore/libs/storage/api/events.h>
+#include <cloud/filestore/libs/storage/core/request_info.h>
 #include <cloud/filestore/libs/storage/model/public.h>
 #include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/blob.h>
@@ -495,6 +496,48 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // NodeCreatedInFollower
+    //
+
+    struct TNodeCreatedInFollower
+    {
+        TRequestInfoPtr RequestInfo;
+        NProto::TCreateNodeResponse FollowerCreateNodeResponse;
+        NProto::TCreateNodeResponse CreateNodeResponse;
+
+        TNodeCreatedInFollower(
+                TRequestInfoPtr requestInfo,
+                NProto::TCreateNodeResponse followerCreateNodeResponse,
+                NProto::TCreateNodeResponse createNodeResponse)
+            : RequestInfo(std::move(requestInfo))
+            , FollowerCreateNodeResponse(std::move(followerCreateNodeResponse))
+            , CreateNodeResponse(std::move(createNodeResponse))
+        {
+        }
+    };
+
+    //
+    // NodeCreatedInFollowerUponCreateHandle
+    //
+
+    struct TNodeCreatedInFollowerUponCreateHandle
+    {
+        TRequestInfoPtr RequestInfo;
+        NProto::TCreateNodeResponse FollowerCreateNodeResponse;
+        NProto::TCreateHandleResponse CreateHandleResponse;
+
+        TNodeCreatedInFollowerUponCreateHandle(
+                TRequestInfoPtr requestInfo,
+                NProto::TCreateNodeResponse followerCreateNodeResponse,
+                NProto::TCreateHandleResponse createHandleResponse)
+            : RequestInfo(std::move(requestInfo))
+            , FollowerCreateNodeResponse(std::move(followerCreateNodeResponse))
+            , CreateHandleResponse(std::move(createHandleResponse))
+        {
+        }
+    };
+
+    //
     // DumpCompactionRange
     //
 
@@ -710,6 +753,9 @@ struct TEvIndexTabletPrivate
 
         EvForcedRangeOperationProgress,
 
+        EvNodeCreatedInFollower,
+        EvNodeCreatedInFollowerUponCreateHandle,
+
         EvEnd
     };
 
@@ -731,6 +777,13 @@ struct TEvIndexTabletPrivate
 
     using TEvForcedRangeOperationProgress =
         TRequestEvent<TForcedRangeOperationProgress, EvForcedRangeOperationProgress>;
+
+    using TEvNodeCreatedInFollower =
+        TRequestEvent<TNodeCreatedInFollower, EvNodeCreatedInFollower>;
+
+    using TEvNodeCreatedInFollowerUponCreateHandle = TRequestEvent<
+        TNodeCreatedInFollowerUponCreateHandle,
+        EvNodeCreatedInFollowerUponCreateHandle>;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -214,6 +214,8 @@ struct TIndexTabletSchema
         struct CommitId     : Column<2, NKikimr::NScheme::NTypeIds::Uint64> {};
         struct Name         : Column<3, NKikimr::NScheme::NTypeIds::String> {};
         struct ChildId      : Column<4, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct FollowerId   : Column<5, NKikimr::NScheme::NTypeIds::String> {};
+        struct FollowerName : Column<6, NKikimr::NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<NodeId, Name>;
 
@@ -221,7 +223,9 @@ struct TIndexTabletSchema
             NodeId,
             CommitId,
             Name,
-            ChildId
+            ChildId,
+            FollowerId,
+            FollowerName
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
@@ -234,6 +238,8 @@ struct TIndexTabletSchema
         struct MaxCommitId  : Column<3, NKikimr::NScheme::NTypeIds::Uint64> {};
         struct Name         : Column<4, NKikimr::NScheme::NTypeIds::String> {};
         struct ChildId      : Column<5, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct FollowerId   : Column<6, NKikimr::NScheme::NTypeIds::String> {};
+        struct FollowerName : Column<7, NKikimr::NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<NodeId, Name, MinCommitId>;
 
@@ -242,7 +248,9 @@ struct TIndexTabletSchema
             MinCommitId,
             MaxCommitId,
             Name,
-            ChildId
+            ChildId,
+            FollowerId,
+            FollowerName
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -432,7 +432,9 @@ public:
         ui64 nodeId,
         ui64 commitId,
         const TString& childName,
-        ui64 childNodeId);
+        ui64 childNodeId,
+        const TString& followerId,
+        const TString& followerName);
 
     void RemoveNodeRef(
         TIndexTabletDatabase& db,
@@ -440,7 +442,9 @@ public:
         ui64 minCommitId,
         ui64 maxCommitId,
         const TString& childName,
-        ui64 prevChildNodeId);
+        ui64 prevChildNodeId,
+        const TString& followerId,
+        const TString& followerName);
 
     bool ReadNodeRef(
         TIndexTabletDatabase& db,
@@ -470,7 +474,9 @@ public:
         ui64 minCommitId,
         ui64 maxCommitId,
         const TString& childName,
-        ui64 childNodeId);
+        ui64 childNodeId,
+        const TString& followerId,
+        const TString& followerName);
 
     //
     // Sessions

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -2,6 +2,8 @@
 
 #include "helpers.h"
 
+#include <cloud/filestore/libs/storage/model/utils.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 namespace
@@ -59,7 +61,8 @@ ui64 TIndexTabletState::CreateNode(
     ui64 commitId,
     const NProto::TNode& attrs)
 {
-    ui64 nodeId = IncrementLastNodeId(db);
+    const ui64 nodeId =
+        ShardedId(IncrementLastNodeId(db), GetFileSystem().GetShardNo());
 
     db.WriteNode(nodeId, commitId, attrs);
     IncrementUsedNodesCount(db);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -157,7 +157,10 @@ void TIndexTabletState::UnlinkNode(
         minCommitId,
         maxCommitId,
         name,
-        node.NodeId);
+        node.NodeId,
+        "", // followerId
+        "" // followerName
+    );
 }
 
 bool TIndexTabletState::ReadNode(
@@ -366,9 +369,17 @@ void TIndexTabletState::CreateNodeRef(
     ui64 nodeId,
     ui64 commitId,
     const TString& childName,
-    ui64 childNodeId)
+    ui64 childNodeId,
+    const TString& followerId,
+    const TString& followerName)
 {
-    db.WriteNodeRef(nodeId, commitId, childName, childNodeId);
+    db.WriteNodeRef(
+        nodeId,
+        commitId,
+        childName,
+        childNodeId,
+        followerId,
+        followerName);
 }
 
 void TIndexTabletState::RemoveNodeRef(
@@ -377,7 +388,9 @@ void TIndexTabletState::RemoveNodeRef(
     ui64 minCommitId,
     ui64 maxCommitId,
     const TString& childName,
-    ui64 prevChildNodeId)
+    ui64 prevChildNodeId,
+    const TString& followerId,
+    const TString& followerName)
 {
     db.DeleteNodeRef(nodeId, childName);
 
@@ -389,7 +402,9 @@ void TIndexTabletState::RemoveNodeRef(
             checkpointId,
             maxCommitId,
             childName,
-            prevChildNodeId);
+            prevChildNodeId,
+            followerId,
+            followerName);
 
         AddCheckpointNode(db, checkpointId, nodeId);
     }
@@ -459,7 +474,9 @@ void TIndexTabletState::RewriteNodeRef(
     ui64 minCommitId,
     ui64 maxCommitId,
     const TString& childName,
-    ui64 childNodeId)
+    ui64 childNodeId,
+    const TString& followerId,
+    const TString& followerName)
 {
     ui64 checkpointId = Impl->Checkpoints.FindCheckpoint(nodeId, minCommitId);
     if (checkpointId != InvalidCommitId) {
@@ -469,7 +486,9 @@ void TIndexTabletState::RewriteNodeRef(
             checkpointId,
             maxCommitId,
             childName,
-            childNodeId);
+            childNodeId,
+            followerId,
+            followerName);
 
         AddCheckpointNode(db, checkpointId, nodeId);
     } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -1,5 +1,7 @@
 #include "tablet_state_impl.h"
 
+#include <cloud/filestore/libs/storage/model/utils.h>
+
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <contrib/ydb/library/actors/core/actor.h>
@@ -454,7 +456,7 @@ ui64 TIndexTabletState::GenerateHandle() const
 {
     ui64 h;
     do {
-        h = RandomNumber<ui64>();
+        h = ShardedId(RandomNumber<ui64>(), GetFileSystem().GetShardNo());
     } while (!h || Impl->HandleById.contains(h));
 
     return h;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -762,7 +762,7 @@ void TIndexTabletState::CommitDupCacheEntry(
     const TString& sessionId,
     ui64 requestId)
 {
-    if (auto session = FindSession(sessionId)) {
+    if (auto* session = FindSession(sessionId)) {
         session->CommitDupCacheEntry(requestId);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -2,7 +2,6 @@
 
 #include "public.h"
 
-#include "cloud/filestore/private/api/protos/tablet.pb.h"
 #include "profile_log_events.h"
 #include "tablet_database.h"
 #include "tablet_private.h"
@@ -17,6 +16,8 @@
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
 #include <cloud/filestore/libs/storage/tablet/model/range_locks.h>
 #include <cloud/filestore/libs/storage/tablet/protos/tablet.pb.h>
+
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -878,6 +878,8 @@ struct TTxIndexTablet
         TMaybe<TIndexTabletDatabase::TNode> ParentNode;
         ui64 TargetNodeId = InvalidNodeId;
         TMaybe<TIndexTabletDatabase::TNode> TargetNode;
+        TString FollowerId;
+        TString FollowerName;
 
         TGetNodeAttr(
                 TRequestInfoPtr requestInfo,
@@ -895,6 +897,8 @@ struct TTxIndexTablet
             ParentNode.Clear();
             TargetNodeId = InvalidNodeId;
             TargetNode.Clear();
+            FollowerId.clear();
+            FollowerName.clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include "cloud/filestore/private/api/protos/tablet.pb.h"
 #include "profile_log_events.h"
 #include "tablet_database.h"
 #include "tablet_private.h"
@@ -65,6 +66,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(LoadState,                          __VA_ARGS__)                       \
     xxx(LoadCompactionMapChunk,             __VA_ARGS__)                       \
     xxx(UpdateConfig,                       __VA_ARGS__)                       \
+    xxx(ConfigureFollowers,                 __VA_ARGS__)                       \
                                                                                \
     xxx(CreateSession,                      __VA_ARGS__)                       \
     xxx(ResetSession,                       __VA_ARGS__)                       \
@@ -345,6 +347,28 @@ struct TTxIndexTablet
             : RequestInfo(std::move(requestInfo))
             , TxId(txId)
             , FileSystem(std::move(fileSystem))
+        {}
+
+        void Clear()
+        {
+            // nothing to do
+        }
+    };
+
+    //
+    // ConfigureFollowers
+    //
+
+    struct TConfigureFollowers
+    {
+        const TRequestInfoPtr RequestInfo;
+        NProtoPrivate::TConfigureFollowersRequest Request;
+
+        TConfigureFollowers(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TConfigureFollowersRequest request)
+            : RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1046,6 +1046,7 @@ struct TTxIndexTablet
         const ui32 Uid;
         const ui32 Gid;
         const TString RequestFollowerId;
+        NProto::THeaders Headers;
 
         ui64 ReadCommitId = InvalidCommitId;
         ui64 WriteCommitId = InvalidCommitId;
@@ -1070,7 +1071,11 @@ struct TTxIndexTablet
             , Uid(request.GetUid())
             , Gid(request.GetGid())
             , RequestFollowerId(request.GetFollowerFileSystemId())
-        {}
+        {
+            if (RequestFollowerId) {
+                Headers = request.GetHeaders();
+            }
+        }
 
         void Clear()
         {

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -68,6 +68,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(LoadCompactionMapChunk,             __VA_ARGS__)                       \
     xxx(UpdateConfig,                       __VA_ARGS__)                       \
     xxx(ConfigureFollowers,                 __VA_ARGS__)                       \
+    xxx(ConfigureAsFollower,                __VA_ARGS__)                       \
                                                                                \
     xxx(CreateSession,                      __VA_ARGS__)                       \
     xxx(ResetSession,                       __VA_ARGS__)                       \
@@ -368,6 +369,28 @@ struct TTxIndexTablet
         TConfigureFollowers(
                 TRequestInfoPtr requestInfo,
                 NProtoPrivate::TConfigureFollowersRequest request)
+            : RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
+        {}
+
+        void Clear()
+        {
+            // nothing to do
+        }
+    };
+
+    //
+    // ConfigureAsFollower
+    //
+
+    struct TConfigureAsFollower
+    {
+        const TRequestInfoPtr RequestInfo;
+        NProtoPrivate::TConfigureAsFollowerRequest Request;
+
+        TConfigureAsFollower(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TConfigureAsFollowerRequest request)
             : RequestInfo(std::move(requestInfo))
             , Request(std::move(request))
         {}

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
@@ -124,7 +124,6 @@ void TIndexTabletProxyActor::OnConnectionError(
 
     CancelActiveRequests(ctx, conn);
     ProcessPendingRequests(ctx, conn);
-
 }
 
 void TIndexTabletProxyActor::ProcessPendingRequests(

--- a/cloud/filestore/libs/storage/testlib/helpers.h
+++ b/cloud/filestore/libs/storage/testlib/helpers.h
@@ -46,16 +46,24 @@ struct TCreateNodeArgs
     ui64 TargetNode = 0;
     TString TargetPath;
 
-    TCreateNodeArgs(ENodeType nodeType, ui64 parent, const TString& name)
+    TString FollowerId;
+
+    TCreateNodeArgs(
+            ENodeType nodeType,
+            ui64 parent,
+            TString name,
+            TString followerId = "")
         : NodeType(nodeType)
         , ParentNode(parent)
-        , Name(name)
+        , Name(std::move(name))
+        , FollowerId(std::move(followerId))
     {}
 
     void Fill(NProto::TCreateNodeRequest& request) const
     {
         request.SetNodeId(ParentNode);
         request.SetName(Name);
+        request.SetFollowerFileSystemId(FollowerId);
 
         switch (NodeType) {
             case ENodeType::Directory: {
@@ -96,9 +104,13 @@ struct TCreateNodeArgs
         return args;
     }
 
-    static TCreateNodeArgs File(ui64 parent, const TString& name, ui32 mode = 0)
+    static TCreateNodeArgs File(
+        ui64 parent,
+        const TString& name,
+        ui32 mode = 0,
+        const TString& followerId = "")
     {
-        TCreateNodeArgs args(ENodeType::File, parent, name);
+        TCreateNodeArgs args(ENodeType::File, parent, name, followerId);
         args.Mode = mode;
         return args;
     }

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -310,6 +310,32 @@ public:
         return request;
     }
 
+    std::unique_ptr<TEvService::TEvGetNodeAttrRequest> CreateGetNodeAttrRequest(
+        const THeaders& headers,
+        const TString& fileSystemId,
+        const ui64 nodeId,
+        const TString& nodeName)
+    {
+        auto request = std::make_unique<TEvService::TEvGetNodeAttrRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetNodeId(nodeId);
+        request->Record.SetName(nodeName);
+        return request;
+    }
+
+    std::unique_ptr<TEvService::TEvListNodesRequest> CreateListNodesRequest(
+        const THeaders& headers,
+        const TString& fileSystemId,
+        const ui64 nodeId)
+    {
+        auto request = std::make_unique<TEvService::TEvListNodesRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetNodeId(nodeId);
+        return request;
+    }
+
 #define FILESTORE_DECLARE_METHOD(name, ns)                                     \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -251,7 +251,8 @@ public:
         const TString& fileSystemId,
         ui64 nodeId,
         const TString& name,
-        ui32 flags)
+        ui32 flags,
+        const TString& followerId = "")
     {
         auto request = std::make_unique<TEvService::TEvCreateHandleRequest>();
         headers.Fill(request->Record);
@@ -259,6 +260,7 @@ public:
         request->Record.SetNodeId(nodeId);
         request->Record.SetName(name);
         request->Record.SetFlags(flags);
+        request->Record.SetFollowerFileSystemId(followerId);
         return request;
     }
 

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -46,7 +46,7 @@ struct TTestEnvConfig
     ui32 ChannelCount = DefaultChannelCount;
     ui32 Groups = 2;
 
-    NActors::NLog::EPriority LogPriority_NFS = NActors::NLog::PRI_DEBUG;
+    NActors::NLog::EPriority LogPriority_NFS = NActors::NLog::PRI_TRACE;
     NActors::NLog::EPriority LogPriority_KiKiMR = NActors::NLog::PRI_WARN;
     NActors::NLog::EPriority LogPriority_Others = NActors::NLog::PRI_WARN;
 };

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -507,3 +507,21 @@ message TConfigureFollowersResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// ConfigureFollowers request/response.
+
+message TConfigureAsFollowerRequest
+{
+    // FileSystem identifier.
+    string FileSystemId = 1;
+
+    // ShardNo (will be used for the high bits of NodeId and HandleId)
+    uint32 ShardNo = 2;
+}
+
+message TConfigureAsFollowerResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -489,3 +489,21 @@ message TForcedOperationResponse
     // Affected range count.
     uint64 RangeCount = 2;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// ConfigureFollowers request/response.
+
+message TConfigureFollowersRequest
+{
+    // FileSystem identifier.
+    string FileSystemId = 1;
+
+    // Follower FileSystem identifiers.
+    repeated string FollowerFileSystemIds = 2;
+}
+
+message TConfigureFollowersResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}

--- a/cloud/filestore/public/api/protos/data.proto
+++ b/cloud/filestore/public/api/protos/data.proto
@@ -61,6 +61,9 @@ message TCreateHandleRequest
 
     // Create group
     uint64 Gid = 11;
+
+    // If set, the node will be created or looked up in the follower FS.
+    string FollowerFileSystemId = 12;
 }
 
 message TCreateHandleResponse
@@ -73,6 +76,11 @@ message TCreateHandleResponse
 
     // Node Attr.
     TNodeAttr NodeAttr = 3;
+
+    // Follower FS id - if the request should be redirected to a follower.
+    string FollowerFileSystemId = 4;
+    // Node name in the follower FS (under RootNode).
+    string FollowerNodeName = 5;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -43,6 +43,8 @@ message TFileStore
 
     // The list of features that are enabled for this fs.
     TFileStoreFeatures Features = 11;
+
+    repeated string FollowerFileSystemIds = 12;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -60,8 +60,8 @@ message TNodeAttr
     // Follower FS id. Set if this node is actually located in the follower FS.
     // ATime, MTime, CTime and Size are stored in the follower FS.
     string FollowerFileSystemId = 11;
-    // Node identifier in the follower FS.
-    uint64 FollowerId = 12;
+    // Node name in the follower FS.
+    string FollowerNodeName = 12;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -119,7 +119,8 @@ message TCreateNodeRequest
         bytes TargetPath = 1;
     }
 
-    message TSocket {
+    message TSocket
+    {
         uint32 Mode = 1;
     }
 

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -152,8 +152,6 @@ message TCreateNodeRequest
 
     // If set, the node will be created in the follower FS.
     string FollowerFileSystemId = 12;
-    // Parent node id in the follower FS.
-    uint64 FollowerNodeId = 13;
 }
 
 message TCreateNodeResponse

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -54,8 +54,14 @@ message TNodeAttr
     // File size.
     uint64 Size = 9;
 
-    // Number of persistent links
+    // Number of persistent links.
     uint32 Links = 10;
+
+    // Follower FS id. Set if this node is actually located in the follower FS.
+    // ATime, MTime, CTime and Size are stored in the follower FS.
+    string FollowerFileSystemId = 11;
+    // Node identifier in the follower FS.
+    uint64 FollowerId = 12;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -143,6 +149,11 @@ message TCreateNodeRequest
         TSymLink SymLink = 8;
         TSocket Socket = 9;
     }
+
+    // If set, the node will be created in the follower FS.
+    string FollowerFileSystemId = 12;
+    // Parent node id in the follower FS.
+    uint64 FollowerNodeId = 13;
 }
 
 message TCreateNodeResponse


### PR DESCRIPTION
Implementing only happy path in the first version. Leaving TODOs in the places where I took shortcuts.

Private API:
* ConfigureFollowers - tells the tablet that it has "follower" tablets - effectively, followers are file node shards
* ConfigureAsFollower - tells the follower tablet that it is the shard with ShardNo=X

ShardNo is needed to split the NodeId and HandleId spaces between the leader and the followers so that they do not intersect.  Follower tablets store regular files (attributes and data) directly under RootNode, names in NodeRefs are guids. Leader tablet stores all the other node types (the most important thing which it stores is the directory structure).

The current PR describes the intended purpose of all these changes via the UTs in service_ut.cpp. My next PR will contain the usage of the things implemented in this PR in TStorageServiceActor.

I left several TODOs regarding the "unhappy" path. Will implement them after successful performance tests of the happy path. Will implement follower metrics aggregation in the leader after that as well.

#1350 