### PR TITLE
[Disk Manager] [Tasks] get rid of OperationCloudId, OperationFolderId and other legacy params like UseDataplaneTasks*

### DIFF
--- a/cloud/disk_manager/api/disk_service.proto
+++ b/cloud/disk_manager/api/disk_service.proto
@@ -64,7 +64,7 @@ service DiskService {
 }
 
 message CreateDiskRequest {
-    reserved 15, 16;
+    reserved 13, 14, 15, 16;
 
     oneof src {
         google.protobuf.Empty src_empty = 1;
@@ -83,8 +83,6 @@ message CreateDiskRequest {
     string placement_group_id = 11;
     // Prevents from creating layered (overlay) disk.
     bool force_not_layered = 12;
-    string operation_cloud_id = 13;
-    string operation_folder_id = 14;
     string storage_pool_name = 17;
     repeated string agent_ids = 18;
     EncryptionDesc encryption_desc = 19;

--- a/cloud/disk_manager/api/image_service.proto
+++ b/cloud/disk_manager/api/image_service.proto
@@ -28,6 +28,8 @@ service ImageService {
 }
 
 message CreateImageRequest {
+    reserved 8, 9;
+
     oneof src {
         string src_snapshot_id = 1;
         string src_image_id = 2;
@@ -36,8 +38,6 @@ message CreateImageRequest {
     }
     string dst_image_id = 6;
     string folder_id = 7;
-    string operation_cloud_id = 8;
-    string operation_folder_id = 9;
     bool pooled = 10;
 }
 
@@ -60,9 +60,9 @@ message UpdateImageMetadata {
 }
 
 message DeleteImageRequest {
+    reserved 2, 3;
+
     string image_id = 1;
-    string operation_cloud_id = 2;
-    string operation_folder_id = 3;
 }
 
 message DeleteImageMetadata {

--- a/cloud/disk_manager/api/snapshot_service.proto
+++ b/cloud/disk_manager/api/snapshot_service.proto
@@ -25,13 +25,11 @@ service SnapshotService {
 }
 
 message CreateSnapshotRequest {
-    reserved 4;
+    reserved 4, 5, 6;
 
     DiskId src = 1;
     string snapshot_id = 2;
     string folder_id = 3;
-    string operation_cloud_id = 5;
-    string operation_folder_id = 6;
     bool zonal = 7;
 }
 
@@ -45,9 +43,9 @@ message CreateSnapshotResponse {
 }
 
 message DeleteSnapshotRequest {
+    reserved 2, 3;
+
     string snapshot_id = 1;
-    string operation_cloud_id = 2;
-    string operation_folder_id = 3;
 }
 
 message DeleteSnapshotMetadata {

--- a/cloud/disk_manager/internal/pkg/dataplane/collect_snapshots_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/collect_snapshots_task.go
@@ -101,8 +101,6 @@ func (t *collectSnapshotsTask) Run(
 				&protos.DeleteSnapshotDataRequest{
 					SnapshotId: snapshot.SnapshotId,
 				},
-				"",
-				"",
 			)
 			if err != nil {
 				return err

--- a/cloud/disk_manager/internal/pkg/dataplane/collect_snapshots_task_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/collect_snapshots_task_test.go
@@ -123,8 +123,6 @@ func TestCollectSnapshotsTaskCollectSeveralSnapshots(t *testing.T) {
 		"dataplane.DeleteSnapshotData",
 		"",
 		mock.Anything,
-		"",
-		"",
 	).Return("task1", nil).Times(1)
 	scheduler.On(
 		"ScheduleTask",
@@ -132,8 +130,6 @@ func TestCollectSnapshotsTaskCollectSeveralSnapshots(t *testing.T) {
 		"dataplane.DeleteSnapshotData",
 		"",
 		mock.Anything,
-		"",
-		"",
 	).Return("task2", nil).Times(1)
 	scheduler.On(
 		"WaitAnyTasks",
@@ -161,8 +157,6 @@ func TestCollectSnapshotsTaskCollectSeveralSnapshots(t *testing.T) {
 		"dataplane.DeleteSnapshotData",
 		"",
 		mock.Anything,
-		"",
-		"",
 	).Return("task3", nil).Times(1)
 	scheduler.On(
 		"WaitAnyTasks",
@@ -194,8 +188,6 @@ func TestCollectSnapshotsTaskCollectSeveralSnapshots(t *testing.T) {
 		"dataplane.DeleteSnapshotData",
 		"",
 		mock.Anything,
-		"",
-		"",
 	).Return("task2", nil).Times(1)
 	scheduler.On(
 		"ScheduleTask",
@@ -203,8 +195,6 @@ func TestCollectSnapshotsTaskCollectSeveralSnapshots(t *testing.T) {
 		"dataplane.DeleteSnapshotData",
 		"",
 		mock.Anything,
-		"",
-		"",
 	).Return("task4", nil).Times(1)
 	scheduler.On(
 		"WaitAnyTasks",

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -481,7 +481,7 @@ func CheckConsistency(t *testing.T, ctx context.Context) {
 
 		for _, diskID := range diskIDs {
 			// TODO: should remove dependency on disk id here.
-			if strings.Contains(diskID, "proxy") {
+			if strings.HasPrefix(diskID, "proxy") {
 				ok = false
 
 				logging.Info(

--- a/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_image_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_image_task.go
@@ -160,8 +160,6 @@ func (t *createDiskFromImageTask) Run(
 				DstDisk:       params.Disk,
 				DstEncryption: encryption,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 
 		t.state.DataplaneTaskId = taskID
@@ -176,8 +174,6 @@ func (t *createDiskFromImageTask) Run(
 				DstDisk:       params.Disk,
 				DstEncryption: encryption,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 
 		t.state.DataplaneTaskId = taskID

--- a/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_snapshot_task.go
@@ -160,8 +160,6 @@ func (t *createDiskFromSnapshotTask) Run(
 				DstDisk:       params.Disk,
 				DstEncryption: encryption,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 
 		t.state.DataplaneTaskId = taskID
@@ -176,8 +174,6 @@ func (t *createDiskFromSnapshotTask) Run(
 				DstDisk:       params.Disk,
 				DstEncryption: encryption,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 
 		t.state.DataplaneTaskId = taskID

--- a/cloud/disk_manager/internal/pkg/services/disks/migrate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/migrate_disk_task.go
@@ -348,8 +348,6 @@ func (t *migrateDiskTask) scheduleReplicateTask(
 			// Performs full copy of base disk if |IgnoreBaseDisk == false|.
 			IgnoreBaseDisk: len(t.state.RelocateInfo.TargetBaseDiskID) != 0,
 		},
-		"",
-		"",
 	)
 	if err != nil {
 		return err

--- a/cloud/disk_manager/internal/pkg/services/disks/protos/create_disk_from_image_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/disks/protos/create_disk_from_image_task.proto
@@ -10,11 +10,10 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateDiskFromImageRequest {
+    reserved 3, 4, 5;
+
     string SrcImageId = 1;
     CreateDiskParams Params = 2;
-    string OperationCloudId = 3;
-    string OperationFolderId = 4;
-    bool UseDataplaneTasksForLegacySnapshots = 5 [deprecated = true];
 }
 
 message CreateDiskFromImageTaskState {

--- a/cloud/disk_manager/internal/pkg/services/disks/protos/create_disk_from_snapshot_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/disks/protos/create_disk_from_snapshot_task.proto
@@ -10,11 +10,10 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateDiskFromSnapshotRequest {
+    reserved 3, 4, 5;
+
     string SrcSnapshotId = 1;
     CreateDiskParams Params = 2;
-    string OperationCloudId = 3;
-    string OperationFolderId = 4;
-    bool UseDataplaneTasksForLegacySnapshots = 5 [deprecated = true];
 }
 
 message CreateDiskFromSnapshotTaskState {

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -323,8 +323,6 @@ func (s *service) CreateDisk(
 			"disks.CreateEmptyDisk",
 			"",
 			params,
-			params.CloudId,
-			params.FolderId,
 		)
 	case *disk_manager.CreateDiskRequest_SrcImageId:
 		allowed, err := s.isOverlayDiskAllowed(ctx, req, src.SrcImageId, params)
@@ -341,8 +339,6 @@ func (s *service) CreateDisk(
 					SrcImageId: src.SrcImageId,
 					Params:     params,
 				},
-				params.CloudId,
-				params.FolderId,
 			)
 		}
 
@@ -351,14 +347,9 @@ func (s *service) CreateDisk(
 			"disks.CreateDiskFromImage",
 			"",
 			&protos.CreateDiskFromImageRequest{
-				SrcImageId:                          src.SrcImageId,
-				Params:                              params,
-				OperationCloudId:                    req.OperationCloudId,
-				OperationFolderId:                   req.OperationFolderId,
-				UseDataplaneTasksForLegacySnapshots: true, // TODO: remove it.
+				SrcImageId: src.SrcImageId,
+				Params:     params,
 			},
-			req.OperationCloudId,
-			req.OperationFolderId,
 		)
 	case *disk_manager.CreateDiskRequest_SrcSnapshotId:
 		return s.taskScheduler.ScheduleTask(
@@ -366,14 +357,9 @@ func (s *service) CreateDisk(
 			"disks.CreateDiskFromSnapshot",
 			"",
 			&protos.CreateDiskFromSnapshotRequest{
-				SrcSnapshotId:                       src.SrcSnapshotId,
-				Params:                              params,
-				OperationCloudId:                    req.OperationCloudId,
-				OperationFolderId:                   req.OperationFolderId,
-				UseDataplaneTasksForLegacySnapshots: true, // TODO: remove it.
+				SrcSnapshotId: src.SrcSnapshotId,
+				Params:        params,
 			},
-			req.OperationCloudId,
-			req.OperationFolderId,
 		)
 	default:
 		return "", errors.NewInvalidArgumentError("unknown src %s", src)
@@ -412,8 +398,6 @@ func (s *service) DeleteDisk(
 			},
 			Sync: req.Sync,
 		},
-		"",
-		"",
 	)
 }
 
@@ -447,8 +431,6 @@ func (s *service) ResizeDisk(
 			},
 			Size: uint64(req.Size),
 		},
-		"",
-		"",
 	)
 }
 
@@ -476,8 +458,6 @@ func (s *service) AlterDisk(
 			CloudId:  req.CloudId,
 			FolderId: req.FolderId,
 		},
-		req.CloudId,
-		req.FolderId,
 	)
 }
 
@@ -506,8 +486,6 @@ func (s *service) AssignDisk(
 			Host:       req.Host,
 			Token:      req.Token,
 		},
-		"",
-		"",
 	)
 }
 
@@ -533,8 +511,6 @@ func (s *service) UnassignDisk(
 				DiskId: req.DiskId.DiskId,
 			},
 		},
-		"",
-		"",
 	)
 }
 
@@ -684,8 +660,6 @@ func (s *service) MigrateDisk(
 			DstPlacementGroupId:        req.DstPlacementGroupId,
 			DstPlacementPartitionIndex: req.DstPlacementPartitionIndex,
 		},
-		"",
-		"",
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/filesystem/service.go
+++ b/cloud/disk_manager/internal/pkg/services/filesystem/service.go
@@ -125,8 +125,6 @@ func (s *service) CreateFilesystem(
 			BlocksCount: blocksCount,
 			StorageKind: kind,
 		},
-		req.CloudId,
-		req.FolderId,
 	)
 }
 
@@ -152,8 +150,6 @@ func (s *service) DeleteFilesystem(
 				FilesystemId: req.FilesystemId.FilesystemId,
 			},
 		},
-		"",
-		"",
 	)
 }
 
@@ -183,8 +179,6 @@ func (s *service) ResizeFilesystem(
 			},
 			Size: uint64(req.Size),
 		},
-		"",
-		"",
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/common.go
+++ b/cloud/disk_manager/internal/pkg/services/images/common.go
@@ -23,8 +23,6 @@ func deleteImage(
 	storage resources.Storage,
 	poolService pools.Service,
 	imageID string,
-	operationCloudID string,
-	operationFolderID string,
 ) error {
 
 	selfTaskID := execCtx.GetTaskID()
@@ -73,8 +71,6 @@ func deleteImage(
 		&dataplane_protos.DeleteSnapshotRequest{
 			SnapshotId: imageID,
 		},
-		operationCloudID,
-		operationFolderID,
 	)
 	if err != nil {
 		return err

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
@@ -108,8 +108,6 @@ func (t *createImageFromDiskTask) run(
 			DstSnapshotId:       t.request.DstImageId,
 			UseS3:               t.request.UseS3,
 		},
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 	if err != nil {
 		return err
@@ -215,8 +213,6 @@ func (t *createImageFromDiskTask) Cancel(
 		t.storage,
 		t.poolService,
 		t.request.DstImageId,
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_image_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_image_task.go
@@ -93,8 +93,6 @@ func (t *createImageFromImageTask) Run(
 				SrcSnapshotId: t.request.SrcImageId,
 				DstSnapshotId: t.request.DstImageId,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 		if err != nil {
 			return err
@@ -133,8 +131,6 @@ func (t *createImageFromImageTask) Run(
 				DstSnapshotId: t.request.DstImageId,
 				UseS3:         t.request.UseS3,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 		if err != nil {
 			return err
@@ -198,8 +194,6 @@ func (t *createImageFromImageTask) Cancel(
 		t.storage,
 		t.poolService,
 		t.request.DstImageId,
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_snapshot_task.go
@@ -93,8 +93,6 @@ func (t *createImageFromSnapshotTask) Run(
 				SrcSnapshotId: t.request.SrcSnapshotId,
 				DstSnapshotId: t.request.DstImageId,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 		if err != nil {
 			return err
@@ -133,8 +131,6 @@ func (t *createImageFromSnapshotTask) Run(
 				DstSnapshotId: t.request.DstImageId,
 				UseS3:         t.request.UseS3,
 			},
-			t.request.OperationCloudId,
-			t.request.OperationFolderId,
 		)
 		if err != nil {
 			return err
@@ -198,8 +194,6 @@ func (t *createImageFromSnapshotTask) Cancel(
 		t.storage,
 		t.poolService,
 		t.request.DstImageId,
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_url_task.go
@@ -94,8 +94,6 @@ func (t *createImageFromURLTask) Run(
 			DstSnapshotId: t.request.DstImageId,
 			UseS3:         t.request.UseS3,
 		},
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 	if err != nil {
 		return err
@@ -160,8 +158,6 @@ func (t *createImageFromURLTask) Cancel(
 		t.storage,
 		t.poolService,
 		t.request.DstImageId,
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/delete_image_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/delete_image_task.go
@@ -50,8 +50,6 @@ func (t *deleteImageTask) deleteImage(
 		t.storage,
 		t.poolService,
 		t.request.ImageId,
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_disk_task.proto
@@ -9,13 +9,12 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateImageFromDiskRequest {
+    reserved 4, 5, 7;
+
     types.Disk SrcDisk = 1;
     string DstImageId = 2;
     string FolderId = 3;
-    string OperationCloudId = 4;
-    string OperationFolderId = 5;
     repeated types.DiskPool DiskPools = 6;
-    bool UseDataplaneTasks = 7;
     bool UseS3 = 8;
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_image_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_image_task.proto
@@ -9,13 +9,12 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateImageFromImageRequest {
+    reserved 4, 5, 7;
+
     string SrcImageId = 1;
     string DstImageId = 2;
     string FolderId = 3;
-    string OperationCloudId = 4;
-    string OperationFolderId = 5;
     repeated types.DiskPool DiskPools = 6;
-    bool UseDataplaneTasksForLegacySnapshots = 7;
     bool UseS3 = 8;
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_snapshot_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_snapshot_task.proto
@@ -9,13 +9,12 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateImageFromSnapshotRequest {
+    reserved 4, 5, 7;
+
     string SrcSnapshotId = 1;
     string DstImageId = 2;
     string FolderId = 3;
-    string OperationCloudId = 4;
-    string OperationFolderId = 5;
     repeated types.DiskPool DiskPools = 6;
-    bool UseDataplaneTasksForLegacySnapshots = 7;
     bool UseS3 = 8;
 }
 

--- a/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_url_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/images/protos/create_image_from_url_task.proto
@@ -9,18 +9,13 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateImageFromURLRequest {
-    reserved 2;
+    reserved 2, 6, 7, 8, 9, 11;
 
     string SrcURL = 1;
     string DstImageId = 3;
     string FolderId = 4;
     repeated types.DiskPool DiskPools = 5;
-    string OperationCloudId = 6;
-    string OperationFolderId = 7;
-    bool UseDataplaneTasks = 8;
-    bool UseDataplaneTasksSupportedFormatsOnly = 9;
     bool UseS3 = 10;
-    bool UseDataplaneTasksForVMDK = 11;
 }
 
 message CreateImageFromURLTaskState {

--- a/cloud/disk_manager/internal/pkg/services/images/protos/delete_image_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/images/protos/delete_image_task.proto
@@ -7,9 +7,9 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message DeleteImageRequest {
+    reserved 2, 3;
+
     string ImageId = 1;
-    string OperationCloudId = 2;
-    string OperationFolderId = 3;
 }
 
 message DeleteImageTaskState {}

--- a/cloud/disk_manager/internal/pkg/services/images/service.go
+++ b/cloud/disk_manager/internal/pkg/services/images/service.go
@@ -54,17 +54,12 @@ func (s *service) CreateImage(
 			"images.CreateImageFromSnapshot",
 			"",
 			&protos.CreateImageFromSnapshotRequest{
-				SrcSnapshotId:                       src.SrcSnapshotId,
-				DstImageId:                          req.DstImageId,
-				FolderId:                            req.FolderId,
-				OperationCloudId:                    req.OperationCloudId,
-				OperationFolderId:                   req.OperationFolderId,
-				DiskPools:                           pools,
-				UseDataplaneTasksForLegacySnapshots: true, // TODO: remove it.
-				UseS3:                               useS3,
+				SrcSnapshotId: src.SrcSnapshotId,
+				DstImageId:    req.DstImageId,
+				FolderId:      req.FolderId,
+				DiskPools:     pools,
+				UseS3:         useS3,
 			},
-			req.OperationCloudId,
-			req.OperationFolderId,
 		)
 	case *disk_manager.CreateImageRequest_SrcImageId:
 		if len(src.SrcImageId) == 0 || len(req.DstImageId) == 0 {
@@ -79,17 +74,12 @@ func (s *service) CreateImage(
 			"images.CreateImageFromImage",
 			"",
 			&protos.CreateImageFromImageRequest{
-				SrcImageId:                          src.SrcImageId,
-				DstImageId:                          req.DstImageId,
-				FolderId:                            req.FolderId,
-				OperationCloudId:                    req.OperationCloudId,
-				OperationFolderId:                   req.OperationFolderId,
-				DiskPools:                           pools,
-				UseDataplaneTasksForLegacySnapshots: true, // TODO: remove it.
-				UseS3:                               useS3,
+				SrcImageId: src.SrcImageId,
+				DstImageId: req.DstImageId,
+				FolderId:   req.FolderId,
+				DiskPools:  pools,
+				UseS3:      useS3,
 			},
-			req.OperationCloudId,
-			req.OperationFolderId,
 		)
 	case *disk_manager.CreateImageRequest_SrcUrl:
 		if len(src.SrcUrl.Url) == 0 || len(req.DstImageId) == 0 {
@@ -104,19 +94,12 @@ func (s *service) CreateImage(
 			"images.CreateImageFromURL",
 			"",
 			&protos.CreateImageFromURLRequest{
-				SrcURL:                                src.SrcUrl.Url,
-				DstImageId:                            req.DstImageId,
-				FolderId:                              req.FolderId,
-				DiskPools:                             pools,
-				OperationCloudId:                      req.OperationCloudId,
-				OperationFolderId:                     req.OperationFolderId,
-				UseDataplaneTasks:                     true, // TODO: remove it.
-				UseDataplaneTasksSupportedFormatsOnly: true, // TODO: remove it.
-				UseS3:                                 useS3,
-				UseDataplaneTasksForVMDK:              true, // TODO: remove it.,
+				SrcURL:     src.SrcUrl.Url,
+				DstImageId: req.DstImageId,
+				FolderId:   req.FolderId,
+				DiskPools:  pools,
+				UseS3:      useS3,
 			},
-			req.OperationCloudId,
-			req.OperationFolderId,
 		)
 	case *disk_manager.CreateImageRequest_SrcDiskId:
 		if len(src.SrcDiskId.ZoneId) == 0 ||
@@ -138,16 +121,11 @@ func (s *service) CreateImage(
 					ZoneId: src.SrcDiskId.ZoneId,
 					DiskId: src.SrcDiskId.DiskId,
 				},
-				DstImageId:        req.DstImageId,
-				FolderId:          req.FolderId,
-				OperationCloudId:  req.OperationCloudId,
-				OperationFolderId: req.OperationFolderId,
-				DiskPools:         pools,
-				UseDataplaneTasks: true, // TODO: remove it.
-				UseS3:             useS3,
+				DstImageId: req.DstImageId,
+				FolderId:   req.FolderId,
+				DiskPools:  pools,
+				UseS3:      useS3,
 			},
-			req.OperationCloudId,
-			req.OperationFolderId,
 		)
 	default:
 		return "", errors.NewInvalidArgumentError("unknown src %s", src)
@@ -171,12 +149,8 @@ func (s *service) DeleteImage(
 		"images.DeleteImage",
 		"",
 		&protos.DeleteImageRequest{
-			ImageId:           req.ImageId,
-			OperationCloudId:  req.OperationCloudId,
-			OperationFolderId: req.OperationFolderId,
+			ImageId: req.ImageId,
 		},
-		req.OperationCloudId,
-		req.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/placementgroup/service.go
+++ b/cloud/disk_manager/internal/pkg/services/placementgroup/service.go
@@ -82,8 +82,6 @@ func (s *service) CreatePlacementGroup(
 			PlacementStrategy:       placementStrategy,
 			PlacementPartitionCount: req.PlacementPartitionCount,
 		},
-		"",
-		"",
 	)
 }
 
@@ -109,8 +107,6 @@ func (s *service) DeletePlacementGroup(
 			ZoneId:  req.GroupId.ZoneId,
 			GroupId: req.GroupId.GroupId,
 		},
-		"",
-		"",
 	)
 }
 
@@ -139,8 +135,6 @@ func (s *service) AlterPlacementGroupMembership(
 			DisksToAdd:              req.DisksToAdd,
 			DisksToRemove:           req.DisksToRemove,
 		},
-		"",
-		"",
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/pools/create_base_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/create_base_disk_task.go
@@ -104,8 +104,6 @@ func (t *createBaseDiskTask) Run(
 						SrcDiskCheckpointId:     t.request.SrcDiskCheckpointId,
 						DstDisk:                 t.request.BaseDisk,
 					},
-					t.cloudID,
-					t.folderID,
 				)
 				if err != nil {
 					return err
@@ -133,8 +131,6 @@ func (t *createBaseDiskTask) Run(
 							SrcSnapshotId: t.request.SrcImageId,
 							DstDisk:       t.request.BaseDisk,
 						},
-						t.cloudID,
-						t.folderID,
 					)
 				} else {
 					taskID, err = t.scheduler.ScheduleZonalTask(
@@ -149,8 +145,6 @@ func (t *createBaseDiskTask) Run(
 							SrcSnapshotId: t.request.SrcImageId,
 							DstDisk:       t.request.BaseDisk,
 						},
-						t.cloudID,
-						t.folderID,
 					)
 				}
 				if err != nil {

--- a/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task.go
@@ -101,8 +101,6 @@ func (t *optimizeBaseDisksTask) Run(
 			"pools.ConfigurePool",
 			"",
 			request,
-			"",
-			"",
 		)
 		if err != nil {
 			return err
@@ -138,8 +136,6 @@ func (t *optimizeBaseDisksTask) Run(
 				ImageId:          request.GetImageId(),
 				UseBaseDiskAsSrc: true,
 			},
-			"",
-			"",
 		)
 		if err != nil {
 			return err

--- a/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task_test.go
@@ -85,8 +85,6 @@ func TestOptimizeBaseDisksTask(t *testing.T) {
 			Capacity:     100,
 			UseImageSize: true,
 		},
-		"",
-		"",
 	).Return("task2", nil)
 
 	scheduler.On(
@@ -100,8 +98,6 @@ func TestOptimizeBaseDisksTask(t *testing.T) {
 			Capacity:     100,
 			UseImageSize: false,
 		},
-		"",
-		"",
 	).Return("task4", nil)
 
 	scheduler.On("WaitTask", mock.Anything, execCtx, "task2").Return(nil, nil)
@@ -118,8 +114,6 @@ func TestOptimizeBaseDisksTask(t *testing.T) {
 			ZoneId:           "zone2",
 			UseBaseDiskAsSrc: true,
 		},
-		"",
-		"",
 	).Return("task2_1", nil)
 
 	scheduler.On(
@@ -132,8 +126,6 @@ func TestOptimizeBaseDisksTask(t *testing.T) {
 			ZoneId:           "zone4",
 			UseBaseDiskAsSrc: true,
 		},
-		"",
-		"",
 	).Return("task4_1", nil)
 
 	scheduler.On("WaitTask", mock.Anything, execCtx, "task2_1").Return(nil, nil)

--- a/cloud/disk_manager/internal/pkg/services/pools/retire_base_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/retire_base_disk_task.go
@@ -78,8 +78,6 @@ func (t *retireBaseDiskTask) Run(
 				TargetBaseDiskId: info.TargetBaseDiskID,
 				SlotGeneration:   info.SlotGeneration,
 			},
-			"",
-			"",
 		)
 		if err != nil {
 			return err

--- a/cloud/disk_manager/internal/pkg/services/pools/retire_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/retire_base_disks_task.go
@@ -117,8 +117,6 @@ func (t *retireBaseDisksTask) Run(
 				BaseDiskId: baseDiskID,
 				SrcDisk:    srcDisk,
 			},
-			"",
-			"",
 		)
 		if err != nil {
 			return err

--- a/cloud/disk_manager/internal/pkg/services/pools/schedule_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/schedule_base_disks_task.go
@@ -57,8 +57,6 @@ func (t *scheduleBaseDisksTask) Run(
 				BaseDiskSize:                        baseDisks[i].Size,
 				UseDataplaneTasksForLegacySnapshots: true, // TODO: remove it.
 			},
-			"",
-			"",
 		)
 		if err != nil {
 			return err

--- a/cloud/disk_manager/internal/pkg/services/pools/service.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/service.go
@@ -32,14 +32,7 @@ func (s *service) AcquireBaseDisk(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.AcquireBaseDisk",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.AcquireBaseDisk", "", req)
 }
 
 func (s *service) ReleaseBaseDisk(
@@ -56,14 +49,7 @@ func (s *service) ReleaseBaseDisk(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.ReleaseBaseDisk",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.ReleaseBaseDisk", "", req)
 }
 
 func (s *service) RebaseOverlayDisk(
@@ -81,14 +67,7 @@ func (s *service) RebaseOverlayDisk(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.RebaseOverlayDisk",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.RebaseOverlayDisk", "", req)
 }
 
 func (s *service) ConfigurePool(
@@ -105,14 +84,7 @@ func (s *service) ConfigurePool(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.ConfigurePool",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.ConfigurePool", "", req)
 }
 
 func (s *service) DeletePool(
@@ -127,14 +99,7 @@ func (s *service) DeletePool(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.DeletePool",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.DeletePool", "", req)
 }
 
 func (s *service) ImageDeleting(
@@ -149,14 +114,7 @@ func (s *service) ImageDeleting(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.ImageDeleting",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.ImageDeleting", "", req)
 }
 
 func (s *service) IsPoolConfigured(
@@ -180,14 +138,7 @@ func (s *service) RetireBaseDisk(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.RetireBaseDisk",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.RetireBaseDisk", "", req)
 }
 
 func (s *service) RetireBaseDisks(
@@ -202,14 +153,7 @@ func (s *service) RetireBaseDisks(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
-		ctx,
-		"pools.RetireBaseDisks",
-		"",
-		req,
-		"",
-		"",
-	)
+	return s.taskScheduler.ScheduleTask(ctx, "pools.RetireBaseDisks", "", req)
 }
 
 func (s *service) OptimizeBaseDisks(ctx context.Context) (string, error) {
@@ -218,8 +162,6 @@ func (s *service) OptimizeBaseDisks(ctx context.Context) (string, error) {
 		"pools.OptimizeBaseDisks",
 		"",
 		&empty.Empty{},
-		"",
-		"",
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -157,8 +157,6 @@ func (t *createSnapshotFromDiskTask) run(
 			UseS3:                   t.request.UseS3,
 			UseProxyOverlayDisk:     t.request.UseProxyOverlayDisk,
 		},
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 	if err != nil {
 		return nil, err
@@ -330,8 +328,6 @@ func (t *createSnapshotFromDiskTask) Cancel(
 		&dataplane_protos.DeleteSnapshotRequest{
 			SnapshotId: t.request.DstSnapshotId,
 		},
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 	if err != nil {
 		return err

--- a/cloud/disk_manager/internal/pkg/services/snapshots/delete_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/delete_snapshot_task.go
@@ -111,8 +111,6 @@ func (t *deleteSnapshotTask) deleteSnapshot(
 		&dataplane_protos.DeleteSnapshotRequest{
 			SnapshotId: t.request.SnapshotId,
 		},
-		t.request.OperationCloudId,
-		t.request.OperationFolderId,
 	)
 	if err != nil {
 		return err

--- a/cloud/disk_manager/internal/pkg/services/snapshots/protos/create_snapshot_from_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/protos/create_snapshot_from_disk_task.proto
@@ -9,14 +9,11 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message CreateSnapshotFromDiskRequest {
-    reserved 4;
+    reserved 4, 5, 6, 7;
 
     types.Disk SrcDisk = 1;
     string DstSnapshotId = 2;
     string FolderId = 3;
-    string OperationCloudId = 5;
-    string OperationFolderId = 6;
-    bool UseDataplaneTasks = 7;
     bool UseS3 = 8;
     bool UseProxyOverlayDisk = 9;
 }

--- a/cloud/disk_manager/internal/pkg/services/snapshots/protos/delete_snapshot_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/protos/delete_snapshot_task.proto
@@ -7,9 +7,9 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message DeleteSnapshotRequest {
+    reserved 2, 3;
+
     string SnapshotId = 1;
-    string OperationCloudId = 2;
-    string OperationFolderId = 3;
 }
 
 message DeleteSnapshotTaskState {}

--- a/cloud/disk_manager/internal/pkg/services/snapshots/service.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/service.go
@@ -51,14 +51,9 @@ func (s *service) CreateSnapshot(
 			},
 			DstSnapshotId:       req.SnapshotId,
 			FolderId:            req.FolderId,
-			OperationCloudId:    req.OperationCloudId,
-			OperationFolderId:   req.OperationFolderId,
-			UseDataplaneTasks:   true, // TODO: remove it.
 			UseS3:               useS3,
 			UseProxyOverlayDisk: s.config.GetUseProxyOverlayDisk(),
 		},
-		req.OperationCloudId,
-		req.OperationFolderId,
 	)
 }
 
@@ -79,12 +74,8 @@ func (s *service) DeleteSnapshot(
 		"snapshots.DeleteSnapshot",
 		"",
 		&protos.DeleteSnapshotRequest{
-			SnapshotId:        req.SnapshotId,
-			OperationCloudId:  req.OperationCloudId,
-			OperationFolderId: req.OperationFolderId,
+			SnapshotId: req.SnapshotId,
 		},
-		req.OperationCloudId,
-		req.OperationFolderId,
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/util/json.go
+++ b/cloud/disk_manager/internal/pkg/util/json.go
@@ -208,8 +208,6 @@ func TaskStateToJSON(state *storage.TaskState) *TaskStateJSON {
 		LastHost:            state.LastHost,
 		LastRunner:          state.LastRunner,
 		ZoneID:              state.ZoneID,
-		CloudID:             state.CloudID,
-		FolderID:            state.FolderID,
 		EstimatedTime:       state.EstimatedTime,
 		PanicCount:          state.PanicCount,
 	}

--- a/cloud/tasks/acceptance_tests/recipe/tasks/chain_task.go
+++ b/cloud/tasks/acceptance_tests/recipe/tasks/chain_task.go
@@ -80,8 +80,6 @@ func (t *ChainTask) scheduleChild(
 		&protos.ChainTaskRequest{
 			Depth: t.request.Depth - 1,
 		},
-		"",
-		"",
 	)
 }
 

--- a/cloud/tasks/acceptance_tests/tasks_acceptance_test.go
+++ b/cloud/tasks/acceptance_tests/tasks_acceptance_test.go
@@ -144,8 +144,6 @@ func (c *client) scheduleChain(
 			&protos.ChainTaskRequest{
 				Depth: uint32(depth),
 			},
-			"",
-			"",
 		)
 		return err
 	})
@@ -275,8 +273,6 @@ func TestTasksAcceptanceHandlePanic(t *testing.T) {
 			"PanicTask",
 			"",
 			&empty.Empty{},
-			"",
-			"",
 		)
 		return err
 	})

--- a/cloud/tasks/mocks/scheduler_mock.go
+++ b/cloud/tasks/mocks/scheduler_mock.go
@@ -21,18 +21,9 @@ func (s *SchedulerMock) ScheduleTask(
 	taskType string,
 	description string,
 	request proto.Message,
-	cloudID string,
-	folderID string,
 ) (string, error) {
 
-	args := s.Called(
-		ctx,
-		taskType,
-		description,
-		request,
-		cloudID,
-		folderID,
-	)
+	args := s.Called(ctx, taskType, description, request)
 	return args.String(0), args.Error(1)
 }
 
@@ -42,19 +33,9 @@ func (s *SchedulerMock) ScheduleZonalTask(
 	description string,
 	zoneID string,
 	request proto.Message,
-	cloudID string,
-	folderID string,
 ) (string, error) {
 
-	args := s.Called(
-		ctx,
-		taskType,
-		description,
-		zoneID,
-		request,
-		cloudID,
-		folderID,
-	)
+	args := s.Called(ctx, taskType, description, zoneID, request)
 	return args.String(0), args.Error(1)
 }
 

--- a/cloud/tasks/scheduler.go
+++ b/cloud/tasks/scheduler.go
@@ -32,8 +32,6 @@ type Scheduler interface {
 		taskType string,
 		description string,
 		request proto.Message,
-		cloudID string,
-		folderID string,
 	) (string, error)
 
 	// Requires "idempotency-key" header in ctx metadata.
@@ -45,8 +43,6 @@ type Scheduler interface {
 		description string,
 		zoneID string,
 		request proto.Message,
-		cloudID string,
-		folderID string,
 	) (string, error)
 
 	ScheduleRegularTasks(

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -42,8 +42,6 @@ func (s *scheduler) ScheduleTask(
 	taskType string,
 	description string,
 	request proto.Message,
-	cloudID string,
-	folderID string,
 ) (string, error) {
 
 	ctx = withComponentLoggingField(ctx)
@@ -51,10 +49,8 @@ func (s *scheduler) ScheduleTask(
 		ctx,
 		taskType,
 		description,
-		"",
+		"", // zoneID
 		request,
-		cloudID,
-		folderID,
 	)
 }
 
@@ -64,8 +60,6 @@ func (s *scheduler) ScheduleZonalTask(
 	description string,
 	zoneID string,
 	request proto.Message,
-	cloudID string,
-	folderID string,
 ) (string, error) {
 
 	ctx = withComponentLoggingField(ctx)
@@ -103,8 +97,6 @@ func (s *scheduler) ScheduleZonalTask(
 		Metadata:       metadata,
 		Dependencies:   tasks_storage.NewStringSet(),
 		ZoneID:         zoneID,
-		CloudID:        cloudID,
-		FolderID:       folderID,
 	})
 	if err != nil {
 		logging.Warn(ctx, "failed to persist task %v: %v", taskType, err)
@@ -527,7 +519,7 @@ func (s *scheduler) WaitTaskSync(
 }
 
 func (s *scheduler) ScheduleBlankTask(ctx context.Context) (string, error) {
-	return s.ScheduleTask(ctx, "tasks.Blank", "", &empty.Empty{}, "", "")
+	return s.ScheduleTask(ctx, "tasks.Blank", "", &empty.Empty{})
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/tasks/scheduler_test.go
+++ b/cloud/tasks/scheduler_test.go
@@ -148,8 +148,6 @@ func TestSchedulerScheduleTask(t *testing.T) {
 		ok = assert.Equal(t, "", state.ErrorMessage) && ok
 		ok = assert.Equal(t, marshalledRequest, state.Request) && ok
 		ok = assert.Equal(t, "", state.ZoneID) && ok
-		ok = assert.Equal(t, "cloud", state.CloudID) && ok
-		ok = assert.Equal(t, "folder", state.FolderID) && ok
 		return ok
 	})).Return("taskID", nil)
 
@@ -158,8 +156,6 @@ func TestSchedulerScheduleTask(t *testing.T) {
 		"task",
 		"Some task",
 		request,
-		"cloud",
-		"folder",
 	)
 	mock.AssertExpectationsForObjects(t, task, storage)
 	assert.NoError(t, err)
@@ -202,8 +198,6 @@ func TestSchedulerScheduleZonalTask(t *testing.T) {
 		ok = assert.Equal(t, "", state.ErrorMessage) && ok
 		ok = assert.Equal(t, marshalledRequest, state.Request) && ok
 		ok = assert.Equal(t, "zone", state.ZoneID) && ok
-		ok = assert.Equal(t, "cloud", state.CloudID) && ok
-		ok = assert.Equal(t, "folder", state.FolderID) && ok
 		return ok
 	})).Return("taskID", nil)
 
@@ -213,8 +207,6 @@ func TestSchedulerScheduleZonalTask(t *testing.T) {
 		"Some task",
 		"zone",
 		request,
-		"cloud",
-		"folder",
 	)
 	mock.AssertExpectationsForObjects(t, task, storage)
 	assert.NoError(t, err)
@@ -247,8 +239,6 @@ func TestSchedulerScheduleTaskFailOnCreateTask(t *testing.T) {
 		"task",
 		"Some task",
 		&empty.Empty{},
-		"",
-		"",
 	)
 	mock.AssertExpectationsForObjects(t, task, storage)
 	assert.Error(t, err)

--- a/cloud/tasks/storage/common.go
+++ b/cloud/tasks/storage/common.go
@@ -164,8 +164,6 @@ func (s *TaskState) structValue() persistence.Value {
 		persistence.StructFieldValue("last_host", persistence.UTF8Value(s.LastHost)),
 		persistence.StructFieldValue("last_runner", persistence.UTF8Value(s.LastRunner)),
 		persistence.StructFieldValue("zone_id", persistence.UTF8Value(s.ZoneID)),
-		persistence.StructFieldValue("cloud_id", persistence.UTF8Value(s.CloudID)),
-		persistence.StructFieldValue("folder_id", persistence.UTF8Value(s.FolderID)),
 		persistence.StructFieldValue("estimated_time", persistence.TimestampValue(s.EstimatedTime)),
 		persistence.StructFieldValue("dependants", persistence.BytesValue(common.MarshalStrings(s.dependants.List()))),
 		persistence.StructFieldValue("panic_count", persistence.Uint64Value(s.PanicCount)),
@@ -200,8 +198,6 @@ func taskStateStructTypeString() string {
 		last_host: Utf8,
 		last_runner: Utf8,
 		zone_id: Utf8,
-		cloud_id: Utf8,
-		folder_id: Utf8,
 		estimated_time: Timestamp,
 		dependants: String,
 		panic_count: Uint64>`
@@ -234,8 +230,8 @@ func taskStateTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("last_host", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("last_runner", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("zone_id", persistence.Optional(persistence.TypeUTF8)),
-		persistence.WithColumn("cloud_id", persistence.Optional(persistence.TypeUTF8)),
-		persistence.WithColumn("folder_id", persistence.Optional(persistence.TypeUTF8)),
+		persistence.WithColumn("cloud_id", persistence.Optional(persistence.TypeUTF8)),  // deprecated
+		persistence.WithColumn("folder_id", persistence.Optional(persistence.TypeUTF8)), // deprecated
 		persistence.WithColumn("estimated_time", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("dependants", persistence.Optional(persistence.TypeBytes)),
 		persistence.WithColumn("panic_count", persistence.Optional(persistence.TypeUint64)),
@@ -354,8 +350,6 @@ func (s *storageYDB) scanTaskState(res persistence.Result) (state TaskState, err
 		persistence.OptionalWithDefault("last_host", &state.LastHost),
 		persistence.OptionalWithDefault("last_runner", &state.LastRunner),
 		persistence.OptionalWithDefault("zone_id", &state.ZoneID),
-		persistence.OptionalWithDefault("cloud_id", &state.CloudID),
-		persistence.OptionalWithDefault("folder_id", &state.FolderID),
 		persistence.OptionalWithDefault("estimated_time", &state.EstimatedTime),
 		persistence.OptionalWithDefault("dependants", &dependants),
 		persistence.OptionalWithDefault("panic_count", &state.PanicCount),

--- a/cloud/tasks/storage/storage.go
+++ b/cloud/tasks/storage/storage.go
@@ -209,8 +209,6 @@ type TaskState struct {
 	LastHost            string
 	LastRunner          string
 	ZoneID              string
-	CloudID             string
-	FolderID            string
 	EstimatedTime       time.Time
 	PanicCount          uint64
 	Events              []int64

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -342,8 +342,6 @@ func TestStorageYDBGetTask(t *testing.T) {
 		State:          []byte{1, 2, 3},
 		Dependencies:   NewStringSet(),
 		ZoneID:         "zone",
-		CloudID:        "cloud",
-		FolderID:       "folder",
 	})
 	require.NoError(t, err)
 
@@ -361,8 +359,6 @@ func TestStorageYDBGetTask(t *testing.T) {
 	require.EqualValues(t, NewStringSet(), taskState.Dependencies)
 	require.WithinDuration(t, time.Time(createdAt), time.Time(taskState.ChangedStateAt), time.Microsecond)
 	require.EqualValues(t, "zone", taskState.ZoneID)
-	require.EqualValues(t, "cloud", taskState.CloudID)
-	require.EqualValues(t, "folder", taskState.FolderID)
 	metricsRegistry.AssertAllExpectations(t)
 }
 

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -256,7 +256,7 @@ func scheduleDoublerTask(
 
 	return scheduler.ScheduleTask(ctx, "doubler", "Doubler task", &wrappers.UInt64Value{
 		Value: request,
-	}, "", "")
+	})
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -308,7 +308,7 @@ func scheduleLongTask(
 	scheduler tasks.Scheduler,
 ) (string, error) {
 
-	return scheduler.ScheduleTask(ctx, "long", "Long task", &empty.Empty{}, "", "")
+	return scheduler.ScheduleTask(ctx, "long", "Long task", &empty.Empty{})
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -386,8 +386,6 @@ func scheduleUnstableTask(
 		&wrappers.UInt64Value{
 			Value: failuresUntilSuccess,
 		},
-		"",
-		"",
 	)
 }
 
@@ -440,8 +438,6 @@ func scheduleFailureTask(
 		"failure",
 		"Failure task",
 		&empty.Empty{},
-		"",
-		"",
 	)
 }
 
@@ -525,7 +521,7 @@ func scheduleSixTimesTask(
 
 	return scheduler.ScheduleTask(ctx, "sixTimes", "SixTimes task", &wrappers.UInt64Value{
 		Value: request,
-	}, "", "")
+	})
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* OperationCloudId, OperationFolderId are legacy params that were used for rate limiting with legacy Snapshot Service, also these params were never used properly and they are **unused** for a long time (since legacy Snapshot Service is deleted)
* It is better to pass such params via headers/metadata instead of adding them to ScheduleTask as arguments
* There should be external limits on running operation count and it is better to consider our system to be agnostic in respect to cloud/folder. Consider autoscaling on demand instead