### PR TITLE
Fix channel count overflow

### DIFF
--- a/cloud/blockstore/libs/storage/core/volume_model.h
+++ b/cloud/blockstore/libs/storage/core/volume_model.h
@@ -59,6 +59,14 @@ struct TPartitionsInfo
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TChannelCounts
+{
+    ui32 ExistingChannelCount = 0;
+    int* WantToAdd = nullptr;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 ui64 ComputeBlocksCountPerPartition(
     const ui64 newBlocksCountPerVolume,
     const ui32 blocksPerStripe,
@@ -98,13 +106,10 @@ ui64 ComputeMaxBlocks(
     const NCloud::NProto::EStorageMediaKind mediaKind,
     ui32 currentPartitions);
 
-void FairComputeLimitNumberOfChannels(
+void ComputeChannelCountLimits(
     int freeChannelCount,
-    ui32 haveMerged,
-    int& wantAddMerged,
-    ui32 haveMixed,
-    int& wantAddMixed,
-    ui32 haveFresh,
-    int& wantAddFresh);
+    TChannelCounts merged,
+    TChannelCounts mixed,
+    TChannelCounts fresh);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_model.h
+++ b/cloud/blockstore/libs/storage/core/volume_model.h
@@ -59,14 +59,6 @@ struct TPartitionsInfo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TChannelCounts
-{
-    ui32 ExistingChannelCount = 0;
-    int* WantToAdd = nullptr;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 ui64 ComputeBlocksCountPerPartition(
     const ui64 newBlocksCountPerVolume,
     const ui32 blocksPerStripe,
@@ -108,8 +100,8 @@ ui64 ComputeMaxBlocks(
 
 void ComputeChannelCountLimits(
     int freeChannelCount,
-    TChannelCounts merged,
-    TChannelCounts mixed,
-    TChannelCounts fresh);
+    int* wantToAddMerged,
+    int* wantToAddMixed,
+    int* wantToAddFresh);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_model.h
+++ b/cloud/blockstore/libs/storage/core/volume_model.h
@@ -98,4 +98,13 @@ ui64 ComputeMaxBlocks(
     const NCloud::NProto::EStorageMediaKind mediaKind,
     ui32 currentPartitions);
 
+void FairComputeLimitNumberOfChannels(
+    int freeChannelCount,
+    ui32 haveMerged,
+    int& wantAddMerged,
+    ui32 haveMixed,
+    int& wantAddMixed,
+    ui32 haveFresh,
+    int& wantAddFresh);
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
@@ -1955,19 +1955,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldNotCapWhenEnoughChannels)
     {
-        const ui32 haveMerged = 50;
-        const ui32 haveMixed = 25;
-        const ui32 haveFresh = 25;
-
         int wantAddMerged = 50;
         int wantAddMixed = 35;
         int wantAddFresh = 15;
 
         ComputeChannelCountLimits(
             100,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
 
         UNIT_ASSERT_VALUES_EQUAL(50, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(35, wantAddMixed);
@@ -1976,19 +1972,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldCapAllWhenNoFreeChannels)
     {
-        const ui32 haveMerged = 50;
-        const ui32 haveMixed = 25;
-        const ui32 haveFresh = 25;
-
         int wantAddMerged = 50;
         int wantAddMixed = 35;
         int wantAddFresh = 15;
 
         ComputeChannelCountLimits(
             0,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
 
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
@@ -1997,19 +1989,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldCapLessAffectedChannel)
     {
-        const ui32 haveMerged = 500;
-        const ui32 haveMixed = 25;
-        const ui32 haveFresh = 2;
-
         int wantAddMerged = 10;
         int wantAddMixed = 1;
         int wantAddFresh = 1;
 
         ComputeChannelCountLimits(
             2,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
@@ -2017,19 +2005,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldDoFairCapping)
     {
-        const ui32 haveMerged = 100;
-        const ui32 haveMixed = 10;
-        const ui32 haveFresh = 1;
-
         int wantAddMerged = 10;
         int wantAddMixed = 100;
         int wantAddFresh = 1;
 
         ComputeChannelCountLimits(
             101,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
         UNIT_ASSERT_VALUES_EQUAL(9, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(91, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
@@ -2037,19 +2021,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldGiveMoreToThoseWhoAskForMore)
     {
-        const ui32 haveMerged = 100;
-        const ui32 haveMixed = 100;
-        const ui32 haveFresh = 1;
-
         int wantAddMerged = 20;
         int wantAddMixed = 2;
         int wantAddFresh = 1;
 
         ComputeChannelCountLimits(
             11,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
 
         UNIT_ASSERT_VALUES_EQUAL(9, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddMixed);
@@ -2058,19 +2038,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldGiveAtLeastOneChannel)
     {
-        const ui32 haveMerged = 0;
-        const ui32 haveMixed = 0;
-        const ui32 haveFresh = 0;
-
         int wantAddMerged = 2000;
         int wantAddMixed = 2;
         int wantAddFresh = 1;
 
         ComputeChannelCountLimits(
             5,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
 
         UNIT_ASSERT_VALUES_EQUAL(3, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddMixed);
@@ -2079,19 +2055,15 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
 
     Y_UNIT_TEST(ShouldGiveTheChannelWhereItIsMostNeeded)
     {
-        const ui32 haveMerged = 100;
-        const ui32 haveMixed = 100;
-        const ui32 haveFresh = 0;
-
         int wantAddMerged = 2000;
         int wantAddMixed = 2000;
         int wantAddFresh = 1;
 
         ComputeChannelCountLimits(
             1,
-            {haveMerged, &wantAddMerged},
-            {haveMixed, &wantAddMixed},
-            {haveFresh, &wantAddFresh});
+            &wantAddMerged,
+            &wantAddMixed,
+            &wantAddFresh);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);

--- a/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
@@ -2030,8 +2030,8 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
             {haveMerged, &wantAddMerged},
             {haveMixed, &wantAddMixed},
             {haveFresh, &wantAddFresh});
-        UNIT_ASSERT_VALUES_EQUAL(5, wantAddMerged);
-        UNIT_ASSERT_VALUES_EQUAL(95, wantAddMixed);
+        UNIT_ASSERT_VALUES_EQUAL(9, wantAddMerged);
+        UNIT_ASSERT_VALUES_EQUAL(91, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
     }
 
@@ -2051,8 +2051,8 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
             {haveMixed, &wantAddMixed},
             {haveFresh, &wantAddFresh});
 
-        UNIT_ASSERT_VALUES_EQUAL(10, wantAddMerged);
-        UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
+        UNIT_ASSERT_VALUES_EQUAL(9, wantAddMerged);
+        UNIT_ASSERT_VALUES_EQUAL(1, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
     }
 

--- a/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
@@ -1963,14 +1963,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 35;
         int wantAddFresh = 15;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             100,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
 
         UNIT_ASSERT_VALUES_EQUAL(50, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(35, wantAddMixed);
@@ -1987,14 +1984,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 35;
         int wantAddFresh = 15;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             0,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
 
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
@@ -2011,15 +2005,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 1;
         int wantAddFresh = 1;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             2,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
-
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
@@ -2035,15 +2025,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 100;
         int wantAddFresh = 1;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             101,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
-
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
         UNIT_ASSERT_VALUES_EQUAL(5, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(95, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
@@ -2059,14 +2045,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 2;
         int wantAddFresh = 1;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             11,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
 
         UNIT_ASSERT_VALUES_EQUAL(10, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
@@ -2083,14 +2066,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 2;
         int wantAddFresh = 1;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             5,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
 
         UNIT_ASSERT_VALUES_EQUAL(3, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddMixed);
@@ -2107,15 +2087,11 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         int wantAddMixed = 2000;
         int wantAddFresh = 1;
 
-        FairComputeLimitNumberOfChannels(
+        ComputeChannelCountLimits(
             1,
-            haveMerged,
-            wantAddMerged,
-            haveMixed,
-            wantAddMixed,
-            haveFresh,
-            wantAddFresh);
-
+            {haveMerged, &wantAddMerged},
+            {haveMixed, &wantAddMixed},
+            {haveFresh, &wantAddFresh});
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMerged);
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1634

При изменении размера диска рассчитывается необходимое каналов. Однако не всегда учитывается что общее количество каналов должно быть не больше 255.
В этом ПРе после рассчетов делается подрезка чтобы влезть в это ограничение. Алгоритм такой:
1. считаем сколько всего каналов должно получиться после досоздания 
2. рассчитываем для каждого типа канала его долю в этом общем количестве
3. начинаем отбирать по одному каналу у того типа, доля которого менее всего пострадает, если ему дадут создать меньше каналов чем он запросил.
4. повторяем пункт 3, пока количество каналов, что хотим создать, не совпадет количеством, которые можем создать