### PR TITLE
Find old external-vhost-servers and terminate it when running new

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -197,6 +197,10 @@ message TServerConfig
 
     // auth token for node registration via ydb discovery api.
     optional string NodeRegistrationToken = 117;
+
+    // How many seconds will the external vhost server continue to work after
+    // the parent process die.
+    optional uint32 VhostServerTimeoutAfterParentExit = 118;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -422,6 +422,7 @@ void TBootstrapBase::Init()
                     ? TString {}
                     : FQDNHostName(),
                 Configs->ServerConfig->GetSocketAccessMode(),
+                Configs->ServerConfig->GetVhostServerTimeoutAfterParentExit(),
                 std::move(vhostEndpointListener));
 
             STORAGE_INFO("VHOST External Vhost EndpointListener initialized");

--- a/cloud/blockstore/libs/endpoints_vhost/cont_io_with_timeout.h
+++ b/cloud/blockstore/libs/endpoints_vhost/cont_io_with_timeout.h
@@ -7,6 +7,10 @@
 
 namespace NCloud::NBlockStore::NServer {
 
+///////////////////////////////////////////////////////////////////////////////
+
+// Similar to TContIO, but DoWrite() and DoRead() operations are executed with a
+// timeout.
 class TContIOWithTimeout
     : public IInputStream
     , public IOutputStream

--- a/cloud/blockstore/libs/endpoints_vhost/cont_io_with_timeout.h
+++ b/cloud/blockstore/libs/endpoints_vhost/cont_io_with_timeout.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <library/cpp/coroutine/engine/sockpool.h>
+
+#include <util/stream/input.h>
+#include <util/stream/output.h>
+
+namespace NCloud::NBlockStore::NServer {
+
+class TContIOWithTimeout
+    : public IInputStream
+    , public IOutputStream
+{
+    SOCKET Fd_;
+    TCont* Cont_;
+    TDuration Timeout;
+
+public:
+    TContIOWithTimeout(SOCKET fd, TCont* cont, TDuration timeout)
+        : Fd_(fd)
+        , Cont_(cont)
+        , Timeout(timeout)
+    {}
+
+    void DoWrite(const void* buf, size_t len) override
+    {
+        NCoro::WriteD(Cont_, Fd_, buf, len, TInstant::Now() + Timeout)
+            .Checked();
+    }
+
+    size_t DoRead(void* buf, size_t len) override
+    {
+        return NCoro::ReadD(Cont_, Fd_, buf, len, TInstant::Now() + Timeout)
+            .Checked();
+    }
+
+    SOCKET Fd() const noexcept
+    {
+        return Fd_;
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -704,6 +704,7 @@ private:
     const ui32 SocketAccessMode;
     const IEndpointListenerPtr FallbackListener;
     const TExternalEndpointFactory EndpointFactory;
+    const TDuration VhostServerTimeoutAfterParentExit;
 
     TLog Log;
 
@@ -717,6 +718,7 @@ public:
             TExecutorPtr executor,
             TString localAgentId,
             ui32 socketAccessMode,
+            TDuration vhostServerTimeoutAfterParentExit,
             IEndpointListenerPtr fallbackListener,
             TExternalEndpointFactory endpointFactory)
         : Logging {std::move(logging)}
@@ -726,6 +728,7 @@ public:
         , SocketAccessMode {socketAccessMode}
         , FallbackListener {std::move(fallbackListener)}
         , EndpointFactory {std::move(endpointFactory)}
+        , VhostServerTimeoutAfterParentExit{vhostServerTimeoutAfterParentExit}
         , Log {Logging->CreateLog("BLOCKSTORE_SERVER")}
     {
         FindRunningEndpoints();
@@ -991,7 +994,9 @@ private:
             "--disk-id", request.GetDiskId(),
             "--serial", deviceName,
             "--socket-path", socketPath,
-            "-q", ToString(request.GetVhostQueuesCount())
+            "-q", ToString(request.GetVhostQueuesCount()),
+            "--wait-after-parent-exit",
+            ToString(VhostServerTimeoutAfterParentExit.Seconds()).c_str()
         };
 
         // TODO: get rid of "if" (was needed for backward compatibility)
@@ -1159,6 +1164,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString binaryPath,
     TString localAgentId,
     ui32 socketAccessMode,
+    TDuration vhostServerTimeoutAfterParentExit,
     IEndpointListenerPtr fallbackListener)
 {
     auto defaultFactory = [=] (
@@ -1188,6 +1194,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(executor),
         std::move(localAgentId),
         socketAccessMode,
+        vhostServerTimeoutAfterParentExit,
         std::move(fallbackListener),
         std::move(defaultFactory));
 }
@@ -1198,6 +1205,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TExecutorPtr executor,
     TString localAgentId,
     ui32 socketAccessMode,
+    TDuration vhostServerTimeoutAfterParentExit,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory)
 {
@@ -1207,6 +1215,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(executor),
         std::move(localAgentId),
         socketAccessMode,
+        vhostServerTimeoutAfterParentExit,
         std::move(fallbackListener),
         std::move(factory));
 }

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -1,4 +1,6 @@
 #include "external_vhost_server.h"
