### PR TITLE
Fix MSAN wrong assumption for AIO reading

### DIFF
--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -46,6 +46,7 @@ void CompleteRequest(
 
     if (req->BufferAllocated || encryptor) {
         if (bio->type == VHD_BDEV_READ && status == VHD_BDEV_SUCCESS) {
+            NSan::Unpoison(req->Data[0].iov_base, req->Data[0].iov_len);
             const bool succ = SgListCopyWithOptionalDecryption(
                 log,
                 static_cast<const char*>(req->Data[0].iov_base),
@@ -90,6 +91,7 @@ void CompleteCompoundRequest(
         }
 
         if (bio->type == VHD_BDEV_READ && status == VHD_BDEV_SUCCESS) {
+            NSan::Unpoison(req->Buffer.get(), bytes);
             bool succ = SgListCopyWithOptionalDecryption(
                 log,
                 req->Buffer.get(),


### PR DESCRIPTION
MSAN не считает память, которую заполнили чтеним через AIO инициализированной.
```
==901720==WARNING: MemorySanitizer: use-of-uninitialized-value
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xf0 has a premature terminator entry at offset 0x100
warning: address range table at offset 0x120 has a premature terminator entry at offset 0x130
    #0 0x13e276a in NCloud::NBlockStore::IsAllZeroes(char const*, unsigned long) /-S/cloud/blockstore/libs/common/iovector.cpp:187:22
    #1 0xae3b99 in NCloud::NBlockStore::NVHostServer::(anonymous namespace)::DoCryptoOperation<&NCloud::NBlockStore::IEncryptor::Decrypt> /-S/cloud/blockstore/vhost-server/request_aio.cpp:33:13
    #2 0xae3b99 in NCloud::NBlockStore::NVHostServer::SgListCopyWithOptionalDecryption(TLog&, char const*, vhd_sglist const&, NCloud::NBlockStore::IEncryptor*, unsigned long) /-S/cloud/blockstore/vhost-server/request_aio.cpp:165:14
    #3 0xacb3dc in NCloud::NBlockStore::NVHostServer::(anonymous namespace)::CompleteRequest /-S/cloud/blockstore/vhost-server/backend_aio.cpp:49:31
    #4 0xacb3dc in NCloud::NBlockStore::NVHostServer::(anonymous namespace)::TAioBackend::CompletionThreadFunc /-S/cloud/blockstore/vhost-server/backend_aio.cpp:448:13
    #5 0xacb3dc in NCloud::NBlockStore::NVHostServer::(anonymous namespace)::TAioBackend::Start()::(anonymous class)::operator() /-S/cloud/blockstore/vhost-server/backend_aio.cpp:260:45
    #6 0xacb3dc in std::__y1::__invoke<(lambda at /-S/cloud/blockstore/vhost-server/backend_aio.cpp:260:36)> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25
    #7 0xacb3dc in std::__y1::__thread_execute<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, (lambda at /-S/cloud/blockstore/vhost-server/backend_aio.cpp:260:36)> /-S/contrib/libs/cxxsupp/libcxx/include/__thread/thread.h:221:5
    #8 0xacb3dc in void* std::__y1::__thread_proxy[abi:v180000]<std::__y1::tuple<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct>>, NCloud::NBlockStore::NVHostServer::(anonymous namespace)::TAioBackend::Start()::$_0>>(void*) /-S/contrib/libs/cxxsupp/libcxx/include/__thread/thread.h:232:5
    #9 0x7f725da44608 in start_thread /build/glibc-LcI20x/glibc-2.31/nptl/pthread_create.c:477:8
    #10 0x7f725d969352 in __clone /build/glibc-LcI20x/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
SUMMARY: MemorySanitizer: use-of-uninitialized-value /-S/cloud/blockstore/libs/common/iovector.cpp:187:22 in NCloud::NBlockStore::IsAllZeroes(char const*, unsigned long)
Exiting
```