### PR TITLE
issue-1350: support for multitablet filesystems in StorageServiceActor

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -281,4 +281,9 @@ message TStorageConfig
     // the same range, it may be beneficial to increase the reported blocksize x-fold.
     // This numeric value is that x.
     optional uint32 PreferredBlockSizeMultiplier = 354;
+
+    // Enables request forwarding to followers in the StorageServiceActor.
+    // Forwarding is done based on the NodeId and Handle high bits.
+    // Disabling this thing shouldn't really be needed apart from tests.
+    optional bool MultiTabletForwardingEnabled = 355;
 }

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -180,9 +180,6 @@ template <typename T>
 TString GetStorageMediaKind(const T& request);
 
 template <typename T>
-ui64 GetNodeId(const T& request);
-
-template <typename T>
 TString GetRequestName(const T& request);
 
 template <typename T>

--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -63,8 +63,6 @@ namespace NCloud::NFileStore::NStorage {
 // TODO: CreateHandle, GetNodeAttr, ListNodes should be handled in two stages:
 // 1. request leader
 // 2. request followers for each TNodeAttr with nonempty FollowerId
-// TODO: WriteData and ReadData requests should be handled by followers if
-// shardNo != 0
 
 #define FILESTORE_SERVICE_REQUESTS_HANDLE(xxx, ...)                            \
     xxx(WriteData,                          __VA_ARGS__)                       \

--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -34,26 +34,37 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateNode,                         __VA_ARGS__)                       \
     xxx(UnlinkNode,                         __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
-    xxx(AccessNode,                         __VA_ARGS__)                       \
     xxx(ListNodes,                          __VA_ARGS__)                       \
     xxx(ReadLink,                           __VA_ARGS__)                       \
                                                                                \
-    xxx(SetNodeAttr,                        __VA_ARGS__)                       \
     xxx(GetNodeAttr,                        __VA_ARGS__)                       \
-    xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
-    xxx(GetNodeXAttr,                       __VA_ARGS__)                       \
-    xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
-    xxx(RemoveNodeXAttr,                    __VA_ARGS__)                       \
                                                                                \
     xxx(CreateHandle,                       __VA_ARGS__)                       \
-    xxx(DestroyHandle,                      __VA_ARGS__)                       \
                                                                                \
     xxx(AcquireLock,                        __VA_ARGS__)                       \
     xxx(ReleaseLock,                        __VA_ARGS__)                       \
     xxx(TestLock,                           __VA_ARGS__)                       \
-                                                                               \
-    xxx(AllocateData,                       __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_FWD
+
+#define FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_NODE_ID(xxx, ...)        \
+    xxx(AccessNode,                         __VA_ARGS__)                       \
+    xxx(SetNodeAttr,                        __VA_ARGS__)                       \
+    xxx(GetNodeXAttr,                       __VA_ARGS__)                       \
+    xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
+    xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
+    xxx(RemoveNodeXAttr,                    __VA_ARGS__)                       \
+// FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_NODE_ID
+
+#define FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_HANDLE(xxx, ...)         \
+    xxx(DestroyHandle,                      __VA_ARGS__)                       \
+    xxx(AllocateData,                       __VA_ARGS__)                       \
+// FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_NODE_ID
+
+// TODO: CreateHandle, GetNodeAttr, ListNodes should be handled in two stages:
+// 1. request leader
+// 2. request followers for each TNodeAttr with nonempty FollowerId
+// TODO: WriteData and ReadData requests should be handled by followers if
+// shardNo != 0
 
 #define FILESTORE_SERVICE_REQUESTS_HANDLE(xxx, ...)                            \
     xxx(WriteData,                          __VA_ARGS__)                       \
@@ -63,6 +74,8 @@ namespace NCloud::NFileStore::NStorage {
 #define FILESTORE_SERVICE_REQUESTS(xxx, ...)                                   \
     FILESTORE_SERVICE_REQUESTS_HANDLE(xxx,   __VA_ARGS__)                      \
     FILESTORE_SERVICE_REQUESTS_FWD(xxx,      __VA_ARGS__)                      \
+    FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_NODE_ID(xxx,  __VA_ARGS__)   \
+    FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_HANDLE(xxx,   __VA_ARGS__)   \
 // FILESTORE_SERVICE_REQUESTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -31,15 +31,9 @@ namespace NCloud::NFileStore::NStorage {
     xxx(DestroyCheckpoint,                  __VA_ARGS__)                       \
                                                                                \
     xxx(ResolvePath,                        __VA_ARGS__)                       \
-    xxx(CreateNode,                         __VA_ARGS__)                       \
     xxx(UnlinkNode,                         __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
-    xxx(ListNodes,                          __VA_ARGS__)                       \
     xxx(ReadLink,                           __VA_ARGS__)                       \
-                                                                               \
-    xxx(GetNodeAttr,                        __VA_ARGS__)                       \
-                                                                               \
-    xxx(CreateHandle,                       __VA_ARGS__)                       \
                                                                                \
     xxx(AcquireLock,                        __VA_ARGS__)                       \
     xxx(ReleaseLock,                        __VA_ARGS__)                       \
@@ -60,13 +54,13 @@ namespace NCloud::NFileStore::NStorage {
     xxx(AllocateData,                       __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_NODE_ID
 
-// TODO: CreateHandle, GetNodeAttr, ListNodes should be handled in two stages:
-// 1. request leader
-// 2. request followers for each TNodeAttr with nonempty FollowerId
-
 #define FILESTORE_SERVICE_REQUESTS_HANDLE(xxx, ...)                            \
     xxx(WriteData,                          __VA_ARGS__)                       \
     xxx(ReadData,                           __VA_ARGS__)                       \
+    xxx(ListNodes,                          __VA_ARGS__)                       \
+    xxx(GetNodeAttr,                        __VA_ARGS__)                       \
+    xxx(CreateHandle,                       __VA_ARGS__)                       \
+    xxx(CreateNode,                         __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_HANDLE
 
 #define FILESTORE_SERVICE_REQUESTS(xxx, ...)                                   \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -159,6 +159,7 @@ namespace {
         TDuration,                                                             \
         TDuration::Seconds(10)                                                )\
     xxx(PreferredBlockSizeMultiplier,                   ui32,      1          )\
+    xxx(MultiTabletForwardingEnabled,                   bool,      false      )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_DECLARE_CONFIG(name, type, value)                            \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -206,6 +206,8 @@ public:
 
     bool GetNewLocalDBCompactionPolicyEnabled() const;
 
+    bool GetMultiTabletForwardingEnabled() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
     void DumpOverridesHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/storage/model/utils.h
+++ b/cloud/filestore/libs/storage/model/utils.h
@@ -20,4 +20,10 @@ inline ui64 ShardedId(ui64 id, ui32 shardNo)
     return (static_cast<ui64>(shardNo) << realBits) | (realMask & id);
 }
 
+inline ui32 ExtractShardNo(ui64 id)
+{
+    const auto realBits = 56U;
+    return id >> realBits;
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -137,6 +137,15 @@ private:
         const TString& sessionId,
         const NActors::TActorContext& ctx);
 
+    TResultOrError<TString> SelectShard(
+        const NActors::TActorContext& ctx,
+        const TString& sessionId,
+        const ui64 seqNo,
+        const TString& methodName,
+        const ui64 requestId,
+        const NProto::TFileStore& filestore,
+        ui32 shardNo) const;
+
 private:
     // actions
     NActors::IActorPtr CreateDrainTabletActionActor(

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -81,6 +81,12 @@ private:
         const typename TMethod::TRequest::TPtr& ev);
 
     template <typename TMethod>
+    void ForwardRequestToFollower(
+        const NActors::TActorContext& ctx,
+        const typename TMethod::TRequest::TPtr& ev,
+        ui32 shardNo);
+
+    template <typename TMethod>
     void CompleteRequest(
         const NActors::TActorContext& ctx,
         const typename TMethod::TResponse::TPtr& ev);

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -1,0 +1,326 @@
+#include "service_actor.h"
+
+#include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TCreateHandleActor final: public TActorBootstrapped<TCreateHandleActor>
+{
+private:
+    // Original request
+    const TRequestInfoPtr RequestInfo;
+    NProto::TCreateHandleRequest CreateHandleRequest;
+
+    // Filesystem-specific params
+    const TString LogTag;
+
+    // Response data
+    NProto::TCreateHandleResponse LeaderResponse;
+    bool LeaderResponded = false;
+
+    // Stats for reporting
+    IRequestStatsPtr RequestStats;
+    IProfileLogPtr ProfileLog;
+    TMaybe<TInFlightRequest> InFlightRequest;
+    const NCloud::NProto::EStorageMediaKind MediaKind;
+
+public:
+    TCreateHandleActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TCreateHandleRequest createHandleRequest,
+        TString logTag,
+        IRequestStatsPtr requestStats,
+        IProfileLogPtr profileLog,
+        NCloud::NProto::EStorageMediaKind mediaKind);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void CreateHandleInLeader(const TActorContext& ctx);
+
+    void HandleCreateHandleResponse(
+        const TEvService::TEvCreateHandleResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void CreateHandleInFollower(const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        NProto::TCreateHandleResponse followerResponse);
+    void HandleError(const TActorContext& ctx, NProto::TError error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCreateHandleActor::TCreateHandleActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TCreateHandleRequest createHandleRequest,
+        TString logTag,
+        IRequestStatsPtr requestStats,
+        IProfileLogPtr profileLog,
+        NCloud::NProto::EStorageMediaKind mediaKind)
+    : RequestInfo(std::move(requestInfo))
+    , CreateHandleRequest(std::move(createHandleRequest))
+    , LogTag(std::move(logTag))
+    , RequestStats(std::move(requestStats))
+    , ProfileLog(std::move(profileLog))
+    , MediaKind(mediaKind)
+{
+}
+
+void TCreateHandleActor::Bootstrap(const TActorContext& ctx)
+{
+    CreateHandleInLeader(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TCreateHandleActor::CreateHandleInLeader(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Executing CreateHandle in leader for %lu, %s, %s",
+        LogTag.c_str(),
+        CreateHandleRequest.GetNodeId(),
+        CreateHandleRequest.GetName().Quote().c_str(),
+        CreateHandleRequest.GetFollowerFileSystemId().c_str());
+
+    auto request = std::make_unique<TEvService::TEvCreateHandleRequest>();
+    request->Record = CreateHandleRequest;
+
+    // RequestType is set in order to properly record the request type
+    InFlightRequest.ConstructInPlace(
+        TRequestInfo(
+            RequestInfo->Sender,
+            RequestInfo->Cookie,
+            RequestInfo->CallContext),
+        ProfileLog,
+        MediaKind,
+        RequestStats);
+
+    InFlightRequest->Start(ctx.Now());
+    InitProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        request->Record);
+
+    // forward request through tablet proxy
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+void TCreateHandleActor::CreateHandleInFollower(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Executing CreateHandle in follower for %lu, %s, %s",
+        LogTag.c_str(),
+        CreateHandleRequest.GetNodeId(),
+        CreateHandleRequest.GetName().Quote().c_str(),
+        CreateHandleRequest.GetFollowerFileSystemId().c_str());
+
+    auto request = std::make_unique<TEvService::TEvCreateHandleRequest>();
+    request->Record = CreateHandleRequest;
+    request->Record.SetFileSystemId(
+        CreateHandleRequest.GetFollowerFileSystemId());
+    request->Record.SetNodeId(RootNodeId);
+    request->Record.SetName(LeaderResponse.GetFollowerNodeName());
+    request->Record.ClearFollowerFileSystemId();
+
+    // RequestType is set in order to properly record the request type
+    InFlightRequest.ConstructInPlace(
+        TRequestInfo(
+            RequestInfo->Sender,
+            RequestInfo->Cookie,
+            RequestInfo->CallContext),
+        ProfileLog,
+        MediaKind,
+        RequestStats);
+
+    InFlightRequest->Start(ctx.Now());
+    InitProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        request->Record);
+
+    // forward request through tablet proxy
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TCreateHandleActor::HandleCreateHandleResponse(
+    const TEvService::TEvCreateHandleResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    TABLET_VERIFY(InFlightRequest);
+
+    InFlightRequest->Complete(ctx.Now(), msg->GetError());
+    FinalizeProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        msg->Record);
+
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, *msg->Record.MutableError());
+        return;
+    }
+
+    if (LeaderResponded) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "CreateHandle succeeded in follower: %lu, %lu",
+            msg->Record.GetNodeAttr().GetId(),
+            msg->Record.GetHandle());
+
+        ReplyAndDie(ctx, std::move(msg->Record));
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "CreateHandle succeeded in leader: %s %s",
+        msg->Record.GetFollowerFileSystemId().c_str(),
+        msg->Record.GetFollowerNodeName().Quote().c_str());
+
+    LeaderResponded = true;
+    LeaderResponse = std::move(msg->Record);
+    CreateHandleInFollower(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TCreateHandleActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    HandleError(ctx, MakeError(E_REJECTED, "request cancelled"));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TCreateHandleActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TCreateHandleResponse followerResponse)
+{
+    auto response = std::make_unique<TEvService::TEvCreateHandleResponse>();
+    response->Record = std::move(followerResponse);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+void TCreateHandleActor::HandleError(
+    const TActorContext& ctx,
+    NProto::TError error)
+{
+    auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(
+        std::move(error));
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TCreateHandleActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvService::TEvCreateHandleResponse,
+            HandleCreateHandleResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleCreateHandle(
+    const TEvService::TEvCreateHandleRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (msg->Record.GetName().Empty()) {
+        // handle creation by NodeId can be handled directly by the follower
+        ForwardRequestToFollower<TEvService::TCreateHandleMethod>(
+            ctx,
+            ev,
+            ExtractShardNo(msg->Record.GetNodeId()));
+        return;
+    }
+
+    const auto& clientId = GetClientId(msg->Record);
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
+
+    auto* session = State->FindSession(sessionId, seqNo);
+    if (!session || session->ClientId != clientId || !session->SessionActor) {
+        auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(
+            ErrorInvalidSession(clientId, sessionId, seqNo));
+        return NCloud::Reply(ctx, *ev, std::move(response));
+    }
+    const NProto::TFileStore& filestore = session->FileStore;
+    const auto& followerId = session->SelectFollower();
+
+    if (!StorageConfig->GetMultiTabletForwardingEnabled() || !followerId) {
+        ForwardRequest<TEvService::TCreateHandleMethod>(ctx, ev);
+        return;
+    }
+
+    msg->Record.SetFollowerFileSystemId(followerId);
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "create handle in follower %s",
+        msg->Record.DebugString().c_str());
+
+    auto [cookie, inflight] = CreateInFlightRequest(
+        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        session->MediaKind,
+        session->RequestStats,
+        ctx.Now());
+
+    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+
+    auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+
+    auto actor = std::make_unique<TCreateHandleActor>(
+        std::move(requestInfo),
+        std::move(msg->Record),
+        filestore.GetFileSystemId(),
+        session->RequestStats,
+        ProfileLog,
+        session->MediaKind);
+
+    NCloud::Register(ctx, std::move(actor));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -1,0 +1,20 @@
+#include "service_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleCreateNode(
+    const TEvService::TEvCreateNodeRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    // TODO: impl follower forwarding
+
+    ForwardRequest<TEvService::TCreateNodeMethod>(ctx, ev);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -20,7 +20,7 @@ void TStorageServiceActor::HandleCreateNode(
 
     auto* session = State->FindSession(sessionId, seqNo);
     if (!session || session->ClientId != clientId || !session->SessionActor) {
-        auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(
+        auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));
     }

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/model/utils.h>
 
 #include <cloud/storage/core/libs/diagnostics/trace_serializer.h>
 
@@ -64,6 +65,87 @@ void TStorageServiceActor::ForwardRequest(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template <typename TMethod>
+void TStorageServiceActor::ForwardRequestToFollower(
+    const TActorContext& ctx,
+    const typename TMethod::TRequest::TPtr& ev,
+    ui32 shardNo)
+{
+    auto* msg = ev->Get();
+
+    const auto& clientId = GetClientId(msg->Record);
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::SERVICE,
+        "[%s][%lu] forward %s #%lu",
+        sessionId.Quote().c_str(),
+        seqNo,
+        TMethod::Name,
+        msg->CallContext->RequestId);
+
+    auto* session = State->FindSession(sessionId, seqNo);
+    if (!session || session->ClientId != clientId || !session->SessionActor) {
+        auto response = std::make_unique<typename TMethod::TResponse>(
+            ErrorInvalidSession(clientId, sessionId, seqNo));
+        return NCloud::Reply(ctx, *ev, std::move(response));
+    }
+    const NProto::TFileStore& filestore = session->FileStore;
+
+    if (StorageConfig->GetMultiTabletForwardingEnabled() && shardNo) {
+        const auto& followerIds = filestore.GetFollowerFileSystemIds();
+        if (followerIds.size() < static_cast<int>(shardNo)) {
+            LOG_ERROR(ctx, TFileStoreComponents::SERVICE,
+                "[%s][%lu] forward %s #%lu - invalid shardNo: %lu/%d",
+                sessionId.Quote().c_str(),
+                seqNo,
+                TMethod::Name,
+                msg->CallContext->RequestId,
+                shardNo,
+                followerIds.size());
+
+            auto response = std::make_unique<typename TMethod::TResponse>(
+                MakeError(E_INVALID_STATE, TStringBuilder() << "shardNo="
+                    << shardNo << ", followerIds.size=" << followerIds.size()));
+            return NCloud::Reply(ctx, *ev, std::move(response));
+        }
+
+        LOG_DEBUG(ctx, TFileStoreComponents::SERVICE,
+            "[%s][%lu] forward %s #%lu to follower %s",
+            sessionId.Quote().c_str(),
+            seqNo,
+            TMethod::Name,
+            msg->CallContext->RequestId,
+            followerIds[shardNo - 1].c_str());
+
+        msg->Record.SetFileSystemId(followerIds[shardNo - 1]);
+    }
+
+    auto [cookie, inflight] = CreateInFlightRequest(
+        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        session->MediaKind,
+        session->RequestStats,
+        ctx.Now());
+
+    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    TraceSerializer->BuildTraceRequest(
+        *msg->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
+        msg->CallContext->LWOrbit);
+
+    auto event = std::make_unique<IEventHandle>(
+        MakeIndexTabletProxyServiceId(),
+        SelfId(),
+        ev->ReleaseBase().Release(),
+        0,          // flags
+        cookie,     // cookie
+        // forwardOnNondelivery
+        nullptr);
+
+    ctx.Send(event.release());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 #define FILESTORE_FORWARD_REQUEST(name, ns)                                    \
     void TStorageServiceActor::Handle##name(                                   \
         const ns::TEv##name##Request::TPtr& ev,                                \
@@ -76,12 +158,46 @@ void TStorageServiceActor::ForwardRequest(
 
 #undef FILESTORE_FORWARD_REQUEST
 
-#define FILESTORE_DEFINE_NO_HANDLE_FORWARD(name, ns)                           \
+#define FILESTORE_FORWARD_REQUEST_TO_FOLLOWER_BY_NODE_ID(name, ns)             \
+    void TStorageServiceActor::Handle##name(                                   \
+        const ns::TEv##name##Request::TPtr& ev,                                \
+        const TActorContext& ctx)                                              \
+    {                                                                          \
+        ForwardRequestToFollower<ns::T##name##Method>(                         \
+            ctx,                                                               \
+            ev,                                                                \
+            ExtractShardNo(ev->Get()->Record.GetNodeId()));                    \
+    }                                                                          \
+
+    FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_NODE_ID(
+        FILESTORE_FORWARD_REQUEST_TO_FOLLOWER_BY_NODE_ID,
+        TEvService)
+
+#undef FILESTORE_FORWARD_REQUEST_TO_FOLLOWER_BY_NODE_ID
+
+#define FILESTORE_FORWARD_REQUEST_TO_FOLLOWER_BY_HANDLE(name, ns)              \
+    void TStorageServiceActor::Handle##name(                                   \
+        const ns::TEv##name##Request::TPtr& ev,                                \
+        const TActorContext& ctx)                                              \
+    {                                                                          \
+        ForwardRequestToFollower<ns::T##name##Method>(                         \
+            ctx,                                                               \
+            ev,                                                                \
+            ExtractShardNo(ev->Get()->Record.GetHandle()));                    \
+    }                                                                          \
+
+    FILESTORE_SERVICE_REQUESTS_FWD_TO_FOLLOWER_BY_HANDLE(
+        FILESTORE_FORWARD_REQUEST_TO_FOLLOWER_BY_HANDLE,
+        TEvService)
+
+#undef FILESTORE_FORWARD_REQUEST_TO_FOLLOWER_BY_NODE_ID
+
+#define FILESTORE_DEFINE_HANDLE_FORWARD(name, ns)                              \
 template void TStorageServiceActor::ForwardRequest<ns::T##name##Method>(       \
     const TActorContext&, const ns::TEv##name##Request::TPtr&);                \
 
-    FILESTORE_SERVICE_REQUESTS_HANDLE(FILESTORE_DEFINE_NO_HANDLE_FORWARD, TEvService)
+    FILESTORE_SERVICE_REQUESTS_HANDLE(FILESTORE_DEFINE_HANDLE_FORWARD, TEvService)
 
-#undef FILESTORE_DEFINE_NO_HANDLE_FORWARD
+#undef FILESTORE_DEFINE_HANDLE_FORWARD
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -231,4 +231,16 @@ template void TStorageServiceActor::ForwardRequest<ns::T##name##Method>(       \
 
 #undef FILESTORE_DEFINE_HANDLE_FORWARD
 
+template void
+TStorageServiceActor::ForwardRequestToFollower<TEvService::TCreateHandleMethod>(
+    const TActorContext& ctx,
+    const TEvService::TCreateHandleMethod::TRequest::TPtr& ev,
+    ui32 shardNo);
+
+template void
+TStorageServiceActor::ForwardRequestToFollower<TEvService::TGetNodeAttrMethod>(
+    const TActorContext& ctx,
+    const TEvService::TGetNodeAttrMethod::TRequest::TPtr& ev,
+    ui32 shardNo);
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -1,0 +1,20 @@
+#include "service_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleGetNodeAttr(
+    const TEvService::TEvGetNodeAttrRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    // TODO: impl follower forwarding
+
+    ForwardRequest<TEvService::TGetNodeAttrMethod>(ctx, ev);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -39,7 +39,7 @@ private:
 public:
     TGetNodeAttrActor(
         TRequestInfoPtr requestInfo,
-        NProto::TGetNodeAttrRequest createHandleRequest,
+        NProto::TGetNodeAttrRequest getNodeAttrRequest,
         TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
@@ -72,13 +72,13 @@ private:
 
 TGetNodeAttrActor::TGetNodeAttrActor(
         TRequestInfoPtr requestInfo,
-        NProto::TGetNodeAttrRequest createHandleRequest,
+        NProto::TGetNodeAttrRequest getNodeAttrRequest,
         TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
         NCloud::NProto::EStorageMediaKind mediaKind)
     : RequestInfo(std::move(requestInfo))
-    , GetNodeAttrRequest(std::move(createHandleRequest))
+    , GetNodeAttrRequest(std::move(getNodeAttrRequest))
     , LogTag(std::move(logTag))
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -1,10 +1,264 @@
 #include "service_actor.h"
 
+#include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
 using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TGetNodeAttrActor final: public TActorBootstrapped<TGetNodeAttrActor>
+{
+private:
+    // Original request
+    const TRequestInfoPtr RequestInfo;
+    NProto::TGetNodeAttrRequest GetNodeAttrRequest;
+
+    // Filesystem-specific params
+    const TString LogTag;
+
+    // Response data
+    NProto::TGetNodeAttrResponse LeaderResponse;
+    bool LeaderResponded = false;
+
+    // Stats for reporting
+    IRequestStatsPtr RequestStats;
+    IProfileLogPtr ProfileLog;
+    TMaybe<TInFlightRequest> InFlightRequest;
+    const NCloud::NProto::EStorageMediaKind MediaKind;
+
+public:
+    TGetNodeAttrActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TGetNodeAttrRequest createHandleRequest,
+        TString logTag,
+        IRequestStatsPtr requestStats,
+        IProfileLogPtr profileLog,
+        NCloud::NProto::EStorageMediaKind mediaKind);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void GetNodeAttrInLeader(const TActorContext& ctx);
+
+    void HandleGetNodeAttrResponse(
+        const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void GetNodeAttrInFollower(const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        NProto::TGetNodeAttrResponse followerResponse);
+    void HandleError(const TActorContext& ctx, NProto::TError error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TGetNodeAttrActor::TGetNodeAttrActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TGetNodeAttrRequest createHandleRequest,
+        TString logTag,
+        IRequestStatsPtr requestStats,
+        IProfileLogPtr profileLog,
+        NCloud::NProto::EStorageMediaKind mediaKind)
+    : RequestInfo(std::move(requestInfo))
+    , GetNodeAttrRequest(std::move(createHandleRequest))
+    , LogTag(std::move(logTag))
+    , RequestStats(std::move(requestStats))
+    , ProfileLog(std::move(profileLog))
+    , MediaKind(mediaKind)
+{
+}
+
+void TGetNodeAttrActor::Bootstrap(const TActorContext& ctx)
+{
+    GetNodeAttrInLeader(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TGetNodeAttrActor::GetNodeAttrInLeader(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Executing GetNodeAttr in leader for %lu, %s",
+        LogTag.c_str(),
+        GetNodeAttrRequest.GetNodeId(),
+        GetNodeAttrRequest.GetName().Quote().c_str());
+
+    auto request = std::make_unique<TEvService::TEvGetNodeAttrRequest>();
+    request->Record = GetNodeAttrRequest;
+
+    // RequestType is set in order to properly record the request type
+    InFlightRequest.ConstructInPlace(
+        TRequestInfo(
+            RequestInfo->Sender,
+            RequestInfo->Cookie,
+            RequestInfo->CallContext),
+        ProfileLog,
+        MediaKind,
+        RequestStats);
+
+    InFlightRequest->Start(ctx.Now());
+    InitProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        request->Record);
+
+    // forward request through tablet proxy
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+void TGetNodeAttrActor::GetNodeAttrInFollower(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Executing GetNodeAttr in follower for %lu, %s, %s",
+        LogTag.c_str(),
+        GetNodeAttrRequest.GetNodeId(),
+        GetNodeAttrRequest.GetName().Quote().c_str());
+
+    auto request = std::make_unique<TEvService::TEvGetNodeAttrRequest>();
+    request->Record = GetNodeAttrRequest;
+    request->Record.SetFileSystemId(
+        LeaderResponse.GetNode().GetFollowerFileSystemId());
+    request->Record.SetNodeId(RootNodeId);
+    request->Record.SetName(LeaderResponse.GetNode().GetFollowerNodeName());
+
+    // RequestType is set in order to properly record the request type
+    InFlightRequest.ConstructInPlace(
+        TRequestInfo(
+            RequestInfo->Sender,
+            RequestInfo->Cookie,
+            RequestInfo->CallContext),
+        ProfileLog,
+        MediaKind,
+        RequestStats);
+
+    InFlightRequest->Start(ctx.Now());
+    InitProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        request->Record);
+
+    // forward request through tablet proxy
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetNodeAttrActor::HandleGetNodeAttrResponse(
+    const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    TABLET_VERIFY(InFlightRequest);
+
+    InFlightRequest->Complete(ctx.Now(), msg->GetError());
+    FinalizeProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        msg->Record);
+
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, *msg->Record.MutableError());
+        return;
+    }
+
+    if (LeaderResponded) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "GetNodeAttr succeeded in follower: %lu",
+            msg->Record.GetNode().GetId());
+
+        ReplyAndDie(ctx, std::move(msg->Record));
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "GetNodeAttr succeeded in leader: %s %s",
+        msg->Record.GetNode().GetFollowerFileSystemId().c_str(),
+        msg->Record.GetNode().GetFollowerNodeName().Quote().c_str());
+
+    if (msg->Record.GetNode().GetFollowerFileSystemId().Empty()) {
+        ReplyAndDie(ctx, std::move(msg->Record));
+        return;
+    }
+
+    LeaderResponded = true;
+    LeaderResponse = std::move(msg->Record);
+    GetNodeAttrInFollower(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetNodeAttrActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    HandleError(ctx, MakeError(E_REJECTED, "request cancelled"));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetNodeAttrActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TGetNodeAttrResponse followerResponse)
+{
+    auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>();
+    response->Record = std::move(followerResponse);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+void TGetNodeAttrActor::HandleError(
+    const TActorContext& ctx,
+    NProto::TError error)
+{
+    auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>(
+        std::move(error));
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TGetNodeAttrActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvService::TEvGetNodeAttrResponse,
+            HandleGetNodeAttrResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            break;
+    }
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -12,9 +266,47 @@ void TStorageServiceActor::HandleGetNodeAttr(
     const TEvService::TEvGetNodeAttrRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    // TODO: impl follower forwarding
+    auto* msg = ev->Get();
 
-    ForwardRequest<TEvService::TGetNodeAttrMethod>(ctx, ev);
+    if (msg->Record.GetName().Empty()) {
+        // handle creation by NodeId can be handled directly by the follower
+        ForwardRequestToFollower<TEvService::TGetNodeAttrMethod>(
+            ctx,
+            ev,
+            ExtractShardNo(msg->Record.GetNodeId()));
+        return;
+    }
+
+    const auto& clientId = GetClientId(msg->Record);
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
+
+    auto* session = State->FindSession(sessionId, seqNo);
+    if (!session || session->ClientId != clientId || !session->SessionActor) {
+        auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>(
+            ErrorInvalidSession(clientId, sessionId, seqNo));
+        return NCloud::Reply(ctx, *ev, std::move(response));
+    }
+
+    auto [cookie, inflight] = CreateInFlightRequest(
+        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        session->MediaKind,
+        session->RequestStats,
+        ctx.Now());
+
+    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+
+    auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+
+    auto actor = std::make_unique<TGetNodeAttrActor>(
+        std::move(requestInfo),
+        std::move(msg->Record),
+        msg->Record.GetFileSystemId(),
+        session->RequestStats,
+        ProfileLog,
+        session->MediaKind);
+
+    NCloud::Register(ctx, std::move(actor));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -1,10 +1,293 @@
 #include "service_actor.h"
 
+#include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
 using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TListNodesActor final: public TActorBootstrapped<TListNodesActor>
+{
+private:
+    // Original request
+    const TRequestInfoPtr RequestInfo;
+    NProto::TListNodesRequest ListNodesRequest;
+
+    // Filesystem-specific params
+    const TString LogTag;
+
+    // Response data
+    NProto::TListNodesResponse Response;
+    ui32 GetNodeAttrResponses = 0;
+
+    // Stats for reporting
+    IRequestStatsPtr RequestStats;
+    IProfileLogPtr ProfileLog;
+    TMaybe<TInFlightRequest> InFlightRequest;
+    const NCloud::NProto::EStorageMediaKind MediaKind;
+
+public:
+    TListNodesActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TListNodesRequest listNodesRequest,
+        TString logTag,
+        IRequestStatsPtr requestStats,
+        IProfileLogPtr profileLog,
+        NCloud::NProto::EStorageMediaKind mediaKind);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void ListNodes(const TActorContext& ctx);
+
+    void HandleListNodesResponse(
+        const TEvService::TEvListNodesResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void GetNodeAttrs(const TActorContext& ctx);
+
+    void HandleGetNodeAttrResponse(
+        const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(const TActorContext& ctx);
+    void HandleError(const TActorContext& ctx, NProto::TError error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TListNodesActor::TListNodesActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TListNodesRequest listNodesRequest,
+        TString logTag,
+        IRequestStatsPtr requestStats,
+        IProfileLogPtr profileLog,
+        NCloud::NProto::EStorageMediaKind mediaKind)
+    : RequestInfo(std::move(requestInfo))
+    , ListNodesRequest(std::move(listNodesRequest))
+    , LogTag(std::move(logTag))
+    , RequestStats(std::move(requestStats))
+    , ProfileLog(std::move(profileLog))
+    , MediaKind(mediaKind)
+{
+}
+
+void TListNodesActor::Bootstrap(const TActorContext& ctx)
+{
+    ListNodes(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TListNodesActor::ListNodes(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Executing ListNodes in leader for %lu",
+        LogTag.c_str(),
+        ListNodesRequest.GetNodeId());
+
+    auto request = std::make_unique<TEvService::TEvListNodesRequest>();
+    request->Record = ListNodesRequest;
+
+    // RequestType is set in order to properly record the request type
+    InFlightRequest.ConstructInPlace(
+        TRequestInfo(
+            RequestInfo->Sender,
+            RequestInfo->Cookie,
+            RequestInfo->CallContext),
+        ProfileLog,
+        MediaKind,
+        RequestStats);
+
+    InFlightRequest->Start(ctx.Now());
+    InitProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        request->Record);
+
+    // forward request through tablet proxy
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+void TListNodesActor::GetNodeAttrs(const TActorContext& ctx)
+{
+    for (ui64 cookie = 0; cookie < Response.NodesSize(); ++cookie) {
+        const auto& node = Response.GetNodes(cookie);
+        if (node.GetFollowerFileSystemId()) {
+            LOG_DEBUG(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "[%s] Executing GetNodeAttr in follower for %s, %s",
+                LogTag.c_str(),
+                node.GetFollowerFileSystemId().c_str(),
+                node.GetFollowerNodeName().Quote().c_str());
+
+            auto request =
+                std::make_unique<TEvService::TEvGetNodeAttrRequest>();
+            request->Record.MutableHeaders()->CopyFrom(
+                ListNodesRequest.GetHeaders());
+            request->Record.SetFileSystemId(node.GetFollowerFileSystemId());
+            request->Record.SetNodeId(RootNodeId);
+            request->Record.SetName(node.GetFollowerNodeName());
+
+            // forward request through tablet proxy
+            ctx.Send(
+                MakeIndexTabletProxyServiceId(),
+                request.release(),
+                0, // flags
+                cookie);
+        } else {
+            ++GetNodeAttrResponses;
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::HandleListNodesResponse(
+    const TEvService::TEvListNodesResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, *msg->Record.MutableError());
+        return;
+    }
+
+    Response = std::move(msg->Record);
+    GetNodeAttrs(ctx);
+
+    if (GetNodeAttrResponses == Response.NodesSize()) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "No nodes at followers for parent %lu",
+            ListNodesRequest.GetNodeId());
+
+        ReplyAndDie(ctx);
+        return;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::HandleGetNodeAttrResponse(
+    const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        LOG_WARN(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "Failed to GetNodeAttr from follower: %s",
+            FormatError(msg->GetError()).Quote().c_str());
+
+        HandleError(ctx, *msg->Record.MutableError());
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "GetNodeAttrResponse from follower: %s",
+        msg->Record.GetNode().DebugString().Quote().c_str());
+
+    TABLET_VERIFY(ev->Cookie < Response.NodesSize());
+    auto* node = Response.MutableNodes(ev->Cookie);
+    *node = std::move(*msg->Record.MutableNode());
+    ++GetNodeAttrResponses;
+
+    if (GetNodeAttrResponses == Response.NodesSize()) {
+        ReplyAndDie(ctx);
+        return;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    HandleError(ctx, MakeError(E_REJECTED, "request cancelled"));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::ReplyAndDie(const TActorContext& ctx)
+{
+    TABLET_VERIFY(InFlightRequest);
+
+    InFlightRequest->Complete(ctx.Now(), Response.GetError());
+    FinalizeProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        Response);
+
+    auto response = std::make_unique<TEvService::TEvListNodesResponse>();
+    response->Record = std::move(Response);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+void TListNodesActor::HandleError(
+    const TActorContext& ctx,
+    NProto::TError error)
+{
+    TABLET_VERIFY(InFlightRequest);
+
+    InFlightRequest->Complete(ctx.Now(), Response.GetError());
+    FinalizeProfileLogRequestInfo(
+        InFlightRequest->ProfileLogRequest,
+        Response);
+
+    auto response = std::make_unique<TEvService::TEvListNodesResponse>(
+        std::move(error));
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TListNodesActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvService::TEvListNodesResponse,
+            HandleListNodesResponse);
+        HFunc(
+            TEvService::TEvGetNodeAttrResponse,
+            HandleGetNodeAttrResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            break;
+    }
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -12,9 +295,38 @@ void TStorageServiceActor::HandleListNodes(
     const TEvService::TEvListNodesRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    // TODO: impl follower forwarding
+    auto* msg = ev->Get();
 
-    ForwardRequest<TEvService::TListNodesMethod>(ctx, ev);
+    const auto& clientId = GetClientId(msg->Record);
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
+
+    auto* session = State->FindSession(sessionId, seqNo);
+    if (!session || session->ClientId != clientId || !session->SessionActor) {
+        auto response = std::make_unique<TEvService::TEvListNodesResponse>(
+            ErrorInvalidSession(clientId, sessionId, seqNo));
+        return NCloud::Reply(ctx, *ev, std::move(response));
+    }
+
+    auto [cookie, inflight] = CreateInFlightRequest(
+        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        session->MediaKind,
+        session->RequestStats,
+        ctx.Now());
+
+    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+
+    auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+
+    auto actor = std::make_unique<TListNodesActor>(
+        std::move(requestInfo),
+        std::move(msg->Record),
+        msg->Record.GetFileSystemId(),
+        session->RequestStats,
+        ProfileLog,
+        session->MediaKind);
+
+    NCloud::Register(ctx, std::move(actor));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -1,0 +1,20 @@
+#include "service_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleListNodes(
+    const TEvService::TEvListNodesRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    // TODO: impl follower forwarding
+
+    ForwardRequest<TEvService::TListNodesMethod>(ctx, ev);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -92,6 +92,8 @@ struct TSessionInfo
 
     bool ShouldStop = false;
 
+    ui32 FollowerSelector = 0;
+
     void GetInfo(NProto::TSessionInfo& info, ui64 seqNo)
     {
         info.SetSessionId(SessionId);
@@ -130,6 +132,16 @@ struct TSessionInfo
         if (auto it = SubSessions.find(seqNo); it != SubSessions.end()) {
             it->second.second = now;
         }
+    }
+
+    const TString& SelectFollower()
+    {
+        const auto& followers = FileStore.GetFollowerFileSystemIds();
+        if (followers.empty()) {
+            return Default<TString>();
+        }
+
+        return followers[FollowerSelector++ % followers.size()];
     }
 };
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2972,27 +2972,30 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             2_MB,
             getNodeAttrResponse.GetNode().GetSize());
 
-        // TODO: ListNodes
-
-        // a less important TODO: test XAttr requests
-
-        /*
         auto listNodesResponse = service.ListNodes(
             headers,
             fsId,
             RootNodeId)->Record;
 
-        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL("file2", listNodesResponse.GetNames(1));
 
-        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NodesSize());
         UNIT_ASSERT_VALUES_EQUAL(
-            shard1Id,
-            listNodesResponse.GetNodes(0).GetFollowerFileSystemId());
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
         UNIT_ASSERT_VALUES_EQUAL(
-            followerNodeName,
-            listNodesResponse.GetNodes(0).GetFollowerNodeName());
-        */
+            2_MB,
+            listNodesResponse.GetNodes(0).GetSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId2,
+            listNodesResponse.GetNodes(1).GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            listNodesResponse.GetNodes(1).GetSize());
+
+        // TODO(#1350): test XAttr requests
     }
 }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2939,6 +2939,13 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         Y_UNUSED(destroyHandleResponse);
 
+        const auto createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file2"))->Record;
+
+        const auto nodeId2 = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL((2LU << 56U) + 2, nodeId2);
+
         // TODO: GetNodeAttr, ListNodes
 
         // a less important TODO: test XAttr requests

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2946,7 +2946,33 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         const auto nodeId2 = createNodeResponse.GetNode().GetId();
         UNIT_ASSERT_VALUES_EQUAL((2LU << 56U) + 2, nodeId2);
 
-        // TODO: GetNodeAttr, ListNodes
+        auto getNodeAttrResponse = service.GetNodeAttr(
+            headers,
+            fsId,
+            RootNodeId,
+            "file1")->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            getNodeAttrResponse.GetNode().GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2_MB,
+            getNodeAttrResponse.GetNode().GetSize());
+
+        getNodeAttrResponse = service.GetNodeAttr(
+            headers,
+            fsId,
+            nodeId1,
+            "")->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            getNodeAttrResponse.GetNode().GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2_MB,
+            getNodeAttrResponse.GetNode().GetSize());
+
+        // TODO: ListNodes
 
         // a less important TODO: test XAttr requests
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2876,16 +2876,20 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             shard1Id)->Record;
 
         UNIT_ASSERT_VALUES_EQUAL(
-            shard1Id,
+            "",
             createHandleResponse.GetFollowerFileSystemId());