+
+#include "cont_io_with_timeout.h"
 #include "external_endpoint_stats.h"
 
 #include <cloud/blockstore/libs/common/device_path.h>
@@ -6,7 +8,6 @@
 #include <cloud/blockstore/libs/diagnostics/server_stats.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
 #include <cloud/blockstore/vhost-server/options.h>
-
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -15,6 +16,7 @@
 #include <library/cpp/coroutine/engine/events.h>
 #include <library/cpp/coroutine/engine/impl.h>
 #include <library/cpp/coroutine/engine/sockpool.h>
+#include <library/cpp/getopt/small/last_getopt.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
@@ -23,13 +25,12 @@
 #include <util/generic/hash.h>
 #include <util/generic/scope.h>
 #include <util/generic/strbuf.h>
+#include <util/stream/file.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
 #include <util/system/file.h>
 #include <util/system/mutex.h>
 #include <util/system/thread.h>
-
-#include <chrono>
 
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -44,6 +45,16 @@ using namespace std::chrono_literals;
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+// When the process starts, there may be a delay until it can process the
+// signals. Therefore, it is possible that the child process will miss our first
+// SIGUSR1 signal. When requesting the first block of statistics, it is
+// necessary to make a reasonable number of repetitions.
+constexpr ui64 ReadFirstStatRetryCount = 10;
+
+// It doesn't make sense to make the delay less than
+// COMPLETION_STATS_WAIT_DURATION.
+constexpr auto StatReadDuration = TDuration::Seconds(1);
 
 enum class EEndpointType
 {
@@ -66,6 +77,94 @@ const char* GetEndpointTypeName(EEndpointType state)
     return "UNDEFINED";
 }
 
