### PR TITLE
blockstore-client API to suspend disk agent

### DIFF
--- a/cloud/blockstore/libs/storage/api/disk_agent.h
+++ b/cloud/blockstore/libs/storage/api/disk_agent.h
@@ -27,6 +27,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(ChecksumDeviceBlocks,     __VA_ARGS__)                                 \
     xxx(DisableConcreteAgent,     __VA_ARGS__)                                 \
     xxx(EnableAgentDevice,        __VA_ARGS__)                                 \
+    xxx(PartiallySuspendAgent,    __VA_ARGS__)                                \
 // BLOCKSTORE_DISK_AGENT_REQUESTS_PROTO
 
 #define BLOCKSTORE_DISK_AGENT_REQUESTS(xxx, ...)                               \
@@ -87,6 +88,9 @@ struct TEvDiskAgent
 
         EvEnableAgentDeviceRequest = EvBegin + 19,
         EvEnableAgentDeviceResponse = EvBegin + 20,
+
+        EvPartiallySuspendAgentRequest = EvBegin + 21,
+        EvPartiallySuspendAgentResponse = EvBegin + 22,
 
         EvEnd
     };

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -77,6 +77,8 @@ private:
 
     NActors::TActorId SessionCacheActor;
 
+    TRequestInfoPtr PartiallySuspendAgentRequestInfo;
+
 public:
     TDiskAgentActor(
         TStorageConfigPtr config,
@@ -190,6 +192,14 @@ private:
     void HandleReportDelayedDiskAgentConfigMismatch(
         const TEvDiskAgentPrivate::TEvReportDelayedDiskAgentConfigMismatch::
             TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUpdateSessionCacheResponse(
+        const TEvDiskAgentPrivate::TEvUpdateSessionCacheResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleCancelSuspension(
+        const TEvDiskAgentPrivate::TEvCancelSuspensionRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     bool HandleRequests(STFUNC_SIG);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_partial_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_partial_suspend.cpp
@@ -49,9 +49,7 @@ void TDiskAgentActor::HandlePartiallySuspendAgent(
     ctx.Schedule(delay, new TEvDiskAgentPrivate::TEvCancelSuspensionRequest());
     State->SetPartiallySuspended(true);
 
-    // There is no need in updating session cache for the primary agent since it
-    // updates cache on every change anyway.
-    if (SessionCacheActor && AgentConfig->GetTemporaryAgent()) {
+    if (SessionCacheActor) {
         PartiallySuspendAgentRequestInfo =
             CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
         NCloud::Send<TEvDiskAgentPrivate::TEvUpdateSessionCacheRequest>(

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_partial_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_partial_suspend.cpp
@@ -1,0 +1,116 @@
+#include "disk_agent_actor.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskAgentActor::HandlePartiallySuspendAgent(
+    const TEvDiskAgent::TEvPartiallySuspendAgentRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    LOG_INFO(ctx, TBlockStoreComponents::DISK_AGENT, "Received SuspendAgent.");
+
+    if (PartiallySuspendAgentRequestInfo) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentResponse>(
+                MakeError(E_REJECTED, "Already suspending.")));
+        return;
+    }
+
+    if (State->GetPartiallySuspended()) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentResponse>(
+                MakeError(S_ALREADY, "Already partially suspended.")));
+        return;
+    }
+
+    const auto* msg = ev->Get();
+    if (!msg->Record.GetCancelSuspensionDelay()) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentResponse>(
+                MakeError(E_ARGUMENT, "Empty CancelSuspensionDelay.")));
+        return;
+    }
+
+    const auto delay =
+        TDuration::MilliSeconds(msg->Record.GetCancelSuspensionDelay());
+    LOG_INFO_S(
+        ctx,
+        TBlockStoreComponents::DISK_AGENT,
+        "Schedule CancelSuspensionRequest at " << delay.ToDeadLine(ctx.Now()));
+    ctx.Schedule(delay, new TEvDiskAgentPrivate::TEvCancelSuspensionRequest());
+    State->SetPartiallySuspended(true);
+
+    // There is no need in updating session cache for the primary agent since it
+    // updates cache on every change anyway.
+    if (SessionCacheActor && AgentConfig->GetTemporaryAgent()) {
+        PartiallySuspendAgentRequestInfo =
+            CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+        NCloud::Send<TEvDiskAgentPrivate::TEvUpdateSessionCacheRequest>(
+            ctx,
+            SessionCacheActor,
+            0,   // cookie
+            State->GetSessions());
+    } else {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentResponse>());
+    }
+}
+
+void TDiskAgentActor::HandleUpdateSessionCacheResponse(
+    const TEvDiskAgentPrivate::TEvUpdateSessionCacheResponse::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (!PartiallySuspendAgentRequestInfo) {
+        return;
+    }
+
+    Y_DEBUG_ABORT_UNLESS(State->GetPartiallySuspended());
+    const auto* msg = ev->Get();
+    LOG_INFO_S(
+        ctx,
+        TBlockStoreComponents::DISK_AGENT,
+        "Session cache update response: " << FormatError(msg->GetError()));
+
+    NCloud::Reply(
+        ctx,
+        *PartiallySuspendAgentRequestInfo,
+        std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentResponse>(
+            msg->GetError()));
+    PartiallySuspendAgentRequestInfo.Reset();
+}
+
+void TDiskAgentActor::HandleCancelSuspension(
+    const TEvDiskAgentPrivate::TEvCancelSuspensionRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    LOG_WARN(
+        ctx,
+        TBlockStoreComponents::DISK_AGENT,
+        "Partial suspension worn off. Going to register in the DR.");
+
+    State->SetPartiallySuspended(false);
+    if (PartiallySuspendAgentRequestInfo) {
+        NCloud::Reply(
+            ctx,
+            *PartiallySuspendAgentRequestInfo,
+            std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentResponse>(
+                MakeError(E_TIMEOUT, "Couldn't update session cache.")));
+        PartiallySuspendAgentRequestInfo.Reset();
+    }
+
+    SendRegisterRequest(ctx);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
@@ -200,6 +200,10 @@ void TDiskAgentActor::HandleConnectionLost(
 {
     Y_UNUSED(ev);
 
+    if (State->GetPartiallySuspended()) {
+        return;
+    }
+
     SendRegisterRequest(ctx);
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
@@ -148,6 +148,10 @@ struct TEvDiskAgentPrivate
     struct TUpdateSessionCacheResponse
     {};
 
+
+    struct TCancelSuspensionRequest
+    {};
+
     //
     // Events declaration
     //
@@ -162,6 +166,7 @@ struct TEvDiskAgentPrivate
         EvSecureEraseCompleted,
         EvWriteOrZeroCompleted,
         EvReportDelayedDiskAgentConfigMismatch,
+        EvCancelSuspensionRequest,
 
         BLOCKSTORE_DECLARE_EVENT_IDS(UpdateSessionCache)
 
@@ -188,6 +193,10 @@ struct TEvDiskAgentPrivate
     using TEvReportDelayedDiskAgentConfigMismatch = TResponseEvent<
         TReportDelayedDiskAgentConfigMismatch,
         EvReportDelayedDiskAgentConfigMismatch>;
+
+    using TEvCancelSuspensionRequest = TRequestEvent<
+        TCancelSuspensionRequest,
+        EvCancelSuspensionRequest>;
 
     BLOCKSTORE_DECLARE_EVENTS(UpdateSessionCache)
 };

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -852,11 +852,13 @@ void TDiskAgentState::StopTarget()
     }
 }
 
-void TDiskAgentState::SetPartiallySuspended(bool partiallySuspended) {
+void TDiskAgentState::SetPartiallySuspended(bool partiallySuspended)
+{
     PartiallySuspended = partiallySuspended;
 }
 
-bool TDiskAgentState::GetPartiallySuspended() const {
+bool TDiskAgentState::GetPartiallySuspended() const
+{
     return PartiallySuspended;
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -162,6 +162,11 @@ private:
         const NProto::EVolumeAccessMode accessMode) const;
     const TDeviceState& GetDeviceStateImpl(const TString& uuid) const;
 
+    void EnsureAccessToDevices(
+        const TVector<TString>& uuids,
+        const TString& clientId,
+        NProto::EVolumeAccessMode accessMode) const;
+
     template <typename T>
     void WriteProfileLog(
         TInstant now,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -62,6 +62,7 @@ private:
     TDeviceClientPtr DeviceClient;
 
     ui32 InitErrorsCount = 0;
+    bool PartiallySuspended = false;
 
 public:
     TDiskAgentState(
@@ -145,6 +146,9 @@ public:
     void ReportDisabledDeviceError(const TString& uuid);
 
     void StopTarget();
+
+    void SetPartiallySuspended(bool partiallySuspended);
+    bool GetPartiallySuspended() const;
 
 private:
     const TDeviceState& GetDeviceState(

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
@@ -291,6 +291,15 @@ public:
         return std::make_unique<TEvDiskAgentPrivate::TEvCollectStatsRequest>();
     }
 
+    auto CreatePartiallySuspendAgentRequest(TDuration cancelSuspensionDelay)
+    {
+        auto request =
+            std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentRequest>();
+        request->Record.SetCancelSuspensionDelay(
+            cancelSuspensionDelay.MilliSeconds());
+        return request;
+    }
+
 #define BLOCKSTORE_DECLARE_METHOD(name, ns)                                    \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \

--- a/cloud/blockstore/libs/storage/disk_agent/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ya.make
@@ -8,6 +8,7 @@ SRCS(
     disk_agent_actor_init.cpp
     disk_agent_actor_io.cpp
     disk_agent_actor_monitoring.cpp
+    disk_agent_actor_partial_suspend.cpp
     disk_agent_actor_register.cpp
     disk_agent_actor_release.cpp
     disk_agent_actor_secure_erase.cpp
@@ -37,12 +38,12 @@ PEERDIR(
     cloud/blockstore/libs/storage/disk_agent/model
     cloud/blockstore/libs/storage/disk_common
     cloud/blockstore/libs/storage/model
-    
+
     cloud/storage/core/libs/common
-    
+
     library/cpp/containers/stack_vector
     library/cpp/deprecated/atomic
-    
+
     contrib/ydb/core/base
     contrib/ydb/core/mind
     contrib/ydb/core/mon

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1651,3 +1651,23 @@ message TWaitDependentDisksToSwitchNodeResponse
     // shutdown.
     repeated TDependentDiskState DependentDiskStates = 2;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Partially suspend agent. Used for blue-green deployment.
+// We need to prepare a running instance that a new instance will be launched
+// soon.
+
+message TPartiallySuspendAgentRequest
+{
+    // Node that agent is running on.
+    uint32 NodeId = 1;
+
+    // Time in ms until Disk Agent goes back to working state.
+    uint32 CancelSuspensionDelay  = 2;
+}
+
+message TPartiallySuspendAgentResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -395,6 +395,10 @@ private:
     TResultOrError<NActors::IActorPtr> CreateWaitDependentDisksToSwitchNodeActor(
         TRequestInfoPtr requestInfo,
         TString input);
+
+    TResultOrError<NActors::IActorPtr> CreatePartiallySuspendDiskAgentActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
@@ -84,6 +84,7 @@ void TServiceActor::HandleExecuteAction(
         {"flushprofilelog",                   &TServiceActor::CreateFlushProfileLogActor                   },
         {"getdiskagentnodeid",                &TServiceActor::CreateGetDiskAgentNodeIdActor                },
         {"waitdependentdiskstoswitchnode",    &TServiceActor::CreateWaitDependentDisksToSwitchNodeActor    },
+        {"partiallysuspenddiskagent",         &TServiceActor::CreatePartiallySuspendDiskAgentActor         },
     };
 
     NProto::TError error;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_suspend_disk_agent.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_suspend_disk_agent.cpp
@@ -1,0 +1,136 @@
+#include "service_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <google/protobuf/util/json_util.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TPartiallySuspendDiskAgentActor final
+    : public TActorBootstrapped<TPartiallySuspendDiskAgentActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString Input;
+
+public:
+    TPartiallySuspendDiskAgentActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        const NProto::TError& error);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleSuspendDiskAgentResponse(
+        const TEvDiskAgent::TEvPartiallySuspendAgentResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TPartiallySuspendDiskAgentActor::TPartiallySuspendDiskAgentActor(
+        TRequestInfoPtr requestInfo,
+        TString input)
+    : RequestInfo(std::move(requestInfo))
+    , Input(std::move(input))
+{}
+
+void TPartiallySuspendDiskAgentActor::Bootstrap(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvDiskAgent::TEvPartiallySuspendAgentRequest>();
+    if (!google::protobuf::util::JsonStringToMessage(Input, &request->Record).ok()) {
+        ReplyAndDie(ctx, MakeError(E_ARGUMENT, "Failed to parse input."));
+        return;
+    }
+
+    if (request->Record.GetNodeId() == 0) {
+        ReplyAndDie(ctx, MakeError(E_ARGUMENT, "Empty NodeId."));
+        return;
+    }
+
+    if (request->Record.GetCancelSuspensionDelay() == 0) {
+        ReplyAndDie(ctx, MakeError(E_ARGUMENT, "Empty CancelSuspensionDelay."));
+        return;
+    }
+
+    Become(&TThis::StateWork);
+
+    NCloud::Send(
+        ctx,
+        MakeDiskAgentServiceId(request->Record.GetNodeId()),
+        std::move(request));
+}
+
+void TPartiallySuspendDiskAgentActor::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProto::TError& error)
+{
+    auto response =
+        std::make_unique<TEvService::TEvExecuteActionResponse>(error);
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TPartiallySuspendDiskAgentActor::HandleSuspendDiskAgentResponse(
+    const TEvDiskAgent::TEvPartiallySuspendAgentResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    ReplyAndDie(ctx, msg->GetError());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TPartiallySuspendDiskAgentActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvDiskAgent::TEvPartiallySuspendAgentResponse,
+            HandleSuspendDiskAgentResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TResultOrError<IActorPtr>
+TServiceActor::CreatePartiallySuspendDiskAgentActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    return {std::make_unique<TPartiallySuspendDiskAgentActor>(
+        std::move(requestInfo),
+        std::move(input))};
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/ya.make
+++ b/cloud/blockstore/libs/storage/service/ya.make
@@ -39,6 +39,7 @@ SRCS(
     service_actor_actions_set_user_id.cpp
     service_actor_actions_setup_channels.cpp
     service_actor_actions_suspend_device.cpp
+    service_actor_actions_suspend_disk_agent.cpp
     service_actor_actions_update_disk_block_size.cpp
     service_actor_actions_update_disk_replica_count.cpp
     service_actor_actions_update_disk_registry_params.cpp

--- a/cloud/blockstore/tests/python/lib/disk_agent_runner.py
+++ b/cloud/blockstore/tests/python/lib/disk_agent_runner.py
@@ -48,7 +48,8 @@ class LocalDiskAgent(Daemon):
             features_config_patch=None,
             rack="rack",
             node_type=None,
-            grpc_trace=None):
+            grpc_trace=None,
+            temporary_agent=False):
         if dynamic_storage_pools is not None:
             assert len(dynamic_storage_pools) >= 2
             self.__dynamic_storage_pools = dynamic_storage_pools
@@ -63,6 +64,7 @@ class LocalDiskAgent(Daemon):
         self.__grpc_trace = grpc_trace
         self.__ic_port = self.__port_manager.get_port()
         self.__mon_port = self.__port_manager.get_port()
+        self.__temporary_agent = temporary_agent
         if disk_agent_binary_path is not None:
             self.__binary_path = disk_agent_binary_path
         else:
@@ -153,8 +155,10 @@ class LocalDiskAgent(Daemon):
             cwd=self.__cwd,
             timeout=180,
             core_pattern=cp,
-            stdout_file=os.path.join(self.log_path(), 'agent_stdout.txt'),
-            stderr_file=os.path.join(self.log_path(), 'agent_stderr.txt'),
+            stdout_file=os.path.join(self.log_path(
+            ), 'temporary_agent_stdout.txt' if self.__temporary_agent else 'agent_stdout.txt'),
+            stderr_file=os.path.join(self.log_path(
+            ), 'temporary_agent_stderr.txt' if self.__temporary_agent else 'agent_stderr.txt'),
         )
 
     @staticmethod
@@ -470,6 +474,9 @@ ModifyScheme {
             "--mon-port", str(self.__mon_port),
             "--scheme-shard-dir", "nbs",
             "--load-configs-from-cms"]
+
+        if self.__temporary_agent:
+            command += ["--temporary-agent"]
 
         if self.__node_type is not None:
             command += ["--node-type", self.__node_type]

--- a/cloud/blockstore/tests/python/lib/test_base.py
+++ b/cloud/blockstore/tests/python/lib/test_base.py
@@ -460,7 +460,7 @@ def wait_for_secure_erase(mon_port, pool='default'):
 ################################################################################
 # result comparison utils
 
-def files_equal(path_0, path_1, block_size=4096, cb=None):
+def files_equal(path_0, path_1, cb=None, block_size=4096):
     file_0 = open(path_0, "rb")
     file_1 = open(path_1, "rb")
 


### PR DESCRIPTION
Related to issue #1502

Added a new message to Disk Agent: `PartiallySuspendAgent`. Only used for blue-green deployment for now. It's sent from the blockstore-client and basically means "another agent will be launched soon, prepare to die".

While the Disk Agent is in this state:
1) It ignores connection loss to the DR.
2) Acquire and Release requests will be rejected, except for acquires which do not change anything.
3) If the Disk Agent is temporary, it will dump the session cache on disk.


