### PR TITLE
issue-1588: Support RPC_GET_VOLUME_STATS capability in csi driver

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -683,7 +683,7 @@ func (s *nodeService) NodeGetVolumeStats(
 	*csi.NodeGetVolumeStatsResponse, error) {
 
 	if s.vmMode {
-		return nil, fmt.Errorf("NodeGetVolumeStats is supported only in vmMode")
+		return nil, fmt.Errorf("NodeGetVolumeStats is not supported in vmMode")
 	}
 
 	var stat unix.Statfs_t

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -679,7 +679,8 @@ func logVolume(volumeId string, format string, v ...any) {
 
 func (s *nodeService) NodeGetVolumeStats(
 	ctx context.Context,
-	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	req *csi.NodeGetVolumeStatsRequest) (
+	*csi.NodeGetVolumeStatsResponse, error) {
 
 	if !s.vmMode {
 		return nil, fmt.Errorf("NodeGetVolumeStats is supported only in vmMode")
@@ -700,6 +701,17 @@ func (s *nodeService) NodeGetVolumeStats(
 	usedNodes := totalNodes - availableNodes
 
 	return &csi.NodeGetVolumeStatsResponse{Usage: []*csi.VolumeUsage{
-		{Available: availableBytes, Used: usedBytes, Total: totalBytes, Unit: csi.VolumeUsage_BYTES},
-		{Available: availableNodes, Used: usedNodes, Total: totalNodes, Unit: csi.VolumeUsage_INODES}}}, nil
+		{
+			Available: availableBytes,
+			Used:      usedBytes,
+			Total:     totalBytes,
+			Unit:      csi.VolumeUsage_BYTES,
+		},
+		{
+			Available: availableNodes,
+			Used:      usedNodes,
+			Total:     totalNodes,
+			Unit:      csi.VolumeUsage_INODES,
+		},
+	}}, nil
 }

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -33,7 +33,7 @@ const nfsSocketName = "nfs.sock"
 const vhostIpc = nbsapi.EClientIpcType_IPC_VHOST
 const nbdIpc = nbsapi.EClientIpcType_IPC_NBD
 
-var capabilities = []*csi.NodeServiceCapability{
+var vmModeCapabilities = []*csi.NodeServiceCapability{
 	{
 		Type: &csi.NodeServiceCapability_Rpc{
 			Rpc: &csi.NodeServiceCapability_RPC{
@@ -50,9 +50,9 @@ var capabilities = []*csi.NodeServiceCapability{
 	},
 }
 
-// CSI driver provides RPC_GET_VOLUME_STATS capability only in vmMode
+// CSI driver provides RPC_GET_VOLUME_STATS capability only in podMode
 // when volume is mounted to the pod as a local directory.
-var vmModeCapabilities = []*csi.NodeServiceCapability{
+var podModeCapabilities = []*csi.NodeServiceCapability{
 	{
 		Type: &csi.NodeServiceCapability_Rpc{
 			Rpc: &csi.NodeServiceCapability_RPC{
@@ -276,7 +276,7 @@ func (s *nodeService) NodeGetCapabilities(
 	}
 
 	return &csi.NodeGetCapabilitiesResponse{
-		Capabilities: capabilities,
+		Capabilities: podModeCapabilities,
 	}, nil
 }
 
@@ -682,7 +682,7 @@ func (s *nodeService) NodeGetVolumeStats(
 	req *csi.NodeGetVolumeStatsRequest) (
 	*csi.NodeGetVolumeStatsResponse, error) {
 
-	if !s.vmMode {
+	if s.vmMode {
 		return nil, fmt.Errorf("NodeGetVolumeStats is supported only in vmMode")
 	}
 

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -506,7 +506,7 @@ func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 	resp, err := nodeService.NodeGetCapabilities(
 		ctx,
 		&csi.NodeGetCapabilitiesRequest{})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	capabilityIndex := slices.IndexFunc(
 		resp.GetCapabilities(),

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -428,12 +428,12 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 	nodeService := newNodeService(
 		"testNodeId",
 		"testClientId",
-		true, // vmMode
+		true,
 		socketsDir,
 		targetFsPathPattern,
-		"", // targetBlkPathPattern
+		"",
 		nbsClient,
-		nil, // nfsClient
+		nil,
 		mounter,
 	)
 
@@ -441,7 +441,7 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 	resp, err := nodeService.NodeGetCapabilities(
 		ctx,
 		&csi.NodeGetCapabilitiesRequest{})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	capabilityIndex := slices.IndexFunc(resp.GetCapabilities(), func(capability *csi.NodeServiceCapability) bool {
 		rpc := capability.GetRpc()
@@ -461,10 +461,12 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 
 	bytesUsage := stat.GetUsage()[0]
 	assert.Equal(t, bytesUsage.Unit, csi.VolumeUsage_BYTES)
+	assert.NotEqual(t, 0, bytesUsage.Total)
 	assert.Equal(t, bytesUsage.Used+bytesUsage.Available, bytesUsage.Total)
 
 	nodesUsage := stat.GetUsage()[1]
 	assert.Equal(t, nodesUsage.Unit, csi.VolumeUsage_INODES)
+	assert.NotEqual(t, 0, nodesUsage.Total)
 	assert.Equal(t, nodesUsage.Used+nodesUsage.Available, nodesUsage.Total)
 }
 
@@ -488,9 +490,9 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	nodeService := newNodeService(
 		"testNodeId",
 		clientID,
-		false, // vmMode
+		false,
 		socketsDir,
-		"", // targetFsPathPattern
+		"",
 		targetBlkPathPattern,
 		nbsClient,
 		nil,

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -413,7 +413,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
+func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	tempDir := os.TempDir()
 
 	nbsClient := mocks.NewNbsClientMock()
@@ -423,7 +423,8 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 	diskID := "test-disk-id-42"
 	socketsDir := filepath.Join(tempDir, "sockets")
 	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
-	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
+	targetFsPathPattern := filepath.Join(tempDir,
+		"pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 
 	nodeService := newNodeService(
 		"testNodeId",
@@ -443,13 +444,14 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 		&csi.NodeGetCapabilitiesRequest{})
 	require.NoError(t, err)
 
-	capabilityIndex := slices.IndexFunc(resp.GetCapabilities(), func(capability *csi.NodeServiceCapability) bool {
-		rpc := capability.GetRpc()
-		if rpc == nil {
-			return false
-		}
-		return rpc.GetType() == csi.NodeServiceCapability_RPC_GET_VOLUME_STATS
-	})
+	capabilityIndex := slices.IndexFunc(resp.GetCapabilities(),
+		func(capability *csi.NodeServiceCapability) bool {
+			rpc := capability.GetRpc()
+			if rpc == nil {
+				return false
+			}
+			return rpc.GetType() == csi.NodeServiceCapability_RPC_GET_VOLUME_STATS
+		})
 	assert.NotEqual(t, -1, capabilityIndex)
 
 	stat, err := nodeService.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
@@ -470,7 +472,7 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 	assert.Equal(t, nodesUsage.Used+nodesUsage.Available, nodesUsage.Total)
 }
 
-func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
+func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 	tempDir := os.TempDir()
 
 	nbsClient := mocks.NewNbsClientMock()
@@ -484,7 +486,8 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	podID := "test-pod-id-13"
 	diskID := "test-disk-id-42"
 	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskID, podID)
-	targetBlkPathPattern := filepath.Join(tempDir, "volumeDevices/publish/([a-z0-9-]+)/([a-z0-9-]+)")
+	targetBlkPathPattern := filepath.Join(tempDir,
+		"volumeDevices/publish/([a-z0-9-]+)/([a-z0-9-]+)")
 	socketsDir := filepath.Join(tempDir, "sockets")
 
 	nodeService := newNodeService(

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -410,4 +411,112 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 		StagingTargetPath: "testStagingTargetPath",
 	})
 	require.NoError(t, err)
+}
+
+func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
+	tempDir := os.TempDir()
+
+	nbsClient := mocks.NewNbsClientMock()
+	mounter := mounter.NewMock()
+
+	podID := "test-pod-id-13"
+	diskID := "test-disk-id-42"
+	socketsDir := filepath.Join(tempDir, "sockets")
+	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
+	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
+
+	nodeService := newNodeService(
+		"testNodeId",
+		"testClientId",
+		true, // vmMode
+		socketsDir,
+		targetFsPathPattern,
+		"", // targetBlkPathPattern
+		nbsClient,
+		nil, // nfsClient
+		mounter,
+	)
+
+	ctx := context.Background()
+	resp, err := nodeService.NodeGetCapabilities(
+		ctx,
+		&csi.NodeGetCapabilitiesRequest{})
+	assert.Nil(t, err)
+
+	capabilityIndex := slices.IndexFunc(resp.GetCapabilities(), func(capability *csi.NodeServiceCapability) bool {
+		rpc := capability.GetRpc()
+		if rpc == nil {
+			return false
+		}
+		return rpc.GetType() == csi.NodeServiceCapability_RPC_GET_VOLUME_STATS
+	})
+	assert.NotEqual(t, -1, capabilityIndex)
+
+	stat, err := nodeService.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   diskID,
+		VolumePath: targetPath,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(stat.GetUsage()))
+
+	bytesUsage := stat.GetUsage()[0]
+	assert.Equal(t, bytesUsage.Unit, csi.VolumeUsage_BYTES)
+	assert.Equal(t, bytesUsage.Used+bytesUsage.Available, bytesUsage.Total)
+
+	nodesUsage := stat.GetUsage()[1]
+	assert.Equal(t, nodesUsage.Unit, csi.VolumeUsage_INODES)
+	assert.Equal(t, nodesUsage.Used+nodesUsage.Available, nodesUsage.Total)
+}
+
+func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
+	tempDir := os.TempDir()
+
+	nbsClient := mocks.NewNbsClientMock()
+	mounter := mounter.NewMock()
+
+	nbdDeviceFile := filepath.Join(tempDir, "dev", "nbd3")
+	err := os.MkdirAll(nbdDeviceFile, 0755)
+	require.NoError(t, err)
+
+	clientID := "testClientId"
+	podID := "test-pod-id-13"
+	diskID := "test-disk-id-42"
+	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskID, podID)
+	targetBlkPathPattern := filepath.Join(tempDir, "volumeDevices/publish/([a-z0-9-]+)/([a-z0-9-]+)")
+	socketsDir := filepath.Join(tempDir, "sockets")
+
+	nodeService := newNodeService(
+		"testNodeId",
+		clientID,
+		false, // vmMode
+		socketsDir,
+		"", // targetFsPathPattern
+		targetBlkPathPattern,
+		nbsClient,
+		nil,
+		mounter,
+	)
+
+	ctx := context.Background()
+	resp, err := nodeService.NodeGetCapabilities(
+		ctx,
+		&csi.NodeGetCapabilitiesRequest{})
+	assert.Nil(t, err)
+
+	capabilityIndex := slices.IndexFunc(
+		resp.GetCapabilities(),
+		func(capability *csi.NodeServiceCapability) bool {
+			rpc := capability.GetRpc()
+			if rpc == nil {
+				return false
+			}
+			return rpc.GetType() == csi.NodeServiceCapability_RPC_GET_VOLUME_STATS
+		})
+	assert.Equal(t, -1, capabilityIndex)
+
+	_, err = nodeService.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   diskID,
+		VolumePath: targetPath,
+	})
+	require.Error(t, err)
 }

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -428,7 +428,7 @@ func TestGetVolumeStatCapabilitiesInVmMode(t *testing.T) {
 	nodeService := newNodeService(
 		"testNodeId",
 		"testClientId",
-		true,
+		false,
 		socketsDir,
 		targetFsPathPattern,
 		"",
@@ -490,7 +490,7 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	nodeService := newNodeService(
 		"testNodeId",
 		clientID,
-		false,
+		true,
 		socketsDir,
 		"",
 		targetBlkPathPattern,


### PR DESCRIPTION
issue: #1588

CSI driver provides RPC_GET_VOLUME_STATS capability only in podMode when volume is mounted to the pod as a local folder.