### PR TITLE
issue-1350: GetNodeAttrBatchEnabled: true for multitablet filestore tests

### DIFF
--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
@@ -6,3 +6,4 @@ ReadAheadCacheRangeSize: 1048576
 NodeIndexCacheMaxNodes: 128
 PreferredBlockSizeMultiplier: 64
 MultiTabletForwardingEnabled: true
+GetNodeAttrBatchEnabled: true


### PR DESCRIPTION
#1350 