### PR TITLE
properly set future returned by Start/Stop methods; issue-1164

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -158,8 +158,6 @@ runs:
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --dump-graph --dump-graph-to-file "$TMP_DIR/ya_graph.json" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
-          -DFORCE_STATIC_LINKING \
-          -DNETLINK \
           "${extra_params[@]}"
         date
 

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -158,6 +158,8 @@ runs:
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --dump-graph --dump-graph-to-file "$TMP_DIR/ya_graph.json" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
+          -DFORCE_STATIC_LINKING \
+          -DNETLINK \
           "${extra_params[@]}"
         date
 

--- a/.github/actions/prepare/action.yaml
+++ b/.github/actions/prepare/action.yaml
@@ -16,7 +16,7 @@ runs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends git wget gnupg lsb-release curl xz-utils tzdata cmake \
           python3-dev python3-pip ninja-build antlr3 m4 libidn11-dev libaio1 libaio-dev make clang-14 lld-14 llvm-14 file \
-          distcc strace qemu-kvm qemu-utils dpkg-dev atop pigz pbzip2 xz-utils pixz
+          distcc strace qemu-kvm qemu-utils dpkg-dev atop pigz pbzip2 xz-utils pixz libnl-3-dev libnl-genl-3-dev
         sudo apt-get remove -y unattended-upgrades
         sudo pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 grpcio grpcio-tools \
              PyHamcrest tornado xmltodict pyarrow boto3 moto[server] psutil yandexcloud==0.258.0 PyGithub==2.2.0 pyinstaller==5.13.2 \

--- a/.github/scripts/github-runner.sh
+++ b/.github/scripts/github-runner.sh
@@ -55,7 +55,7 @@ sudo apt-get install -y --no-install-recommends \
              dpkg-dev docker-ce docker-ce-cli containerd.io \
              docker-buildx-plugin docker-compose-plugin jq \
              aria2 jq tree tmux atop awscli iftop htop \
-             pixz pigz pbzip2 xz-utils
+             pixz pigz pbzip2 xz-utils libnl-3-dev libnl-genl-3-dev
 cat << EOF > /tmp/requirements.txt
 conan==1.59
 pytest==7.1.3

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -595,13 +595,13 @@ struct TServer: IEndpointProxyServer
 
                     } catch (const std::exception& e) {
                         STORAGE_ERROR(request.ShortDebugString().Quote()
-                            << "Unable to create netlink device: " << e.what()
-                            << "falling back to ioctl")
+                            << " - Unable to create netlink device: " << e.what()
+                            << ", falling back to ioctl");
                     }
 #else
                     STORAGE_ERROR(request.ShortDebugString().Quote()
-                        << "Built without netlink support, falling back to "
-                        << "ioctl");
+                        << " - Built without netlink support"
+                        << "", falling back to ioctl");
 #endif
                 }
                 if (ep.NbdDevice == nullptr) {

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -615,10 +615,10 @@ struct TServer: IEndpointProxyServer
                 if (HasError(value)) {
                     STORAGE_ERROR(
                         "unable to start nbd device: " << value.GetMessage());
+                } else {
+                    STORAGE_INFO(request.ShortDebugString().Quote()
+                        << " - Started NBD device connection");
                 }
-
-                STORAGE_INFO(request.ShortDebugString().Quote()
-                    << " - Started NBD device connection");
             } else {
                 STORAGE_WARN(request.ShortDebugString().Quote()
                     << " - NbdDevice missing - no nbd connection with the"

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -594,12 +594,14 @@ struct TServer: IEndpointProxyServer
                             true);                  // reconfigure existing device
 
                     } catch (const std::exception& e) {
-                        STORAGE_ERROR(
-                            "unable to create netlink device: " << e.what());
+                        STORAGE_ERROR(request.ShortDebugString().Quote()
+                            << "Unable to create netlink device: " << e.what()
+                            << "falling back to ioctl")
                     }
 #else
