### PR TITLE
issue-1350: renamenode should work for files in the same shard

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -198,7 +198,8 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
             && args.ChildNode->NodeId == args.NewChildNode->NodeId;
         const bool isSameExternalNode = args.ChildRef->FollowerId
             && args.NewChildRef->FollowerId
-            && args.ChildRef->FollowerId == args.NewChildRef->FollowerId;
+            && args.ChildRef->FollowerId == args.NewChildRef->FollowerId
+            && args.ChildRef->FollowerName == args.NewChildRef->FollowerName;
         if (isSameNode || isSameExternalNode) {
             args.Error = MakeError(S_ALREADY, "is the same file");
             return true;


### PR DESCRIPTION
Observed the following problem:

```
2024-07-10T14:51:26.782934Z       GetNodeAttr     0.000442s       S_OK    {parent_node_id=31657, node_name=config.lock, flags=0, mode=33188, node_id=504403158265505008, handle=0, size=240}
2024-07-10T14:51:35.110923Z       GetNodeAttr     0.000511s       S_OK    {parent_node_id=31657, node_name=config, flags=0, mode=33188, node_id=504403158265504888, handle=0, size=204}
2024-07-10T14:51:35.111627Z       RenameNode      0.000383s       S_ALREADY       {parent_node_id=31657, node_name=config.lock, new_parent_node_id=31657, new_node_name=config}
2024-07-10T14:51:41.823435Z       GetNodeAttr     0.000384s       S_OK    {parent_node_id=31657, node_name=config.lock, flags=0, mode=33188, node_id=504403158265505008, handle=0, size=240}
```

The problem was because two files shared the same shard:
```
504403158265505008 >> 56 = 7
504403158265504888 >> 56 = 7
```

References #1350