### PR TITLE
MaxSessionHistoryId shouldn't be a global variable - session history ids for different tablets are completely unrelated. This commit fixes a race as well.

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -41,6 +41,7 @@ struct TIndexTabletState::TImpl
     TSessionHandleMap HandleById;
     TSessionLockMap LockById;
     TSessionLockMultiMap LocksByHandle;
+    ui64 MaxSessionHistoryEntryId = 1;
 
     TWriteRequestList WriteBatch;
 


### PR DESCRIPTION
Race: https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/10104124729/1/nebius-x86-64-tsan/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/client/test-results/py3test/chunk2/testing_out_stuff/filestore-server.err

```
==================
WARNING: ThreadSanitizer: data race (pid=307118)
  Write of size 8 at 0x000028490e80 by thread T51:
    #0 NCloud::NFileStore::NStorage::TSessionHistoryEntry::GetMaxEntryId /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/session.h:277:31 (filestore-server+0x27058277) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #1 NCloud::NFileStore::NStorage::TSessionHistoryEntry::TSessionHistoryEntry(NCloud::NFileStore::NProto::TSession const&, NCloud::NFileStore::NStorage::TSessionHistoryEntry::EUpdateType) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/session.h:258:20 (filestore-server+0x27058277)
    #2 NCloud::NFileStore::NStorage::TIndexTabletState::CreateSession(NCloud::NFileStore::NStorage::TIndexTabletDatabase&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, unsigned long, bool, NActors::TActorId const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp:151:9 (filestore-server+0x2705789a) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #3 NCloud::NFileStore::NStorage::TIndexTabletActor::ExecuteTx_CreateSession(NActors::TActorContext const&, NKikimr::NTabletFlatExecutor::TTransactionContext&, NCloud::NFileStore::NStorage::TTxIndexTablet::TCreateSession&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp:408:5 (filestore-server+0x272d2ce8) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #4 NCloud::NFileStore::NStorage::TIndexTabletActor::TCreateSession::ExecuteTx<NCloud::NFileStore::NStorage::TIndexTabletActor, const NActors::TActorContext &, NKikimr::NTabletFlatExecutor::TTransactionContext &, NCloud::NFileStore::NStorage::TTxIndexTablet::TCreateSession &> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor.h:524:5 (filestore-server+0x272d85d9) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #5 NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::TTransaction<NCloud::NFileStore::NStorage::TIndexTabletActor::TCreateSession>::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/core/tablet.h:163:13 (filestore-server+0x272d85d9)
    #6 NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(TAutoPtr<NKikimr::NTabletFlatExecutor::TSeat, TDelete>, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_executor.cpp:1701:35 (filestore-server+0x13d185e8) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #7 NKikimr::NTabletFlatExecutor::TExecutor::DoExecute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, bool, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_executor.cpp:1673:5 (filestore-server+0x13d16421) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #8 NKikimr::NTabletFlatExecutor::TExecutor::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_executor.cpp:1677:5 (filestore-server+0x13d19eca) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #9 NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/tablet_flat_executed.cpp:39:46 (filestore-server+0x13ce77e5) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #10 NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/tablet_flat_executed.cpp:34:5 (filestore-server+0x13ce77e5)
    #11 void NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::ExecuteTx<NCloud::NFileStore::NStorage::TIndexTabletActor::TCreateSession, TIntrusivePtr<NCloud::NFileStore::NStorage::TRequestInfo, TDefaultIntrusivePtrOps<NCloud::NFileStore::NStorage::TRequestInfo>>, NCloud::NFileStore::NProtoPrivate::TCreateSessionRequest&>(NActors::TActorContext const&, TIntrusivePtr<NCloud::NFileStore::NStorage::TRequestInfo, TDefaultIntrusivePtrOps<NCloud::NFileStore::NStorage::TRequestInfo>>&&, NCloud::NFileStore::NProtoPrivate::TCreateSessionRequest&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/core/tablet.h:199:30 (filestore-server+0x272d18cd) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #12 NCloud::NFileStore::NStorage::TIndexTabletActor::HandleCreateSession(TAutoPtr<NActors::TEventHandle<NCloud::NFileStore::NStorage::TProtoRequestEvent<NCloud::NFileStore::NProtoPrivate::TCreateSessionRequest, 275055000u>>, TDelete> const&, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp:287:5 (filestore-server+0x272d1714) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #13 NCloud::NFileStore::NStorage::TIndexTabletActor::HandleRequests(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor.cpp:650:9 (filestore-server+0x270167b5) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #14 NCloud::NFileStore::NStorage::TIndexTabletActor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor.cpp:778:9 (filestore-server+0x2700c478) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #15 NActors::TActorCallbackBehaviour::Receive(NActors::IActor*, TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.cpp:232:9 (filestore-server+0x1103bcc3) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #16 NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.h:526:23 (filestore-server+0x1108d722) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #17 NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TReadAsFilledMailbox>(NActors::TMailboxTable::TReadAsFilledMailbox*, unsigned int, bool) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:251:28 (filestore-server+0x110837d5) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #18 NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:440:25 (filestore-server+0x1107148a) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #19 NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:492:13 (filestore-server+0x11070a54) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #20 NActors::TExecutorThread::ThreadProc() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:523:9 (filestore-server+0x110721ca) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #21 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-server+0xf9231b2) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #22 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-server+0xf92668c) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)

  Previous write of size 8 at 0x000028490e80 by thread T49:
    #0 NCloud::NFileStore::NStorage::TSessionHistoryEntry::GetMaxEntryId /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/session.h:277:31 (filestore-server+0x27058277) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #1 NCloud::NFileStore::NStorage::TSessionHistoryEntry::TSessionHistoryEntry(NCloud::NFileStore::NProto::TSession const&, NCloud::NFileStore::NStorage::TSessionHistoryEntry::EUpdateType) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/session.h:258:20 (filestore-server+0x27058277)
    #2 NCloud::NFileStore::NStorage::TIndexTabletState::CreateSession(NCloud::NFileStore::NStorage::TIndexTabletDatabase&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, unsigned long, bool, NActors::TActorId const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp:151:9 (filestore-server+0x2705789a) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #3 NCloud::NFileStore::NStorage::TIndexTabletActor::ExecuteTx_CreateSession(NActors::TActorContext const&, NKikimr::NTabletFlatExecutor::TTransactionContext&, NCloud::NFileStore::NStorage::TTxIndexTablet::TCreateSession&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp:408:5 (filestore-server+0x272d2ce8) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #4 NCloud::NFileStore::NStorage::TIndexTabletActor::TCreateSession::ExecuteTx<NCloud::NFileStore::NStorage::TIndexTabletActor, const NActors::TActorContext &, NKikimr::NTabletFlatExecutor::TTransactionContext &, NCloud::NFileStore::NStorage::TTxIndexTablet::TCreateSession &> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor.h:524:5 (filestore-server+0x272d85d9) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #5 NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::TTransaction<NCloud::NFileStore::NStorage::TIndexTabletActor::TCreateSession>::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/core/tablet.h:163:13 (filestore-server+0x272d85d9)
    #6 NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(TAutoPtr<NKikimr::NTabletFlatExecutor::TSeat, TDelete>, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_executor.cpp:1701:35 (filestore-server+0x13d185e8) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #7 NKikimr::NTabletFlatExecutor::TExecutor::DoExecute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, bool, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_executor.cpp:1673:5 (filestore-server+0x13d16421) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #8 NKikimr::NTabletFlatExecutor::TExecutor::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_executor.cpp:1677:5 (filestore-server+0x13d19eca) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #9 NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/tablet_flat_executed.cpp:39:46 (filestore-server+0x13ce77e5) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #10 NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/tablet_flat_executed.cpp:34:5 (filestore-server+0x13ce77e5)
    #11 void NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::ExecuteTx<NCloud::NFileStore::NStorage::TIndexTabletActor::TCreateSession, TIntrusivePtr<NCloud::NFileStore::NStorage::TRequestInfo, TDefaultIntrusivePtrOps<NCloud::NFileStore::NStorage::TRequestInfo>>, NCloud::NFileStore::NProtoPrivate::TCreateSessionRequest&>(NActors::TActorContext const&, TIntrusivePtr<NCloud::NFileStore::NStorage::TRequestInfo, TDefaultIntrusivePtrOps<NCloud::NFileStore::NStorage::TRequestInfo>>&&, NCloud::NFileStore::NProtoPrivate::TCreateSessionRequest&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/core/tablet.h:199:30 (filestore-server+0x272d18cd) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #12 NCloud::NFileStore::NStorage::TIndexTabletActor::HandleCreateSession(TAutoPtr<NActors::TEventHandle<NCloud::NFileStore::NStorage::TProtoRequestEvent<NCloud::NFileStore::NProtoPrivate::TCreateSessionRequest, 275055000u>>, TDelete> const&, NActors::TActorContext const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp:287:5 (filestore-server+0x272d1714) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #13 NCloud::NFileStore::NStorage::TIndexTabletActor::HandleRequests(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor.cpp:650:9 (filestore-server+0x270167b5) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #14 NCloud::NFileStore::NStorage::TIndexTabletActor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/tablet/tablet_actor.cpp:778:9 (filestore-server+0x2700c478) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #15 NActors::TActorCallbackBehaviour::Receive(NActors::IActor*, TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.cpp:232:9 (filestore-server+0x1103bcc3) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #16 NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.h:526:23 (filestore-server+0x1108d722) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #17 NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TReadAsFilledMailbox>(NActors::TMailboxTable::TReadAsFilledMailbox*, unsigned int, bool) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:251:28 (filestore-server+0x110837d5) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #18 NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:440:25 (filestore-server+0x1107148a) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #19 NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:492:13 (filestore-server+0x11070a54) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #20 NActors::TExecutorThread::ThreadProc() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:523:9 (filestore-server+0x110721ca) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #21 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-server+0xf9231b2) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
    #22 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-server+0xf92668c) (BuildId: a4cdf72a14a93cff1fecb3f61b00569c7d9cb092)
```