### PR TITLE
issue-1350: GetNodeAttrBatch implementation in TListNodesActor

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -301,4 +301,8 @@ message TStorageConfig
 
     // Allow to destroy filestore with active sessions
     optional bool AllowFileStoreForceDestroy = 357;
+
+    // Enables usage of GetNodeAttrBatch requests instead of GetNodeAttr when
+    // appropriate.
+    optional bool GetNodeAttrBatchEnabled = 358;
 }

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -18,6 +18,7 @@ namespace NCloud::NFileStore{
     xxx(CreateSessionError)                                                    \
     xxx(DescribeFileStoreError)                                                \
     xxx(NodeNotFoundInFollower)                                                \
+    xxx(NotEnoughResultsInGetNodeAttrBatchResponses)                           \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \
@@ -31,6 +32,7 @@ namespace NCloud::NFileStore{
     xxx(FailedToCreateHandle)                                                  \
     xxx(ChildRefIsNull)                                                        \
     xxx(NewChildNodeIsNull)                                                    \
+    xxx(IndexOutOfBounds)                                                      \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -163,6 +163,7 @@ namespace {
         TDuration::Seconds(10)                                                )\
     xxx(PreferredBlockSizeMultiplier,                   ui32,      1          )\
     xxx(MultiTabletForwardingEnabled,                   bool,      false      )\
+    xxx(GetNodeAttrBatchEnabled,                        bool,      false      )\
     xxx(AllowFileStoreForceDestroy,                     bool,      false      )\
 // FILESTORE_STORAGE_CONFIG
 

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -207,6 +207,7 @@ public:
     bool GetNewLocalDBCompactionPolicyEnabled() const;
 
     bool GetMultiTabletForwardingEnabled() const;
+    bool GetGetNodeAttrBatchEnabled() const;
 
     NProto::EBlobIndexOpsPriority GetBlobIndexOpsPriority() const;
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -155,6 +155,7 @@ void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
             }
 
             batch.Record.AddNames(node.GetFollowerNodeName());
+            batch.NodeIndices.push_back(i);
         } else {
             ++GetNodeAttrResponses;
         }
@@ -297,7 +298,7 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
             LOG_WARN(
                 ctx,
                 TFileStoreComponents::SERVICE,
-                "Failed to GetNodeAttr from follower: %s, %s",
+                "Failed to GetNodeAttrBatch from follower: %s, %s",
                 followerId.c_str(),
                 FormatError(msg->GetError()).Quote().c_str());
 
@@ -343,6 +344,7 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
                 << FormatError(responseIter->GetError()).Quote();
             ReportNodeNotFoundInFollower(message);
             LOG_ERROR(ctx, TFileStoreComponents::SERVICE, message);
+            ++responseIter;
             continue;
         }
 
@@ -354,6 +356,7 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
                 Response.GetNames(i).Quote().c_str(),
                 followerId.c_str(),
                 FormatError(responseIter->GetError()).Quote().c_str());
+            ++responseIter;
             continue;
         }
 
@@ -364,7 +367,6 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
     }
 
     GetNodeAttrResponses += nodeIndices.size();
