### PR TITLE
[Disk Manager] acceptance tests: support different types of disks, add flag to skip images

### DIFF
--- a/cloud/blockstore/pylibs/ycp/ycp.py
+++ b/cloud/blockstore/pylibs/ycp/ycp.py
@@ -210,6 +210,7 @@ class Ycp:
             self.created_at = dateparser.parse(info['created_at'])
             self.instance_ids = info.get('instance_ids', [])
             self.folder_id = info.get('folder_id', '')
+            self.type_id = info.get('type_id', '')  # TODO:_ test it?
             self.size = info.get('size', 0)
             self.block_size = info.get('block_size', 0)
             self.zone_id = info.get('zone_id', '')

--- a/cloud/blockstore/pylibs/ycp/ycp.py
+++ b/cloud/blockstore/pylibs/ycp/ycp.py
@@ -210,7 +210,7 @@ class Ycp:
             self.created_at = dateparser.parse(info['created_at'])
             self.instance_ids = info.get('instance_ids', [])
             self.folder_id = info.get('folder_id', '')
-            self.type_id = info.get('type_id', '')  # TODO:_ test it?
+            self.type_id = info.get('type_id', '')
             self.size = info.get('size', 0)
             self.block_size = info.get('block_size', 0)
             self.zone_id = info.get('zone_id', '')

--- a/cloud/disk_manager/test/acceptance/main.go
+++ b/cloud/disk_manager/test/acceptance/main.go
@@ -834,10 +834,6 @@ func main() {
 		"skip creation of images and creation of disks from images",
 	)
 
-	if skipImages && len(urlForCreateImageFromURLTest) != 0 {
-		log.Fatalf("skip images option is set, but image url is present: %v", urlForCreateImageFromURLTest)
-	}
-
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed to execute: %v", err)
 	}

