### PR TITLE
issue-1146: preliminary changes: extract some localdb methods to the interface, add stub for index cache

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -390,7 +390,7 @@ bool TIndexTabletActor::PrepareTx_AddBlob(
 
     bool ready = true;
     for (auto [id, maxOffset]: args.WriteRanges) {
-        TMaybe<TIndexTabletDatabase::TNode> node;
+        TMaybe<IIndexState::TNode> node;
         if (!ReadNode(db, id, args.CommitId, node)) {
             ready = false;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -490,7 +490,7 @@ bool TIndexTabletActor::PrepareTx_Compaction(
 
     bool ready = true;
     for (auto nodeId: nodes) {
-        TMaybe<TIndexTabletDatabase::TNode> node;
+        TMaybe<IIndexState::TNode> node;
         if (!ReadNode(db, nodeId, args.CommitId, node)) {
             ready = false;
             continue;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -111,7 +111,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
         }
 
         // check whether child node exists
-        TMaybe<TIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<IIndexState::TNodeRef> ref;
         if (!ReadNodeRef(db, args.NodeId, args.ReadCommitId, args.Name, ref)) {
             return false;   // not ready
         }
@@ -192,7 +192,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             args.WriteCommitId,
             attrs);
 
-        args.TargetNode = TIndexTabletDatabase::TNode {
+        args.TargetNode = IIndexState::TNode {
             args.TargetNodeId,
             attrs,
             args.WriteCommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -152,7 +152,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
     TABLET_VERIFY(args.ParentNode);
 
     // validate target node doesn't exist
-    TMaybe<TIndexTabletDatabase::TNodeRef> childRef;
+    TMaybe<IIndexState::TNodeRef> childRef;
     if (!ReadNodeRef(db, args.ParentNodeId, args.CommitId, args.Name, childRef)) {
         return false;   // not ready
     }
@@ -216,7 +216,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             args.CommitId,
             args.Attrs);
 
-        args.ChildNode = TIndexTabletDatabase::TNode {
+        args.ChildNode = IIndexState::TNode {
             args.ChildNodeId,
             args.Attrs,
             args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -84,7 +84,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
 
             if (ready) {
                 for (ui64 nodeId: args.NodeIds) {
-                    TMaybe<TIndexTabletDatabase::TNode> node;
+                    TMaybe<IIndexState::TNode> node;
                     if (!db.ReadNodeVer(nodeId, args.CommitId, node)) {
                         ready = false;
                     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -100,7 +100,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
             continue;
         }
 
-        TMaybe<TIndexTabletDatabase::TNode> node;
+        TMaybe<IIndexState::TNode> node;
         if (!ReadNode(db, handle.GetNodeId(), commitId, node)) {
             ready = false;
         } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
@@ -66,7 +66,7 @@ bool TIndexTabletActor::PrepareTx_FilterAliveNodes(
     TIndexTabletDatabase db(tx.DB);
 
     args.CommitId = GetCurrentCommitId();
-    TMaybe<TIndexTabletDatabase::TNode> node;
+    TMaybe<IIndexState::TNode> node;
 
     bool ready = true;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -130,7 +130,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttr(
         TABLET_VERIFY(args.ParentNode);
 
         // validate target node exists
-        TMaybe<TIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<IIndexState::TNodeRef> ref;
         if (!ReadNodeRef(db, args.NodeId, args.CommitId, args.Name, ref)) {
             return false;   // not ready
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -171,7 +171,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
             }
 
             // 1 entry is enough to prevent rename
-            TVector<TIndexTabletDatabase::TNodeRef> refs;
+            TVector<IIndexState::TNodeRef> refs;
             if (!ReadNodeRefs(db, args.NewChildNode->NodeId, args.CommitId, {}, refs, 1)) {
                 return false;
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -86,7 +86,7 @@ bool TIndexTabletActor::PrepareTx_ResetSession(
             continue;
         }
 
-        TMaybe<TIndexTabletDatabase::TNode> node;
+        TMaybe<IIndexState::TNode> node;
         if (!ReadNode(db, handle.GetNodeId(), commitId, node)) {
             ready = false;
         } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -111,7 +111,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
     // TODO: AccessCheck
     TABLET_VERIFY(args.ChildNode);
     if (args.ChildNode->Attrs.GetType() == NProto::E_DIRECTORY_NODE) {
-        TVector<TIndexTabletDatabase::TNodeRef> refs;
+        TVector<IIndexState::TNodeRef> refs;
         // 1 entry is enough to prevent deletion
         if (!ReadNodeRefs(db, args.ChildRef->ChildNodeId, args.CommitId, {}, refs, 1)) {
             return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -354,7 +354,7 @@ bool TIndexTabletActor::PrepareTx_WriteBatch(
         // load inodes so we could check and update stats later
         auto it = args.Nodes.find(write.NodeId);
         if (it == args.Nodes.end()) {
-            TMaybe<TIndexTabletDatabase::TNode> node;
+            TMaybe<IIndexState::TNode> node;
             if (!ReadNode(db, write.NodeId, args.CommitId, node)) {
                 ready = false;
                 continue;

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -155,7 +155,7 @@ void TIndexTabletDatabase::DeleteNode(ui64 nodeId)
 bool TIndexTabletDatabase::ReadNode(
     ui64 nodeId,
     ui64 commitId,
-    TMaybe<TIndexTabletDatabase::TNode>& node)
+    TMaybe<IIndexState::TNode>& node)
 {
     using TTable = TIndexTabletSchema::Nodes;
 
@@ -215,7 +215,7 @@ void TIndexTabletDatabase::DeleteNodeVer(ui64 nodeId, ui64 commitId)
 bool TIndexTabletDatabase::ReadNodeVer(
     ui64 nodeId,
     ui64 commitId,
-    TMaybe<TIndexTabletDatabase::TNode>& node)
+    TMaybe<IIndexState::TNode>& node)
 {
     using TTable = TIndexTabletSchema::Nodes_Ver;
 
@@ -507,7 +507,7 @@ bool TIndexTabletDatabase::ReadNodeRef(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
-    TMaybe<TIndexTabletDatabase::TNodeRef>& ref)
+    TMaybe<IIndexState::TNodeRef>& ref)
 {
     using TTable = TIndexTabletSchema::NodeRefs;
 
@@ -640,7 +640,7 @@ bool TIndexTabletDatabase::ReadNodeRefVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
-    TMaybe<TIndexTabletDatabase::TNodeRef>& ref)
+    TMaybe<IIndexState::TNodeRef>& ref)
 {
     using TTable = TIndexTabletSchema::NodeRefs_Ver;
 
@@ -685,7 +685,7 @@ bool TIndexTabletDatabase::ReadNodeRefVer(
 bool TIndexTabletDatabase::ReadNodeRefVers(
     ui64 nodeId,
     ui64 commitId,
-    TVector<TIndexTabletDatabase::TNodeRef>& refs)
+    TVector<IIndexState::TNodeRef>& refs)
 {
     using TTable = TIndexTabletSchema::NodeRefs_Ver;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "tablet_state_iface.h"
+
 #include <cloud/filestore/config/storage.pb.h>
 #include <cloud/filestore/libs/storage/tablet/model/block_list.h>
 #include <cloud/filestore/libs/storage/tablet/model/compaction_map.h>
@@ -58,7 +60,8 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 class TIndexTabletDatabase
-    : public NKikimr::NIceDb::TNiceDb
+    : public IIndexState
+    , public NKikimr::NIceDb::TNiceDb
 {
 public:
     TIndexTabletDatabase(NKikimr::NTable::TDatabase& database)
@@ -98,15 +101,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     void WriteNode(ui64 nodeId, ui64 commitId, const NProto::TNode& attrs);
     void DeleteNode(ui64 nodeId);
 
-    struct TNode
-    {
-        ui64 NodeId;
-        NProto::TNode Attrs;
-        ui64 MinCommitId;
-        ui64 MaxCommitId;
-    };
-
-    bool ReadNode(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node);
+    bool ReadNode(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) override;
 
     //
     // Nodes_Ver
@@ -120,7 +115,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 
     void DeleteNodeVer(ui64 nodeId, ui64 commitId);
 
-    bool ReadNodeVer(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node);
+    bool ReadNodeVer(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) override;
 
     //
     // NodeAttrs
@@ -135,23 +130,16 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 
     void DeleteNodeAttr(ui64 nodeId, const TString& name);
 
-    struct TNodeAttr
-    {
-        ui64 NodeId;
-        TString Name;
-        TString Value;
-        ui64 MinCommitId;
-        ui64 MaxCommitId;
-        ui64 Version;
-    };
-
     bool ReadNodeAttr(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<TNodeAttr>& attr);
+        TMaybe<TNodeAttr>& attr) override;
 
-    bool ReadNodeAttrs(ui64 nodeId, ui64 commitId, TVector<TNodeAttr>& attrs);
+    bool ReadNodeAttrs(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeAttr>& attrs) override;
 
     //
     // NodeAttrs_Ver
@@ -171,12 +159,12 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<TNodeAttr>& attr);
+        TMaybe<TNodeAttr>& attr) override;
 
     bool ReadNodeAttrVers(
         ui64 nodeId,
         ui64 commitId,
-        TVector<TNodeAttr>& attrs);
+        TVector<TNodeAttr>& attrs) override;
 
     //
     // NodeRefs
@@ -190,20 +178,11 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 
     void DeleteNodeRef(ui64 nodeId, const TString& name);
 
-    struct TNodeRef
-    {
-        ui64 NodeId;
-        TString Name;
-        ui64 ChildNodeId;
-        ui64 MinCommitId;
-        ui64 MaxCommitId;
-    };
-
     bool ReadNodeRef(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<TNodeRef>& ref);
+        TMaybe<TNodeRef>& ref) override;
 
     bool ReadNodeRefs(
         ui64 nodeId,
@@ -211,7 +190,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& cookie,
         TVector<TNodeRef>& refs,
         ui32 maxBytes,
-        TString* next = nullptr);
+        TString* next = nullptr) override;
 
     bool PrechargeNodeRefs(
         ui64 nodeId,
@@ -235,9 +214,12 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<TNodeRef>& ref);
+        TMaybe<TNodeRef>& ref) override;
 
-    bool ReadNodeRefVers(ui64 nodeId, ui64 commitId, TVector<TNodeRef>& refs);
+    bool ReadNodeRefVers(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeRef>& refs) override;
 
     //
     // TruncateQueue

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -72,15 +72,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         });
 
         executor.ReadTx([&] (TIndexTabletDatabase db) {
-            TMaybe<TIndexTabletDatabase::TNode> node1;
+            TMaybe<IIndexState::TNode> node1;
             UNIT_ASSERT(db.ReadNode(nodeId1, commitId, node1));
             UNIT_ASSERT(node1);
 
-            TMaybe<TIndexTabletDatabase::TNode> node2;
+            TMaybe<IIndexState::TNode> node2;
             UNIT_ASSERT(db.ReadNode(nodeId2, commitId, node2));
             UNIT_ASSERT(node2);
 
-            TMaybe<TIndexTabletDatabase::TNode> node3;
+            TMaybe<IIndexState::TNode> node3;
             UNIT_ASSERT(db.ReadNode(12345, commitId, node3));
             UNIT_ASSERT(!node3);
         });
@@ -140,15 +140,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         });
 
         executor.ReadTx([&] (TIndexTabletDatabase db) {
-            TMaybe<TIndexTabletDatabase::TNodeRef> ref1;
+            TMaybe<IIndexState::TNodeRef> ref1;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child1", ref1));
             UNIT_ASSERT_EQUAL(ref1->ChildNodeId, childNodeId1);
 
-            TMaybe<TIndexTabletDatabase::TNodeRef> ref2;
+            TMaybe<IIndexState::TNodeRef> ref2;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child2", ref2));
             UNIT_ASSERT_EQUAL(ref2->ChildNodeId, childNodeId2);
 
-            TMaybe<TIndexTabletDatabase::TNodeRef> ref3;
+            TMaybe<IIndexState::TNodeRef> ref3;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child3", ref3));
             UNIT_ASSERT(!ref3);
         });

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -337,7 +337,7 @@ public:
 
     void RemoveNode(
         TIndexTabletDatabase& db,
-        const TIndexTabletDatabase::TNode& node,
+        const IIndexState::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId);
 
@@ -345,15 +345,15 @@ public:
         TIndexTabletDatabase& db,
         ui64 parentNodeId,
         const TString& name,
-        const TIndexTabletDatabase::TNode& node,
+        const IIndexState::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId);
 
     bool ReadNode(
-        TIndexTabletDatabase& db,
+        IIndexState& db,
         ui64 nodeId,
         ui64 commitId,
-        TMaybe<TIndexTabletDatabase::TNode>& node);
+        TMaybe<IIndexState::TNode>& node);
 
     void RewriteNode(
         TIndexTabletDatabase& db,
@@ -403,14 +403,14 @@ public:
         const TIndexTabletDatabase::TNodeAttr& attr);
 
     bool ReadNodeAttr(
-        TIndexTabletDatabase& db,
+        IIndexState& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<TIndexTabletDatabase::TNodeAttr>& attr);
 
     bool ReadNodeAttrs(
-        TIndexTabletDatabase& db,
+        IIndexState& db,
         ui64 nodeId,
         ui64 commitId,
         TVector<TIndexTabletDatabase::TNodeAttr>& attrs);
@@ -443,18 +443,18 @@ public:
         ui64 prevChildNodeId);
 
     bool ReadNodeRef(
-        TIndexTabletDatabase& db,
+        IIndexState& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<TIndexTabletDatabase::TNodeRef>& ref);
+        TMaybe<IIndexState::TNodeRef>& ref);
 
     bool ReadNodeRefs(
-        TIndexTabletDatabase& db,
+        IIndexState& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& cookie,
-        TVector<TIndexTabletDatabase::TNodeRef>& refs,
+        TVector<IIndexState::TNodeRef>& refs,
         ui32 maxBytes,
         TString* next = nullptr);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -1,0 +1,116 @@
+#include "helpers.h"
+
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// This interface contains a subset of the methods that can be performed over
+// the localDB tables. Throughout the code two implementations are supported:
+// one for the localDB access, and one for the in-memory cache.
+class IIndexState
+{
+public:
+    struct TNode
+    {
+        ui64 NodeId;
+        NProto::TNode Attrs;
+        ui64 MinCommitId;
+        ui64 MaxCommitId;
+    };
+
+    struct TNodeRef
+    {
+        ui64 NodeId;
+        TString Name;
+        ui64 ChildNodeId;
+        ui64 MinCommitId;
+        ui64 MaxCommitId;
+    };
+
+    struct TNodeAttr
+    {
+        ui64 NodeId;
+        TString Name;
+        TString Value;
+        ui64 MinCommitId;
+        ui64 MaxCommitId;
+        ui64 Version;
+    };
+
+public:
+    virtual ~IIndexState() = default;
+
+    //
+    // Nodes
+    //
+
+    virtual bool ReadNode(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) = 0;
+
+    //
+    // NodeAttrs
+    //
+
+    virtual bool ReadNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) = 0;
+
+    virtual bool
+    ReadNodeAttrs(ui64 nodeId, ui64 commitId, TVector<TNodeAttr>& attrs) = 0;
+
+    //
+    // NodeRefs
+    //
+
+    virtual bool ReadNodeRef(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeRef>& ref) = 0;
+
+    virtual bool ReadNodeRefs(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& cookie,
+        TVector<TNodeRef>& refs,
+        ui32 maxBytes,
+        TString* next) = 0;
+
+    //
+    // Nodes_Ver
+    //
+
+    virtual bool
+    ReadNodeVer(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) = 0;
+
+    //
+    // NodeAttrs_Ver
+    //
+
+    virtual bool ReadNodeAttrVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) = 0;
+
+    virtual bool
+    ReadNodeAttrVers(ui64 nodeId, ui64 commitId, TVector<TNodeAttr>& attrs) = 0;
+
+    //
+    // NodeRefs_Ver
+    //
+
+    virtual bool ReadNodeRefVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeRef>& ref) = 0;
+
+    virtual bool
+    ReadNodeRefVers(ui64 nodeId, ui64 commitId, TVector<TNodeRef>& refs) = 0;
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -4,6 +4,7 @@
 
 #include "tablet_schema.h"
 #include "tablet_state.h"
+#include "tablet_state_in_memory_index_state.h"
 
 #include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/block_list.h>
@@ -52,6 +53,8 @@ struct TIndexTabletState::TImpl
     TTruncateQueue TruncateQueue;
     TReadAheadCache ReadAheadCache;
     TNodeIndexCache NodeIndexCache;
+    TInMemoryIndexState InMemoryIndexState;
+
 
     TCheckpointStore Checkpoints;
     TChannels Channels;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_in_memory_index_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_in_memory_index_state.cpp
@@ -1,0 +1,124 @@
+#include "tablet_state_in_memory_index_state.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TInMemoryIndexState::ReadNode(
+    ui64 nodeId,
+    ui64 commitId,
+    TMaybe<TNode>& node)
+{
+    Y_UNUSED(nodeId, commitId, node);
+    return false;
+}
+
+//
+// NodeAttrs
+//
+
+bool TInMemoryIndexState::ReadNodeAttr(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeAttr>& attr)
+{
+    Y_UNUSED(nodeId, commitId, name, attr);
+    return false;
+}
+
+bool TInMemoryIndexState::ReadNodeAttrs(
+    ui64 nodeId,
+    ui64 commitId,
+    TVector<TNodeAttr>& attrs)
+{
+    Y_UNUSED(nodeId, commitId, attrs);
+    return false;
+}
+
+//
+// NodeRefs
+//
+
+bool TInMemoryIndexState::ReadNodeRef(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeRef>& ref)
+{
+    Y_UNUSED(nodeId, commitId, name, ref);
+    return false;
+}
+
+bool TInMemoryIndexState::ReadNodeRefs(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& cookie,
+    TVector<TNodeRef>& refs,
+    ui32 maxBytes,
+    TString* next)
+{
+    Y_UNUSED(nodeId, commitId, cookie, refs, maxBytes, next);
+    return false;
+}
+
+//
+// Nodes_Ver
+//
+
+bool TInMemoryIndexState::ReadNodeVer(
+    ui64 nodeId,
+    ui64 commitId,
+    TMaybe<TNode>& node)
+{
+    Y_UNUSED(nodeId, commitId, node);
+    return false;
+}
+
+//
+// NodeAttrs_Ver
+//
+
+bool TInMemoryIndexState::ReadNodeAttrVer(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeAttr>& attr)
+{
+    Y_UNUSED(nodeId, commitId, name, attr);
+    return false;
+}
+
+bool TInMemoryIndexState::ReadNodeAttrVers(
+    ui64 nodeId,
+    ui64 commitId,
+    TVector<TNodeAttr>& attrs)
+{
+    Y_UNUSED(nodeId, commitId, attrs);
+    return false;
+}
+
+//
+// NodeRefs_Ver
+//
+
+bool TInMemoryIndexState::ReadNodeRefVer(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeRef>& ref)
+{
+    Y_UNUSED(nodeId, commitId, name, ref);
+    return false;
+}
+
+bool TInMemoryIndexState::ReadNodeRefVers(
+    ui64 nodeId,
+    ui64 commitId,
+    TVector<TNodeRef>& refs)
+{
+    Y_UNUSED(nodeId, commitId, refs);
+    return false;
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_in_memory_index_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_in_memory_index_state.h
@@ -1,0 +1,90 @@
+#pragma once
+#include "public.h"
+
+#include <cloud/filestore/libs/storage/tablet/tablet_database.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Stores a subset of the actual index state for caching purposes.
+class TInMemoryIndexState: public IIndexState
+{
+public:
+    //
+    // Nodes
+    //
+
+    bool ReadNode(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) override;
+
+    //
+    // NodeAttrs
+    //
+
+    bool ReadNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) override;
+
+    bool ReadNodeAttrs(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeAttr>& attrs) override;
+
+    //
+    // NodeRefs
+    //
+
+    bool ReadNodeRef(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeRef>& ref) override;
+
+    bool ReadNodeRefs(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& cookie,
+        TVector<TNodeRef>& refs,
+        ui32 maxBytes,
+        TString* next) override;
+
+    //
+    // Nodes_Ver
+    //
+
+    bool ReadNodeVer(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) override;
+
+    //
+    // NodeAttrs_Ver
+    //
+
+    bool ReadNodeAttrVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) override;
+
+    bool ReadNodeAttrVers(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeAttr>& attrs) override;
+
+    //
+    // NodeRefs_Ver
+    //
+
+    bool ReadNodeRefVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeRef>& ref) override;
+
+    bool ReadNodeRefVers(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeRef>& refs) override;
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -97,7 +97,7 @@ void TIndexTabletState::UpdateNode(
 
 void TIndexTabletState::RemoveNode(
     TIndexTabletDatabase& db,
-    const TIndexTabletDatabase::TNode& node,
+    const IIndexState::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId)
 {
@@ -127,7 +127,7 @@ void TIndexTabletState::UnlinkNode(
     TIndexTabletDatabase& db,
     ui64 parentNodeId,
     const TString& name,
-    const TIndexTabletDatabase::TNode& node,
+    const IIndexState::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId)
 {
@@ -158,10 +158,10 @@ void TIndexTabletState::UnlinkNode(
 }
 
 bool TIndexTabletState::ReadNode(
-    TIndexTabletDatabase& db,
+    IIndexState& db,
     ui64 nodeId,
     ui64 commitId,
-    TMaybe<TIndexTabletDatabase::TNode>& node)
+    TMaybe<IIndexState::TNode>& node)
 {
     bool ready = db.ReadNode(nodeId, commitId, node);
 
@@ -285,7 +285,7 @@ void TIndexTabletState::RemoveNodeAttr(
 }
 
 bool TIndexTabletState::ReadNodeAttr(
-    TIndexTabletDatabase& db,
+    IIndexState& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -310,7 +310,7 @@ bool TIndexTabletState::ReadNodeAttr(
 }
 
 bool TIndexTabletState::ReadNodeAttrs(
-    TIndexTabletDatabase& db,
+    IIndexState& db,
     ui64 nodeId,
     ui64 commitId,
     TVector<TIndexTabletDatabase::TNodeAttr>& attrs)
@@ -395,11 +395,11 @@ void TIndexTabletState::RemoveNodeRef(
 }
 
 bool TIndexTabletState::ReadNodeRef(
-    TIndexTabletDatabase& db,
+    IIndexState& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
-    TMaybe<TIndexTabletDatabase::TNodeRef>& ref)
+    TMaybe<IIndexState::TNodeRef>& ref)
 {
     bool ready = db.ReadNodeRef(nodeId, commitId, name, ref);
 
@@ -420,11 +420,11 @@ bool TIndexTabletState::ReadNodeRef(
 }
 
 bool TIndexTabletState::ReadNodeRefs(
-    TIndexTabletDatabase& db,
+    IIndexState& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& cookie,
-    TVector<TIndexTabletDatabase::TNodeRef>& refs,
+    TVector<IIndexState::TNodeRef>& refs,
     ui32 maxBytes,
     TString* next)
 {

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -194,7 +194,7 @@ struct TNodeOps
         return value;
     }
 
-    static auto GetNodeId(const TIndexTabletDatabase::TNode& node)
+    static auto GetNodeId(const IIndexState::TNode& node)
     {
         return node.NodeId;
     }
@@ -219,7 +219,7 @@ struct TNodeOps
 };
 
 using TNodeSet = THashSet<
-    TIndexTabletDatabase::TNode,
+    IIndexState::TNode,
     TNodeOps::TNodeSetHash,
     TNodeOps::TNodeSetEqual>;
 
@@ -261,7 +261,7 @@ struct TTxIndexTablet
         NProto::TFileSystem FileSystem;
         NProto::TFileSystemStats FileSystemStats;
         NCloud::NProto::TTabletStorageInfo TabletStorageInfo;
-        TMaybe<TIndexTabletDatabase::TNode> RootNode;
+        TMaybe<IIndexState::TNode> RootNode;
         TVector<NProto::TSession> Sessions;
         TVector<NProto::TSessionHandle> Handles;
         TVector<NProto::TSessionLock> Locks;
@@ -478,9 +478,9 @@ struct TTxIndexTablet
         ui64 CommitId = InvalidCommitId;
 
         TVector<ui64> NodeIds;
-        TVector<TIndexTabletDatabase::TNode> Nodes;
+        TVector<IIndexState::TNode> Nodes;
         TVector<TIndexTabletDatabase::TNodeAttr> NodeAttrs;
-        TVector<TIndexTabletDatabase::TNodeRef> NodeRefs;
+        TVector<IIndexState::TNodeRef> NodeRefs;
 
         TVector<TIndexTabletDatabase::TCheckpointBlob> Blobs;
         TVector<TIndexTabletDatabase::TMixedBlob> MixedBlobs;
@@ -553,9 +553,9 @@ struct TTxIndexTablet
         const NProto::TNode Attrs;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<IIndexState::TNode> ParentNode;
         ui64 ChildNodeId = InvalidNodeId;
-        TMaybe<TIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<IIndexState::TNode> ChildNode;
 
         NProto::TCreateNodeResponse Response;
 
@@ -596,9 +596,9 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<TIndexTabletDatabase::TNode> ChildNode;
-        TMaybe<TIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<IIndexState::TNode> ParentNode;
+        TMaybe<IIndexState::TNode> ChildNode;
+        TMaybe<IIndexState::TNodeRef> ChildRef;
 
         NProto::TUnlinkNodeResponse Response;
 
@@ -636,13 +636,13 @@ struct TTxIndexTablet
         const ui32 Flags;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<TIndexTabletDatabase::TNode> ChildNode;
-        TMaybe<TIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<IIndexState::TNode> ParentNode;
+        TMaybe<IIndexState::TNode> ChildNode;
+        TMaybe<IIndexState::TNodeRef> ChildRef;
 
-        TMaybe<TIndexTabletDatabase::TNode> NewParentNode;
-        TMaybe<TIndexTabletDatabase::TNode> NewChildNode;
-        TMaybe<TIndexTabletDatabase::TNodeRef> NewChildRef;
+        TMaybe<IIndexState::TNode> NewParentNode;
+        TMaybe<IIndexState::TNode> NewChildNode;
+        TMaybe<IIndexState::TNodeRef> NewChildRef;
 
         NProto::TRenameNodeResponse Response;
 
@@ -684,7 +684,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TAccessNode(
                 TRequestInfoPtr requestInfo,
@@ -713,7 +713,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TReadLink(
                 TRequestInfoPtr requestInfo,
@@ -743,9 +743,9 @@ struct TTxIndexTablet
         const ui32 MaxBytes;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
-        TVector<TIndexTabletDatabase::TNodeRef> ChildRefs;
-        TVector<TIndexTabletDatabase::TNode> ChildNodes;
+        TMaybe<IIndexState::TNode> Node;
+        TVector<IIndexState::TNodeRef> ChildRefs;
+        TVector<IIndexState::TNode> ChildNodes;
         TString Next;
 
         ui32 BytesToPrecharge = 0;
@@ -787,7 +787,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TSetNodeAttr(
                 TRequestInfoPtr requestInfo,
@@ -817,9 +817,9 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<IIndexState::TNode> ParentNode;
         ui64 TargetNodeId = InvalidNodeId;
-        TMaybe<TIndexTabletDatabase::TNode> TargetNode;
+        TMaybe<IIndexState::TNode> TargetNode;
 
         TGetNodeAttr(
                 TRequestInfoPtr requestInfo,
@@ -854,7 +854,7 @@ struct TTxIndexTablet
 
         ui64 Version = 0;
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
         TMaybe<TIndexTabletDatabase::TNodeAttr> Attr;
 
         TSetNodeXAttr(
@@ -889,7 +889,7 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
         TMaybe<TIndexTabletDatabase::TNodeAttr> Attr;
 
         TGetNodeXAttr(
@@ -921,7 +921,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
         TVector<TIndexTabletDatabase::TNodeAttr> Attrs;
 
         TListNodeXAttr(
@@ -953,7 +953,7 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
         TMaybe<TIndexTabletDatabase::TNodeAttr> Attr;
 
         TRemoveNodeXAttr(
@@ -991,8 +991,8 @@ struct TTxIndexTablet
         ui64 ReadCommitId = InvalidCommitId;
         ui64 WriteCommitId = InvalidCommitId;
         ui64 TargetNodeId = InvalidNodeId;
-        TMaybe<TIndexTabletDatabase::TNode> TargetNode;
-        TMaybe<TIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<IIndexState::TNode> TargetNode;
+        TMaybe<IIndexState::TNode> ParentNode;
 
         NProto::TCreateHandleResponse Response;
 
@@ -1030,7 +1030,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProto::TDestroyHandleRequest Request;
 
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TDestroyHandle(
                 TRequestInfoPtr requestInfo,
@@ -1135,7 +1135,7 @@ struct TTxIndexTablet
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
         TMaybe<TByteRange> ReadAheadRange;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
         TVector<TBlockDataRef> Blocks;
         TVector<TBlockBytes> Bytes;
 
@@ -1194,7 +1194,7 @@ struct TTxIndexTablet
 
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TWriteData(
                 TRequestInfoPtr requestInfo,
@@ -1238,7 +1238,7 @@ struct TTxIndexTablet
         ui64 CommitId;
 
         ui64 NodeId = InvalidNodeId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TAddData(
                 TRequestInfoPtr requestInfo,
@@ -1308,7 +1308,7 @@ struct TTxIndexTablet
 
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
-        TMaybe<TIndexTabletDatabase::TNode> Node;
+        TMaybe<IIndexState::TNode> Node;
 
         TAllocateData(
                 TRequestInfoPtr requestInfo,


### PR DESCRIPTION
Currently RO transactions access `TIndexTabletDatabase` via `TIndexTabletState` methods like 
```c++
TIndexTabletState::ReadNode(
    TIndexTabletDatabase& db,
    ...
```
which in turn calls do stuff like `db.ReadNode(nodeId, commitId, node)`.


We want to cache some index data from the Index tables.

In order for this in-memory cache to implement the same set of methods, `TIndexTabletDatabase` is replaced with an interface `IIndexState`, which is implemented by `TInMemoryIndexState` (which, for now, is a stub) and by `TIndexTabletDatabase`