### PR TITLE
issue-1350: the handles generated by old filestore-server tablet code versions can have random crap instead of shardNo in the high bits - we should ignore this crap until we don't have legacy handles anymore

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -27,7 +27,7 @@ TResultOrError<TString> TStorageServiceActor::SelectShard(
     if (StorageConfig->GetMultiTabletForwardingEnabled() && shardNo) {
         const auto& followerIds = filestore.GetFollowerFileSystemIds();
         if (followerIds.size() < static_cast<int>(shardNo)) {
-            LOG_WARN(ctx, TFileStoreComponents::SERVICE,
+            LOG_DEBUG(ctx, TFileStoreComponents::SERVICE,
                 "[%s][%lu] forward %s #%lu - invalid shardNo: %u/%d"
                 " (legacy handle?)",
                 sessionId.Quote().c_str(),

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -27,8 +27,9 @@ TResultOrError<TString> TStorageServiceActor::SelectShard(
     if (StorageConfig->GetMultiTabletForwardingEnabled() && shardNo) {
         const auto& followerIds = filestore.GetFollowerFileSystemIds();
         if (followerIds.size() < static_cast<int>(shardNo)) {
-            LOG_ERROR(ctx, TFileStoreComponents::SERVICE,
-                "[%s][%lu] forward %s #%lu - invalid shardNo: %lu/%d",
+            LOG_WARN(ctx, TFileStoreComponents::SERVICE,
+                "[%s][%lu] forward %s #%lu - invalid shardNo: %u/%d"
+                " (legacy handle?)",
                 sessionId.Quote().c_str(),
                 seqNo,
                 methodName.c_str(),
@@ -36,8 +37,10 @@ TResultOrError<TString> TStorageServiceActor::SelectShard(
                 shardNo,
                 followerIds.size());
 
-            return MakeError(E_INVALID_STATE, TStringBuilder() << "shardNo="
-                    << shardNo << ", followerIds.size=" << followerIds.size());
+            // TODO(#1350): uncomment when there are no legacy handles anymore
+            //return MakeError(E_INVALID_STATE, TStringBuilder() << "shardNo="
+            //        << shardNo << ", followerIds.size=" << followerIds.size());
+            return TString();
         }
 
         LOG_DEBUG(ctx, TFileStoreComponents::SERVICE,


### PR DESCRIPTION
#1350 