### PR TITLE
issue-1350: logging CreateNode requests to OpLog + some preparation for replaying them upon tablet restart, implemented DupCache for CreateNode requests for external nodes, retrying errors in TCreateNodeInFollowerActor

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4068,7 +4068,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             unlinkResponse->GetError().GetMessage());
     }
 
-    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponFollowerRestart)
+    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponLeaderRestart)
     {
         NProto::TStorageConfig config;
         config.SetMultiTabletForwardingEnabled(true);
@@ -4187,7 +4187,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
 
-    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponFollowerRestartForRenameNode)
+    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponLeaderRestartForRenameNode)
     {
         NProto::TStorageConfig config;
         config.SetMultiTabletForwardingEnabled(true);
@@ -4322,6 +4322,112 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
+
+    Y_UNIT_TEST(ShouldRetryNodeCreationInFollower)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        TAutoPtr<IEventHandle> followerCreateResponse;
+        bool intercept = true;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        auto response = std::make_unique<
+                            TEvService::TEvCreateNodeResponse>(
+                            MakeError(E_REJECTED, "error"));
+
+                        followerCreateResponse = new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie);
+
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const ui64 requestId = 111;
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        ui32 iterations = 0;
+        while (!followerCreateResponse && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(followerCreateResponse);
+        intercept = false;
+        env.GetRuntime().Send(followerCreateResponse.Release());
+
+        auto createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+
+        const auto nodeId1 = createResponse->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL((1LU << 56U) + 2, nodeId1);
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+
+        // checking DupCache logic - just in case
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createResponse->Record.GetNode().GetId());
+    }
+
+    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponLeaderRestart
+    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandle
+    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandleUponLeaderRestart
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -192,6 +192,10 @@ message TOpLogEntry
 {
     uint64 EntryId = 1;
 
+    // for DupCache patch & commit
+    string SessionId = 2;
+    uint64 RequestId = 3;
+
     oneof Request {
         TCreateNodeRequest CreateNodeRequest = 101;
         TUnlinkNodeRequest UnlinkNodeRequest = 102;

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -173,6 +173,20 @@ public:
         return nullptr;
     }
 
+    TDupCacheEntry* AccessDupEntry(ui64 requestId)
+    {
+        if (!requestId) {
+            return nullptr;
+        }
+
+        auto it = DupCache.find(requestId);
+        if (it != DupCache.end()) {
+            return it->second;
+        }
+
+        return nullptr;
+    }
+
     void AddDupCacheEntry(NProto::TDupCacheEntry proto, bool commited)
     {
         Y_ABORT_UNLESS(proto.GetRequestId());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -77,20 +77,20 @@ class TCreateNodeInFollowerActor final
 private:
     const TString LogTag;
     TRequestInfoPtr RequestInfo;
-    const TString FollowerId;
-    const TString FollowerName;
     const TActorId ParentId;
-    NProto::TCreateNodeRequest Request;
+    const NProto::TCreateNodeRequest Request;
+    const ui64 RequestId;
+    const ui64 OpLogEntryId;
     NProto::TCreateNodeResponse Response;
 
 public:
     TCreateNodeInFollowerActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         const TActorId& parentId,
         NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         NProto::TCreateNodeResponse response);
 
     void Bootstrap(const TActorContext& ctx);
@@ -116,17 +116,17 @@ private:
 TCreateNodeInFollowerActor::TCreateNodeInFollowerActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         const TActorId& parentId,
         NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         NProto::TCreateNodeResponse response)
     : LogTag(std::move(logTag))
     , RequestInfo(std::move(requestInfo))
-    , FollowerId(std::move(followerId))
-    , FollowerName(std::move(followerName))
     , ParentId(parentId)
     , Request(std::move(request))
+    , RequestId(requestId)
+    , OpLogEntryId(opLogEntryId)
     , Response(std::move(response))
 {}
 
