### PR TITLE
[Disk Manager]: Add separate certificate for IAM

### DIFF
--- a/cloud/disk_manager/internal/pkg/auth/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/auth/config/config.proto
@@ -12,6 +12,7 @@ message ServiceAccount {
     required string Id = 1;
     required string KeyId = 2;
     required string Audience = 3;
+    required string CertFile = 4;
 }
 
 message AuthConfig {

--- a/cloud/disk_manager/internal/pkg/auth/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/auth/config/config.proto
@@ -12,7 +12,7 @@ message ServiceAccount {
     required string Id = 1;
     required string KeyId = 2;
     required string Audience = 3;
-    required string CertFile = 4;
+    required string TokenPrivateKeyFile = 4;
 }
 
 message AuthConfig {

--- a/cloud/disk_manager/internal/pkg/auth/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/auth/config/config.proto
@@ -12,7 +12,7 @@ message ServiceAccount {
     required string Id = 1;
     required string KeyId = 2;
     required string Audience = 3;
-    required string TokenPrivateKeyFile = 4;
+    required string TokenSigningCertFile = 4;
 }
 
 message AuthConfig {

--- a/cloud/disk_manager/internal/pkg/auth/credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials.go
@@ -39,7 +39,7 @@ func NewCredentials(
 			credentials.WithJWTSubjectToken(
 				credentials.WithSigningMethod(jwt.SigningMethodRS256),
 				credentials.WithKeyID(config.GetServiceAccount().GetKeyId()),
-				credentials.WithRSAPrivateKeyPEMFile(config.GetServiceAccount().GetCertFile()),
+				credentials.WithRSAPrivateKeyPEMFile(config.GetServiceAccount().GetTokenPrivateKeyFile()),
 				credentials.WithIssuer(config.GetServiceAccount().GetId()),
 				credentials.WithSubject(config.GetServiceAccount().GetId()),
 				credentials.WithAudience(config.GetServiceAccount().GetAudience()),

--- a/cloud/disk_manager/internal/pkg/auth/credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials.go
@@ -39,7 +39,7 @@ func NewCredentials(
 			credentials.WithJWTSubjectToken(
 				credentials.WithSigningMethod(jwt.SigningMethodRS256),
 				credentials.WithKeyID(config.GetServiceAccount().GetKeyId()),
-				credentials.WithRSAPrivateKeyPEMFile(config.GetCertFile()),
+				credentials.WithRSAPrivateKeyPEMFile(config.GetServiceAccount().GetCertFile()),
 				credentials.WithIssuer(config.GetServiceAccount().GetId()),
 				credentials.WithSubject(config.GetServiceAccount().GetId()),
 				credentials.WithAudience(config.GetServiceAccount().GetAudience()),

--- a/cloud/disk_manager/internal/pkg/auth/credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials.go
@@ -39,7 +39,7 @@ func NewCredentials(
 			credentials.WithJWTSubjectToken(
 				credentials.WithSigningMethod(jwt.SigningMethodRS256),
 				credentials.WithKeyID(config.GetServiceAccount().GetKeyId()),
-				credentials.WithRSAPrivateKeyPEMFile(config.GetServiceAccount().GetTokenPrivateKeyFile()),
+				credentials.WithRSAPrivateKeyPEMFile(config.GetServiceAccount().GetTokenSigningCertFile()),
 				credentials.WithIssuer(config.GetServiceAccount().GetId()),
 				credentials.WithSubject(config.GetServiceAccount().GetId()),
 				credentials.WithAudience(config.GetServiceAccount().GetAudience()),


### PR DESCRIPTION
AuthConfig.CertFile is intended as a certificate for verifying TLS for access service, not for token signing. Fix the semantic.