### PR TITLE
issue-1384: check active sessions before destroying fs

### DIFF
--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -293,7 +293,7 @@ void TFileStoreCommand::Stop()
     TFileStoreServiceCommand::Stop();
 }
 
-void TFileStoreCommand::CreateSession()
+TFileStoreCommand::TSessionGuard TFileStoreCommand::CreateSession()
 {
     // TODO use ISession instead
     auto request = std::make_shared<NProto::TCreateSessionRequest>();
@@ -309,6 +309,8 @@ void TFileStoreCommand::CreateSession()
 
     Headers.SetClientId(ClientId);
     Headers.SetSessionId(sessionId);
+
+    return TSessionGuard(*this);
 }
 
 void TFileStoreCommand::DestroySession()

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -311,6 +311,22 @@ void TFileStoreCommand::CreateSession()
     Headers.SetSessionId(sessionId);
 }
 
+void TFileStoreCommand::DestroySession()
+{
+    if (Headers.GetSessionId().Empty()) {
+        return;
+    }
+
+    auto request = std::make_shared<NProto::TDestroySessionRequest>();
+    request->SetFileSystemId(FileSystemId);
+    request->MutableHeaders()->SetSessionId(Headers.GetSessionId());
+    request->MutableHeaders()->SetClientId(Headers.GetClientId());
+
+    TCallContextPtr ctx = MakeIntrusive<TCallContext>();
+    auto response = WaitFor(Client->DestroySession(ctx, std::move(request)));
+    CheckResponse(response);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 NProto::TNodeAttr TFileStoreCommand::ResolveNode(

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -139,9 +139,6 @@ public:
     void Start() override;
     void Stop() override;
 
-    void CreateSession();
-    void DestroySession();
-
 protected:
     template <typename T>
     std::shared_ptr<T> CreateRequest()
@@ -174,6 +171,32 @@ protected:
     TVector<TPathEntry> ResolvePath(
         TStringBuf path,
         bool ignoreMissing);
+
+    class TSessionGuard final
+    {
+        TFileStoreCommand& FileStoreCmd;
+
+    public:
+        explicit TSessionGuard(TFileStoreCommand& fileStoreCmd)
+            : FileStoreCmd(fileStoreCmd)
+        {
+            FileStoreCmd.CreateSession();
+        }
+
+        ~TSessionGuard()
+        {
+            FileStoreCmd.DestroySession();
+        }
+    };
+
+    TSessionGuard CreateNewSession()
+    {
+        return TSessionGuard(*this);
+    }
+
+private:
+    void CreateSession();
+    void DestroySession();
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -180,7 +180,6 @@ protected:
         explicit TSessionGuard(TFileStoreCommand& fileStoreCmd)
             : FileStoreCmd(fileStoreCmd)
         {
-            FileStoreCmd.CreateSession();
         }
 
         ~TSessionGuard()
@@ -189,13 +188,9 @@ protected:
         }
     };
 
-    TSessionGuard CreateNewSession()
-    {
-        return TSessionGuard(*this);
-    }
+    [[nodiscard]] TSessionGuard CreateSession();
 
 private:
-    void CreateSession();
     void DestroySession();
 };
 

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -140,6 +140,7 @@ public:
     void Stop() override;
 
     void CreateSession();
+    void DestroySession();
 
 protected:
     template <typename T>

--- a/cloud/filestore/apps/client/lib/ls.cpp
+++ b/cloud/filestore/apps/client/lib/ls.cpp
@@ -7,6 +7,7 @@
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
+#include <util/generic/scope.h>
 #include <util/stream/format.h>
 
 #include <sys/stat.h>
