### PR TITLE
issue-1668: TLocalFileSystem::ReadDataAsync/WriteDataAsync 

### DIFF
--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -11,6 +11,8 @@
 #include <cloud/filestore/libs/server/server.h>
 #include <cloud/filestore/libs/storage/core/config.h>
 #include <cloud/filestore/libs/storage/init/actorsystem.h>
+#include <cloud/storage/core/libs/aio/service.h>
+#include <cloud/storage/core/libs/common/file_io_service.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
@@ -118,6 +120,7 @@ void TBootstrapCommon::Start()
 {
     FILESTORE_LOG_START_COMPONENT(Logging);
     FILESTORE_LOG_START_COMPONENT(Monitoring);
+    FILESTORE_LOG_START_COMPONENT(FileIOService);
     FILESTORE_LOG_START_COMPONENT(Metrics);
     FILESTORE_LOG_START_COMPONENT(TraceProcessor);
     FILESTORE_LOG_START_COMPONENT(TraceSerializer);
@@ -162,6 +165,7 @@ void TBootstrapCommon::Stop()
     FILESTORE_LOG_STOP_COMPONENT(TraceSerializer);
     FILESTORE_LOG_STOP_COMPONENT(TraceProcessor);
     FILESTORE_LOG_STOP_COMPONENT(Metrics);
+    FILESTORE_LOG_STOP_COMPONENT(FileIOService);
     FILESTORE_LOG_STOP_COMPONENT(Monitoring);
     FILESTORE_LOG_STOP_COMPONENT(Logging);
 }
@@ -217,6 +221,8 @@ void TBootstrapCommon::Init()
     if (Configs->Options->Service == EServiceKind::Kikimr) {
         InitActorSystem();
     }
+
+    FileIOService = CreateAIOService();
 
     InitDiagnostics();
     InitComponents();

--- a/cloud/filestore/libs/daemon/common/bootstrap.h
+++ b/cloud/filestore/libs/daemon/common/bootstrap.h
@@ -64,6 +64,7 @@ protected:
     ISchedulerPtr BackgroundScheduler;
     ILoggingServicePtr Logging;
     IMonitoringServicePtr Monitoring;
+    IFileIOServicePtr FileIOService;
     NMetrics::IMetricsServicePtr Metrics;
     IRequestStatsRegistryPtr StatsRegistry;
     IStatsUpdaterPtr RequestStatsUpdater;

--- a/cloud/filestore/libs/daemon/common/ya.make
+++ b/cloud/filestore/libs/daemon/common/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     cloud/filestore/libs/storage/core
     cloud/filestore/libs/storage/init
 
+    cloud/storage/core/libs/aio
     cloud/storage/core/libs/common
     cloud/storage/core/libs/daemon
     cloud/storage/core/libs/diagnostics

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -157,6 +157,7 @@ void TBootstrapServer::InitLocalService()
         Timer,
         Scheduler,
         Logging,
+        FileIOService,
         ThreadPool);
 }
 

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -292,6 +292,7 @@ void TBootstrapVhost::InitEndpoints()
             Timer,
             Scheduler,
             Logging,
+            FileIOService,
             ThreadPool);
 
         STORAGE_INFO("initialized LocalService: %s",

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -375,7 +375,7 @@ void TBootstrapVhost::StartComponents()
     NVhost::StartServer();
 
     FILESTORE_LOG_START_COMPONENT(ThreadPool);
-    FILESTORE_LOG_START_COMPONENT(LocalService);
+    // LocalService is started inside FileStoreEndpoints
     FILESTORE_LOG_START_COMPONENT(FileStoreEndpoints);
     FILESTORE_LOG_START_COMPONENT(EndpointManager);
     FILESTORE_LOG_START_COMPONENT(Server);
@@ -390,7 +390,7 @@ void TBootstrapVhost::StopComponents()
     FILESTORE_LOG_STOP_COMPONENT(Server);
     FILESTORE_LOG_STOP_COMPONENT(EndpointManager);
     FILESTORE_LOG_STOP_COMPONENT(FileStoreEndpoints);
-    FILESTORE_LOG_STOP_COMPONENT(LocalService);
+    // LocalService is stopped inside FileStoreEndpoints
     FILESTORE_LOG_STOP_COMPONENT(ThreadPool);
 
     NVhost::StopServer();

--- a/cloud/filestore/libs/service_local/fs.cpp
+++ b/cloud/filestore/libs/service_local/fs.cpp
@@ -10,11 +10,13 @@ TLocalFileSystem::TLocalFileSystem(
         TFsPath root,
         ITimerPtr timer,
         ISchedulerPtr scheduler,
-        ILoggingServicePtr logging)
+        ILoggingServicePtr logging,
+        IFileIOServicePtr fileIOService)
     : Config(std::move(config))
     , Root(std::move(root))
     , Timer(std::move(timer))
     , Scheduler(std::move(scheduler))
+    , FileIOService(std::move(fileIOService))
     , Store(std::move(store))
 {
     Log = logging->CreateLog(Store.GetFileSystemId());

--- a/cloud/filestore/libs/service_local/fs.h
+++ b/cloud/filestore/libs/service_local/fs.h
@@ -88,6 +88,7 @@ private:
     const TFsPath Root;
     const ITimerPtr Timer;
     const ISchedulerPtr Scheduler;
+    const IFileIOServicePtr FileIOService;
 
     NProto::TFileStore Store;
     TLog Log;
@@ -109,7 +110,8 @@ public:
         TFsPath root,
         ITimerPtr timer,
         ISchedulerPtr scheduler,
-        ILoggingServicePtr logging);
+        ILoggingServicePtr logging,
+        IFileIOServicePtr fileIOService);
 
 #define FILESTORE_DECLARE_METHOD_SYNC(name, ...)                               \
     NProto::T##name##Response name(                                            \
