### PR TITLE
NBSNEBIUS-351: Erase devices using deallocate in 1GB chunks

### DIFF
--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -31,6 +31,5 @@ struct INvmeManager
 ////////////////////////////////////////////////////////////////////////////////
 
 INvmeManagerPtr CreateNvmeManager(TDuration timeout);
-INvmeManagerPtr CreateNvmeManagerStub(bool isDeviceSsd = true);
 
 }   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/nvme_stub.h
+++ b/cloud/blockstore/libs/nvme/nvme_stub.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "nvme.h"
+
+namespace NCloud::NBlockStore::NNvme {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using NvmeDeallocateHistory = TVector<std::tuple<ui64, ui64>>;
+using NvmeDeallocateHistoryPtr = std::shared_ptr<NvmeDeallocateHistory>;
+
+INvmeManagerPtr CreateNvmeManagerStub(
+    bool isDeviceSsd = true,
+    NvmeDeallocateHistoryPtr deallocateHistory = nullptr);
+
+}   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/service_local/storage_aio_ut_large.cpp
+++ b/cloud/blockstore/libs/service_local/storage_aio_ut_large.cpp
@@ -4,7 +4,7 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/storage.h>
 #include <cloud/blockstore/libs/service/storage_provider.h>
-#include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/nvme/nvme_stub.h>
 
 #include <cloud/storage/core/libs/aio/service.h>
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -2,7 +2,7 @@
 
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/service/storage.h>
-#include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/nvme/nvme_stub.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/disk_agent.h>


### PR DESCRIPTION
Deallocating large device chunks (e.g., 93GB) on certain SSD models resulted in
incomplete erasure, leaving ~20 pages uncleared. This commit mitigates the issue
by deallocating in smaller 1GB chunks, ensuring complete device erasure.
