### PR TITLE
issue-1161: not initializing most of the per-filesystem request counters until we actually receive at least 1 request of the type

### DIFF
--- a/cloud/storage/core/libs/diagnostics/request_counters.h
+++ b/cloud/storage/core/libs/diagnostics/request_counters.h
@@ -33,6 +33,7 @@ public:
         ReportDataPlaneHistogram    = (1 << 1),
         ReportControlPlaneHistogram = (1 << 2),
         AddSpecialCounters          = (1 << 3),
+        LazyRequestInitialization   = (1 << 4),
     };
 
     using TRequestType = TDiagnosticsRequestType;
@@ -129,6 +130,8 @@ private:
 
     template<typename TMethod, typename... TArgs>
     void NotifySubscribers(TMethod&& m, TArgs&&... args);
+
+    TStatCounters& AccessRequestStats(TRequestType t);
 };
 
 Y_DECLARE_OPERATORS_FOR_FLAGS(TRequestCounters::EOptions);


### PR DESCRIPTION
Unlike NBS we have a lot of different request types in Filestore. And we report a lot of metrics for each <requestType, fsId> pair which generates a lot of work for the monitoring systems that we use. Most of the filesystems never receive the majority of these request types. In this PR I'm not reporting any per-FS counters except Count and Errors/Fatal for the request types which have never been seen by this FS. It should radically decrease the total number of metrics that we report (we'll get rid of a lot of unnecessarily reported zeroes).

#1161 