+TString ReadFromFile(const TString& fileName)
+{
+    TFsPath path(fileName);
+    try {
+        if (!path.Exists()) {
+            return {};
+        }
+        return TFileInput(fileName).ReadAll();
+    } catch (...) {
+        return {};
+    }
+}
+
+TString ParseDiskIdFormCmdLine(const TString& cmdLine)
+{
+    // Prepare argv from string with zero-separated params.
+    std::vector<const char*> argv;
+    for (size_t i = 0; i < cmdLine.size(); ++i) {
+        const bool prevCharIsZero = i == 0 || (cmdLine[i - 1] == 0);
+        if (cmdLine[i] != 0 && prevCharIsZero) {
+            argv.push_back(&cmdLine[i]);
+        }
+    }
+    if (argv.empty()) {
+        return {};
+    }
+    argv.push_back(nullptr);
+
+    // Parse command line to get disk-id.
+    TString diskId;
+    NLastGetopt::TOpts opts;
+    opts.AddLongOption("disk-id").StoreResult(&diskId);
+    opts.AddLongOption('i', "serial");
+    opts.AddLongOption('s', "socket-path");
+    opts.AddLongOption("device");
+    opts.AddLongOption("client-id");
+    opts.AddLongOption("device-backend");
+    opts.AddLongOption("block-size");
+    opts.AddLongOption('r', "read-only");
+    opts.AddLongOption('B', "batch-size");
+    opts.AddLongOption('q', "queue-count");
+    opts.AddLongOption('a', "socket-access-mode");
+    opts.AddLongOption('v', "verbose");
+    opts.AddLongOption("log-type");
+    opts.AddLongOption("rdma-queue-size");
+    opts.AddLongOption("rdma-max-buffer-size");
+    opts.AddLongOption("wait-after-parent-exit");
+
+    // Attention! The parser ignores all of the following parameters if it
+    // encounters an unknown parameter. Therefore, you should keep the list of
+    // parameters up-to-date.
+    opts.AllowUnknownCharOptions_ = true;
+    opts.AllowUnknownLongOptions_ = true;
+
+    NLastGetopt::TOptsParseResult parsedOpts(&opts, argv.size(), argv.data());
+    return diskId;
+}
+
+TString FindDiskIdForRunningProcess(int pid)
+{
+    TFsPath proc("/proc");
+    TString processCmd = ReadFromFile(proc / ToString(pid) / "cmdline");
+    if (!processCmd) {
+        return {};
+    }
+    try {
+        return ParseDiskIdFormCmdLine(processCmd);
+    } catch (...) {
+        return {};
+    }
+}
+
+bool PrefetchBinaryToCache(const TString& binaryPath)
+{
+    try {
+        TFile binary(
+            binaryPath,
+            EOpenModeFlag::OpenExisting | EOpenModeFlag::RdOnly |
+                EOpenModeFlag::Seq);
+
+        binary.PrefetchCache(0, 0, true);
+        return true;
+    } catch (const TFileError& e) {
+        // Just ignore
+        return false;
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TChild
@@ -75,12 +174,14 @@ struct TChild
     TFileHandle StdErr;
 
 public:
-    TChild() = default;
+    explicit TChild(pid_t pid)
+        : Pid{pid}
+    {}
 
     TChild(pid_t pid, TFileHandle stdOut, TFileHandle stdErr)
-        : Pid {pid}
-        , StdOut {std::move(stdOut)}
-        , StdErr {std::move(stdErr)}
+        : Pid{pid}
+        , StdOut{std::move(stdOut)}
+        , StdErr{std::move(stdErr)}
     {}
 
     TChild(const TChild&) = delete;
@@ -105,14 +206,39 @@ public:
         StdErr.Swap(rhs.StdErr);
     }
 
-    int Kill(int sig) noexcept
+    int SendSignal(int sig) const noexcept
     {
         return ::kill(Pid, sig);
     }
 
-    void Terminate() noexcept
+    void Terminate() const noexcept
     {
-        Kill(SIGTERM);
+        SendSignal(SIGTERM);
+    }
+
+    NProto::TError Wait() const
+    {
+        int status = 0;
+
+        if (::waitpid(Pid, &status, 0) == -1) {
+            int err = errno;
+            return MakeError(
+                MAKE_SYSTEM_ERROR(err),
+                TStringBuilder() << "waitpid: " << ::strerror(err));
+        }
+
+        if (WIFSIGNALED(status)) {
+            const char* message =
+                WCOREDUMP(status) ? "core dump" : "terminated by a signal";
+
+            return MakeError(MAKE_SYSTEM_ERROR(WTERMSIG(status)), message);
+        }
+
+        if (WIFEXITED(status) && WEXITSTATUS(status)) {
+            return MakeError(MAKE_SYSTEM_ERROR(WEXITSTATUS(status)));
+        }
+
+        return {};
     }
 };
 
@@ -164,6 +290,7 @@ TChild SpawnChild(
     }
 
     if (childPid) {
+        // Parent process.
         return TChild {childPid, std::move(stdOut.R), std::move(stdErr.R)};
     }
 
