### PR TITLE
[Disk Manager] fix delete_disk_task

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
@@ -82,7 +82,7 @@ func (t *deleteDiskTask) deleteDisk(
 	taskID, err := t.scheduler.ScheduleTask(
 		headers.SetIncomingIdempotencyKey(
 			ctx,
-			"delete_disk_from_incremental_"+":"+zoneID+":"+diskID,
+			"delete_disk_from_incremental"+":"+zoneID+":"+diskID,
 		),
 		"dataplane.DeleteDiskFromIncremental",
 		"",

--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
@@ -82,7 +82,7 @@ func (t *deleteDiskTask) deleteDisk(
 	taskID, err := t.scheduler.ScheduleTask(
 		headers.SetIncomingIdempotencyKey(
 			ctx,
-			"delete_disk_from_incremental"+":"+zoneID+":"+diskID,
+			selfTaskID+"_delete_disk_from_incremental",
 		),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
@@ -121,7 +121,7 @@ func (t *deleteDiskTask) deleteDisk(
 		taskID, err = t.poolService.ReleaseBaseDisk(
 			headers.SetIncomingIdempotencyKey(
 				ctx,
-				"release_base_disk"+":"+zoneID+":"+diskID,
+				selfTaskID+"_release_base_disk",
 			),
 			&pools_protos.ReleaseBaseDiskRequest{
 				OverlayDisk: &types.Disk{

--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
@@ -80,11 +80,17 @@ func (t *deleteDiskTask) deleteDisk(
 	}
 
 	taskID, err := t.scheduler.ScheduleTask(
-		headers.SetIncomingIdempotencyKey(ctx, execCtx.GetTaskID()),
+		headers.SetIncomingIdempotencyKey(
+			ctx,
+			"delete_disk_from_incremental_"+":"+zoneID+":"+diskID,
+		),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		&dataplane_protos.DeleteDiskFromIncrementalRequest{
-			Disk: t.request.Disk,
+			Disk: &types.Disk{
+				ZoneId: zoneID,
+				DiskId: diskID,
+			},
 		},
 	)
 	if err != nil {
@@ -113,7 +119,10 @@ func (t *deleteDiskTask) deleteDisk(
 	// Only overlay disks (created from image) should be released.
 	if len(diskMeta.SrcImageID) != 0 {
 		taskID, err = t.poolService.ReleaseBaseDisk(
-			headers.SetIncomingIdempotencyKey(ctx, selfTaskID),
+			headers.SetIncomingIdempotencyKey(
+				ctx,
+				"release_base_disk"+":"+zoneID+":"+diskID,
+			),
 			&pools_protos.ReleaseBaseDiskRequest{
 				OverlayDisk: &types.Disk{
 					ZoneId: zoneID,

--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task_test.go
@@ -61,7 +61,7 @@ func testDeleteDiskTaskRun(t *testing.T, sync bool) {
 
 	scheduler.On(
 		"ScheduleTask",
-		mock.Anything,
+		headers.SetIncomingIdempotencyKey(ctx, "delete_disk_from_incremental:zone:disk"),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		mock.Anything,
@@ -118,7 +118,7 @@ func TestDeleteDiskTaskRunWithDiskCreatedFromImage(t *testing.T) {
 
 	scheduler.On(
 		"ScheduleTask",
-		mock.Anything,
+		headers.SetIncomingIdempotencyKey(ctx, "delete_disk_from_incremental:zone:disk"),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		mock.Anything,
@@ -131,7 +131,7 @@ func TestDeleteDiskTaskRunWithDiskCreatedFromImage(t *testing.T) {
 
 	poolService.On(
 		"ReleaseBaseDisk",
-		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id"),
+		headers.SetIncomingIdempotencyKey(ctx, "release_base_disk:zone:disk"),
 		&pools_protos.ReleaseBaseDiskRequest{
 			OverlayDisk: disk,
 		}).Return("release", nil)
@@ -181,7 +181,7 @@ func TestDeleteDiskTaskCancel(t *testing.T) {
 
 	scheduler.On(
 		"ScheduleTask",
-		mock.Anything,
+		headers.SetIncomingIdempotencyKey(ctx, "delete_disk_from_incremental:zone:disk"),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		mock.Anything,
@@ -191,7 +191,7 @@ func TestDeleteDiskTaskCancel(t *testing.T) {
 
 	poolService.On(
 		"ReleaseBaseDisk",
-		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id"),
+		headers.SetIncomingIdempotencyKey(ctx, "release_base_disk:zone:disk"),
 		&pools_protos.ReleaseBaseDiskRequest{
 			OverlayDisk: disk,
 		}).Return("release", nil)

--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task_test.go
@@ -61,7 +61,7 @@ func testDeleteDiskTaskRun(t *testing.T, sync bool) {
 
 	scheduler.On(
 		"ScheduleTask",
-		headers.SetIncomingIdempotencyKey(ctx, "delete_disk_from_incremental:zone:disk"),
+		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id_delete_disk_from_incremental"),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		mock.Anything,
@@ -118,7 +118,7 @@ func TestDeleteDiskTaskRunWithDiskCreatedFromImage(t *testing.T) {
 
 	scheduler.On(
 		"ScheduleTask",
-		headers.SetIncomingIdempotencyKey(ctx, "delete_disk_from_incremental:zone:disk"),
+		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id_delete_disk_from_incremental"),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		mock.Anything,
@@ -131,7 +131,7 @@ func TestDeleteDiskTaskRunWithDiskCreatedFromImage(t *testing.T) {
 
 	poolService.On(
 		"ReleaseBaseDisk",
-		headers.SetIncomingIdempotencyKey(ctx, "release_base_disk:zone:disk"),
+		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id_release_base_disk"),
 		&pools_protos.ReleaseBaseDiskRequest{
 			OverlayDisk: disk,
 		}).Return("release", nil)
@@ -181,7 +181,7 @@ func TestDeleteDiskTaskCancel(t *testing.T) {
 
 	scheduler.On(
 		"ScheduleTask",
-		headers.SetIncomingIdempotencyKey(ctx, "delete_disk_from_incremental:zone:disk"),
+		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id_delete_disk_from_incremental"),
 		"dataplane.DeleteDiskFromIncremental",
 		"",
 		mock.Anything,
@@ -191,7 +191,7 @@ func TestDeleteDiskTaskCancel(t *testing.T) {
 
 	poolService.On(
 		"ReleaseBaseDisk",
-		headers.SetIncomingIdempotencyKey(ctx, "release_base_disk:zone:disk"),
+		headers.SetIncomingIdempotencyKey(ctx, "toplevel_task_id_release_base_disk"),
 		&pools_protos.ReleaseBaseDiskRequest{
 			OverlayDisk: disk,
 		}).Return("release", nil)


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1636

проблема была в том, что были одинаковые IdempotencyKeys у двух разных задач разного типа 

таким образом одна из них забывалась (releaseBaseDisk)

тут есть вопрос к тому что scheduler мог бы проверять, что нет задачи ДРУГОГО типа с ТАКИМ же IdempotencyKey