-
     if (GetNodeAttrResponses == Response.NodesSize()) {
         ReplyAndDie(ctx);
         return;

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -1,8 +1,11 @@
 #include "service_actor.h"
 
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 #include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <util/string/join.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
@@ -30,11 +33,15 @@ private:
     NProto::TListNodesResponse Response;
     ui32 GetNodeAttrResponses = 0;
 
+    TVector<TVector<ui32>> Cookie2NodeIndices;
+    TVector<TString> Cookie2FollowerId;
+
     // Stats for reporting
     IRequestStatsPtr RequestStats;
     IProfileLogPtr ProfileLog;
 
     const bool MultiTabletForwardingEnabled;
+    const bool GetNodeAttrBatchEnabled;
 
 public:
     TListNodesActor(
@@ -43,7 +50,8 @@ public:
         TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
-        bool multiTabletForwardingEnabled);
+        bool multiTabletForwardingEnabled,
+        bool getNodeAttrBatchEnabled);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -54,6 +62,12 @@ private:
 
     void HandleListNodesResponse(
         const TEvService::TEvListNodesResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void GetNodeAttrsBatch(const TActorContext& ctx);
+
+    void HandleGetNodeAttrBatchResponse(
+        const TEvIndexTablet::TEvGetNodeAttrBatchResponse::TPtr& ev,
         const TActorContext& ctx);
 
     void GetNodeAttrs(const TActorContext& ctx);
@@ -78,13 +92,15 @@ TListNodesActor::TListNodesActor(
         TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
-        bool multiTabletForwardingEnabled)
+        bool multiTabletForwardingEnabled,
+        bool getNodeAttrBatchEnabled)
     : RequestInfo(std::move(requestInfo))
     , ListNodesRequest(std::move(listNodesRequest))
     , LogTag(std::move(logTag))
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
     , MultiTabletForwardingEnabled(multiTabletForwardingEnabled)
+    , GetNodeAttrBatchEnabled(getNodeAttrBatchEnabled)
 {
 }
 
@@ -110,7 +126,9 @@ void TListNodesActor::ListNodes(const TActorContext& ctx)
     ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
 }
 