@@ -139,19 +139,15 @@ void TCreateNodeInFollowerActor::Bootstrap(const TActorContext& ctx)
 void TCreateNodeInFollowerActor::SendRequest(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
-    request->Record = std::move(Request);
-    request->Record.SetFileSystemId(FollowerId);
-    request->Record.SetNodeId(RootNodeId);
-    request->Record.SetName(FollowerName);
-    request->Record.ClearFollowerFileSystemId();
+    request->Record = Request;
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
         "%s Sending CreateNodeRequest to follower %s, %s",
         LogTag.c_str(),
-        FollowerId.c_str(),
-        FollowerName.c_str());
+        Request.GetFileSystemId().c_str(),
+        Request.GetName().c_str());
 
     ctx.Send(
         MakeIndexTabletProxyServiceId(),
@@ -164,27 +160,57 @@ void TCreateNodeInFollowerActor::HandleCreateNodeResponse(
 {
     auto* msg = ev->Get();
 
+    if (msg->GetError().GetCode() == E_FS_EXIST) {
+        // EXIST can arrive after a successful operation is retried, it's ok
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s Follower node creation for %s, %s returned EEXIST %s",
+            LogTag.c_str(),
+            Request.GetFileSystemId().c_str(),
+            Request.GetName().c_str(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        msg->Record.ClearError();
+    }
+
     if (HasError(msg->GetError())) {
+        if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::TABLET_WORKER,
+                "%s Follower node creation failed for %s, %s with error %s"
+                ", retrying",
+                LogTag.c_str(),
+                Request.GetFileSystemId().c_str(),
+                Request.GetName().c_str(),
+                FormatError(msg->GetError()).Quote().c_str());
+
+            SendRequest(ctx);
+            return;
+        }
+
         LOG_ERROR(
             ctx,
             TFileStoreComponents::TABLET_WORKER,
-            "%s Follower node creation failed for %s, %s with error %s",
+            "%s Follower node creation failed for %s, %s with error %s"
+            ", will not retry",
             LogTag.c_str(),
-            FollowerId.c_str(),
-            FollowerName.c_str(),
+            Request.GetFileSystemId().c_str(),
+            Request.GetName().c_str(),
             FormatError(msg->GetError()).Quote().c_str());
 
         ReplyAndDie(ctx, msg->GetError());
         return;
     }
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
         "%s Follower node created for %s, %s",
         LogTag.c_str(),
-        FollowerId.c_str(),
-        FollowerName.c_str());
+        Request.GetFileSystemId().c_str(),
+        Request.GetName().c_str());
 
     *Response.MutableNode() = std::move(*msg->Record.MutableNode());
 
@@ -204,14 +230,15 @@ void TCreateNodeInFollowerActor::ReplyAndDie(
     NProto::TError error)
 {
     if (HasError(error)) {
-        // TODO(#1350): properly retry node creation via the leader fs
-        // don't forget to properly handle EEXIST after a retry
         *Response.MutableError() = std::move(error);
     }
 
     using TResponse = TEvIndexTabletPrivate::TEvNodeCreatedInFollower;
     ctx.Send(ParentId, std::make_unique<TResponse>(
         std::move(RequestInfo),
+        Request.GetHeaders().GetSessionId(),
+        RequestId,
+        OpLogEntryId,
         std::move(Response)));
 
     Die(ctx);
@@ -248,6 +275,12 @@ void TIndexTabletActor::HandleCreateNode(
     if (const auto* e = session->LookupDupEntry(GetRequestId(msg->Record))) {
         auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
         GetDupCacheEntry(e, response->Record);
+        if (response->Record.GetNode().GetId() == 0) {
+            // it's an external node which is not yet created in follower
+            *response->Record.MutableError() = MakeError(
+                E_REJECTED,
+                "node not yet created in follower");
+        }
         return NCloud::Reply(ctx, *ev, std::move(response));
     }
 
@@ -399,6 +432,21 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
                 args.CommitId,
                 InvalidCommitId
             };
+        } else {
+            // OpLogEntryId doesn't have to be a CommitId - it's just convenient to
+            // use CommitId here in order not to generate some other unique ui64
+            args.OpLogEntry.SetEntryId(args.CommitId);
+            args.OpLogEntry.SetSessionId(args.SessionId);
+            args.OpLogEntry.SetRequestId(args.RequestId);
+            auto* followerRequest = args.OpLogEntry.MutableCreateNodeRequest();
+            followerRequest->CopyFrom(args.Request);
+            followerRequest->SetFileSystemId(args.FollowerId);
+            followerRequest->SetNodeId(RootNodeId);
+            followerRequest->SetName(args.FollowerName);
+            followerRequest->ClearFollowerFileSystemId();
+
+            db.WriteOpLogEntry(args.OpLogEntry);
+
         }
     } else {
         // hard link
@@ -445,34 +493,28 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             *args.Response.MutableNode(),
             args.ChildNodeId,
             args.ChildNode->Attrs);
