### PR TITLE
[NBS] POC: default encryption for NRD

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -480,7 +480,10 @@ void TCommand::Init()
 
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateDefaultEncryptionKeyProvider());
+        CreateDefaultEncryptionKeyProvider(),
+        CreateVolumeEncryptionClientFactory(
+            Logging,
+            CreateDefaultEncryptionKeyProvider()));
 
     if (!ClientEndpoint) {
         ClientStats = CreateClientStats(

--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -478,12 +478,11 @@ void TCommand::Init()
         EVolumeStatsType::EClientStats,
         Timer);
 
+    auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateDefaultEncryptionKeyProvider(),
-        CreateVolumeEncryptionClientFactory(
-            Logging,
-            CreateDefaultEncryptionKeyProvider()));
+        encryptionKeyProvider,
+        CreateVolumeEncryptionClientFactory(Logging, encryptionKeyProvider));
 
     if (!ClientEndpoint) {
         ClientStats = CreateClientStats(

--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -478,11 +478,18 @@ void TCommand::Init()
         EVolumeStatsType::EClientStats,
         Timer);
 
-    auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
+    auto encryptionKeyProvider =
+        CreateEncryptionKeyProvider(CreateKmsKeyProviderStub());
+
+    auto defaultEncryptionKeyProvider =
+        CreateDefaultEncryptionKeyProvider(CreateRootKmsKeyProviderStub());
+
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
         encryptionKeyProvider,
-        CreateVolumeEncryptionClientFactory(Logging, encryptionKeyProvider));
+        CreateVolumeEncryptionClientFactory(
+            Logging,
+            defaultEncryptionKeyProvider));
 
     if (!ClientEndpoint) {
         ClientStats = CreateClientStats(

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1011,4 +1011,7 @@ message TStorageServiceConfig
     // Delay that DR uses to wait unavailable agents to register before allowing
     // infra to deploy a host.
     optional uint32 IdleAgentDeployByCmsDelay = 377;
+
+    // Enable default enctyption for NRD/Mirrored disks.
+    optional bool DefaultEncryptionEnabled = 377;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1013,5 +1013,5 @@ message TStorageServiceConfig
     optional uint32 IdleAgentDeployByCmsDelay = 377;
 
     // Enable default enctyption for NRD/Mirrored disks.
-    optional bool DefaultEncryptionForNonReplicatedDisksEnabled = 378;
+    optional bool DefaultEncryptionForDiskRegistryBasedDisksEnabled = 378;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1013,5 +1013,5 @@ message TStorageServiceConfig
     optional uint32 IdleAgentDeployByCmsDelay = 377;
 
     // Enable default enctyption for NRD/Mirrored disks.
-    optional bool DefaultEncryptionEnabled = 377;
+    optional bool DefaultEncryptionForNonReplicatedDisksEnabled = 378;
 }

--- a/cloud/blockstore/libs/client/bench/main.cpp
+++ b/cloud/blockstore/libs/client/bench/main.cpp
@@ -47,7 +47,7 @@ struct TBootstrap
     {
         EncryptionClientFactory = CreateEncryptionClientFactory(
             Logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateEncryptionKeyProvider(CreateKmsKeyProviderStub()));
     }
 
     IBlockStorePtr CreateClient()

--- a/cloud/blockstore/libs/common/iovector.cpp
+++ b/cloud/blockstore/libs/common/iovector.cpp
@@ -198,4 +198,9 @@ bool IsAllZeroes(const char* src, size_t size)
     }
 }
 
+bool IsAllZeroes(TBlockDataRef block)
+{
+    return block.Data() == nullptr || IsAllZeroes(block.Data(), block.Size());
+}
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/iovector.h
+++ b/cloud/blockstore/libs/common/iovector.h
@@ -47,4 +47,5 @@ size_t CopyAndTrimVoidBuffers(
 
 // Checks that the buffer contains only zeros.
 [[nodiscard]] bool IsAllZeroes(const char* src, size_t size);
+[[nodiscard]] bool IsAllZeroes(TBlockDataRef block);
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -339,7 +339,7 @@ void TBootstrapBase::Init()
     }
 
     if (!RootKmsKeyProvider) {
-        RootKmsKeyProvider = CreateKmsKeyProviderStub();
+        RootKmsKeyProvider = CreateRootKmsKeyProviderStub();
     }
 
     auto encryptionClientFactory = CreateEncryptionClientFactory(
@@ -347,7 +347,7 @@ void TBootstrapBase::Init()
         CreateEncryptionKeyProvider(KmsKeyProvider),
         CreateVolumeEncryptionClientFactory(
             Logging,
-            CreateEncryptionKeyProvider(RootKmsKeyProvider)));
+            CreateDefaultEncryptionKeyProvider(RootKmsKeyProvider)));
 
     auto sessionManager = CreateSessionManager(
         Timer,

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -338,14 +338,16 @@ void TBootstrapBase::Init()
         KmsKeyProvider = CreateKmsKeyProviderStub();
     }
 
-    auto encryptionKeyProvider = CreateEncryptionKeyProvider(KmsKeyProvider);
+    if (!RootKmsKeyProvider) {
+        RootKmsKeyProvider = CreateKmsKeyProviderStub();
+    }
 
     auto encryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        encryptionKeyProvider,
+        CreateEncryptionKeyProvider(KmsKeyProvider),
         CreateVolumeEncryptionClientFactory(
             Logging,
-            encryptionKeyProvider));
+            CreateEncryptionKeyProvider(RootKmsKeyProvider)));
 
     auto sessionManager = CreateSessionManager(
         Timer,

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -338,9 +338,14 @@ void TBootstrapBase::Init()
         KmsKeyProvider = CreateKmsKeyProviderStub();
     }
 
+    auto encryptionKeyProvider = CreateEncryptionKeyProvider(KmsKeyProvider);
+
     auto encryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateEncryptionKeyProvider(KmsKeyProvider));
+        encryptionKeyProvider,
+        CreateVolumeEncryptionClientFactory(
+            Logging,
+            encryptionKeyProvider));
 
     auto sessionManager = CreateSessionManager(
         Timer,

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -64,7 +64,7 @@ protected:
     IFileIOServicePtr FileIOService;
     IStorageProviderPtr StorageProvider;
     IKmsKeyProviderPtr KmsKeyProvider;
-    IKmsKeyProviderPtr RootKmsKeyProvider;
+    IRootKmsKeyProviderPtr RootKmsKeyProvider;
     TExecutorPtr Executor;
     IServerPtr Server;
     NSpdk::ISpdkEnvPtr Spdk;

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -64,6 +64,7 @@ protected:
     IFileIOServicePtr FileIOService;
     IStorageProviderPtr StorageProvider;
     IKmsKeyProviderPtr KmsKeyProvider;
+    IKmsKeyProviderPtr RootKmsKeyProvider;
     TExecutorPtr Executor;
     IServerPtr Server;
     NSpdk::ISpdkEnvPtr Spdk;

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -15,6 +15,7 @@
 #include <cloud/blockstore/libs/discovery/fetch.h>
 #include <cloud/blockstore/libs/discovery/healthcheck.h>
 #include <cloud/blockstore/libs/discovery/ping.h>
+#include <cloud/blockstore/libs/encryption/encryption_key.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/kms/iface/compute_client.h>
 #include <cloud/blockstore/libs/kms/iface/key_provider.h>
@@ -24,6 +25,7 @@
 #include <cloud/blockstore/libs/notify/config.h>
 #include <cloud/blockstore/libs/notify/notify.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/root_kms/key_provider.h>
 #include <cloud/blockstore/libs/rdma/iface/probes.h>
 #include <cloud/blockstore/libs/rdma/iface/client.h>
 #include <cloud/blockstore/libs/rdma/iface/config.h>
@@ -347,7 +349,7 @@ void TBootstrapYdb::InitKikimrService()
 
     STORAGE_INFO("KmsKeyProvider initialized");
 
-    RootKmsKeyProvider = CreateRootKmsKeyProvider(Executor);
+    RootKmsKeyProvider = CreateRootKmsKeyProvider();
 
     STORAGE_INFO("RootKmsKeyProvider initialized");
 
@@ -549,6 +551,8 @@ void TBootstrapYdb::InitKikimrService()
         }();
     args.VolumeBalancerSwitch = VolumeBalancerSwitch;
     args.EndpointEventHandler = EndpointEventHandler;
+    args.DefaultEncryptionKeyProvider =
+        CreateDefaultEncryptionKeyProvider(RootKmsKeyProvider);
 
     ActorSystem = NStorage::CreateActorSystem(args);
 

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -347,6 +347,10 @@ void TBootstrapYdb::InitKikimrService()
 
     STORAGE_INFO("KmsKeyProvider initialized");
 
+    RootKmsKeyProvider = CreateRootKmsKeyProvider(Executor);
+
+    STORAGE_INFO("RootKmsKeyProvider initialized");
+
     auto discoveryConfig = Configs->DiscoveryConfig;
     if (discoveryConfig->GetConductorGroups()
             || discoveryConfig->GetInstanceListFile())

--- a/cloud/blockstore/libs/daemon/ydb/ya.make
+++ b/cloud/blockstore/libs/daemon/ydb/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     cloud/blockstore/libs/logbroker/iface
     cloud/blockstore/libs/notify
     cloud/blockstore/libs/nvme
