### PR TITLE
issue-1673: Unaligned requests support in ThreeStageWrite pipeline - IndexTablet part

### DIFF
--- a/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
@@ -25,6 +25,7 @@ TAddDataActor::TAddDataActor(
         TRequestInfoPtr requestInfo,
         ui64 commitId,
         TVector<TMergedBlob> blobs,
+        TVector<TBlockBytesMeta> unalignedDataParts,
         TWriteRange writeRange)
     : TraceSerializer(std::move(traceSerializer))
     , LogTag(std::move(logTag))
@@ -32,6 +33,7 @@ TAddDataActor::TAddDataActor(
     , RequestInfo(std::move(requestInfo))
     , CommitId(commitId)
     , Blobs(std::move(blobs))
+    , UnalignedDataParts(std::move(unalignedDataParts))
     , WriteRange(writeRange)
 {
     for (const auto& blob: Blobs) {
@@ -56,6 +58,7 @@ void TAddDataActor::AddBlob(const TActorContext& ctx)
         RequestInfo->CallContext);
     request->Mode = EAddBlobMode::Write;
     request->WriteRanges.push_back(WriteRange);
+    request->UnalignedDataParts = std::move(UnalignedDataParts);
 
     for (const auto& blob: Blobs) {
         request->MergedBlobs.emplace_back(

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.h
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.h
@@ -25,7 +25,8 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const ui64 CommitId;
-    /*const*/ TVector<TMergedBlob> Blobs;
+    const TVector<TMergedBlob> Blobs;
+    TVector<TBlockBytesMeta> UnalignedDataParts;
     const TWriteRange WriteRange;
     ui32 BlobsSize = 0;
 
@@ -37,6 +38,7 @@ public:
         TRequestInfoPtr requestInfo,
         ui64 commitId,
         TVector<TMergedBlob> blobs,
+        TVector<TBlockBytesMeta> unalignedDataParts,
         TWriteRange writeRange);
 
     void Bootstrap(const TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/model/block.h
+++ b/cloud/filestore/libs/storage/tablet/model/block.h
@@ -134,6 +134,17 @@ struct TBlockWithBytes
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TBlockBytesMeta
+{
+    ui64 NodeId = 0;
+    ui32 BlockIndex = 0;
+    ui64 MinCommitId = 0;
+    ui32 OffsetInBlock = 0;
+    TString Data;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 // XXX not the best place for this struct
 struct TFlushBytesCleanupInfo
 {

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -79,6 +79,28 @@ void TFreshBytes::DeleteBytes(
     }
 }
 
+NProto::TError TFreshBytes::CheckBytes(
+    ui64 nodeId,
+    ui64 offset,
+    TStringBuf data,
+    ui64 commitId) const
+{
+    // might use these in the future
+    Y_UNUSED(nodeId);
+    Y_UNUSED(offset);
+    Y_UNUSED(data);
+
+    const auto& c = Chunks.back();
+    if (c.FirstCommitId != InvalidCommitId && commitId < c.FirstCommitId) {
+        return MakeError(
+            E_REJECTED,
+            TStringBuilder() << "bytes' commitId too old: " << commitId << " < "
+                << c.FirstCommitId);
+    }
+
+    return {};
+}
+
 void TFreshBytes::AddBytes(
     ui64 nodeId,
     ui64 offset,

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -6,6 +6,7 @@
 
 #include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/storage/core/libs/common/byte_vector.h>
+#include <cloud/storage/core/libs/common/error.h>
 
 #include <util/generic/map.h>
 #include <util/generic/deque.h>
@@ -100,6 +101,11 @@ public:
         LogTag = std::move(logTag);
     }
 
+    NProto::TError CheckBytes(
+        ui64 nodeId,
+        ui64 offset,
+        TStringBuf data,
+        ui64 commitId) const;
     void AddBytes(ui64 nodeId, ui64 offset, TStringBuf data, ui64 commitId);
     void AddDeletionMarker(ui64 nodeId, ui64 offset, ui64 len, ui64 commitId);
 

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
@@ -71,7 +71,13 @@ Y_UNIT_TEST_SUITE(TFreshBytesTest)
         freshBytes.AddBytes(1, 50, "cCc", 12);
         freshBytes.AddBytes(1, 50, "dDd", 13);
         freshBytes.AddBytes(2, 100, "eEeEe", 14);
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            freshBytes.CheckBytes(2, 1000, "fFf", 15).GetCode());
         freshBytes.AddBytes(2, 1000, "fFf", 15);
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            freshBytes.CheckBytes(2, 1000, "zzz", 9).GetCode());
         freshBytes.AddDeletionMarker(2, 100, 3, 16);
 
         {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -145,9 +145,6 @@ private:
         for (const auto& part: args.UnalignedDataParts) {
             const auto offset = part.OffsetInBlock
                 + static_cast<ui64>(part.BlockIndex) * Tablet.GetBlockSize();
-            // TODO: check whether MinCommitId is not older than what's
-            // expected by FreshBytes
-            // if it's older, return an error
             Tablet.WriteFreshBytes(
                 db,
                 part.NodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -401,8 +401,6 @@ void TIndexTabletActor::HandleAddData(
         unalignedDataParts.push_back({
             0, // NodeId is not known at this point
             blockIndex,
-            // TODO: fix the situation when the current chunk's FirstCommitId
-            // is greater than CommitId from the request
             msg->Record.GetCommitId(),
             offsetInBlock,
             std::move(*part.MutableContent())});

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -18,7 +18,6 @@ using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
-
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,6 +76,10 @@ bool TIndexTabletActor::PrepareTx_AddData(
     args.NodeId = handle->GetNodeId();
     ui64 commitId = GetCurrentCommitId();
 
+    for (auto& part: args.UnalignedDataParts) {
+        part.NodeId = args.NodeId;
+    }
+
     LOG_TRACE(
         ctx,
         TFileStoreComponents::TABLET,
@@ -93,6 +96,7 @@ bool TIndexTabletActor::PrepareTx_AddData(
     }
 
     // TODO: access check
+    // TODO: replace VERIFY with a check + critical event
     TABLET_VERIFY(args.Node);
     if (!HasSpaceLeft(args.Node->Attrs, args.ByteRange.End())) {
         args.Error = ErrorNoSpaceLeft();
@@ -110,9 +114,7 @@ void TIndexTabletActor::ExecuteTx_AddData(
     Y_UNUSED(ctx, tx, args);
 
     // Note: unlike ExecuteTx_WriteData, we do not need to call UpdateNode here,
-    // as it is done in AddBlob operation. If unaligned data is to be supported
-    // for AddData, UpdateNode should be called here as well, analogously to
-    // WriteData.
+    // as it is done in AddBlob operation.
 }
 
 void TIndexTabletActor::CompleteTx_AddData(
@@ -189,6 +191,7 @@ void TIndexTabletActor::CompleteTx_AddData(
         args.RequestInfo,
         args.CommitId,
         std::move(blobs),
+        std::move(args.UnalignedDataParts),
         TWriteRange{args.NodeId, args.ByteRange.End()});
 
     auto actorId = NCloud::Register(ctx, std::move(actor));
@@ -373,16 +376,62 @@ void TIndexTabletActor::HandleAddData(
                 E_ARGUMENT,
                 "empty list of blobs given in AddData request"));
         NCloud::Reply(ctx, *ev, std::move(response));
+        return;
     }
+
+    TVector<TBlockBytesMeta> unalignedDataParts;
+    for (auto& part: *msg->Record.MutableUnalignedDataRanges()) {
+        const ui32 blockIndex = part.GetOffset() / GetBlockSize();
+        const ui32 lastBlockIndex =
+            (part.GetOffset() + part.GetContent().Size() - 1) / GetBlockSize();
+        if (blockIndex != lastBlockIndex) {
+            auto response =
+                std::make_unique<TEvIndexTablet::TEvAddDataResponse>(MakeError(
+                    E_ARGUMENT,
+                    TStringBuilder() << "unaligned part spanning more than one"
+                        << " block: " << part.GetOffset() << ":"
+                        << part.GetContent().Size()));
+            NCloud::Reply(ctx, *ev, std::move(response));
+            return;
+        }
+
+        const ui32 offsetInBlock =
+            part.GetOffset() - static_cast<ui64>(blockIndex) * GetBlockSize();
+
+        unalignedDataParts.push_back({
+            0, // NodeId is not known at this point
+            blockIndex,
+            // TODO: fix the situation when the current chunk's FirstCommitId
+            // is greater than CommitId from the request
+            msg->Record.GetCommitId(),
+            offsetInBlock,
+            std::move(*part.MutableContent())});
+    }
+
+    auto unalignedMsg = [&] () {
+        TStringBuilder sb;
+        for (auto& part: unalignedDataParts) {
+            if (sb.Size()) {
+                sb << ", ";
+            }
+
+            sb << part.BlockIndex
+                << ":" << part.MinCommitId
+                << ":" << part.OffsetInBlock
+                << ":" << part.Data.Size();
+        }
+        return sb;
+    };
 
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET,
-        "%s %s: blobId: %s,... (total: %lu)",
+        "%s %s: blobId: %s,... (total: %lu), unaligned: %s",
         LogTag.c_str(),
         "AddData",
         blobIds[0].ToString().c_str(),
-        blobIds.size());
+        blobIds.size(),
+        unalignedMsg().c_str());
 
     AddTransaction<TEvIndexTablet::TAddDataMethod>(*requestInfo);
 
@@ -392,6 +441,7 @@ void TIndexTabletActor::HandleAddData(
         msg->Record,
         range,
         std::move(blobIds),
+        std::move(unalignedDataParts),
         msg->Record.GetCommitId());
     txStarted = true;
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -334,6 +334,7 @@ struct TEvIndexTabletPrivate
         TVector<TMixedBlobMeta> MixedBlobs;
         TVector<TMergedBlobMeta> MergedBlobs;
         TVector<TWriteRange> WriteRanges;
+        TVector<TBlockBytesMeta> UnalignedDataParts;
     };
 
     struct TAddBlobResponse

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -706,6 +706,12 @@ public:
         ui64 commitId,
         TByteRange byteRange) const;
 
+    NProto::TError CheckFreshBytes(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset,
+        TStringBuf data) const;
+
     void WriteFreshBytes(
         TIndexTabletDatabase& db,
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -308,6 +308,19 @@ void TIndexTabletState::FindFreshBytes(
         commitId);
 }
 
+NProto::TError TIndexTabletState::CheckFreshBytes(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 offset,
+    TStringBuf data) const
+{
+    return Impl->FreshBytes.CheckBytes(
+        nodeId,
+        offset,
+        data,
+        commitId);
+}
+
 void TIndexTabletState::WriteFreshBytes(
     TIndexTabletDatabase& db,
     ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1499,6 +1499,7 @@ struct TTxIndexTablet
 
         ui64 CommitId = InvalidCommitId;
         TNodeSet Nodes;
+        NProto::TError Error;
 
         TAddBlob(
                 TRequestInfoPtr requestInfo,
@@ -1526,6 +1527,7 @@ struct TTxIndexTablet
 
             CommitId = InvalidCommitId;
             Nodes.clear();
+            Error.Clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1385,6 +1385,7 @@ struct TTxIndexTablet
         const ui64 Handle;
         const TByteRange ByteRange;
         TVector<NKikimr::TLogoBlobID> BlobIds;
+        TVector<TBlockBytesMeta> UnalignedDataParts;
         ui64 CommitId;
 
         ui64 NodeId = InvalidNodeId;
@@ -1395,12 +1396,14 @@ struct TTxIndexTablet
                 const NProtoPrivate::TAddDataRequest& request,
                 TByteRange byteRange,
                 TVector<NKikimr::TLogoBlobID> blobIds,
+                TVector<TBlockBytesMeta> unalignedDataParts,
                 ui64 commitId)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , Handle(request.GetHandle())
             , ByteRange(byteRange)
             , BlobIds(std::move(blobIds))
+            , UnalignedDataParts(std::move(unalignedDataParts))
             , CommitId(commitId)
         {}
 
@@ -1492,6 +1495,7 @@ struct TTxIndexTablet
         /*const*/ TVector<TMixedBlobMeta> MixedBlobs;
         /*const*/ TVector<TMergedBlobMeta> MergedBlobs;
         const TVector<TWriteRange> WriteRanges;
+        const TVector<TBlockBytesMeta> UnalignedDataParts;
 
         ui64 CommitId = InvalidCommitId;
         TNodeSet Nodes;
@@ -1503,7 +1507,8 @@ struct TTxIndexTablet
                 TVector<TBlock> srcBlocks,
                 TVector<TMixedBlobMeta> mixedBlobs,
                 TVector<TMergedBlobMeta> mergedBlobs,
-                TVector<TWriteRange> writeRanges)
+                TVector<TWriteRange> writeRanges,
+                TVector<TBlockBytesMeta> unalignedDataParts)
             : TProfileAware(EFileStoreSystemRequest::AddBlob)
             , RequestInfo(std::move(requestInfo))
             , Mode(mode)
@@ -1512,6 +1517,7 @@ struct TTxIndexTablet
             , MixedBlobs(std::move(mixedBlobs))
             , MergedBlobs(std::move(mergedBlobs))
             , WriteRanges(std::move(writeRanges))
+            , UnalignedDataParts(std::move(unalignedDataParts))
         {}
 
         void Clear()

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -605,7 +605,8 @@ public:
         ui64 offset,
         ui64 length,
         const TVector<NKikimr::TLogoBlobID>& blobIds,
-        ui64 commitId)
+        ui64 commitId,
+        TVector<NProtoPrivate::TFreshDataRange> unalignedDataParts = {})
     {
         auto request = CreateSessionRequest<
             TEvIndexTablet::TEvAddDataRequest>();
@@ -619,6 +620,9 @@ public:
                 request->Record.MutableBlobIds()->Add());
         }
         request->Record.SetCommitId(commitId);
+        for (auto& part: unalignedDataParts) {
+            *request->Record.AddUnalignedDataRanges() = std::move(part);
+        }
         return request;
     }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -449,6 +449,9 @@ message TAddDataRequest
 
     // Commit id.
     uint64 CommitId = 8;
+
+    // Unaligned data parts - supposed to contain unaligned head and tail.
+    repeated TFreshDataRange UnalignedDataRanges = 9;
 }
 
 message TAddDataResponse


### PR DESCRIPTION
IndexTablet's AddData now accepts a list of unaligned data parts alongside the other data (BlobIds)
ServiceActor will cut off the unaligned head and tail for large unaligned writes, proceed with the usual GenerateBlobIds -> PutUserData -> AddData pipeline, adding those unaligned head and tail parts to the AddData request
The logic in ServiceActor will not be enabled unless a specific flag is set in StorageServiceConfig (we need to deploy all this code first and enable the flag only when we are sure that the IndexTablet part is deployed everywhere)

#1673 