-                    STORAGE_ERROR(
-                        "built without netlink support, falling back to ioctl");
+                    STORAGE_ERROR(request.ShortDebugString().Quote()
+                        << "Built without netlink support, falling back to "
+                        << "ioctl");
 #endif
                 }
                 if (ep.NbdDevice == nullptr) {
@@ -613,8 +615,9 @@ struct TServer: IEndpointProxyServer
                 auto start = ep.NbdDevice->Start();
                 const auto& value = start.GetValue();
                 if (HasError(value)) {
-                    STORAGE_ERROR(
-                        "unable to start nbd device: " << value.GetMessage());
+                    STORAGE_ERROR(request.ShortDebugString().Quote()
+                        << " - Unable to start nbd device: "
+                        << value.GetMessage());
                 } else {
                     STORAGE_INFO(request.ShortDebugString().Quote()
                         << " - Started NBD device connection");

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -601,7 +601,7 @@ struct TServer: IEndpointProxyServer
 #else
                     STORAGE_ERROR(request.ShortDebugString().Quote()
                         << " - Built without netlink support"
-                        << "", falling back to ioctl");
+                        << ", falling back to ioctl");
 #endif
                 }
                 if (ep.NbdDevice == nullptr) {

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -212,7 +212,8 @@ public:
         }
 
         try {
-            TMemoryInput stream(DeviceName.data() + pos + NBD_DEVICE_SUFFIX.size());
+            TMemoryInput stream(
+                DeviceName.data() + pos + NBD_DEVICE_SUFFIX.size());
             stream >> DeviceIndex;
         } catch (...) {
             throw TServiceError(E_ARGUMENT)
@@ -251,8 +252,11 @@ public:
             StopResult.SetValue(MakeError(S_OK));
 
         } catch (const TServiceError& e) {
-            StopResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-                << "unable to disconnect " << DeviceName << ": " << e.what()));
+            StopResult.SetValue(MakeError(
+                E_FAIL,
+                TStringBuilder()
+                    << "unable to disconnect " << DeviceName << ": "
+                    << e.what()));
         }
 
         return StopResult.GetFuture();
@@ -316,7 +320,9 @@ void TNetlinkDevice::DoConnectDevice(bool connected)
         const auto& info = Handler->GetExportInfo();
         message.Put(NBD_ATTR_INDEX, DeviceIndex);
         message.Put(NBD_ATTR_SIZE_BYTES, static_cast<ui64>(info.Size));
-        message.Put(NBD_ATTR_BLOCK_SIZE_BYTES, static_cast<ui64>(info.MinBlockSize));
+        message.Put(
+            NBD_ATTR_BLOCK_SIZE_BYTES,
+            static_cast<ui64>(info.MinBlockSize));
         message.Put(NBD_ATTR_SERVER_FLAGS, static_cast<ui64>(info.Flags));
 
         if (Timeout) {
@@ -324,7 +330,9 @@ void TNetlinkDevice::DoConnectDevice(bool connected)
         }
 
         if (DeadConnectionTimeout) {
-            message.Put(NBD_ATTR_DEAD_CONN_TIMEOUT, DeadConnectionTimeout.Seconds());
+            message.Put(
+                NBD_ATTR_DEAD_CONN_TIMEOUT,
+                DeadConnectionTimeout.Seconds());
         }
 
         {
@@ -337,9 +345,10 @@ void TNetlinkDevice::DoConnectDevice(bool connected)
         StartResult.SetValue(MakeError(S_OK));
 
     } catch (const TServiceError& e) {
-        StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "unable to configure " << DeviceName << ": " << e.what()));
-        return;
+        StartResult.SetValue(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to configure " << DeviceName << ": " << e.what()));
     }
 }
 
@@ -373,8 +382,10 @@ void TNetlinkDevice::ConnectDevice()
         message.Send(socket);
 
     } catch (const TServiceError& e) {
-        StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "unable to configure " << DeviceName << ": " << e.what()));
+        StartResult.SetValue(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to configure " << DeviceName << ": " << e.what()));
     }
 }
 
@@ -402,14 +413,18 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
             genlmsg_attrlen(header, 0),
             NULL))
     {
-        context->Device->StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "unable to parse NBD_CMD_STATUS response: " << err));
+        context->Device->StartResult.SetValue(MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "unable to parse NBD_CMD_STATUS response: " << err));
         return NL_STOP;
     }
 
     if (!attr[NBD_ATTR_DEVICE_LIST]) {
-        context->Device->StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "did not receive NBD_ATTR_DEVICE_LIST"));
+        context->Device->StartResult.SetValue(MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "did not receive NBD_ATTR_DEVICE_LIST"));
         return NL_STOP;
     }
 
