### PR TITLE
issue-1161: not generating deletion markers upon symlink removal

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -116,12 +116,16 @@ void TIndexTabletState::RemoveNode(
         AddCheckpointNode(db, checkpointId, node.NodeId);
     }
 
-    Truncate(
-        db,
-        node.NodeId,
-        maxCommitId,
-        node.Attrs.GetSize(),
-        0);
+    // SymLinks have size (equal to TargetPath) but store no real data so there
+    // is no need to write deletion markers upon SymLink removal
+    if (!node.Attrs.GetSymLink()) {
+        Truncate(
+            db,
+            node.NodeId,
+            maxCommitId,
+            node.Attrs.GetSize(),
+            0);
+    }
 
     InvalidateNodeIndexCache(node.NodeId);
 }


### PR DESCRIPTION
SymLinks have size but store no real data => there's no need to generate deletion markers upon removal of symlinks.

#1161 