### PR TITLE
fix unexpected event for partition nonrepl rdma actor

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -600,9 +600,14 @@ STFUNC(TNonreplicatedPartitionRdmaActor::StateZombie)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
 
+        HFunc(TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest, RejectChecksumBlocks);
+
         HFunc(TEvNonreplPartitionPrivate::TEvReadBlocksCompleted, HandleReadBlocksCompleted);
         HFunc(TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted, HandleWriteBlocksCompleted);
         HFunc(TEvNonreplPartitionPrivate::TEvZeroBlocksCompleted, HandleZeroBlocksCompleted);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvChecksumBlocksCompleted,
+            HandleChecksumBlocksCompleted);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, RejectDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, RejectGetCompactionStatus);


### PR DESCRIPTION
```
NBS_SERVER[747829]: 2024-08-09T17:38:53.818594Z :BLOCKSTORE_PARTITION ERROR: Unexpected event: (0x10620789) NCloud::NBlockStore::TResponseEvent<NCloud::NBlockStore::NStorage::TEvNonreplPartitionPrivate::TOperationCompleted, 274859913u>

``` 