### PR TITLE
[Disk Manager] logs: write explicitly either task running or cancelling when starting execution

### DIFF
--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -114,7 +114,7 @@ func (r *runnerForRun) executeTask(
 
 	logging.Info(
 		ctx,
-		"started execution %v with id %v (run)",
+		"started execution of %v with id %v (run)",
 		taskType,
 		taskID,
 	)

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -114,7 +114,7 @@ func (r *runnerForRun) executeTask(
 
 	logging.Info(
 		ctx,
-		"started execution of %v with id %v (run)",
+		"started execution of %v with task id %v (run)",
 		taskType,
 		taskID,
 	)

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -114,7 +114,7 @@ func (r *runnerForRun) executeTask(
 
 	logging.Info(
 		ctx,
-		"started %v with id %v",
+		"started execution %v with id %v (run)",
 		taskType,
 		taskID,
 	)
@@ -364,7 +364,7 @@ func (r *runnerForCancel) executeTask(
 
 	logging.Info(
 		ctx,
-		"started execution of %v with task id %v",
+		"started execution of %v with task id %v (cancel)",
 		taskType,
 		taskID,
 	)


### PR DESCRIPTION
Когда раннер берёт таск на исполнение, он пишет об этом в лог. Но по сообщению не понятно, идёт ли речь о штатном исполнении или об отмене. Хотя эту информацию обычно можно восстановить из контекста, лучше писать об этом явно.