@@ -118,7 +120,7 @@ public:
 
 #define FILESTORE_DECLARE_METHOD_ASYNC(name, ...)                              \
     NThreading::TFuture<NProto::T##name##Response> name##Async(                \
-        const NProto::T##name##Request& request);                              \
+        NProto::T##name##Request& request);                                    \
 // FILESTORE_DECLARE_METHOD_SYNC
 
     FILESTORE_SERVICE_LOCAL_SYNC(FILESTORE_DECLARE_METHOD_SYNC)

--- a/cloud/filestore/libs/service_local/fs.h
+++ b/cloud/filestore/libs/service_local/fs.h
@@ -28,6 +28,56 @@ namespace NCloud::NFileStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#define FILESTORE_DATA_METHODS_LOCAL_SYNC(xxx, ...)                            \
+    xxx(StatFileStore,                      __VA_ARGS__)                       \
+                                                                               \
+    xxx(SubscribeSession,                   __VA_ARGS__)                       \
+    xxx(GetSessionEvents,                   __VA_ARGS__)                       \
+    xxx(ResetSession,                       __VA_ARGS__)                       \
+                                                                               \
+    xxx(ResolvePath,                        __VA_ARGS__)                       \
+    xxx(CreateNode,                         __VA_ARGS__)                       \
+    xxx(UnlinkNode,                         __VA_ARGS__)                       \
+    xxx(RenameNode,                         __VA_ARGS__)                       \
+    xxx(AccessNode,                         __VA_ARGS__)                       \
+    xxx(ListNodes,                          __VA_ARGS__)                       \
+    xxx(ReadLink,                           __VA_ARGS__)                       \
+                                                                               \
+    xxx(SetNodeAttr,                        __VA_ARGS__)                       \
+    xxx(GetNodeAttr,                        __VA_ARGS__)                       \
+    xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
+    xxx(GetNodeXAttr,                       __VA_ARGS__)                       \
+    xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
+    xxx(RemoveNodeXAttr,                    __VA_ARGS__)                       \
+                                                                               \
+    xxx(CreateHandle,                       __VA_ARGS__)                       \
+    xxx(DestroyHandle,                      __VA_ARGS__)                       \
+                                                                               \
+    xxx(AcquireLock,                        __VA_ARGS__)                       \
+    xxx(ReleaseLock,                        __VA_ARGS__)                       \
+    xxx(TestLock,                           __VA_ARGS__)                       \
+                                                                               \
+    xxx(AllocateData,                       __VA_ARGS__)                       \
+// FILESTORE_DATA_METHODS_LOCAL_SYNC
+
+#define FILESTORE_DATA_METHODS_LOCAL_ASYNC(xxx, ...)                           \
+    xxx(ReadData,                           __VA_ARGS__)                       \
+    xxx(WriteData,                          __VA_ARGS__)                       \
+// FILESTORE_DATA_METHODS_LOCAL_ASYNC
+
+#define FILESTORE_SERVICE_LOCAL_SYNC(xxx, ...)                                 \
+    xxx(Ping,                               __VA_ARGS__)                       \
+    xxx(PingSession,                        __VA_ARGS__)                       \
+    FILESTORE_SERVICE_METHODS(xxx,          __VA_ARGS__)                       \
+    FILESTORE_DATA_METHODS_LOCAL_SYNC(xxx,  __VA_ARGS__)                       \
+// FILESTORE_SERVICE_LOCAL_SYNC
+
+#define FILESTORE_SERVICE_LOCAL_ASYNC(xxx, ...)                                \
+    FILESTORE_DATA_METHODS_LOCAL_ASYNC(xxx,  __VA_ARGS__)                      \
+// FILESTORE_SERVICE_LOCAL_SYNC
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TLocalFileSystem final
     : public std::enable_shared_from_this<TLocalFileSystem>
 {
@@ -61,14 +111,21 @@ public:
         ISchedulerPtr scheduler,
         ILoggingServicePtr logging);
 
-#define FILESTORE_DECLARE_METHOD(name, ...)                                    \
+#define FILESTORE_DECLARE_METHOD_SYNC(name, ...)                               \
     NProto::T##name##Response name(                                            \
         const NProto::T##name##Request& request);                              \
-// FILESTORE_DECLARE_METHOD
+// FILESTORE_DECLARE_METHOD_SYNC
 
-    FILESTORE_SERVICE(FILESTORE_DECLARE_METHOD)
+#define FILESTORE_DECLARE_METHOD_ASYNC(name, ...)                              \
+    NThreading::TFuture<NProto::T##name##Response> name##Async(                \
+        const NProto::T##name##Request& request);                              \
+// FILESTORE_DECLARE_METHOD_SYNC
 
-#undef FILESTORE_DECLARE_METHOD
+    FILESTORE_SERVICE_LOCAL_SYNC(FILESTORE_DECLARE_METHOD_SYNC)
+    FILESTORE_SERVICE_LOCAL_ASYNC(FILESTORE_DECLARE_METHOD_ASYNC)
+
+#undef FILESTORE_DECLARE_METHOD_SYNC
+#undef FILESTORE_DECLARE_METHOD_ASYNC
 
     NProto::TFileStore GetConfig() const
     {

--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -2,6 +2,8 @@
 
 #include "lowlevel.h"
 
+#include <cloud/storage/core/libs/common/file_io_service.h>
+
 #include <util/string/builder.h>
 
 namespace NCloud::NFileStore {
@@ -29,7 +31,7 @@ NProto::TCreateHandleResponse TLocalFileSystem::CreateHandle(
     const int mode = request.GetMode()
         ? request.GetMode() : Config->GetDefaultPermissions();
 
-    TFile handle;
+    TFileHandle handle;
     TFileStat stat;
     if (const auto& pathname = request.GetName()) {
         handle = node->OpenHandle(pathname, flags, mode);
@@ -43,10 +45,11 @@ NProto::TCreateHandleResponse TLocalFileSystem::CreateHandle(
         stat = node->Stat();
     }
 
-    session->InsertHandle(handle);
+    const FHANDLE fd = handle;
+    session->InsertHandle(std::move(handle));
 
     NProto::TCreateHandleResponse response;
-    response.SetHandle(handle.GetHandle());
+    response.SetHandle(fd);
     ConvertStats(stat, *response.MutableNodeAttr());
 
     return response;
@@ -64,47 +67,71 @@ NProto::TDestroyHandleResponse TLocalFileSystem::DestroyHandle(
 }
 
 TFuture<NProto::TReadDataResponse> TLocalFileSystem::ReadDataAsync(
-    const NProto::TReadDataRequest& request)
+    NProto::TReadDataRequest& request)
 {
     STORAGE_TRACE("ReadData " << DumpMessage(request));
 
     auto session = GetSession(request);
-    auto handle = session->LookupHandle(request.GetHandle());
-    if (!handle.IsOpen()) {
+    auto* handle = session->LookupHandle(request.GetHandle());
+    if (!handle || !handle->IsOpen()) {
         return MakeFuture<NProto::TReadDataResponse>(
             TErrorResponse(ErrorInvalidHandle(request.GetHandle())));
     }
 
-    auto buffer = TString::Uninitialized(request.GetLength());
-    size_t bytesRead = handle.Pread(
-        const_cast<char*>(buffer.data()),
-        buffer.size(),
-        request.GetOffset());
-    buffer.resize(bytesRead);
-
-    NProto::TReadDataResponse response;
-    response.SetBuffer(std::move(buffer));
-
-    return MakeFuture(response);
+    auto b = TString::Uninitialized(request.GetLength());
+    TArrayRef<char> data(b.begin(), b.vend());
+    auto promise = NewPromise<NProto::TReadDataResponse>();
+    FileIOService->AsyncRead(*handle, request.GetOffset(), data).Subscribe(
+        [b = std::move(b), promise] (const TFuture<ui32>& f) mutable {
+            NProto::TReadDataResponse response;
+            try {
+                auto bytesRead = f.GetValue();
+                b.resize(bytesRead);
+                response.SetBuffer(std::move(b));
+            } catch (...) {
+                *response.MutableError() =
+                    MakeError(E_IO, CurrentExceptionMessage());
+            }
+            promise.SetValue(std::move(response));
+        });
+    return promise;
 }
 
 TFuture<NProto::TWriteDataResponse> TLocalFileSystem::WriteDataAsync(
-    const NProto::TWriteDataRequest& request)
+    NProto::TWriteDataRequest& request)
 {
     STORAGE_TRACE("WriteData " << DumpMessage(request));
 
     auto session = GetSession(request);
-    auto handle = session->LookupHandle(request.GetHandle());
-    if (!handle.IsOpen()) {
+    auto* handle = session->LookupHandle(request.GetHandle());
+    if (!handle || !handle->IsOpen()) {
         return MakeFuture<NProto::TWriteDataResponse>(
             TErrorResponse(ErrorInvalidHandle(request.GetHandle())));
     }
 
-    const auto& buffer = request.GetBuffer();
-    handle.Pwrite(buffer.data(), buffer.size(), request.GetOffset());
-    handle.Flush(); // TODO
+    const FHANDLE fd = *handle;
+    auto b = std::move(*request.MutableBuffer());
+    TArrayRef<char> data(b.begin(), b.vend());
+    auto promise = NewPromise<NProto::TWriteDataResponse>();
+    FileIOService->AsyncWrite(*handle, request.GetOffset(), data).Subscribe(
+        [b = std::move(b), promise, fd] (const TFuture<ui32>& f) mutable {
+            NProto::TWriteDataResponse response;
+            try {
+                f.GetValue();
+                TFileHandle h(fd);
+                const bool flushed = h.Flush();
+                h.Release();
+                if (!flushed) {
+                    throw yexception() << "failed to flush " << fd;
+                }
+            } catch (...) {
+                *response.MutableError() =
+                    MakeError(E_IO, CurrentExceptionMessage());
+            }
+            promise.SetValue(std::move(response));
+        });
 
-    return MakeFuture<NProto::TWriteDataResponse>();
+    return promise;
 }
 
 NProto::TAllocateDataResponse TLocalFileSystem::AllocateData(
@@ -114,15 +141,19 @@ NProto::TAllocateDataResponse TLocalFileSystem::AllocateData(
         << " flags: " << FallocateFlagsToString(request.GetFlags()));
 
     auto session = GetSession(request);
-    auto handle = session->LookupHandle(request.GetHandle());
-    if (!handle.IsOpen()) {
+    auto* handle = session->LookupHandle(request.GetHandle());
+    if (!handle || !handle->IsOpen()) {
         return TErrorResponse(ErrorInvalidHandle(request.GetHandle()));
     }
 
     const int flags = FallocateFlagsToSystem(request.GetFlags());
 
-    NLowLevel::Allocate(handle, flags, request.GetOffset(), request.GetLength());
-    handle.Flush(); // TODO
+    NLowLevel::Allocate(
+        *handle,
+        flags,
+        request.GetOffset(),
+        request.GetLength());
+    handle->Flush(); // TODO
 
     return {};
 }

--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -104,7 +104,7 @@ TFuture<NProto::TWriteDataResponse> TLocalFileSystem::WriteDataAsync(
     handle.Pwrite(buffer.data(), buffer.size(), request.GetOffset());
     handle.Flush(); // TODO
 
-    return {};
+    return MakeFuture<NProto::TWriteDataResponse>();
 }
 
 NProto::TAllocateDataResponse TLocalFileSystem::AllocateData(

--- a/cloud/filestore/libs/service_local/index.cpp
+++ b/cloud/filestore/libs/service_local/index.cpp
@@ -34,12 +34,12 @@ TIndexNodePtr TIndexNode::CreateDirectory(const TString& name, int mode)
 
 TIndexNodePtr TIndexNode::CreateFile(const TString& name, int mode)
 {
-    auto node = NLowLevel::OpenAt(NodeFd, name, O_CREAT | O_EXCL | O_WRONLY, mode);
+    auto node =
+        NLowLevel::OpenAt(NodeFd, name, O_CREAT | O_EXCL | O_WRONLY, mode);
+    auto resolved = NLowLevel::Open(node, O_PATH, 0);
+    auto stat = NLowLevel::Stat(resolved);
 
-    node = NLowLevel::Open(node, O_PATH, 0);
-    auto stat = NLowLevel::Stat(node);
-
-    return std::make_shared<TIndexNode>(stat.INode, std::move(node));
+    return std::make_shared<TIndexNode>(stat.INode, std::move(resolved));
 }
 
 TIndexNodePtr TIndexNode::CreateSocket(const TString& name, int mode)
@@ -107,12 +107,12 @@ TFileStat TIndexNode::Stat(const TString& name)
     return NLowLevel::StatAt(NodeFd, name);
 }
 
-TFile TIndexNode::OpenHandle(int flags)
+TFileHandle TIndexNode::OpenHandle(int flags)
 {
     return NLowLevel::Open(NodeFd, flags, 0);
 }
 
-TFile TIndexNode::OpenHandle(const TString& name, int flags, int mode)
+TFileHandle TIndexNode::OpenHandle(const TString& name, int flags, int mode)
 {
     return NLowLevel::OpenAt(NodeFd, name.data(), flags, mode);
 }

--- a/cloud/filestore/libs/service_local/index.h
+++ b/cloud/filestore/libs/service_local/index.h
@@ -19,10 +19,10 @@ class TIndexNode
 {
 private:
     const ui64 NodeId;
-    const TFile NodeFd;
+    const TFileHandle NodeFd;
 
 public:
-    TIndexNode(ui64 nodeId, TFile node)
+    TIndexNode(ui64 nodeId, TFileHandle node)
         : NodeId(nodeId)
         , NodeFd(std::move(node))
     {}
@@ -55,8 +55,8 @@ public:
     TFileStat Stat();
     TFileStat Stat(const TString& name);
 
-    TFile OpenHandle(int flags);
-    TFile OpenHandle(const TString& name, int flags, int mode);
+    TFileHandle OpenHandle(int flags);
+    TFileHandle OpenHandle(const TString& name, int flags, int mode);
 
     //
     // Attrs

--- a/cloud/filestore/libs/service_local/lowlevel.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel.cpp
@@ -84,81 +84,101 @@ timespec ToTimeSpec(TInstant ts)
     return spec;
 }
 
+FHANDLE Fd(const TFileHandle& handle)
+{
+    return handle;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TFile Open(const TString& path, int flags, int mode)
+TFileHandle Open(const TString& path, int flags, int mode)
 {
     int fd = open(path.data(), flags, mode);
     Y_ENSURE_EX(fd != -1, TServiceError(GetSystemErrorCode())
         << "failed to open " << path.Quote()
         << ": " << LastSystemErrorText());
 
-    return TFile(fd);
+    return fd;
 }
 
-TFile Open(const TFile& handle, int flags, int mode)
+TFileHandle Open(const TFileHandle& handle, int flags, int mode)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int fd = open(path, flags, mode);
     Y_ENSURE_EX(fd != -1, TServiceError(GetSystemErrorCode())
         << "failed to open: " << LastSystemErrorText());
 
-    return TFile(fd);
+    return fd;
 }
 
-TFile OpenAt(const TFile& handle, const TString& name, int flags, int mode)
+TFileHandle OpenAt(
+    const TFileHandle& handle,
+    const TString& name,
+    int flags,
+    int mode)
 {
-    int fd = openat(handle.GetHandle(), name.data(), flags, mode);
+    int fd = openat(Fd(handle), name.data(), flags, mode);
     Y_ENSURE_EX(fd != -1, TServiceError(GetSystemErrorCode())
         << "failed to open " << name.Quote()
         << ": " << LastSystemErrorText());
 
-    return TFile(fd);
+    return fd;
 }
 
-void MkDirAt(const TFile& handle, const TString& name, int mode)
+void MkDirAt(const TFileHandle& handle, const TString& name, int mode)
 {
-    int res = mkdirat(handle.GetHandle(), name.data(), mode);
+    int res = mkdirat(Fd(handle), name.data(), mode);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "failed to create dir: " << name.Quote()
         << ": " << LastSystemErrorText());
 }
 
-void MkSockAt(const TFile& handle, const TString& name, int mode)
+void MkSockAt(const TFileHandle& handle, const TString& name, int mode)
 {
-    int res = mknodat(handle.GetHandle(), name.data(), mode | S_IFSOCK, dev_t{});
+    int res = mknodat(Fd(handle), name.data(), mode | S_IFSOCK, dev_t{});
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "failed to create socket: " << name.Quote()
         << ": " << LastSystemErrorText());
 }
 
-void LinkAt(const TFile& node, const TFile& parent, const TString& name)
+void LinkAt(
+    const TFileHandle& node,
+    const TFileHandle& parent,
+    const TString& name)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", node.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(node));
 
-    int res = linkat(AT_FDCWD, path, parent.GetHandle(), name.data(), AT_SYMLINK_FOLLOW);
+    int res = linkat(
+        AT_FDCWD,
+        path,
+        Fd(parent),
+        name.data(),
+        AT_SYMLINK_FOLLOW);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "failed to create link: " << name.Quote()
         << ": " << LastSystemErrorText());
 }
 
-void SymLinkAt(const TString target, const TFile& handle, const TString& name)
+void SymLinkAt(
+    const TString& target,
+    const TFileHandle& handle,
+    const TString& name)
 {
-    int res = symlinkat(target.data(), handle.GetHandle(), name.data());
+    int res = symlinkat(target.data(), Fd(handle), name.data());
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
-        << "failed to create symlink: " << name.Quote() << " -> " << target.Quote()
-        << ": " << LastSystemErrorText());
+        << "failed to create symlink: " << name.Quote() << " -> "
+        << target.Quote() << ": " << LastSystemErrorText());
 }
 
 void RenameAt(
-    const TFile& handle,
+    const TFileHandle& handle,
     const TString& name,
-    const TFile& newhandle,
+    const TFileHandle& newHandle,
     const TString& newname,
     unsigned int flags)
 {
@@ -166,9 +186,9 @@ void RenameAt(
     // https://lwn.net/Articles/655028/
     int res = syscall(
         SYS_renameat2,
-        handle.GetHandle(),
+        Fd(handle),
         name.data(),
-        newhandle.GetHandle(),
+        Fd(newHandle),
         newname.data(),
         flags);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
@@ -176,29 +196,29 @@ void RenameAt(
         << ": " << LastSystemErrorText());
 }
 
-void UnlinkAt(const TFile& handle, const TString& name, bool directory)
+void UnlinkAt(const TFileHandle& handle, const TString& name, bool directory)
 {
     int flags = directory ? AT_REMOVEDIR : 0;
-    int res = unlinkat(handle.GetHandle(), name.data(), flags);
+    int res = unlinkat(Fd(handle), name.data(), flags);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "failed to remove " << (directory ? "file " : "dir ") << name.Quote()
         << ": " << LastSystemErrorText());
 }
 
