### PR TITLE
Fix missed error check

### DIFF
--- a/cloud/storage/core/tools/common/go/configurator/configurator.go
+++ b/cloud/storage/core/tools/common/go/configurator/configurator.go
@@ -428,7 +428,10 @@ func trimWhiteSpaceLines(filePath string) error {
 	if err != nil {
 		return err
 	}
-	tmpFile.Close()
+	err = tmpFile.Close()
+	if err != nil {
+		return err
+	}
 
 	return os.Rename(tmpFile.Name(), filePath)
 }


### PR DESCRIPTION
`ya test -DAUTOCHECK=yes --style -F 'configurator.a.vet.txt::govet' cloud/storage/core/tools/common/go/configurator`
В нашей github репе эта команда не работает. Нужно разобраться и подлить недостающее.