### PR TITLE
issue-1384: add force flag to destroy fs

### DIFF
--- a/cloud/filestore/apps/client/lib/destroy.cpp
+++ b/cloud/filestore/apps/client/lib/destroy.cpp
@@ -9,13 +9,20 @@ namespace {
 class TDestroyCommand final
     : public TFileStoreCommand
 {
+    bool ForceDestroy = false;
 public:
+    TDestroyCommand()
+    {
+        Opts.AddLongOption("force").StoreTrue(&ForceDestroy);
+    }
+
     bool Execute() override
     {
         auto callContext = PrepareCallContext();
 
         auto request = std::make_shared<NProto::TDestroyFileStoreRequest>();
         request->SetFileSystemId(FileSystemId);
+        request->SetForceDestroy(ForceDestroy);
 
         auto response = WaitFor(
             Client->DestroyFileStore(

--- a/cloud/filestore/apps/client/lib/destroy.cpp
+++ b/cloud/filestore/apps/client/lib/destroy.cpp
@@ -9,7 +9,9 @@ namespace {
 class TDestroyCommand final
     : public TFileStoreCommand
 {
+private:
     bool ForceDestroy = false;
+
 public:
     TDestroyCommand()
     {

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -298,4 +298,7 @@ message TStorageConfig
 
     // Controls BlobIndexOps' priority over each other.
     optional EBlobIndexOpsPriority BlobIndexOpsPriority = 356;
+
+    // Allow to destroy filestore with active sessions
+    optional bool AllowFileStoreForceDestroy = 357;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -163,6 +163,7 @@ namespace {
         TDuration::Seconds(10)                                                )\
     xxx(PreferredBlockSizeMultiplier,                   ui32,      1          )\
     xxx(MultiTabletForwardingEnabled,                   bool,      false      )\
+    xxx(AllowFileStoreForceDestroy,                     bool,      false      )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_DECLARE_CONFIG(name, type, value)                            \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -210,6 +210,8 @@ public:
 
     NProto::EBlobIndexOpsPriority GetBlobIndexOpsPriority() const;
 
+    bool GetAllowFileStoreForceDestroy() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
     void DumpOverridesHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -24,7 +24,7 @@ class TDestroyFileStoreActor final
 private:
     const TRequestInfoPtr RequestInfo;
     const TString FileSystemId;
-    const bool ForceDestroy = false;
+    const bool ForceDestroy;
 
 public:
     TDestroyFileStoreActor(
@@ -71,8 +71,7 @@ void TDestroyFileStoreActor::Bootstrap(const TActorContext& ctx)
 {
     if (ForceDestroy) {
         DestroyFileStore(ctx);
-    }
-    else {
+    } else {
         DescribeSessions(ctx);
     }
     Become(&TThis::StateWork);
@@ -186,7 +185,7 @@ void TStorageServiceActor::HandleDestroyFileStore(
         cookie,
         msg->CallContext);
 
-    auto forceDestroy = msg->Record.GetForceDestroy() &&
+    bool forceDestroy = msg->Record.GetForceDestroy() &&
                         StorageConfig->GetAllowFileStoreForceDestroy();
     auto actor = std::make_unique<TDestroyFileStoreActor>(
         std::move(requestInfo),

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -59,9 +59,9 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TDestroyFileStoreActor::TDestroyFileStoreActor(
-    TRequestInfoPtr requestInfo,
-    TString fileSystemId,
-    bool forceDestroy)
+        TRequestInfoPtr requestInfo,
+        TString fileSystemId,
+        bool forceDestroy)
     : RequestInfo(std::move(requestInfo))
     , FileSystemId(std::move(fileSystemId))
     , ForceDestroy(forceDestroy)

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -24,11 +24,13 @@ class TDestroyFileStoreActor final
 private:
     const TRequestInfoPtr RequestInfo;
     const TString FileSystemId;
+    const bool ForceDestroy = false;
 
 public:
     TDestroyFileStoreActor(
         TRequestInfoPtr requestInfo,
-        TString fileSystemId);
+        TString fileSystemId,
+        bool forceDestroy);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -57,15 +59,22 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TDestroyFileStoreActor::TDestroyFileStoreActor(
-        TRequestInfoPtr requestInfo,
-        TString fileSystemId)
+    TRequestInfoPtr requestInfo,
+    TString fileSystemId,
+    bool forceDestroy)
     : RequestInfo(std::move(requestInfo))
     , FileSystemId(std::move(fileSystemId))
+    , ForceDestroy(forceDestroy)
 {}
 
 void TDestroyFileStoreActor::Bootstrap(const TActorContext& ctx)
 {
-    DescribeSessions(ctx);
+    if (ForceDestroy) {
+        DestroyFileStore(ctx);
+    }
+    else {
+        DescribeSessions(ctx);
+    }
     Become(&TThis::StateWork);
 }
 
@@ -177,9 +186,12 @@ void TStorageServiceActor::HandleDestroyFileStore(
         cookie,
         msg->CallContext);
 
+    auto forceDestroy = msg->Record.GetForceDestroy() &&
+                        StorageConfig->GetAllowFileStoreForceDestroy();
     auto actor = std::make_unique<TDestroyFileStoreActor>(
         std::move(requestInfo),
-        msg->Record.GetFileSystemId());
+        msg->Record.GetFileSystemId(),
+        forceDestroy);
 
     NCloud::Register(ctx, std::move(actor));
 }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3763,6 +3763,50 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
+
+    Y_UNIT_TEST(ShouldForceDestroyWithAllowFileStoreForceDestroyFlag)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetAllowFileStoreForceDestroy(true);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+        ui32 nodeIdx = env.CreateNode("nfs");
+        const TString fsId = "test";
+        const auto initialBlockCount = 1'000;
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, initialBlockCount);
+
+        auto headers = THeaders{fsId, "client", ""};
+        auto createSessionResponse = service.CreateSession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createSessionResponse->GetStatus(),
+            createSessionResponse->GetErrorReason());
+        auto destroyFileStoreResponse = service.DestroyFileStore(fsId, true);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            destroyFileStoreResponse->GetStatus(),
+            destroyFileStoreResponse->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ForceDestroyWithoutAllowFileStoreForceDestroyFlagShouldFail)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+        ui32 nodeIdx = env.CreateNode("nfs");
+        const TString fsId = "test";
+        const auto initialBlockCount = 1'000;
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, initialBlockCount);
+
+        auto headers = THeaders{fsId, "client", ""};
+        auto createSessionResponse = service.CreateSession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createSessionResponse->GetStatus(),
+            createSessionResponse->GetErrorReason());
+        service.AssertDestroyFileStoreFailed(fsId, true);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -137,10 +137,14 @@ public:
         return request;
     }
 
-    auto CreateDestroyFileStoreRequest(const TString& fileSystemId)
+    auto CreateDestroyFileStoreRequest(
+        const TString& fileSystemId,
+        bool forceDestroy = false)
     {
-        auto request = std::make_unique<TEvService::TEvDestroyFileStoreRequest>();
+        auto request =
+            std::make_unique<TEvService::TEvDestroyFileStoreRequest>();
         request->Record.SetFileSystemId(fileSystemId);
+        request->Record.SetForceDestroy(forceDestroy);
         return request;
     }
 

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -160,6 +160,9 @@ message TDestroyFileStoreRequest
 
     // FileSystem identifier.
     string FileSystemId = 2;
+
+    // Destroy mounted filestore
+    bool ForceDestroy = 3;
 }
 
 message TDestroyFileStoreResponse


### PR DESCRIPTION
issue: #1384 

1. Add AllowFileStoreForceDestroy flag to storage configuration
2. Add ForceDestroy flag to filestore client

ForceDestroy flag should allow to destroy mounted filestore(with active sessions) if it's allowed in the storage configuration.