### PR TITLE
External vhost server exits from parent process group and works along with timeout

### DIFF
--- a/cloud/blockstore/tests/.gitignore
+++ b/cloud/blockstore/tests/.gitignore
@@ -49,3 +49,4 @@ spare_node/cloud-blockstore-tests-spare_node
 stats_aggregator_perf/stats_aggregator_perf
 storage_discovery/cloud-blockstore-tests-storage_discovery
 vhost-server/cloud-blockstore-tests-vhost-server
+vhost-server/run_and_die/run-and-die

--- a/cloud/blockstore/tests/vhost-server/run_and_die/__main__.py
+++ b/cloud/blockstore/tests/vhost-server/run_and_die/__main__.py
@@ -1,0 +1,22 @@
+import argparse
+import subprocess
+import sys
+import json
+from time import sleep
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cmd', required=True)
+    args = parser.parse_args()
+
+    server = subprocess.Popen(
+        json.loads(args.cmd),
+        stdin=None,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        bufsize=0,
+        universal_newlines=True)
+
+    sleep(1)
+    print(server.pid)

--- a/cloud/blockstore/tests/vhost-server/run_and_die/__main__.py
+++ b/cloud/blockstore/tests/vhost-server/run_and_die/__main__.py
@@ -12,11 +12,11 @@ if __name__ == '__main__':
 
     server = subprocess.Popen(
         json.loads(args.cmd),
-        stdin=None,
+        stdin=sys.stdin,
         stdout=sys.stdout,
         stderr=sys.stderr,
         bufsize=0,
         universal_newlines=True)
 
-    sleep(1)
     print(server.pid)
+    sleep(1)

--- a/cloud/blockstore/tests/vhost-server/run_and_die/ya.make
+++ b/cloud/blockstore/tests/vhost-server/run_and_die/ya.make
@@ -1,0 +1,7 @@
+PY3_PROGRAM(run-and-die)
+
+PY_SRCS(
+    __main__.py
+)
+
+END()

--- a/cloud/blockstore/tests/vhost-server/test.py
+++ b/cloud/blockstore/tests/vhost-server/test.py
@@ -3,12 +3,23 @@ import os
 import signal
 import subprocess
 import tempfile
+from time import sleep
 import yatest.common as yatest_common
+
+
+VHOST_SERVER_BINARY_PATH = yatest_common.binary_path(
+    "cloud/blockstore/vhost-server/blockstore-vhost-server")
+RUN_AND_DIE_BINARY_PATH = yatest_common.binary_path(
+    "cloud/blockstore/tests/vhost-server/run_and_die/run-and-die")
 
 
 def __read_json(f):
     line = f.readline().strip()
-    return json.loads(line)
+    try:
+        return json.loads(line)
+    except Exception:
+        print("Read not a json line: ", line)
+        return None
 
 
 def __wait_message(f, msg):
@@ -18,12 +29,26 @@ def __wait_message(f, msg):
             break
 
 
-def test_vhost_server():
-    binary_path = yatest_common.binary_path("cloud/blockstore/vhost-server/blockstore-vhost-server")
-    data_file_size = 4096
+def __read_comm(pid):
+    comm_path = os.path.join('/proc', str(pid), 'comm')
+    with open(comm_path, 'r') as f:
+        return f.readline()
+
+
+def __prepare_data_file(data_file_size):
     data_file_path = os.path.join(
         yatest_common.output_path(),
         'pci-0000:00:16.0-sas-phy2-lun-0')
+    with open(data_file_path, 'wb') as f:
+        f.seek(data_file_size)
+        f.write(b'\0')
+        f.flush()
+    return data_file_path
+
+
+def test_vhost_server():
+    data_file_size = 4096
+    data_file_path = __prepare_data_file(data_file_size)
 
     out_r_fd, out_w_fd = os.pipe()
     err_r_fd, err_w_fd = os.pipe()
@@ -38,15 +63,11 @@ def test_vhost_server():
 
         assert not os.path.exists(socket_path)
 
