### PR TITLE
Added DisableDiskWithCloudIdDestruction option

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -997,4 +997,7 @@ message TStorageServiceConfig
 
     // Min scrubbing bandwidth in MiB/s.
     optional uint64 MinScrubbingBandwidth = 373;
+
+    // Destroy disk only with empty CloudId field
+    optional bool DisableDiskWithCloudIdDestruction = 374;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -494,6 +494,7 @@ TDuration MSeconds(ui32 value)
                                                                                   \
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
+    xxx(DisableDiskWithCloudIdDestruction,              bool,      false         )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -583,6 +583,7 @@ public:
     bool GetOptimizeVoidBuffersTransferForReadsEnabled() const;
 
     ui32 GetVolumeHistoryCleanupItemCount() const;
+    bool GetDisableDiskWithCloudIdDestruction() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
@@ -329,12 +329,12 @@ void TDestroyVolumeActor::HandleStatVolumeResponse(
         return;
     }
 
-    auto cloudId = msg->Record.GetVolume().GetCloudId();
+    const auto& cloudId = msg->Record.GetVolume().GetCloudId();
     if (DisableDiskWithCloudIdDestruction && !cloudId.Empty()) {
         auto e = MakeError(
             E_REJECTED,
             TStringBuilder() << "CloudId=" << cloudId <<
-            ", only disks with empty CloudId disks are allowed to be deleted");
+            ", only disks with empty CloudId are allowed to be deleted");
 
         ReplyAndDie(
             ctx,

--- a/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
@@ -29,6 +29,7 @@ private:
     const ui64 Cookie;
 
     const TDuration AttachedDiskDestructionTimeout;
+    const bool DisableDiskWithCloudIdDestruction;
     const TString DiskId;
     const bool DestroyIfBroken;
     const bool Sync;
@@ -41,6 +42,7 @@ public:
         const TActorId& sender,
         ui64 cookie,
         TDuration attachedDiskDestructionTimeout,
+        bool disableDiskWithCloudIdDestruction,
         TString diskId,
         bool destroyIfBroken,
         bool sync,
@@ -89,6 +91,7 @@ TDestroyVolumeActor::TDestroyVolumeActor(
         const TActorId& sender,
         ui64 cookie,
         TDuration attachedDiskDestructionTimeout,
+        bool disableDiskWithCloudIdDestruction,
         TString diskId,
         bool destroyIfBroken,
         bool sync,
@@ -96,6 +99,7 @@ TDestroyVolumeActor::TDestroyVolumeActor(
     : Sender(sender)
     , Cookie(cookie)
     , AttachedDiskDestructionTimeout(attachedDiskDestructionTimeout)
+    , DisableDiskWithCloudIdDestruction(disableDiskWithCloudIdDestruction)
     , DiskId(std::move(diskId))
     , DestroyIfBroken(destroyIfBroken)
     , Sync(sync)
@@ -325,6 +329,20 @@ void TDestroyVolumeActor::HandleStatVolumeResponse(
         return;
     }
 
+    auto cloudId = msg->Record.GetVolume().GetCloudId();
+    if (DisableDiskWithCloudIdDestruction && !cloudId.Empty()) {
+        auto e = MakeError(
+            E_REJECTED,
+            TStringBuilder() << "CloudId=" << cloudId <<
+            ", only disks with empty CloudId disks are allowed to be deleted");
+
+        ReplyAndDie(
+            ctx,
+            std::make_unique<TEvService::TEvDestroyVolumeResponse>(
+                std::move(e)));
+        return;
+    }
+
     for (const auto& client: msg->Record.GetClients()) {
         if (client.GetInstanceId()) {
             const auto timeout = AttachedDiskDestructionTimeout;
@@ -427,6 +445,7 @@ void TServiceActor::HandleDestroyVolume(
         ev->Sender,
         ev->Cookie,
         Config->GetAttachedDiskDestructionTimeout(),
+        Config->GetDisableDiskWithCloudIdDestruction(),
         diskId,
         destroyIfBroken,
         sync,


### PR DESCRIPTION
Quick fix to be able to distinguish old-style disks (with CloudId field) from new-style disks (without CloudId field) in Destroy operation.