### PR TITLE
issue-1350: OpLog - UnlinkNode

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4011,7 +4011,13 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 return false;
             });
 
-        service.SendUnlinkNodeRequest(headers, RootNodeId, "file1");
+        const ui64 requestId = 111;
+        service.SendUnlinkNodeRequest(
+            headers,
+            RootNodeId,
+            "file1",
+            false, // unlinkDirectory
+            requestId);
 
         ui32 iterations = 0;
         while (!followerUnlinkResponse && iterations++ < 100) {
@@ -4038,6 +4044,139 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         auto headers1 = headers;
         headers1.FileSystemId = shard1Id;
+
+        listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        // checking DupCache logic - just in case
+        service.SendUnlinkNodeRequest(
+            headers,
+            RootNodeId,
+            "file1",
+            false, // unlinkDirectory
+            requestId);
+
+        unlinkResponse = service.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            unlinkResponse->GetError().GetCode(),
+            unlinkResponse->GetError().GetMessage());
+    }
+
+    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponFollowerRestart)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        ui64 tabletId = -1;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeFileStoreResponse: {
+                        using TDesc = TEvSSProxy::TEvDescribeFileStoreResponse;
+                        const auto* msg = event->Get<TDesc>();
+                        const auto& desc =
+                            msg->PathDescription.GetFileStoreDescription();
+                        if (desc.GetConfig().GetFileSystemId() == fsId) {
+                            tabletId = desc.GetIndexTabletId();
+                        }
+                    }
+                }
+
+                return false;
+            });
+
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"))->Record;
+
+        const auto nodeId1 = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL((1LU << 56U) + 2, nodeId1);
+
+        bool intercept = true;
+        bool intercepted = false;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvUnlinkNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvUnlinkNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        intercepted = true;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        service.SendUnlinkNodeRequest(headers, RootNodeId, "file1");
+
+        ui32 iterations = 0;
+        while (!intercepted && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(intercepted);
+        intercept = false;
+
+        auto headers1 = headers;
+        headers1.FileSystemId = shard1Id;
+
+        auto listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.RebootTablet();
+
+        auto unlinkResponse = service.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            unlinkResponse->GetError().GetCode(),
+            unlinkResponse->GetError().GetMessage());
+
+        // remaking session since CreateSessionActor doesn't do it by itself
+        // because EvWakeup never arrives because Scheduling doesn't work by
+        // default and RegistrationObservers get reset after RebootTablet
+        headers = service.InitSession(fsId, "client");
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
 
         listNodesResponse = service.ListNodes(
             headers1,

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -185,3 +185,15 @@ message TTruncateEntry
     uint64 Offset = 2;
     uint64 Length = 3;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TOpLogEntry
+{
+    uint64 EntryId = 1;
+
+    oneof Request {
+        TCreateNodeRequest CreateNodeRequest = 101;
+        TUnlinkNodeRequest UnlinkNodeRequest = 102;
+    }
+}

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -914,6 +914,8 @@ STFUNC(TIndexTabletActor::StateBroken)
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 void TIndexTabletActor::RebootTabletOnCommitOverflow(
     const TActorContext& ctx,
     const TString& request)
@@ -926,6 +928,7 @@ void TIndexTabletActor::RebootTabletOnCommitOverflow(
     ReportTabletCommitIdOverflow();
     Suicide(ctx);
 }
+
 void TIndexTabletActor::RegisterFileStore(const NActors::TActorContext& ctx)
 {
     if (!GetFileSystemId()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -371,6 +371,10 @@ private:
         ui64 opLogEntryId,
         TUnlinkNodeInFollowerResult result);
 
+    void ReplayOpLog(
+        const NActors::TActorContext& ctx,
+        const TVector<NProto::TOpLogEntry>& opLog);
+
 private:
     template <typename TMethod>
     TSession* AcceptRequest(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -366,9 +366,9 @@ private:
     void RegisterUnlinkNodeInFollowerActor(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         NProto::TUnlinkNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         TUnlinkNodeInFollowerResult result);
 
 private:

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -109,7 +109,8 @@ bool TIndexTabletActor::PrepareTx_LoadState(
         db.ReadCheckpoints(args.Checkpoints),
         db.ReadTruncateQueue(args.TruncateQueue),
         db.ReadStorageConfig(args.StorageConfig),
-        db.ReadSessionHistoryEntries(args.SessionHistory)
+        db.ReadSessionHistoryEntries(args.SessionHistory),
+        db.ReadOpLog(args.OpLog)
     };
 
     bool ready = std::accumulate(
@@ -300,6 +301,10 @@ void TIndexTabletActor::CompleteTx_LoadState(
     RegisterFileStore(ctx);
     RegisterStatCounters();
     ResetThrottlingPolicy();
+
+    LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+        LogTag << " Scheduling OpLog ops");
+    ReplayOpLog(ctx, args.OpLog);
 
     CompleteStateLoad();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -1,0 +1,45 @@
+#include "tablet_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_DeleteOpLogEntry(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDeleteOpLogEntry& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_DeleteOpLogEntry(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDeleteOpLogEntry& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabase db(tx.DB);
+    db.DeleteOpLogEntry(args.EntryId);
+}
+
+void TIndexTabletActor::CompleteTx_DeleteOpLogEntry(
+    const TActorContext& ctx,
+    TTxIndexTablet::TDeleteOpLogEntry& args)
+{
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s DeleteOpLogEntry completed (%lu)",
+        LogTag.c_str(),
+        args.EntryId);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -9,6 +9,32 @@ using namespace NKikimr::NTabletFlatExecutor;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TIndexTabletActor::ReplayOpLog(
+    const NActors::TActorContext& ctx,
+    const TVector<NProto::TOpLogEntry>& opLog)
+{
+    for (const auto& op: opLog) {
+        if (op.HasCreateNodeRequest()) {
+            // TODO
+        } else if (op.HasUnlinkNodeRequest()) {
+            RegisterUnlinkNodeInFollowerActor(
+                ctx,
+                nullptr, // requestInfo
+                op.GetUnlinkNodeRequest(),
+                0, // requestId
+                op.GetEntryId(),
+                {} // result
+            );
+        } else {
+            TABLET_VERIFY_C(
+                0,
+                "Unexpected OpLog entry: " << op.DebugString().Quote());
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 bool TIndexTabletActor::PrepareTx_DeleteOpLogEntry(
     const TActorContext& ctx,
     TTransactionContext& tx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -336,6 +336,8 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.NewChildRef->MinCommitId,
                 args.CommitId);
 
+            // TODO: fill OpLogEntry
+
             args.FollowerIdForUnlink = args.NewChildRef->FollowerId;
             args.FollowerNameForUnlink = args.NewChildRef->FollowerName;
         }
@@ -392,8 +394,6 @@ void TIndexTabletActor::CompleteTx_RenameNode(
     const TActorContext& ctx,
     TTxIndexTablet::TRenameNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
-
     if (!HasError(args.Error) && !args.ChildRef) {
         auto message = ReportChildRefIsNull(TStringBuilder()
             << "RenameNode: " << args.Request.ShortDebugString());
@@ -443,6 +443,8 @@ void TIndexTabletActor::CompleteTx_RenameNode(
         }
         NotifySessionEvent(ctx, sessionEvent);
     }
+
+    RemoveTransaction(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(args.Error);
     CompleteResponse<TEvService::TRenameNodeMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -470,6 +470,14 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         TVector<TCompactionRangeInfo>& compactionMap,
         ui32 firstRangeId,
         ui32 rangeCount);
+
+    //
+    // OpLog
+    //
+
+    void WriteOpLogEntry(const NProto::TOpLogEntry& entry);
+    void DeleteOpLogEntry(ui64 entryId);
+    bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -543,13 +543,22 @@ struct TEvIndexTabletPrivate
 
     struct TNodeUnlinkedInFollower
     {
-        TRequestInfoPtr RequestInfo;
+        const TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
         TUnlinkNodeInFollowerResult Result;
 
         TNodeUnlinkedInFollower(
                 TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
                 TUnlinkNodeInFollowerResult result)
             : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
             , Result(std::move(result))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -480,11 +480,25 @@ struct TIndexTabletSchema
         using StoragePolicy = TStoragePolicy<IndexChannel>;
     };
 
-
     struct SessionHistory: TTableSchema<24>
     {
         struct Id       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
         struct Proto    : ProtoColumn<2, NProto::TSessionHistoryEntry> {};
+
+        using TKey = TableKey<Id>;
+
+        using TColumns = TableColumns<
+            Id,
+            Proto
+        >;
+
+        using StoragePolicy = TStoragePolicy<IndexChannel>;
+    };
+
+    struct OpLog: TTableSchema<25>
+    {
+        struct Id       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct Proto    : ProtoColumn<2, NProto::TOpLogEntry> {};
 
         using TKey = TableKey<Id>;
 
@@ -520,7 +534,8 @@ struct TIndexTabletSchema
         SessionDupCache,
         TabletStorageInfo,
         TruncateQueue,
-        SessionHistory
+        SessionHistory,
+        OpLog
     >;
 
     using TSettings = SchemaSettings<

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -119,6 +119,8 @@ namespace NCloud::NFileStore::NStorage {
                                                                                \
     xxx(FilterAliveNodes,                   __VA_ARGS__)                       \
     xxx(ChangeStorageConfig,                __VA_ARGS__)                       \
+                                                                               \
+    xxx(DeleteOpLogEntry,                   __VA_ARGS__)                       \
 // FILESTORE_TABLET_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -659,6 +661,8 @@ struct TTxIndexTablet
         TMaybe<IIndexTabletDatabase::TNode> ChildNode;
         TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
 
+        NProto::TOpLogEntry OpLogEntry;
+
         NProto::TUnlinkNodeResponse Response;
 
         TUnlinkNode(
@@ -677,6 +681,7 @@ struct TTxIndexTablet
             ParentNode.Clear();
             ChildNode.Clear();
             ChildRef.Clear();
+            OpLogEntry.Clear();
             Response.Clear();
         }
     };
@@ -703,6 +708,8 @@ struct TTxIndexTablet
         TMaybe<IIndexTabletDatabase::TNode> NewParentNode;
         TMaybe<IIndexTabletDatabase::TNode> NewChildNode;
         TMaybe<IIndexTabletDatabase::TNodeRef> NewChildRef;
+
+        NProto::TOpLogEntry OpLogEntry;
 
         NProto::TRenameNodeResponse Response;
 
@@ -732,6 +739,8 @@ struct TTxIndexTablet
             NewParentNode.Clear();
             NewChildNode.Clear();
             NewChildRef.Clear();
+
+            OpLogEntry.Clear();
 
             Response.Clear();
 
@@ -1760,6 +1769,26 @@ struct TTxIndexTablet
         {
             StorageConfigFromDB.Clear();
             ResultStorageConfig.Clear();
+        }
+    };
+
+    //
+    // DeleteOpLogEntry
+    //
+
+    struct TDeleteOpLogEntry
+    {
+        // actually unused, needed in tablet_tx.h to avoid sophisticated
+        // template tricks
+        const TRequestInfoPtr RequestInfo;
+        const ui64 EntryId;
+
+        explicit TDeleteOpLogEntry(ui64 entryId)
+            : EntryId(entryId)
+        {}
+
+        void Clear()
+        {
         }
     };
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -281,6 +281,7 @@ struct TTxIndexTablet
         TVector<NProto::TTruncateEntry> TruncateQueue;
         TMaybe<NProto::TStorageConfig> StorageConfig;
         TVector<NProto::TSessionHistoryEntry> SessionHistory;
+        TVector<NProto::TOpLogEntry> OpLog;
 
         NProto::TError Error;
 
@@ -302,6 +303,7 @@ struct TTxIndexTablet
             TruncateQueue.clear();
             StorageConfig.Clear();
             SessionHistory.clear();
+            OpLog.clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -46,6 +46,7 @@ SRCS(
     tablet_actor_listnodexattr.cpp
     tablet_actor_loadstate.cpp
     tablet_actor_monitoring.cpp
+    tablet_actor_oplog.cpp
     tablet_actor_readblob.cpp
     tablet_actor_readdata.cpp
     tablet_actor_readlink.cpp

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -236,11 +236,13 @@ public:
         const THeaders& headers,
         const ui64 parent,
         const TString& name,
-        bool unlinkDirectory = false)
+        bool unlinkDirectory = false,
+        const ui64 requestId = 0)
     {
         auto request = std::make_unique<TEvService::TEvUnlinkNodeRequest>();
         request->Record.SetFileSystemId(headers.FileSystemId);
         headers.Fill(request->Record);
+        request->Record.MutableHeaders()->SetRequestId(requestId);
         request->Record.SetNodeId(parent);
         request->Record.SetName(name);
         request->Record.SetUnlinkDirectory(unlinkDirectory);


### PR DESCRIPTION
Implementing persistent OpLog - needed to retry leader->follower operations that haven't finished successfully. 

Main changes:
1. retrying errors in TUnlinkNodeInFollowerActor
2. recording Unlink ops to OpLog, deleting them upon successful completion
3. replaying OpLog ops upon tablet startup

#1350 