### PR TITLE
NBSDUTY-33: fix ShouldFillTimePercentiles

### DIFF
--- a/cloud/blockstore/libs/diagnostics/request_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/request_stats_ut.cpp
@@ -374,13 +374,18 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
 
         requestStats->UpdateStats(true);
 
+        auto us2ms = [](const ui64 us)
+        {
+            return TDuration::MicroSeconds(us).MilliSeconds();
+        };
+
         {
             auto percentiles = totalCounters->GetSubgroup("percentiles", "Time");
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
-            UNIT_ASSERT_VALUES_EQUAL(600063, p100->Val());
-            UNIT_ASSERT_VALUES_EQUAL(200063, p50->Val());
+            UNIT_ASSERT_VALUES_EQUAL(600, us2ms(p100->Val()));
+            UNIT_ASSERT_VALUES_EQUAL(200, us2ms(p50->Val()));
         }
 
         {
@@ -388,8 +393,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
-            UNIT_ASSERT_VALUES_EQUAL(300031, p100->Val());
-            UNIT_ASSERT_VALUES_EQUAL(200063, p50->Val());
+            UNIT_ASSERT_VALUES_EQUAL(300, us2ms(p100->Val()));
+            UNIT_ASSERT_VALUES_EQUAL(200, us2ms(p50->Val()));
         }
 
         {
@@ -397,8 +402,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
-            UNIT_ASSERT_VALUES_EQUAL(600063, p100->Val());
-            UNIT_ASSERT_VALUES_EQUAL(500223, p50->Val());
+            UNIT_ASSERT_VALUES_EQUAL(600, us2ms(p100->Val()));
+            UNIT_ASSERT_VALUES_EQUAL(500, us2ms(p50->Val()));
         }
 
         {
@@ -407,8 +412,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
-            UNIT_ASSERT_VALUES_EQUAL(30015, p100->Val());
-            UNIT_ASSERT_VALUES_EQUAL(20015, p50->Val());
+            UNIT_ASSERT_VALUES_EQUAL(30, us2ms(p100->Val()));
+            UNIT_ASSERT_VALUES_EQUAL(20, us2ms(p50->Val()));
         }
     }
 


### PR DESCRIPTION
Problem:
Flaky ShouldFillTimePercentiles test

`[[bad]]assertion failed at cloud/blockstore/libs/diagnostics/request_stats_ut.cpp:383, virtual void NCloud::NBlockStore::NTestSuiteTRequestStatsTest::TTestCaseShouldFillTimePercentiles::Execute_(NUnitTest::TTestContext &): (200063 == p50->Val()) failed: (200063 != 200191) [[rst]]`

Reproducible on the developer vm after running stress

Analysis:
The most important thing here is how the duration of the request is [calculated](https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/diagnostics/request_stats_ut.cpp#L36)

1. calculate requestStarted time via GetCycleCount() 
2. pass fake requestStarted time to requestStats.RequestCompleted by subtracting request.RequestTime(defined in the test) from requestStarted time
3. calculate request duration time by calling again GetCycleCount() and subtracting fake requestStartedTime

As a result in the test expectations we use magic numbers in microseconds like 600063(600 milliseconds  request.RequestTime + some margin)


Quick solution:

Reduce precision and compare expectations and results in milliseconds. It should improve stability of the test as we didn't observe big difference beetween the expectation and the result in our CI. However it's still possible to reproduce  failure under the stress.