### PR TITLE
[Disk Manager] do not need nbs creds in dm admin tool

### DIFF
--- a/cloud/disk_manager/pkg/admin/private.go
+++ b/cloud/disk_manager/pkg/admin/private.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/api"
-	internal_auth "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth"
 	internal_client "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/client"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
 	client_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/configs/client/config"
@@ -547,11 +546,9 @@ type getCheckpointSizeCmd struct {
 
 func (c *getCheckpointSizeCmd) run() error {
 	ctx := newContext(c.clientConfig)
-	creds := internal_auth.NewCredentials(ctx, c.serverConfig.GetAuthConfig())
-	nbsFactory, err := nbs.NewFactoryWithCreds(
+	nbsFactory, err := nbs.NewFactory(
 		ctx,
 		c.serverConfig.NbsConfig,
-		creds,
 		metrics.NewEmptyRegistry(),
 		metrics.NewEmptyRegistry(),
 	)


### PR DESCRIPTION
не нужно, так как контекст выше содержит IAM для авторизации - так правильнее тут 