+    cloud/blockstore/libs/root_kms
     cloud/blockstore/libs/server
     cloud/blockstore/libs/service
     cloud/blockstore/libs/service_kikimr

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -60,6 +60,7 @@ namespace NCloud::NBlockStore {
     xxx(BlockDigestMismatchInBlob)                                             \
     xxx(DiskRegistryResumeDeviceFailed)                                        \
     xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
+    xxx(EncryptorGeneratedZeroBlock)                                           \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -726,7 +726,6 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TMountVolumeRequest> request) override
     {
-        // XXX: wait for MountResponse?
         if (request->HasEncryptionSpec() &&
             request->GetEncryptionSpec().GetMode() != NProto::NO_ENCRYPTION)
         {

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -768,10 +768,6 @@ private:
     NProto::TError HandleMountVolumeResponse(
         const NProto::TMountVolumeResponse& response)
     {
-        if (Initialized) {
-            return {};
-        }
-
         const auto& volume = response.GetVolume();
 
         if (!volume.HasEncryptionDesc()) {
@@ -784,11 +780,15 @@ private:
         }
 
         if (desc.GetMode() != NProto::ENCRYPTION_AES_XTS_NO_TRACK_UNUSED) {
-            return MakeError(E_ARGUMENT, "Invalid encription mode");
+            return MakeError(E_ARGUMENT, "Unexpected encription mode");
         }
 
         if (desc.GetKeyHash().empty()) {
-            return MakeError(E_ARGUMENT, "Invalid KeyHash");
+            return MakeError(E_ARGUMENT, "Empty KeyHash");
+        }
+
+        if (Initialized) {
+            return {};
         }
 
         STORAGE_INFO(

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -3,6 +3,7 @@
 #include "encryptor.h"
 
 #include <cloud/blockstore/libs/common/iovector.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service.h>
@@ -644,6 +645,9 @@ NProto::TError TEncryptionClient::Encrypt(
         }
 
         if (IsAllZeroes(dst[i])) {
+            ReportEncryptorGeneratedZeroBlock(TStringBuilder()
+                << "block #" << startIndex + i);
+
             return MakeError(E_FAIL, "Encryptor has generated a zero block!");
         }
     }

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -643,10 +643,14 @@ NProto::TError TEncryptionClient::Encrypt(
         }
 
         if (IsAllZeroes(dst[i])) {
-            ReportEncryptorGeneratedZeroBlock(TStringBuilder()
-                << "block #" << startIndex + i);
+            auto err = MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "Encryptor has generated a zero block (#"
+                                 << startIndex + i << ")!");
 
-            return MakeError(E_FAIL, "Encryptor has generated a zero block!");
+            ReportEncryptorGeneratedZeroBlock(err.GetMessage());
+
+            return err;
         }
     }
 

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -726,6 +726,7 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TMountVolumeRequest> request) override
     {
+        // XXX: wait for MountResponse?
         if (request->HasEncryptionSpec() &&
             request->GetEncryptionSpec().GetMode() != NProto::NO_ENCRYPTION)
         {

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -13,8 +13,9 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Create an encryption client which uses EncryptionDesc from the Volume config.
-IBlockStorePtr CreateDefaultEncryptionClient(
+// Create an encryption client that uses EncryptionDesc from the Volume config.
+IBlockStorePtr CreateVolumeEncryptionClient(
+    IVolumeEncryptionClientFactoryPtr volumeEncryptionClientFactory,
     IBlockStorePtr client,
     ILoggingServicePtr logging);
 
@@ -45,7 +46,25 @@ struct IEncryptionClientFactory
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct IVolumeEncryptionClientFactory
+{
+    using TResponse = TResultOrError<IBlockStorePtr>;
+
+    virtual ~IVolumeEncryptionClientFactory() = default;
+
+    virtual NThreading::TFuture<TResponse> CreateEncryptionClient(
+        IBlockStorePtr client,
+        const NProto::TVolume& volume) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 IEncryptionClientFactoryPtr CreateEncryptionClientFactory(
+    ILoggingServicePtr logging,
+    IEncryptionKeyProviderPtr encryptionKeyProvider,
+    IVolumeEncryptionClientFactoryPtr volumeEncryptionClientFactory);
+
+IVolumeEncryptionClientFactoryPtr CreateVolumeEncryptionClientFactory(
     ILoggingServicePtr logging,
     IEncryptionKeyProviderPtr encryptionKeyProvider);
 

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -13,6 +13,7 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Create an encryption client which uses EncryptionDesc from the Volume config.
 IBlockStorePtr CreateDefaultEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging);

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -66,6 +66,6 @@ IEncryptionClientFactoryPtr CreateEncryptionClientFactory(
 
 IVolumeEncryptionClientFactoryPtr CreateVolumeEncryptionClientFactory(
     ILoggingServicePtr logging,
-    IEncryptionKeyProviderPtr encryptionKeyProvider);
+    IDefaultEncryptionKeyProviderPtr keyProvider);
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -13,6 +13,10 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+IBlockStorePtr CreateDefaultEncryptionClient(
+    IBlockStorePtr client,
+    ILoggingServicePtr logging);
+
 IBlockStorePtr CreateEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging,

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -1232,7 +1232,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
         auto testClient = std::make_shared<TTestService>();
 
-        // Mount a volume with an unexpected encription mode
+        // Mount a volume with an unexpected encryption mode
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
                 UNIT_ASSERT(!request->HasEncryptionSpec());
@@ -1249,7 +1249,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
             auto response = MountVolume(*encryptionClient);
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_ARGUMENT, // Unexpected encription mode
+                E_ARGUMENT, // Unexpected encryption mode
                 response.GetError().GetCode(),
                 FormatError(response.GetError()));
         }
@@ -1263,9 +1263,9 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
                 volume.SetBlockSize(blockSize);
 
-                auto& desc = *volume.MutableEncryptionDesc();
+                NProto::TEncryptionDesc& desc = *volume.MutableEncryptionDesc();
                 desc.SetMode(NProto::ENCRYPTION_DEFAULT_AES_XTS);
-                desc.SetKeyHash(Base64Encode(key));
+                desc.MutableDataKey()->SetEncryptedDEK(Base64Encode(key));
 
                 return MakeFuture(std::move(response));
             };

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -72,21 +72,13 @@ struct TTestEncryptor final
         ui64 blockIndex) override
     {
         UNIT_ASSERT(srcRef.Size() == dstRef.Size());
-
-        if (srcRef.Data() == nullptr) {
-            char* dstPtr = const_cast<char*>(dstRef.Data());
-            for (size_t i = 0; i < srcRef.Size(); ++i) {
-                *dstPtr = static_cast<char>(blockIndex) ^ (i % 256);
-                ++dstPtr;
-            }
-            return {};
-        }
+        UNIT_ASSERT(srcRef.Data() != nullptr);
 
         const char* srcPtr = srcRef.Data();
         char* dstPtr = const_cast<char*>(dstRef.Data());
 
         for (size_t i = 0; i < srcRef.Size(); ++i) {
-            *dstPtr = *srcPtr ^ (i % 256) - static_cast<char>(blockIndex);
+            *dstPtr = (*srcPtr ^ (i % 256)) - static_cast<char>(blockIndex);
             ++srcPtr;
             ++dstPtr;
         }

--- a/cloud/blockstore/libs/encryption/encryption_key.h
+++ b/cloud/blockstore/libs/encryption/encryption_key.h
@@ -18,7 +18,7 @@ private:
     TString Key;
 
 public:
-    TEncryptionKey(TString key = {});
+    explicit TEncryptionKey(TString key = {});
     ~TEncryptionKey();
 
     TEncryptionKey(TEncryptionKey&&) noexcept = default;

--- a/cloud/blockstore/libs/encryption/encryption_service.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_service.cpp
@@ -113,15 +113,12 @@ public:
         TCallContextPtr ctx,
         std::shared_ptr<NProto::TMountVolumeRequest> request) override
     {
-        const auto& encryptionSpec = request->GetEncryptionSpec();
-        if (encryptionSpec.GetMode() == NProto::NO_ENCRYPTION) {
-            return Service->MountVolume(std::move(ctx), std::move(request));
-        }
-
         auto session = GetSession(request->GetHeaders().GetClientId());
         if (session) {
             return session->MountVolume(std::move(ctx), std::move(request));
         }
+
+        const auto& encryptionSpec = request->GetEncryptionSpec();
 
         STORAGE_INFO(
             TRequestInfo(

--- a/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
@@ -267,7 +267,7 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
 
         auto clientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider(),
+            CreateEncryptionKeyProvider(CreateKmsKeyProviderStub()),
             std::make_shared<TVolumeEncryptionClientFactory>());
 
         auto service = std::make_shared<TTestService>();

--- a/cloud/blockstore/libs/encryption/encryptor_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryptor_ut.cpp
@@ -40,7 +40,8 @@ Y_UNIT_TEST_SUITE(TEncryptorTest)
         auto eDataRef = TBlockDataRef{ eData.data(), eData.size() };
         auto dDataRef = TBlockDataRef{ dData.data(), dData.size() };
 
-        auto encryptor = CreateAesXtsEncryptor(DefaultEncryptionKey);
+        auto encryptor =
+            CreateAesXtsEncryptor(TEncryptionKey{DefaultEncryptionKey});
 
         auto err1 = encryptor->Encrypt(dataRef, eDataRef, blockIndex);
         UNIT_ASSERT_VALUES_EQUAL_C(S_OK, err1.GetCode(), err1);
@@ -60,7 +61,8 @@ Y_UNIT_TEST_SUITE(TEncryptorTest)
         TString tmpData = TString::Uninitialized(DefaultBlockSize);
         auto dDataRef = TBlockDataRef{ tmpData.data(), tmpData.size() };
 
-        auto encryptor = CreateAesXtsEncryptor(DefaultEncryptionKey);
+        auto encryptor =
+            CreateAesXtsEncryptor(TEncryptionKey{DefaultEncryptionKey});
 
         auto err = encryptor->Decrypt(eDataRef, dDataRef, blockIndex);
         UNIT_ASSERT_VALUES_EQUAL_C(S_OK, err.GetCode(), err);
@@ -85,7 +87,8 @@ Y_UNIT_TEST_SUITE(TEncryptorTest)
         auto eDataRef1 = TBlockDataRef{ eData1.data(), eData1.size() };
         auto eDataRef2 = TBlockDataRef{ eData2.data(), eData2.size() };
 
-        auto encryptor = CreateAesXtsEncryptor(DefaultEncryptionKey);
+        auto encryptor =
+            CreateAesXtsEncryptor(TEncryptionKey{DefaultEncryptionKey});
 
         {
             auto err1 = encryptor->Encrypt(dataRef, eDataRef1, blockIndex1);

--- a/cloud/blockstore/libs/encryption/public.h
+++ b/cloud/blockstore/libs/encryption/public.h
@@ -18,4 +18,7 @@ using IKmsKeyProviderPtr = std::shared_ptr<IKmsKeyProvider>;
 struct IEncryptionClientFactory;
 using IEncryptionClientFactoryPtr = std::shared_ptr<IEncryptionClientFactory>;
 
+struct IVolumeEncryptionClientFactory;
+using IVolumeEncryptionClientFactoryPtr = std::shared_ptr<IVolumeEncryptionClientFactory>;
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/encryption/public.h
+++ b/cloud/blockstore/libs/encryption/public.h
@@ -12,8 +12,14 @@ using IEncryptorPtr = std::shared_ptr<IEncryptor>;
 struct IEncryptionKeyProvider;
 using IEncryptionKeyProviderPtr = std::shared_ptr<IEncryptionKeyProvider>;
 
+struct IDefaultEncryptionKeyProvider;
+using IDefaultEncryptionKeyProviderPtr = std::shared_ptr<IDefaultEncryptionKeyProvider>;
+
 struct IKmsKeyProvider;
 using IKmsKeyProviderPtr = std::shared_ptr<IKmsKeyProvider>;
+
+struct IRootKmsKeyProvider;
+using IRootKmsKeyProviderPtr = std::shared_ptr<IRootKmsKeyProvider>;
 
 struct IEncryptionClientFactory;
 using IEncryptionClientFactoryPtr = std::shared_ptr<IEncryptionClientFactory>;

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -430,9 +430,13 @@ IEndpointManagerPtr CreateEndpointManager(TBootstrap& bootstrap)
         sessionManagerOptions.DefaultClientConfig.SetRequestTimeout(
             TestRequestTimeout.MilliSeconds());
 
+        auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             bootstrap.Logging,
-            CreateDefaultEncryptionKeyProvider());
+            encryptionKeyProvider,
+            CreateVolumeEncryptionClientFactory(
+                bootstrap.Logging,
+                encryptionKeyProvider));
 
         bootstrap.SessionManager = CreateSessionManager(
             bootstrap.Timer,

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -430,7 +430,8 @@ IEndpointManagerPtr CreateEndpointManager(TBootstrap& bootstrap)
         sessionManagerOptions.DefaultClientConfig.SetRequestTimeout(
             TestRequestTimeout.MilliSeconds());
 
-        auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
+        auto encryptionKeyProvider =
+            CreateEncryptionKeyProvider(CreateKmsKeyProviderStub());
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             bootstrap.Logging,
             encryptionKeyProvider,

--- a/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
@@ -120,9 +120,13 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         auto executor = TExecutor::Create("TestService");
         auto logging = CreateLoggingService("console");
 
+        auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider());
+            encryptionKeyProvider,
+            CreateVolumeEncryptionClientFactory(
+                logging,
+                encryptionKeyProvider));
 
         auto sessionManager = CreateSessionManager(
             CreateWallClockTimer(),
@@ -235,9 +239,14 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         options.TemporaryServer = temporaryServer;
         options.DisableDurableClient = true;
 
+        auto defaultEncryptionKeyProvider =
+            CreateDefaultEncryptionKeyProvider();
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider());
+            defaultEncryptionKeyProvider,
+            CreateVolumeEncryptionClientFactory(
+                logging,
+                defaultEncryptionKeyProvider));
 
         auto sessionManager = CreateSessionManager(
             CreateWallClockTimer(),

--- a/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
@@ -120,7 +120,8 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         auto executor = TExecutor::Create("TestService");
         auto logging = CreateLoggingService("console");
 
-        auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
+        auto encryptionKeyProvider =
+            CreateEncryptionKeyProvider(CreateKmsKeyProviderStub());
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
             encryptionKeyProvider,
@@ -240,7 +241,7 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         options.DisableDurableClient = true;
 
         auto defaultEncryptionKeyProvider =
-            CreateDefaultEncryptionKeyProvider();
+            CreateEncryptionKeyProvider(CreateKmsKeyProviderStub());
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
             defaultEncryptionKeyProvider,

--- a/cloud/blockstore/libs/kms/iface/key_provider.h
+++ b/cloud/blockstore/libs/kms/iface/key_provider.h
@@ -19,6 +19,4 @@ IKmsKeyProviderPtr CreateKmsKeyProvider(
     IComputeClientPtr computeClient,
     IKmsClientPtr kmsClient);
 
-IKmsKeyProviderPtr CreateRootKmsKeyProvider(TExecutorPtr executor);
-
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/kms/iface/key_provider.h
+++ b/cloud/blockstore/libs/kms/iface/key_provider.h
@@ -19,4 +19,6 @@ IKmsKeyProviderPtr CreateKmsKeyProvider(
     IComputeClientPtr computeClient,
     IKmsClientPtr kmsClient);
 
+IKmsKeyProviderPtr CreateRootKmsKeyProvider(TExecutorPtr executor);
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/root_kms/key_provider.cpp
+++ b/cloud/blockstore/libs/root_kms/key_provider.cpp
@@ -1,0 +1,90 @@
+#include "key_provider.h"
+
+#include <cloud/blockstore/libs/encryption/encryption_key.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <library/cpp/string_utils/base64/base64.h>
+
+#include <util/random/entropy.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TResultOrError<TString> SafeBase64Decode(TStringBuf encoded)
+{
+    try {
+        return Base64Decode(encoded);
+    } catch (...) {
+        return MakeError(E_ARGUMENT, CurrentExceptionMessage());
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRootKmsKeyProvider final
+    : public IRootKmsKeyProvider
+{
+public:
+    auto GetKey(const NProto::TKmsKey& kmsKey, const TString& diskId)
+        -> TFuture<TResultOrError<TEncryptionKey>> override
+    {
+        if (kmsKey.GetKekId()) {
+            return MakeFuture<TResultOrError<TEncryptionKey>>(
+                MakeError(E_NOT_IMPLEMENTED, "TODO: get DEK from Root KMS"));
+        }
+
+        auto [key, error] = SafeBase64Decode(kmsKey.GetEncryptedDEK());
+        if (HasError(error)) {
+            return MakeFuture<TResultOrError<TEncryptionKey>>(MakeError(
+                error.GetCode(),
+                TStringBuilder() << "failed to decode DEK for disk " << diskId
+                                 << ", error: " << error));
+        }
+
+        return MakeFuture<TResultOrError<TEncryptionKey>>(TEncryptionKey(key));
+    }
+
+    auto GenerateDataEncryptionKey(const TString& diskId)
+        -> TFuture<TResultOrError<NProto::TKmsKey>> override
+    {
+        Y_UNUSED(diskId);
+
+        // TODO: use Root KMS client
+
+        try {
+            TString key;
+            key.resize(32);
+            EntropyPool().Read(key.Detach(), key.size());
+
+            NProto::TKmsKey kmsKey;
+            kmsKey.SetEncryptedDEK(Base64Encode(key));
+
+            return MakeFuture<TResultOrError<NProto::TKmsKey>>(
+                std::move(kmsKey));
+
+        } catch (...) {
+            return MakeFuture<TResultOrError<NProto::TKmsKey>>(MakeError(
+                E_FAIL,
+                TStringBuilder() << "failed to generate DEK for disk " << diskId
+                                 << ", error: " << CurrentExceptionMessage()));
+        }
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IRootKmsKeyProviderPtr CreateRootKmsKeyProvider()
+{
+    return std::make_shared<TRootKmsKeyProvider>();
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/root_kms/key_provider.h
+++ b/cloud/blockstore/libs/root_kms/key_provider.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/libs/encryption/public.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IRootKmsKeyProviderPtr CreateRootKmsKeyProvider();
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/root_kms/key_provider_ut.cpp
+++ b/cloud/blockstore/libs/root_kms/key_provider_ut.cpp
@@ -1,0 +1,56 @@
+#include "key_provider.h"
+
+#include <cloud/blockstore/libs/encryption/encryption_key.h>
+
+#include <library/cpp/string_utils/base64/base64.h>
+#include <library/cpp/testing/unittest/env.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NThreading;
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TRootKmsKeyProviderTest)
+{
+    Y_UNIT_TEST(ShouldGenerateUnencyptedKey)
+    {
+        const TString diskId = "vol0";
+        auto keyProvider = CreateRootKmsKeyProvider();
+
+        NProto::TKmsKey generatedKey = [&] {
+            auto [key, error] =
+                keyProvider->GenerateDataEncryptionKey(diskId).GetValueSync();
+
+            UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error);
+            UNIT_ASSERT_VALUES_EQUAL("", key.GetKekId());
+            UNIT_ASSERT_VALUES_UNEQUAL("", key.GetEncryptedDEK());
+
+            return key;
+        }();
+
+        {
+            NProto::TKmsKey kmsKey;
+            kmsKey.SetKekId("kek");
+            kmsKey.SetEncryptedDEK("xxx");
+            const auto& [_, error] =
+                keyProvider->GetKey(kmsKey, diskId).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_NOT_IMPLEMENTED,
+                error.GetCode(),
+                error);
+        }
+
+        const auto& [key, error] =
+            keyProvider->GetKey(generatedKey, diskId).GetValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), error);
+        UNIT_ASSERT_VALUES_EQUAL(
+            Base64Decode(generatedKey.GetEncryptedDEK()),
+            key.GetKey());
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/root_kms/public.h
+++ b/cloud/blockstore/libs/root_kms/public.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/cloud/blockstore/libs/root_kms/ut/ya.make
+++ b/cloud/blockstore/libs/root_kms/ut/ya.make
@@ -1,0 +1,13 @@
+UNITTEST_FOR(cloud/blockstore/libs/root_kms)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    key_provider_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/testing/unittest
+)
+
+END()

--- a/cloud/blockstore/libs/root_kms/ya.make
+++ b/cloud/blockstore/libs/root_kms/ya.make
@@ -1,0 +1,17 @@
+LIBRARY()
+
+SRCS(
+    key_provider.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/common
+    cloud/blockstore/libs/encryption
+
+    library/cpp/string_utils/base64
+    library/cpp/threading/future
+)
+
+END()
+
+RECURSE_FOR_TESTS(ut)

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -499,7 +499,7 @@ TDuration MSeconds(ui32 value)
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(IdleAgentDeployByCmsDelay,                      TDuration, Hours(1)      )\
-    xxx(DefaultEncryptionEnabled,                       bool,      false         )\
+    xxx(DefaultEncryptionForNonReplicatedDisksEnabled,  bool,      false      )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
@@ -531,6 +531,7 @@ BLOCKSTORE_STORAGE_CONFIG(BLOCKSTORE_STORAGE_DECLARE_CONFIG)
     xxx(ReplaceDevice)                                                         \
     xxx(UseNonReplicatedHDDInsteadOfReplicated)                                \
     xxx(AddingUnconfirmedBlobs)                                                \
+    xxx(DefaultEncryptionForNonReplicatedDisks)                                \
 
 // BLOCKSTORE_BINARY_FEATURES
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -499,7 +499,7 @@ TDuration MSeconds(ui32 value)
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(IdleAgentDeployByCmsDelay,                      TDuration, Hours(1)      )\
-    xxx(DefaultEncryptionForNonReplicatedDisksEnabled,  bool,      false      )\
+    xxx(DefaultEncryptionForDiskRegistryBasedDisksEnabled,  bool,      false      )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -499,6 +499,7 @@ TDuration MSeconds(ui32 value)
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(IdleAgentDeployByCmsDelay,                      TDuration, Hours(1)      )\
+    xxx(DefaultEncryptionEnabled,                       bool,      false         )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -593,7 +593,7 @@ public:
 
     TDuration GetIdleAgentDeployByCmsDelay() const;
 
-    [[nodiscard]] bool GetDefaultEncryptionForNonReplicatedDisksEnabled() const;
+    [[nodiscard]] bool GetDefaultEncryptionForDiskRegistryBasedDisksEnabled() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -588,6 +588,8 @@ public:
     TVector<TString> GetDestructionAllowedOnlyForDisksWithIdPrefixes() const;
 
     TDuration GetIdleAgentDeployByCmsDelay() const;
+
+    [[nodiscard]] bool GetDefaultEncryptionEnabled() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -352,6 +352,10 @@ public:
         const TString& cloudId,
         const TString& folderId,
         const TString& diskId) const;
+    [[nodiscard]] bool IsDefaultEncryptionForNonReplicatedDisksFeatureEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& diskId) const;
 
     TDuration GetMaxTimedOutDeviceStateDurationFeatureValue(
         const TString& cloudId,
@@ -589,7 +593,7 @@ public:
 
     TDuration GetIdleAgentDeployByCmsDelay() const;
 
-    [[nodiscard]] bool GetDefaultEncryptionEnabled() const;
+    [[nodiscard]] bool GetDefaultEncryptionForNonReplicatedDisksEnabled() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -100,6 +100,12 @@ NProto::TEncryptionDesc ConvertToEncryptionDesc(
     NProto::TEncryptionDesc resultDesc;
     resultDesc.SetMode(mode);
     resultDesc.SetKeyHash(desc.GetKeyHash());
+    if (desc.HasEncryptedDEK()) {
+        NProto::TKmsKey& key = *resultDesc.MutableDataKey();
+        key.SetKekId(desc.GetEncryptedDEK().GetKekId());
+        key.SetEncryptedDEK(desc.GetEncryptedDEK().GetCiphertext());
+    }
+
     return resultDesc;
 }
 

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -108,8 +108,8 @@ private:
     const TServerActorSystemArgs Args;
 
 public:
-    TStorageServicesInitializer(const TServerActorSystemArgs& args)
-        : Args(args)
+    explicit TStorageServicesInitializer(TServerActorSystemArgs args)
+        : Args(std::move(args))
     {}
 
     void InitializeServices(
@@ -213,7 +213,8 @@ public:
             Args.EndpointEventHandler,
             Args.RdmaClient,
             Args.VolumeStats,
-            Args.PreemptedVolumes);
+            Args.PreemptedVolumes,
+            Args.DefaultEncryptionKeyProvider);
 
         setup->LocalServices.emplace_back(
             MakeStorageServiceId(),

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/common/public.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/discovery/public.h>
+#include <cloud/blockstore/libs/encryption/public.h>
 #include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/nvme/public.h>
@@ -66,6 +67,7 @@ struct TServerActorSystemArgs
     NNvme::INvmeManagerPtr NvmeManager;
     IVolumeBalancerSwitchPtr VolumeBalancerSwitch;
     NServer::IEndpointEventHandlerPtr EndpointEventHandler;
+    IDefaultEncryptionKeyProviderPtr DefaultEncryptionKeyProvider;
 
     TVector<NCloud::NStorage::IUserMetricsSupplierPtr> UserCounterProviders;
 

--- a/cloud/blockstore/libs/storage/service/service.cpp
+++ b/cloud/blockstore/libs/storage/service/service.cpp
@@ -18,7 +18,8 @@ IActorPtr CreateStorageService(
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     IVolumeStatsPtr volumeStats,
-    TManuallyPreemptedVolumesPtr preemptedVolumes)
+    TManuallyPreemptedVolumesPtr preemptedVolumes,
+    IDefaultEncryptionKeyProviderPtr defaultEncryptionKeyProvider)
 {
     return std::make_unique<TServiceActor>(
         std::move(config),
@@ -30,7 +31,8 @@ IActorPtr CreateStorageService(
         std::move(endpointEventHandler),
         std::move(rdmaClient),
         std::move(volumeStats),
-        std::move(preemptedVolumes));
+        std::move(preemptedVolumes),
+        std::move(defaultEncryptionKeyProvider));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service.h
+++ b/cloud/blockstore/libs/storage/service/service.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/discovery/public.h>
+#include <cloud/blockstore/libs/encryption/public.h>
 #include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
@@ -23,6 +24,7 @@ NActors::IActorPtr CreateStorageService(
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     IVolumeStatsPtr volumeStats,
-    TManuallyPreemptedVolumesPtr preemptedVolumes);
+    TManuallyPreemptedVolumesPtr preemptedVolumes,
+    IDefaultEncryptionKeyProviderPtr defaultEncryptionKeyProvider);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -27,7 +27,8 @@ TServiceActor::TServiceActor(
         NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         IVolumeStatsPtr volumeStats,
-        TManuallyPreemptedVolumesPtr preemptedVolumes)
+        TManuallyPreemptedVolumesPtr preemptedVolumes,
+        IDefaultEncryptionKeyProviderPtr defaultEncryptionKeyProvider)
     : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
