### PR TITLE
issue-1395: run cleaning process per device pool

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -42,6 +42,7 @@ TDiskRegistryActor::TDiskRegistryActor(
     , TTabletBase(owner, std::move(storage))
     , Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
+    , SecureEraseInProgressPerPool(NProto::EDevicePoolKind_ARRAYSIZE, false)
     , LogbrokerService(std::move(logbrokerService))
     , NotifyService(std::move(notifyService))
     , Logging(std::move(logging))

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -42,7 +42,6 @@ TDiskRegistryActor::TDiskRegistryActor(
     , TTabletBase(owner, std::move(storage))
     , Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
-    , SecureEraseInProgressPerPool(NProto::EDevicePoolKind_ARRAYSIZE, false)
     , LogbrokerService(std::move(logbrokerService))
     , NotifyService(std::move(notifyService))
     , Logging(std::move(logging))

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -90,7 +90,7 @@ private:
     bool UsersNotificationInProgress = false;
     bool DiskStatesPublicationInProgress = false;
     bool AutomaticallyReplacedDevicesDeletionInProgress = false;
-    bool SecureEraseInProgress = false;
+    TVector<bool> SecureEraseInProgressPerPool;
     bool StartMigrationInProgress = false;
 
     TVector<TString> DisksBeingDestroyed;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -90,7 +90,7 @@ private:
     bool UsersNotificationInProgress = false;
     bool DiskStatesPublicationInProgress = false;
     bool AutomaticallyReplacedDevicesDeletionInProgress = false;
-    TVector<bool> SecureEraseInProgressPerPool;
+    THashSet<TString> SecureEraseInProgressPerPool;
     bool StartMigrationInProgress = false;
 
     TVector<TString> DisksBeingDestroyed;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -371,7 +371,7 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
     auto it = dirtyDevices.begin();
     while (it != dirtyDevices.end()) {
         auto first = it;
-        const auto& poolName = first->GetPoolName();
+        const auto poolName = first->GetPoolName();
         it = std::partition(
             first,
             dirtyDevices.end(),

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -378,14 +378,18 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
         if (!inserted) {
             continue;
         }
-        auto request = std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseRequest>(
-         poolName,
-         std::move(devices),
-         Config->GetNonReplicatedSecureEraseTimeout());
+        auto request =
+            std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseRequest>(
+                poolName,
+                std::move(devices),
+                Config->GetNonReplicatedSecureEraseTimeout());
 
-        auto deadline = Min(SecureEraseStartTs, ctx.Now()) + TDuration::Seconds(5);
+        auto deadline =
+            Min(SecureEraseStartTs, ctx.Now()) + TDuration::Seconds(5);
         if (deadline > ctx.Now()) {
-            LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
+            LOG_INFO(
+                ctx,
+                TBlockStoreComponents::DISK_REGISTRY,
                 "[%lu] Scheduled secure erase for pool: %s, now: %lu, "
                 "deadline: %lu",
                 TabletID(),
@@ -398,7 +402,9 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
                 new IEventHandle(ctx.SelfID, ctx.SelfID, request.get()));
             request.release();
         } else {
-            LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
+            LOG_INFO(
+                ctx,
+                TBlockStoreComponents::DISK_REGISTRY,
                 "[%lu] Sending secure erase request",
                 TabletID());
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -378,8 +378,9 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
             [&poolName](const auto& device)
             { return poolName == device.GetPoolName(); });
 
-        auto [_, inserted] = SecureEraseInProgressPerPool.insert(poolName);
-        if (!inserted) {
+        auto [_, alreadyInProgress] =
+            SecureEraseInProgressPerPool.insert(poolName);
+        if (!alreadyInProgress) {
             continue;
         }
 
@@ -406,8 +407,7 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
 
             ctx.ExecutorThread.Schedule(
                 deadline,
-                new IEventHandle(ctx.SelfID, ctx.SelfID, request.get()));
-            request.release();
+                new IEventHandle(ctx.SelfID, ctx.SelfID, request.release()));
         } else {
             LOG_INFO(
                 ctx,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -24,7 +24,7 @@ private:
     const TRequestInfoPtr Request;
     const TDuration RequestTimeout;
 
-    TString PoolName;
+    const TString PoolName;
     TVector<NProto::TDeviceConfig> Devices;
     TVector<TString> CleanDevices;
 
@@ -369,7 +369,7 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
         dirtyDevices.size());
 
     TMap<TString, TVector<NProto::TDeviceConfig>> poolMap;
-    for(auto& device : dirtyDevices) {
+    for (auto& device: dirtyDevices) {
         poolMap[device.GetPoolName()].push_back(std::move(device));
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -426,8 +426,9 @@ void TDiskRegistryActor::HandleSecureErase(
 {
     BLOCKSTORE_DISK_REGISTRY_COUNTER(SecureErase);
 
-    auto* msg = ev->Get();
     SecureEraseStartTs = ctx.Now();
+
+    auto* msg = ev->Get();
 
     LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
         "[%lu] Received SecureErase request: DirtyDevices=%lu",

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
@@ -96,7 +96,9 @@ void TDiskRegistryActor::CompleteWritableState(
     DisksNotificationInProgress = false;
     UsersNotificationInProgress = false;
     DiskStatesPublicationInProgress = false;
-    SecureEraseInProgress = false;
+    SecureEraseInProgressPerPool.assign(
+        NProto::EDevicePoolKind_ARRAYSIZE,
+        false);
     StartMigrationInProgress = false;
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
@@ -96,9 +96,7 @@ void TDiskRegistryActor::CompleteWritableState(
     DisksNotificationInProgress = false;
     UsersNotificationInProgress = false;
     DiskStatesPublicationInProgress = false;
-    SecureEraseInProgressPerPool.assign(
-        NProto::EDevicePoolKind_ARRAYSIZE,
-        false);
+    SecureEraseInProgressPerPool.clear();
     StartMigrationInProgress = false;
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -267,15 +267,15 @@ struct TEvDiskRegistryPrivate
 
     struct TSecureEraseRequest
     {
-        NProto::EDevicePoolKind PoolKind;
+        TString PoolName;
         TVector<NProto::TDeviceConfig> DirtyDevices;
         TDuration RequestTimeout;
 
         explicit TSecureEraseRequest(
-            NProto::EDevicePoolKind poolKind,
+            TString poolName,
             TVector<NProto::TDeviceConfig> dirtyDevices,
             TDuration requestTimeout)
-            : PoolKind(poolKind)
+            : PoolName(std::move(poolName))
             , DirtyDevices(std::move(dirtyDevices))
             , RequestTimeout(requestTimeout)
         {}
@@ -283,15 +283,15 @@ struct TEvDiskRegistryPrivate
 
     struct TSecureEraseResponse
     {
-        NProto::EDevicePoolKind PoolKind;
+        TString PoolName;
         size_t CleanDevices = 0;
 
         TSecureEraseResponse() = default;
 
         explicit TSecureEraseResponse(
-            NProto::EDevicePoolKind poolKind,
+            TString poolName,
             size_t cleanDevices)
-            : PoolKind(poolKind)
+            : PoolName(std::move(poolName))
             , CleanDevices(cleanDevices)
         {}
     };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -267,25 +267,32 @@ struct TEvDiskRegistryPrivate
 
     struct TSecureEraseRequest
     {
+        NProto::EDevicePoolKind PoolKind;
         TVector<NProto::TDeviceConfig> DirtyDevices;
         TDuration RequestTimeout;
 
         explicit TSecureEraseRequest(
-                TVector<NProto::TDeviceConfig> dirtyDevices,
-                TDuration requestTimeout)
-            : DirtyDevices(std::move(dirtyDevices))
+            NProto::EDevicePoolKind poolKind,
+            TVector<NProto::TDeviceConfig> dirtyDevices,
+            TDuration requestTimeout)
+            : PoolKind(poolKind)
+            , DirtyDevices(std::move(dirtyDevices))
             , RequestTimeout(requestTimeout)
         {}
     };
 
     struct TSecureEraseResponse
     {
+        NProto::EDevicePoolKind PoolKind;
         size_t CleanDevices = 0;
 
         TSecureEraseResponse() = default;
 
-        explicit TSecureEraseResponse(size_t cleanDevices)
-            : CleanDevices(cleanDevices)
+        explicit TSecureEraseResponse(
+            NProto::EDevicePoolKind poolKind,
+            size_t cleanDevices)
+            : PoolKind(poolKind)
+            , CleanDevices(cleanDevices)
         {}
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -271,7 +271,7 @@ struct TEvDiskRegistryPrivate
         TVector<NProto::TDeviceConfig> DirtyDevices;
         TDuration RequestTimeout;
 
-        explicit TSecureEraseRequest(
+        TSecureEraseRequest(
                 TString poolName,
                 TVector<NProto::TDeviceConfig> dirtyDevices,
                 TDuration requestTimeout)
@@ -288,7 +288,7 @@ struct TEvDiskRegistryPrivate
 
         TSecureEraseResponse() = default;
 
-        explicit TSecureEraseResponse(
+        TSecureEraseResponse(
                 TString poolName,
                 size_t cleanDevices)
             : PoolName(std::move(poolName))

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -272,9 +272,9 @@ struct TEvDiskRegistryPrivate
         TDuration RequestTimeout;
 
         explicit TSecureEraseRequest(
-            TString poolName,
-            TVector<NProto::TDeviceConfig> dirtyDevices,
-            TDuration requestTimeout)
+                TString poolName,
+                TVector<NProto::TDeviceConfig> dirtyDevices,
+                TDuration requestTimeout)
             : PoolName(std::move(poolName))
             , DirtyDevices(std::move(dirtyDevices))
             , RequestTimeout(requestTimeout)
@@ -289,8 +289,8 @@ struct TEvDiskRegistryPrivate
         TSecureEraseResponse() = default;
 
         explicit TSecureEraseResponse(
-            TString poolName,
-            size_t cleanDevices)
+                TString poolName,
+                size_t cleanDevices)
             : PoolName(std::move(poolName))
             , CleanDevices(cleanDevices)
         {}

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -2222,6 +2222,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
     Y_UNIT_TEST(ShouldSecureEraseDevicesFromDifferentPools)
     {
+        // 1 .Create devices from two different pools with pool kind
+        // DEVICE_POOL_KIND_LOCAL. Devices are created in the suspended state.
+        // 2. Set observer for EvCleanupDevicesRequest which check that
+        // all devices from one message belong to the same pool.
+        // 3. Call ResumeDevice for all devices. Internally ResumeDevice
+        // triggers SecureErase.
+
         auto agent1 = CreateAgentConfig(
             "agent-1",
             {Device("dev-1", "uuid-1", "rack-1", 10_GB) |

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -745,6 +745,7 @@ public:
         TDuration requestTimeout = {})
     {
         return std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseRequest>(
+            NProto::EDevicePoolKind::DEVICE_POOL_KIND_DEFAULT,
             std::move(devices),
             requestTimeout);
     }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -745,7 +745,7 @@ public:
         TDuration requestTimeout = {})
     {
         return std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseRequest>(
-            NProto::EDevicePoolKind::DEVICE_POOL_KIND_DEFAULT,
+            TString{},
             std::move(devices),
             requestTimeout);
     }


### PR DESCRIPTION
Issue: #1395

Problem:
Erasing of hdd disks is significantly slower compare to erasing of nvme disks. Disk registry blocks next erase by setting SecureEraseInProgress flag while current erase is in progress. As a result we can delay erase of the next bunch of nvme disks despite of no nvme disks erase is in progress.

SecureErase is a background process which is regularly triggered by disk registry actor.

Solution:
1. Split SecureErase by pool name
2. Use different SecureEraseInProgress flags depend on the pool name.