### PR TITLE
merge to stable-23-3: multitablet filestore fixes (RenameNode for nodes in the same shard, CreateNode for hardlinks) and [almost-]proper multitablet transactions (CreateNode + CreateNode, CreateHandle + CreateNode, UnlinkNode + UnlinkNode, RenameNode + UnlinkNode), metrics aggregation, less TABLET_VERIFYs

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.cpp
+++ b/cloud/filestore/libs/diagnostics/critical_events.cpp
@@ -19,19 +19,46 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 // FILESTORE_INIT_CRITICAL_EVENT_COUNTER
 
     FILESTORE_CRITICAL_EVENTS(FILESTORE_INIT_CRITICAL_EVENT_COUNTER)
+    FILESTORE_IMPOSSIBLE_EVENTS(FILESTORE_INIT_CRITICAL_EVENT_COUNTER)
 #undef FILESTORE_INIT_CRITICAL_EVENT_COUNTER
 
     NCloud::InitCriticalEventsCounter(std::move(counters));
 }
 
 #define FILESTORE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                          \
-    void Report##name()                                                        \
+    TString Report##name(const TString& message)                               \
     {                                                                          \
-        ReportCriticalEvent("AppCriticalEvents/"#name, "", false);             \
+        return ReportCriticalEvent(                                            \
+            GetCriticalEventFor##name(),                                       \
+            message,                                                           \
+            false);                                                            \
     }                                                                          \
+                                                                               \
+    const TString GetCriticalEventFor##name()                                  \
+    {                                                                          \
+        return "AppCriticalEvents/"#name;                                      \
+    }                                                                        \
 // FILESTORE_DEFINE_CRITICAL_EVENT_ROUTINE
 
     FILESTORE_CRITICAL_EVENTS(FILESTORE_DEFINE_CRITICAL_EVENT_ROUTINE)
 #undef FILESTORE_DEFINE_CRITICAL_EVENT_ROUTINE
+
+#define FILESTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE(name)                        \
+    TString Report##name(const TString& message)                               \
+    {                                                                          \
+        return ReportCriticalEvent(                                            \
+            GetCriticalEventFor##name(),                                       \
+            message,                                                           \
+            true);                                                             \
+    }                                                                          \
+                                                                               \
+    const TString GetCriticalEventFor##name()                                  \
+    {                                                                          \
+        return "AppCriticalEvents/"#name;                                      \
+    }                                                                          \
+// FILESTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE
+
+    FILESTORE_IMPOSSIBLE_EVENTS(FILESTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE)
+#undef FILESTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -20,15 +20,28 @@ namespace NCloud::NFileStore{
     xxx(NodeNotFoundInFollower)                                                \
 // FILESTORE_CRITICAL_EVENTS
 
+#define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \
+    xxx(CancelRoutineIsNotSet)                                                 \
+// FILESTORE_IMPOSSIBLE_EVENTS
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 
 #define FILESTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                         \
-    void Report##name();                                                       \
+    TString Report##name(const TString& message = "");                         \
+    const TString GetCriticalEventFor##name();                                 \
 // FILESTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 
     FILESTORE_CRITICAL_EVENTS(FILESTORE_DECLARE_CRITICAL_EVENT_ROUTINE)
 #undef FILESTORE_DECLARE_CRITICAL_EVENT_ROUTINE
+
+#define FILESTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE(name)                       \
+    TString Report##name(const TString& message = "");                         \
+    const TString GetCriticalEventFor##name();                                 \
+// FILESTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
+
+    FILESTORE_IMPOSSIBLE_EVENTS(FILESTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
+#undef FILESTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -29,6 +29,8 @@ namespace NCloud::NFileStore{
     xxx(TargetNodeWithoutRef)                                                  \
     xxx(ParentNodeIsNull)                                                      \
     xxx(FailedToCreateHandle)                                                  \
+    xxx(ChildRefIsNull)                                                        \
+    xxx(NewChildNodeIsNull)                                                    \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -22,6 +22,13 @@ namespace NCloud::NFileStore{
 
 #define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \
     xxx(CancelRoutineIsNotSet)                                                 \
+    xxx(ChildNodeWithoutRef)                                                   \
+    xxx(SessionNotFoundInTx)                                                   \
+    xxx(InvalidNodeIdForLocalNode)                                             \
+    xxx(ChildNodeIsNull)                                                       \
+    xxx(TargetNodeWithoutRef)                                                  \
+    xxx(ParentNodeIsNull)                                                      \
+    xxx(FailedToCreateHandle)                                                  \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -1,10 +1,268 @@
 #include "service_actor.h"
 
+#include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <util/generic/guid.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
 using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief This actor is used only for creating hard links in multi-tablet mode.
+ * First it creates a hardlink in the follower, then it creates a nodeRef in the
+ * leader, pointing to the hardlink in the follower.
+ */
+class TLinkActor final: public TActorBootstrapped<TLinkActor>
+{
+private:
+    // Original request
+    const TRequestInfoPtr RequestInfo;
+    NProto::TCreateNodeRequest CreateNodeRequest;
+    const TString FollowerId;
+    const TString FollowerNodeName;
+
+    // Filesystem-specific params
+    const TString LogTag;
+
+    // Response data
+    bool FollowerResponded = false;
+
+    // Stats for reporting
+    IProfileLogPtr ProfileLog;
+
+public:
+    TLinkActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TCreateNodeRequest createNodeRequest,
+        TString followerId,
+        TString logTag,
+        IProfileLogPtr profileLog);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void CreateNodeInFollower(const TActorContext& ctx);
+
+    void HandleCreateResponse(
+        const TEvService::TEvCreateNodeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleLeaderResponse(
+        const TEvService::TEvCreateNodeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleFollowerResponse(
+        const TEvService::TEvCreateNodeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        NProto::TCreateNodeResponse followerResponse);
+
+    void HandleError(const TActorContext& ctx, NProto::TError error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLinkActor::TLinkActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TCreateNodeRequest createNodeRequest,
+        TString followerId,
+        TString logTag,
+        IProfileLogPtr profileLog)
+    : RequestInfo(std::move(requestInfo))
+    , CreateNodeRequest(std::move(createNodeRequest))
+    , FollowerId(std::move(followerId))
+    , FollowerNodeName(CreateGuidAsString())
+    , LogTag(std::move(logTag))
+    , ProfileLog(std::move(profileLog))
+{}
+
+void TLinkActor::Bootstrap(const TActorContext& ctx)
+{
+    CreateNodeInFollower(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TLinkActor::CreateNodeInFollower(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
+
+    request->Record.CopyFrom(CreateNodeRequest);
+    // hard links should be located at the root node of the follower
+    request->Record.SetFileSystemId(FollowerId);
+    request->Record.SetNodeId(RootNodeId);
+    // Explicitly pick the follower name to reuse afterwards in the leader
+    request->Record.SetName(FollowerNodeName);
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Creating node in follower for %lu, %s",
+        LogTag.c_str(),
+        CreateNodeRequest.GetLink().GetTargetNode(),
+        FollowerId.c_str());
+
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+void TLinkActor::HandleFollowerResponse(
+    const TEvService::TEvCreateNodeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        LOG_ERROR(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "[%s] Error creating link in follower for %lu, with error %s",
+            LogTag.c_str(),
+            CreateNodeRequest.GetLink().GetTargetNode(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        HandleError(ctx, msg->GetError());
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Link created in follower %s with nodeId %s",
+        LogTag.c_str(),
+        FollowerId.c_str(),
+        msg->Record.GetNode().DebugString().Quote().c_str());
+
+    auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
+    // By setting the follower filesystem id, we let the leader know that he
+    // should not verify the target node existence and just create a nodeRef
+    CreateNodeRequest.SetFollowerFileSystemId(FollowerId);
+    CreateNodeRequest.MutableLink()->SetTargetNode(
+        msg->Record.GetNode().GetId());
+    CreateNodeRequest.MutableLink()->SetFollowerNodeName(FollowerNodeName);
+
+    request->Record = std::move(CreateNodeRequest);
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Creating nodeRef in leader for %lu, %s",
+        LogTag.c_str(),
+        msg->Record.GetNode().GetId(),
+        CreateNodeRequest.GetLink().GetTargetNode());
+
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+
+    // TODO(#1350): add proper mechanism for handling dangling links for the
+    // cases, when the hardlink has been created in the follower, but the
+    // nodeRef creation in the leader was not completed or failed
+}
+
+void TLinkActor::HandleLeaderResponse(
+    const TEvService::TEvCreateNodeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        LOG_ERROR(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "[%s] Error creating nodeRef in leader for %lu, with error %s",
+            LogTag.c_str(),
+            CreateNodeRequest.GetLink().GetTargetNode(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        HandleError(ctx, msg->GetError());
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] NodeRef created in leader for %lu",
+        LogTag.c_str(),
+        msg->Record.GetNode().GetId());
+
+    ReplyAndDie(ctx, std::move(msg->Record));
+}
+
+void TLinkActor::HandleCreateResponse(
+    const TEvService::TEvCreateNodeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    if (!FollowerResponded) {
+        FollowerResponded = true;
+        HandleFollowerResponse(ev, ctx);
+    } else {
+        HandleLeaderResponse(ev, ctx);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TLinkActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    HandleError(ctx, MakeError(E_REJECTED, "request cancelled"));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TLinkActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TCreateNodeResponse followerResponse)
+{
+    auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
+    response->Record = std::move(followerResponse);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+void TLinkActor::HandleError(const TActorContext& ctx, NProto::TError error)
+{
+    auto response =
+        std::make_unique<TEvService::TEvCreateNodeResponse>(std::move(error));
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TLinkActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(TEvService::TEvCreateNodeResponse, HandleCreateResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            break;
+    }
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -30,6 +288,51 @@ void TStorageServiceActor::HandleCreateNode(
 
         if (StorageConfig->GetMultiTabletForwardingEnabled() && followerId) {
             msg->Record.SetFollowerFileSystemId(followerId);
+        }
+    } else if (msg->Record.HasLink()) {
+        auto shardNo = ExtractShardNo(msg->Record.GetLink().GetTargetNode());
+
+        const NProto::TFileStore& filestore = session->FileStore;
+
+        auto [followerId, error] = SelectShard(
+            ctx,
+            sessionId,
+            seqNo,
+            "",
+            msg->CallContext->RequestId,
+            filestore,
+            shardNo);
+        if (HasError(error)) {
+            auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
+                std::move(error));
+            return NCloud::Reply(ctx, *ev, std::move(response));
+        }
+        if (followerId && StorageConfig->GetMultiTabletForwardingEnabled()) {
+            // If the target node is located on a shard, start a worker actor
+            // to separately increment the link count in the follower and insert
+            // the node in the leader.
+
+            auto [cookie, inflight] = CreateInFlightRequest(
+                TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+                session->MediaKind,
+                session->RequestStats,
+                ctx.Now());
+
+            InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+
+            auto requestInfo =
+                CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+
+            auto actor = std::make_unique<TLinkActor>(
+                std::move(requestInfo),
+                std::move(msg->Record),
+                followerId,
+                filestore.GetFileSystemId(),
+                ProfileLog);
+
+            NCloud::Register(ctx, std::move(actor));
+
+            return;
         }
     }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3805,6 +3805,117 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             getNodeAttrResponse->GetErrorReason().c_str());
     }
 
+    Y_UNIT_TEST(ShouldLinkExternalNodes)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        auto headers1 = headers;
+        headers1.FileSystemId = shard1Id;
+
+        const auto nodeId1 =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file1"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId1));
+
+        auto node = service.GetNodeAttr(headers, fsId, RootNodeId, "file1")
+                        ->Record.GetNode();
+        UNIT_ASSERT_VALUES_EQUAL(1, node.GetLinks());
+
+        auto linkNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Link(RootNodeId, "file2", nodeId1));
+        UNIT_ASSERT(linkNodeResponse);
+        UNIT_ASSERT_C(
+            SUCCEEDED(linkNodeResponse->GetStatus()),
+            linkNodeResponse->GetErrorReason().c_str());
+
+        // validate that the links field is incremented
+        auto links = service.GetNodeAttr(headers, fsId, RootNodeId, "file1")
+                         ->Record.GetNode().GetLinks();
+        UNIT_ASSERT_VALUES_EQUAL(2, links);
+
+        // get node attr should also work with the link
+        links = service.GetNodeAttr(headers, fsId, RootNodeId, "file1")
+                    ->Record.GetNode().GetLinks();
+        UNIT_ASSERT_VALUES_EQUAL(2, links);
+
+        // validate that reading from hardlinked file works
+        auto data = GenerateValidateData(256_KB);
+        ui64 handle = service
+            .CreateHandle(headers, fsId, RootNodeId, "file1", TCreateHandleArgs::RDWR)
+            ->Record.GetHandle();
+        service.WriteData(headers, fsId, nodeId1, handle, 0, data);
+
+        ui64 handle2 = service
+            .CreateHandle(headers, fsId, RootNodeId, "file2", TCreateHandleArgs::RDWR)
+            ->Record.GetHandle();
+
+        auto data2 = service.ReadData(
+            headers,
+            fsId,
+            linkNodeResponse->Record.GetNode().GetId(),
+            handle2,
+            0,
+            data.Size())->Record.GetBuffer();
+        UNIT_ASSERT_VALUES_EQUAL(data, data2);
+
+        // Removal of both the file and a hardlink should remove file from both
+        // the follower and a leader
+
+        service.DestroyHandle(headers, fsId, nodeId1, handle);
+        service.DestroyHandle(headers, fsId, linkNodeResponse->Record.GetNode().GetId(), handle2);
+
+        service.UnlinkNode(headers, RootNodeId, "file1");
+        service.UnlinkNode(headers, RootNodeId, "file2");
+
+        // Now listing of the root should show no files
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        // GetNodeAttr should fail as well
+
+        service.AssertGetNodeAttrFailed(headers, fsId, RootNodeId, "file1");
+        service.AssertGetNodeAttrFailed(headers, fsId, RootNodeId, "file2");
+
+        // Creating hardlinks to non-existing files should fail. It is
+        // reasonable to assume that nodeId + 100 is not a valid node id.
+        linkNodeResponse = service.AssertCreateNodeFailed(
+            headers,
+            TCreateNodeArgs::Link(RootNodeId, "file3", nodeId1 + 100));
+    }
+
     Y_UNIT_TEST(ShouldAggregateFileSystemMetrics)
     {
         NProto::TStorageConfig config;

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3728,6 +3728,81 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        // now try to move to another subdirectory
+
+        auto subdirId =
+            service
+                .CreateNode(
+                    headers,
+                    TCreateNodeArgs::Directory(RootNodeId, "subdir"))
+                ->Record.GetNode()
+                .GetId();
+
+        renameNodeResponse = service.RenameNode(
+            headers,
+            RootNodeId,
+            "file2",
+            subdirId,
+            "file2",
+            0);
+
+        // listing should show only subdir with file2 in it
+
+        listNodesResponse =service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("subdir", listNodesResponse.GetNames(0));
+
+        listNodesResponse = service.ListNodes(headers, fsId, subdirId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file2", listNodesResponse.GetNames(0));
+
+        // create 2 files in the same shard
+
+        ui64 nodeId4 =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file4"))
+                ->Record.GetNode()
+                .GetId();
+
+        // round robin is used for 2 clusters, so we just skip one shard by
+        // creating a file in it
+        service.CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file5"));
+
+        ui64 nodeId6 =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file6"))
+                ->Record.GetNode()
+                .GetId();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            ExtractShardNo(nodeId4),
+            ExtractShardNo(nodeId6));
+
+        // now move to the same shard
+
+        renameNodeResponse = service.RenameNode(
+            headers,
+            RootNodeId,
+            "file4",
+            RootNodeId,
+            "file6",
+            0);
+
+        // file4 should not be present in the listing
+
+        service.SendGetNodeAttrRequest(headers, fsId, RootNodeId, "file4");
+
+        auto getNodeAttrResponse = service.RecvGetNodeAttrResponse();
+        UNIT_ASSERT(getNodeAttrResponse);
+        UNIT_ASSERT_C(
+            FAILED(getNodeAttrResponse->GetStatus()),
+            getNodeAttrResponse->GetErrorReason().c_str());
     }
 }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3804,6 +3804,77 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             FAILED(getNodeAttrResponse->GetStatus()),
             getNodeAttrResponse->GetErrorReason().c_str());
     }
+
+    Y_UNIT_TEST(ShouldAggregateFileSystemMetrics)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        // creating 2 files
+
+        auto createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"))->Record;
+
+        const auto nodeId1 = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId1));
+
+        createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file2"))->Record;
+
+        const auto nodeId2 = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(2, ExtractShardNo(nodeId2));
+
+        ui64 handle1 = service.CreateHandle(
+            headers,
+            fsId,
+            nodeId1,
+            "",
+            TCreateHandleArgs::RDWR)->Record.GetHandle();
+
+        auto data1 = GenerateValidateData(256_KB);
+        service.WriteData(headers, fsId, nodeId1, handle1, 0, data1);
+
+        ui64 handle2 = service.CreateHandle(
+            headers,
+            fsId,
+            nodeId2,
+            "",
+            TCreateHandleArgs::RDWR)->Record.GetHandle();
+
+        auto data2 = GenerateValidateData(512_KB);
+        service.WriteData(headers, fsId, nodeId2, handle2, 0, data2);
+
+        const auto fsStat = service.StatFileStore(headers, fsId)->Record;
+        const auto& fileStore = fsStat.GetFileStore();
+        UNIT_ASSERT_VALUES_EQUAL(fsId, fileStore.GetFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(1'000, fileStore.GetBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(4_KB, fileStore.GetBlockSize());
+
+        const auto& fileStoreStats = fsStat.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(2, fileStoreStats.GetUsedNodesCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            768_KB / 4_KB,
+            fileStoreStats.GetUsedBlocksCount());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3990,7 +3990,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             unlinkResponse->GetError().GetMessage());
     }
 
