### PR TITLE
fix msan errors

### DIFF
--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -5,6 +5,7 @@
 #include <cloud/storage/core/libs/common/file_io_service.h>
 
 #include <util/string/builder.h>
+#include <util/system/sanitizers.h>
 
 namespace NCloud::NFileStore {
 
@@ -79,6 +80,8 @@ TFuture<NProto::TReadDataResponse> TLocalFileSystem::ReadDataAsync(
     }
 
     auto b = TString::Uninitialized(request.GetLength());
+    NSan::Unpoison(b.Data(), b.Size());
+
     TArrayRef<char> data(b.begin(), b.vend());
     auto promise = NewPromise<NProto::TReadDataResponse>();
     FileIOService->AsyncRead(*handle, request.GetOffset(), data).Subscribe(


### PR DESCRIPTION
Fix for errors in service_local like:

warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xf0 has a premature terminator entry at offset 0x100
    #0 0xd2c87d in __interceptor_bcmp /-S/contrib/libs/clang16-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:954:10
    #1 0xc221d2 in std::__y1::char_traits<char>::compare /-S/contrib/libs/cxxsupp/libcxx/include/__string/char_traits.h:219:16
    #2 0xc221d2 in std::__y1::basic_string_view<char, std::__y1::char_traits<char> >::compare /-S/contrib/libs/cxxsupp/libcxx/include/string_view:487:24
    #3 0xc221d2 in std::__y1::operator==<char, std::__y1::char_traits<char> > /-S/contrib/libs/cxxsupp/libcxx/include/string_view:790:18
    #4 0xc221d2 in TStringBase<TBasicString<char, std::__y1::char_traits<char> >, char, std::__y1::char_traits<char> >::equal /-S/util/generic/strbase.h:208:34
    #5 0xc221d2 in TStringBase<TBasicString<char, std::__y1::char_traits<char> >, char, std::__y1::char_traits<char> >::operator==<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::char_traits<char> > /-S/util/generic/strbase.h:278:16
    #6 0xc221d2 in NUnitTest::NPrivate::TCompareValuesImpl<TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, false>::Compare /-S/library/cpp/testing/unittest/registar.h:672:26
    #7 0xc221d2 in NUnitTest::NPrivate::CompareEqual<TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> > > /-S/library/cpp/testing/unittest/registar.h: