### PR TITLE
issue-1350: simplified node creation in follower code, added a test for errors received from follower in this case, fixed DupCache entry commitment in CreateHandle, made TabletProxy immortal, deleted inactive pipe tracking and closure in TabletProxy, added some comments, fixed logging a bit

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -264,7 +264,7 @@ void TStorageServiceActor::HandleCreateHandle(
         ctx,
         TFileStoreComponents::SERVICE,
         "create handle in follower %s",
-        msg->Record.DebugString().c_str());
+        msg->Record.ShortDebugString().Quote().c_str());
 
     auto [cookie, inflight] = CreateInFlightRequest(
         TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -198,7 +198,7 @@ void TListNodesActor::HandleGetNodeAttrResponse(
         return;
     }
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TFileStoreComponents::SERVICE,
         "GetNodeAttrResponse from follower: %s",

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3144,6 +3144,59 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             data.Size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse.GetBuffer());
     }
+
+    Y_UNIT_TEST(ShouldHandleCreateNodeErrorFromFollowerUponCreateHandleViaLeader)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto error = MakeError(E_FS_INVALID_SESSION, "bad session");
+
+        env.GetRuntime().SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvCreateNodeResponse: {
+                        auto* msg =
+                            event->Get<TEvService::TEvCreateNodeResponse>();
+                        msg->Record.MutableError()->CopyFrom(error);
+
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        service.SendCreateHandleRequest(
+            headers,
+            fsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::CREATE_EXL);
+
+        auto response = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            error.GetCode(),
+            response->GetError().GetCode(),
+            FormatError(response->GetError()));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -836,6 +836,13 @@ STFUNC(TIndexTabletActor::StateZombie)
         IgnoreFunc(TEvLocal::TEvTabletMetrics);
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollower,
+            HandleNodeCreatedInFollower);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle,
+            HandleNodeCreatedInFollowerUponCreateHandle);
+
         default:
             HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);
             break;
@@ -868,6 +875,13 @@ STFUNC(TIndexTabletActor::StateBroken)
         IgnoreFunc(TEvIndexTabletPrivate::TEvAddDataCompleted);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
+
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollower,
+            HandleNodeCreatedInFollower);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle,
+            HandleNodeCreatedInFollowerUponCreateHandle);
 
         default:
             HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -471,6 +471,7 @@ void TIndexTabletActor::CompleteTx_CreateSession(
         std::move(response));
 
     auto actorId = NCloud::Register(ctx, std::move(actor));
+    // XXX TABLET_PROXY KILLS PIPES! SHARDS WILL DESTROY SESSIONS!!!
 
     Y_UNUSED(actorId);
     // TODO(#1350): register actorId in WorkerActors, erase upon completion

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -471,7 +471,6 @@ void TIndexTabletActor::CompleteTx_CreateSession(
         std::move(response));
 
     auto actorId = NCloud::Register(ctx, std::move(actor));
-    // XXX TABLET_PROXY KILLS PIPES! SHARDS WILL DESTROY SESSIONS!!!
 
     Y_UNUSED(actorId);
     // TODO(#1350): register actorId in WorkerActors, erase upon completion

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -165,6 +165,8 @@ void TIndexTabletActor::CompleteTx_DestroySession(
 {
     RemoveTransaction(*args.RequestInfo);
 
+    // TODO(#1350): destroy follower sessions
+
     auto response = std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>();
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -152,6 +152,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
 
     // TODO(#1350): unlink external nodes
     if (args.ChildRef->FollowerId) {
+        // XXX ref not unlinked as well
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -502,15 +502,12 @@ struct TEvIndexTabletPrivate
     struct TNodeCreatedInFollower
     {
         TRequestInfoPtr RequestInfo;
-        NProto::TCreateNodeResponse FollowerCreateNodeResponse;
         NProto::TCreateNodeResponse CreateNodeResponse;
 
         TNodeCreatedInFollower(
                 TRequestInfoPtr requestInfo,
-                NProto::TCreateNodeResponse followerCreateNodeResponse,
                 NProto::TCreateNodeResponse createNodeResponse)
             : RequestInfo(std::move(requestInfo))
-            , FollowerCreateNodeResponse(std::move(followerCreateNodeResponse))
             , CreateNodeResponse(std::move(createNodeResponse))
         {
         }
@@ -523,15 +520,12 @@ struct TEvIndexTabletPrivate
     struct TNodeCreatedInFollowerUponCreateHandle
     {
         TRequestInfoPtr RequestInfo;
-        NProto::TCreateNodeResponse FollowerCreateNodeResponse;
         NProto::TCreateHandleResponse CreateHandleResponse;
 
         TNodeCreatedInFollowerUponCreateHandle(
                 TRequestInfoPtr requestInfo,
-                NProto::TCreateNodeResponse followerCreateNodeResponse,
                 NProto::TCreateHandleResponse createHandleResponse)
             : RequestInfo(std::move(requestInfo))
-            , FollowerCreateNodeResponse(std::move(followerCreateNodeResponse))
             , CreateHandleResponse(std::move(createHandleResponse))
         {
         }

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.h
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.h
@@ -52,9 +52,6 @@ class TIndexTabletProxyActor final
         TString Path;
 
         TDeque<NActors::IEventHandlePtr> Requests;
-        TInstant LastActivity;
-        ui64 RequestsInflight = 0;
-        bool ActivityCheckScheduled = false;
 
         TConnection(ui64 id, TString fileSystemId)
             : Id(id)
@@ -114,9 +111,7 @@ private:
         const NActors::TActorContext& ctx,
         TConnection& conn);
 
-    void CancelActiveRequests(
-        const NActors::TActorContext& ctx,
-        TConnection& conn);
+    void CancelActiveRequests(TConnection& conn);
 
     void PostponeRequest(
         const NActors::TActorContext& ctx,
@@ -134,10 +129,6 @@ private:
         TConnection& conn);
 
 private:
-    void ScheduleConnectionShutdown(
-        const NActors::TActorContext& ctx,
-        TConnection& conn);
-
     void HandleClientConnected(
         NKikimr::TEvTabletPipe::TEvClientConnected::TPtr& ev,
         const NActors::TActorContext& ctx);
@@ -148,10 +139,6 @@ private:
 
     void HandleDescribeFileStoreResponse(
         const TEvSSProxy::TEvDescribeFileStoreResponse::TPtr& ev,
-        const NActors::TActorContext& ctx);
-
-    void HandleWakeup(
-        const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandlePoisonPill(

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -252,10 +252,12 @@ public:
         ui64 nodeId,
         const TString& name,
         ui32 flags,
-        const TString& followerId = "")
+        const TString& followerId = "",
+        const ui64 requestId = 0)
     {
         auto request = std::make_unique<TEvService::TEvCreateHandleRequest>();
         headers.Fill(request->Record);
+        request->Record.MutableHeaders()->SetRequestId(requestId);
         request->Record.SetFileSystemId(fileSystemId);
         request->Record.SetNodeId(nodeId);
         request->Record.SetName(name);


### PR DESCRIPTION
DupCache entry commit was simply forgotten for the multi-tablet mode in my previous PRs. And as for TabletProxy - we send various requests to IndexTablets via TabletProxy and there is some weird logic in IndexTablet which sends EvPoisonPill in response to some previously sent CreateSessionRequests - this logic controls the lifecycle of the CreateSessionActor and is quite fragile so I'm not planning to change it right now. But this logic might kill TabletProxy in some cases which renders the filestore-server instance almost unusable. VolumeProxy in NBS is already immortal - making TabletProxy immortal in a similar fashion. As for the inactive pipe tracking logic - it's not really needed and it messes with the leader->follower session creation logic (followers destroy sessions after pipe destruction which breaks some scenarios). Deleting that unneeded logic is the most straightforward solution.

#1350 