### PR TITLE
fix: throw exception if device is not open

### DIFF
--- a/cloud/blockstore/libs/nbd/device.cpp
+++ b/cloud/blockstore/libs/nbd/device.cpp
@@ -165,6 +165,11 @@ void TDevice::ConnectDevice()
     STORAGE_DEBUG("Connect device");
 
     TFileHandle device(DeviceName, OpenExisting | RdWr);
+
+    if (!device.IsOpen()) {
+         ythrow TFileError() << "cannot open device with name " << DeviceName;
+    }
+
     ioctl(device, NBD_CLEAR_SOCK);
 
     const auto& exportInfo = Handler->GetExportInfo();


### PR DESCRIPTION
In case of not opened device we throw exception below in the code with not relevant message ["could not setup device block size"](https://github.com/ydb-platform/nbs/blob/13b2bfb36076128c189f3da0d09564a63d07494f/cloud/blockstore/libs/nbd/device.cpp#L189)

It's better to check `device.IsOpen()` and throw exception with correct error message