### PR TITLE
issue-1350: supported RenameNode for multitablet filesystems, fixed CreateHandle by Name for existing files - request should be sent to the follower specified in the Leader's response, not to the follower specified in the request

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -120,7 +120,7 @@ void TCreateHandleActor::CreateHandleInFollower(const TActorContext& ctx)
     auto request = std::make_unique<TEvService::TEvCreateHandleRequest>();
     request->Record = CreateHandleRequest;
     request->Record.SetFileSystemId(
-        CreateHandleRequest.GetFollowerFileSystemId());
+        LeaderResponse.GetFollowerFileSystemId());
     request->Record.SetNodeId(RootNodeId);
     request->Record.SetName(LeaderResponse.GetFollowerNodeName());
     request->Record.ClearFollowerFileSystemId();

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3623,12 +3623,14 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             TCreateNodeArgs::File(RootNodeId, "file1"))->Record;
 
         const auto nodeId1 = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId1));
 
         createNodeResponse = service.CreateNode(
             headers,
             TCreateNodeArgs::File(RootNodeId, "file2"))->Record;
 
         const auto nodeId2 = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(2, ExtractShardNo(nodeId2));
 
         ui64 handle1 = service.CreateHandle(
             headers,
@@ -3747,6 +3749,19 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(
             nodeId1,
             listNodesResponse.GetNodes(0).GetId());
+
+        // listing in shard2 should show nothing
+
+        auto headers2 = headers;
+        headers2.FileSystemId = shard2Id;
+
+        listNodesResponse = service.ListNodes(
+            headers2,
+            shard2Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
 }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3608,6 +3608,161 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         // TODO(#1350): leader should check that followers' ShardNos correspond
         // to the follower order in leader's config
     }
+
+    Y_UNIT_TEST(ShouldRenameExternalNodes)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        // creating 2 files
+
+        auto createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"))->Record;
+
+        const auto nodeId1 = createNodeResponse.GetNode().GetId();
+
+        createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file2"))->Record;
+
+        const auto nodeId2 = createNodeResponse.GetNode().GetId();
+
+        ui64 handle1 = service.CreateHandle(
+            headers,
+            fsId,
+            nodeId1,
+            "",
+            TCreateHandleArgs::RDWR)->Record.GetHandle();
+
+        // writing some data to file1 then moving file1 to file3
+
+        auto data1 = GenerateValidateData(256_KB);
+        service.WriteData(headers, fsId, nodeId1, handle1, 0, data1);
+
+        auto renameNodeResponse = service.RenameNode(
+            headers,
+            RootNodeId,
+            "file1",
+            RootNodeId,
+            "file3",
+            0);
+
+        // opening file3 for reading
+
+        auto createHandleResponse = service.CreateHandle(
+            headers,
+            fsId,
+            RootNodeId,
+            "file3",
+            TCreateHandleArgs::RDNLY)->Record;
+
+        // checking that file3 refers to the same node as formerly file1
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createHandleResponse.GetNodeAttr().GetId());
+
+        auto handle1r = createHandleResponse.GetHandle();
+
+        // checking that we can read the data that we wrote to file1
+
+        auto readDataResponse = service.ReadData(
+            headers,
+            fsId,
+            nodeId1,
+            handle1r,
+            0,
+            data1.Size())->Record;
+        UNIT_ASSERT_VALUES_EQUAL(data1, readDataResponse.GetBuffer());
+
+        // checking that node listing shows file3 and file2
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file2", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL("file3", listNodesResponse.GetNames(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId2,
+            listNodesResponse.GetNodes(0).GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(1).GetId());
+
+        // checking that move into an existing file (file2) works
+
+        renameNodeResponse = service.RenameNode(
+            headers,
+            RootNodeId,
+            "file3",
+            RootNodeId,
+            "file2",
+            0);
+
+        // checking that we can still read the same data
+
+        createHandleResponse = service.CreateHandle(
+            headers,
+            fsId,
+            RootNodeId,
+            "file2",
+            TCreateHandleArgs::RDNLY)->Record;
+
+        // nodeId should be kept intact
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createHandleResponse.GetNodeAttr().GetId());
+
+        handle1r = createHandleResponse.GetHandle();
+
+        readDataResponse = service.ReadData(
+            headers,
+            fsId,
+            nodeId1,
+            handle1r,
+            0,
+            data1.Size())->Record;
+        UNIT_ASSERT_VALUES_EQUAL(data1, readDataResponse.GetBuffer());
+
+        // listing should show only file2 now
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file2", listNodesResponse.GetNames(0));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3490,21 +3490,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             E_ARGUMENT,
             createHandleResponseEvent->GetError().GetCode(),
             createHandleResponseEvent->GetErrorReason());
