### PR TITLE
issue 1394: optimize cleanup devices

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -275,7 +275,7 @@ void TDiskRegistryActor::ExecuteCleanupDevices(
 {
     TDiskRegistryDatabase db(tx.DB);
     args.SyncDeallocatedDisks =
-        State->MarkDeviceAsClean(ctx.Now(), db, args.Devices);
+        State->MarkDevicesAsClean(ctx.Now(), db, args.Devices);
 }
 
 void TDiskRegistryActor::CompleteCleanupDevices(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -273,16 +273,9 @@ void TDiskRegistryActor::ExecuteCleanupDevices(
     TTransactionContext& tx,
     TTxDiskRegistry::TCleanupDevices& args)
 {
-    Y_UNUSED(ctx);
-
     TDiskRegistryDatabase db(tx.DB);
-
-    for (const auto& uuid: args.Devices) {
-        auto diskId = State->MarkDeviceAsClean(ctx.Now(), db, uuid);
-        if (diskId) {
-            args.SyncDeallocatedDisks.push_back(std::move(diskId));
-        }
-    }
+    args.SyncDeallocatedDisks =
+        State->MarkDeviceAsClean(ctx.Now(), db, args.Devices);
 }
 
 void TDiskRegistryActor::CompleteCleanupDevices(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3644,7 +3644,7 @@ TVector<TDiskRegistryState::TDeviceId> TDiskRegistryState::TryUpdateDevices(
         }
         ret.push_back(uuid);
         agentsMap.emplace(agent->agentid());
-        AdjustDeviceIfNeeded(*device, {});
+        AdjustDeviceIfNeeded(*device, Now());
     }
 
     for (const auto& agentId: agentsMap) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3585,21 +3585,37 @@ bool TDiskRegistryState::MarkDeviceAsDirty(
     return true;
 }
 
-TString TDiskRegistryState::MarkDeviceAsClean(
+TDiskRegistryState::TDiskId TDiskRegistryState::MarkDeviceAsClean(
     TInstant now,
     TDiskRegistryDatabase& db,
     const TDeviceId& uuid)
 {
-    DeviceList.MarkDeviceAsClean(uuid);
-    db.DeleteDirtyDevice(uuid);
+    auto ret = MarkDeviceAsClean(now, db, TVector<TDeviceId>{uuid});
+    return ret.empty() ? "" : ret[0];
+}
 
-    if (!DeviceList.IsSuspendedDevice(uuid)) {
-        db.DeleteSuspendedDevice(uuid);
+TVector<TDiskRegistryState::TDiskId> TDiskRegistryState::MarkDeviceAsClean(
+    TInstant now,
+    TDiskRegistryDatabase& db,
+    const TVector<TDeviceId>& uuids)
+{
+    for (const auto& uuid: uuids) {
+        DeviceList.MarkDeviceAsClean(uuid);
+        db.DeleteDirtyDevice(uuid);
+
+        if (!DeviceList.IsSuspendedDevice(uuid)) {
+            db.DeleteSuspendedDevice(uuid);
+        }
     }
 
-    TryUpdateDevice(now, db, uuid);
+    TVector<TDiskId> ret;
+    for (const auto& uuid: TryUpdateDevices(now, db, uuids)) {
+        if (auto diskId = PendingCleanup.EraseDevice(uuid); !diskId.empty()) {
+            ret.push_back(std::move(diskId));
+        }
+    }
 
-    return PendingCleanup.EraseDevice(uuid);
+    return ret;
 }
 
 bool TDiskRegistryState::TryUpdateDevice(
@@ -3607,19 +3623,36 @@ bool TDiskRegistryState::TryUpdateDevice(
     TDiskRegistryDatabase& db,
     const TDeviceId& uuid)
 {
+    return !TryUpdateDevices(now, db, {uuid}).empty();
+}
+
+TVector<TDiskRegistryState::TDeviceId> TDiskRegistryState::TryUpdateDevices(
+    TInstant now,
+    TDiskRegistryDatabase& db,
+    const TVector<TDeviceId>& uuids)
+{
     Y_UNUSED(now);
 
-    auto [agent, device] = FindDeviceLocation(uuid);
-    if (!agent || !device) {
-        return false;
+    TVector<TDeviceId> ret;
+    ret.reserve(uuids.size());
+
+    TMap<TString, NProto::TAgentConfig*> agentsMap;
+    for(const auto& uuid : uuids) {
+        auto [agent, device] = FindDeviceLocation(uuid);
+        if (!agent || !device) {
+            continue;
+        }
+        ret.push_back(uuid);
+        agentsMap.emplace(agent->agentid(), agent);
+        AdjustDeviceIfNeeded(*device, {});
     }
 
-    AdjustDeviceIfNeeded(*device, {});
+    for(const auto& [_, agent] : agentsMap) {
+        UpdateAgent(db, *agent);
+        DeviceList.UpdateDevices(*agent, DevicePoolConfigs);
+    }
 
-    UpdateAgent(db, *agent);
-    DeviceList.UpdateDevices(*agent, DevicePoolConfigs);
-
-    return true;
+    return ret;
 }
 
 TVector<TString> TDiskRegistryState::CollectBrokenDevices(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3590,11 +3590,11 @@ TDiskRegistryState::TDiskId TDiskRegistryState::MarkDeviceAsClean(
     TDiskRegistryDatabase& db,
     const TDeviceId& uuid)
 {
-    auto ret = MarkDeviceAsClean(now, db, TVector<TDeviceId>{uuid});
+    auto ret = MarkDevicesAsClean(now, db, TVector<TDeviceId>{uuid});
     return ret.empty() ? "" : ret[0];
 }
 
-TVector<TDiskRegistryState::TDiskId> TDiskRegistryState::MarkDeviceAsClean(
+TVector<TDiskRegistryState::TDiskId> TDiskRegistryState::MarkDevicesAsClean(
     TInstant now,
     TDiskRegistryDatabase& db,
     const TVector<TDeviceId>& uuids)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3631,8 +3631,6 @@ TVector<TDiskRegistryState::TDeviceId> TDiskRegistryState::TryUpdateDevices(
     TDiskRegistryDatabase& db,
     const TVector<TDeviceId>& uuids)
 {
-    Y_UNUSED(now);
-
     TVector<TDeviceId> ret;
     ret.reserve(uuids.size());
 
@@ -3644,7 +3642,7 @@ TVector<TDiskRegistryState::TDeviceId> TDiskRegistryState::TryUpdateDevices(
         }
         ret.push_back(uuid);
         agentsMap.emplace(agent->agentid());
-        AdjustDeviceIfNeeded(*device, Now());
+        AdjustDeviceIfNeeded(*device, now);
     }
 
     for (const auto& agentId: agentsMap) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -497,7 +497,7 @@ public:
         TInstant now,
         TDiskRegistryDatabase& db,
         const TDeviceId& uuid);
-    TVector<TDiskId> MarkDeviceAsClean(
+    TVector<TDiskId> MarkDevicesAsClean(
         TInstant now,
         TDiskRegistryDatabase& db,
         const TVector<TDeviceId>& uuids);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1133,6 +1133,7 @@ private:
 
     /// Try to update configuration of selected device and its agent
     /// in the disk registry database
+    /// @return true if the device updates successfully; otherwise, return false
     bool TryUpdateDevice(
         TInstant now,
         TDiskRegistryDatabase& db,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -493,10 +493,14 @@ public:
     TVector<NProto::TDeviceConfig> GetBrokenDevices() const;
 
     TVector<NProto::TDeviceConfig> GetDirtyDevices() const;
-    TString MarkDeviceAsClean(
+    TDiskId MarkDeviceAsClean(
         TInstant now,
         TDiskRegistryDatabase& db,
         const TDeviceId& uuid);
+    TVector<TDiskId> MarkDeviceAsClean(
+        TInstant now,
+        TDiskRegistryDatabase& db,
+        const TVector<TDeviceId>& uuids);
     bool MarkDeviceAsDirty(TDiskRegistryDatabase& db, const TDeviceId& uuid);
 
     NProto::TError CreatePlacementGroup(
@@ -1123,6 +1127,11 @@ private:
         TInstant now,
         TDiskRegistryDatabase& db,
         const TDeviceId& uuid);
+
+    TVector<TDeviceId> TryUpdateDevices(
+        TInstant now,
+        TDiskRegistryDatabase& db,
+        const TVector<TDeviceId>& uuids);
 
     TDeviceList::TAllocationQuery MakeMigrationQuery(
         const TDiskId& sourceDiskId,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -493,10 +493,18 @@ public:
     TVector<NProto::TDeviceConfig> GetBrokenDevices() const;
 
     TVector<NProto::TDeviceConfig> GetDirtyDevices() const;
+
+    /// Mark selected device as clean and remove it
+    /// from lists of suspended/dirty/pending cleanup devices
+    /// @return disk id where selected device was allocated
     TDiskId MarkDeviceAsClean(
         TInstant now,
         TDiskRegistryDatabase& db,
         const TDeviceId& uuid);
+
+    /// Mark selected devices as clean and remove them
+    /// from lists of suspended/dirty/pending cleanup devices
+    /// @return vector of disk ids where selected devices were allocated
     TVector<TDiskId> MarkDevicesAsClean(
         TInstant now,
         TDiskRegistryDatabase& db,
@@ -1123,11 +1131,16 @@ private:
         TDiskRegistryDatabase& db,
         const TString& diskId);
 
+    /// Try to update configuration of selected device and its agent
+    /// in the disk registry database
     bool TryUpdateDevice(
         TInstant now,
         TDiskRegistryDatabase& db,
         const TDeviceId& uuid);
 
+    /// Try to update configuration of selected devices and their agents
+    /// in the disk registry database
+    /// @return List of updated devices
     TVector<TDeviceId> TryUpdateDevices(
         TInstant now,
         TDiskRegistryDatabase& db,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -11602,7 +11602,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
             {
-                const auto& cleanDisks = state.MarkDeviceAsClean(
+                const auto& cleanDisks = state.MarkDevicesAsClean(
                     Now(),
                     db,
                     TVector<TString>{"uuid-1", "uuid-2"});
@@ -11641,7 +11641,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
             {
-                const auto& cleanDisks = state.MarkDeviceAsClean(
+                const auto& cleanDisks = state.MarkDevicesAsClean(
                     Now(),
                     db,
                     TVector<TString>{"uuid-1", "uuid-2"});

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
@@ -110,7 +110,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                         return config;
                     }())
                 .WithAgents(agents)
-                .WithDirtyDevices({"uuid-1.1"})
+                .WithDirtyDevices({TDirtyDevice{"uuid-1.1", {}}})
                 .Build();
 
         auto agentsInfo = state.QueryAgentsInfo();

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
@@ -59,11 +59,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({ Disk("disk-1", {"uuid-1.1"}) })
-            .WithDirtyDevices({"uuid-2.1"})
-            .Build();
+        TDiskRegistryState state =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents(agents)
+                .WithDisks({Disk("disk-1", {"uuid-1.1"})})
+                .WithDirtyDevices({TDirtyDevice{"uuid-2.1", {}}})
+                .Build();
 
         auto deviceByName = [] (auto agentId, auto name) {
             NProto::TDeviceConfig config;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -66,14 +66,18 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({
-                Disk("foo", { "uuid-1.1", "uuid-1.2" }),    // rack-1
-                Disk("bar", { "uuid-2.1" })                 // rack-2
-            })
-            .WithDirtyDevices({"uuid-4.1", "uuid-4.2", "uuid-4.3"})
-            .Build();
+        TDiskRegistryState state =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents(agents)
+                .WithDisks({
+                    Disk("foo", {"uuid-1.1", "uuid-1.2"}),   // rack-1
+                    Disk("bar", {"uuid-2.1"})                // rack-2
+                })
+                .WithDirtyDevices(
+                    {TDirtyDevice{"uuid-4.1", {}},
+                     TDirtyDevice{"uuid-4.2", {}},
+                     TDirtyDevice{"uuid-4.3", {}}})
+                .Build();
 
         UNIT_ASSERT(state.IsMigrationListEmpty());
 

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
@@ -561,16 +561,9 @@ TDiskRegistryStateBuilder& TDiskRegistryStateBuilder::WithDisks(
 }
 
 TDiskRegistryStateBuilder& TDiskRegistryStateBuilder::WithDirtyDevices(
-    TVector<TString> dirtyDevices)
+    TVector<TDirtyDevice> dirtyDevices)
 {
-    DirtyDevices.clear();
-    DirtyDevices.reserve(dirtyDevices.size());
-    for (auto& s: dirtyDevices) {
-        DirtyDevices.emplace_back(TDirtyDevice {
-            .Id = std::move(s)
-        });
-    }
-
+    DirtyDevices = std::move(dirtyDevices);
     return *this;
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h
@@ -276,7 +276,7 @@ struct TDiskRegistryStateBuilder
 
     TDiskRegistryStateBuilder& WithDisks(TVector<NProto::TDiskConfig> disks);
 
-    TDiskRegistryStateBuilder& WithDirtyDevices(TVector<TString> dirtyDevices);
+    TDiskRegistryStateBuilder& WithDirtyDevices(TVector<TDirtyDevice> dirtyDevices);
 
     TDiskRegistryStateBuilder& WithSuspendedDevices(
         TVector<TString> suspendedDevices);


### PR DESCRIPTION
Issue: #1394

1. Pass all devices as an argument for MarkDevicesAsClean
2. Update each agent only once.

TryUpdateDevices iterates via devices and save agents in the map to call UpdateAgent and DeviceList.UpdateDevices for each agent only once.