### PR TITLE
[Disk Manager] fix disk not found error handling in rebase_overlay_disk task

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go
@@ -74,7 +74,7 @@ func (t *rebaseOverlayDiskTask) rebaseOverlayDisk(
 	if err != nil {
 		if nbs.IsDiskNotFoundError(err) {
 			// Disk might not be created yet.
-			// Restart task to avoid this race (NBS-3761).
+			// Restart task to avoid this race (issue #1577).
 			return errors.NewInterruptExecutionError()
 		}
 

--- a/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go
@@ -61,12 +61,6 @@ func (t *rebaseOverlayDiskTask) rebaseOverlayDisk(
 		SlotGeneration:   t.request.SlotGeneration,
 	})
 	if err != nil {
-		if nbs.IsDiskNotFoundError(err) {
-			// Disk might not be created yet.
-			// Restart task to avoid this race (NBS-3761).
-			return errors.NewInterruptExecutionError()
-		}
-
 		return err
 	}
 
@@ -78,6 +72,12 @@ func (t *rebaseOverlayDiskTask) rebaseOverlayDisk(
 		t.request.TargetBaseDiskId,
 	)
 	if err != nil {
+		if nbs.IsDiskNotFoundError(err) {
+			// Disk might not be created yet.
+			// Restart task to avoid this race (NBS-3761).
+			return errors.NewInterruptExecutionError()
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
#1577

Seems that we've already tried to fix this race earlier by [returning](https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go#L67) NewInterruptExecutionError in case of "disk not found" error. But this was used in the wrong place.

It does not make sense for error returned by [storage.OverlayDiskRebasing](https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go#L57). Indeed, [IsDiskNotFoundError](https://github.com/ydb-platform/nbs/blob/86d5c631e861bef09377512cd76f46655f61e6d7/cloud/disk_manager/internal/pkg/clients/nbs/client.go#L358) looks for errors from nbs client, not from storage.

We should handle error from [client.Rebase](https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/services/pools/rebase_overlay_disk_task.go#L73) instead. Indeed, in practice the error is returned by DescribeVolume call inside client.Rebase.