-
-        // followers shouldn't commit CreateNode DupCache entries since:
-        // 1. there will be no duplicates - node name is generated by the leader
-        // 2. the leader serves all file creation operations and has its own
-        //  dupcache
-        if (!GetFileSystem().GetShardNo()) {
-            AddDupCacheEntry(
-                db,
-                session,
-                args.RequestId,
-                args.Response,
-                Config->GetDupCacheEntryCount());
-        }
     }
 
-    // TODO(#1350): support DupCache for external nodes - modify DupCache entry
-    // upon CreateNode completion in follower - in the same tx that would
-    // delete the corresponding CreateNode op from the op log table
+    // followers shouldn't commit CreateNode DupCache entries since:
+    // 1. there will be no duplicates - node name is generated by the leader
+    // 2. the leader serves all file creation operations and has its own
+    //  dupcache
+    if (!GetFileSystem().GetShardNo()) {
+        AddDupCacheEntry(
+            db,
+            session,
+            args.RequestId,
+            args.Response,
+            Config->GetDupCacheEntryCount());
+    }
 }
 
 void TIndexTabletActor::CompleteTx_CreateNode(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
-
-    if (args.FollowerId && !HasError(args.Error)) {
-        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+    if (args.OpLogEntry.HasCreateNodeRequest() && !HasError(args.Error)) {
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
             "%s Creating node in follower upon CreateNode: %s, %s",
             LogTag.c_str(),
             args.FollowerId.c_str(),
@@ -481,10 +523,10 @@ void TIndexTabletActor::CompleteTx_CreateNode(
         auto actor = std::make_unique<TCreateNodeInFollowerActor>(
             LogTag,
             args.RequestInfo,
-            args.FollowerId,
-            args.FollowerName,
             ctx.SelfID,
-            std::move(args.Request),
+            std::move(*args.OpLogEntry.MutableCreateNodeRequest()),
+            args.RequestId,
+            args.OpLogEntry.GetEntryId(),
             std::move(args.Response));
 
         auto actorId = NCloud::Register(ctx, std::move(actor));
@@ -492,6 +534,8 @@ void TIndexTabletActor::CompleteTx_CreateNode(
 
         return;
     }
+
+    RemoveTransaction(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvService::TEvCreateNodeResponse>(args.Error);
@@ -540,16 +584,67 @@ void TIndexTabletActor::HandleNodeCreatedInFollower(
     auto* msg = ev->Get();
 
     auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
-    response->Record = std::move(msg->CreateNodeResponse);
+    response->Record = msg->CreateNodeResponse;
 
     CompleteResponse<TEvService::TCreateNodeMethod>(
         response->Record,
         msg->RequestInfo->CallContext,
         ctx);
 
+    // replying before DupCacheEntry is committed to reduce response latency
     NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
 
     WorkerActors.erase(ev->Sender);
+    ExecuteTx<TCommitNodeCreationInFollower>(
+        ctx,
+        std::move(msg->SessionId),
+        msg->RequestId,
+        std::move(msg->CreateNodeResponse),
+        msg->OpLogEntryId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_CommitNodeCreationInFollower(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCommitNodeCreationInFollower& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_CommitNodeCreationInFollower(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCommitNodeCreationInFollower& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabase db(tx.DB);
+    PatchDupCacheEntry(
+        db,
+        args.SessionId,
+        args.RequestId,
+        std::move(args.Response));
+    db.DeleteOpLogEntry(args.EntryId);
+}
+
+void TIndexTabletActor::CompleteTx_CommitNodeCreationInFollower(
+    const TActorContext& ctx,
+    TTxIndexTablet::TCommitNodeCreationInFollower& args)
+{
+    CommitDupCacheEntry(args.SessionId, args.RequestId);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s CommitNodeCreationInFollower completed (%lu): %s, %lu",
+        LogTag.c_str(),
+        args.EntryId,
+        args.SessionId.c_str(),
+        args.RequestId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -507,13 +507,22 @@ struct TEvIndexTabletPrivate
 
     struct TNodeCreatedInFollower
     {
-        TRequestInfoPtr RequestInfo;
+        const TRequestInfoPtr RequestInfo;
+        TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
         NProto::TCreateNodeResponse CreateNodeResponse;
 
         TNodeCreatedInFollower(
                 TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
                 NProto::TCreateNodeResponse createNodeResponse)
             : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
             , CreateNodeResponse(std::move(createNodeResponse))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -638,6 +638,12 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_DECLARE_DUPCACHE)
 
 #undef FILESTORE_DECLARE_DUPCACHE
 
+    void PatchDupCacheEntry(
+        TIndexTabletDatabase& db,
+        const TString& sessionId,
+        ui64 requestId,
+        NProto::TCreateNodeResponse response);
+
     void CommitDupCacheEntry(
         const TString& sessionId,
         ui64 requestId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -760,6 +760,31 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_IMPLEMENT_DUPCACHE)
 
 #undef FILESTORE_IMPLEMENT_DUPCACHE
 
+void TIndexTabletState::PatchDupCacheEntry(
+    TIndexTabletDatabase& db,
+    const TString& sessionId,
+    ui64 requestId,
+    NProto::TCreateNodeResponse response)
+{
+    if (!requestId) {
+        return;
+    }
+
+    auto* session = FindSession(sessionId);
+    if (!session) {
+        return;
+    }
+
+    auto* entry = session->AccessDupEntry(requestId);
+    if (!entry) {
+        return;
+    }
+
+    *entry->MutableCreateNode()->MutableNode() =
+        std::move(*response.MutableNode());
+    db.WriteSessionDupCacheEntry(*entry);
+}
+
 void TIndexTabletState::CommitDupCacheEntry(
     const TString& sessionId,
     ui64 requestId)

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -121,6 +121,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ChangeStorageConfig,                __VA_ARGS__)                       \
                                                                                \
     xxx(DeleteOpLogEntry,                   __VA_ARGS__)                       \
+    xxx(CommitNodeCreationInFollower,       __VA_ARGS__)                       \
 // FILESTORE_TABLET_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -616,6 +617,8 @@ struct TTxIndexTablet
         ui64 ChildNodeId = InvalidNodeId;
         TMaybe<IIndexTabletDatabase::TNode> ChildNode;
 
+        NProto::TOpLogEntry OpLogEntry;
+
         NProto::TCreateNodeResponse Response;
 
         TCreateNode(
@@ -642,6 +645,8 @@ struct TTxIndexTablet
             ParentNode.Clear();
             ChildNodeId = InvalidNodeId;
             ChildNode.Clear();
+
+            OpLogEntry.Clear();
 
             Response.Clear();
         }
@@ -1787,6 +1792,36 @@ struct TTxIndexTablet
 
         explicit TDeleteOpLogEntry(ui64 entryId)
             : EntryId(entryId)
+        {}
+
+        void Clear()
+        {
+        }
+    };
+
+    //
+    // CommitNodeCreationInFollower
+    //
+
+    struct TCommitNodeCreationInFollower
+    {
+        // actually unused, needed in tablet_tx.h to avoid sophisticated
+        // template tricks
+        const TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        NProto::TCreateNodeResponse Response;
+        const ui64 EntryId;
+
+        explicit TCommitNodeCreationInFollower(
+                TString sessionId,
+                ui64 requestId,
+                NProto::TCreateNodeResponse response,
+                ui64 entryId)
+            : SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , Response(std::move(response))
+            , EntryId(entryId)
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -223,11 +223,13 @@ public:
 
     auto CreateCreateNodeRequest(
         const THeaders& headers,
-        const TCreateNodeArgs& args)
+        const TCreateNodeArgs& args,
+        const ui64 requestId = 0)
     {
         auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
         request->Record.SetFileSystemId(headers.FileSystemId);
         headers.Fill(request->Record);
+        request->Record.MutableHeaders()->SetRequestId(requestId);
         args.Fill(request->Record);
         return request;
     }


### PR DESCRIPTION
This PR is similar to https://github.com/ydb-platform/nbs/pull/1586, but a bit more complex due to the DupCache-related things

#1350 