### PR TITLE
Cleanup agents from DR on REMOVE_HOST cms action

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1000,4 +1000,8 @@ message TStorageServiceConfig
 
     // Allow destruction only for those disks whose id matches one of the given prefixes.
     repeated string DestructionAllowedOnlyForDisksWithIdPrefixes = 374;
+
+    // CMS actions such as "REMOVE_HOST" and "REMOVE_DEVICE" will attempt to
+    // remove devices and the host from DR memory (including persistent storage).
+    optional bool CleanupDRConfigOnCMSActions = 375;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -419,6 +419,7 @@ TDuration MSeconds(ui32 value)
     xxx(MaxLocalVolumes,                           ui32,      100             )\
                                                                                \
     xxx(DiskRegistryVolumeConfigUpdatePeriod,      TDuration, Minutes(5)      )\
+    xxx(CleanupDRConfigOnCMSActions,               bool,      false           )\
                                                                                \
     xxx(ReassignRequestRetryTimeout,               TDuration, Seconds(5)      )\
     xxx(ReassignChannelsPercentageThreshold,       ui32,      10              )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -453,6 +453,7 @@ public:
     ui32 GetMaxLocalVolumes() const;
 
     TDuration GetDiskRegistryVolumeConfigUpdatePeriod() const;
+    bool GetCleanupDRConfigOnCMSActions() const;
     TDuration GetReassignRequestRetryTimeout() const;
     ui32 GetReassignChannelsPercentageThreshold() const;
 

--- a/cloud/blockstore/libs/storage/core/pending_request.h
+++ b/cloud/blockstore/libs/storage/core/pending_request.h
@@ -3,6 +3,8 @@
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
+#include <utility>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -16,7 +18,7 @@ struct TPendingRequest
 
     TPendingRequest(NActors::IEventHandlePtr event, TRequestInfoPtr requestInfo)
         : Event(std::move(event))
-        , RequestInfo(requestInfo)
+        , RequestInfo(std::move(requestInfo))
     {}
 };
 