@@ -37,6 +38,7 @@ TServiceActor::TServiceActor(
     , EndpointEventHandler(std::move(endpointEventHandler))
     , RdmaClient(std::move(rdmaClient))
     , VolumeStats(std::move(volumeStats))
+    , DefaultEncryptionKeyProvider(std::move(defaultEncryptionKeyProvider))
     , SharedCounters(MakeIntrusive<TSharedServiceCounters>(Config))
     , State(std::move(preemptedVolumes))
 {}

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/discovery/discovery.h>
+#include <cloud/blockstore/libs/encryption/public.h>
 #include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
@@ -47,6 +48,7 @@ private:
     const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const NRdma::IClientPtr RdmaClient;
     const IVolumeStatsPtr VolumeStats;
+    const IDefaultEncryptionKeyProviderPtr DefaultEncryptionKeyProvider;
 
     TSharedServiceCountersPtr SharedCounters;
 
@@ -73,8 +75,10 @@ public:
         NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         IVolumeStatsPtr volumeStats,
-        TManuallyPreemptedVolumesPtr preemptedVolumes);
-    ~TServiceActor();
+        TManuallyPreemptedVolumesPtr preemptedVolumes,
+        IDefaultEncryptionKeyProviderPtr defaultEncryptionKeyProvider);
+
+    ~TServiceActor() override;
 
     void Bootstrap(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/service/service_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create.cpp
@@ -231,9 +231,16 @@ void TCreateVolumeActor::CreateVolume(const TActorContext& ctx)
              Request.GetFolderId(),
              Request.GetDiskId())))
     {
+        LOG_INFO_S(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Create volume " << Request.GetDiskId().Quote()
+                             << " with default AES XTS encryption");
+
         auto& desc = *config.MutableEncryptionDesc();
         desc.SetMode(NProto::ENCRYPTION_AES_XTS_NO_TRACK_UNUSED);
 
+        // XXX: use EncryptionKeyProvider?
         TString key;
         key.resize(32);
         EntropyPool().Read(key.Detach(), key.size());

--- a/cloud/blockstore/libs/storage/service/service_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create.cpp
@@ -19,6 +19,8 @@
 #include <util/random/entropy.h>
 #include <util/string/ascii.h>
 
+#include <library/cpp/string_utils/base64/base64.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -245,7 +247,7 @@ void TCreateVolumeActor::CreateVolume(const TActorContext& ctx)
         key.resize(32);
         EntropyPool().Read(key.Detach(), key.size());
         // XXX: store key in KeyHash for now
-        desc.SetKeyHash(std::move(key));
+        desc.SetKeyHash(Base64Encode(key));
     }
 
     auto request = std::make_unique<TEvSSProxy::TEvCreateVolumeRequest>(

--- a/cloud/blockstore/libs/storage/service/service_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create.cpp
@@ -205,10 +205,14 @@ void TCreateVolumeActor::DescribeBaseVolume(const TActorContext& ctx)
 
 bool TCreateVolumeActor::ShouldCreateVolumeWithDefaultEncryption() const
 {
+    if (GetStorageMediaKind() == NProto::STORAGE_MEDIA_SSD_LOCAL) {
+        // TODO: XXX
+        return false;
+    }
+
     return IsDiskRegistryMediaKind(GetStorageMediaKind()) &&
-        GetStorageMediaKind() != NProto::STORAGE_MEDIA_SSD_LOCAL &&    // XXX
         Request.GetEncryptionSpec().GetMode() == NProto::NO_ENCRYPTION &&
-        (Config->GetDefaultEncryptionForNonReplicatedDisksEnabled() ||
+        (Config->GetDefaultEncryptionForDiskRegistryBasedDisksEnabled() ||
          Config->IsDefaultEncryptionForNonReplicatedDisksFeatureEnabled(
              Request.GetCloudId(),
              Request.GetFolderId(),
@@ -265,7 +269,7 @@ void TCreateVolumeActor::HandleCreateEncryptionKeyResponse(
                              << " with default AES XTS encryption");
 
         auto& desc = encryptionDesc.emplace();
-        desc.SetMode(NProto::ENCRYPTION_DEFAULT_AES_XTS_INSECURE);
+        desc.SetMode(NProto::ENCRYPTION_DEFAULT_AES_XTS);
         desc.SetKeyHash(msg->EncryptionKey);
     }
 

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -241,8 +241,7 @@ struct TEvServicePrivate
 
     struct TCreateEncryptionKeyResponse
     {
-        TString KekId;
-        TString EncryptedDEK;
+        NProto::TKmsKey KmsKey;
     };
 
     //

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -236,6 +236,15 @@ struct TEvServicePrivate
     };
 
     //
+    // Create encryption key
+    //
+
+    struct TCreateEncryptionKeyResponse
+    {
+        TString EncryptionKey;
+    };
+
+    //
     // UpdateManuallyPreemptedVolume notification
     //
 
@@ -298,6 +307,7 @@ struct TEvServicePrivate
         EvUpdateManuallyPreemptedVolume,
         EvSyncManuallyPreemptedVolumesComplete,
         EvSelfPing,
+        EvCreateEncryptionKeyResponse,
 
         EvEnd
     };
@@ -387,6 +397,11 @@ struct TEvServicePrivate
     >;
 
     using TEvSelfPing = TRequestEvent<TSelfPing, EvSelfPing>;
+
+    using TEvCreateEncryptionKeyResponse = TResponseEvent<
+        TCreateEncryptionKeyResponse,
+        EvCreateEncryptionKeyResponse
+    >;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -241,7 +241,8 @@ struct TEvServicePrivate
 
     struct TCreateEncryptionKeyResponse
     {
-        TString EncryptionKey;
+        TString KekId;
+        TString EncryptedDEK;
     };
 
     //

--- a/cloud/blockstore/libs/storage/service/service_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_create.cpp
@@ -867,8 +867,7 @@ Y_UNIT_TEST_SUITE(TServiceCreateVolumeTest)
             auto response = service.DescribeVolume("vol0");
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
             auto desc = response->Record.GetVolume().GetEncryptionDesc();
-            UNIT_ASSERT(
-                NProto::ENCRYPTION_DEFAULT_AES_XTS_INSECURE == desc.GetMode());
+            UNIT_ASSERT(NProto::ENCRYPTION_DEFAULT_AES_XTS == desc.GetMode());
             UNIT_ASSERT_VALUES_UNEQUAL("", desc.GetKeyHash());
         }
 

--- a/cloud/blockstore/libs/storage/service/service_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_create.cpp
@@ -868,7 +868,8 @@ Y_UNIT_TEST_SUITE(TServiceCreateVolumeTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
             auto desc = response->Record.GetVolume().GetEncryptionDesc();
             UNIT_ASSERT(NProto::ENCRYPTION_DEFAULT_AES_XTS == desc.GetMode());
-            UNIT_ASSERT_VALUES_UNEQUAL("", desc.GetKeyHash());
+            UNIT_ASSERT(desc.HasUnencryptedDEK());
+            UNIT_ASSERT_VALUES_UNEQUAL("", desc.GetUnencryptedDEK());
         }
 
         {

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/discovery/discovery.h>
+#include <cloud/blockstore/libs/encryption/encryption_key.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
@@ -374,9 +375,11 @@ ui32 TTestEnv::CreateBlockStoreNode(
         NDiscovery::CreateDiscoveryServiceStub(),
         TraceSerializer,
         NServer::CreateEndpointEventProxy(),
-        nullptr, // rdmaClient
+        nullptr,   // rdmaClient
         CreateVolumeStatsStub(),
-        std::move(manuallyPreemptedVolumes));
+        std::move(manuallyPreemptedVolumes),
+        CreateDefaultEncryptionKeyProvider(CreateRootKmsKeyProviderStub()));
+
     auto storageServiceId = Runtime.Register(
         storageService.release(),
         nodeIdx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -39,12 +39,13 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
             // TODO(drbasic)
             // For encrypted disk-registry based disks, we will continue to
             // write a map of encrypted blocks for a while.
-            const bool encryptedDiskRegistryBasedDisk =
+            const bool encryptedByUserDiskRegistryBasedDisk =
                 State->IsDiskRegistryMediaKind() &&
                 State->GetMeta()
                         .GetVolumeConfig()
                         .GetEncryptionDesc()
-                        // Encrypted by the user
+                        // Default encryption doesn't require tracking of used
+                        // blocks.
                         .GetMode() == NProto::ENCRYPTION_AES_XTS;
 
             // For overlay disks we need to ensure that the only bits that are
@@ -53,7 +54,8 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
             // update the map only after the block has been successfully
             // written.
             const bool needReliableUsedBlockTracking =
-                encryptedDiskRegistryBasedDisk || overlayDiskRegistryBasedDisk;
+                encryptedByUserDiskRegistryBasedDisk ||
+                overlayDiskRegistryBasedDisk;
             NCloud::Register<TWriteAndMarkUsedActor<TMethod>>(
                 ctx,
                 std::move(requestInfo),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -32,8 +32,7 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
         State->IsDiskRegistryMediaKind() && !State->GetBaseDiskId().Empty();
 
     if constexpr (IsWriteMethod<TMethod>) {
-        if (State->GetTrackUsedBlocks() || State->HasCheckpointLight())
-        {
+        if (State->GetTrackUsedBlocks() || State->HasCheckpointLight()) {
             auto requestInfo =
                 CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
@@ -45,7 +44,8 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
                 State->GetMeta()
                         .GetVolumeConfig()
                         .GetEncryptionDesc()
-                        .GetMode() != NProto::NO_ENCRYPTION;
+                        // Encrypted by the user
+                        .GetMode() == NProto::ENCRYPTION_AES_XTS;
 
             // For overlay disks we need to ensure that the only bits that are
             // set in the used block map are the bits that correspond to the

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -249,8 +249,8 @@ void TVolumeState::Reset()
         // For encrypted disk-registry based disks, we will continue to
         // write a map of encrypted blocks for a while.
         const bool encrypted =
-            Meta.GetVolumeConfig().GetEncryptionDesc().GetMode() !=
-            NProto::NO_ENCRYPTION;
+            Meta.GetVolumeConfig().GetEncryptionDesc().GetMode() ==
+            NProto::ENCRYPTION_AES_XTS;
         if (encrypted || overlay) {
             TrackUsedBlocks = true;
         }

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -248,10 +248,11 @@ void TVolumeState::Reset()
         // TODO(drbasic)
         // For encrypted disk-registry based disks, we will continue to
         // write a map of encrypted blocks for a while.
-        const bool encrypted =
+        const bool encryptedByUser =
             Meta.GetVolumeConfig().GetEncryptionDesc().GetMode() ==
-            NProto::ENCRYPTION_AES_XTS;
-        if (encrypted || overlay) {
+            NProto::ENCRYPTION_AES_XTS;   // default encryption doesn't require
+                                          // tracking of used blocks
+        if (encryptedByUser || overlay) {
             TrackUsedBlocks = true;
         }
     } else {

--- a/cloud/blockstore/libs/ya.make
+++ b/cloud/blockstore/libs/ya.make
@@ -25,6 +25,7 @@ RECURSE(
     nvme
     rdma
     rdma_test
+    root_kms
     server
     service
     service_kikimr

--- a/cloud/blockstore/public/api/protos/encryption.proto
+++ b/cloud/blockstore/public/api/protos/encryption.proto
@@ -11,7 +11,16 @@ enum EEncryptionMode
 {
     NO_ENCRYPTION = 0;
     ENCRYPTION_AES_XTS = 1;
+    ENCRYPTION_AES_XTS_NO_TRACK_UNUSED = 2;
 }
+
+/*
+enum EEncryptionAlgo
+{
+    ENCRYPTION_ALGO_AES_XTS = 0;
+    ENCRYPTION_ALGO_CAESAR = 1;
+    ENCRYPTION_ALGO_NOOP = 2;
+}*/
 
 ////////////////////////////////////////////////////////////////////////////////
 // KMS key options

--- a/cloud/blockstore/public/api/protos/encryption.proto
+++ b/cloud/blockstore/public/api/protos/encryption.proto
@@ -11,16 +11,11 @@ enum EEncryptionMode
 {
     NO_ENCRYPTION = 0;
     ENCRYPTION_AES_XTS = 1;
-    ENCRYPTION_AES_XTS_NO_TRACK_UNUSED = 2;
-}
 
-/*
-enum EEncryptionAlgo
-{
-    ENCRYPTION_ALGO_AES_XTS = 0;
-    ENCRYPTION_ALGO_CAESAR = 1;
-    ENCRYPTION_ALGO_NOOP = 2;
-}*/
+    // Default AES XTS encryption. DEK is stored in
+    // VolumeConfig.EncryptionDesc.KeyHash as base64.
+    ENCRYPTION_DEFAULT_AES_XTS_INSECURE = 2;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // KMS key options

--- a/cloud/blockstore/public/api/protos/encryption.proto
+++ b/cloud/blockstore/public/api/protos/encryption.proto
@@ -13,8 +13,8 @@ enum EEncryptionMode
     ENCRYPTION_AES_XTS = 1;
 
     // Default AES XTS encryption. DEK is stored in
-    // VolumeConfig.EncryptionDesc.KeyHash as base64.
-    ENCRYPTION_DEFAULT_AES_XTS_INSECURE = 2;
+    // VolumeConfig.EncryptionDesc: EncryptedDEK or UnencryptedDEK.
+    ENCRYPTION_DEFAULT_AES_XTS = 2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/public/api/protos/encryption.proto
+++ b/cloud/blockstore/public/api/protos/encryption.proto
@@ -10,10 +10,13 @@ option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/public/api/pro
 enum EEncryptionMode
 {
     NO_ENCRYPTION = 0;
+
+    // AES XTS encryption with DEK provided by the user.
     ENCRYPTION_AES_XTS = 1;
 
-    // Default AES XTS encryption. DEK is stored in
-    // VolumeConfig.EncryptionDesc: EncryptedDEK or UnencryptedDEK.
+    // Default AES XTS encryption. Encrypted DEK is stored in
+    // VolumeConfig.EncryptionDesc.EncryptedDEK. DEK decryption is performed by
+    // Root KMS.
     ENCRYPTION_DEFAULT_AES_XTS = 2;
 }
 

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -165,6 +165,7 @@ message TEncryptionDesc
 {
     EEncryptionMode Mode = 1;
     bytes KeyHash = 2;
+    TKmsKey DataKey = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/public/sdk/python/client/client.py
+++ b/cloud/blockstore/public/sdk/python/client/client.py
@@ -58,7 +58,8 @@ class Client(_SafeClient):
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
-            request_timeout: int | None = None) -> futures.Future:
+            request_timeout: int | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> futures.Future:
 
         request = protos.TMountVolumeRequest(
             DiskId=disk_id,
@@ -66,7 +67,8 @@ class Client(_SafeClient):
             VolumeAccessMode=access_mode,
             VolumeMountMode=mount_mode,
             MountFlags=mount_flags,
-            MountSeqNumber=mount_seq_number
+            MountSeqNumber=mount_seq_number,
+            EncryptionSpec=encryption_spec,
         )
 
         future = futures.Future()
@@ -107,7 +109,8 @@ class Client(_SafeClient):
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
-            request_timeout: int | None = None) -> dict:
+            request_timeout: int | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> dict:
 
         request = protos.TMountVolumeRequest(
             DiskId=disk_id,
@@ -115,7 +118,8 @@ class Client(_SafeClient):
             VolumeAccessMode=access_mode,
             VolumeMountMode=mount_mode,
             MountFlags=mount_flags,
-            MountSeqNumber=mount_seq_number
+            MountSeqNumber=mount_seq_number,
+            EncryptionSpec=encryption_spec,
         )
         response = self._impl.mount_volume(
             request,
@@ -361,7 +365,8 @@ class Client(_SafeClient):
             timestamp: datetime | None = None,
             trace_id: str | None = None,
             request_timeout: int | None = None,
-            device_name: str | None = None) -> futures.Future:
+            device_name: str | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> futures.Future:
 
         request = protos.TStartEndpointRequest(
             UnixSocketPath=unix_socket_path,
@@ -373,7 +378,8 @@ class Client(_SafeClient):
             MountFlags=mount_flags,
             UnalignedRequestsDisabled=unaligned_requests_disabled,
             MountSeqNumber=seq_number,
-            VhostQueuesCount=vhost_queues
+            VhostQueuesCount=vhost_queues,
+            EncryptionSpec=encryption_spec,
         )
 
         if endpoint_request_timeout is not None:
@@ -430,7 +436,8 @@ class Client(_SafeClient):
             timestamp: datetime | None = None,
             trace_id: str | None = None,
             request_timeout: int | None = None,
-            device_name: str | None = None) -> dict:
+            device_name: str | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> dict:
 
         request = protos.TStartEndpointRequest(
             UnixSocketPath=unix_socket_path,
@@ -442,7 +449,8 @@ class Client(_SafeClient):
             MountFlags=mount_flags,
             UnalignedRequestsDisabled=unaligned_requests_disabled,
             MountSeqNumber=seq_number,
-            VhostQueuesCount=vhost_queues
+            VhostQueuesCount=vhost_queues,
+            EncryptionSpec=encryption_spec,
         )
 
         if endpoint_request_timeout is not None:

--- a/cloud/blockstore/public/sdk/python/client/safe_client.py
+++ b/cloud/blockstore/public/sdk/python/client/safe_client.py
@@ -69,7 +69,8 @@ class _SafeClient(object):
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
-            request_timeout: int | None = None) -> futures.Future:
+            request_timeout: int | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> futures.Future:
 
         request = protos.TCreateVolumeRequest(
             DiskId=disk_id,
@@ -84,7 +85,8 @@ class _SafeClient(object):
             BaseDiskId=base_disk_id,
             BaseDiskCheckpointId=base_disk_checkpoint_id,
             PartitionsCount=partitions_count,
-            StoragePoolName=storage_pool_name
+            StoragePoolName=storage_pool_name,
+            EncryptionSpec=encryption_spec,
         )
         return self.__impl.create_volume_async(
             request,
@@ -112,7 +114,8 @@ class _SafeClient(object):
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
-            request_timeout: int | None = None):
+            request_timeout: int | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None):
 
         request = protos.TCreateVolumeRequest(
             DiskId=disk_id,
@@ -127,7 +130,8 @@ class _SafeClient(object):
             BaseDiskId=base_disk_id,
             BaseDiskCheckpointId=base_disk_checkpoint_id,
             PartitionsCount=partitions_count,
-            StoragePoolName=storage_pool_name
+            StoragePoolName=storage_pool_name,
+            EncryptionSpec=encryption_spec,
         )
         self.__impl.create_volume(
             request,

--- a/cloud/blockstore/public/sdk/python/client/session.py
+++ b/cloud/blockstore/public/sdk/python/client/session.py
@@ -104,7 +104,8 @@ class Session(object):
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
-            request_timeout: int | None = None) -> futures.Future:
+            request_timeout: int | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> futures.Future:
 
         result = futures.Future()
 
@@ -143,7 +144,8 @@ class Session(object):
             idempotence_id,
             timestamp,
             trace_id,
-            request_timeout)
+            request_timeout,
+            encryption_spec)
 
         def process_mount_response(f):
             with self.__mount_lock:
@@ -165,13 +167,15 @@ class Session(object):
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
-            request_timeout: int | None = None) -> dict:
+            request_timeout: int | None = None,
+            encryption_spec: protos.TEncryptionSpec | None = None) -> dict:
 
         return self.mount_volume_async(
             idempotence_id,
             timestamp,
             trace_id,
-            request_timeout).result()
+            request_timeout,
+            encryption_spec).result()
 
     @_handle_errors
     def unmount_volume_async(

--- a/cloud/blockstore/public/sdk/python/protos/__init__.py
+++ b/cloud/blockstore/public/sdk/python/protos/__init__.py
@@ -4,6 +4,7 @@ from cloud.blockstore.public.api.protos.client_pb2 import *         # noqa
 from cloud.blockstore.public.api.protos.cms_pb2 import *            # noqa
 from cloud.blockstore.public.api.protos.discovery_pb2 import *      # noqa
 from cloud.blockstore.public.api.protos.disk_pb2 import *           # noqa
+from cloud.blockstore.public.api.protos.encryption_pb2 import *     # noqa
 from cloud.blockstore.public.api.protos.endpoints_pb2 import *      # noqa
 from cloud.blockstore.public.api.protos.headers_pb2 import *        # noqa
 from cloud.blockstore.public.api.protos.io_pb2 import *             # noqa

--- a/cloud/blockstore/tests/default_encryption/test.py
+++ b/cloud/blockstore/tests/default_encryption/test.py
@@ -1,0 +1,250 @@
+import logging
+import os
+import pytest
+import time
+
+from cloud.blockstore.public.api.protos.encryption_pb2 import TEncryptionSpec,\
+    ENCRYPTION_AES_XTS, TKeyPath
+from cloud.blockstore.public.sdk.python.client.session import Session
+from cloud.blockstore.public.sdk.python.client import CreateClient, \
+    ClientError
+from cloud.blockstore.public.sdk.python.protos import TCmsActionRequest, \
+    TAction, STORAGE_MEDIA_SSD_NONREPLICATED
+
+from cloud.blockstore.tests.python.lib.client import NbsClient
+from cloud.blockstore.tests.python.lib.config import NbsConfigurator, \
+    generate_disk_agent_txt
+from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
+    start_disk_agent, get_fqdn
+
+import yatest.common as yatest_common
+
+from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+    ensure_path_exists
+
+from library.python.retry import retry
+
+
+DEFAULT_BLOCK_SIZE = 4096
+DEVICE_SIZE = 1024**3   # 1 GiB
+DEVICE_COUNT = 2
+
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("test_logger")
+
+
+@pytest.fixture(name='data_path')
+def create_storage():
+
+    p = get_unique_path_for_current_test(
+        output_path=yatest_common.output_path(),
+        sub_folder="data")
+
+    p = os.path.join(p, "dev", "disk", "by-partlabel")
+    ensure_path_exists(p)
+
+    for i in range(DEVICE_COUNT):
+        with open(os.path.join(p, f"NVMENBS{i + 1:02}"), 'wb') as f:
+            f.seek(DEVICE_SIZE - 1)
+            f.write(b'\0')
+            f.flush()
+
+    return p
+
+
+@pytest.fixture(name='disk_agent_configurator')
+def create_disk_agent_configurator(ydb, data_path):
+
+    configurator = NbsConfigurator(ydb, 'disk-agent')
+    configurator.generate_default_nbs_configs()
+
+    disk_agent_config = generate_disk_agent_txt(
+        agent_id='',
+        device_erase_method='DEVICE_ERASE_METHOD_NONE',  # speed up tests
+        storage_discovery_config={
+            "PathConfigs": [{
+                "PathRegExp": f"{data_path}/NVMENBS([0-9]+)",
+                "PoolConfigs": [{
+                    "MinSize": DEVICE_SIZE,
+                }]}]
+            })
+
+    configurator.files["disk-agent"] = disk_agent_config
+
+    return configurator
+
+
+@pytest.fixture(name='ydb')
+def start_ydb_cluster():
+
+    ydb_cluster = start_ydb()
+
+    yield ydb_cluster
+
+    ydb_cluster.stop()
+
+
+@pytest.fixture(name='nbs')
+def start_nbs_daemon(ydb):
+
+    cfg = NbsConfigurator(ydb)
+    cfg.generate_default_nbs_configs()
+
+    cfg.files["storage"].NonReplicatedDontSuspendDevices = True
+    cfg.files["storage"].DefaultEncryptionEnabled = True
+    cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
+
+    daemon = start_nbs(cfg)
+
+    yield daemon
+
+    daemon.kill()
+
+
+@pytest.fixture(name='disk_agent')
+def start_disk_agent_daemon(ydb, disk_agent_configurator):
+
+    daemon = start_disk_agent(disk_agent_configurator)
+
+    yield daemon
+
+    daemon.kill()
+
+
+@pytest.fixture(autouse=True)
+def setup_env(nbs, disk_agent, data_path):
+
+    client = CreateClient(f"localhost:{nbs.port}")
+    client.execute_action(
+        action="DiskRegistrySetWritableState",
+        input_bytes=str.encode('{"State": true}'))
+
+    disk_agent.wait_for_registration()
+
+    request = TCmsActionRequest()
+
+    action = request.Actions.add()
+    action.Type = TAction.ADD_HOST
+    action.Host = get_fqdn()
+
+    response = client.cms_action(request)
+
+    assert len(response.ActionResults) == 1
+    for r in response.ActionResults:
+        assert r.Result.Code == 0, r
+
+    # wait for devices to be cleared
+    nbs_client = NbsClient(nbs.port)
+    while True:
+        bkp = nbs_client.backup_disk_registry_state()["Backup"]
+        if bkp.get("DirtyDevices", 0) == 0:
+            break
+        time.sleep(1)
+
+
+def __read_raw_blocks(device, start_index, blocks_count):
+    offset = start_index * DEFAULT_BLOCK_SIZE
+
+    blocks = []
+
+    with open(device.DeviceName, 'rb') as f:
+        f.seek(offset)
+        for i in range(blocks_count):
+            blocks.append(f.read(DEFAULT_BLOCK_SIZE))
+
+    return blocks
+
+
+def test_encryption(nbs):
+
+    client = CreateClient(f"localhost:{nbs.port}")
+
+    data_encryption_key = os.urandom(32)
+
+    # encryption_spec = TEncryptionSpec(
+    #     Mode=ENCRYPTION_AES_XTS,
+    #     KeyData=data_encryption_key)
+
+    key_path = get_unique_path_for_current_test(
+        output_path=yatest_common.output_path(),
+        sub_folder="")
+
+    ensure_path_exists(key_path)
+    key_path = os.path.join(key_path, "dek.bin")
+
+    with open(key_path, 'wb') as f:
+        f.write(data_encryption_key)
+
+    encryption_spec = TEncryptionSpec(
+        Mode=ENCRYPTION_AES_XTS,
+        KeyPath=TKeyPath(
+            FilePath=key_path.encode('utf-8')
+        ))
+
+    @retry(max_times=10, exception=ClientError)
+    def create_vol0():
+        client.create_volume(
+            disk_id="vol0",
+            block_size=DEFAULT_BLOCK_SIZE,
+            blocks_count=2*DEVICE_SIZE//DEFAULT_BLOCK_SIZE,
+            storage_media_kind=STORAGE_MEDIA_SSD_NONREPLICATED,
+            storage_pool_name="",
+            encryption_spec=encryption_spec)
+
+    create_vol0()
+
+    session = Session(
+        client,
+        "vol0",
+        mount_token='',
+        log=logger)
+
+    volume = session.mount_volume(encryption_spec=encryption_spec)["Volume"]
+
+    assert len(volume.Devices) == 2
+    device = volume.Devices[0]
+
+    test_data = os.urandom(DEFAULT_BLOCK_SIZE)
+
+    # read zeroes
+    raw = __read_raw_blocks(device, start_index=0, blocks_count=2)
+    assert len(raw) == 2
+    assert all(len(b) == DEFAULT_BLOCK_SIZE for b in raw)
+    for b in raw:
+        assert all(x == 0 for x in b)
+
+    # write single block
+    session.write_blocks(start_index=0, blocks=[test_data])
+
+    # check data
+    blocks = session.read_blocks(
+        start_index=0,
+        blocks_count=2,
+        checkpoint_id='')
+
+    assert len(blocks) == 2
+    # assert all(len(b) == DEFAULT_BLOCK_SIZE for b in blocks)
+    assert len(blocks[0]) == DEFAULT_BLOCK_SIZE
+    assert len(blocks[1]) == 0
+
+    # first block must be with data
+    assert test_data == blocks[0]
+
+    # second block must be zeroed
+    # assert all(x == 0 for x in blocks[1])
+
+    # read data bypass the volume
+
+    raw = __read_raw_blocks(device, start_index=0, blocks_count=2)
+    assert len(raw) == 2
+    assert all(len(b) == DEFAULT_BLOCK_SIZE for b in raw)
+    # first block must be encoded
+    assert raw[0] != test_data
+    # end non zeroed
+    assert any(x != 0 for x in raw[0])
+
+    # second block must be zeroed
+    assert all(x == 0 for x in raw[1])
+
+    session.unmount_volume()

--- a/cloud/blockstore/tests/default_encryption/test.py
+++ b/cloud/blockstore/tests/default_encryption/test.py
@@ -145,7 +145,7 @@ def setup_env(nbs, disk_agent, data_path):
 
 
 def __read_raw_blocks(device, start_index, blocks_count):
-    offset = start_index * DEFAULT_BLOCK_SIZE
+    offset = device.PhysicalOffset + start_index * DEFAULT_BLOCK_SIZE
 
     blocks = []
 

--- a/cloud/blockstore/tests/default_encryption/test.py
+++ b/cloud/blockstore/tests/default_encryption/test.py
@@ -92,7 +92,10 @@ def start_nbs_daemon(ydb):
     cfg.generate_default_nbs_configs()
 
     cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
-    cfg.files["storage"].DefaultEncryptionForNonReplicatedDisksEnabled = True
+
+    encryption_feature = cfg.files["features"].Features.add()
+    encryption_feature.Name = 'DefaultEncryptionForNonReplicatedDisks'
+    encryption_feature.Whitelist.EntityIds.append("vol0")
 
     daemon = start_nbs(cfg)
 

--- a/cloud/blockstore/tests/default_encryption/ya.make
+++ b/cloud/blockstore/tests/default_encryption/ya.make
@@ -1,0 +1,21 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+TEST_SRCS(test.py)
+
+DEPENDS(
+    cloud/blockstore/apps/client
+    cloud/blockstore/apps/disk_agent
+    cloud/blockstore/apps/server
+    contrib/ydb/apps/ydbd
+)
+
+PEERDIR(
+    cloud/blockstore/tests/python/lib
+    contrib/python/requests/py3
+
+    library/python/retry
+)
+
+END()

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -260,7 +260,7 @@ def __run_test(test_case):
         storage.AgentRequestTimeout = 5000      # 5 sec
         storage.RejectLateRequestsAtDiskAgentEnabled = test_case.reject_late_requests_at_disk_agent
         storage.AssignIdToWriteAndZeroRequestsEnabled = test_case.reject_late_requests_at_disk_agent
-        storage.DefaultEncryptionForNonReplicatedDisksEnabled = test_case.enable_default_encryption
+        storage.DefaultEncryptionForDiskRegistryBasedDisksEnabled = test_case.enable_default_encryption
 
         if test_case.dump_block_digests:
             storage.BlockDigestsEnabled = True

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -55,7 +55,8 @@ class TestCase(object):
             agent_count=1,
             storage_pool_name=None,
             dump_block_digests=False,
-            reject_late_requests_at_disk_agent=False):
+            reject_late_requests_at_disk_agent=False,
+            enable_default_encryption=False):
         self.name = name
         self.config_path = config_path
         self.restart_interval = restart_interval