-
-        // a request with FollowerId != the real FollowerId which owns the node
-        service.SendCreateHandleRequest(
-            headers,
-            fsId,
-            RootNodeId,
-            "file1",
-            TCreateHandleArgs::RDWR,
-            shard2Id);
-
-        createHandleResponseEvent = service.RecvCreateHandleResponse();
-        UNIT_ASSERT_VALUES_EQUAL_C(
-            E_ARGUMENT,
-            createHandleResponseEvent->GetError().GetCode(),
-            createHandleResponseEvent->GetErrorReason());
     }
 
     Y_UNIT_TEST(ShouldValidateFollowerConfiguration)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -363,6 +363,14 @@ private:
 
     bool CheckSessionForDestroy(const TSession* session, ui64 seqNo);
 
+    void RegisterUnlinkNodeInFollowerActor(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo,
+        TString followerId,
+        TString followerName,
+        NProto::TUnlinkNodeRequest request,
+        TUnlinkNodeInFollowerResult result);
+
 private:
     template <typename TMethod>
     TSession* AcceptRequest(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -361,6 +361,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
     }
 
     if (args.TargetNodeId != InvalidNodeId) {
+        // XXX unneeded check
         if (args.RequestFollowerId) {
             const auto shardNo = ExtractShardNo(args.TargetNodeId);
             const auto& followerIds =

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -361,25 +361,6 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
     }
 
     if (args.TargetNodeId != InvalidNodeId) {
-        // XXX unneeded check
-        if (args.RequestFollowerId) {
-            const auto shardNo = ExtractShardNo(args.TargetNodeId);
-            const auto& followerIds =
-                GetFileSystem().GetFollowerFileSystemIds();
-            const ui32 followerCount = followerIds.size();
-            const auto& followerId = shardNo && shardNo <= followerCount
-                ? followerIds[shardNo - 1]
-                : Default<TString>();
-            if (args.RequestFollowerId != followerId) {
-                args.Error = MakeError(
-                    E_ARGUMENT,
-                    TStringBuilder() << "Invalid FollowerId in request: "
-                        << args.RequestFollowerId << ", shard mismatch: "
-                        << shardNo << ", real FollowerId: " << followerId);
-                return true;
-            }
-        }
-
         if (!ReadNode(db, args.TargetNodeId, args.ReadCommitId, args.TargetNode)) {
             return false;   // not ready
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -381,22 +381,18 @@ void TIndexTabletActor::CompleteTx_RenameNode(
                 args.FollowerIdForUnlink.c_str(),
                 args.FollowerNameForUnlink.c_str());
 
-            // TODO
-            /*
-            auto actor = std::make_unique<TUnlinkNodeInFollowerActor>(
-                LogTag,
+            NProto::TUnlinkNodeRequest request;
+            request.MutableHeaders()->CopyFrom(args.Headers);
+
+            RegisterUnlinkNodeInFollowerActor(
+                ctx,
                 args.RequestInfo,
-                args.ChildRef->FollowerId,
-                args.ChildRef->FollowerName,
-                ctx.SelfID,
-                args.Request,
+                std::move(args.FollowerIdForUnlink),
+                std::move(args.FollowerNameForUnlink),
+                std::move(request),
                 std::move(args.Response));
 
-            auto actorId = NCloud::Register(ctx, std::move(actor));
-            WorkerActors.insert(actorId);
-
             return;
-            */
         }
 
         // TODO(#1350): support session events for external nodes

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -1,5 +1,4 @@
 #include "tablet_actor.h"
-#include "cloud/filestore/public/api/protos/node.pb.h"
 
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -1,4 +1,5 @@
 #include "tablet_actor.h"
+#include "cloud/filestore/public/api/protos/node.pb.h"
 
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 
@@ -38,7 +39,7 @@ private:
     const TString FollowerName;
     const TActorId ParentId;
     NProto::TUnlinkNodeRequest Request;
-    NProto::TUnlinkNodeResponse Response;
+    TUnlinkNodeInFollowerResult Result;
 
 public:
     TUnlinkNodeInFollowerActor(
@@ -48,7 +49,7 @@ public:
         TString followerName,
         const TActorId& parentId,
         NProto::TUnlinkNodeRequest request,
-        NProto::TUnlinkNodeResponse response);
+        TUnlinkNodeInFollowerResult result);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -77,14 +78,14 @@ TUnlinkNodeInFollowerActor::TUnlinkNodeInFollowerActor(
         TString followerName,
         const TActorId& parentId,
         NProto::TUnlinkNodeRequest request,
-        NProto::TUnlinkNodeResponse response)
+        TUnlinkNodeInFollowerResult result)
     : LogTag(std::move(logTag))
     , RequestInfo(std::move(requestInfo))
     , FollowerId(std::move(followerId))
     , FollowerName(std::move(followerName))
     , ParentId(parentId)
     , Request(std::move(request))