@@ -171,6 +298,10 @@ TChild SpawnChild(
 
     stdOut.LinkTo(STDOUT_FILENO);
     stdErr.LinkTo(STDERR_FILENO);
+
+    // Last chance to figure out what's going on.
+    // freopen((TString("/tmp/out.") + ToString(::getpid())).c_str(), "w", stdout);
+    // freopen((TString("/tmp/err.") + ToString(::getpid())).c_str(), "w", stderr);
 
     // Following "const_cast"s are safe:
     // http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
@@ -189,34 +320,6 @@ TChild SpawnChild(
     int err = errno;
     char buf[64] {};
     Y_ABORT("Process was not created: %s", ::strerror_r(err, buf, sizeof(buf)));
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-NProto::TError WaitPid(pid_t pid)
-{
-    int status = 0;
-
-    if (::waitpid(pid, &status, 0) == -1) {
-        int err = errno;
-        return MakeError(
-            MAKE_SYSTEM_ERROR(err),
-            TStringBuilder() << "waitpid: " << ::strerror(err));
-    }
-
-    if (WIFSIGNALED(status)) {
-        const char* message = WCOREDUMP(status)
-            ? "core dump"
-            : "terminated by a signal";
-
-        return MakeError(MAKE_SYSTEM_ERROR(WTERMSIG(status)), message);
-    }
-
-    if (WIFEXITED(status) && WEXITSTATUS(status)) {
-        return MakeError(MAKE_SYSTEM_ERROR(WEXITSTATUS(status)));
-    }
-
-    return {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +352,7 @@ public:
         , Process {std::move(process)}
     {}
 
-    ~TEndpointProcess()
+    ~TEndpointProcess() override
     {
         if (!ShouldStop) {
             Process.Terminate();
@@ -265,51 +368,76 @@ public:
     void Stop()
     {
         ShouldStop = true;
-        Process.Kill(SIGINT);
+        Process.SendSignal(SIGINT);
     }
 
     NProto::TError Wait()
     {
-        return WaitPid(Process.Pid);
+        return Process.Wait();
     }
 
 private:
     void ReadStats(TCont* c)
     {
-        TIntrusivePtr<TEndpointProcess> holder {this};
+        TIntrusivePtr<TEndpointProcess> holder{this};
+        // Since it is not guaranteed that the vhost-server will receive first
+        // signal to generate statistics, we need to read the response with a
+        // timeout.
+        TContIOWithTimeout io{Process.StdOut, c, StatReadDuration * 2};
 
-        try {
-            ReadStatsImpl(c);
-        } catch (...) {
-            const auto logPriority = ShouldStop
-                ? TLOG_INFO
-                : TLOG_ERR;
+        bool firstRead = true;
+        for (ui64 i = 0; !ShouldStop; ++i) {
+            const auto startReadStatAt = TInstant::Now();
 
-            STORAGE_LOG(logPriority, "[" << ClientId << "] Read stats error: "
-                << CurrentExceptionMessage());
+            try {
+                ReadStatsImpl(io);
+                firstRead = false;
+            } catch (...) {
+                if (ShouldStop) {
+                    STORAGE_INFO(
+                        "[" << ClientId << "] Read stats error: "
+                            << CurrentExceptionMessage());
+                    break;
+                }
+
+                if (firstRead) {
+                    if (i < ReadFirstStatRetryCount) {
+                        STORAGE_WARN(
+                            "[" << ClientId << "] Retying read first stat #"
+                                << i + 1
+                                << ". Error: " << CurrentExceptionMessage());
+                    } else {
+                        STORAGE_ERROR(
+                            "[" << ClientId
+                                << "] Stop retying read first stat. Error: "
+                                << CurrentExceptionMessage());
+                        break;
+                    }
+                } else {
+                    STORAGE_ERROR(
+                        "[" << ClientId << "] Stop read stat. On #" << i
+                            << ". Error: " << CurrentExceptionMessage());
+                    break;
+                }
+            }
+
+            auto elapsedTime = TInstant::Now() - startReadStatAt;
+            if (elapsedTime < StatReadDuration) {
+                c->SleepT(StatReadDuration - elapsedTime);
+            }
         }
     }
 
-    void ReadStatsImpl(TCont* c)
+    void ReadStatsImpl(TContIOWithTimeout& io)
     {
-        TContIO io {Process.StdOut, c};
+        Process.SendSignal(SIGUSR1);
 
-        for (;;) {
-            c->SleepT(1s);
+        NJson::TJsonValue stats;
+        NJson::ReadJsonTree(io.ReadLine(), &stats, true);
 
-            if (ShouldStop) {
-                break;
-            }
+        STORAGE_DEBUG("[" << ClientId << "] " << stats);
 
-            Process.Kill(SIGUSR1);
-
-            NJson::TJsonValue stats;
-            NJson::ReadJsonTree(io.ReadLine(), &stats, true);
-
-            STORAGE_DEBUG("[" << ClientId << "] " << stats);
-
-            Stats.Update(stats);
-        }
+        Stats.Update(stats);
     }
 
     void ReadStdErr(TCont* c)
@@ -442,9 +570,21 @@ public:
         , Stats {std::move(stats)}
     {}
 
-    ~TEndpoint()
+    ~TEndpoint() override
     {
         Y_DEBUG_ABORT_UNLESS(ShouldStop);
+    }
+
+    void PrepareToStart() override
+    {
+        const auto startAt = TInstant::Now();
+        const bool succ = PrefetchBinaryToCache(BinaryPath);
+        const auto logPriority = succ ? TLOG_INFO : TLOG_ERR;
+
+        STORAGE_LOG(
+            logPriority,
+            "Prefetch binary " << (succ ? "success" : "failed") << ". It took "
+                               << (TInstant::Now() - startAt).ToString());
     }
 
     void Start() override
@@ -568,6 +708,7 @@ private:
     TLog Log;
 
     THashMap<TString, IExternalEndpointPtr> Endpoints;
+    THashMap<TString, i32> OldEndpoints;
 
 public:
     TExternalVhostEndpointListener(
@@ -586,7 +727,9 @@ public:
         , FallbackListener {std::move(fallbackListener)}
         , EndpointFactory {std::move(endpointFactory)}
         , Log {Logging->CreateLog("BLOCKSTORE_SERVER")}
-    {}
+    {
+        FindRunningEndpoints();
+    }
 
     TFuture<NProto::TError> StartEndpoint(
         const NProto::TStartEndpointRequest& request,
@@ -845,6 +988,7 @@ private:
             : request.GetInstanceId();
 
         TVector<TString> args {
+            "--disk-id", request.GetDiskId(),
             "--serial", deviceName,
             "--socket-path", socketPath,
             "-q", ToString(request.GetVhostQueuesCount())
@@ -859,9 +1003,6 @@ private:
         if (epType == EEndpointType::Rdma) {
             args.emplace_back("--client-id");
             args.emplace_back(clientId);
-
-            args.emplace_back("--disk-id");
-            args.emplace_back(request.GetDiskId());
 
             args.emplace_back("--device-backend");
             args.emplace_back(GetDeviceBackend(epType));
@@ -903,6 +1044,8 @@ private:
             std::move(cgroups)
         );
 
+        ep->PrepareToStart();
+        ShutdownOldEndpoint(request.GetDiskId());
         ep->Start();
 
         Endpoints[socketPath] = std::move(ep);
@@ -945,6 +1088,63 @@ private:
         }
 
         return true;
+    }
+
+    void FindRunningEndpoints() {
+        TFsPath proc("/proc");
+        TVector<TFsPath> allProcesses;
+        proc.List(allProcesses);
+        for (const auto& process: allProcesses) {
+            if (!process.IsDirectory()) {
+                continue;
+            }
+
+            i32 pid = 0;
+            if (!TryFromString<i32>(process.Basename(), pid)) {
+                continue;
+            }
+
+            auto processMark = ReadFromFile(process / "comm");
+            if (!processMark.StartsWith("vhost-")) {
+                continue;
+            }
+
+            const auto diskId = FindDiskIdForRunningProcess(pid);
+            if (diskId) {
+                OldEndpoints[diskId] = pid;
+                STORAGE_INFO(
+                    "Find running external-vhost-server PID:"
+                    << pid << " for disk-id: " << diskId.Quote());
+            }
+        }
+    }
+
+    void ShutdownOldEndpoint(const TString& diskId)
+    {
+        const auto* oldEndpoint = OldEndpoints.FindPtr(diskId);
+        if (!oldEndpoint) {
+            return;
+        }
+
+        const i32 pid = *oldEndpoint;
+
+        const auto oldDiskId = FindDiskIdForRunningProcess(pid);
+        if (oldDiskId != diskId) {
+            // There is a time interval between the search for old processes and
+            // their termination. We are checking here that another process has
+            // not been started under the same pid.
+            return;
+        }
+
+        TChild child(pid);
+
+        STORAGE_WARN(
+            "Send TERMINATE to external-vhost-server with PID:"
+            << pid << " for disk-id: " << diskId.Quote());
+        child.Terminate();
+        child.Wait();
+
+        OldEndpoints.erase(diskId);
     }
 };
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -94,19 +94,18 @@ TString ParseDiskIdFromCmdLine(const TString& cmdLine)
     // parameter. Therefore, we discard all the parameters that are in front of
     // the --disk-id.
     std::vector<const char*> argv;
-    bool diskIdSeen = false;
-    for (size_t i = 0; i < cmdLine.size(); ++i) {
-        if (TStringBuf{&cmdLine[i]} == "--disk-id") {
-            diskIdSeen = true;
-        }
-        const bool prevCharIsZero = i == 0 || (cmdLine[i - 1] == 0);
-        const bool shouldTakeParam = (i == 0) || diskIdSeen;
-        if (cmdLine[i] != 0 && prevCharIsZero && shouldTakeParam) {
-            argv.push_back(&cmdLine[i]);
-        }
-    }
-    if (argv.empty()) {
+    size_t diskIdOffset = cmdLine.find("--disk-id");
+    if (diskIdOffset == TString::npos || diskIdOffset == 0) {
         return {};
+    }
+
+    argv.push_back("dummy");
+    argv.push_back(&cmdLine[diskIdOffset]);
+    for (size_t i = diskIdOffset + 1; i < cmdLine.size(); ++i) {
+        if (cmdLine[i] != 0 && cmdLine[i - 1] == 0) {
+            argv.push_back(&cmdLine[i]);
+            break;
+        }
     }
     argv.push_back(nullptr);
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -212,6 +212,11 @@ public:
         SendSignal(SIGTERM);
     }
 
+    void Kill() const noexcept
+    {
+        SendSignal(SIGKILL);
+    }
+
     NProto::TError Wait() const
     {
         int status = 0;
@@ -1148,7 +1153,7 @@ private:
         STORAGE_WARN(
             "Send TERMINATE to external-vhost-server with PID:"
             << pid << " for disk-id: " << diskId.Quote());
-        child.Terminate();
+        child.Kill();
         child.Wait();
 
         OldEndpoints.erase(diskId);

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -18,6 +18,7 @@ namespace NCloud::NBlockStore::NServer {
 struct IExternalEndpoint
 {
     virtual ~IExternalEndpoint() = default;
+    virtual void PrepareToStart() = 0;
     virtual void Start() = 0;
     virtual NThreading::TFuture<NProto::TError> Stop() = 0;
 };

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -40,6 +40,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TString binaryPath,
     TString localAgentId,
     ui32 socketAccessMode,
+    TDuration vhostServerTimeoutAfterParentExit,
     IEndpointListenerPtr fallbackListener);
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
@@ -48,6 +49,7 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TExecutorPtr executor,
     TString localAgentId,
     ui32 socketAccessMode,
+    TDuration vhostServerTimeoutAfterParentExit,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory);
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -261,6 +261,7 @@ struct TFixture
         Executor,
         LocalAgentId,
         S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR,
+        TDuration::Seconds(30),
         CreateFallbackListener(),
         CreateExternalEndpointFactory());
 
@@ -409,12 +410,18 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
                 --device ...                        2
                 --device ...                        2
                 --read-only                         1
-                                                   11
+                --wait-after-parent-exit ...        2
+                                                   15
             */
 
-            UNIT_ASSERT_VALUES_EQUAL(13, create->CmdArgs.size());
+            UNIT_ASSERT_VALUES_EQUAL(15, create->CmdArgs.size());
             UNIT_ASSERT_VALUES_EQUAL("local0", GetArg(create->CmdArgs, "--serial"));
-            UNIT_ASSERT_VALUES_EQUAL("vol0", GetArg(create->CmdArgs, "--disk-id"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "vol0",
+                GetArg(create->CmdArgs, "--disk-id"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "30",
+                GetArg(create->CmdArgs, "--wait-after-parent-exit"));
 
             UNIT_ASSERT_VALUES_EQUAL(
                 "/tmp/socket.vhost",
@@ -493,10 +500,11 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
                 --device ...                        2
                 --device ...                        2
                 --read-only                         1
-                                                   19
+                --wait-after-parent-exit ...        2
+                                                   21
             */
 
-            UNIT_ASSERT_VALUES_EQUAL(19, create->CmdArgs.size());
+            UNIT_ASSERT_VALUES_EQUAL(21, create->CmdArgs.size());
             UNIT_ASSERT_VALUES_EQUAL("local0", GetArg(create->CmdArgs, "--serial"));
 
             UNIT_ASSERT_VALUES_EQUAL(
@@ -508,6 +516,9 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
             UNIT_ASSERT_VALUES_EQUAL("client", GetArg(create->CmdArgs, "--client-id"));
 
             UNIT_ASSERT_VALUES_EQUAL("vol0", GetArg(create->CmdArgs, "--disk-id"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "30",
+                GetArg(create->CmdArgs, "--wait-after-parent-exit"));
 
             UNIT_ASSERT_VALUES_EQUAL("rdma", GetArg(create->CmdArgs, "--device-backend"));
 

--- a/cloud/blockstore/libs/endpoints_vhost/ya.make
+++ b/cloud/blockstore/libs/endpoints_vhost/ya.make
@@ -13,6 +13,8 @@ PEERDIR(
     cloud/blockstore/libs/endpoints
     cloud/blockstore/libs/service
     cloud/blockstore/libs/vhost
+
+    library/cpp/getopt/small
 )
 
 END()

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -100,6 +100,7 @@ constexpr TDuration Seconds(int s)
     xxx(AllowAllRequestsViaUDS,      bool,                  false             )\
     xxx(NodeRegistrationToken,       TString,               "root@builtin"    )\
     xxx(EndpointStorageNotImplementedErrorIsFatal,  bool,   false             )\
+    xxx(VhostServerTimeoutAfterParentExit, TDuration,       Seconds(60)       )\
 // BLOCKSTORE_SERVER_CONFIG
 
 #define BLOCKSTORE_SERVER_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -133,6 +133,7 @@ public:
     TString GetEndpointProxySocketPath() const;
     bool GetAllowAllRequestsViaUDS() const;
     bool GetEndpointStorageNotImplementedErrorIsFatal() const;
+    TDuration GetVhostServerTimeoutAfterParentExit() const;
     TString GetNodeRegistrationToken() const;
 
     void Dump(IOutputStream& out) const override;

--- a/cloud/blockstore/tests/.gitignore
+++ b/cloud/blockstore/tests/.gitignore
@@ -1,5 +1,6 @@
 client/cloud-blockstore-tests-client
 cms/cloud-blockstore-tests-cms
+external_endpoint/cloud-blockstore-tests-external_endpoint
 fio/qemu-vhost-kikimr-test/cloud-blockstore-tests-fio-qemu-vhost-kikimr-test
 fio/qemu-vhost-local-test/cloud-blockstore-tests-fio-qemu-vhost-local-test
 fio/qemu-vhost-null-test/cloud-blockstore-tests-fio-qemu-vhost-null-test

--- a/cloud/blockstore/tests/external_endpoint/test.py
+++ b/cloud/blockstore/tests/external_endpoint/test.py
@@ -236,7 +236,7 @@ def test_external_endpoint(nbs, fake_vhost_server):
 
         # expect the old server servicing the "vol0" will terminate when the new one starts.
         nbs.old_vhost_server_vol0.communicate(timeout=1)
-        assert nbs.old_vhost_server_vol0.returncode == 0
+        assert nbs.old_vhost_server_vol0.returncode == -9
 
         # expect old vhost-server for "vol1" still running.
         try:

--- a/cloud/blockstore/tests/external_endpoint/test.py
+++ b/cloud/blockstore/tests/external_endpoint/test.py
@@ -124,7 +124,7 @@ def start_nbs_daemon(ydb, fake_vhost_server):
         [
             FAKE_VHOST_SERVER,
             "--disk-id", "vol0",
-            "--port", "1024",
+            "--port", str(PortManager().get_port()),
             "-s", "/tmp/dummy",
             "-i", "dummy",
             "--device", "/dev/vda:1000000:0"
@@ -133,7 +133,7 @@ def start_nbs_daemon(ydb, fake_vhost_server):
         [
             FAKE_VHOST_SERVER,
             "--disk-id", "vol1",
-            "--port", "1025",
+            "--port", str(PortManager().get_port()),
             "-s", "/tmp/dummy",
             "-i", "dummy",
             "--device", "/dev/vda:1000000:0"
@@ -235,7 +235,7 @@ def test_external_endpoint(nbs, fake_vhost_server):
         wait_for_vhost_server()
 
         # expect the old server servicing the "vol0" will terminate when the new one starts.
-        nbs.old_vhost_server_vol0.communicate()
+        nbs.old_vhost_server_vol0.communicate(timeout=1)
         assert nbs.old_vhost_server_vol0.returncode == 0
 
         # expect old vhost-server for "vol1" still running.

--- a/cloud/blockstore/tools/testing/fake-vhost-server/__main__.py
+++ b/cloud/blockstore/tools/testing/fake-vhost-server/__main__.py
@@ -23,6 +23,11 @@ def _prepare_logging(verbose):
         format="[%(levelname)s] [%(asctime)s] %(message)s")
 
 
+def __set_comm(proc_name):
+    with open(f'/proc/self/comm', 'w') as f:
+        f.write(proc_name)
+
+
 class _DeviceChunk:
 
     def __init__(self, s: str):
@@ -94,6 +99,8 @@ def _create_handler(args, app: _App):
 
 
 def _run_server(args):
+    __set_comm("vhost-" + args.disk_id)
+
     app = _App()
 
     server = HTTPServer(('localhost', args.port), _create_handler(args, app))

--- a/cloud/blockstore/tools/testing/fake-vhost-server/__main__.py
+++ b/cloud/blockstore/tools/testing/fake-vhost-server/__main__.py
@@ -24,7 +24,7 @@ def _prepare_logging(verbose):
 
 
 def __set_comm(proc_name):
-    with open(f'/proc/self/comm', 'w') as f:
+    with open('/proc/self/comm', 'w') as f:
         f.write(proc_name)
 
 

--- a/cloud/blockstore/tools/testing/fake-vhost-server/__main__.py
+++ b/cloud/blockstore/tools/testing/fake-vhost-server/__main__.py
@@ -244,6 +244,12 @@ def main():
         metavar="INT",
         default=4*1024**2 + 4096)
 
+    parser.add_argument(
+        "--wait-after-parent-exit",
+        help="How many seconds keep alive after the parent process is exited",
+        type=int,
+        metavar="INT")
+
     args = parser.parse_args()
 
     _prepare_logging(args.verbose)

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -132,12 +132,6 @@ void TOptions::Parse(int argc, char** argv)
             [this](const auto& timeout)
             { WaitAfterParentExit = TDuration::Seconds(timeout); });
 
-    Y_DEBUG_ABORT_UNLESS(
-        opts.GetOpts().size() == 20,
-        "Keep the list of parameters synchronized with the "
-        "ParseDiskIdFormCmdLine() from "
-        "cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp ");
-
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.FindLongOptParseResult("verbose") && VerboseLevel.empty()) {

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -132,6 +132,12 @@ void TOptions::Parse(int argc, char** argv)
             [this](const auto& timeout)
             { WaitAfterParentExit = TDuration::Seconds(timeout); });
 
+    Y_DEBUG_ABORT_UNLESS(
+        opts.GetOpts().size() == 20,
+        "Keep the list of parameters synchronized with the "
+        "ParseDiskIdFormCmdLine() from "
+        "cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp ");
+
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.FindLongOptParseResult("verbose") && VerboseLevel.empty()) {


### PR DESCRIPTION
1. на стороне NBS находим все запущенные external-vhost-server
2. при запуске нового external-vhost-server останвливаем старый, если он был
3. прогреваем файловый кэш чтобы новый external-vhost-server запускался быстрее
4. учитывается что external-vhost-server может не сразу начать обрабатывать сигналы, и делается несколько попыток получения статистики от него в первый раз https://github.com/ydb-platform/nbs/issues/1242
5. в external-vhost-server передается новый параметр - сколько он имеет право жить без родителя