@@ -69,6 +70,7 @@ class TestCase(object):
         self.storage_pool_name = storage_pool_name
         self.dump_block_digests = dump_block_digests
         self.reject_late_requests_at_disk_agent = reject_late_requests_at_disk_agent
+        self.enable_default_encryption = enable_default_encryption
 
 
 TESTS = [
@@ -123,6 +125,11 @@ TESTS = [
     TestCase(
         "local-encryption-overlay",
         "cloud/blockstore/tests/loadtest/local-nonrepl/local-encryption-overlay.txt",
+    ),
+    TestCase(
+        "default-encryption",
+        "cloud/blockstore/tests/loadtest/local-nonrepl/default-encryption.txt",
+        enable_default_encryption=True,
     ),
     TestCase(
         "local-nonrepl-overlay",
@@ -242,6 +249,7 @@ def __run_test(test_case):
         storage.AgentRequestTimeout = 5000      # 5 sec
         storage.RejectLateRequestsAtDiskAgentEnabled = test_case.reject_late_requests_at_disk_agent
         storage.AssignIdToWriteAndZeroRequestsEnabled = test_case.reject_late_requests_at_disk_agent
+        storage.DefaultEncryptionForNonReplicatedDisksEnabled = test_case.enable_default_encryption
 
         if test_case.dump_block_digests:
             storage.BlockDigestsEnabled = True

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -128,12 +128,23 @@ TESTS = [
     ),
     TestCase(
         "default-encryption",
-        "cloud/blockstore/tests/loadtest/local-nonrepl/default-encryption.txt",
+        "cloud/blockstore/tests/loadtest/local-nonrepl/local-nonrepl.txt",
         enable_default_encryption=True,
     ),
     TestCase(
         "local-nonrepl-overlay",
         "cloud/blockstore/tests/loadtest/local-nonrepl/local-nonrepl-overlay.txt",
+    ),
+    TestCase(
+        "default-encryption-overlay",
+        "cloud/blockstore/tests/loadtest/local-nonrepl/local-nonrepl-overlay.txt",
+        enable_default_encryption=True,
+    ),
+    TestCase(
+        "default-encryption-migration",
+        "cloud/blockstore/tests/loadtest/local-nonrepl/local-migration.txt",
+        dump_block_digests=True,
+        enable_default_encryption=True,
     ),
     TestCase(
         "load-hdd",

--- a/cloud/blockstore/tests/python/lib/config.py
+++ b/cloud/blockstore/tests/python/lib/config.py
@@ -5,6 +5,8 @@ from contrib.ydb.tests.library.common.yatest_common import PortManager
 from google.protobuf.json_format import ParseDict
 from google.protobuf.text_format import MessageToString
 
+from cloud.storage.core.config.features_pb2 import TFeaturesConfig
+
 from cloud.blockstore.config.diagnostics_pb2 import TDiagnosticsConfig
 from cloud.blockstore.config.disk_pb2 import TDiskRegistryProxyConfig, \
     TDiskAgentConfig, TFileDeviceArgs, TStorageDiscoveryConfig, \
@@ -77,6 +79,7 @@ class NbsConfigurator:
         self.files["dr-proxy"] = generate_dr_proxy_txt()
         self.files["domains"] = self.__ydb.config.domains_txt
         self.files["location"] = generate_location_txt()
+        self.files["features"] = TFeaturesConfig()
 
     def install(self, config_folder):
 

--- a/cloud/blockstore/tests/ya.make
+++ b/cloud/blockstore/tests/ya.make
@@ -9,6 +9,7 @@ RECURSE(
     client
     cms
     csi_driver
+    default_encryption
     disk_agent_config
     external_endpoint
     e2e-tests

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -129,7 +129,7 @@ IEncryptorPtr CreateEncryptor(
 
     STORAGE_INFO("Encryption. Get key " << encryptionSpec.AsJSON());
 
-    auto keyProvider = CreateDefaultEncryptionKeyProvider();
+    auto keyProvider = CreateEncryptionKeyProvider(CreateKmsKeyProviderStub());
     auto keyFuture =
         keyProvider->GetKey(options.GetEncryptionSpec(), options.DiskId);
     auto keyOrError = std::move(keyFuture).ExtractValue();

--- a/cloud/vm/blockstore/lib/plugin.cpp
+++ b/cloud/vm/blockstore/lib/plugin.cpp
@@ -244,9 +244,11 @@ TPlugin::TPlugin(
     , Config(std::move(config))
     , Log(Logging->CreateLog("BLOCKSTORE_PLUGIN"))
 {
+    auto encryptionKeyProvider = CreateDefaultEncryptionKeyProvider();
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateDefaultEncryptionKeyProvider());
+        encryptionKeyProvider,
+        CreateVolumeEncryptionClientFactory(Logging, encryptionKeyProvider));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/contrib/ydb/core/protos/blockstore_config.proto
+++ b/contrib/ydb/core/protos/blockstore_config.proto
@@ -19,9 +19,15 @@ enum EPartitionType {
     NonReplicated = 1; // directly mapped network partitions
 }
 
+message TEncryptedDEK {
+    optional string KekId = 1;
+    optional bytes Ciphertext = 2;
+};
+
 message TEncryptionDesc {
     optional uint32 Mode = 1;
     optional bytes KeyHash = 2;
+    optional TEncryptedDEK EncryptedDEK = 3;
 }
 
 message TVolumeConfig {


### PR DESCRIPTION
If a user didn't specify encryption parameters when creating the disk, the default encryption (for some disk types) is applied.
An encryption key is generated and stored as plain text in VolumeConfig.

To avoid blocking User pool, the generation of encryption keys takes place in IO pool (in TCreateEncryptionKeyActor).

The creation of an encrypted disk is controlled by `DefaultEncryptionForNonReplicatedDisksEnabled` (if True, all disks without an explicit encryption specification will be created with the default encryption) and a feature `DefaultEncryptionForNonReplicatedDisks` (for enabling the default encryption for a specific cloud/folder).

`TVolumeEncryptionClient` is necessary in order to create a resultant disk client (regular or encryption), after MountVolume (when VolumeConfig is available).

#176 