-    , Response(std::move(response))
+    , Result(std::move(result))
 {}
 
 void TUnlinkNodeInFollowerActor::Bootstrap(const TActorContext& ctx)
@@ -137,7 +138,7 @@ void TUnlinkNodeInFollowerActor::HandleUnlinkNodeResponse(
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
-        "%s Follower node created for %s, %s",
+        "%s Follower node unlinked for %s, %s",
         LogTag.c_str(),
         FollowerId.c_str(),
         FollowerName.c_str());
@@ -160,13 +161,21 @@ void TUnlinkNodeInFollowerActor::ReplyAndDie(
     if (HasError(error)) {
         // TODO(#1350): properly retry node unlinking via the leader fs
         // don't forget to properly handle ENOENT after a retry
-        *Response.MutableError() = std::move(error);
+        if (auto* x = std::get_if<NProto::TRenameNodeResponse>(&Result)) {
+            *x->MutableError() = std::move(error);
+        } else if (auto* x = std::get_if<NProto::TUnlinkNodeResponse>(&Result)) {
+            *x->MutableError() = std::move(error);
+        } else {
+            TABLET_VERIFY_C(
+                0,
+                TStringBuilder() << "bad variant index: " << Result.index());
+        }
     }
 
     using TResponse = TEvIndexTabletPrivate::TEvNodeUnlinkedInFollower;
     ctx.Send(ParentId, std::make_unique<TResponse>(
         std::move(RequestInfo),
-        std::move(Response)));
+        std::move(Result)));
 
     Die(ctx);
 }
@@ -370,17 +379,13 @@ void TIndexTabletActor::CompleteTx_UnlinkNode(
                 args.ChildRef->FollowerId.c_str(),
                 args.ChildRef->FollowerName.c_str());
 
-            auto actor = std::make_unique<TUnlinkNodeInFollowerActor>(
-                LogTag,
+            RegisterUnlinkNodeInFollowerActor(
+                ctx,
                 args.RequestInfo,
-                args.ChildRef->FollowerId,
-                args.ChildRef->FollowerName,
-                ctx.SelfID,
+                std::move(args.ChildRef->FollowerId),
+                std::move(args.ChildRef->FollowerName),
                 args.Request,
                 std::move(args.Response));
-
-            auto actorId = NCloud::Register(ctx, std::move(actor));
-            WorkerActors.insert(actorId);
 
             return;
         }
