### PR TITLE
NBSNEBIUS-351: Erase devices using deallocate in 1GB chunks (#1717)

### DIFF
--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -31,6 +31,5 @@ struct INvmeManager
 ////////////////////////////////////////////////////////////////////////////////
 
 INvmeManagerPtr CreateNvmeManager(TDuration timeout);
-INvmeManagerPtr CreateNvmeManagerStub(bool isDeviceSsd = true);
 
 }   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/nvme_stub.h
+++ b/cloud/blockstore/libs/nvme/nvme_stub.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "nvme.h"
+
+namespace NCloud::NBlockStore::NNvme {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TDeallocateReq
+{
+    ui64 Offset;
+    ui64 Size;
+
+    bool operator==(const TDeallocateReq& other) const
+    {
+        return Offset == other.Offset && Size == other.Size;
+    }
+};
+
+using TNvmeDeallocateHistory = TVector<TDeallocateReq>;
+using TNvmeDeallocateHistoryPtr = std::shared_ptr<TNvmeDeallocateHistory>;
+
+INvmeManagerPtr CreateNvmeManagerStub(
+    bool isDeviceSsd = true,
+    TNvmeDeallocateHistoryPtr deallocateHistory = nullptr);
+
+}   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/nvme_stub.h
+++ b/cloud/blockstore/libs/nvme/nvme_stub.h
@@ -11,6 +11,11 @@ struct TDeallocateReq
     ui64 Offset;
     ui64 Size;
 
+    TDeallocateReq(ui64 offset, ui64 size)
+        : Offset(offset)
+        , Size(size)
+    {}
+
     bool operator==(const TDeallocateReq& other) const
     {
         return Offset == other.Offset && Size == other.Size;

--- a/cloud/blockstore/libs/service_local/storage_aio_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_aio_ut.cpp
@@ -4,7 +4,7 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/storage.h>
 #include <cloud/blockstore/libs/service/storage_provider.h>
-#include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/nvme/nvme_stub.h>
 
 #include <cloud/storage/core/libs/aio/service.h>
 #include <cloud/storage/core/libs/common/error.h>
@@ -651,6 +651,68 @@ Y_UNIT_TEST_SUITE(TAioStorageTest)
         UNIT_ASSERT_SUCCEEDED(response.GetValue());
 
         validatePattern(0x0);
+    }
+
+    Y_UNIT_TEST(ShouldDeallocate1GBChunkInEraseDeviceUsingDeallocate)
+    {
+        const ui32 blockSize = 4_KB;
+        const ui64 blockCount = 3_GB / blockSize + 10;
+        const auto filePath = TryGetRamDrivePath() / "test";
+
+        TFile fileData(filePath, EOpenModeFlag::CreateAlways);
+        fileData.Resize(blockSize * blockCount);
+
+        auto service = CreateAIOService();
+        service->Start();
+        Y_DEFER { service->Stop(); };
+
+        auto deallocateHistory = std::make_shared<TNvmeDeallocateHistory>();
+        auto provider = CreateAioStorageProvider(
+            service,
+            CreateNvmeManagerStub(true, deallocateHistory),
+            true,   // directIO
+            EAioSubmitQueueOpt::DontUse);
+
+        NProto::TVolume volume;
+        volume.SetDiskId(filePath);
+        volume.SetBlockSize(blockSize);
+        volume.SetBlocksCount(blockCount);
+
+        auto future = provider->CreateStorage(
+            volume,
+            "",
+            NProto::VOLUME_ACCESS_READ_WRITE);
+        auto storage = future.GetValue();
+
+        auto fillWithPattern = [&] (char p) {
+            fileData.Seek(0, sSet);
+            TVector<char> buffer(blockSize, p);
+            for (ui32 i = 0; i != blockCount; ++i) {
+                fileData.Write(buffer.data(), blockSize);
+            }
+
+            fileData.Flush();
+        };
+
+
+        // disk filled with 0x0 validates ok
+        fillWithPattern(0x0);
+        auto response =
+            storage->EraseDevice(NProto::DEVICE_ERASE_METHOD_DEALLOCATE);
+        UNIT_ASSERT_NO_EXCEPTION(response.Wait(WaitTimeout));
+        UNIT_ASSERT_SUCCEEDED(response.GetValue());
+
+        UNIT_ASSERT_EQUAL(4, deallocateHistory->size());
+        UNIT_ASSERT_EQUAL(TDeallocateReq(0, 1_GB), deallocateHistory->at(0));
+        UNIT_ASSERT_EQUAL(
+            TDeallocateReq(1_GB, 1_GB),
+            deallocateHistory->at(1));
+        UNIT_ASSERT_EQUAL(
+            TDeallocateReq(2_GB, 1_GB),
+            deallocateHistory->at(2));
+        UNIT_ASSERT_EQUAL(
+            TDeallocateReq(3_GB, 10 * 4_KB),
+            deallocateHistory->at(3));
     }
 }
 

--- a/cloud/blockstore/libs/service_local/storage_aio_ut_large.cpp
+++ b/cloud/blockstore/libs/service_local/storage_aio_ut_large.cpp
@@ -4,7 +4,7 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/storage.h>
 #include <cloud/blockstore/libs/service/storage_provider.h>
-#include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/nvme/nvme_stub.h>
 
 #include <cloud/storage/core/libs/aio/service.h>
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -2,7 +2,7 @@
 
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/service/storage.h>
-#include <cloud/blockstore/libs/nvme/nvme.h>
+#include <cloud/blockstore/libs/nvme/nvme_stub.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/disk_agent.h>


### PR DESCRIPTION
* NBSNEBIUS-351: Erase devices using deallocate in 1GB chunks

Deallocating large device chunks (e.g., 93GB) on certain SSD models resulted in
incomplete erasure, leaving ~20 pages uncleared. This commit mitigates the issue
by deallocating in smaller 1GB chunks, ensuring complete device erasure.
