### PR TITLE
issue-1657: set custom monitoring port in minikube manifest

### DIFF
--- a/cloud/blockstore/tools/csi_driver/deploy/manifests/6-csi-daemonset.yaml
+++ b/cloud/blockstore/tools/csi_driver/deploy/manifests/6-csi-daemonset.yaml
@@ -81,6 +81,9 @@ spec:
               mountPath: /run/nbsd/sockets
             - name: dev
               mountPath: /mnt/dev
+          ports:
+            - containerPort: 8775
+              name: http-monitoring
       volumes:
         - name: registration-dir
           hostPath:


### PR DESCRIPTION
Default port 8774 is already in use by csi controller pod