### PR TITLE
[Disk Manager]: Add logging on chunk write success

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_impl.go
@@ -651,6 +651,12 @@ func (s *storageYDB) writeDataChunk(
 		return "", err
 	}
 
+	logging.Debug(
+		ctx,
+		"written chunk %v for snapshot %v",
+		chunk.ID,
+		snapshotID,
+	)
 	return chunk.ID, nil
 }
 


### PR DESCRIPTION
In disk manager nemesis tests, the milestone of the snapshot creation is not being updated, despite write of all the chunks to the YDB is started. Add more verbose logging for finished chunk writes.