-
-        const auto followerNodeName =
-            createHandleResponse.GetFollowerNodeName();
-
-        UNIT_ASSERT_VALUES_UNEQUAL("", followerNodeName);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            createHandleResponse.GetFollowerNodeName());
 
         const auto nodeId1 = createHandleResponse.GetNodeAttr().GetId();
         UNIT_ASSERT_VALUES_EQUAL((1LU << 56U) + 2, nodeId1);
+
+        const auto handle1 = createHandleResponse.GetHandle();
+
+        UNIT_ASSERT_C(
+            handle1 >= (1LU << 56U) && handle1 < (2LU << 56U),
+            handle1);
 
         auto accessNodeResponse = service.AccessNode(
             headers,
@@ -2905,26 +2909,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             setNodeAttrResponse.GetNode().GetId());
 
         UNIT_ASSERT_VALUES_EQUAL(1_MB, setNodeAttrResponse.GetNode().GetSize());
-
-        auto headers1 = headers;
-        headers1.FileSystemId = shard1Id;
-
-        createHandleResponse = service.CreateHandle(
-            headers1,
-            headers1.FileSystemId,
-            RootNodeId,
-            followerNodeName,
-            TCreateHandleArgs::RDWR)->Record;
-
-        auto handle1 = createHandleResponse.GetHandle();
-
-        UNIT_ASSERT_C(
-            handle1 >= (1LU << 56U) && handle1 < (2LU << 56U),
-            handle1);
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            nodeId1,
-            createHandleResponse.GetNodeAttr().GetId());
 
         auto allocateDataResponse = service.AllocateData(
             headers,
@@ -2955,7 +2939,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         Y_UNUSED(destroyHandleResponse);
 
-        // TODO: CreateHandle, GetNodeAttr, ListNodes
+        // TODO: GetNodeAttr, ListNodes
 
         // a less important TODO: test XAttr requests
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2936,6 +2936,17 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         Y_UNUSED(allocateDataResponse);
 
+        auto data = GenerateValidateData(256_KB);
+        service.WriteData(headers, fsId, nodeId1, handle1, 0, data);
+        auto readDataResponse = service.ReadData(
+            headers,
+            fsId,
+            nodeId1,
+            handle1,
+            0,
+            data.Size())->Record;
+        UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse.GetBuffer());
+
         auto destroyHandleResponse = service.DestroyHandle(
             headers,
             fsId,
@@ -2945,7 +2956,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         Y_UNUSED(destroyHandleResponse);
 
         // TODO: CreateHandle, GetNodeAttr, ListNodes
-        // TODO: WriteData and ReadData
 
         // a less important TODO: test XAttr requests
 

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -16,14 +16,18 @@ SRCS(
     service_actor_alterfs.cpp
     service_actor_complete.cpp
     service_actor_createfs.cpp
+    service_actor_createhandle.cpp
+    service_actor_createnode.cpp
     service_actor_createsession.cpp
     service_actor_describefsmodel.cpp
     service_actor_destroyfs.cpp
     service_actor_destroysession.cpp
     service_actor_forward.cpp
     service_actor_getfsinfo.cpp
+    service_actor_getnodeattr.cpp
     service_actor_getsessionevents.cpp
     service_actor_list.cpp
+    service_actor_listnodes.cpp
     service_actor_monitoring.cpp
     service_actor_monitoring_search.cpp
     service_actor_ping.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -250,6 +250,7 @@ void TIndexTabletActor::HandleCreateHandle(
                 << msg->Record.GetFollowerFileSystemId());
             auto response = std::make_unique<TResponse>(std::move(error));
             NCloud::Reply(ctx, *ev, std::move(response));
+            return;
         }
     }
 

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -336,6 +336,66 @@ public:
         return request;
     }
 
