### PR TITLE
issue-1350: replaying CreateNode requests from OpLog upon tablet restart, retrying CreateNode requests happening upon CreateHandle requests, ut

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4912,10 +4912,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             createHandleResponse->Record.GetNodeAttr().GetId());
     }
-
-    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponLeaderRestart
-    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandle
-    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandleUponLeaderRestart
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4520,7 +4520,147 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             listNodesResponse.GetNodes(0).GetId());
 
-        // checking DupCache logic - just in case
+        // checking DupCache logic
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createResponse->Record.GetNode().GetId());
+    }
+
+    Y_UNIT_TEST(ShouldRetryNodeCreationInFollowerUponLeaderRestart)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        ui64 tabletId = -1;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeFileStoreResponse: {
+                        using TDesc = TEvSSProxy::TEvDescribeFileStoreResponse;
+                        const auto* msg = event->Get<TDesc>();
+                        const auto& desc =
+                            msg->PathDescription.GetFileStoreDescription();
+                        if (desc.GetConfig().GetFileSystemId() == fsId) {
+                            tabletId = desc.GetIndexTabletId();
+                        }
+                    }
+                }
+
+                return false;
+            });
+
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        bool intercept = true;
+        bool intercepted = false;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        intercepted = true;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const ui64 requestId = 111;
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        ui32 iterations = 0;
+        while (!intercepted && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(intercepted);
+        intercept = false;
+
+        // TODO listNodes in leader?
+
+        auto headers1 = headers;
+        headers1.FileSystemId = shard1Id;
+
+        auto listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.RebootTablet();
+
+        auto createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+
+        // remaking session since CreateSessionActor doesn't do it by itself
+        // because EvWakeup never arrives because Scheduling doesn't work by
+        // default and RegistrationObservers get reset after RebootTablet
+        // restoreClientSession = true
+        headers = service.InitSession(fsId, "client", {}, true);
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        const ui64 nodeId1 = (1LU << 56U) + 2;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+
+        listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+
+        // checking DupCache logic
         service.SendCreateNodeRequest(
             headers,
             TCreateNodeArgs::File(RootNodeId, "file1"),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -363,6 +363,14 @@ private:
 
     bool CheckSessionForDestroy(const TSession* session, ui64 seqNo);
 
+    void RegisterCreateNodeInFollowerActor(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo,
+        NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
+        NProto::TCreateNodeResponse response);
+
     void RegisterUnlinkNodeInFollowerActor(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -541,8 +541,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         followerRequest->SetName(args.FollowerName);
         followerRequest->ClearFollowerFileSystemId();
 
-        // TODO
-        // db.WriteOpLogEntry(args.OpLogEntry);
+        db.WriteOpLogEntry(args.OpLogEntry);
     }
 
     AddDupCacheEntry(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -531,17 +531,13 @@ void TIndexTabletActor::CompleteTx_CreateNode(
             args.FollowerId.c_str(),
             args.FollowerName.c_str());
 
-        auto actor = std::make_unique<TCreateNodeInFollowerActor>(
-            LogTag,
+        RegisterCreateNodeInFollowerActor(
+            ctx,
             args.RequestInfo,
-            ctx.SelfID,
             std::move(*args.OpLogEntry.MutableCreateNodeRequest()),
             args.RequestId,
             args.OpLogEntry.GetEntryId(),
             std::move(args.Response));
-
-        auto actorId = NCloud::Register(ctx, std::move(actor));
-        WorkerActors.insert(actorId);
 
         return;
     }
@@ -601,13 +597,15 @@ void TIndexTabletActor::HandleNodeCreatedInFollower(
     auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
     response->Record = msg->CreateNodeResponse;
 
-    CompleteResponse<TEvService::TCreateNodeMethod>(
-        response->Record,
-        msg->RequestInfo->CallContext,
-        ctx);
+    if (msg->RequestInfo) {
+        CompleteResponse<TEvService::TCreateNodeMethod>(
+            response->Record,
+            msg->RequestInfo->CallContext,
+            ctx);
 
-    // replying before DupCacheEntry is committed to reduce response latency
-    NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+        // replying before DupCacheEntry is committed to reduce response latency
+        NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+    }
 
     WorkerActors.erase(ev->Sender);
     ExecuteTx<TCommitNodeCreationInFollower>(
@@ -660,6 +658,29 @@ void TIndexTabletActor::CompleteTx_CommitNodeCreationInFollower(
         args.EntryId,
         args.SessionId.c_str(),
         args.RequestId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::RegisterCreateNodeInFollowerActor(
+    const NActors::TActorContext& ctx,
+    TRequestInfoPtr requestInfo,
+    NProto::TCreateNodeRequest request,
+    ui64 requestId,
+    ui64 opLogEntryId,
+    NProto::TCreateNodeResponse response)
+{
+    auto actor = std::make_unique<TCreateNodeInFollowerActor>(
+        LogTag,
+        std::move(requestInfo),
+        ctx.SelfID,
+        std::move(request),
+        requestId,
+        opLogEntryId,
+        std::move(response));
+
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -451,7 +451,6 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             followerRequest->ClearFollowerFileSystemId();
 
             db.WriteOpLogEntry(args.OpLogEntry);
-
         }
     } else {
         // hard link
@@ -598,6 +597,8 @@ void TIndexTabletActor::HandleNodeCreatedInFollower(
     response->Record = msg->CreateNodeResponse;
 
     if (msg->RequestInfo) {
+        RemoveTransaction(*msg->RequestInfo);
+
         CompleteResponse<TEvService::TCreateNodeMethod>(
             response->Record,
             msg->RequestInfo->CallContext,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -13,9 +13,23 @@ void TIndexTabletActor::ReplayOpLog(
     const NActors::TActorContext& ctx,
     const TVector<NProto::TOpLogEntry>& opLog)
 {
+    // TODO(#1350): requests to followers should be ordered, otherwise weird
+    // races are possible, e.g. create + unlink ops for the same node can arrive
+    // in opposite order (original requests won't come in opposite order, but
+    // if one of those requests gets rejected and is retried, the final order
+    // may change)
     for (const auto& op: opLog) {
         if (op.HasCreateNodeRequest()) {
-            // TODO
+            RegisterCreateNodeInFollowerActor(
+                ctx,
+                nullptr, // requestInfo
+                op.GetCreateNodeRequest(),
+                op.GetRequestId(), // needed for DupCache update (only for
+                                   // follower requests originating from
+                                   // CreateNode requests)
+                op.GetEntryId(),
+                {} // response
+            );
         } else if (op.HasUnlinkNodeRequest()) {
             RegisterUnlinkNodeInFollowerActor(
                 ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -535,12 +535,21 @@ struct TEvIndexTabletPrivate
     struct TNodeCreatedInFollowerUponCreateHandle
     {
         TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
         NProto::TCreateHandleResponse CreateHandleResponse;
 
         TNodeCreatedInFollowerUponCreateHandle(
                 TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
                 NProto::TCreateHandleResponse createHandleResponse)
             : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
             , CreateHandleResponse(std::move(createHandleResponse))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1092,6 +1092,8 @@ struct TTxIndexTablet
         TMaybe<IIndexTabletDatabase::TNode> TargetNode;
         TMaybe<IIndexTabletDatabase::TNode> ParentNode;
 
+        NProto::TOpLogEntry OpLogEntry;
+
         NProto::TCreateHandleResponse Response;
 
         TCreateHandle(
@@ -1120,6 +1122,8 @@ struct TTxIndexTablet
             IsNewFollowerNode = false;
             TargetNode.Clear();
             ParentNode.Clear();
+
+            OpLogEntry.Clear();
 
             Response.Clear();
         }


### PR DESCRIPTION
Followup for https://github.com/ydb-platform/nbs/pull/1594

#1350 