-        with open(data_file_path, 'wb') as f:
-            f.seek(data_file_size)
-            f.write(b'\0')
-            f.flush()
-
         server = subprocess.Popen(
             [
-                binary_path,
+                VHOST_SERVER_BINARY_PATH,
                 '-i', 'local0',
+                '--disk-id', 'volume_with_long_name',
                 '-s', socket_path,
                 '-q', '2',
                 '--device', f"{data_file_path}:{data_file_size}:0",
@@ -61,6 +82,13 @@ def test_vhost_server():
 
         assert os.path.exists(socket_path)
 
+        # check comm string
+        assert 'vhost-volume_wi\n' == __read_comm(server.pid)
+
+        # check pgid of server differs from its parent pgid
+        assert os.getpgid(server.pid) != os.getpgid(os.getpid())
+
+        # check stat request
         for _ in range(3):
             server.send_signal(signal.SIGUSR1)
             s = __read_json(out_r)
@@ -75,3 +103,69 @@ def test_vhost_server():
         assert not os.path.exists(socket_path)
 
         __wait_message(err_r, 'Server has been stopped')
+
+
+def test_vhost_server_work_along():
+    work_along_time = 5
+    data_file_size = 4096
+    data_file_path = __prepare_data_file(data_file_size)
+
+    out_r_fd, out_w_fd = os.pipe()
+    err_r_fd, err_w_fd = os.pipe()
+
+    with tempfile.TemporaryDirectory() as tmp_dir, \
+            os.fdopen(out_r_fd, 'r') as out_r, \
+            os.fdopen(out_w_fd, 'w') as out_w, \
+            os.fdopen(err_r_fd, 'r') as err_r, \
+            os.fdopen(err_w_fd, 'w') as err_w:
+
+        socket_path = os.path.join(tmp_dir, 'local0.vhost')
+
+        assert not os.path.exists(socket_path)
+
+        # prepare vhost command line
+        vhost_cmd = [
+            VHOST_SERVER_BINARY_PATH,
+            '-i', 'local0',
+            '--disk-id', 'volume_with_long_name',
+            '-s', socket_path,
+            '-q', '2',
+            '--device', f"{data_file_path}:{data_file_size}:0",
+            '--wait-after-parent-exit', str(work_along_time)
+        ]
+
+        # run proxy process that will launch our vhost-server
+        proxy = subprocess.Popen(
+            [
+                RUN_AND_DIE_BINARY_PATH,
+                '--cmd', json.dumps(vhost_cmd)
+            ],
+            stdin=None,
+            stdout=out_w,
+            stderr=err_w,
+            bufsize=0,
+            universal_newlines=True)
+
+        # wait proxy exit
+        proxy.communicate()
+        assert proxy.returncode == 0
+
+        # get pid of vhost-server
+        pid = int(out_r.readline().strip())
+        print("Vhost-server pid=", pid)
+
+        # work with vhost-server
+        __wait_message(err_r, 'Server started')
+
+        # check stat request
+        for _ in range(3):
+            os.kill(pid, signal.SIGUSR1)
+            s = __read_json(out_r)
+            assert s['elapsed_ms'] != 0
+
+        # wait vhost-server to shut down after a timeout
+        sleep(work_along_time)
+
+        __wait_message(err_r, 'Server has been stopped')
+
+        assert not os.path.exists(socket_path)

--- a/cloud/blockstore/tests/vhost-server/ya.make
+++ b/cloud/blockstore/tests/vhost-server/ya.make
@@ -6,6 +6,7 @@ TEST_SRCS(test.py)
 
 DEPENDS(
     cloud/blockstore/vhost-server
+    cloud/blockstore/tests/vhost-server/run_and_die
 )
 
 DATA(

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
     sigaddset(&sigset, SIGPIPE);
     pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
 
-    auto delayAfterParentExit = TDuration::Seconds(options.WaitAfterParentExit);
+    auto delayAfterParentExit = options.WaitAfterParentExit;
     // wait for signal to stop the server (Ctrl+C) or dump statistics.
     for (bool running = true, parentExit = false; running;) {
         int sig = 0;
@@ -214,8 +214,7 @@ int main(int argc, char** argv)
             sig = ::sigtimedwait(&sigset, &info, &timeout);
 
             // Reduce the remaining time.
-            delayAfterParentExit -=
-                Min(delayAfterParentExit, TInstant::Now() - startAt);
+            delayAfterParentExit -= TInstant::Now() - startAt;
         } else {
             // Wait for signal without timeout.
             sigwait(&sigset, &sig);

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -8,9 +8,11 @@
 #include <library/cpp/json/json_writer.h>
 
 #include <util/datetime/base.h>
+#include <util/system/thread.h>
 
 #include <pthread.h>
 #include <signal.h>
+#include <sys/prctl.h>
 
 using namespace NCloud::NBlockStore::NVHostServer;
 
@@ -18,11 +20,22 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TCerrJsonLogBackend
+constexpr int MaxHandle = 1024;
+
+timespec ToTimeSpec(TDuration t)
+{
+    return timespec{
+        .tv_sec = static_cast<int>(t.Seconds()),
+        .tv_nsec = t.MicroSecondsOfSecond() * 1000};
+}
+
+class TCerrJsonLogBackend
     : public TLogBackend
 {
     ELogPriority VerboseLevel;
+    bool PipeClosed = false;
 
+public:
     explicit TCerrJsonLogBackend(ELogPriority verboseLevel)
         : VerboseLevel {verboseLevel}
     {}
@@ -34,6 +47,10 @@ struct TCerrJsonLogBackend
 
     void WriteData(const TLogRecord& rec) override
     {
+        if (PipeClosed) {
+            return;
+        }
+
         TStringStream ss;
         NJsonWriter::TBuf buf {NJsonWriter::HEM_DONT_ESCAPE_HTML, &ss};
         buf.BeginObject();
@@ -44,8 +61,13 @@ struct TCerrJsonLogBackend
         buf.EndObject();
         ss << '\n';
 
-        Cerr << ss.Str();
-        Cerr.Flush();
+        try {
+            Cerr << ss.Str();
+            Cerr.Flush();
+        } catch (const TSystemError& e) {
+            // Ignore broken pipe
+            PipeClosed = true;
+        }
     }
 
     void ReopenLog() override
@@ -108,6 +130,27 @@ IBackendPtr CreateBackend(
         options.DeviceBackend.c_str());
 }
 
+void CloseAllFileHandlesExceptSTD()
+{
+    for (int h = 0; h < MaxHandle; ++h) {
+        if (h == STDIN_FILENO || h == STDOUT_FILENO || h == STDERR_FILENO) {
+            continue;
+        }
+        ::close(h);
+    }
+}
+
+void EscapeFromParentProcessGroup()
+{
+    ::setpgid(0, 0);
+}
+
+void SetProcessMark(const TString& diskId)
+{
+    TString id = "vhost-" + diskId;
+    TThread::SetCurrentThreadName(id.c_str());
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -123,7 +166,12 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    // tune the signal to block on waiting for "stop server" command
+    CloseAllFileHandlesExceptSTD();
+    EscapeFromParentProcessGroup();
+    SetProcessMark(options.DiskId);
+
+    // Attention! We set the SIG_BLOCK mask before creating backends so that the
+    // forked threads inherit this mask.
     sigset_t sigset;
     sigemptyset(&sigset);
     sigaddset(&sigset, SIGINT);
@@ -133,25 +181,82 @@ int main(int argc, char** argv)
     auto logService = CreateLogService(options);
     auto backend = CreateBackend(options, logService);
     auto server = CreateServer(logService, backend);
+    auto Log = logService->CreateLog("SERVER");
 
     server->Start(options);
 
     TSimpleStats prevStats;
     TInstant ts = Now();
 
-    // wait for signal to stop the server (Ctrl+C)
-    int sig;
-    while (!sigwait(&sigset, &sig) && sig != SIGINT) {
-        auto stats = server->GetStats(prevStats);
-        auto now = Now();
-        DumpStats(
-            stats,
-            prevStats,
-            now - ts,
-            Cout,
-            GetCyclesPerMillisecond());
+    // Translate parent process exit to SIGUSR2
+    ::prctl(PR_SET_PDEATHSIG, SIGUSR2);
 
-        ts = now;
+    // Tune the signal to block on waiting for "stop server", "dump", "parent
+    // exit" signals.
+    sigaddset(&sigset, SIGUSR2);
+    sigaddset(&sigset, SIGPIPE);
+    pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
+
+    auto delayAfterParentExit = TDuration::Seconds(options.WaitAfterParentExit);
+    // wait for signal to stop the server (Ctrl+C) or dump statistics.
+    for (bool running = true, parentExit = false; running;) {
+        int sig = 0;
+        if (parentExit) {
+            if (!delayAfterParentExit) {
+                break;
+            }
+            // Wait for signal with timeout.
+            STORAGE_INFO("Wait for timeout " << delayAfterParentExit);
+            timespec timeout = ToTimeSpec(delayAfterParentExit);
+            siginfo_t info;
+            memset(&info, 0, sizeof(info));
+            TInstant startAt = TInstant::Now();
+            sig = ::sigtimedwait(&sigset, &info, &timeout);
+
+            // Reduce the remaining time.
+            delayAfterParentExit -=
+                Min(delayAfterParentExit, TInstant::Now() - startAt);
+        } else {
+            // Wait for signal without timeout.
+            sigwait(&sigset, &sig);
+        }
+        switch (sig) {
+            case SIGUSR1: {
+                auto stats = server->GetStats(prevStats);
+                auto now = Now();
+                try {
+                    DumpStats(
+                        stats,
+                        prevStats,
+                        now - ts,
+                        Cout,
+                        GetCyclesPerMillisecond());
+                } catch (const TSystemError& e) {
+                    STORAGE_INFO("DumpStats error: " << e.AsStrBuf());
+                }
+                ts = now;
+            } break;
+            case SIGINT: {
+                STORAGE_INFO("Exit. SIGINT");
+                running = false;
+            } break;
+            case SIGUSR2: {
+                STORAGE_INFO("Parent process exit.");
+                parentExit = true;
+            } break;
+            case SIGPIPE: {
+                STORAGE_INFO("Pipe to parent process broken.");
+                parentExit = true;
+            } break;
+            case -1: {
+                STORAGE_WARN("Exit. Timeout after parent process exit has expired.");
+                running = false;
+            } break;
+            default: {
+                STORAGE_ERROR("Exit. Unexpected signal: " << sig);
+                running = false;
+            }
+        }
     }
 
     server->Stop();

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -127,8 +127,10 @@ void TOptions::Parse(int argc, char** argv)
     opts.AddLongOption(
             "wait-after-parent-exit",
             "How many seconds keep alive after the parent process is exited")
-        .RequiredArgument("INT")
-        .StoreResultDef(&WaitAfterParentExit);
+        .OptionalArgument("NUM")
+        .Handler1T<ui32>(
+            [this](const auto& timeout)
+            { WaitAfterParentExit = TDuration::Seconds(timeout); });
 
     TOptsParseResultException res(&opts, argc, argv);
 

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -124,6 +124,12 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("INT")
         .StoreResultDef(&RdmaClient.MaxBufferSize);
 
+    opts.AddLongOption(
+            "wait-after-parent-exit",
+            "How many seconds keep alive after the parent process is exited")
+        .RequiredArgument("INT")
+        .StoreResultDef(&WaitAfterParentExit);
+
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.FindLongOptParseResult("verbose") && VerboseLevel.empty()) {

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -2,6 +2,7 @@
 
 #include <cloud/storage/core/libs/common/affinity.h>
 
+#include <util/datetime/base.h>
 #include <util/generic/size_literals.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
@@ -37,7 +38,7 @@ struct TOptions
     TString VerboseLevel = "info";
 
     TString ClientId = "vhost-server";
-    ui32 WaitAfterParentExit = 60;
+    TDuration WaitAfterParentExit = TDuration::Seconds(60);
 
     struct
     {

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -37,6 +37,7 @@ struct TOptions
     TString VerboseLevel = "info";
 
     TString ClientId = "vhost-server";
+    ui32 WaitAfterParentExit = 60;
 
     struct
     {


### PR DESCRIPTION
1. Оторвал время жизни vhost-server от порождающего его процесса. 
2. Однако оставшись без родителя он будет жить не вечно, а пока не истечет таймаут wait-after-parent-exit. 
3. процесс выставляет себе имя главного потока как vhost-disk-id, которое могут читать другие процессы через /proc/process-id/proc. Из-за ограничений ОС это имя обрезается.
4. сделал закрытие всех хэндлов, унаследованных от родительского процесса, на старте