@@ -419,14 +434,18 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
             attr[NBD_ATTR_DEVICE_LIST],
             deviceItemPolicy))
     {
-        context->Device->StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "unable to parse NBD_ATTR_DEVICE_LIST: " << err));
+        context->Device->StartResult.SetValue(MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "unable to parse NBD_ATTR_DEVICE_LIST: " << err));
         return NL_STOP;
     }
 
     if (!deviceItem[NBD_DEVICE_ITEM]) {
-        context->Device->StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "did not receive NBD_DEVICE_ITEM"));
+        context->Device->StartResult.SetValue(MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "did not receive NBD_DEVICE_ITEM"));
         return NL_STOP;
     }
 
@@ -436,14 +455,18 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
             deviceItem[NBD_DEVICE_ITEM],
             devicePolicy))
     {
-        context->Device->StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "unable to parse NBD_DEVICE_ITEM: " << err));
+        context->Device->StartResult.SetValue(MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "unable to parse NBD_DEVICE_ITEM: " << err));
         return NL_STOP;
     }
 
     if (!device[NBD_DEVICE_CONNECTED]) {
-        context->Device->StartResult.SetValue(MakeError(E_FAIL, TStringBuilder()
-            << "did not receive NBD_DEVICE_CONNECTED"));
+        context->Device->StartResult.SetValue(MakeError(
+                E_FAIL,
+                TStringBuilder()
+                    << "did not receive NBD_DEVICE_CONNECTED"));
         return NL_STOP;
     }
 

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -133,7 +133,8 @@ public:
     void Put(int attribute, T data)
     {
         if (nla_put(Message, attribute, sizeof(T), &data) < 0) {
-            throw TServiceError(E_FAIL) << "unable to put attribute " << attribute;
+            throw TServiceError(E_FAIL) << "unable to put attribute "
+                << attribute;
         }
     }
 
@@ -254,9 +255,8 @@ public:
         } catch (const TServiceError& e) {
             StopResult.SetValue(MakeError(
                 E_FAIL,
-                TStringBuilder()
-                    << "unable to disconnect " << DeviceName << ": "
-                    << e.what()));
+                TStringBuilder() << "unable to disconnect " << DeviceName
+                                 << ": " << e.what()));
         }
 
         return StopResult.GetFuture();
@@ -464,9 +464,9 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
 
     if (!device[NBD_DEVICE_CONNECTED]) {
         context->Device->StartResult.SetValue(MakeError(
-                E_FAIL,
-                TStringBuilder()
-                    << "did not receive NBD_DEVICE_CONNECTED"));
+            E_FAIL,
+            TStringBuilder()
+                << "did not receive NBD_DEVICE_CONNECTED"));
         return NL_STOP;
     }
 

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -423,8 +423,7 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
     if (!attr[NBD_ATTR_DEVICE_LIST]) {
         context->Device->StartResult.SetValue(MakeError(
             E_FAIL,
-            TStringBuilder()
-                << "did not receive NBD_ATTR_DEVICE_LIST"));
+            "did not receive NBD_ATTR_DEVICE_LIST"));
         return NL_STOP;
     }
 
@@ -444,8 +443,7 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
     if (!deviceItem[NBD_DEVICE_ITEM]) {
         context->Device->StartResult.SetValue(MakeError(
             E_FAIL,
-            TStringBuilder()
-                << "did not receive NBD_DEVICE_ITEM"));
+            "did not receive NBD_DEVICE_ITEM"));
         return NL_STOP;
     }
 
@@ -465,8 +463,7 @@ int TNetlinkDevice::StatusHandler(nl_msg* message, void* argument)
     if (!device[NBD_DEVICE_CONNECTED]) {
         context->Device->StartResult.SetValue(MakeError(
             E_FAIL,
-            TStringBuilder()
-                << "did not receive NBD_DEVICE_CONNECTED"));
+            "did not receive NBD_DEVICE_CONNECTED"));
         return NL_STOP;
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/ydb-platform/nbs/pull/1437

Properly propagates device status to the future returned by Start and Stop methods. Also sets up proper context for HandleStatus and catches exception potentially thrown by TNetlinkDevice constructor