### PR TITLE
[Filestore] print client id & fix required parameters

### DIFF
--- a/cloud/filestore/apps/client/lib/create_session.cpp
+++ b/cloud/filestore/apps/client/lib/create_session.cpp
@@ -8,8 +8,12 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void Print(const NProto::TCreateSessionResponse& response, bool jsonOutput)
+void Print(
+    const TString& clientId,
+    const NProto::TCreateSessionResponse& response,
+    bool jsonOutput)
 {
+    Cout << "Client ID: " << clientId << Endl;
     if (jsonOutput) {
         Cout << response.AsJSON() << Endl;
     } else {
@@ -53,7 +57,7 @@ public:
         TCallContextPtr ctx = MakeIntrusive<TCallContext>();
         auto response = WaitFor(Client->CreateSession(ctx, std::move(request)));
         CheckResponse(response);
-        Print(response, JsonOutput);
+        Print(ClientId, response, JsonOutput);
 
         return true;
     }

--- a/cloud/filestore/apps/client/lib/destroy_session.cpp
+++ b/cloud/filestore/apps/client/lib/destroy_session.cpp
@@ -30,10 +30,12 @@ public:
     TDestroySessionCommand()
     {
         Opts.AddLongOption("session-id")
+            .Required()
             .RequiredArgument("SESSION_ID")
             .StoreResult(&SessionId);
 
         Opts.AddLongOption("client-id")
+            .Required()
             .RequiredArgument("CLIENT_ID")
             .StoreResult(&ClientId);
 


### PR DESCRIPTION
1. print client id in the output of "create session" command. It's required to have client-id to destroy session via filestore client.
2. session-id and client-is are required parameters for "destroy session" command.