-    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponFollowerRestart)
+    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponLeaderRestart)
     {
         NProto::TStorageConfig config;
         config.SetMultiTabletForwardingEnabled(true);
@@ -4109,7 +4109,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
 
-    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponFollowerRestartForRenameNode)
+    Y_UNIT_TEST(ShouldRetryUnlinkingInFollowerUponLeaderRestartForRenameNode)
     {
         NProto::TStorageConfig config;
         config.SetMultiTabletForwardingEnabled(true);
@@ -4244,6 +4244,112 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
+
+    Y_UNIT_TEST(ShouldRetryNodeCreationInFollower)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        TAutoPtr<IEventHandle> followerCreateResponse;
+        bool intercept = true;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        auto response = std::make_unique<
+                            TEvService::TEvCreateNodeResponse>(
+                            MakeError(E_REJECTED, "error"));
+
+                        followerCreateResponse = new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie);
+
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const ui64 requestId = 111;
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        ui32 iterations = 0;
+        while (!followerCreateResponse && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(followerCreateResponse);
+        intercept = false;
+        env.GetRuntime().Send(followerCreateResponse.Release());
+
+        auto createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+
+        const auto nodeId1 = createResponse->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL((1LU << 56U) + 2, nodeId1);
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+
+        // checking DupCache logic - just in case
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createResponse->Record.GetNode().GetId());
+    }
+
+    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponLeaderRestart
+    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandle
+    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandleUponLeaderRestart
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4442,7 +4442,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             listNodesResponse.GetNodes(0).GetId());
 
