### PR TITLE
Fix arcadia build

### DIFF
--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
 )
 
 CHECK_DEPENDENT_DIRS(ALLOW_ONLY PEERDIRS
+    build/internal/platform
     build/platform
     certs
     cloud/blockstore


### PR DESCRIPTION
В аркадию приехал новый clang и появилась новая зависимость.
```
Error[-WBadDep]: in $B/cloud/blockstore/apps/server_lightweight/nbsd-lightweight: forbids direct or indirect PEERDIR dependency to module $B/build/internal/platform/clang_toolchain_info/internal-platform-clang_toolchain_info.pkg.fake via CHECK_DEPENDENT_DIRS
    $B/cloud/blockstore/apps/server_lightweight/nbsd-lightweight -> $B/contrib/libs/cxxsupp/libcontrib-libs-cxxsupp.a
    $B/contrib/libs/cxxsupp/libcontrib-libs-cxxsupp.a -> $B/contrib/libs/cxxsupp/libcxx/liblibs-cxxsupp-libcxx.a
    $B/contrib/libs/cxxsupp/libcxx/liblibs-cxxsupp-libcxx.a -> $B/contrib/libs/cxxsupp/libcxxabi-parts/liblibs-cxxsupp-libcxxabi-parts.a
    $B/contrib/libs/cxxsupp/libcxxabi-parts/liblibs-cxxsupp-libcxxabi-parts.a -> $B/build/internal/platform/clang_toolchain_info/internal-platform-clang_toolchain_info.pkg.fake
```