-TFileStat Stat(const TFile& handle)
+TFileStat Stat(const TFileHandle& handle)
 {
     struct stat fs = {};
-    int res = fstat(handle.GetHandle(), &fs);
+    int res = fstat(Fd(handle), &fs);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "failed to stat: " << LastSystemErrorText());
 
     return GetFileStat(fs);
 }
 
-TFileStat StatAt(const TFile& handle, const TString& name)
+TFileStat StatAt(const TFileHandle& handle, const TString& name)
 {
     struct stat fs = {};
-    int res = fstatat(handle.GetHandle(), name.data(), &fs, AT_SYMLINK_NOFOLLOW);
+    int res = fstatat(Fd(handle), name.data(), &fs, AT_SYMLINK_NOFOLLOW);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "failed to stat " << name.Quote()
         << ": " << LastSystemErrorText());
@@ -206,13 +226,15 @@ TFileStat StatAt(const TFile& handle, const TString& name)
     return GetFileStat(fs);
 }
 
-TVector<std::pair<TString, TFileStat>> ListDirAt(const TFile& handle, bool ignoreErrors)
+TVector<std::pair<TString, TFileStat>> ListDirAt(
+    const TFileHandle& handle,
+    bool ignoreErrors)
 {
-    auto fd = openat(handle.GetHandle(), ".", O_RDONLY);
+    auto fd = openat(Fd(handle), ".", O_RDONLY);
     Y_ENSURE_EX(fd != -1, TServiceError(GetSystemErrorCode())
         << "failed to open: " << LastSystemErrorText());
 
-    auto dir = fdopendir(fd);
+    auto* dir = fdopendir(fd);
     if (!dir) {
         close(fd);
         ythrow TServiceError(GetSystemErrorCode())
@@ -230,7 +252,7 @@ TVector<std::pair<TString, TFileStat>> ListDirAt(const TFile& handle, bool ignor
     TVector<std::pair<TString, TFileStat>> results;
 
     errno = 0;
-    while (auto entry = readdir(dir)) {
+    while (auto* entry = readdir(dir)) {
         TString name(entry->d_name);
         if (name == Dot || name == Dotdot) {
             continue;
@@ -259,10 +281,10 @@ TVector<std::pair<TString, TFileStat>> ListDirAt(const TFile& handle, bool ignor
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void Access(const TFile& handle, int mode)
+void Access(const TFileHandle& handle, int mode)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = access(path, mode);
     if (res != 0) {
@@ -272,10 +294,10 @@ void Access(const TFile& handle, int mode)
     }
 }
 
-void Chmod(const TFile& handle, int mode)
+void Chmod(const TFileHandle& handle, int mode)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = chmod(path, mode);
     if (res != 0) {
@@ -285,10 +307,10 @@ void Chmod(const TFile& handle, int mode)
     }
 }
 
-void Chown(const TFile& handle, unsigned int uid, unsigned int gid)
+void Chown(const TFileHandle& handle, unsigned int uid, unsigned int gid)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = chown(path, uid, gid);
     if (res != 0) {
@@ -298,12 +320,12 @@ void Chown(const TFile& handle, unsigned int uid, unsigned int gid)
     }
 }
 
-void Utimes(const TFile& handle, TInstant atime, TInstant mtime)
+void Utimes(const TFileHandle& handle, TInstant atime, TInstant mtime)
 {
     timespec tv[2] = {ToTimeSpec(atime), ToTimeSpec(mtime)};
 
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = utimensat(AT_FDCWD, path, tv, 0);
     if (res != 0) {
@@ -313,10 +335,10 @@ void Utimes(const TFile& handle, TInstant atime, TInstant mtime)
     }
 }
 
-void Truncate(const TFile& handle, size_t size)
+void Truncate(const TFileHandle& handle, size_t size)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = truncate(path, size);
     if (res != 0) {
@@ -326,19 +348,19 @@ void Truncate(const TFile& handle, size_t size)
     }
 }
 
-void Allocate(const TFile& handle, int flags, off_t offset, off_t length)
+void Allocate(const TFileHandle& handle, int flags, off_t offset, off_t length)
 {
-    int res = fallocate(handle.GetHandle(), flags, offset, length);
+    int res = fallocate(Fd(handle), flags, offset, length);
     Y_ENSURE_EX(res != -1, TServiceError(GetSystemErrorCode())
         << "allocate failed: "
         << LastSystemErrorText());
 }
 
-TString ReadLink(const TFile& handle)
+TString ReadLink(const TFileHandle& handle)
 {
     TString link(PATH_MAX, '\0');
 
-    int res = readlinkat(handle.GetHandle(), "", &link[0], link.size());
+    int res = readlinkat(Fd(handle), "", &link[0], link.size());
     if (res == -1) {
         ythrow TServiceError(GetSystemErrorCode())
             << "readlink failed: "
@@ -356,10 +378,10 @@ TString ReadLink(const TFile& handle)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TString GetXAttr(const TFile& handle, const TString& name)
+TString GetXAttr(const TFileHandle& handle, const TString& name)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     TVector<char> buf;
 
@@ -397,10 +419,13 @@ TString GetXAttr(const TFile& handle, const TString& name)
     }
 }
 
-void SetXAttr(const TFile& handle, const TString& name, const TString& value)
+void SetXAttr(
+    const TFileHandle& handle,
+    const TString& name,
+    const TString& value)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = setxattr(
         path,
@@ -416,10 +441,10 @@ void SetXAttr(const TFile& handle, const TString& name, const TString& value)
     }
 }
 
-void RemoveXAttr(const TFile& handle, const TString& name)
+void RemoveXAttr(const TFileHandle& handle, const TString& name)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     int res = removexattr(path, name.c_str());
     if (res != 0) {
@@ -429,10 +454,10 @@ void RemoveXAttr(const TFile& handle, const TString& name)
     }
 }
 
-TVector<TString> ListXAttrs(const TFile& handle)
+TVector<TString> ListXAttrs(const TFileHandle& handle)
 {
     char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", handle.GetHandle());
+    sprintf(path, "/proc/self/fd/%i", Fd(handle));
 
     TVector<char> buf;
 
@@ -476,7 +501,11 @@ TVector<TString> ListXAttrs(const TFile& handle)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool AcquireLock(const TFile& handle, int offset, int len, bool shared)
+bool AcquireLock(
+    const TFileHandle& handle,
+    off_t offset,
+    off_t len,
+    bool shared)
 {
     struct flock lck = {};
     lck.l_whence = SEEK_SET,
@@ -484,7 +513,7 @@ bool AcquireLock(const TFile& handle, int offset, int len, bool shared)
     lck.l_len = len;
     lck.l_type = shared ? F_RDLCK : F_WRLCK;
 
-    int res = fcntl(handle.GetHandle(), F_OFD_SETLK, &lck);
+    int res = fcntl(Fd(handle), F_OFD_SETLK, &lck);
     if (res != 0) {
         if (errno != EAGAIN) {
             ythrow TServiceError(GetSystemErrorCode())
@@ -498,7 +527,7 @@ bool AcquireLock(const TFile& handle, int offset, int len, bool shared)
     return true;
 }
 
-bool TestLock(const TFile& handle, int offset, int len, bool shared)
+bool TestLock(const TFileHandle& handle, off_t offset, off_t len, bool shared)
 {
     struct flock lck = {};
     lck.l_whence = SEEK_SET,
@@ -506,7 +535,7 @@ bool TestLock(const TFile& handle, int offset, int len, bool shared)
     lck.l_len = len;
     lck.l_type = shared ? F_RDLCK : F_WRLCK;
 
-    int res = fcntl(handle.GetHandle(), F_OFD_GETLK, &lck);
+    int res = fcntl(Fd(handle), F_OFD_GETLK, &lck);
     if (res != 0) {
         ythrow TServiceError(GetSystemErrorCode())
             << "test lock failed at (" << offset << ", " << len << "): "
@@ -516,7 +545,7 @@ bool TestLock(const TFile& handle, int offset, int len, bool shared)
     return lck.l_type == F_UNLCK;
 }
 
-void ReleaseLock(const TFile& handle, int offset, int len)
+void ReleaseLock(const TFileHandle& handle, off_t offset, off_t len)
 {
     struct flock lck = {};
     lck.l_whence = SEEK_SET,
@@ -524,7 +553,7 @@ void ReleaseLock(const TFile& handle, int offset, int len)
     lck.l_len = len;
     lck.l_type = F_UNLCK;
 
-    int res = fcntl(handle.GetHandle(), F_OFD_SETLK, &lck);
+    int res = fcntl(Fd(handle), F_OFD_SETLK, &lck);
     if (res != 0) {
         ythrow TServiceError(GetSystemErrorCode())
             << "unlock failed at (" << offset << ", " << len << "): "
@@ -532,9 +561,9 @@ void ReleaseLock(const TFile& handle, int offset, int len)
     }
 }
 
-bool Flock(const TFile& handle, int operation)
+bool Flock(const TFileHandle& handle, int operation)
 {
-    int res = flock(handle.GetHandle(), operation);
+    int res = flock(Fd(handle), operation);
     if (res != 0) {
         if (errno != EAGAIN) {
             ythrow TServiceError(GetSystemErrorCode())

--- a/cloud/filestore/libs/service_local/lowlevel.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel.cpp
@@ -371,10 +371,7 @@ TString GetXAttr(const TFile& handle, const TString& name)
             0);
 
         if (res < 0) {
-            // TODO MAKE_FILESTORE_ERROR(NProto::E_FS_NOXATTR),
-            ythrow TServiceError(E_NOT_FOUND)
-                << "failed to get attribute (" << name.Quote() << "): "
-                << LastSystemErrorText();
+            ythrow TServiceError(ErrorAttributeDoesNotExist(name));
         }
 
         buf.resize(res + 1);

--- a/cloud/filestore/libs/service_local/lowlevel.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel.cpp
@@ -371,6 +371,7 @@ TString GetXAttr(const TFile& handle, const TString& name)
             0);
 
         if (res < 0) {
+            // TODO MAKE_FILESTORE_ERROR(NProto::E_FS_NOXATTR),
             ythrow TServiceError(E_NOT_FOUND)
                 << "failed to get attribute (" << name.Quote() << "): "
                 << LastSystemErrorText();

--- a/cloud/filestore/libs/service_local/lowlevel.h
+++ b/cloud/filestore/libs/service_local/lowlevel.h
@@ -13,59 +13,78 @@ namespace NLowLevel {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TFile Open(const TString& path, int flags, int mode);
-TFile Open(const TFile& handle, int flags, int mode);
-TFile OpenAt(const TFile& handle, const TString& name, int flags, int mode);
+TFileHandle Open(const TString& path, int flags, int mode);
+TFileHandle Open(const TFileHandle& handle, int flags, int mode);
+TFileHandle OpenAt(
+    const TFileHandle& handle,
+    const TString& name,
+    int flags,
+    int mode);
 
-void MkDirAt(const TFile& handle, const TString& name, int mode);
-void MkSockAt(const TFile& handle, const TString& name, int mode);
+void MkDirAt(const TFileHandle& handle, const TString& name, int mode);
+void MkSockAt(const TFileHandle& handle, const TString& name, int mode);
 
 void RenameAt(
-    const TFile& handle,
+    const TFileHandle& handle,
     const TString& name,
-    const TFile& newhandle,
+    const TFileHandle& newhandle,
     const TString& newname,
     unsigned int flags);
 
-void LinkAt(const TFile& node, const TFile& parent, const TString& name);
-void SymLinkAt(const TString target, const TFile& handle, const TString& name);
-void UnlinkAt(const TFile& handle, const TString& name, bool directory);
+void LinkAt(
+    const TFileHandle& node,
+    const TFileHandle& parent,
+    const TString& name);
+void SymLinkAt(
+    const TString& target,
+    const TFileHandle& handle,
+    const TString& name);
+void UnlinkAt(const TFileHandle& handle, const TString& name, bool directory);
 
-TString ReadLink(const TFile& handle);
+TString ReadLink(const TFileHandle& handle);
 
-TFileStat Stat(const TFile& handle);
-TFileStat StatAt(const TFile& handle, const TString& name);
+TFileStat Stat(const TFileHandle& handle);
+TFileStat StatAt(const TFileHandle& handle, const TString& name);
 
-TVector<std::pair<TString, TFileStat>> ListDirAt(const TFile& handle, bool ignoreErrors);
+TVector<std::pair<TString, TFileStat>> ListDirAt(
+    const TFileHandle& handle,
+    bool ignoreErrors);
 
 //
 // Attrs
 //
 
-void Access(const TFile& handle, int mode);
-void Chmod(const TFile& handle, int mode);
-void Chown(const TFile& handle, unsigned int uid, unsigned int gid);
-void Utimes(const TFile& handle, TInstant atime, TInstant mtime);
-void Truncate(const TFile& handle, size_t size);
-void Allocate(const TFile& handle, int flags, off_t offset, off_t length);
+void Access(const TFileHandle& handle, int mode);
+void Chmod(const TFileHandle& handle, int mode);
+void Chown(const TFileHandle& handle, unsigned int uid, unsigned int gid);
+void Utimes(const TFileHandle& handle, TInstant atime, TInstant mtime);
+void Truncate(const TFileHandle& handle, size_t size);
+void Allocate(const TFileHandle& handle, int flags, off_t offset, off_t length);
 
 //
 // X Attrs
 //
 
-TString GetXAttr(const TFile& handle, const TString& name);
-TVector<TString> ListXAttrs(const TFile& handle);
-void RemoveXAttr(const TFile& handle, const TString& name);
-void SetXAttr(const TFile& handle, const TString& name, const TString& value);
+TString GetXAttr(const TFileHandle& handle, const TString& name);
+TVector<TString> ListXAttrs(const TFileHandle& handle);
+void RemoveXAttr(const TFileHandle& handle, const TString& name);
+void SetXAttr(
+    const TFileHandle& handle,
+    const TString& name,
+    const TString& value);
 
 //
 // Locks
 //
 
-bool AcquireLock(const TFile& handle, int offset, int len, bool shared);
-bool TestLock(const TFile& handle, int offset, int len, bool shared);
-void ReleaseLock(const TFile& handle, int offset, int len);
-bool Flock(const TFile& handle, int operation);
+bool AcquireLock(
+    const TFileHandle& handle,
+    off_t offset,
+    off_t len,
+    bool shared);
+bool TestLock(const TFileHandle& handle, off_t offset, off_t len, bool shared);
+void ReleaseLock(const TFileHandle& handle, off_t offset, off_t len);
+bool Flock(const TFileHandle& handle, int operation);
 
 }   // namespace NLowLevel
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_local/service.cpp
+++ b/cloud/filestore/libs/service_local/service.cpp
@@ -357,6 +357,8 @@ void TLocalFileStore::Start()
                 continue;
             }
 
+            STORAGE_INFO("restoring local store " << id.Quote());
+
             NProto::TFileStore store;
             LoadFileStoreProto(path, store);
             InitFileSystem(id, child, store);
@@ -456,7 +458,7 @@ NProto::TAlterFileStoreResponse TLocalFileStore::AlterFileStore(
     auto it = FileSystems.find(id);
     if (it == FileSystems.end()) {
         return TErrorResponse(E_ARGUMENT, TStringBuilder()
-            << "file store doesn't exists: " << id.Quote());
+            << "file store doesn't exist: " << id.Quote());
     }
 
     NProto::TFileStore store = it->second->GetConfig();

--- a/cloud/filestore/libs/service_local/service.h
+++ b/cloud/filestore/libs/service_local/service.h
@@ -16,6 +16,7 @@ IFileStoreServicePtr CreateLocalFileStore(
     ITimerPtr timer,
     ISchedulerPtr scheduler,
     ILoggingServicePtr logging,
+    IFileIOServicePtr fileIOService,
     ITaskQueuePtr taskQueue);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_local/service_ut_stress.cpp
+++ b/cloud/filestore/libs/service_local/service_ut_stress.cpp
@@ -5,7 +5,9 @@
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/service/filestore.h>
 
+#include <cloud/storage/core/libs/aio/service.h>
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/file_io_service.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/timer.h>
@@ -268,6 +270,7 @@ struct TTestBootstrap
     ITimerPtr Timer = CreateWallClockTimer();
     ISchedulerPtr Scheduler = CreateScheduler();
     ITaskQueuePtr TaskQueue = CreateTaskQueueStub();
+    IFileIOServicePtr AIOService = CreateAIOService();
 
     TTempDirectoryPtr Cwd;
     IFileStoreServicePtr Store;
@@ -277,11 +280,13 @@ struct TTestBootstrap
     TTestBootstrap(const TTempDirectoryPtr& cwd = std::make_shared<TTempDirectory>())
         : Cwd(cwd)
     {
+        AIOService->Start();
         Store = CreateLocalFileStore(
             CreateConfig(),
             Timer,
             Scheduler,
             Logging,
+            AIOService,
             TaskQueue);
         Store->Start();
     }
@@ -289,11 +294,13 @@ struct TTestBootstrap
     TTestBootstrap(const TString& id, const TString& client = "client", const TString& session = {})
         : Cwd(std::make_shared<TTempDirectory>())
     {
+        AIOService->Start();
         Store = CreateLocalFileStore(
             CreateConfig(),
             Timer,
             Scheduler,
             Logging,
+            AIOService,
             TaskQueue);
         Store->Start();
 
@@ -301,6 +308,11 @@ struct TTestBootstrap
         if (client) {
             Headers.SessionId = CreateSession(id, client, session).GetSession().GetSessionId();
         }
+    }
+
+    ~TTestBootstrap()
+    {
+        AIOService->Stop();
     }
 
     TLocalFileStoreConfigPtr CreateConfig()

--- a/cloud/filestore/libs/service_local/ut/ya.make
+++ b/cloud/filestore/libs/service_local/ut/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(cloud/filestore/libs/service_local)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
 
+PEERDIR(
+    cloud/storage/core/libs/aio
+)
+
 SRCS(
     service_ut.cpp
 )

--- a/cloud/filestore/libs/service_local/ut_stress/ya.make
+++ b/cloud/filestore/libs/service_local/ut_stress/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(cloud/filestore/libs/service_local)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
 
+PEERDIR(
+    cloud/storage/core/libs/aio
+)
+
 SRCS(
     service_ut_stress.cpp
 )

--- a/util/system/file.h
+++ b/util/system/file.h
@@ -77,6 +77,13 @@ public:
         other.Fd_ = INVALID_FHANDLE;
     }
 
+    TFileHandle& operator=(TFileHandle&& other) noexcept
+    {
+        Close();
+        Fd_ = other.Release();
+        return *this;
+    }
+
     TFileHandle(const char* fName, EOpenMode oMode) noexcept;
     TFileHandle(const TString& fName, EOpenMode oMode) noexcept;
     TFileHandle(const std::filesystem::path& path, EOpenMode oMode) noexcept;


### PR DESCRIPTION
ReadData and WriteData calls are now processed using libaio instead of pread/pwrite
This leads to the need to replace TFile usage by TFileHandle in LocalService (TFile is basically an intrusive ptr for TFileHandle + some convenience wrappers for TFileHandle's methods - all of this is not needed in LocalService) 

#1668 