--- a/cloud/blockstore/libs/storage/disk_common/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/disk_common/monitoring_utils.cpp
@@ -6,21 +6,34 @@ namespace NCloud::NBlockStore::NStorage {
 
 IOutputStream& DumpAgentState(
     IOutputStream& out,
-    NProto::EAgentState state)
+    NProto::EAgentState state,
+    bool connected)
 {
     switch (state) {
         case NProto::AGENT_STATE_ONLINE:
-            return out << "<font color=green>online</font>";
+            out << "<font color=green>online</font>";
+            break;
         case NProto::AGENT_STATE_WARNING:
-            return out << "<font color=brown>warning</font>";
+            out << "<font color=brown>warning</font>";
+            break;
         case NProto::AGENT_STATE_UNAVAILABLE:
-            return out << "<font color=red>unavailable</font>";
+            out << "<font color=red>unavailable</font>";
+            break;
         default:
-            return out
-                << "(Unknown EAgentState value "
-                << static_cast<int>(state)
+            out << "(Unknown EAgentState value " << static_cast<int>(state)
                 << ")";
+            break;
     }
+
+    if (state != NProto::AGENT_STATE_UNAVAILABLE) {
+        if (!connected) {
+            out << " <font color=gray>disconnected</font>";
+        }
+    } else if (connected) {
+        out << " <font color=gray>connected</font>";
+    }
+
+    return out;
 }
 
 IOutputStream& DumpDiskState(

--- a/cloud/blockstore/libs/storage/disk_common/monitoring_utils.h
+++ b/cloud/blockstore/libs/storage/disk_common/monitoring_utils.h
@@ -32,7 +32,8 @@ inline EDeviceStateFlags& operator|=(EDeviceStateFlags& a, EDeviceStateFlags b)
 
 IOutputStream& DumpAgentState(
     IOutputStream& out,
-    NProto::EAgentState state);
+    NProto::EAgentState state,
+    bool connected);
 
 IOutputStream& DumpDiskState(
     IOutputStream& out,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -517,7 +517,14 @@ void TDiskRegistryActor::RenderAgentHtmlInfo(
             out << "Rack: " << rack;
         }
 
-        DIV() { out << "State: "; DumpAgentState(out, agent->GetState()); }
+        DIV() {
+            out << "State: ";
+
+            auto it = AgentRegInfo.find(agent->GetAgentId());
+            const bool connected =
+                it != AgentRegInfo.end() && it->second.Connected;
+            DumpAgentState(out, agent->GetState(), connected);
+        }
         DIV() {
             out << "State Timestamp: "
                 << TInstant::MicroSeconds(agent->GetStateTs());
@@ -695,7 +702,11 @@ void TDiskRegistryActor::RenderDiskHtmlInfo(
                             != NProto::AGENT_STATE_ONLINE)
                     {
                         out << " ";
-                        DumpAgentState(out, agent->GetState());
+
+                        auto it = AgentRegInfo.find(agent->GetAgentId());
+                        const bool connected =
+                            it != AgentRegInfo.end() && it->second.Connected;
+                        DumpAgentState(out, agent->GetState(), connected);
                     }
                 } else {
                     out << device.GetNodeId();
@@ -1793,22 +1804,10 @@ void TDiskRegistryActor::RenderAgentList(
                             out << config.GetSeqNumber();
                         }
                         TABLED() {
-                            DumpAgentState(out, config.GetState());
-
                             auto it = AgentRegInfo.find(config.GetAgentId());
-
                             const bool connected = it != AgentRegInfo.end()
                                 && it->second.Connected;
-
-                            if (config.GetState()
-                                    != NProto::AGENT_STATE_UNAVAILABLE)
-                            {
-                                if (!connected) {
-                                    out << " <font color=gray>disconnected</font>";
-                                }
-                            } else if (connected) {
-                                out << " <font color=gray>connected</font>";
-                            }
+                            DumpAgentState(out, config.GetState(), connected);
                         }
                         TABLED() {
                             out << (config.GetDedicatedDiskAgent()

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4690,6 +4690,24 @@ NProto::TError TDiskRegistryState::UpdateAgentState(
         return error;
     }
 
+    // Unavailable hosts are a problem when infra tries to request ADD_HOST on
+    // an idle agent. DR waits for it to become online and blocks host
+    // deployment.
+    if (StorageConfig->GetCleanupDRConfigOnCMSActions() &&
+        newState == NProto::EAgentState::AGENT_STATE_UNAVAILABLE &&
+        agent->GetDevices().empty())
+    {
+        bool success = RemoveAgent(db, agent->GetNodeId());
+        if (!success) {
+            return MakeError(
+                E_FAIL,
+                TStringBuilder() << "Couldn't remove the agent "
+                                 << agent->GetAgentId().Quote());
+        }
+
+        return {};
+    }
+
     const auto cmsTs = TInstant::MicroSeconds(agent->GetCmsTs());
     const auto oldState = agent->GetState();
     const auto cmsDeadline = cmsTs + GetInfraTimeout(*StorageConfig, oldState);
@@ -5042,6 +5060,18 @@ NProto::TError TDiskRegistryState::UpdateCmsHostState(
     ApplyAgentStateChange(db, *agent, now, affectedDisks);
 
     if (newState != NProto::AGENT_STATE_ONLINE && !HasError(result)) {
+        auto error = TryToRemoveAgentDevices(db, agent->GetAgentId());
+        if (!HasError(error)) {
+            return result;
+        }
+
+        // Do not return the error from "TryToRemoveAgentDevices()" since it's
+        // internal and shouldn't block node removal.
+        STORAGE_WARN(
+            "Could not remove device from agent %s: %s",
+            agent->GetAgentId().Quote().c_str(),
+            FormatError(error).c_str());
+
         SuspendLocalDevices(db, *agent);
     }
 
@@ -5222,6 +5252,38 @@ bool TDiskRegistryState::TryUpdateDiskState(
         timestamp);
 
     return true;
+}
+
+NProto::TError TDiskRegistryState::TryToRemoveAgentDevices(
+    TDiskRegistryDatabase& db,
+    const TAgentId& agentId)
+{
+    if (!StorageConfig->GetCleanupDRConfigOnCMSActions()) {
+        return MakeError(
+            E_INVALID_STATE,
+            "CleanupDRConfigOnCMSActions is disabled.");
+    }
+
+    auto newConfig = GetConfig();
+    auto* agents = newConfig.MutableKnownAgents();
+    const auto agentIt = FindIf(
+        *agents,
+        [&](const auto& x) { return x.GetAgentId() == agentId; });
+    if (agentIt == agents->end()) {
+        return MakeError(
+            E_NOT_FOUND,
+            TStringBuilder() << "Couldn't find agent " << agentId.Quote()
+                             << " in the DR config.");
+    }
+
+    agents->erase(agentIt);
+    TVector<TString> affectedDisks;
+    auto error = UpdateConfig(
+        db,
+        std::move(newConfig),
+        false,   // ignoreVersion
+        affectedDisks);
+    return error;
 }
 
 void TDiskRegistryState::DeleteDiskStateUpdate(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -585,8 +585,8 @@ public:
     NProto::TError UpdateAgentState(
         TDiskRegistryDatabase& db,
         const TString& agentId,
-        NProto::EAgentState state,
-        TInstant now,
+        NProto::EAgentState newState,
+        TInstant timestamp,
         TString reason,
         TVector<TDiskId>& affectedDisks);
 
@@ -932,6 +932,10 @@ private:
         const TString& diskId,
         TDiskState& disk,
         TInstant timestamp);
+
+    NProto::TError TryToRemoveAgentDevices(
+        TDiskRegistryDatabase& db,
+        const TAgentId& agentId);
 
     NProto::TPlacementGroupConfig::TDiskInfo* CollectRacks(
         const TString& diskId,

--- a/cloud/blockstore/tests/infra-cms/test.py
+++ b/cloud/blockstore/tests/infra-cms/test.py
@@ -36,6 +36,16 @@ class CMS:
     def __init__(self, nbs_client):
         self.__nbs_client = nbs_client
 
+    def add_agent(self, host):
+        logging.info('[CMS] Try to add agent "{}"'.format(host))
+
+        request = protos.TCmsActionRequest()
+        action = request.Actions.add()
+        action.Type = protos.TAction.ADD_HOST
+        action.Host = host
+        r = self.__nbs_client.cms_action(request)
+        return r
+
     def remove_agent(self, host):
         logging.info('[CMS] Try to remove agent "{}"'.format(host))
 
@@ -63,7 +73,7 @@ class TestCmsRemoveAgentNoUserDisks:
     def __init__(self, name):
         self.name = name
 
-    def run(self, storage, nbs, disk_agent, cms, devices):
+    def run(self, storage, nbs, disk_agent, cms, devices, cleanup_dr_state):
         response = cms.remove_agent("localhost")
 
         assert response.ActionResults[0].Timeout == 0
@@ -77,15 +87,30 @@ class TestCmsRemoveAgentNoUserDisks:
         assert response.ActionResults[0].Timeout == 0
 
         disk_agent.stop()
-        nbs.wait_for_stats(AgentsInUnavailableState=1)
-
-        time.sleep(storage.NonReplicatedAgentMaxTimeout / 1000)
+        if cleanup_dr_state:
+            # The agent will be deleted after timeout.
+            nbs.wait_for_stats(AgentsInWarningState=0)
+            assert nbs.get_stats("AgentsInUnavailableState") == 0
+            assert nbs.get_stats("AgentsInOnlineState") == 0
+        else:
+            nbs.wait_for_stats(AgentsInUnavailableState=1)
 
         disk_agent.start()
         wait_for_nbs_server(disk_agent.nbs_port)
-        nbs.wait_for_stats(AgentsInWarningState=1)
+        if cleanup_dr_state:
+            # The agent is online but all devices are unknown.
+            nbs.wait_for_stats(AgentsInOnlineState=1)
+            assert nbs.get_stats("UnknownDevices") == 4
 
-        nbs.change_agent_state("localhost", 0)
+            # Add agent and its devices.
+            response = cms.add_agent("localhost")
+            assert response.ActionResults[0].Timeout == 0
+            nbs.wait_for_stats(UnknownDevices=0)
+        else:
+            nbs.wait_for_stats(AgentsInWarningState=1)
+            assert nbs.get_stats("UnknownDevices") == 0
+            nbs.change_agent_state("localhost", 0)
+
         nbs.create_volume("vol0")
         nbs.read_blocks("vol0", start_index=0, block_count=32)
 
@@ -97,7 +122,7 @@ class TestCmsRemoveAgent:
     def __init__(self, name):
         self.name = name
 
-    def run(self, storage, nbs, disk_agent, cms, devices):
+    def run(self, storage, nbs, disk_agent, cms, devices, cleanup_dr_state):
         nbs.create_volume("vol0")
 
         response = cms.remove_agent("localhost")
@@ -119,13 +144,30 @@ class TestCmsRemoveAgent:
         assert response.ActionResults[0].Timeout == 0
 
         disk_agent.stop()
-        nbs.wait_for_stats(AgentsInUnavailableState=1)
+        if cleanup_dr_state:
+            # The agent will be deleted after timeout.
+            nbs.wait_for_stats(AgentsInWarningState=0)
+            assert nbs.get_stats("AgentsInUnavailableState") == 0
+            assert nbs.get_stats("AgentsInOnlineState") == 0
+        else:
+            nbs.wait_for_stats(AgentsInUnavailableState=1)
 
         disk_agent.start()
         wait_for_nbs_server(disk_agent.nbs_port)
-        nbs.wait_for_stats(AgentsInWarningState=1)
+        if cleanup_dr_state:
+            # The agent is online but all devices are unknown.
+            nbs.wait_for_stats(AgentsInOnlineState=1)
+            assert nbs.get_stats("UnknownDevices") == 4
 
-        nbs.change_agent_state("localhost", 0)
+            # Add agent and its devices.
+            response = cms.add_agent("localhost")
+            assert response.ActionResults[0].Result.Code == 0
+            assert response.ActionResults[0].Timeout == 0
+            nbs.wait_for_stats(UnknownDevices=0)
+        else:
+            nbs.wait_for_stats(AgentsInWarningState=1)
+            assert nbs.get_stats("UnknownDevices") == 0
+            nbs.change_agent_state("localhost", 0)
 
         nbs.create_volume("vol1")
         nbs.read_blocks("vol1", start_index=0, block_count=32)
@@ -138,7 +180,7 @@ class TestCmsRemoveDevice:
     def __init__(self, name):
         self.name = name
 
-    def run(self, storage, nbs, disk_agent, cms, devices):
+    def run(self, storage, nbs, disk_agent, cms, devices, cleanup_dr_state):
         nbs.create_volume("vol0")
 
         device = devices[0]
@@ -176,7 +218,7 @@ class TestCmsRemoveDeviceNoUserDisks:
     def __init__(self, name):
         self.name = name
 
-    def run(self, storage, nbs, disk_agent, cms, devices):
+    def run(self, storage, nbs, disk_agent, cms, devices, cleanup_dr_state):
         device = devices[0]
 
         response = cms.remove_device("localhost", device.path)
@@ -296,6 +338,7 @@ class Nbs(LocalNbs):
 
             for name, expected in kwargs.items():
                 val = get_sensor_by_name(sensors, 'disk_registry', name)
+                logging.info('looking for {}, current val = {}, waitong for = {}'.format(name, val, expected))
                 if val != expected:
                     break
                 satisfied.add(name)
@@ -304,8 +347,12 @@ class Nbs(LocalNbs):
                 break
             time.sleep(1)
 
+    def get_stats(self, name):
+        sensors = get_nbs_counters(self.mon_port)['sensors']
+        return get_sensor_by_name(sensors, 'disk_registry', name)
 
-def __run_test(test_case):
+
+def __run_test(test_case, cleanup_dr_state):
     kikimr_binary_path = yatest_common.binary_path("contrib/ydb/apps/ydbd/ydbd")
 
     configurator = KikimrConfigGenerator(
@@ -356,6 +403,7 @@ def __run_test(test_case):
     storage.NonReplicatedAgentMaxTimeout = 3000
     storage.NonReplicatedDiskRecyclingPeriod = 5000
     storage.DisableLocalService = False
+    storage.CleanupDRConfigOnCMSActions = cleanup_dr_state
 
     nbs = Nbs(
         kikimr_port,
@@ -399,7 +447,8 @@ def __run_test(test_case):
     wait_for_secure_erase(nbs.mon_port)
 
     try:
-        ret = test_case.run(storage, nbs, disk_agent, CMS(nbs_client), devices)
+        ret = test_case.run(storage, nbs, disk_agent, CMS(
+            nbs_client), devices, cleanup_dr_state)
     finally:
         nbs.stop()
         disk_agent.stop()
@@ -413,5 +462,6 @@ def __run_test(test_case):
 
 
 @pytest.mark.parametrize("test_case", TESTS, ids=[x.name for x in TESTS])
-def test_cms(test_case):
-    assert __run_test(test_case) is True
+@pytest.mark.parametrize("cleanup_dr_state", [True, False], ids=["docleanupdrstate", "dontcleanupdrstate"])
+def test_cms(test_case, cleanup_dr_state):
+    assert __run_test(test_case, cleanup_dr_state) is True

--- a/cloud/blockstore/tests/infra-cms/test.py
+++ b/cloud/blockstore/tests/infra-cms/test.py
@@ -338,7 +338,6 @@ class Nbs(LocalNbs):
 
             for name, expected in kwargs.items():
                 val = get_sensor_by_name(sensors, 'disk_registry', name)
-                logging.info('looking for {}, current val = {}, waitong for = {}'.format(name, val, expected))
                 if val != expected:
                     break
                 satisfied.add(name)

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -10,3 +10,5 @@ UseShadowDisksForNonreplDiskCheckpoints: true
 MaxShadowDiskFillIoDepth: 4
 OptimizeVoidBuffersTransferForReadsEnabled: true
 MaxShadowDiskFillBandwidth: 1000
+MaxMigrationBandwidth: 1000
+CleanupDRConfigOnCMSActions: true


### PR DESCRIPTION
Первым шагом я начинаю удалять девайсы у агента из DR при вызове REMOVE_HOST. При этом, если на хосте есть диск со сломанным девайсом - поведение не изменится и ни один девайс не будет удалён.
Если все девайсы были удалены, то после выключения агента мы полностью сотрём его из памяти.

По умолчанию поведение также не меняется.

Далее по плану у меня:
1) Удалять кеш у диск агента
2) Перевозить диски в "чистилище" 
3) Удалять девайсы по REMOVE_DEVICE
