### PR TITLE
issue-1673: AddData + UnalignedDataParts: using CommitId, generated in AddBlobTx (since the same CommitId is used for the blobs), adding some checks

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -33,6 +33,7 @@ namespace NCloud::NFileStore{
     xxx(ChildRefIsNull)                                                        \
     xxx(NewChildNodeIsNull)                                                    \
     xxx(IndexOutOfBounds)                                                      \
+    xxx(CheckFreshBytesFailed)                                                 \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/block.h
+++ b/cloud/filestore/libs/storage/tablet/model/block.h
@@ -138,7 +138,6 @@ struct TBlockBytesMeta
 {
     ui64 NodeId = 0;
     ui32 BlockIndex = 0;
-    ui64 MinCommitId = 0;
     ui32 OffsetInBlock = 0;
     TString Data;
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -2,6 +2,7 @@
 
 #include "profile_log_events.h"
 
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/storage/tablet/model/group_by.h>
 
 #include <util/generic/set.h>
@@ -93,11 +94,12 @@ private:
                 + static_cast<ui64>(part.BlockIndex) * Tablet.GetBlockSize();
             auto error = Tablet.CheckFreshBytes(
                 part.NodeId,
-                part.MinCommitId,
+                args.CommitId,
                 offset,
                 part.Data);
 
             if (HasError(error)) {
+                ReportCheckFreshBytesFailed(error.GetMessage());
                 args.Error = std::move(error);
                 return;
             }
@@ -148,7 +150,7 @@ private:
             Tablet.WriteFreshBytes(
                 db,
                 part.NodeId,
-                part.MinCommitId,
+                args.CommitId,
                 offset,
                 part.Data);
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -459,6 +459,17 @@ void TIndexTabletActor::HandleAddDataCompleted(
 {
     auto* msg = ev->Get();
 
+    if (HasError(msg->Error)) {
+        LOG_ERROR(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s AddData failed: %s",
+            LogTag.c_str(),
+            FormatError(msg->Error).Quote().c_str());
+    } else {
+        Metrics.AddData.Update(msg->Count, msg->Size, msg->Time);
+    }
+
     // We try to release commit barrier twice: once for the lock
     // acquired by the GenerateBlob request and once for the lock
     // acquired by the AddData request. Though, the first lock is
@@ -469,8 +480,6 @@ void TIndexTabletActor::HandleAddDataCompleted(
 
     WorkerActors.erase(ev->Sender);
     EnqueueBlobIndexOpIfNeeded(ctx);
-
-    Metrics.AddData.Update(msg->Count, msg->Size, msg->Time);
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
Followup for https://github.com/ydb-platform/nbs/pull/1740 

#1673 