### PR TITLE
issue-1320: Add broken and decommissioned space to DeviceInfo

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -7074,6 +7074,25 @@ TVector<NProto::TAgentInfo> TDiskRegistryState::QueryAgentsInfo() const
                 continue;
             }
 
+            const auto agentState = agent.GetState();
+            const auto deviceState = device.GetState();
+            if (agentState == NProto::AGENT_STATE_UNAVAILABLE ||
+                deviceState == NProto::DEVICE_STATE_ERROR)
+            {
+                deviceInfo.SetDeviceBrokenSpaceInBytes(
+                    deviceInfo.GetDeviceBrokenSpaceInBytes() + deviceBytes);
+                continue;
+            }
+
+            if (agentState == NProto::AGENT_STATE_WARNING ||
+                deviceState == NProto::DEVICE_STATE_WARNING)
+            {
+                deviceInfo.SetDeviceDecommissionedSpaceInBytes(
+                    deviceInfo.GetDeviceDecommissionedSpaceInBytes() +
+                    deviceBytes);
+                continue;
+            }
+
             if (allocated) {
                 deviceInfo.SetDeviceAllocatedSpaceInBytes(
                     deviceInfo.GetDeviceAllocatedSpaceInBytes() + deviceBytes);

--- a/cloud/blockstore/public/api/protos/disk.proto
+++ b/cloud/blockstore/public/api/protos/disk.proto
@@ -188,6 +188,12 @@ message TDeviceInfo
 
     // Suspended space in bytes.
     uint64 DeviceSuspendedSpaceInBytes = 7;
+
+    // Broken space in bytes.
+    uint64 DeviceBrokenSpaceInBytes = 8;
+
+    // Decomissioned space in bytes.
+    uint64 DeviceDecommissionedSpaceInBytes = 9;
 }
 
 message TAgentInfo {


### PR DESCRIPTION
Issue: https://github.com/ydb-platform/nbs/issues/1320

Add  DeviceBrokenSpaceInBytes and DeviceDecommissionedSpaceInBytes to DeviceInfo to return them as part of QueryAgentsInfo response