-void TListNodesActor::GetNodeAttrs(const TActorContext& ctx)
+////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
 {
     if (!MultiTabletForwardingEnabled) {
         GetNodeAttrResponses = Response.NodesSize();
@@ -118,7 +136,66 @@ void TListNodesActor::GetNodeAttrs(const TActorContext& ctx)
     }
 
     // TODO(#1350): register inflight requests for these GetNodeAttr requests
-    // TODO(#1350): batch GetNodeAttr requests by FollowerFileSystemId
+
+    struct TBatch
+    {
+        NProtoPrivate::TGetNodeAttrBatchRequest Record;
+        TVector<ui32> NodeIndices;
+    };
+    THashMap<TString, TBatch> batches;
+
+    for (ui32 i = 0; i < Response.NodesSize(); ++i) {
+        const auto& node = Response.GetNodes(i);
+        if (node.GetFollowerFileSystemId()) {
+            auto& batch = batches[node.GetFollowerFileSystemId()];
+            if (batch.Record.GetHeaders().GetSessionId().Empty()) {
+                batch.Record.MutableHeaders()->CopyFrom(ListNodesRequest.GetHeaders());
+                batch.Record.SetFileSystemId(node.GetFollowerFileSystemId());
+                batch.Record.SetNodeId(RootNodeId);
+            }
+
+            batch.Record.AddNames(node.GetFollowerNodeName());
+        } else {
+            ++GetNodeAttrResponses;
+        }
+    }
+
+    ui64 cookie = 0;
+    Cookie2NodeIndices.resize(batches.size());
+    Cookie2FollowerId.resize(batches.size());
+    for (auto& [_, batch]: batches) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "[%s] Executing GetNodeAttrBatch in follower for %s, %s",
+            LogTag.c_str(),
+            batch.Record.GetFileSystemId().c_str(),
+            JoinSeq(", ", batch.Record.GetNames()).c_str());
+
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvGetNodeAttrBatchRequest>();
+        request->Record = std::move(batch.Record);
+
+        Cookie2NodeIndices[cookie] = std::move(batch.NodeIndices);
+        Cookie2FollowerId[cookie] = request->Record.GetFileSystemId();
+
+        // forward request through tablet proxy
+        ctx.Send(
+            MakeIndexTabletProxyServiceId(),
+            request.release(),
+            0, // flags
+            cookie);
+
+        ++cookie;
+    }
+}
+
+void TListNodesActor::GetNodeAttrs(const TActorContext& ctx)
+{
+    if (!MultiTabletForwardingEnabled) {
+        GetNodeAttrResponses = Response.NodesSize();
+        return;
+    }
 
     for (ui64 cookie = 0; cookie < Response.NodesSize(); ++cookie) {
         const auto& node = Response.GetNodes(cookie);
@@ -165,7 +242,11 @@ void TListNodesActor::HandleListNodesResponse(
     }
 
     Response = std::move(msg->Record);
-    GetNodeAttrs(ctx);
+    if (GetNodeAttrBatchEnabled) {
+        GetNodeAttrsBatch(ctx);
+    } else {
+        GetNodeAttrs(ctx);
+    }
 
     if (GetNodeAttrResponses == Response.NodesSize()) {
         LOG_DEBUG(
@@ -180,6 +261,115 @@ void TListNodesActor::HandleListNodesResponse(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::HandleGetNodeAttrBatchResponse(
+    const TEvIndexTablet::TEvGetNodeAttrBatchResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    TABLET_VERIFY(ev->Cookie < Cookie2NodeIndices.size());
+    const auto& nodeIndices = Cookie2NodeIndices[ev->Cookie];
+    TABLET_VERIFY(ev->Cookie < Cookie2FollowerId.size());
+    const auto& followerId = Cookie2FollowerId[ev->Cookie];
+
+    const auto noent = MAKE_FILESTORE_ERROR(NProto::E_FS_NOENT);
+    if (HasError(msg->GetError())) {
+        if (msg->GetError().GetCode() == noent) {
+            ReportNodeNotFoundInFollower();
+
+            TStringBuilder names;
+            for (auto i: nodeIndices) {
+                if (names) {
+                    names << ", ";
+                }
+                names << Response.GetNames(i).Quote();
+            }
+
+            LOG_ERROR(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "Nodes not found in follower: %s, %s, %s",
+                followerId.c_str(),
+                FormatError(msg->GetError()).Quote().c_str(),
+                names.c_str());
+        } else {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "Failed to GetNodeAttr from follower: %s, %s",
+                followerId.c_str(),
+                FormatError(msg->GetError()).Quote().c_str());
+
+            HandleError(ctx, *msg->Record.MutableError());
+            return;
+        }
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "GetNodeAttrBatchResponse from follower: %s",
+        msg->Record.DebugString().Quote().c_str());
+
+    auto& responses = *msg->Record.MutableResponses();
+    auto responseIter = responses.begin();
+    for (const auto i: nodeIndices) {
+        if (i >= Response.NodesSize()) {
+            const auto message = TStringBuilder() << "NodeIndex " << i
+                << " >= " << Response.NodesSize() << ", FollowerId: "
+                << followerId;
+            ReportIndexOutOfBounds(message);
+            LOG_ERROR(ctx, TFileStoreComponents::SERVICE, message);
+            continue;
+        }
+
+        if (responseIter == responses.end()) {
+            const auto message = TStringBuilder() << "NodeIndex " << i
+                << " >= " << responses.size() << ", FollowerId: " << followerId;
+            ReportNotEnoughResultsInGetNodeAttrBatchResponses(message);
+            LOG_ERROR(ctx, TFileStoreComponents::SERVICE, message);
+            continue;
+        }
+
+        if (responseIter->GetError().GetCode() == noent) {
+            // TODO(#1350): mb this shouldn't be a critical event - list ->
+            // unlink -> get attr race may lead to such cases
+            // nodes and names for which getnodeattr returns an error should be
+            // removed from the response
+            const auto message = TStringBuilder() << "Node not found in follower: "
+                << Response.GetNames(i).Quote() << ", FollowerId: "
+                << followerId << ", Error: "
+                << FormatError(responseIter->GetError()).Quote();
+            ReportNodeNotFoundInFollower(message);
+            LOG_ERROR(ctx, TFileStoreComponents::SERVICE, message);
+            continue;
+        }
+
+        if (HasError(responseIter->GetError())) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "Failed to GetNodeAttr from follower: %s, %s, %s",
+                Response.GetNames(i).Quote().c_str(),
+                followerId.c_str(),
+                FormatError(responseIter->GetError()).Quote().c_str());
+            continue;
+        }
+
+        auto* node = Response.MutableNodes(i);
+        *node = std::move(*responseIter->MutableNode());
+
+        ++responseIter;
+    }
+
+    GetNodeAttrResponses += nodeIndices.size();
+
+    if (GetNodeAttrResponses == Response.NodesSize()) {
+        ReplyAndDie(ctx);
+        return;
+    }
+}
 
 void TListNodesActor::HandleGetNodeAttrResponse(
     const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
@@ -271,6 +461,9 @@ STFUNC(TListNodesActor::StateWork)
         HFunc(
             TEvService::TEvGetNodeAttrResponse,
             HandleGetNodeAttrResponse);
+        HFunc(
+            TEvIndexTablet::TEvGetNodeAttrBatchResponse,
+            HandleGetNodeAttrBatchResponse);
 
         default:
             HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
@@ -318,7 +511,8 @@ void TStorageServiceActor::HandleListNodes(
         msg->Record.GetFileSystemId(),
         session->RequestStats,
         ProfileLog,
-        multiTabletForwardingEnabled);
+        multiTabletForwardingEnabled,
+        StorageConfig->GetGetNodeAttrBatchEnabled());
 
     NCloud::Register(ctx, std::move(actor));
 }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3473,6 +3473,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             listNodesResponse.NamesSize());
         const ui32 idxToUnlink = 13;
         const auto shard1NodeName = listNodesResponse.GetNames(idxToUnlink);
