### PR TITLE
Fix wrong media kind usage

### DIFF
--- a/cloud/blockstore/libs/client/durable.cpp
+++ b/cloud/blockstore/libs/client/durable.cpp
@@ -28,16 +28,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NCloud::NProto::EStorageMediaKind GetStorageMediaKind(
-    const IVolumeInfoPtr& volume)
-{
-    return volume
-        ? volume->GetInfo().GetStorageMediaKind()
-        : NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 ELogPriority GetDetailsLogPriority(const NProto::TError& error)
 {
     const auto kind = GetDiagnosticsErrorKind(error);
@@ -314,7 +304,7 @@ private:
                 }
 
                 RequestStats->AddRetryStats(
-                    GetStorageMediaKind(volumeInfo),
+                    VolumeStats->GetStorageMediaKind(diskId),
                     T::Request,
                     errorKind,
                     errorFlags);

--- a/cloud/blockstore/libs/client/session.cpp
+++ b/cloud/blockstore/libs/client/session.cpp
@@ -25,16 +25,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NCloud::NProto::EStorageMediaKind GetStorageMediaKind(
-    const IVolumeInfoPtr& volume)
-{
-    return volume
-        ? volume->GetInfo().GetStorageMediaKind()
-        : NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TReadBlocksLocalMethod
 {
     static constexpr EBlockStoreRequest RequestType = EBlockStoreRequest::ReadBlocks;
@@ -956,7 +946,7 @@ void TSession::HandleResponse(
         }
 
         RequestStats->AddRetryStats(
-            GetStorageMediaKind(volumeInfo),
+            VolumeStats->GetStorageMediaKind(request->GetDiskId()),
             T::RequestType,
             errorKind,
             errorFlags);

--- a/cloud/blockstore/libs/diagnostics/request_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/request_stats.cpp
@@ -368,7 +368,9 @@ public:
             errorKind,
             errorFlags);
 
-        if (IsReadWriteRequest(requestType)) {
+        if (IsReadWriteRequest(requestType) &&
+            mediaKind != NProto::STORAGE_MEDIA_DEFAULT)
+        {
             GetRequestCounters(mediaKind).AddRetryStats(
                 static_cast<TRequestCounters::TRequestType>(
                     TranslateLocalRequestType(requestType)),

--- a/cloud/blockstore/libs/diagnostics/request_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/request_stats.cpp
@@ -270,7 +270,9 @@ public:
                 TranslateLocalRequestType(requestType)),
             requestBytes);
 
-        if (IsReadWriteRequest(requestType)) {
+        if (IsReadWriteRequest(requestType) &&
+            mediaKind != NProto::STORAGE_MEDIA_DEFAULT)
+        {
             GetRequestCounters(mediaKind).RequestStarted(
                 static_cast<TRequestCounters::TRequestType>(
                     TranslateLocalRequestType(requestType)),
@@ -304,7 +306,9 @@ public:
             calcMaxTime,
             responseSent);
 
-        if (IsReadWriteRequest(requestType)) {
+        if (IsReadWriteRequest(requestType) &&
+            mediaKind != NProto::STORAGE_MEDIA_DEFAULT)
+        {
             GetRequestCounters(mediaKind).RequestCompleted(
                 static_cast<TRequestCounters::TRequestType>(
                     TranslateLocalRequestType(requestType)),
@@ -346,7 +350,9 @@ public:
             requestTime.TotalTime,
             calcMaxTime);
 
-        if (IsReadWriteRequest(requestType)) {
+        if (IsReadWriteRequest(requestType) &&
+            mediaKind != NProto::STORAGE_MEDIA_DEFAULT)
+        {
             GetRequestCounters(mediaKind).AddIncompleteStats(
                 static_cast<TRequestCounters::TRequestType>(
                     TranslateLocalRequestType(requestType)),
@@ -433,7 +439,9 @@ public:
             timeHist,
             sizeHist);
 
-        if (IsReadWriteRequest(requestType)) {
+        if (IsReadWriteRequest(requestType) &&
+            mediaKind != NProto::STORAGE_MEDIA_DEFAULT)
+        {
             GetRequestCounters(mediaKind).BatchCompleted(
                 static_cast<TRequestCounters::TRequestType>(requestType),
                 count,

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -624,6 +624,17 @@ public:
         return infoIt->second;
     }
 
+    NProto::EStorageMediaKind GetStorageMediaKind(
+        const TString& diskId) const override
+    {
+        TReadGuard guard(Lock);
+
+        const auto volumeIt = Volumes.find(diskId);
+        return volumeIt != Volumes.end()
+                   ? volumeIt->second.VolumeBase->Volume.GetStorageMediaKind()
+                   : NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
+    }
+
     ui32 GetBlockSize(const TString& diskId) const override
     {
         TWriteGuard guard(Lock);
@@ -995,6 +1006,14 @@ struct TVolumeStatsStub final
         Y_UNUSED(clientId);
 
         return nullptr;
+    }
+
+    NProto::EStorageMediaKind GetStorageMediaKind(
+        const TString& diskId) const override
+    {
+        Y_UNUSED(diskId);
+
+        return NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
     }
 
     ui32 GetBlockSize(const TString& diskId) const override

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -103,6 +103,9 @@ struct IVolumeStats
         const TString& diskId,
         const TString& clientId) const = 0;
 
+    virtual NProto::EStorageMediaKind GetStorageMediaKind(
+        const TString& diskId) const = 0;
+
     virtual ui32 GetBlockSize(const TString& diskId) const = 0;
 
     virtual void TrimVolumes() = 0;

--- a/cloud/blockstore/libs/diagnostics/volume_stats_test.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_test.h
@@ -236,6 +236,13 @@ public:
         return TVolumeProcessingPolicy::GetVolumeInfo(diskId, clientId);
     }
 
+    NProto::EStorageMediaKind GetStorageMediaKind(
+        const TString& diskId) const override
+    {
+        Y_UNUSED(diskId);
+        return NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
+    }
+
     ui32 GetBlockSize(const TString& diskId) const override
     {
         Y_UNUSED(diskId);

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -146,6 +146,13 @@ struct TVolumeStatsTestMock final
         return nullptr;
     }
 
+    NProto::EStorageMediaKind GetStorageMediaKind(
+        const TString& diskId) const override
+    {
+        Y_UNUSED(diskId);
+        return NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
+    }
+
     ui32 GetBlockSize(const TString& diskId) const override
     {
         Y_UNUSED(diskId);


### PR DESCRIPTION
Тут мы можем получить nullptr в volumeInfo
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/client/session.cpp#L954
GetStorageMediaKind(nullptr) -> STORAGE_MEDIA_DEFAULT
STORAGE_MEDIA_DEFAULT превращается в TotalHDD
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/diagnostics/request_stats.cpp#L498
и начинаем всю статистику ретраев валить в hdd