-        // checking DupCache logic - just in case
+        // checking DupCache logic
         service.SendCreateNodeRequest(
             headers,
             TCreateNodeArgs::File(RootNodeId, "file1"),
@@ -4458,9 +4458,382 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             createResponse->Record.GetNode().GetId());
     }
 
-    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponLeaderRestart
-    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandle
-    // TODO(#1350): ShouldRetryNodeCreationInFollowerUponCreateHandleUponLeaderRestart
+    Y_UNIT_TEST(ShouldRetryNodeCreationInFollowerUponLeaderRestart)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        ui64 tabletId = -1;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeFileStoreResponse: {
+                        using TDesc = TEvSSProxy::TEvDescribeFileStoreResponse;
+                        const auto* msg = event->Get<TDesc>();
+                        const auto& desc =
+                            msg->PathDescription.GetFileStoreDescription();
+                        if (desc.GetConfig().GetFileSystemId() == fsId) {
+                            tabletId = desc.GetIndexTabletId();
+                        }
+                    }
+                }
+
+                return false;
+            });
+
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        bool intercept = true;
+        bool intercepted = false;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        intercepted = true;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const ui64 requestId = 111;
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        ui32 iterations = 0;
+        while (!intercepted && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(intercepted);
+        intercept = false;
+
+        // TODO listNodes in leader?
+
+        auto headers1 = headers;
+        headers1.FileSystemId = shard1Id;
+
+        auto listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.RebootTablet();
+
+        auto createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+
+        // remaking session since CreateSessionActor doesn't do it by itself
+        // because EvWakeup never arrives because Scheduling doesn't work by
+        // default and RegistrationObservers get reset after RebootTablet
+        // restoreClientSession = true
+        headers = service.InitSession(fsId, "client", {}, true);
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        const ui64 nodeId1 = (1LU << 56U) + 2;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+
+        listNodesResponse = service.ListNodes(
+            headers1,
+            shard1Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+
+        // checking DupCache logic
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"),
+            requestId);
+
+        createResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetError().GetCode(),
+            createResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createResponse->Record.GetNode().GetId());
+    }
+
+    Y_UNIT_TEST(ShouldRetryNodeCreationInFollowerUponCreateHandle)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        TAutoPtr<IEventHandle> followerCreateResponse;
+        bool intercept = true;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        auto response = std::make_unique<
+                            TEvService::TEvCreateNodeResponse>(
+                            MakeError(E_REJECTED, "error"));
+
+                        followerCreateResponse = new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie);
+
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const ui64 requestId = 111;
+        service.SendCreateHandleRequest(
+            headers,
+            fsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::CREATE,
+            "", // followerId
+            requestId);
+
+        ui32 iterations = 0;
+        while (!followerCreateResponse && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(followerCreateResponse);
+        intercept = false;
+        env.GetRuntime().Send(followerCreateResponse.Release());
+
+        auto createHandleResponse = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createHandleResponse->GetError().GetCode(),
+            createHandleResponse->GetError().GetMessage());
+
+        const auto nodeId1 = createHandleResponse->Record.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL((1LU << 56U) + 2, nodeId1);
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+
+        // checking DupCache logic
+        service.SendCreateHandleRequest(
+            headers,
+            fsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::CREATE,
+            "", // followerId
+            requestId);
+
+        createHandleResponse = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createHandleResponse->GetError().GetCode(),
+            createHandleResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createHandleResponse->Record.GetNodeAttr().GetId());
+    }
+
+    Y_UNIT_TEST(ShouldRetryNodeCreationInFollowerUponCreateHandleUponLeaderRestart)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto shard1Id = fsId + "-f1";
+        const auto shard2Id = fsId + "-f2";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        ui64 tabletId = -1;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeFileStoreResponse: {
+                        using TDesc = TEvSSProxy::TEvDescribeFileStoreResponse;
+                        const auto* msg = event->Get<TDesc>();
+                        const auto& desc =
+                            msg->PathDescription.GetFileStoreDescription();
+                        if (desc.GetConfig().GetFileSystemId() == fsId) {
+                            tabletId = desc.GetIndexTabletId();
+                        }
+                    }
+                }
+
+                return false;
+            });
+
+        service.CreateFileStore(fsId, 1'000);
+        service.CreateFileStore(shard1Id, 1'000);
+        service.CreateFileStore(shard2Id, 1'000);
+
+        ConfigureFollowers(service, fsId, shard1Id, shard2Id);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        bool intercept = true;
+        bool intercepted = false;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        event->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept
+                            && msg->Record.GetFileSystemId() == shard1Id)
+                    {
+                        intercepted = true;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const ui64 requestId = 111;
+        service.SendCreateHandleRequest(
+            headers,
+            fsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::CREATE,
+            "", // followerId
+            requestId);
+
+        ui32 iterations = 0;
+        while (!intercepted && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(intercepted);
+        intercept = false;
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.RebootTablet();
+
+        auto createHandleResponse = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            createHandleResponse->GetError().GetCode(),
+            createHandleResponse->GetError().GetMessage());
+
+        const auto nodeId1 = (1LU << 56U) + 2;
+
+        // remaking session since CreateSessionActor doesn't do it by itself
+        // because EvWakeup never arrives because Scheduling doesn't work by
+        // default and RegistrationObservers get reset after RebootTablet
+        // restoreClientSession = true
+        headers = service.InitSession(fsId, "client", {}, true);
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            listNodesResponse.GetNodes(0).GetId());
+
+        // checking DupCache logic
+        service.SendCreateHandleRequest(
+            headers,
+            fsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::CREATE,
+            "", // followerId
+            requestId);
+
+        createHandleResponse = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createHandleResponse->GetError().GetCode(),
+            createHandleResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodeId1,
+            createHandleResponse->Record.GetNodeAttr().GetId());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/CMakeLists.darwin-x86_64.txt
+++ b/cloud/filestore/libs/storage/tablet/CMakeLists.darwin-x86_64.txt
@@ -99,6 +99,7 @@ target_sources(libs-storage-tablet PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp

--- a/cloud/filestore/libs/storage/tablet/CMakeLists.linux-aarch64.txt
+++ b/cloud/filestore/libs/storage/tablet/CMakeLists.linux-aarch64.txt
@@ -100,6 +100,7 @@ target_sources(libs-storage-tablet PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp

--- a/cloud/filestore/libs/storage/tablet/CMakeLists.linux-x86_64.txt
+++ b/cloud/filestore/libs/storage/tablet/CMakeLists.linux-x86_64.txt
@@ -100,6 +100,7 @@ target_sources(libs-storage-tablet PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp

--- a/cloud/filestore/libs/storage/tablet/CMakeLists.windows-x86_64.txt
+++ b/cloud/filestore/libs/storage/tablet/CMakeLists.windows-x86_64.txt
@@ -99,6 +99,7 @@ target_sources(libs-storage-tablet PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -185,3 +185,15 @@ message TTruncateEntry
     uint64 Offset = 2;
     uint64 Length = 3;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TOpLogEntry
+{
+    uint64 EntryId = 1;
+
+    oneof Request {
+        TCreateNodeRequest CreateNodeRequest = 101;
+        TUnlinkNodeRequest UnlinkNodeRequest = 102;
+    }
+}

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -192,6 +192,10 @@ message TOpLogEntry
 {
     uint64 EntryId = 1;
 
+    // for DupCache patch & commit
+    string SessionId = 2;
+    uint64 RequestId = 3;
+
     oneof Request {
         TCreateNodeRequest CreateNodeRequest = 101;
         TUnlinkNodeRequest UnlinkNodeRequest = 102;

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -173,6 +173,20 @@ public:
         return nullptr;
     }
 
+    TDupCacheEntry* AccessDupEntry(ui64 requestId)
+    {
+        if (!requestId) {
+            return nullptr;
+        }
+
+        auto it = DupCache.find(requestId);
+        if (it != DupCache.end()) {
+            return it->second;
+        }
+
+        return nullptr;
+    }
+
     void AddDupCacheEntry(NProto::TDupCacheEntry proto, bool commited)
     {
         Y_ABORT_UNLESS(proto.GetRequestId());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -901,6 +901,8 @@ STFUNC(TIndexTabletActor::StateBroken)
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 void TIndexTabletActor::RebootTabletOnCommitOverflow(
     const TActorContext& ctx,
     const TString& request)
@@ -913,6 +915,7 @@ void TIndexTabletActor::RebootTabletOnCommitOverflow(
     ReportTabletCommitIdOverflow();
     Suicide(ctx);
 }
+
 void TIndexTabletActor::RegisterFileStore(const NActors::TActorContext& ctx)
 {
     if (!GetFileSystemId()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -277,7 +277,7 @@ void TIndexTabletActor::TerminateTransactions(const TActorContext& ctx)
         TRequestInfo* requestInfo = ActiveTransactions.PopFront();
         TABLET_VERIFY(requestInfo->RefCount() >= 1);
 
-        requestInfo->CancelRoutine(ctx, *requestInfo);
+        requestInfo->CancelRequest(ctx);
         requestInfo->UnRef();
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -366,10 +366,14 @@ private:
     void RegisterUnlinkNodeInFollowerActor(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         NProto::TUnlinkNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         TUnlinkNodeInFollowerResult result);
+
+    void ReplayOpLog(
+        const NActors::TActorContext& ctx,
+        const TVector<NProto::TOpLogEntry>& opLog);
 
 private:
     template <typename TMethod>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -363,6 +363,14 @@ private:
 
     bool CheckSessionForDestroy(const TSession* session, ui64 seqNo);
 
+    void RegisterCreateNodeInFollowerActor(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo,
+        NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
+        NProto::TCreateNodeResponse response);
+
     void RegisterUnlinkNodeInFollowerActor(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -288,7 +288,7 @@ private:
             TRequestInfo& requestInfo)
         {
             auto response = std::make_unique<typename TMethod::TResponse>(
-                MakeError(E_REJECTED, "tablet is dead"));
+                MakeError(E_REJECTED, "tablet is shutting down"));
 
             NCloud::Reply(ctx, requestInfo, std::move(response));
         };
@@ -321,7 +321,7 @@ private:
             TRequestInfo& requestInfo)
         {
             auto response = std::make_unique<typename TMethod::TResponse>(
-                MakeError(E_REJECTED, "request cancelled"));
+                MakeError(E_REJECTED, "tablet is shutting down"));
 
             NCloud::Reply(ctx, requestInfo, std::move(response));
         };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
@@ -114,7 +114,7 @@ void TCleanupSessionsActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TCleanupSessionsActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -257,7 +257,7 @@ void TCollectGarbageActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TCollectGarbageActor::HandleError(NProto::TError error)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -256,7 +256,7 @@ void TCompactionActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TCompactionActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -43,28 +43,27 @@ NProto::TError ValidateRequest(const NProto::TCreateHandleRequest& request)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// TODO(#1350): extract common code, see TCreateNodeInFollowerActor
 class TCreateNodeInFollowerUponCreateHandleActor final
     : public TActorBootstrapped<TCreateNodeInFollowerUponCreateHandleActor>
 {
 private:
     const TString LogTag;
     TRequestInfoPtr RequestInfo;
-    const TString FollowerId;
-    const TString FollowerName;
     const TActorId ParentId;
-    const NProto::TNode Attrs;
-    NProto::THeaders Headers;
+    const NProto::TCreateNodeRequest Request;
+    const ui64 RequestId;
+    const ui64 OpLogEntryId;
     NProto::TCreateHandleResponse Response;
 
 public:
     TCreateNodeInFollowerUponCreateHandleActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         const TActorId& parentId,
-        NProto::TNode attrs,
-        NProto::THeaders headers,
+        NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         NProto::TCreateHandleResponse response);
 
     void Bootstrap(const TActorContext& ctx);
@@ -90,19 +89,17 @@ private:
 TCreateNodeInFollowerUponCreateHandleActor::TCreateNodeInFollowerUponCreateHandleActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         const TActorId& parentId,
-        NProto::TNode attrs,
-        NProto::THeaders headers,
+        NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         NProto::TCreateHandleResponse response)
     : LogTag(std::move(logTag))
     , RequestInfo(std::move(requestInfo))
-    , FollowerId(std::move(followerId))
-    , FollowerName(std::move(followerName))
     , ParentId(parentId)
-    , Attrs(std::move(attrs))
-    , Headers(std::move(headers))
+    , Request(std::move(request))
+    , RequestId(requestId)
+    , OpLogEntryId(opLogEntryId)
     , Response(std::move(response))
 {}
 
@@ -115,22 +112,15 @@ void TCreateNodeInFollowerUponCreateHandleActor::Bootstrap(const TActorContext& 
 void TCreateNodeInFollowerUponCreateHandleActor::SendRequest(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
-    *request->Record.MutableHeaders() = std::move(Headers);
-    request->Record.MutableFile()->SetMode(Attrs.GetMode());
-    request->Record.SetUid(Attrs.GetUid());
-    request->Record.SetGid(Attrs.GetGid());
-    request->Record.SetFileSystemId(FollowerId);
-    request->Record.SetNodeId(RootNodeId);
-    request->Record.SetName(FollowerName);
-    request->Record.ClearFollowerFileSystemId();
+    request->Record = Request;
 
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
         "%s Sending CreateNodeRequest to follower %s, %s",
         LogTag.c_str(),
-        FollowerId.c_str(),
-        FollowerName.c_str());
+        Request.GetFileSystemId().c_str(),
+        Request.GetName().c_str());
 
     ctx.Send(
         MakeIndexTabletProxyServiceId(),
@@ -143,27 +133,57 @@ void TCreateNodeInFollowerUponCreateHandleActor::HandleCreateNodeResponse(
 {
     auto* msg = ev->Get();
 
+    if (msg->GetError().GetCode() == E_FS_EXIST) {
+        // EXIST can arrive after a successful operation is retried, it's ok
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s Follower node creation for %s, %s returned EEXIST %s",
+            LogTag.c_str(),
+            Request.GetFileSystemId().c_str(),
+            Request.GetName().c_str(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        msg->Record.ClearError();
+    }
+
     if (HasError(msg->GetError())) {
+        if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::TABLET_WORKER,
+                "%s Follower node creation failed for %s, %s with error %s"
+                ", retrying",
+                LogTag.c_str(),
+                Request.GetFileSystemId().c_str(),
+                Request.GetName().c_str(),
+                FormatError(msg->GetError()).Quote().c_str());
+
+            SendRequest(ctx);
+            return;
+        }
+
         LOG_ERROR(
             ctx,
             TFileStoreComponents::TABLET_WORKER,
-            "%s Follower node creation failed for %s, %s with error %s",
+            "%s Follower node creation failed for %s, %s with error %s"
+            ", will not retry",
             LogTag.c_str(),
-            FollowerId.c_str(),
-            FollowerName.c_str(),
+            Request.GetFileSystemId().c_str(),
+            Request.GetName().c_str(),
             FormatError(msg->GetError()).Quote().c_str());
 
         ReplyAndDie(ctx, msg->GetError());
         return;
     }
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
         "%s Follower node created for %s, %s",
         LogTag.c_str(),
-        FollowerId.c_str(),
-        FollowerName.c_str());
+        Request.GetFileSystemId().c_str(),
+        Request.GetName().c_str());
 
     *Response.MutableNodeAttr() = std::move(*msg->Record.MutableNode());
 
@@ -183,18 +203,16 @@ void TCreateNodeInFollowerUponCreateHandleActor::ReplyAndDie(
     NProto::TError error)
 {
     if (HasError(error)) {
-        // TODO(#1350): properly retry node creation via the leader fs
         *Response.MutableError() = std::move(error);
     }
 
-    // TODO(#1350): reply directly to the client (not to the tablet) upon
-    // poisoning
-    // or keep this RequestInfo in the ActiveTransactions list until this event
-    // gets processed by the tablet
     using TResponse =
         TEvIndexTabletPrivate::TEvNodeCreatedInFollowerUponCreateHandle;
     ctx.Send(ParentId, std::make_unique<TResponse>(
         std::move(RequestInfo),
+        Request.GetHeaders().GetSessionId(),
+        RequestId,
+        OpLogEntryId,
         std::move(Response)));
 
     Die(ctx);
@@ -509,6 +527,23 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         args.Response.SetFollowerNodeName(args.FollowerName);
     }
 
+    if (args.IsNewFollowerNode) {
+        // OpLogEntryId doesn't have to be a CommitId - it's just convenient to
+        // use CommitId here in order not to generate some other unique ui64
+        args.OpLogEntry.SetEntryId(args.WriteCommitId);
+        auto* followerRequest = args.OpLogEntry.MutableCreateNodeRequest();
+        *followerRequest->MutableHeaders() = args.Request.GetHeaders();
+        followerRequest->MutableFile()->SetMode(args.Mode);
+        followerRequest->SetUid(args.Uid);
+        followerRequest->SetGid(args.Gid);
+        followerRequest->SetFileSystemId(args.FollowerId);
+        followerRequest->SetNodeId(RootNodeId);
+        followerRequest->SetName(args.FollowerName);
+        followerRequest->ClearFollowerFileSystemId();
+
+        db.WriteOpLogEntry(args.OpLogEntry);
+    }
+
     AddDupCacheEntry(
         db,
         session,
@@ -523,8 +558,6 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateHandle& args)
 {
-    RemoveTransaction(*args.RequestInfo);
-
     if (args.Error.GetCode() == E_ARGUMENT) {
         // service actor sent something inappropriate, we'd better log it
         LOG_ERROR(
@@ -535,11 +568,7 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
             FormatError(args.Error).Quote().c_str());
     }
 
-    if (!HasError(args.Error)) {
-        CommitDupCacheEntry(args.SessionId, args.RequestId);
-    }
-
-    if (args.IsNewFollowerNode && !HasError(args.Error)) {
+    if (args.OpLogEntry.HasCreateNodeRequest() && !HasError(args.Error)) {
         LOG_INFO(ctx, TFileStoreComponents::TABLET,
             "%s Creating node in follower upon CreateHandle: %s, %s",
             LogTag.c_str(),
@@ -549,11 +578,10 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         auto actor = std::make_unique<TCreateNodeInFollowerUponCreateHandleActor>(
             LogTag,
             args.RequestInfo,
-            args.FollowerId,
-            args.FollowerName,
             ctx.SelfID,
-            CreateRegularAttrs(args.Mode, args.Uid, args.Gid),
-            std::move(*args.Request.MutableHeaders()),
+            std::move(*args.OpLogEntry.MutableCreateNodeRequest()),
+            args.RequestId,
+            args.OpLogEntry.GetEntryId(),
             std::move(args.Response));
 
         auto actorId = NCloud::Register(ctx, std::move(actor));
@@ -562,10 +590,13 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         return;
     }
 
+    RemoveTransaction(*args.RequestInfo);
+
     auto response =
         std::make_unique<TEvService::TEvCreateHandleResponse>(args.Error);
 
     if (!HasError(args.Error)) {
+        CommitDupCacheEntry(args.SessionId, args.RequestId);
         response->Record = std::move(args.Response);
     }
 
@@ -588,6 +619,9 @@ void TIndexTabletActor::HandleNodeCreatedInFollowerUponCreateHandle(
     auto response = std::make_unique<TEvService::TEvCreateHandleResponse>();
     response->Record = std::move(msg->CreateHandleResponse);
 
+    RemoveTransaction(*msg->RequestInfo);
+    CommitDupCacheEntry(msg->SessionId, msg->RequestId);
+
     CompleteResponse<TEvService::TCreateHandleMethod>(
         response->Record,
         msg->RequestInfo->CallContext,
@@ -596,6 +630,7 @@ void TIndexTabletActor::HandleNodeCreatedInFollowerUponCreateHandle(
     NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
 
     WorkerActors.erase(ev->Sender);
+    ExecuteTx<TDeleteOpLogEntry>(ctx, msg->OpLogEntryId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -77,20 +77,20 @@ class TCreateNodeInFollowerActor final
 private:
     const TString LogTag;
     TRequestInfoPtr RequestInfo;
-    const TString FollowerId;
-    const TString FollowerName;
     const TActorId ParentId;
-    NProto::TCreateNodeRequest Request;
+    const NProto::TCreateNodeRequest Request;
+    const ui64 RequestId;
+    const ui64 OpLogEntryId;
     NProto::TCreateNodeResponse Response;
 
 public:
     TCreateNodeInFollowerActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         const TActorId& parentId,
         NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         NProto::TCreateNodeResponse response);
 
     void Bootstrap(const TActorContext& ctx);
@@ -116,17 +116,17 @@ private:
 TCreateNodeInFollowerActor::TCreateNodeInFollowerActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
-        TString followerId,
-        TString followerName,
         const TActorId& parentId,
         NProto::TCreateNodeRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId,
         NProto::TCreateNodeResponse response)
     : LogTag(std::move(logTag))
     , RequestInfo(std::move(requestInfo))
-    , FollowerId(std::move(followerId))
-    , FollowerName(std::move(followerName))
     , ParentId(parentId)
     , Request(std::move(request))
+    , RequestId(requestId)
+    , OpLogEntryId(opLogEntryId)
     , Response(std::move(response))
 {}
 
@@ -139,19 +139,15 @@ void TCreateNodeInFollowerActor::Bootstrap(const TActorContext& ctx)
 void TCreateNodeInFollowerActor::SendRequest(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
-    request->Record = std::move(Request);
-    request->Record.SetFileSystemId(FollowerId);
-    request->Record.SetNodeId(RootNodeId);
-    request->Record.SetName(FollowerName);
-    request->Record.ClearFollowerFileSystemId();
+    request->Record = Request;
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
         "%s Sending CreateNodeRequest to follower %s, %s",
         LogTag.c_str(),
-        FollowerId.c_str(),
-        FollowerName.c_str());
+        Request.GetFileSystemId().c_str(),
+        Request.GetName().c_str());
 
     ctx.Send(
         MakeIndexTabletProxyServiceId(),
@@ -164,27 +160,57 @@ void TCreateNodeInFollowerActor::HandleCreateNodeResponse(
 {
     auto* msg = ev->Get();
 
+    if (msg->GetError().GetCode() == E_FS_EXIST) {
+        // EXIST can arrive after a successful operation is retried, it's ok
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s Follower node creation for %s, %s returned EEXIST %s",
+            LogTag.c_str(),
+            Request.GetFileSystemId().c_str(),
+            Request.GetName().c_str(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        msg->Record.ClearError();
+    }
+
     if (HasError(msg->GetError())) {
+        if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::TABLET_WORKER,
+                "%s Follower node creation failed for %s, %s with error %s"
+                ", retrying",
+                LogTag.c_str(),
+                Request.GetFileSystemId().c_str(),
+                Request.GetName().c_str(),
+                FormatError(msg->GetError()).Quote().c_str());
+
+            SendRequest(ctx);
+            return;
+        }
+
         LOG_ERROR(
             ctx,
             TFileStoreComponents::TABLET_WORKER,
-            "%s Follower node creation failed for %s, %s with error %s",
+            "%s Follower node creation failed for %s, %s with error %s"
+            ", will not retry",
             LogTag.c_str(),
-            FollowerId.c_str(),
-            FollowerName.c_str(),
+            Request.GetFileSystemId().c_str(),
+            Request.GetName().c_str(),
             FormatError(msg->GetError()).Quote().c_str());
 
         ReplyAndDie(ctx, msg->GetError());
         return;
     }
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET_WORKER,
         "%s Follower node created for %s, %s",
         LogTag.c_str(),
-        FollowerId.c_str(),
-        FollowerName.c_str());
+        Request.GetFileSystemId().c_str(),
+        Request.GetName().c_str());
 
     *Response.MutableNode() = std::move(*msg->Record.MutableNode());
 
@@ -204,14 +230,15 @@ void TCreateNodeInFollowerActor::ReplyAndDie(
     NProto::TError error)
 {
     if (HasError(error)) {
-        // TODO(#1350): properly retry node creation via the leader fs
-        // don't forget to properly handle EEXIST after a retry
         *Response.MutableError() = std::move(error);
     }
 
     using TResponse = TEvIndexTabletPrivate::TEvNodeCreatedInFollower;
     ctx.Send(ParentId, std::make_unique<TResponse>(
         std::move(RequestInfo),
+        Request.GetHeaders().GetSessionId(),
+        RequestId,
+        OpLogEntryId,
         std::move(Response)));
 
     Die(ctx);
@@ -248,6 +275,12 @@ void TIndexTabletActor::HandleCreateNode(
     if (const auto* e = session->LookupDupEntry(GetRequestId(msg->Record))) {
         auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
         GetDupCacheEntry(e, response->Record);
+        if (response->Record.GetNode().GetId() == 0) {
+            // it's an external node which is not yet created in follower
+            *response->Record.MutableError() = MakeError(
+                E_REJECTED,
+                "node not yet created in follower");
+        }
         return NCloud::Reply(ctx, *ev, std::move(response));
     }
 
@@ -399,6 +432,21 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
                 args.CommitId,
                 InvalidCommitId
             };
+        } else {
+            // OpLogEntryId doesn't have to be a CommitId - it's just convenient to
+            // use CommitId here in order not to generate some other unique ui64
+            args.OpLogEntry.SetEntryId(args.CommitId);
+            args.OpLogEntry.SetSessionId(args.SessionId);
+            args.OpLogEntry.SetRequestId(args.RequestId);
+            auto* followerRequest = args.OpLogEntry.MutableCreateNodeRequest();
+            followerRequest->CopyFrom(args.Request);
+            followerRequest->SetFileSystemId(args.FollowerId);
+            followerRequest->SetNodeId(RootNodeId);
+            followerRequest->SetName(args.FollowerName);
+            followerRequest->ClearFollowerFileSystemId();
+
+            db.WriteOpLogEntry(args.OpLogEntry);
+
         }
     } else {
         // hard link
@@ -445,34 +493,28 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             *args.Response.MutableNode(),
             args.ChildNodeId,
             args.ChildNode->Attrs);
-
-        // followers shouldn't commit CreateNode DupCache entries since:
-        // 1. there will be no duplicates - node name is generated by the leader
-        // 2. the leader serves all file creation operations and has its own
-        //  dupcache
-        if (!GetFileSystem().GetShardNo()) {
-            AddDupCacheEntry(
-                db,
-                session,
-                args.RequestId,
-                args.Response,
-                Config->GetDupCacheEntryCount());
-        }
     }
 
-    // TODO(#1350): support DupCache for external nodes - modify DupCache entry
-    // upon CreateNode completion in follower - in the same tx that would
-    // delete the corresponding CreateNode op from the op log table
+    // followers shouldn't commit CreateNode DupCache entries since:
+    // 1. there will be no duplicates - node name is generated by the leader
+    // 2. the leader serves all file creation operations and has its own
+    //  dupcache
+    if (!GetFileSystem().GetShardNo()) {
+        AddDupCacheEntry(
+            db,
+            session,
+            args.RequestId,
+            args.Response,
+            Config->GetDupCacheEntryCount());
+    }
 }
 
 void TIndexTabletActor::CompleteTx_CreateNode(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
-
-    if (args.FollowerId && !HasError(args.Error)) {
-        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+    if (args.OpLogEntry.HasCreateNodeRequest() && !HasError(args.Error)) {
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
             "%s Creating node in follower upon CreateNode: %s, %s",
             LogTag.c_str(),
             args.FollowerId.c_str(),
@@ -481,10 +523,10 @@ void TIndexTabletActor::CompleteTx_CreateNode(
         auto actor = std::make_unique<TCreateNodeInFollowerActor>(
             LogTag,
             args.RequestInfo,
-            args.FollowerId,
-            args.FollowerName,
             ctx.SelfID,
-            std::move(args.Request),
+            std::move(*args.OpLogEntry.MutableCreateNodeRequest()),
+            args.RequestId,
+            args.OpLogEntry.GetEntryId(),
             std::move(args.Response));
 
         auto actorId = NCloud::Register(ctx, std::move(actor));
@@ -492,6 +534,8 @@ void TIndexTabletActor::CompleteTx_CreateNode(
 
         return;
     }
+
+    RemoveTransaction(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvService::TEvCreateNodeResponse>(args.Error);
@@ -540,16 +584,67 @@ void TIndexTabletActor::HandleNodeCreatedInFollower(
     auto* msg = ev->Get();
 
     auto response = std::make_unique<TEvService::TEvCreateNodeResponse>();
-    response->Record = std::move(msg->CreateNodeResponse);
+    response->Record = msg->CreateNodeResponse;
 
     CompleteResponse<TEvService::TCreateNodeMethod>(
         response->Record,
         msg->RequestInfo->CallContext,
         ctx);
 
+    // replying before DupCacheEntry is committed to reduce response latency
     NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
 
     WorkerActors.erase(ev->Sender);
+    ExecuteTx<TCommitNodeCreationInFollower>(
+        ctx,
+        std::move(msg->SessionId),
+        msg->RequestId,
+        std::move(msg->CreateNodeResponse),
+        msg->OpLogEntryId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_CommitNodeCreationInFollower(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCommitNodeCreationInFollower& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_CommitNodeCreationInFollower(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCommitNodeCreationInFollower& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabase db(tx.DB);
+    PatchDupCacheEntry(
+        db,
+        args.SessionId,
+        args.RequestId,
+        std::move(args.Response));
+    db.DeleteOpLogEntry(args.EntryId);
+}
+
+void TIndexTabletActor::CompleteTx_CommitNodeCreationInFollower(
+    const TActorContext& ctx,
+    TTxIndexTablet::TCommitNodeCreationInFollower& args)
+{
+    CommitDupCacheEntry(args.SessionId, args.RequestId);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s CommitNodeCreationInFollower completed (%lu): %s, %lu",
+        LogTag.c_str(),
+        args.EntryId,
+        args.SessionId.c_str(),
+        args.RequestId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroycheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroycheckpoint.cpp
@@ -158,7 +158,7 @@ void TDestroyCheckpointActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TDestroyCheckpointActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -162,7 +162,7 @@ void TFlushActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TFlushActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -404,7 +404,7 @@ void TFlushBytesActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TFlushBytesActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -109,7 +109,8 @@ bool TIndexTabletActor::PrepareTx_LoadState(
         db.ReadCheckpoints(args.Checkpoints),
         db.ReadTruncateQueue(args.TruncateQueue),
         db.ReadStorageConfig(args.StorageConfig),
-        db.ReadSessionHistoryEntries(args.SessionHistory)
+        db.ReadSessionHistoryEntries(args.SessionHistory),
+        db.ReadOpLog(args.OpLog)
     };
 
     bool ready = std::accumulate(
@@ -300,6 +301,10 @@ void TIndexTabletActor::CompleteTx_LoadState(
     RegisterFileStore(ctx);
     RegisterStatCounters();
     ResetThrottlingPolicy();
+
+    LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+        LogTag << " Scheduling OpLog ops");
+    ReplayOpLog(ctx, args.OpLog);
 
     CompleteStateLoad();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -859,7 +859,7 @@ struct TIndexTabletMonitoringActor
         const TActorContext& ctx)
     {
         Y_UNUSED(ev);
-        ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"), {});
+        ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"), {});
     }
 
     void ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -1,0 +1,71 @@
+#include "tablet_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::ReplayOpLog(
+    const NActors::TActorContext& ctx,
+    const TVector<NProto::TOpLogEntry>& opLog)
+{
+    for (const auto& op: opLog) {
+        if (op.HasCreateNodeRequest()) {
+            // TODO
+        } else if (op.HasUnlinkNodeRequest()) {
+            RegisterUnlinkNodeInFollowerActor(
+                ctx,
+                nullptr, // requestInfo
+                op.GetUnlinkNodeRequest(),
+                0, // requestId
+                op.GetEntryId(),
+                {} // result
+            );
+        } else {
+            TABLET_VERIFY_C(
+                0,
+                "Unexpected OpLog entry: " << op.DebugString().Quote());
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_DeleteOpLogEntry(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDeleteOpLogEntry& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_DeleteOpLogEntry(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDeleteOpLogEntry& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabase db(tx.DB);
+    db.DeleteOpLogEntry(args.EntryId);
+}
+
+void TIndexTabletActor::CompleteTx_DeleteOpLogEntry(
+    const TActorContext& ctx,
+    TTxIndexTablet::TDeleteOpLogEntry& args)
+{
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s DeleteOpLogEntry completed (%lu)",
+        LogTag.c_str(),
+        args.EntryId);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -13,9 +13,23 @@ void TIndexTabletActor::ReplayOpLog(
     const NActors::TActorContext& ctx,
     const TVector<NProto::TOpLogEntry>& opLog)
 {
+    // TODO(#1350): requests to followers should be ordered, otherwise weird
+    // races are possible, e.g. create + unlink ops for the same node can arrive
+    // in opposite order (original requests won't come in opposite order, but
+    // if one of those requests gets rejected and is retried, the final order
+    // may change)
     for (const auto& op: opLog) {
         if (op.HasCreateNodeRequest()) {
-            // TODO
+            RegisterCreateNodeInFollowerActor(
+                ctx,
+                nullptr, // requestInfo
+                op.GetCreateNodeRequest(),
+                op.GetRequestId(), // needed for DupCache update (only for
+                                   // follower requests originating from
+                                   // CreateNode requests)
+                op.GetEntryId(),
+                {} // response
+            );
         } else if (op.HasUnlinkNodeRequest()) {
             RegisterUnlinkNodeInFollowerActor(
                 ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
@@ -245,7 +245,7 @@ void TReadBlobActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TReadBlobActor::ReplyError(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -429,7 +429,7 @@ void TReadDataActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TReadDataActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -336,6 +336,8 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.NewChildRef->MinCommitId,
                 args.CommitId);
 
+            // TODO: fill OpLogEntry
+
             args.FollowerIdForUnlink = args.NewChildRef->FollowerId;
             args.FollowerNameForUnlink = args.NewChildRef->FollowerName;
         }
@@ -392,8 +394,6 @@ void TIndexTabletActor::CompleteTx_RenameNode(
     const TActorContext& ctx,
     TTxIndexTablet::TRenameNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
-
     if (!HasError(args.Error) && !args.ChildRef) {
         auto message = ReportChildRefIsNull(TStringBuilder()
             << "RenameNode: " << args.Request.ShortDebugString());
@@ -401,8 +401,6 @@ void TIndexTabletActor::CompleteTx_RenameNode(
     }
 
     if (!HasError(args.Error)) {
-        CommitDupCacheEntry(args.SessionId, args.RequestId);
-
         if (args.FollowerIdForUnlink) {
             LOG_INFO(ctx, TFileStoreComponents::TABLET,
                 "%s Unlinking node in follower upon RenameNode: %s, %s",
@@ -412,17 +410,22 @@ void TIndexTabletActor::CompleteTx_RenameNode(
 
             NProto::TUnlinkNodeRequest request;
             request.MutableHeaders()->CopyFrom(args.Request.GetHeaders());
+            request.SetFileSystemId(args.FollowerIdForUnlink);
+            request.SetNodeId(RootNodeId);
+            request.SetName(args.FollowerNameForUnlink);
 
             RegisterUnlinkNodeInFollowerActor(
                 ctx,
                 args.RequestInfo,
-                std::move(args.FollowerIdForUnlink),
-                std::move(args.FollowerNameForUnlink),
                 std::move(request),
+                args.RequestId,
+                args.OpLogEntry.GetEntryId(),
                 std::move(args.Response));
 
             return;
         }
+
+        CommitDupCacheEntry(args.SessionId, args.RequestId);
 
         // TODO(#1350): support session events for external nodes
         NProto::TSessionEvent sessionEvent;
@@ -440,6 +443,8 @@ void TIndexTabletActor::CompleteTx_RenameNode(
         }
         NotifySessionEvent(ctx, sessionEvent);
     }
+
+    RemoveTransaction(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(args.Error);
     CompleteResponse<TEvService::TRenameNodeMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -198,7 +198,8 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
             && args.ChildNode->NodeId == args.NewChildNode->NodeId;
         const bool isSameExternalNode = args.ChildRef->FollowerId
             && args.NewChildRef->FollowerId
-            && args.ChildRef->FollowerId == args.NewChildRef->FollowerId;
+            && args.ChildRef->FollowerId == args.NewChildRef->FollowerId
+            && args.ChildRef->FollowerName == args.NewChildRef->FollowerName;
         if (isSameNode || isSameExternalNode) {
             args.Error = MakeError(S_ALREADY, "is the same file");
             return true;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -156,6 +156,11 @@ void TIndexTabletActor::HandleUpdateConfig(
         return;
     }
 
+    // Setting the fields that schemeshard is not aware of.
+    *newConfig.MutableFollowerFileSystemIds() =
+        oldConfig.GetFollowerFileSystemIds();
+    newConfig.SetShardNo(oldConfig.GetShardNo());
+
     // Config update occured due to alter/resize.
     if (auto error = ValidateUpdateConfigRequest(oldConfig, newConfig)) {
         LOG_ERROR(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -175,7 +175,7 @@ void TWriteBatchActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TWriteBatchActor::ReplyAndDie(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -180,7 +180,7 @@ void TWriteBlobActor::HandlePoisonPill(
     const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    ReplyAndDie(ctx, MakeError(E_REJECTED, "request cancelled"));
+    ReplyAndDie(ctx, MakeError(E_REJECTED, "tablet is shutting down"));
 }
 
 void TWriteBlobActor::ReplyError(

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -470,6 +470,14 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         TVector<TCompactionRangeInfo>& compactionMap,
         ui32 firstRangeId,
         ui32 rangeCount);
+
+    //
+    // OpLog
+    //
+
+    void WriteOpLogEntry(const NProto::TOpLogEntry& entry);
+    void DeleteOpLogEntry(ui64 entryId);
+    bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -543,13 +543,22 @@ struct TEvIndexTabletPrivate
 
     struct TNodeUnlinkedInFollower
     {
-        TRequestInfoPtr RequestInfo;
+        const TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
         TUnlinkNodeInFollowerResult Result;
 
         TNodeUnlinkedInFollower(
                 TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
                 TUnlinkNodeInFollowerResult result)
             : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
             , Result(std::move(result))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -535,12 +535,21 @@ struct TEvIndexTabletPrivate
     struct TNodeCreatedInFollowerUponCreateHandle
     {
         TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
         NProto::TCreateHandleResponse CreateHandleResponse;
 
         TNodeCreatedInFollowerUponCreateHandle(
                 TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
                 NProto::TCreateHandleResponse createHandleResponse)
             : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
             , CreateHandleResponse(std::move(createHandleResponse))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -507,13 +507,22 @@ struct TEvIndexTabletPrivate
 
     struct TNodeCreatedInFollower
     {
-        TRequestInfoPtr RequestInfo;
+        const TRequestInfoPtr RequestInfo;
+        TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
         NProto::TCreateNodeResponse CreateNodeResponse;
 
         TNodeCreatedInFollower(
                 TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
                 NProto::TCreateNodeResponse createNodeResponse)
             : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
             , CreateNodeResponse(std::move(createNodeResponse))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -480,11 +480,25 @@ struct TIndexTabletSchema
         using StoragePolicy = TStoragePolicy<IndexChannel>;
     };
 
-
     struct SessionHistory: TTableSchema<24>
     {
         struct Id       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
         struct Proto    : ProtoColumn<2, NProto::TSessionHistoryEntry> {};
+
+        using TKey = TableKey<Id>;
+
+        using TColumns = TableColumns<
+            Id,
+            Proto
+        >;
+
+        using StoragePolicy = TStoragePolicy<IndexChannel>;
+    };
+
+    struct OpLog: TTableSchema<25>
+    {
+        struct Id       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct Proto    : ProtoColumn<2, NProto::TOpLogEntry> {};
 
         using TKey = TableKey<Id>;
 
@@ -520,7 +534,8 @@ struct TIndexTabletSchema
         SessionDupCache,
         TabletStorageInfo,
         TruncateQueue,
-        SessionHistory
+        SessionHistory,
+        OpLog
     >;
 
     using TSettings = SchemaSettings<

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -638,6 +638,12 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_DECLARE_DUPCACHE)
 
 #undef FILESTORE_DECLARE_DUPCACHE
 
+    void PatchDupCacheEntry(
+        TIndexTabletDatabase& db,
+        const TString& sessionId,
+        ui64 requestId,
+        NProto::TCreateNodeResponse response);
+
     void CommitDupCacheEntry(
         const TString& sessionId,
         ui64 requestId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -761,6 +761,31 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_IMPLEMENT_DUPCACHE)
 
 #undef FILESTORE_IMPLEMENT_DUPCACHE
 
+void TIndexTabletState::PatchDupCacheEntry(
+    TIndexTabletDatabase& db,
+    const TString& sessionId,
+    ui64 requestId,
+    NProto::TCreateNodeResponse response)
+{
+    if (!requestId) {
+        return;
+    }
+
+    auto* session = FindSession(sessionId);
+    if (!session) {
+        return;
+    }
+
+    auto* entry = session->AccessDupEntry(requestId);
+    if (!entry) {
+        return;
+    }
+
+    *entry->MutableCreateNode()->MutableNode() =
+        std::move(*response.MutableNode());
+    db.WriteSessionDupCacheEntry(*entry);
+}
+
 void TIndexTabletState::CommitDupCacheEntry(
     const TString& sessionId,
     ui64 requestId)

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -121,6 +121,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ChangeStorageConfig,                __VA_ARGS__)                       \
                                                                                \
     xxx(DeleteOpLogEntry,                   __VA_ARGS__)                       \
+    xxx(CommitNodeCreationInFollower,       __VA_ARGS__)                       \
 // FILESTORE_TABLET_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -616,6 +617,8 @@ struct TTxIndexTablet
         ui64 ChildNodeId = InvalidNodeId;
         TMaybe<IIndexTabletDatabase::TNode> ChildNode;
 
+        NProto::TOpLogEntry OpLogEntry;
+
         NProto::TCreateNodeResponse Response;
 
         TCreateNode(
@@ -642,6 +645,8 @@ struct TTxIndexTablet
             ParentNode.Clear();
             ChildNodeId = InvalidNodeId;
             ChildNode.Clear();
+
+            OpLogEntry.Clear();
 
             Response.Clear();
         }
@@ -1787,6 +1792,36 @@ struct TTxIndexTablet
 
         explicit TDeleteOpLogEntry(ui64 entryId)
             : EntryId(entryId)
+        {}
+
+        void Clear()
+        {
+        }
+    };
+
+    //
+    // CommitNodeCreationInFollower
+    //
+
+    struct TCommitNodeCreationInFollower
+    {
+        // actually unused, needed in tablet_tx.h to avoid sophisticated
+        // template tricks
+        const TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        NProto::TCreateNodeResponse Response;
+        const ui64 EntryId;
+
+        explicit TCommitNodeCreationInFollower(
+                TString sessionId,
+                ui64 requestId,
+                NProto::TCreateNodeResponse response,
+                ui64 entryId)
+            : SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , Response(std::move(response))
+            , EntryId(entryId)
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -663,12 +663,12 @@ struct TTxIndexTablet
 
         TUnlinkNode(
                 TRequestInfoPtr requestInfo,
-                const NProto::TUnlinkNodeRequest& request)
+                NProto::TUnlinkNodeRequest request)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
-            , Request(request)
-            , ParentNodeId(request.GetNodeId())
-            , Name(request.GetName())
+            , Request(std::move(request))
+            , ParentNodeId(Request.GetNodeId())
+            , Name(Request.GetName())
         {}
 
         void Clear()
@@ -693,7 +693,7 @@ struct TTxIndexTablet
         const ui64 NewParentNodeId;
         const TString NewName;
         const ui32 Flags;
-        const NProto::THeaders Headers;
+        const NProto::TRenameNodeRequest Request;
 
         ui64 CommitId = InvalidCommitId;
         TMaybe<IIndexTabletDatabase::TNode> ParentNode;
@@ -711,7 +711,7 @@ struct TTxIndexTablet
 
         TRenameNode(
                 TRequestInfoPtr requestInfo,
-                NProto::TRenameNodeRequest& request)
+                NProto::TRenameNodeRequest request)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , ParentNodeId(request.GetNodeId())
@@ -719,7 +719,7 @@ struct TTxIndexTablet
             , NewParentNodeId(request.GetNewParentId())
             , NewName(std::move(*request.MutableNewName()))
             , Flags(request.GetFlags())
-            , Headers(std::move(*request.MutableHeaders()))
+            , Request(std::move(request))
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -634,7 +634,13 @@ struct TTxIndexTablet
             , Name(request.GetName())
             , Attrs(std::move(attrs))
             , FollowerId(request.GetFollowerFileSystemId())
-            , FollowerName(CreateGuidAsString())
+            // For multishard filestore, selection of the follower node name for
+            // hard links is done by the client, not the leader. Thus, the
+            // client is able to provide the follower node name explicitly:
+            , FollowerName(
+                  request.HasLink() && request.GetLink().GetFollowerNodeName()
+                      ? request.GetLink().GetFollowerNodeName()
+                      : CreateGuidAsString())
             , Request(std::move(request))
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -616,22 +616,20 @@ struct TTxIndexTablet
 
         TCreateNode(
                 TRequestInfoPtr requestInfo,
-                const NProto::TCreateNodeRequest request,
+                NProto::TCreateNodeRequest request,
                 ui64 parentNodeId,
                 ui64 targetNodeId,
-                const NProto::TNode& attrs)
+                NProto::TNode attrs)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , ParentNodeId(parentNodeId)
             , TargetNodeId(targetNodeId)
             , Name(request.GetName())
-            , Attrs(attrs)
+            , Attrs(std::move(attrs))
             , FollowerId(request.GetFollowerFileSystemId())
             , FollowerName(CreateGuidAsString())
+            , Request(std::move(request))
         {
-            if (FollowerId) {
-                Request = request;
-            }
         }
 
         void Clear()
@@ -1061,7 +1059,7 @@ struct TTxIndexTablet
         const ui32 Uid;
         const ui32 Gid;
         const TString RequestFollowerId;
-        NProto::THeaders Headers;
+        NProto::TCreateHandleRequest Request;
 
         ui64 ReadCommitId = InvalidCommitId;
         ui64 WriteCommitId = InvalidCommitId;
@@ -1076,7 +1074,7 @@ struct TTxIndexTablet
 
         TCreateHandle(
                 TRequestInfoPtr requestInfo,
-                const NProto::TCreateHandleRequest& request)
+                NProto::TCreateHandleRequest request)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , NodeId(request.GetNodeId())
@@ -1086,10 +1084,8 @@ struct TTxIndexTablet
             , Uid(request.GetUid())
             , Gid(request.GetGid())
             , RequestFollowerId(request.GetFollowerFileSystemId())
+            , Request(std::move(request))
         {
-            if (RequestFollowerId) {
-                Headers = request.GetHeaders();
-            }
         }
 
         void Clear()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -119,6 +119,8 @@ namespace NCloud::NFileStore::NStorage {
                                                                                \
     xxx(FilterAliveNodes,                   __VA_ARGS__)                       \
     xxx(ChangeStorageConfig,                __VA_ARGS__)                       \
+                                                                               \
+    xxx(DeleteOpLogEntry,                   __VA_ARGS__)                       \
 // FILESTORE_TABLET_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -279,6 +281,7 @@ struct TTxIndexTablet
         TVector<NProto::TTruncateEntry> TruncateQueue;
         TMaybe<NProto::TStorageConfig> StorageConfig;
         TVector<NProto::TSessionHistoryEntry> SessionHistory;
+        TVector<NProto::TOpLogEntry> OpLog;
 
         NProto::TError Error;
 
@@ -300,6 +303,7 @@ struct TTxIndexTablet
             TruncateQueue.clear();
             StorageConfig.Clear();
             SessionHistory.clear();
+            OpLog.clear();
         }
     };
 
@@ -659,6 +663,8 @@ struct TTxIndexTablet
         TMaybe<IIndexTabletDatabase::TNode> ChildNode;
         TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
 
+        NProto::TOpLogEntry OpLogEntry;
+
         NProto::TUnlinkNodeResponse Response;
 
         TUnlinkNode(
@@ -677,6 +683,7 @@ struct TTxIndexTablet
             ParentNode.Clear();
             ChildNode.Clear();
             ChildRef.Clear();
+            OpLogEntry.Clear();
             Response.Clear();
         }
     };
@@ -703,6 +710,8 @@ struct TTxIndexTablet
         TMaybe<IIndexTabletDatabase::TNode> NewParentNode;
         TMaybe<IIndexTabletDatabase::TNode> NewChildNode;
         TMaybe<IIndexTabletDatabase::TNodeRef> NewChildRef;
+
+        NProto::TOpLogEntry OpLogEntry;
 
         NProto::TRenameNodeResponse Response;
 
@@ -732,6 +741,8 @@ struct TTxIndexTablet
             NewParentNode.Clear();
             NewChildNode.Clear();
             NewChildRef.Clear();
+
+            OpLogEntry.Clear();
 
             Response.Clear();
 
@@ -1760,6 +1771,26 @@ struct TTxIndexTablet
         {
             StorageConfigFromDB.Clear();
             ResultStorageConfig.Clear();
+        }
+    };
+
+    //
+    // DeleteOpLogEntry
+    //
+
+    struct TDeleteOpLogEntry
+    {
+        // actually unused, needed in tablet_tx.h to avoid sophisticated
+        // template tricks
+        const TRequestInfoPtr RequestInfo;
+        const ui64 EntryId;
+
+        explicit TDeleteOpLogEntry(ui64 entryId)
+            : EntryId(entryId)
+        {}
+
+        void Clear()
+        {
         }
     };
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1092,6 +1092,8 @@ struct TTxIndexTablet
         TMaybe<IIndexTabletDatabase::TNode> TargetNode;
         TMaybe<IIndexTabletDatabase::TNode> ParentNode;
 
+        NProto::TOpLogEntry OpLogEntry;
+
         NProto::TCreateHandleResponse Response;
 
         TCreateHandle(
@@ -1120,6 +1122,8 @@ struct TTxIndexTablet
             IsNewFollowerNode = false;
             TargetNode.Clear();
             ParentNode.Clear();
+
+            OpLogEntry.Clear();
 
             Response.Clear();
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -4377,9 +4377,11 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             return false;
         });
 
-        env.GetRuntime().DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
-
-        UNIT_ASSERT(putSeen);
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] {
+            return putSeen;
+        };
+        env.GetRuntime().DispatchEvents(options);
 
         tablet.RebootTablet();
 
@@ -4387,6 +4389,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL_C(
             E_REJECTED,
             response->GetStatus(),
+            response->GetErrorReason());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "tablet is shutting down",
             response->GetErrorReason());
     }
 
@@ -4440,9 +4446,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             return false;
         });
 
-        env.GetRuntime().DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] {
+            return getSeen;
+        };
 
-        UNIT_ASSERT(getSeen);
+        env.GetRuntime().DispatchEvents(options);
 
         failGet = false;
         tablet.RebootTablet();
@@ -4451,6 +4460,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL_C(
             E_REJECTED,
             response->GetStatus(),
+            response->GetErrorReason());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "tablet is shutting down",
             response->GetErrorReason());
     }
 

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -46,6 +46,7 @@ SRCS(
     tablet_actor_listnodexattr.cpp
     tablet_actor_loadstate.cpp
     tablet_actor_monitoring.cpp
+    tablet_actor_oplog.cpp
     tablet_actor_readblob.cpp
     tablet_actor_readdata.cpp
     tablet_actor_readlink.cpp

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -219,11 +219,13 @@ public:
 
     auto CreateCreateNodeRequest(
         const THeaders& headers,
-        const TCreateNodeArgs& args)
+        const TCreateNodeArgs& args,
+        const ui64 requestId = 0)
     {
         auto request = std::make_unique<TEvService::TEvCreateNodeRequest>();
         request->Record.SetFileSystemId(headers.FileSystemId);
         headers.Fill(request->Record);
+        request->Record.MutableHeaders()->SetRequestId(requestId);
         args.Fill(request->Record);
         return request;
     }

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -232,11 +232,13 @@ public:
         const THeaders& headers,
         const ui64 parent,
         const TString& name,
-        bool unlinkDirectory = false)
+        bool unlinkDirectory = false,
+        const ui64 requestId = 0)
     {
         auto request = std::make_unique<TEvService::TEvUnlinkNodeRequest>();
         request->Record.SetFileSystemId(headers.FileSystemId);
         headers.Fill(request->Record);
+        request->Record.MutableHeaders()->SetRequestId(requestId);
         request->Record.SetNodeId(parent);
         request->Record.SetName(name);
         request->Record.SetUnlinkDirectory(unlinkDirectory);

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -462,6 +462,16 @@ public:
         return request;
     }
 
+    std::unique_ptr<TEvService::TEvStatFileStoreRequest> CreateStatFileStoreRequest(
+        const THeaders& headers,
+        const TString& fileSystemId)
+    {
+        auto request = std::make_unique<TEvService::TEvStatFileStoreRequest>();
+        headers.Fill(request->Record);
+        request->Record.SetFileSystemId(fileSystemId);
+        return request;
+    }
+
 #define FILESTORE_DECLARE_METHOD(name, ns)                                     \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -112,6 +112,9 @@ message TCreateNodeRequest
     message TLink
     {
         uint64 TargetNode = 1;
+        // when creating hardlinks, one can enforce the FollowerNodeName and
+        // avoid using the generated one
+        string FollowerNodeName = 2;
     }
 
     message TSymLink


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/commit/fac35abec8b1989b3a57ff6853e4bf04e276a67c

https://github.com/ydb-platform/nbs/commit/a833cad09513c885de5b532e04429449ee318abd

https://github.com/ydb-platform/nbs/commit/eaa44eee3fe1f08fe1f4a5320ec83ba020ca6380

https://github.com/ydb-platform/nbs/commit/41910654aa119464cf50f1e0c9c607644d91a33c

https://github.com/ydb-platform/nbs/commit/23f089e39840fc74f4967827c4fd5606785b48ef

https://github.com/ydb-platform/nbs/commit/f2b2c1f7fd021fd70b9e06e698e5cc439c7d8453

https://github.com/ydb-platform/nbs/commit/c00c2f5c09a2f09d6c8fdf86e2a91d237c8a7644

https://github.com/ydb-platform/nbs/commit/238049a9551ca9599528a1f58f81e9df84c75f37

https://github.com/ydb-platform/nbs/commit/a33fbbf6ca921eb7591b9db5d552b4bdc3104b94

merging this very old commit as well: https://github.com/ydb-platform/nbs/commit/8054069aecacf1b30f5e926a7ba0c35379476250

#1350 