### PR TITLE
issue-539: use `NKikimrBlobStorage::UserData` for three-stage write, not `NKikimrBlobStorage::TabletLog`

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -183,14 +183,16 @@ private:
                 request = std::make_unique<TEvBlobStorage::TEvPut>(
                     blobId,
                     WriteRequest.GetBuffer(),
-                    TInstant::Max());
+                    TInstant::Max(),
+                    NKikimrBlobStorage::UserData);
             } else {
                 request = std::make_unique<TEvBlobStorage::TEvPut>(
                     blobId,
                     TString(
                         WriteRequest.GetBuffer().Data() + offset,
                         blobId.BlobSize()),
-                    TInstant::Max());
+                    TInstant::Max(),
+                    NKikimrBlobStorage::UserData);
             }
             NKikimr::TActorId proxy =
                 MakeBlobStorageProxyID(blob.GetBSGroupId());

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2238,6 +2238,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                             event->Recipient.IsService() &&
                             event->Recipient.ServiceId().StartsWith("bsproxy"))
                         {
+                            auto* msg =
+                                event->template Get<TEvBlobStorage::TEvPut>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                NKikimrBlobStorage::UserData,
+                                msg->HandleClass);
                             ++putRequestCount;
                         }
                         break;


### PR DESCRIPTION
`TEvBlobStorage::TEvPut` constructor's default handle class is NKikimrBlobStorage::TabletLog:
https://github.com/ydb-platform/nbs/blob/c2d7171d98e18699e072461d486908392662c72d/contrib/ydb/core/base/blobstorage.h#L912-L913

 This is not the handle class we want to use for user data.
 
 Long overdue fix for #539.