+    std::unique_ptr<TEvService::TEvAccessNodeRequest> CreateAccessNodeRequest(
+        const THeaders& headers,
+        const TString& fileSystemId,
+        const ui64 nodeId)
+    {
+        auto request = std::make_unique<TEvService::TEvAccessNodeRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetNodeId(nodeId);
+        return request;
+    }
+
+    std::unique_ptr<TEvService::TEvSetNodeAttrRequest> CreateSetNodeAttrRequest(
+        const THeaders& headers,
+        const TString& fileSystemId,
+        const ui64 nodeId,
+        const ui64 size)
+    {
+        auto request = std::make_unique<TEvService::TEvSetNodeAttrRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetNodeId(nodeId);
+        request->Record.MutableUpdate()->SetSize(size);
+        request->Record.SetFlags(
+            ProtoFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE));
+        return request;
+    }
+
+    std::unique_ptr<TEvService::TEvDestroyHandleRequest> CreateDestroyHandleRequest(
+        const THeaders& headers,
+        const TString& fileSystemId,
+        const ui64 nodeId,
+        const ui64 handle)
+    {
+        auto request = std::make_unique<TEvService::TEvDestroyHandleRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetNodeId(nodeId);
+        request->Record.SetHandle(handle);
+        return request;
+    }
+
+    std::unique_ptr<TEvService::TEvAllocateDataRequest> CreateAllocateDataRequest(
+        const THeaders& headers,
+        const TString& fileSystemId,
+        const ui64 nodeId,
+        const ui64 handle,
+        const ui64 offset,
+        const ui64 len)
+    {
+        auto request = std::make_unique<TEvService::TEvAllocateDataRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetNodeId(nodeId);
+        request->Record.SetHandle(handle);
+        request->Record.SetOffset(offset);
+        request->Record.SetLength(len);
+        return request;
+    }
+
 #define FILESTORE_DECLARE_METHOD(name, ns)                                     \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp
@@ -121,6 +121,7 @@ void TFileSystem::GetAttr(
     }
 
     auto request = StartRequest<NProto::TGetNodeAttrRequest>(ino);
+    // XXX handle seems to be unneeded
     request->SetHandle(handle);
 
     Session->GetNodeAttr(callContext, std::move(request))

--- a/cloud/filestore/public/api/protos/data.proto
+++ b/cloud/filestore/public/api/protos/data.proto
@@ -231,6 +231,7 @@ message TAllocateDataResponse
 
 ////////////////////////////////////////////////////////////////////////////////
 // TruncateData request/response
+// XXX unused
 
 message TTruncateDataRequest
 {

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -371,6 +371,7 @@ message TSetNodeAttrRequest
     uint64 NodeId = 3;
 
     // IO handle.
+    // XXX seems to be unneeded
     uint64 Handle = 4;
 
     // Update.
@@ -415,6 +416,7 @@ message TGetNodeAttrRequest
     bytes Name = 4;
 
     // IO handle.
+    // XXX seems to be unneeded
     uint64 Handle = 5;
 
     // Specifies information to get.


### PR DESCRIPTION
Forwarded based on NodeId:
* AccessNode
* SetNodeAttr
* GetNodeXAttr
* SetNodeXAttr
* ListNodeXAttr
* RemoveNodeXAttr

Forwarded based on Handle:
* DestroyHandle
* AllocateData

Former handling logic augmented by shard selection based on Handle:
* WriteData
* ReadData

Two-stage handling (request leader -> request follower[s]):
* CreateHandle
* GetNodeAttr
* ListNodes

#1350 