--- a/cloud/disk_manager/test/acceptance/main.go
+++ b/cloud/disk_manager/test/acceptance/main.go
@@ -49,7 +49,7 @@ func createSnapshotFromDisk(
 	suffix string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-snapshot", suffix)
+	name := createUniqueName("acc-snapshot", suffix)
 
 	logging.Info(
 		ctx,
@@ -118,7 +118,7 @@ func createImageFromSnapshot(
 	suffix string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-image", suffix)
+	name := createUniqueName("acc-image", suffix)
 
 	logging.Info(
 		ctx,
@@ -152,7 +152,7 @@ func createImageFromImage(
 	suffix string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-image", suffix)
+	name := createUniqueName("acc-image", suffix)
 
 	logging.Info(
 		ctx,
@@ -184,7 +184,7 @@ func createImageFromDisk(
 	suffix string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-image", suffix)
+	name := createUniqueName("acc-image", suffix)
 
 	logging.Info(ctx, "Creating image with name %v from disk %v", name, diskID)
 
@@ -211,7 +211,7 @@ func createImageFromURL(
 	url string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-image", suffix)
+	name := createUniqueName("acc-image", suffix)
 
 	logging.Info(ctx, "Creating image with name %v from url %v", name, url)
 
@@ -240,7 +240,7 @@ func createDiskFromSnapshot(
 	suffix string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-disk", suffix)
+	name := createUniqueName("acc-disk", suffix)
 
 	logging.Info(
 		ctx,
@@ -279,7 +279,7 @@ func createDiskFromImage(
 	suffix string,
 ) (string, error) {
 
-	name := createUniqueName("acceptance-test-disk", suffix)
+	name := createUniqueName("acc-disk", suffix)
 
 	logging.Info(
 		ctx,
@@ -801,7 +801,7 @@ func main() {
 		&suffix,
 		"suffix",
 		"",
-		"add unique suffix to entity name (ex. acceptance-test-disk-<suffix>-<timestamp>)")
+		"add unique suffix to entity name (ex. acc-disk-<suffix>-<timestamp>)")
 	rootCmd.Flags().StringVar(
 		&outputDiskIDs,
 		"output-disk-ids",

--- a/cloud/disk_manager/test/acceptance/main.go
+++ b/cloud/disk_manager/test/acceptance/main.go
@@ -831,11 +831,11 @@ func main() {
 		&skipImages,
 		"skip-images",
 		false,
-		"do not skip creation of images and creation of disks from images",
+		"skip creation of images and creation of disks from images",
 	)
 
 	if skipImages && len(urlForCreateImageFromURLTest) != 0 {
-		log.Fatalf("skip images option is used, but image url present: %v", urlForCreateImageFromURLTest)
+		log.Fatalf("skip images option is set, but image url is present: %v", urlForCreateImageFromURLTest)
 	}
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cloud/disk_manager/test/acceptance/test_runner/README.md
+++ b/cloud/disk_manager/test/acceptance/test_runner/README.md
@@ -30,16 +30,16 @@ This binary is used in `acceptance` and `eternal` tests and performs the followi
    * creates image-2 from disk-2
    * creates image-3 from image-2
    * removes images, disks and snapshots (if `output-disk-ids` is present disks are conserved, the same goes for snapshots and `output-snapshot-ids`, those parameters are file paths, those files store "\n" separated disk/snapshot ids respectively).
-   * In case of the test utility failure, the following entities would remain and not be cleaned up: `acceptance-test-image-{suffix}-{timestamp}`, `acceptance-test-snapshot-{suffix}-{timestamp}`, `acceptance-test-disk-{suffix}-{timestamp}`
+   * In case of the test utility failure, the following entities would remain and not be cleaned up: `acc-image-{suffix}-{timestamp}`, `acc-snapshot-{suffix}-{timestamp}`, `acc-disk-{suffix}-{timestamp}`
 2. `createImageFromURLTest`
    * For this test, `url-for-create-image-from-url-test` parameter is required and must be a valid and accessible from the host running the test S3 image url. Image shall be of the following formats: `QCOW2`, `raw`, `VMDK`.
    * Image is created from the S3 URL.
-   * Image is deleted afterward. In case of the test failure image is not being cleaned up. Created image has the following format: `acceptance-test-image-{suffix}-{timestamp}`, where suffix is optional.
+   * Image is deleted afterward. In case of the test failure image is not being cleaned up. Created image has the following format: `acc-image-{suffix}-{timestamp}`, where suffix is optional.
 3. `cancelTest`
    * starts snapshot creation operation from the source disk in the background
    * deletes snapshots
    * checks if the snapshot is actually deleted
-   * If the test case is interrupted/fails before the snapshot creation is cancelled, the snapshot `acceptance-test-snapshot-{suffix}-{timestamp}` would remain.
+   * If the test case is interrupted/fails before the snapshot creation is cancelled, the snapshot `acc-snapshot-{suffix}-{timestamp}` would remain.
 
 
 ## Dependencies
@@ -80,7 +80,7 @@ $ ./disk-manager-ci-acceptance-test-suite --cluster <cluster> --acceptance-test 
 
 ### Description
 1. Creates instance.
-2. Tries to find disk with name regex `acceptance-test-eternal-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+` (first number is the test disk size, second - blocksize).
+2. Tries to find disk with name regex `acc-eternal-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+` (first number is the test disk size, second - blocksize).
 3. If disk wasn't found on previous step, then creates it.
 4. Attaches disk to instance.
 5. Fills disk with random data (remotely via `fio`).
@@ -104,14 +104,14 @@ $ ./disk-manager-ci-acceptance-test-suite --cluster <cluster> --acceptance-test 
 
 ### Description
 1. Creates instance.
-2. Tries to find disk with name regex `acceptance-test-sync-disk-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+` (first number is the test disk size, second - blocksize).
+2. Tries to find disk with name regex `acc-sync-disk-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+` (first number is the test disk size, second - blocksize).
 3. If disk wasn't found on previous step, then creates it.
 4. Attaches disk to instance.
 5. Creates ext4 filesystem on the disk and mounts the disk to the `/tmp` subdirectory.
 6. Creates 3 files on the disk, fills them with random data from `/dev/random`.
 7. Saves those file's checksums into a local variable.
-8. Creates a snapshot with name `sync-acceptance-test-snapshot-<timestamp>` from the disk with files.
-9. Creates a disk `acceptance-test-sync-<size>-<block-size>-<timestamp>-from-snapshot` from the snapshot
+8. Creates a snapshot with name `sync-acc-snapshot-<timestamp>` from the disk with files.
+9. Creates a disk `acc-sync-<size>-<block-size>-<timestamp>-from-snapshot` from the snapshot
 10. Attaches the disk and compares files checksums
 
 **NOTE:** Source disk is not deleted after the test is finished. It must be deleted manually!
@@ -124,33 +124,33 @@ $ ./disk-manager-ci-acceptance-test-suite --cluster <cluster> --acceptance-test 
 ### Leaked resources and cleanup process:
 Here's the list of the resources and regular expressions matching those resources:
 * For `acceptance` tests: 
-  * For instances: `^acceptance-test-acceptance-(small|medium|big|enormous)-[0-9]+$`
+  * For instances: `^acc-acceptance-(small|medium|big|enormous)-[0-9]+$`
   * For disks:
-    - `^acceptance-test-acceptance-(small|medium|big|enormous)-[0-9]+$`
-    - `^acceptance-test-disk-acceptance-[0-9]+$` (These disks are created by previous tests versions)
-    - `^acceptance-test-disk-acceptance-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
+    - `^acc-acceptance-(small|medium|big|enormous)-[0-9]+$`
+    - `^acc-disk-acceptance-[0-9]+$` (These disks are created by previous tests versions)
+    - `^acc-disk-acceptance-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
   * For images:
-    - `^acceptance-test-image-acceptance-[0-9]+$` (These images are created by previous tests versions)
-    - `^acceptance-test-image-acceptance-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
+    - `^acc-image-acceptance-[0-9]+$` (These images are created by previous tests versions)
+    - `^acc-image-acceptance-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
   * For snapshots:
-    - `^acceptance-test-snapshot-acceptance-[0-9]+$` (These snapshots are created by previous tests versions)
-    - `^acceptance-test-snapshot-acceptance-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
+    - `^acc-snapshot-acceptance-[0-9]+$` (These snapshots are created by previous tests versions)
+    - `^acc-snapshot-acceptance-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
 * For `eternal` tests
-  * For instances: `^acceptance-test-eternal-[0-9]+$`
+  * For instances: `^acc-eternal-[0-9]+$`
   * For disks:
-    * `^acceptance-test-eternal-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+$` (This disk is a base disk)
-    * `^acceptance-test-disk-eternal-[0-9]+$` (These disks are created by previous tests versions)
-    * `^acceptance-test-disk-eternal-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
+    * `^acc-eternal-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+$` (This disk is a base disk)
+    * `^acc-disk-eternal-[0-9]+$` (These disks are created by previous tests versions)
+    * `^acc-disk-eternal-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
   * For images:
-    * `^acceptance-test-image-eternal-[0-9]+$` (These images are created by previous tests versions)
-    * `^acceptance-test-image-eternal-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
+    * `^acc-image-eternal-[0-9]+$` (These images are created by previous tests versions)
+    * `^acc-image-eternal-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
   * For snapshots:
-    * `^acceptance-test-snapshot-eternal-[0-9]+$` (These snapshots are created by previous tests versions)
-    * `^acceptance-test-snapshot-eternal-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
+    * `^acc-snapshot-eternal-[0-9]+$` (These snapshots are created by previous tests versions)
+    * `^acc-snapshot-eternal-[0-9]+(tib|gib|mib|kib|b)-[0-9]+(tib|gib|mib|kib|b)-[0-9]+$`
 * For sync tests:
-  * For instances: `^acceptance-test-sync-[0-9]+$`
+  * For instances: `^acc-sync-[0-9]+$`
   * For disks:
-    * `^acceptance-test-sync-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+` (This disk is a base disk)
-    * `^acceptance-test-sync-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+-from-snapshot$`
-  * For snapshots: `^sync-acceptance-test-snapshot-.*$`
+    * `^acc-sync-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+` (This disk is a base disk)
+    * `^acc-sync-[0-9]+(b|kib|mib|gib|tib)-[0-9]+(b|kib|mib|gib|tib)-[0-9]+-from-snapshot$`
+  * For snapshots: `^sync-acc-snapshot-.*$`
 Note that for the `sync` and `eternal` tests, at least on "base" disk should be kept present, because sync and eternal tests check incremental snapshots.

--- a/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
@@ -21,9 +21,10 @@ class AcceptanceTestBinaryExecutor(BaseTestBinaryExecutor):
     def __init__(self, args, *arguments, **kwargs):
         super(AcceptanceTestBinaryExecutor, self).__init__(args, *arguments, **kwargs)
         location = args.bucket_location or args.profile_name or args.cluster
-        self._acceptance_test_cmd.extend([
-            '--url-for-create-image-from-url-test',
-            f"https://{self._s3_host}/{location}.disk-manager/acceptance-tests/ubuntu-1604-ci-stable"])
+        if not args.skip_images:
+            self._acceptance_test_cmd.extend([
+                '--url-for-create-image-from-url-test',
+                f"https://{self._s3_host}/{location}.disk-manager/acceptance-tests/ubuntu-1604-ci-stable"])
 
 
 class AcceptanceTestCleaner(BaseResourceCleaner):

--- a/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
@@ -34,9 +34,13 @@ class AcceptanceTestCleaner(BaseResourceCleaner):
             rf'^acc-{args.test_type}-'
             rf'{args.test_suite}-[0-9]+$',
         )
+        _old_instance_name_pattern = re.compile(
+            rf'^acceptance-test-{args.test_type}-'
+            rf'{args.test_suite}-[0-9]+$',
+        )
         self._patterns = {
-            'instance': [_instance_name_pattern],
-            'disk': [_instance_name_pattern],
+            'instance': [_instance_name_pattern, _old_instance_name_pattern],
+            'disk': [_instance_name_pattern, _old_instance_name_pattern],
         }
 
 

--- a/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/acceptance_test_runner.py
@@ -30,7 +30,7 @@ class AcceptanceTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(AcceptanceTestCleaner, self).__init__(ycp, args)
         _instance_name_pattern = re.compile(
-            rf'^acceptance-test-{args.test_type}-'
+            rf'^acc-{args.test_type}-'
             rf'{args.test_suite}-[0-9]+$',
         )
         self._patterns = {
@@ -67,7 +67,7 @@ class AcceptanceTestRunner(BaseAcceptanceTestRunner):
             disk_policy = YcpNewDiskPolicy(
                 self._create_ycp(self._args.cluster),
                 zone_id=self._args.zone_id,
-                name=f'acceptance-test-{self._args.test_type}-'
+                name=f'acc-{self._args.test_type}-'
                      f'{self._args.test_suite}-{self._timestamp}',
                 size=test_case.disk_size,
                 blocksize=test_case.disk_blocksize,
@@ -139,7 +139,7 @@ class AcceptanceTestRunner(BaseAcceptanceTestRunner):
     def run(self, profiler: common.Profiler) -> None:
         self._initialize_run(
             profiler,
-            f'acceptance-test-{self._args.test_type}-{self._args.test_suite}-'
+            f'acc-{self._args.test_type}-{self._args.test_suite}-'
             f'{self._timestamp}',
             'acceptance',
         )

--- a/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
@@ -79,7 +79,7 @@ class BaseTestBinaryExecutor:
                 '--suffix',
                 (
                     f'{self._entity_suffix}-'
-                    f'{self.make_disk_parameters_string(disk_type, int(disk_size), int(disk_blocksize))}'.lower()
+                    f'{make_disk_parameters_string(disk_type, int(disk_size), int(disk_blocksize))}'.lower()
                 ),
             ]
         )

--- a/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
@@ -26,7 +26,6 @@ from .cleanup import (
 from .lib import (
     check_ssh_connection,
     create_ycp,
-    size_prettifier,
     make_disk_parameters_string,
     Error,
     YcpNewInstancePolicy,
@@ -75,8 +74,6 @@ class BaseTestBinaryExecutor:
         self._s3_host = getattr(args, 's3_host', None)
 
     def run(self, disk_type: str, disk_id: str, disk_size: str, disk_blocksize: str) -> None:
-        # TODO:_ check how cleanup will work
-        # TODO:_ ok
         self._acceptance_test_cmd.extend(
             [
                 '--suffix',
@@ -369,7 +366,7 @@ class BaseAcceptanceTestRunner(ABC):
                     error=error,
                 )
 
-    def disk_parameters_string(self, delim = "-"):
+    def _make_disk_parameters_string(self, delim: str = "-"):
         return make_disk_parameters_string(
             self._args.disk_type,
             self._args.disk_size * (1024 ** 3),

--- a/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
@@ -70,6 +70,8 @@ class BaseTestBinaryExecutor:
 
         if args.verbose:
             self._acceptance_test_cmd.append('--verbose')
+        if args.skip_images:
+            self._acceptance_test_cmd.append('--skip-images')
 
         self._s3_host = getattr(args, 's3_host', None)
 

--- a/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
@@ -40,7 +40,9 @@ def _cleanup_stale_entities(
             if entity.created_at > should_be_older_than:
                 continue
             for pattern in regexps.get(entity_type, []):
+                print(pattern, entity)
                 if re.match(pattern, entity.name):
+                    print('matched')
                     _logger.info(
                         "Deleting %s with name %s",
                         entity_type, entity.name)
@@ -54,6 +56,7 @@ def _cleanup_stale_entities(
                             exc_info=e,
                         )
                     break
+                print('not matched')
 
 
 def cleanup_previous_acceptance_tests_results(
@@ -104,7 +107,7 @@ class BaseResourceCleaner:
         self._disk_size = None
         self._disk_blocksize = None
         if hasattr(args, 'disk_type'):
-            self._disk_type = size_prettifier(args.disk_type).lower()
+            self._disk_type = args.disk_type.lower()
         if hasattr(args, 'disk_size'):
             self._disk_size = size_prettifier(
                 args.disk_size * (1024 ** 3)).lower()

--- a/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
@@ -80,11 +80,11 @@ def cleanup_previous_acceptance_tests_results(
     regexps = {
         entity_type: [
             re.compile(
-                fr'^acceptance-test-{entity_type}-'
+                fr'^acc-{entity_type}-'
                 fr'{test_type}-'
                 fr'{make_disk_parameters_string(disk_type, disk_size, disk_blocksize)}-[0-9]+$',
             ),
-            re.compile(fr'^acceptance-test-{entity_type}-{test_type}-[0-9]+$')
+            re.compile(fr'^acc-{entity_type}-{test_type}-[0-9]+$')
         ] for entity_type in entity_accessors
     }
     _cleanup_stale_entities(
@@ -120,7 +120,7 @@ class BaseResourceCleaner:
         }
         self._patterns: dict[str, list[re.Pattern]] = {
             'instance':  [
-                re.compile(rf'^acceptance-test-{args.test_type}-[0-9]+$')
+                re.compile(rf'^acc-{args.test_type}-[0-9]+$')
             ],
         }
 

--- a/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Callable, Any
 
 from cloud.blockstore.pylibs.ycp import YcpWrapper
-from cloud.disk_manager.test.acceptance.test_runner.lib import size_prettifier
+from cloud.disk_manager.test.acceptance.test_runner.lib import size_prettifier, make_disk_parameters_string
 
 _logger = logging.getLogger(__file__)
 
@@ -59,24 +59,28 @@ def _cleanup_stale_entities(
 def cleanup_previous_acceptance_tests_results(
         ycp: YcpWrapper,
         test_type: str,
+        disk_type: str,
         disk_size: int,
         disk_blocksize: int,
         entity_ttl: timedelta = timedelta(days=1),
 ):
     entity_accessors = _get_entity_accessors(ycp)
+    disk_parameters_string = make_disk_parameters_string(disk_type, disk_size, disk_blocksize)
     disk_size = size_prettifier(disk_size).lower()
     disk_blocksize = size_prettifier(disk_blocksize).lower()
     _logger.info(
-        "Performing cleanup for %s disk size %s, disk block size %s",
+        "Performing cleanup for %s, disk type %s, disk size %s, disk block size %s",
         test_type,
+        disk_type,
         disk_size,
         disk_blocksize,
     )
     regexps = {
         entity_type: [
+            # TODO:_ ok
             re.compile(
                 fr'^acceptance-test-{entity_type}-'
-                fr'{test_type}-{disk_size}-{disk_blocksize}-[0-9]+$',
+                fr'{test_type}-{disk_parameters_string}-[0-9]+$',
             ),
             re.compile(fr'^acceptance-test-{entity_type}-{test_type}-[0-9]+$')
         ] for entity_type in entity_accessors
@@ -96,8 +100,11 @@ class BaseResourceCleaner:
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         self._ycp = ycp
         self._args = args
+        self._disk_type = None
         self._disk_size = None
         self._disk_blocksize = None
+        if hasattr(args, 'disk_type'):
+            self._disk_type = size_prettifier(args.disk_type).lower()
         if hasattr(args, 'disk_size'):
             self._disk_size = size_prettifier(
                 args.disk_size * (1024 ** 3)).lower()
@@ -130,3 +137,6 @@ class BaseResourceCleaner:
             self._entity_ttls,
             self._patterns,
         )
+
+    def disk_parameters_string(self):
+        return make_disk_parameters_string(self._disk_type, self._disk_size, self._disk_blocksize)

--- a/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
@@ -84,7 +84,12 @@ def cleanup_previous_acceptance_tests_results(
                 fr'{test_type}-'
                 fr'{make_disk_parameters_string(disk_type, disk_size, disk_blocksize)}-[0-9]+$',
             ),
-            re.compile(fr'^acc-{entity_type}-{test_type}-[0-9]+$')
+            re.compile(fr'^acc-{entity_type}-{test_type}-[0-9]+$'),
+            re.compile(
+                fr'^acceptance-test-{entity_type}-'
+                fr'{test_type}-{disk_size}-{disk_blocksize}-[0-9]+$',
+            ),
+            re.compile(fr'^acceptance-test-{entity_type}-{test_type}-[0-9]+$')
         ] for entity_type in entity_accessors
     }
     _cleanup_stale_entities(
@@ -120,7 +125,8 @@ class BaseResourceCleaner:
         }
         self._patterns: dict[str, list[re.Pattern]] = {
             'instance':  [
-                re.compile(rf'^acc-{args.test_type}-[0-9]+$')
+                re.compile(rf'^acc-{args.test_type}-[0-9]+$'),
+                re.compile(rf'^acceptance-test-{args.test_type}-[0-9]+$'),
             ],
         }
 

--- a/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/cleanup.py
@@ -88,7 +88,7 @@ def cleanup_previous_acceptance_tests_results(
             re.compile(
                 fr'^acceptance-test-{entity_type}-'
                 fr'{test_type}-{disk_size}-{disk_blocksize}-[0-9]+$',
-            ),
+            ),  # Should cleanup for both old and new formats of entity names (#1576)
             re.compile(fr'^acceptance-test-{entity_type}-{test_type}-[0-9]+$')
         ] for entity_type in entity_accessors
     }

--- a/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
@@ -32,7 +32,7 @@ class EternalTestCleaner(BaseResourceCleaner):
         super(EternalTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
         disk_name_pattern = re.compile(
-            fr'^acceptance-test-{test_type}-'
+            fr'^acc-{test_type}-'
             fr'{self._disk_parameters_string}-[0-9]+$',
         )
         self._entity_ttls = self._entity_ttls | {
@@ -75,7 +75,7 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
     def run(self, profiler: common.Profiler) -> None:
         self._initialize_run(
             profiler,
-            f'acceptance-test-{self._args.test_type}-{self._timestamp}',
+            f'acc-{self._args.test_type}-{self._timestamp}',
             'eternal',
         )
 
@@ -105,7 +105,7 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
                            instance.ip)
 
             disk_name_prefix = (
-                f'acceptance-test-{self._args.test_type}-'
+                f'acc-{self._args.test_type}-'
                 f'{self._make_disk_parameters_string()}').lower()
             disk = self._find_or_create_eternal_disk(disk_name_prefix)
 

--- a/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
@@ -13,7 +13,6 @@ from .base_acceptance_test_runner import BaseAcceptanceTestRunner, \
 from .cleanup import BaseResourceCleaner
 from .lib import (
     check_ssh_connection,
-    size_prettifier,
     Error,
 )
 
@@ -32,10 +31,9 @@ class EternalTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(EternalTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
-        # TODO:_ ok
         disk_name_pattern = re.compile(
             fr'^acceptance-test-{test_type}-'
-            fr'{self.disk_parameters_string()}-[0-9]+$',
+            fr'{self._disk_parameters_string}-[0-9]+$',
         )
         self._entity_ttls = self._entity_ttls | {
             'disk': timedelta(days=5),
@@ -55,12 +53,10 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
     def _remote_cmp_path(self) -> str:
         return '/usr/bin/acceptance-cmp'
 
-    # TODO:_ is it ok to change name of test suite?
-    # TODO:_ ok
     def _get_test_suite(self):
         return (
             f'{self._args.zone_id}_eternal_'
-            f'{self.disk_parameters_string(delim="_")}'.lower()
+            f'{self._make_disk_parameters_string(delim="_")}'.lower()
         )
 
     def _report_compute_failure(self, error):
@@ -108,11 +104,9 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
                            self._remote_cmp_path,
                            instance.ip)
 
-            # TODO:_ ok
             disk_name_prefix = (
                 f'acceptance-test-{self._args.test_type}-'
-                f'{self.disk_parameters_string()}'.lower()
-            )
+                f'{self._make_disk_parameters_string()}').lower()
             disk = self._find_or_create_eternal_disk(disk_name_prefix)
 
             _logger.info(

--- a/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
@@ -31,16 +31,23 @@ class EternalTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(EternalTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
+
         disk_name_pattern = re.compile(
             fr'^acc-{test_type}-'
             fr'{self._disk_parameters_string}-[0-9]+$',
         )
+        old_disk_name_pattern = re.compile(
+            fr'^acceptance-test-{test_type}-'
+            fr'{self._disk_size}-'
+            fr'{self._disk_blocksize}-[0-9]+$',
+        )
+
         self._entity_ttls = self._entity_ttls | {
             'disk': timedelta(days=5),
         }
         self._patterns = {
             **self._patterns,
-            'disk': [disk_name_pattern],
+            'disk': [disk_name_pattern, old_disk_name_pattern],
         }
 
 

--- a/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/eternal_acceptance_test_runner.py
@@ -32,10 +32,10 @@ class EternalTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(EternalTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
+        # TODO:_ ok
         disk_name_pattern = re.compile(
             fr'^acceptance-test-{test_type}-'
-            fr'{self._disk_size}-'
-            fr'{self._disk_blocksize}-[0-9]+$',
+            fr'{self.disk_parameters_string()}-[0-9]+$',
         )
         self._entity_ttls = self._entity_ttls | {
             'disk': timedelta(days=5),
@@ -55,11 +55,12 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
     def _remote_cmp_path(self) -> str:
         return '/usr/bin/acceptance-cmp'
 
+    # TODO:_ is it ok to change name of test suite?
+    # TODO:_ ok
     def _get_test_suite(self):
         return (
             f'{self._args.zone_id}_eternal_'
-            f'{size_prettifier(self._args.disk_size * (1024 ** 3))}_'
-            f'{size_prettifier(self._args.disk_blocksize)}'.lower()
+            f'{self.disk_parameters_string(delim="_")}'.lower()
         )
 
     def _report_compute_failure(self, error):
@@ -107,10 +108,11 @@ class EternalAcceptanceTestRunner(BaseAcceptanceTestRunner):
                            self._remote_cmp_path,
                            instance.ip)
 
+            # TODO:_ ok
             disk_name_prefix = (
                 f'acceptance-test-{self._args.test_type}-'
-                f'{size_prettifier(self._args.disk_size * (1024 ** 3))}'
-                f'-{size_prettifier(self._args.disk_blocksize)}').lower()
+                f'{self.disk_parameters_string()}'.lower()
+            )
             disk = self._find_or_create_eternal_disk(disk_name_prefix)
 
             _logger.info(

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -7,7 +7,7 @@ import shlex
 import socket
 import time
 
-from typing import Callable, Protocol, Union
+from typing import Callable, Protocol
 
 from .errors import Error
 
@@ -204,14 +204,14 @@ def size_prettifier(size_bytes: int) -> str:
         return '%sB' % size_bytes
 
 
-# Example of type string: network-ssd-1tib-4kib
+# Example of disk parameters string: network-ssd-1tib-4kib
 def make_disk_parameters_string(
         disk_type: str,
-        size: Union[int, str],
-        block_size: Union[int, str],
-        delim = "-") -> str:  # TODO:_ do we really need '_' delim?
-    if isinstance(size, int):
+        size: int | str,
+        block_size: int | str,
+        delim: str = "-") -> str:
+    if not isinstance(size, str):
         size = size_prettifier(size)
-    if isinstance(block_size, int):
+    if not isinstance(block_size, str):
         block_size = size_prettifier(block_size)
     return f'{disk_type}{delim}{size}{delim}{block_size}'.lower()

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -7,7 +7,7 @@ import shlex
 import socket
 import time
 
-from typing import Callable, Protocol
+from typing import Callable, Protocol, Union
 
 from .errors import Error
 
@@ -204,5 +204,14 @@ def size_prettifier(size_bytes: int) -> str:
         return '%sB' % size_bytes
 
 
-def make_disk_parameters_string(type_id: str, size: int, block_size: int, delim = "-") -> str:
-    return f'{type_id}{delim}{size_prettifier(size)}{delim}{size_prettifier(block_size)}'.lower()
+# Example of type string: network-ssd-1tib-4kib
+def make_disk_parameters_string(
+        disk_type: str,
+        size: Union[int, str],
+        block_size: Union[int, str],
+        delim = "-") -> str:  # TODO:_ do we really need '_' delim?
+    if isinstance(size, int):
+        size = size_prettifier(size)
+    if isinstance(block_size, int):
+        block_size = size_prettifier(block_size)
+    return f'{disk_type}{delim}{size}{delim}{block_size}'.lower()

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -202,3 +202,7 @@ def size_prettifier(size_bytes: int) -> str:
         return '%sKiB' % (size_bytes // 1024)
     else:
         return '%sB' % size_bytes
+
+
+def make_disk_parameters_string(type_id: str, size: int, block_size: int, delim = "-") -> str:
+    return f'{type_id}{delim}{size_prettifier(size)}{delim}{size_prettifier(block_size)}'.lower()

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -204,12 +204,27 @@ def size_prettifier(size_bytes: int) -> str:
         return '%sB' % size_bytes
 
 
+def shorten_disk_type(disk_type: str) -> str:
+    match disk_type:
+        case "network-ssd-nonreplicated":
+            return "ssd-nonrepl"
+        case "network-hdd-nonreplicated":
+            return "hdd-nonrepl"
+        case "network-ssd-io-m2":
+            return "ssd-io-m2"
+        case "network-ssd-io-m3":
+            return "ssd-io-m3"
+        case _:
+            return disk_type
+
+
 # Example of disk parameters string: network-ssd-1tib-4kib
 def make_disk_parameters_string(
         disk_type: str,
         size: int | str,
         block_size: int | str,
         delim: str = "-") -> str:
+    disk_type = shorten_disk_type(disk_type)
     if not isinstance(size, str):
         size = size_prettifier(size)
     if not isinstance(block_size, str):

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
@@ -67,6 +67,7 @@ def generate_test_cases(test_suite: str, cluster_name: str) -> List[TestCase]:
         'medium': _generate_test_cases_for_medium_test_suite,
         'big': _generate_test_cases_for_big_test_suite,
         'enormous': _generate_test_cases_for_enormous_test_suite,
+        'dr_based': _generate_test_cases_for_dr_based_test_suite,
     }
     try:
         func = test_suite_to_func[test_suite]
@@ -170,6 +171,26 @@ def _generate_test_cases_for_enormous_test_suite(
             [2 * 1024, 4 * 1024, 8 * 1024],  # GB
             [4 * 1024],  # bytes
             [64],
+            [4 * 1024 * 1024]  # bytes
+        )
+    ]
+
+
+def _generate_test_cases_for_dr_based_test_suite(
+        cluster_name: str) -> List[TestCase]:
+    return [
+        TestCase('dr_based',
+                 disk_type,
+                 disk_size,
+                 disk_blocksize,
+                 step,
+                 verify_blocksize)
+        for disk_type, disk_size, disk_blocksize, step, verify_blocksize
+        in itertools.product(
+            ['network-ssd-nonreplicated', 'network-ssd-io-m3'],
+            [372],  # GB
+            [4 * 1024],  # bytes
+            [4],
             [4 * 1024 * 1024]  # bytes
         )
     ]

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
@@ -67,7 +67,7 @@ def generate_test_cases(test_suite: str, cluster_name: str) -> List[TestCase]:
         'medium': _generate_test_cases_for_medium_test_suite,
         'big': _generate_test_cases_for_big_test_suite,
         'enormous': _generate_test_cases_for_enormous_test_suite,
-        'dr_based': _generate_test_cases_for_dr_based_test_suite,
+        'disk_registry_based': _generate_test_cases_for_disk_registry_based_test_suite,
     }
     try:
         func = test_suite_to_func[test_suite]
@@ -176,10 +176,10 @@ def _generate_test_cases_for_enormous_test_suite(
     ]
 
 
-def _generate_test_cases_for_dr_based_test_suite(  # TODO:_ check it!
+def _generate_test_cases_for_disk_registry_based_test_suite(
         cluster_name: str) -> List[TestCase]:
     return [
-        TestCase('dr_based',
+        TestCase('disk_registry_based',
                  disk_type,
                  disk_size,
                  disk_blocksize,
@@ -190,7 +190,7 @@ def _generate_test_cases_for_dr_based_test_suite(  # TODO:_ check it!
             ['network-ssd-nonreplicated', 'network-ssd-io-m3'],
             [372],  # GB
             [4 * 1024],  # bytes
-            [4],
+            [8],
             [4 * 1024 * 1024]  # bytes
         )
     ]

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
@@ -176,7 +176,7 @@ def _generate_test_cases_for_enormous_test_suite(
     ]
 
 
-def _generate_test_cases_for_dr_based_test_suite(
+def _generate_test_cases_for_dr_based_test_suite(  # TODO:_ check it!
         cluster_name: str) -> List[TestCase]:
     return [
         TestCase('dr_based',

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/test_cases.py
@@ -67,7 +67,7 @@ def generate_test_cases(test_suite: str, cluster_name: str) -> List[TestCase]:
         'medium': _generate_test_cases_for_medium_test_suite,
         'big': _generate_test_cases_for_big_test_suite,
         'enormous': _generate_test_cases_for_enormous_test_suite,
-        'disk_registry_based': _generate_test_cases_for_disk_registry_based_test_suite,
+        'drbased': _generate_test_cases_for_drbased_test_suite,
     }
     try:
         func = test_suite_to_func[test_suite]
@@ -176,10 +176,10 @@ def _generate_test_cases_for_enormous_test_suite(
     ]
 
 
-def _generate_test_cases_for_disk_registry_based_test_suite(
+def _generate_test_cases_for_drbased_test_suite(
         cluster_name: str) -> List[TestCase]:
     return [
-        TestCase('disk_registry_based',
+        TestCase('drbased',
                  disk_type,
                  disk_size,
                  disk_blocksize,

--- a/cloud/disk_manager/test/acceptance/test_runner/main.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/main.py
@@ -104,10 +104,6 @@ def parse_args() -> argparse.Namespace:
         type=str,
         required=True,
         help='path to cmp-util binary')
-    eternal_test_type_parser.add_argument(
-        '--skip-images',
-        action='store_true',
-        help='will skip creation of images and creation of disks from images')
 
     # sync test type stuff
     sync_test_type_parser = subparsers.add_parser(
@@ -137,11 +133,6 @@ def parse_args() -> argparse.Namespace:
         default=_DEFAULT_WRITE_SIZE_PERCENTAGE,
         help=f'verification write size percentage (default is'
              f' {_DEFAULT_WRITE_SIZE_PERCENTAGE}')
-    # TODO:_ do we need it for sync?
-    sync_test_type_parser.add_argument(
-        '--skip-images',
-        action='store_true',
-        help='will skip creation of images and creation of disks from images')
 
     # common stuff
     test_arguments_group = parser.add_argument_group('common arguments')
@@ -153,8 +144,7 @@ def parse_args() -> argparse.Namespace:
     test_arguments_group.add_argument(
         '--results-path',
         type=str,
-        help='specify path to test results',
-    )
+        help='specify path to test results')
     test_arguments_group.add_argument(
         '--conserve-snapshots',
         action='store_true',
@@ -209,8 +199,11 @@ def parse_args() -> argparse.Namespace:
         dest='cleanup_before_tests',
         action='store_true',
         default=False,
-        help='Clean up outdated resources in place'
-    )
+        help='Clean up outdated resources in place')
+    test_arguments_group.add_argument(
+        '--skip-images',
+        action='store_true',
+        help='will skip creation of images and creation of disks from images')
     args = parser.parse_args()
 
     if args.profile_name is None:

--- a/cloud/disk_manager/test/acceptance/test_runner/main.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/main.py
@@ -104,7 +104,12 @@ def parse_args() -> argparse.Namespace:
         type=str,
         required=True,
         help='path to cmp-util binary')
+    eternal_test_type_parser.add_argument(
+        '--skip-images',
+        action='store_true',
+        help='will skip creation of images and creation of disks from images')
 
+    # sync test type stuff
     sync_test_type_parser = subparsers.add_parser(
         'sync',
         help='will create an instance, network-ssd disk with ext4'
@@ -132,6 +137,11 @@ def parse_args() -> argparse.Namespace:
         default=_DEFAULT_WRITE_SIZE_PERCENTAGE,
         help=f'verification write size percentage (default is'
              f' {_DEFAULT_WRITE_SIZE_PERCENTAGE}')
+    # TODO:_ do we need it for sync?
+    sync_test_type_parser.add_argument(
+        '--skip-images',
+        action='store_true',
+        help='will skip creation of images and creation of disks from images')
 
     # common stuff
     test_arguments_group = parser.add_argument_group('common arguments')

--- a/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
@@ -22,6 +22,7 @@ class SyncTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(SyncTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
+
         disk_name_string = (
             fr'^acc-{test_type}-'
             fr'{self._disk_parameters_string}-[0-9]+'
@@ -30,14 +31,29 @@ class SyncTestCleaner(BaseResourceCleaner):
         secondary_disk_name_pattern = re.compile(
             fr'{disk_name_string}-from-snapshot$',
         )
+
+        old_disk_name_string = (
+            fr'^acceptance-test-{test_type}-'
+            fr'{self._disk_size}-'
+            fr'{self._disk_blocksize}-[0-9]+'
+        )
+        old_disk_name_pattern = re.compile(fr'{old_disk_name_string}$')
+        old_secondary_disk_name_pattern = re.compile(
+            fr'{old_disk_name_string}-from-snapshot$',
+        )
+
         self._entity_ttls = self._entity_ttls | {
             'disk': datetime.timedelta(days=5),
             'snapshot': datetime.timedelta(days=5),
         }
         self._patterns = {
             **self._patterns,
-            'disk': [disk_name_pattern, secondary_disk_name_pattern],
-            'snapshot': [re.compile(r'^sync-acc-snapshot-.*$')]
+            'disk': [disk_name_pattern,
+                     secondary_disk_name_pattern,
+                     old_disk_name_pattern,
+                     old_secondary_disk_name_pattern],
+            'snapshot': [re.compile(r'^sync-acc-snapshot-.*$'),
+                         re.compile(r'^sync-acceptance-test-snapshot-.*$')]
         }
 
 

--- a/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
@@ -7,7 +7,6 @@ from cloud.blockstore.pylibs.ycp import YcpWrapper
 from .base_acceptance_test_runner import BaseAcceptanceTestRunner, \
     BaseTestBinaryExecutor, BaseResourceCleaner
 from .lib import (
-    make_disk_parameters_string,
     Error,
 )
 
@@ -28,8 +27,9 @@ class SyncTestCleaner(BaseResourceCleaner):
         # TODO:_ ok
         disk_name_string = (
             fr'^acceptance-test-{test_type}-'
-            fr'{self.disk_parameters_string()}-[0-9]+',
+            fr'{self.disk_parameters_string()}-[0-9]+'
         )
+        print(f'SyncTestCleaner: disk_name_string: {disk_name_string}')
         disk_name_pattern = re.compile(fr'{disk_name_string}$')
         secondary_disk_name_pattern = re.compile(
             fr'{disk_name_string}-from-snapshot$',

--- a/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
@@ -7,7 +7,7 @@ from cloud.blockstore.pylibs.ycp import YcpWrapper
 from .base_acceptance_test_runner import BaseAcceptanceTestRunner, \
     BaseTestBinaryExecutor, BaseResourceCleaner
 from .lib import (
-    size_prettifier,
+    make_disk_parameters_string,
     Error,
 )
 
@@ -25,10 +25,10 @@ class SyncTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(SyncTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
+        # TODO:_ ok
         disk_name_string = (
             fr'^acceptance-test-{test_type}-'
-            fr'{self._disk_size}-'
-            fr'{self._disk_blocksize}-[0-9]+'
+            fr'{self.disk_parameters_string()}-[0-9]+',
         )
         disk_name_pattern = re.compile(fr'{disk_name_string}$')
         secondary_disk_name_pattern = re.compile(
@@ -50,11 +50,11 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
     _cleaner_type = SyncTestCleaner
     _single_disk_test_ttl = datetime.timedelta(days=5)
 
+    # TODO:_ ok
     def _get_test_suite(self):
         return (
             f'{self._args.zone_id}_sync_'
-            f'{size_prettifier(self._args.disk_size * (1024 ** 3))}_'
-            f'{size_prettifier(self._args.disk_blocksize)}'.lower()
+            f'{self.disk_parameters_string(delim="_")}'.lower()
         )
 
     def _report_compute_failure(self, error):
@@ -86,10 +86,11 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
                 {},
                 self._get_test_suite(),
             ):
+                # TODO:_ ok
                 disk_name_prefix = (
                     f'acceptance-test-{self._args.test_type}-'
-                    f'{size_prettifier(self._args.disk_size * (1024 ** 3))}'
-                    f'-{size_prettifier(self._args.disk_blocksize)}').lower()
+                    f'{self.disk_parameters_string()}'.lower()
+                )
                 disk = self._find_or_create_eternal_disk(disk_name_prefix)
 
                 _logger.info(

--- a/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
@@ -6,9 +6,7 @@ import re
 from cloud.blockstore.pylibs.ycp import YcpWrapper
 from .base_acceptance_test_runner import BaseAcceptanceTestRunner, \
     BaseTestBinaryExecutor, BaseResourceCleaner
-from .lib import (
-    Error,
-)
+from .lib import Error
 
 from cloud.blockstore.pylibs import common
 
@@ -24,12 +22,10 @@ class SyncTestCleaner(BaseResourceCleaner):
     def __init__(self, ycp: YcpWrapper, args: argparse.Namespace):
         super(SyncTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
-        # TODO:_ ok
         disk_name_string = (
             fr'^acceptance-test-{test_type}-'
-            fr'{self.disk_parameters_string()}-[0-9]+'
+            fr'{self._disk_parameters_string}-[0-9]+'
         )
-        print(f'SyncTestCleaner: disk_name_string: {disk_name_string}')
         disk_name_pattern = re.compile(fr'{disk_name_string}$')
         secondary_disk_name_pattern = re.compile(
             fr'{disk_name_string}-from-snapshot$',
@@ -50,12 +46,10 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
     _cleaner_type = SyncTestCleaner
     _single_disk_test_ttl = datetime.timedelta(days=5)
 
-    # TODO:_ ok
     def _get_test_suite(self):
         return (
             f'{self._args.zone_id}_sync_'
-            f'{self.disk_parameters_string(delim="_")}'.lower()
-        )
+            f'{self._make_disk_parameters_string(delim="_")}').lower()
 
     def _report_compute_failure(self, error):
         if self._results_processor is not None:
@@ -86,11 +80,9 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
                 {},
                 self._get_test_suite(),
             ):
-                # TODO:_ ok
                 disk_name_prefix = (
                     f'acceptance-test-{self._args.test_type}-'
-                    f'{self.disk_parameters_string()}'.lower()
-                )
+                    f'{self._make_disk_parameters_string()}').lower()
                 disk = self._find_or_create_eternal_disk(disk_name_prefix)
 
                 _logger.info(

--- a/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/sync_acceptance_test_runner.py
@@ -23,7 +23,7 @@ class SyncTestCleaner(BaseResourceCleaner):
         super(SyncTestCleaner, self).__init__(ycp, args)
         test_type = args.test_type
         disk_name_string = (
-            fr'^acceptance-test-{test_type}-'
+            fr'^acc-{test_type}-'
             fr'{self._disk_parameters_string}-[0-9]+'
         )
         disk_name_pattern = re.compile(fr'{disk_name_string}$')
@@ -37,7 +37,7 @@ class SyncTestCleaner(BaseResourceCleaner):
         self._patterns = {
             **self._patterns,
             'disk': [disk_name_pattern, secondary_disk_name_pattern],
-            'snapshot': [re.compile(r'^sync-acceptance-test-snapshot-.*$')]
+            'snapshot': [re.compile(r'^sync-acc-snapshot-.*$')]
         }
 
 
@@ -67,7 +67,7 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
     def run(self, profiler: common.Profiler) -> None:
         self._initialize_run(
             profiler,
-            f'acceptance-test-{self._args.test_type}-{self._timestamp}',
+            f'acc-{self._args.test_type}-{self._timestamp}',
             'sync',
         )
         with self.instance_policy_obtained(self._report_compute_failure) as instance:
@@ -81,7 +81,7 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
                 self._get_test_suite(),
             ):
                 disk_name_prefix = (
-                    f'acceptance-test-{self._args.test_type}-'
+                    f'acc-{self._args.test_type}-'
                     f'{self._make_disk_parameters_string()}').lower()
                 disk = self._find_or_create_eternal_disk(disk_name_prefix)
 
@@ -144,7 +144,7 @@ class SyncAcceptanceTestRunner(BaseAcceptanceTestRunner):
         _logger.info('Creating snapshot')
 
         suffix = datetime.datetime.now().strftime("%y-%m-%d-%H-%M-%S")
-        snapshot_name = f"sync-acceptance-test-snapshot-{suffix}"
+        snapshot_name = f"sync-acc-snapshot-{suffix}"
         self._ycp.create_snapshot(disk.id, snapshot_name)
 
         _logger.info('Created snapshot')

--- a/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
@@ -401,21 +401,22 @@ def test_cleanup():
     gib = 1024 ** 3
     inner_test_cleanup_fixture = [
         (
-            ('acceptance', 4 * gib, 4096, timedelta(days=1)),
+            ('acceptance', 'network-ssd', 4 * gib, 4096, timedelta(days=1)),
             should_delete_inner_test_acceptance_4gib_4kib,
         ),
         (
-            ('acceptance', 8 * 1024 * gib, 2048, timedelta(days=1)),
+            ('acceptance', 'network-ssd', 8 * 1024 * gib, 2048, timedelta(days=1)),
             should_delete_inner_test_acceptance_8tib_2kib,
         ),
         (
-            ('eternal', 8 * 1024 * gib, 16 * 1024 ** 3, timedelta(days=5)),
+            ('eternal', 'network-ssd', 8 * 1024 * gib, 16 * 1024 ** 3, timedelta(days=5)),
             should_delete_inner_test_eternal_8tib_16gib,
         ),
         (
-            ('eternal', 256 * gib, 2 * 1024 ** 2, timedelta(days=5)),
+            ('eternal', 'network-ssd', 256 * gib, 2 * 1024 ** 2, timedelta(days=5)),
             should_delete_inner_test_eternal_256gib_2mib,
         ),
+        # TODO:_ test case for another disk type !!!
     ]
     for [
         cleanup_args,
@@ -431,6 +432,7 @@ def test_cleanup():
             ) == set(
                 expected_should_delete_data,
             ), f"Failed cleanup for args {cleanup_args}"
+    # TODO:_ test case for another disk type !!!
     test_cleanup_fixture = [
         (
             AcceptanceTestCleaner,
@@ -481,6 +483,7 @@ def test_cleanup():
             EternalTestCleaner,
             _ArgumentNamespaceMock(
                 test_type='eternal',
+                disk_type='network-ssd',
                 disk_size=1024,
                 disk_blocksize=4096,
             ),
@@ -491,6 +494,7 @@ def test_cleanup():
             EternalTestCleaner,
             _ArgumentNamespaceMock(
                 test_type='eternal',
+                disk_type='network-ssd',
                 disk_size=8,
                 disk_blocksize=8 * 1024,
             ),
@@ -501,6 +505,7 @@ def test_cleanup():
             SyncTestCleaner,
             _ArgumentNamespaceMock(
                 test_type='sync',
+                disk_type='network-ssd',
                 disk_size=8,
                 disk_blocksize=4 * 1024 ** 2,
             ),

--- a/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
@@ -301,9 +301,9 @@ def test_cleanup():
             created_at=_now - timedelta(days=9),
         ),
     ]
-    should_delete_test_acceptance_disk_registry_based = [
+    should_delete_test_acceptance_drbased = [
         _Resource(
-            name='acc-acceptance-disk_registry_based-2412341243',
+            name='acc-acceptance-drbased-2412341243',
             resource_type='disk',
             created_at=_now - timedelta(days=9),
         ),
@@ -453,7 +453,7 @@ def test_cleanup():
                 *should_delete_test_acceptance_medium,
                 *should_delete_test_acceptance_big,
                 *should_delete_test_acceptance_enormous,
-                *should_delete_test_acceptance_disk_registry_based,
+                *should_delete_test_acceptance_drbased,
                 *should_delete_test_acceptance_default,
                 *should_delete_test_eternal_1tib_4kib,
                 *should_delete_test_eternal_8gib_8kib,
@@ -546,9 +546,9 @@ def test_cleanup():
             AcceptanceTestCleaner,
             _ArgumentNamespaceMock(
                 test_type='acceptance',
-                test_suite='disk_registry_based',
+                test_suite='drbased',
             ),
-            should_delete_test_acceptance_disk_registry_based,
+            should_delete_test_acceptance_drbased,
 
         ),
         (

--- a/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
@@ -157,22 +157,22 @@ def test_cleanup():
     should_delete_inner_test_acceptance_nonrepl_93gib_8kib = [
         *should_delete_inner_test_acceptance_common,
         _Resource(
-            name='acc-disk-acceptance-network-ssd-nonreplicated-93gib-8kib-1823123123',
+            name='acc-disk-acceptance-ssd-nonrepl-93gib-8kib-1823123123',
             resource_type='disk',
             created_at=_now - timedelta(hours=34)
         ),
         _Resource(
-            name='acc-image-acceptance-network-ssd-nonreplicated-93gib-8kib-10',
+            name='acc-image-acceptance-ssd-nonrepl-93gib-8kib-10',
             resource_type='image',
             created_at=_now - timedelta(days=367),
         ),
         _Resource(
-            name='acc-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19199199',
+            name='acc-snapshot-acceptance-ssd-nonrepl-93gib-8kib-19199199',
             resource_type='snapshot',
             created_at=_now - timedelta(days=3),
         ),
         _Resource(
-            name='acc-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19',
+            name='acc-snapshot-acceptance-ssd-nonrepl-93gib-8kib-19',
             resource_type='snapshot',
             created_at=_now - timedelta(days=2),
         ),
@@ -238,17 +238,17 @@ def test_cleanup():
     should_delete_inner_test_eternal_nonrepl_372gib_8kib = [
         *should_delete_inner_test_eternal_common,
         _Resource(
-            name='acc-disk-eternal-network-ssd-nonreplicated-372gib-8kib-12391293',
+            name='acc-disk-eternal-ssd-nonrepl-372gib-8kib-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=19),
         ),
         _Resource(
-            name='acc-snapshot-eternal-network-ssd-nonreplicated-372gib-8kib-1707897850',
+            name='acc-snapshot-eternal-ssd-nonrepl-372gib-8kib-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=14),
         ),
         _Resource(
-            name='acc-image-eternal-network-ssd-nonreplicated-372gib-8kib-123123213',
+            name='acc-image-eternal-ssd-nonrepl-372gib-8kib-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=15),
         ),
@@ -340,7 +340,7 @@ def test_cleanup():
     ]
     should_delete_test_eternal_nonrepl_93gib_4kib = [
         _Resource(
-            name='acc-eternal-network-ssd-nonreplicated-93gib-4kib-1703757663',
+            name='acc-eternal-ssd-nonrepl-93gib-4kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),

--- a/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
@@ -89,6 +89,7 @@ class _Resource(NamedTuple):
 class _ArgumentNamespaceMock(NamedTuple):
     test_type: str
     test_suite: str = "not-specified"
+    disk_type: str = ""
     disk_size: int = 0
     disk_blocksize: int = 0
 
@@ -115,17 +116,17 @@ def test_cleanup():
     should_delete_inner_test_acceptance_4gib_4kib = [
         *should_delete_inner_test_acceptance_common,
         _Resource(
-            name='acceptance-test-disk-acceptance-4gib-4kib-123124134',
+            name='acceptance-test-disk-acceptance-network-ssd-4gib-4kib-123124134',
             resource_type='disk',
             created_at=_now - timedelta(hours=28)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-4gib-4kib-120849534',
+            name='acceptance-test-image-acceptance-network-ssd-4gib-4kib-120849534',
             resource_type='image',
             created_at=_now - timedelta(hours=36),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-4gib-4kib-12931283',
+            name='acceptance-test-snapshot-acceptance-network-ssd-4gib-4kib-12931283',
             resource_type='snapshot',
             created_at=_now - timedelta(hours=39),
         ),
@@ -133,22 +134,45 @@ def test_cleanup():
     should_delete_inner_test_acceptance_8tib_2kib = [
         *should_delete_inner_test_acceptance_common,
         _Resource(
-            name='acceptance-test-disk-acceptance-8tib-2kib-1823123123',
+            name='acceptance-test-disk-acceptance-network-ssd-8tib-2kib-1823123123',
             resource_type='disk',
             created_at=_now - timedelta(hours=34)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-8tib-2kib-10',
+            name='acceptance-test-image-acceptance-network-ssd-8tib-2kib-10',
             resource_type='image',
             created_at=_now - timedelta(days=367),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-8tib-2kib-19199199',
+            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19199199',
             resource_type='snapshot',
             created_at=_now - timedelta(days=3),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-8tib-2kib-19',
+            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19',
+            resource_type='snapshot',
+            created_at=_now - timedelta(days=2),
+        ),
+    ]
+    should_delete_inner_test_acceptance_nonrepl_93gib_8kib = [
+        *should_delete_inner_test_acceptance_common,
+        _Resource(
+            name='acceptance-test-disk-acceptance-network-ssd-nonreplicated-93gib-8kib-1823123123',
+            resource_type='disk',
+            created_at=_now - timedelta(hours=34)
+        ),
+        _Resource(
+            name='acceptance-test-image-acceptance-network-ssd-nonreplicated-93gib-8kib-10',
+            resource_type='image',
+            created_at=_now - timedelta(days=367),
+        ),
+        _Resource(
+            name='acceptance-test-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19199199',
+            resource_type='snapshot',
+            created_at=_now - timedelta(days=3),
+        ),
+        _Resource(
+            name='acceptance-test-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19',
             resource_type='snapshot',
             created_at=_now - timedelta(days=2),
         ),
@@ -178,17 +202,17 @@ def test_cleanup():
     should_delete_inner_test_eternal_8tib_16gib = [
         *should_delete_inner_test_eternal_common,
         _Resource(
-            name='acceptance-test-disk-eternal-8tib-16gib-12391293',
+            name='acceptance-test-disk-eternal-network-ssd-8tib-16gib-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=10),
         ),
         _Resource(
-            name='acceptance-test-snapshot-eternal-8tib-16gib-1707897850',
+            name='acceptance-test-snapshot-eternal-network-ssd-8tib-16gib-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=22),
         ),
         _Resource(
-            name='acceptance-test-image-eternal-8tib-16gib-123123213',
+            name='acceptance-test-image-eternal-network-ssd-8tib-16gib-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=12),
         ),
@@ -196,17 +220,35 @@ def test_cleanup():
     should_delete_inner_test_eternal_256gib_2mib = [
         *should_delete_inner_test_eternal_common,
         _Resource(
-            name='acceptance-test-disk-eternal-256gib-2mib-12391293',
+            name='acceptance-test-disk-eternal-network-ssd-256gib-2mib-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=19),
         ),
         _Resource(
-            name='acceptance-test-snapshot-eternal-256gib-2mib-1707897850',
+            name='acceptance-test-snapshot-eternal-network-ssd-256gib-2mib-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=14),
         ),
         _Resource(
-            name='acceptance-test-image-eternal-256gib-2mib-123123213',
+            name='acceptance-test-image-eternal-network-ssd-256gib-2mib-123123213',
+            resource_type='image',
+            created_at=_now - timedelta(days=15),
+        ),
+    ]
+    should_delete_inner_test_eternal_nonrepl_372gib_8kib = [
+        *should_delete_inner_test_eternal_common,
+        _Resource(
+            name='acceptance-test-disk-eternal-network-ssd-nonreplicated-372gib-8kib-12391293',
+            resource_type='disk',
+            created_at=_now - timedelta(days=19),
+        ),
+        _Resource(
+            name='acceptance-test-snapshot-eternal-network-ssd-nonreplicated-372gib-8kib-1707897850',
+            resource_type='snapshot',
+            created_at=_now - timedelta(days=14),
+        ),
+        _Resource(
+            name='acceptance-test-image-eternal-network-ssd-nonreplicated-372gib-8kib-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=15),
         ),
@@ -259,6 +301,13 @@ def test_cleanup():
             created_at=_now - timedelta(days=9),
         ),
     ]
+    should_delete_test_acceptance_dr_based = [
+        _Resource(
+            name='acceptance-test-acceptance-dr_based-2412341243',
+            resource_type='disk',
+            created_at=_now - timedelta(days=9),
+        ),
+    ]
     should_delete_test_acceptance_default = [
         _Resource(
             name='acceptance-test-acceptance-default-2412341243',
@@ -275,7 +324,7 @@ def test_cleanup():
     ]
     should_delete_test_eternal_1tib_4kib = [
         _Resource(
-            name='acceptance-test-eternal-1tib-4kib-1703757663',
+            name='acceptance-test-eternal-network-ssd-1tib-4kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),
@@ -283,7 +332,15 @@ def test_cleanup():
     ]
     should_delete_test_eternal_8gib_8kib = [
         _Resource(
-            name='acceptance-test-eternal-8gib-8kib-1703757663',
+            name='acceptance-test-eternal-network-ssd-8gib-8kib-1703757663',
+            resource_type='disk',
+            created_at=_now - timedelta(days=104),
+        ),
+        *should_delete_inner_test_eternal_common,
+    ]
+    should_delete_test_eternal_nonrepl_93gib_4kib = [
+        _Resource(
+            name='acceptance-test-eternal-network-ssd-nonreplicated-93gib-4kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),
@@ -296,12 +353,12 @@ def test_cleanup():
             created_at=_now - timedelta(hours=35),
         ),
         _Resource(
-            name='acceptance-test-sync-8gib-4mib-1703764831',
+            name='acceptance-test-sync-network-ssd-8gib-4mib-1703764831',
             resource_type='disk',
             created_at=_now - timedelta(days=7),
         ),
         _Resource(
-            name='acceptance-test-sync-8gib-4mib-1706616105-from-snapshot',
+            name='acceptance-test-sync-network-ssd-8gib-4mib-1706616105-from-snapshot',
             resource_type='disk',
             created_at=_now - timedelta(days=8),
         ),
@@ -328,37 +385,37 @@ def test_cleanup():
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-disk-acceptance-8tib-2kib-1823123123',
+            name='acceptance-test-disk-acceptance-network-ssd-8tib-2kib-1823123123',
             resource_type='disk',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-8tib-2kib-10',
+            name='acceptance-test-image-acceptance-network-ssd-8tib-2kib-10',
             resource_type='image',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-8tib-2kib-19199199',
+            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19199199',
             resource_type='snapshot',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-8tib-2kib-19',
+            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19',
             resource_type='snapshot',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-disk-acceptance-8tib-8tib-123124134',
+            name='acceptance-test-disk-acceptance-network-ssd-8tib-8tib-123124134',
             resource_type='disk',
             created_at=_now - timedelta(hours=28)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-8tib-8tib-120849534',
+            name='acceptance-test-image-acceptance-network-ssd-8tib-8tib-120849534',
             resource_type='image',
             created_at=_now - timedelta(hours=36),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-8tib-8tib-12931283',
+            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-8tib-12931283',
             resource_type='snapshot',
             created_at=_now - timedelta(hours=1),
         ),
@@ -377,21 +434,30 @@ def test_cleanup():
             resource_type='disk',
             created_at=_now - timedelta(hours=2),
         ),
+        _Resource(
+            name='acceptance-test-eternal-network-ssd-93gib-4kib-1703757663',
+            resource_type='disk',
+            created_at=_now - timedelta(days=104),
+        ),
     ]
     ycp_mock = _YcpMock(
         [
             *{
                 *should_delete_inner_test_acceptance_4gib_4kib,
                 *should_delete_inner_test_acceptance_8tib_2kib,
+                *should_delete_inner_test_acceptance_nonrepl_93gib_8kib,
                 *should_delete_inner_test_eternal_8tib_16gib,
                 *should_delete_inner_test_eternal_256gib_2mib,
+                *should_delete_inner_test_eternal_nonrepl_372gib_8kib,
                 *should_delete_test_acceptance_small,
                 *should_delete_test_acceptance_medium,
                 *should_delete_test_acceptance_big,
                 *should_delete_test_acceptance_enormous,
+                *should_delete_test_acceptance_dr_based,
                 *should_delete_test_acceptance_default,
                 *should_delete_test_eternal_1tib_4kib,
                 *should_delete_test_eternal_8gib_8kib,
+                *should_delete_test_eternal_nonrepl_93gib_4kib,
                 *should_delete_test_sync_8gib_4mib,
                 *should_not_delete,
             }
@@ -409,6 +475,10 @@ def test_cleanup():
             should_delete_inner_test_acceptance_8tib_2kib,
         ),
         (
+            ('acceptance', 'network-ssd-nonreplicated', 93 * gib, 8192, timedelta(days=1)),
+            should_delete_inner_test_acceptance_nonrepl_93gib_8kib,
+        ),
+        (
             ('eternal', 'network-ssd', 8 * 1024 * gib, 16 * 1024 ** 3, timedelta(days=5)),
             should_delete_inner_test_eternal_8tib_16gib,
         ),
@@ -416,7 +486,10 @@ def test_cleanup():
             ('eternal', 'network-ssd', 256 * gib, 2 * 1024 ** 2, timedelta(days=5)),
             should_delete_inner_test_eternal_256gib_2mib,
         ),
-        # TODO:_ test case for another disk type !!!
+        (
+            ('eternal', 'network-ssd-nonreplicated', 372 * gib, 8192, timedelta(days=5)),
+            should_delete_inner_test_eternal_nonrepl_372gib_8kib,
+        ),
     ]
     for [
         cleanup_args,
@@ -474,6 +547,15 @@ def test_cleanup():
             AcceptanceTestCleaner,
             _ArgumentNamespaceMock(
                 test_type='acceptance',
+                test_suite='dr_based',
+            ),
+            should_delete_test_acceptance_dr_based,
+
+        ),
+        (
+            AcceptanceTestCleaner,
+            _ArgumentNamespaceMock(
+                test_type='acceptance',
                 test_suite='default',
             ),
             should_delete_test_acceptance_default,
@@ -499,6 +581,17 @@ def test_cleanup():
                 disk_blocksize=8 * 1024,
             ),
             should_delete_test_eternal_8gib_8kib,
+
+        ),
+        (
+            EternalTestCleaner,
+            _ArgumentNamespaceMock(
+                test_type='eternal',
+                disk_type='network-ssd-nonreplicated',
+                disk_size=93,
+                disk_blocksize=4 * 1024,
+            ),
+            should_delete_test_eternal_nonrepl_93gib_4kib,
 
         ),
         (

--- a/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
@@ -301,9 +301,9 @@ def test_cleanup():
             created_at=_now - timedelta(days=9),
         ),
     ]
-    should_delete_test_acceptance_dr_based = [
+    should_delete_test_acceptance_disk_registry_based = [
         _Resource(
-            name='acceptance-test-acceptance-dr_based-2412341243',
+            name='acceptance-test-acceptance-disk_registry_based-2412341243',
             resource_type='disk',
             created_at=_now - timedelta(days=9),
         ),
@@ -453,7 +453,7 @@ def test_cleanup():
                 *should_delete_test_acceptance_medium,
                 *should_delete_test_acceptance_big,
                 *should_delete_test_acceptance_enormous,
-                *should_delete_test_acceptance_dr_based,
+                *should_delete_test_acceptance_disk_registry_based,
                 *should_delete_test_acceptance_default,
                 *should_delete_test_eternal_1tib_4kib,
                 *should_delete_test_eternal_8gib_8kib,
@@ -505,7 +505,6 @@ def test_cleanup():
             ) == set(
                 expected_should_delete_data,
             ), f"Failed cleanup for args {cleanup_args}"
-    # TODO:_ test case for another disk type !!!
     test_cleanup_fixture = [
         (
             AcceptanceTestCleaner,
@@ -547,9 +546,9 @@ def test_cleanup():
             AcceptanceTestCleaner,
             _ArgumentNamespaceMock(
                 test_type='acceptance',
-                test_suite='dr_based',
+                test_suite='disk_registry_based',
             ),
-            should_delete_test_acceptance_dr_based,
+            should_delete_test_acceptance_disk_registry_based,
 
         ),
         (

--- a/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/tests/test.py
@@ -98,17 +98,17 @@ def test_cleanup():
     _now = datetime.now(timezone.utc)
     should_delete_inner_test_acceptance_common = [
         _Resource(
-            name='acceptance-test-snapshot-acceptance-12931283',
+            name='acc-snapshot-acceptance-12931283',
             resource_type='snapshot',
             created_at=_now - timedelta(hours=25),
         ),
         _Resource(
-            name='acceptance-test-disk-acceptance-100000',
+            name='acc-disk-acceptance-100000',
             resource_type='disk',
             created_at=_now - timedelta(days=5),
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-120384710234',
+            name='acc-image-acceptance-120384710234',
             resource_type='image',
             created_at=_now - timedelta(days=2),
         ),
@@ -116,17 +116,17 @@ def test_cleanup():
     should_delete_inner_test_acceptance_4gib_4kib = [
         *should_delete_inner_test_acceptance_common,
         _Resource(
-            name='acceptance-test-disk-acceptance-network-ssd-4gib-4kib-123124134',
+            name='acc-disk-acceptance-network-ssd-4gib-4kib-123124134',
             resource_type='disk',
             created_at=_now - timedelta(hours=28)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-network-ssd-4gib-4kib-120849534',
+            name='acc-image-acceptance-network-ssd-4gib-4kib-120849534',
             resource_type='image',
             created_at=_now - timedelta(hours=36),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-4gib-4kib-12931283',
+            name='acc-snapshot-acceptance-network-ssd-4gib-4kib-12931283',
             resource_type='snapshot',
             created_at=_now - timedelta(hours=39),
         ),
@@ -134,22 +134,22 @@ def test_cleanup():
     should_delete_inner_test_acceptance_8tib_2kib = [
         *should_delete_inner_test_acceptance_common,
         _Resource(
-            name='acceptance-test-disk-acceptance-network-ssd-8tib-2kib-1823123123',
+            name='acc-disk-acceptance-network-ssd-8tib-2kib-1823123123',
             resource_type='disk',
             created_at=_now - timedelta(hours=34)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-network-ssd-8tib-2kib-10',
+            name='acc-image-acceptance-network-ssd-8tib-2kib-10',
             resource_type='image',
             created_at=_now - timedelta(days=367),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19199199',
+            name='acc-snapshot-acceptance-network-ssd-8tib-2kib-19199199',
             resource_type='snapshot',
             created_at=_now - timedelta(days=3),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19',
+            name='acc-snapshot-acceptance-network-ssd-8tib-2kib-19',
             resource_type='snapshot',
             created_at=_now - timedelta(days=2),
         ),
@@ -157,44 +157,44 @@ def test_cleanup():
     should_delete_inner_test_acceptance_nonrepl_93gib_8kib = [
         *should_delete_inner_test_acceptance_common,
         _Resource(
-            name='acceptance-test-disk-acceptance-network-ssd-nonreplicated-93gib-8kib-1823123123',
+            name='acc-disk-acceptance-network-ssd-nonreplicated-93gib-8kib-1823123123',
             resource_type='disk',
             created_at=_now - timedelta(hours=34)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-network-ssd-nonreplicated-93gib-8kib-10',
+            name='acc-image-acceptance-network-ssd-nonreplicated-93gib-8kib-10',
             resource_type='image',
             created_at=_now - timedelta(days=367),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19199199',
+            name='acc-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19199199',
             resource_type='snapshot',
             created_at=_now - timedelta(days=3),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19',
+            name='acc-snapshot-acceptance-network-ssd-nonreplicated-93gib-8kib-19',
             resource_type='snapshot',
             created_at=_now - timedelta(days=2),
         ),
     ]
     should_delete_inner_test_eternal_common = [
         _Resource(
-            name='acceptance-test-disk-eternal-12391293',
+            name='acc-disk-eternal-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=6),
         ),
         _Resource(
-            name='acceptance-test-disk-eternal-1',
+            name='acc-disk-eternal-1',
             resource_type='disk',
             created_at=_now - timedelta(days=21),
         ),
         _Resource(
-            name='acceptance-test-image-eternal-123123213',
+            name='acc-image-eternal-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=7),
         ),
         _Resource(
-            name='acceptance-test-snapshot-eternal-1707897850',
+            name='acc-snapshot-eternal-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=11),
         ),
@@ -202,17 +202,17 @@ def test_cleanup():
     should_delete_inner_test_eternal_8tib_16gib = [
         *should_delete_inner_test_eternal_common,
         _Resource(
-            name='acceptance-test-disk-eternal-network-ssd-8tib-16gib-12391293',
+            name='acc-disk-eternal-network-ssd-8tib-16gib-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=10),
         ),
         _Resource(
-            name='acceptance-test-snapshot-eternal-network-ssd-8tib-16gib-1707897850',
+            name='acc-snapshot-eternal-network-ssd-8tib-16gib-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=22),
         ),
         _Resource(
-            name='acceptance-test-image-eternal-network-ssd-8tib-16gib-123123213',
+            name='acc-image-eternal-network-ssd-8tib-16gib-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=12),
         ),
@@ -220,17 +220,17 @@ def test_cleanup():
     should_delete_inner_test_eternal_256gib_2mib = [
         *should_delete_inner_test_eternal_common,
         _Resource(
-            name='acceptance-test-disk-eternal-network-ssd-256gib-2mib-12391293',
+            name='acc-disk-eternal-network-ssd-256gib-2mib-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=19),
         ),
         _Resource(
-            name='acceptance-test-snapshot-eternal-network-ssd-256gib-2mib-1707897850',
+            name='acc-snapshot-eternal-network-ssd-256gib-2mib-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=14),
         ),
         _Resource(
-            name='acceptance-test-image-eternal-network-ssd-256gib-2mib-123123213',
+            name='acc-image-eternal-network-ssd-256gib-2mib-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=15),
         ),
@@ -238,93 +238,93 @@ def test_cleanup():
     should_delete_inner_test_eternal_nonrepl_372gib_8kib = [
         *should_delete_inner_test_eternal_common,
         _Resource(
-            name='acceptance-test-disk-eternal-network-ssd-nonreplicated-372gib-8kib-12391293',
+            name='acc-disk-eternal-network-ssd-nonreplicated-372gib-8kib-12391293',
             resource_type='disk',
             created_at=_now - timedelta(days=19),
         ),
         _Resource(
-            name='acceptance-test-snapshot-eternal-network-ssd-nonreplicated-372gib-8kib-1707897850',
+            name='acc-snapshot-eternal-network-ssd-nonreplicated-372gib-8kib-1707897850',
             resource_type='snapshot',
             created_at=_now - timedelta(days=14),
         ),
         _Resource(
-            name='acceptance-test-image-eternal-network-ssd-nonreplicated-372gib-8kib-123123213',
+            name='acc-image-eternal-network-ssd-nonreplicated-372gib-8kib-123123213',
             resource_type='image',
             created_at=_now - timedelta(days=15),
         ),
     ]
     should_delete_test_acceptance_small = [
         _Resource(
-            name='acceptance-test-acceptance-small-2412341243',
+            name='acc-acceptance-small-2412341243',
             resource_type='instance',
             created_at=_now - timedelta(hours=38),
         ),
         _Resource(
-            name='acceptance-test-acceptance-small-349856485',
+            name='acc-acceptance-small-349856485',
             resource_type='disk',
             created_at=_now - timedelta(days=18),
         ),
     ]
     should_delete_test_acceptance_medium = [
         _Resource(
-            name='acceptance-test-acceptance-medium-2412341243',
+            name='acc-acceptance-medium-2412341243',
             resource_type='disk',
             created_at=_now - timedelta(days=8),
         ),
         _Resource(
-            name='acceptance-test-acceptance-medium-23943849',
+            name='acc-acceptance-medium-23943849',
             resource_type='instance',
             created_at=_now - timedelta(hours=31)
         ),
         _Resource(
-            name='acceptance-test-acceptance-medium-212',
+            name='acc-acceptance-medium-212',
             resource_type='disk',
             created_at=_now - timedelta(days=77),
         ),
     ]
     should_delete_test_acceptance_big = [
         _Resource(
-            name='acceptance-test-acceptance-big-3745438',
+            name='acc-acceptance-big-3745438',
             resource_type='disk',
             created_at=_now - timedelta(days=32),
         ),
         _Resource(
-            name='acceptance-test-acceptance-big-2412341243',
+            name='acc-acceptance-big-2412341243',
             resource_type='instance',
             created_at=_now - timedelta(days=13),
         ),
     ]
     should_delete_test_acceptance_enormous = [
         _Resource(
-            name='acceptance-test-acceptance-enormous-2412341243',
+            name='acc-acceptance-enormous-2412341243',
             resource_type='disk',
             created_at=_now - timedelta(days=9),
         ),
     ]
     should_delete_test_acceptance_disk_registry_based = [
         _Resource(
-            name='acceptance-test-acceptance-disk_registry_based-2412341243',
+            name='acc-acceptance-disk_registry_based-2412341243',
             resource_type='disk',
             created_at=_now - timedelta(days=9),
         ),
     ]
     should_delete_test_acceptance_default = [
         _Resource(
-            name='acceptance-test-acceptance-default-2412341243',
+            name='acc-acceptance-default-2412341243',
             resource_type='instance',
             created_at=_now - timedelta(days=14),
         )
     ]
     should_delete_inner_test_eternal_common = [
         _Resource(
-            name='acceptance-test-eternal-12931239',
+            name='acc-eternal-12931239',
             resource_type='instance',
             created_at=_now - timedelta(hours=31),
         ),
     ]
     should_delete_test_eternal_1tib_4kib = [
         _Resource(
-            name='acceptance-test-eternal-network-ssd-1tib-4kib-1703757663',
+            name='acc-eternal-network-ssd-1tib-4kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),
@@ -332,7 +332,7 @@ def test_cleanup():
     ]
     should_delete_test_eternal_8gib_8kib = [
         _Resource(
-            name='acceptance-test-eternal-network-ssd-8gib-8kib-1703757663',
+            name='acc-eternal-network-ssd-8gib-8kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),
@@ -340,7 +340,7 @@ def test_cleanup():
     ]
     should_delete_test_eternal_nonrepl_93gib_4kib = [
         _Resource(
-            name='acceptance-test-eternal-network-ssd-nonreplicated-93gib-4kib-1703757663',
+            name='acc-eternal-network-ssd-nonreplicated-93gib-4kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),
@@ -348,94 +348,94 @@ def test_cleanup():
     ]
     should_delete_test_sync_8gib_4mib = [
         _Resource(
-            name='acceptance-test-sync-1231312342',
+            name='acc-sync-1231312342',
             resource_type='instance',
             created_at=_now - timedelta(hours=35),
         ),
         _Resource(
-            name='acceptance-test-sync-network-ssd-8gib-4mib-1703764831',
+            name='acc-sync-network-ssd-8gib-4mib-1703764831',
             resource_type='disk',
             created_at=_now - timedelta(days=7),
         ),
         _Resource(
-            name='acceptance-test-sync-network-ssd-8gib-4mib-1706616105-from-snapshot',
+            name='acc-sync-network-ssd-8gib-4mib-1706616105-from-snapshot',
             resource_type='disk',
             created_at=_now - timedelta(days=8),
         ),
         _Resource(
-            name='sync-acceptance-test-snapshot-24-02-13-12-01-35',
+            name='sync-acc-snapshot-24-02-13-12-01-35',
             resource_type='snapshot',
             created_at=_now - timedelta(days=29),
         )
     ]
     should_not_delete = [
         _Resource(
-            name='acceptance-test-snapshot-acceptance-12931283',
+            name='acc-snapshot-acceptance-12931283',
             resource_type='snapshot',
             created_at=_now - timedelta(hours=3),
         ),
         _Resource(
-            name='acceptance-test-disk-acceptance-100000',
+            name='acc-disk-acceptance-100000',
             resource_type='disk',
             created_at=_now - timedelta(hours=2),
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-120384710234',
+            name='acc-image-acceptance-120384710234',
             resource_type='image',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-disk-acceptance-network-ssd-8tib-2kib-1823123123',
+            name='acc-disk-acceptance-network-ssd-8tib-2kib-1823123123',
             resource_type='disk',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-network-ssd-8tib-2kib-10',
+            name='acc-image-acceptance-network-ssd-8tib-2kib-10',
             resource_type='image',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19199199',
+            name='acc-snapshot-acceptance-network-ssd-8tib-2kib-19199199',
             resource_type='snapshot',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-2kib-19',
+            name='acc-snapshot-acceptance-network-ssd-8tib-2kib-19',
             resource_type='snapshot',
             created_at=_now,
         ),
         _Resource(
-            name='acceptance-test-disk-acceptance-network-ssd-8tib-8tib-123124134',
+            name='acc-disk-acceptance-network-ssd-8tib-8tib-123124134',
             resource_type='disk',
             created_at=_now - timedelta(hours=28)
         ),
         _Resource(
-            name='acceptance-test-image-acceptance-network-ssd-8tib-8tib-120849534',
+            name='acc-image-acceptance-network-ssd-8tib-8tib-120849534',
             resource_type='image',
             created_at=_now - timedelta(hours=36),
         ),
         _Resource(
-            name='acceptance-test-snapshot-acceptance-network-ssd-8tib-8tib-12931283',
+            name='acc-snapshot-acceptance-network-ssd-8tib-8tib-12931283',
             resource_type='snapshot',
             created_at=_now - timedelta(hours=1),
         ),
         _Resource(
-            name='acceptance-test-acceptance-medium-2412341243',
+            name='acc-acceptance-medium-2412341243',
             resource_type='disk',
             created_at=_now - timedelta(hours=3),
         ),
         _Resource(
-            name='acceptance-test-acceptance-medium-23943849',
+            name='acc-acceptance-medium-23943849',
             resource_type='instance',
             created_at=_now - timedelta(hours=5)
         ),
         _Resource(
-            name='acceptance-test-acceptance-medium-212',
+            name='acc-acceptance-medium-212',
             resource_type='disk',
             created_at=_now - timedelta(hours=2),
         ),
         _Resource(
-            name='acceptance-test-eternal-network-ssd-93gib-4kib-1703757663',
+            name='acc-eternal-network-ssd-93gib-4kib-1703757663',
             resource_type='disk',
             created_at=_now - timedelta(days=104),
         ),


### PR DESCRIPTION
We want to run acceptace tests for disk registry based disks. Now acceptance tests have flag that specifies disk type, but we can not run tests for disk registry based based for 2 reasons:

1) We can not create images from dr based disks yet.
2) Names of resources created by tests consist of test type, disk size and disk block size (e.g. acceptance-test-disk-eternal-8tib-4kib-1720126075). These names do not contain disk type. This is crucial for eternal tests, because they reuse disks from previous runs and choose the disk to reuse according to its name.

This pr fixes both problems:
1) Add flag that skip all work with images (so we are going to use this flag test cases with dr based disks).
2) Change name format: add disk type to all names of disks and other resources.

Note: when this pr is commited, eternal tests will not remove outdated resources with old name format. So one has to remove resources with old name format manually.

UPD
Turned out that all names of disks/snapshots/images must not contain more than 63 characters. So i had to shorted names, that's why i use 'acc' prefix instead of 'acceptance-test'.