@@ -413,18 +418,58 @@ void TIndexTabletActor::HandleNodeUnlinkedInFollower(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
+    auto& res = msg->Result;
 
-    auto response = std::make_unique<TEvService::TEvUnlinkNodeResponse>();
-    response->Record = std::move(msg->UnlinkNodeResponse);
+    if (auto* x = std::get_if<NProto::TRenameNodeResponse>(&res)) {
+        auto response = std::make_unique<TEvService::TEvRenameNodeResponse>();
+        response->Record = std::move(*x);
 
-    CompleteResponse<TEvService::TUnlinkNodeMethod>(
-        response->Record,
-        msg->RequestInfo->CallContext,
-        ctx);
+        CompleteResponse<TEvService::TRenameNodeMethod>(
+            response->Record,
+            msg->RequestInfo->CallContext,
+            ctx);
 
-    NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+        NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+    } else if (auto* x = std::get_if<NProto::TUnlinkNodeResponse>(&res)) {
+        auto response = std::make_unique<TEvService::TEvUnlinkNodeResponse>();
+        response->Record = std::move(*x);
+
+        CompleteResponse<TEvService::TUnlinkNodeMethod>(
+            response->Record,
+            msg->RequestInfo->CallContext,
+            ctx);
+
+        NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+    } else {
+        TABLET_VERIFY_C(
+            0,
+            TStringBuilder() << "bad variant index: " << res.index());
+    }
 
     WorkerActors.erase(ev->Sender);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::RegisterUnlinkNodeInFollowerActor(
+    const NActors::TActorContext& ctx,
+    TRequestInfoPtr requestInfo,
+    TString followerId,
+    TString followerName,
+    NProto::TUnlinkNodeRequest request,
+    TUnlinkNodeInFollowerResult result)
+{
+    auto actor = std::make_unique<TUnlinkNodeInFollowerActor>(
+        LogTag,
+        std::move(requestInfo),
+        std::move(followerId),
+        std::move(followerName),
+        ctx.SelfID,
+        std::move(request),
+        std::move(result));
+
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -156,6 +156,12 @@ struct TWriteRange
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TUnlinkNodeInFollowerResult = std::variant<
+    NProto::TUnlinkNodeResponse,
+    NProto::TRenameNodeResponse>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TEvIndexTabletPrivate
 {
     //
@@ -538,13 +544,13 @@ struct TEvIndexTabletPrivate
     struct TNodeUnlinkedInFollower
     {
         TRequestInfoPtr RequestInfo;
-        NProto::TUnlinkNodeResponse UnlinkNodeResponse;
+        TUnlinkNodeInFollowerResult Result;
 
         TNodeUnlinkedInFollower(
                 TRequestInfoPtr requestInfo,
-                NProto::TUnlinkNodeResponse unlinkNodeResponse)
+                TUnlinkNodeInFollowerResult result)
             : RequestInfo(std::move(requestInfo))
-            , UnlinkNodeResponse(std::move(unlinkNodeResponse))
+            , Result(std::move(result))
         {
         }
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -695,6 +695,7 @@ struct TTxIndexTablet
         const ui64 NewParentNodeId;
         const TString NewName;
         const ui32 Flags;
+        const NProto::THeaders Headers;
 
         ui64 CommitId = InvalidCommitId;
         TMaybe<IIndexTabletDatabase::TNode> ParentNode;
@@ -720,6 +721,7 @@ struct TTxIndexTablet
             , NewParentNodeId(request.GetNewParentId())
             , NewName(std::move(*request.MutableNewName()))
             , Flags(request.GetFlags())
+            , Headers(std::move(*request.MutableHeaders()))
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -707,6 +707,9 @@ struct TTxIndexTablet
 
         NProto::TRenameNodeResponse Response;
 
+        TString FollowerIdForUnlink;
+        TString FollowerNameForUnlink;
+
         TRenameNode(
                 TRequestInfoPtr requestInfo,
                 NProto::TRenameNodeRequest& request)
@@ -731,6 +734,9 @@ struct TTxIndexTablet
             NewChildRef.Clear();
 
             Response.Clear();
+
+            FollowerIdForUnlink.clear();
+            FollowerNameForUnlink.clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -243,6 +243,25 @@ public:
         return request;
     }
 
+    auto CreateRenameNodeRequest(
+        const THeaders& headers,
+        const ui64 parent,
+        const TString& name,
+        const ui64 newParent,
+        const TString& newName,
+        ui32 flags)
+    {
+        auto request = std::make_unique<TEvService::TEvRenameNodeRequest>();
+        request->Record.SetFileSystemId(headers.FileSystemId);
+        headers.Fill(request->Record);
+        request->Record.SetNodeId(parent);
+        request->Record.SetName(name);
+        request->Record.SetNewParentId(newParent);
+        request->Record.SetNewName(newName);
+        request->Record.SetFlags(flags);
+        return request;
+    }
+
     static auto CreateWriteDataRequest(
         const THeaders& headers,
         const TString& fileSystemId,


### PR DESCRIPTION
#1350 