+        const ui64 unlinkedId = listNodesResponse.GetNodes(idxToUnlink).GetId();
 
         listNodesResponse = service.ListNodes(
             headers,
@@ -3498,7 +3499,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         for (ui32 i = 0; i < names.size(); ++i) {
             UNIT_ASSERT_VALUES_EQUAL(names[i], listNodesResponse.GetNames(i));
             UNIT_ASSERT_VALUES_EQUAL(
-                i == idxToUnlink ? InvalidNodeId : ids[i],
+                ids[i] == unlinkedId ? InvalidNodeId : ids[i],
                 listNodesResponse.GetNodes(i).GetId());
         }
     }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3342,10 +3342,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             FormatError(response->GetError()));
     }
 
-    Y_UNIT_TEST(ShouldNotFailListNodesUponGetAttrENOENT)
+    void DoTestShouldNotFailListNodesUponGetAttrENOENT(
+        NProto::TStorageConfig config)
     {
-        NProto::TStorageConfig config;
-        config.SetMultiTabletForwardingEnabled(true);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 
@@ -3410,6 +3409,21 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         const auto counter =
             counters->GetCounter("AppCriticalEvents/NodeNotFoundInFollower");
         UNIT_ASSERT_EQUAL(1, counter->GetAtomic());
+    }
+
+    Y_UNIT_TEST(ShouldNotFailListNodesUponGetAttrENOENT)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        DoTestShouldNotFailListNodesUponGetAttrENOENT(std::move(config));
+    }
+
+    Y_UNIT_TEST(ShouldNotFailListNodesUponGetAttrENOENTWithGetNodeAttrBatch)
+    {
+        NProto::TStorageConfig config;
+        config.SetMultiTabletForwardingEnabled(true);
+        config.SetGetNodeAttrBatchEnabled(true);
+        DoTestShouldNotFailListNodesUponGetAttrENOENT(std::move(config));
     }
 
     Y_UNIT_TEST(DestroyFileStoreWithActiveSessionShouldFail)


### PR DESCRIPTION
Doing this under a feature flag to keep backwards-compatibility with old filestore-server versions and to be able to compare the performance of the batch and non-batch versions

#1350 