@@ -285,6 +286,9 @@ public:
         Y_ENSURE(CliArgs.Mode != EModeType::Unknown, "Mode type is not set");
 
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         TPageInfo page;
         switch (CliArgs.Mode) {

--- a/cloud/filestore/apps/client/lib/ls.cpp
+++ b/cloud/filestore/apps/client/lib/ls.cpp
@@ -284,7 +284,7 @@ public:
     {
         Y_ENSURE(CliArgs.Mode != EModeType::Unknown, "Mode type is not set");
 
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         TPageInfo page;
         switch (CliArgs.Mode) {

--- a/cloud/filestore/apps/client/lib/ls.cpp
+++ b/cloud/filestore/apps/client/lib/ls.cpp
@@ -7,7 +7,6 @@
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
-#include <util/generic/scope.h>
 #include <util/stream/format.h>
 
 #include <sys/stat.h>
@@ -285,10 +284,7 @@ public:
     {
         Y_ENSURE(CliArgs.Mode != EModeType::Unknown, "Mode type is not set");
 
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         TPageInfo page;
         switch (CliArgs.Mode) {

--- a/cloud/filestore/apps/client/lib/mkdir.cpp
+++ b/cloud/filestore/apps/client/lib/mkdir.cpp
@@ -33,7 +33,7 @@ public:
 
     bool Execute() override
     {
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         auto makeDir = [&] (ui64 nodeId, TStringBuf name) {
             auto request = CreateRequest<NProto::TCreateNodeRequest>();

--- a/cloud/filestore/apps/client/lib/mkdir.cpp
+++ b/cloud/filestore/apps/client/lib/mkdir.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
+#include <util/generic/scope.h>
 #include <util/stream/file.h>
 #include <util/system/sysstat.h>
 
@@ -34,6 +35,9 @@ public:
     bool Execute() override
     {
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         auto makeDir = [&] (ui64 nodeId, TStringBuf name) {
             auto request = CreateRequest<NProto::TCreateNodeRequest>();
@@ -82,7 +86,6 @@ public:
         );
 
         makeDir(parent.Node.GetId(), resolved.back().Name);
-
         return true;
     }
 };

--- a/cloud/filestore/apps/client/lib/mkdir.cpp
+++ b/cloud/filestore/apps/client/lib/mkdir.cpp
@@ -2,7 +2,6 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
-#include <util/generic/scope.h>
 #include <util/stream/file.h>
 #include <util/system/sysstat.h>
 
@@ -34,10 +33,7 @@ public:
 
     bool Execute() override
     {
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         auto makeDir = [&] (ui64 nodeId, TStringBuf name) {
             auto request = CreateRequest<NProto::TCreateNodeRequest>();
@@ -86,6 +82,7 @@ public:
         );
 
         makeDir(parent.Node.GetId(), resolved.back().Name);
+
         return true;
     }
 };

--- a/cloud/filestore/apps/client/lib/read.cpp
+++ b/cloud/filestore/apps/client/lib/read.cpp
@@ -38,7 +38,7 @@ public:
 
     bool Execute() override
     {
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         const auto resolved = ResolvePath(Path, false);
 

--- a/cloud/filestore/apps/client/lib/read.cpp
+++ b/cloud/filestore/apps/client/lib/read.cpp
@@ -1,6 +1,5 @@
 #include "command.h"
 
-#include <util/generic/scope.h>
 #include <util/generic/size_literals.h>
 #include <util/system/align.h>
 
@@ -39,10 +38,7 @@ public:
 
     bool Execute() override
     {
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         const auto resolved = ResolvePath(Path, false);
 

--- a/cloud/filestore/apps/client/lib/read.cpp
+++ b/cloud/filestore/apps/client/lib/read.cpp
@@ -1,5 +1,6 @@
 #include "command.h"
 
+#include <util/generic/scope.h>
 #include <util/generic/size_literals.h>
 #include <util/system/align.h>
 
@@ -39,6 +40,9 @@ public:
     bool Execute() override
     {
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         const auto resolved = ResolvePath(Path, false);
 

--- a/cloud/filestore/apps/client/lib/rm.cpp
+++ b/cloud/filestore/apps/client/lib/rm.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
+#include <util/generic/scope.h>
 #include <util/stream/file.h>
 
 namespace NCloud::NFileStore::NClient {
@@ -33,6 +34,9 @@ public:
     bool Execute() override
     {
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         const auto resolved = ResolvePath(Path, false);
 

--- a/cloud/filestore/apps/client/lib/rm.cpp
+++ b/cloud/filestore/apps/client/lib/rm.cpp
@@ -2,7 +2,6 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
-#include <util/generic/scope.h>
 #include <util/stream/file.h>
 
 namespace NCloud::NFileStore::NClient {
@@ -33,10 +32,7 @@ public:
 
     bool Execute() override
     {
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         const auto resolved = ResolvePath(Path, false);
 

--- a/cloud/filestore/apps/client/lib/rm.cpp
+++ b/cloud/filestore/apps/client/lib/rm.cpp
@@ -32,7 +32,7 @@ public:
 
     bool Execute() override
     {
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         const auto resolved = ResolvePath(Path, false);
 

--- a/cloud/filestore/apps/client/lib/stat.cpp
+++ b/cloud/filestore/apps/client/lib/stat.cpp
@@ -39,7 +39,7 @@ public:
 
     bool Execute() override
     {
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         const auto resolved = ResolvePath(Path, false);
         Y_ABORT_UNLESS(resolved.size() >= 2);

--- a/cloud/filestore/apps/client/lib/stat.cpp
+++ b/cloud/filestore/apps/client/lib/stat.cpp
@@ -3,7 +3,6 @@
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
 #include <util/datetime/base.h>
-#include <util/generic/scope.h>
 #include <util/stream/file.h>
 #include <util/system/sysstat.h>
 
@@ -40,10 +39,7 @@ public:
 
     bool Execute() override
     {
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         const auto resolved = ResolvePath(Path, false);
         Y_ABORT_UNLESS(resolved.size() >= 2);

--- a/cloud/filestore/apps/client/lib/stat.cpp
+++ b/cloud/filestore/apps/client/lib/stat.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
 #include <util/datetime/base.h>
+#include <util/generic/scope.h>
 #include <util/stream/file.h>
 #include <util/system/sysstat.h>
 
@@ -40,6 +41,9 @@ public:
     bool Execute() override
     {
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         const auto resolved = ResolvePath(Path, false);
         Y_ABORT_UNLESS(resolved.size() >= 2);

--- a/cloud/filestore/apps/client/lib/touch.cpp
+++ b/cloud/filestore/apps/client/lib/touch.cpp
@@ -28,7 +28,7 @@ public:
 
     bool Execute() override
     {
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         auto resolved = ResolvePath(Path, true);
 

--- a/cloud/filestore/apps/client/lib/touch.cpp
+++ b/cloud/filestore/apps/client/lib/touch.cpp
@@ -2,7 +2,6 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
-#include <util/generic/scope.h>
 #include <util/stream/file.h>
 #include <util/system/sysstat.h>
 
@@ -29,10 +28,7 @@ public:
 
     bool Execute() override
     {
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         auto resolved = ResolvePath(Path, true);
 

--- a/cloud/filestore/apps/client/lib/touch.cpp
+++ b/cloud/filestore/apps/client/lib/touch.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
+#include <util/generic/scope.h>
 #include <util/stream/file.h>
 #include <util/system/sysstat.h>
 
@@ -29,6 +30,9 @@ public:
     bool Execute() override
     {
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         auto resolved = ResolvePath(Path, true);
 

--- a/cloud/filestore/apps/client/lib/write.cpp
+++ b/cloud/filestore/apps/client/lib/write.cpp
@@ -2,7 +2,6 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
-#include <util/generic/scope.h>
 #include <util/stream/file.h>
 
 namespace NCloud::NFileStore::NClient {
@@ -41,10 +40,7 @@ public:
     {
         TString data = TIFStream(DataPath).ReadAll();
 
-        CreateSession();
-        Y_DEFER {
-            DestroySession();
-        };
+        auto sessionGuard = CreateNewSession();
 
         const auto resolved = ResolvePath(Path, true);
 

--- a/cloud/filestore/apps/client/lib/write.cpp
+++ b/cloud/filestore/apps/client/lib/write.cpp
@@ -40,7 +40,7 @@ public:
     {
         TString data = TIFStream(DataPath).ReadAll();
 
-        auto sessionGuard = CreateNewSession();
+        auto sessionGuard = CreateSession();
 
         const auto resolved = ResolvePath(Path, true);
 

--- a/cloud/filestore/apps/client/lib/write.cpp
+++ b/cloud/filestore/apps/client/lib/write.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
+#include <util/generic/scope.h>
 #include <util/stream/file.h>
 
 namespace NCloud::NFileStore::NClient {
@@ -41,6 +42,9 @@ public:
         TString data = TIFStream(DataPath).ReadAll();
 
         CreateSession();
+        Y_DEFER {
+            DestroySession();
+        };
 
         const auto resolved = ResolvePath(Path, true);
 

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -71,11 +71,9 @@ void TDestroyFileStoreActor::Bootstrap(const TActorContext& ctx)
 
 void TDestroyFileStoreActor::DescribeSessions(const TActorContext& ctx)
 {
-    NProtoPrivate::TDescribeSessionsRequest request;
-    request.SetFileSystemId(FileSystemId);
     auto requestToTablet =
         std::make_unique<TEvIndexTablet::TEvDescribeSessionsRequest>();
-    requestToTablet->Record = std::move(request);
+    requestToTablet->Record.SetFileSystemId(FileSystemId);
 
     NCloud::Send(
         ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -94,6 +94,7 @@ void TDestroyFileStoreActor::HandleDescribeSessionsResponse(
         ReplyAndDie(
             ctx,
             MakeError(E_REJECTED, "FileStore has active sessions"));
+        return;
     }
 
     DestroyFileStore(ctx);

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -88,6 +88,11 @@ void TDestroyFileStoreActor::HandleDescribeSessionsResponse(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        ReplyAndDie(ctx, msg->GetError());
+        return;
+    }
+
     if (msg->Record.SessionsSize() != 0) {
         ReplyAndDie(
             ctx,

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3377,6 +3377,41 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             counters->GetCounter("AppCriticalEvents/NodeNotFoundInFollower");
         UNIT_ASSERT_EQUAL(1, counter->GetAtomic());
     }
+
+    Y_UNIT_TEST(DestroyFileStoreWithActiveSessionShouldFail)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto initialBlockCount = 1'000;
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, initialBlockCount);
+
+        auto headers = THeaders{fsId, "client", ""};
+        auto createSessionResponse = service.CreateSession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createSessionResponse->GetStatus(),
+            createSessionResponse->GetErrorReason());
+        service.AssertDestroyFileStoreFailed(fsId);
+
+        headers.SessionId =
+            createSessionResponse->Record.GetSession().GetSessionId();
+        auto destroySessionResponse = service.DestroySession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            destroySessionResponse->GetStatus(),
+            destroySessionResponse->GetErrorReason());
+
+        auto destroyFileStoreResponse = service.DestroyFileStore(fsId);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            destroyFileStoreResponse->GetStatus(),
+            destroyFileStoreResponse->GetErrorReason());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
issue: #1384 

1. Reject DestroyFileStore request in case of available active sessions.
2. Destroy session after executing commands in filestore client: 35fef8a180947a75af2fa2f8e583d82bcc44dde7