### PR TITLE
issue-1146: add dummy tablet database proxy + populate oplog in RW transactions

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -38,7 +38,7 @@ public:
         TTransactionContext& tx,
         TTxIndexTablet::TAddBlob& args)
     {
-        TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+        TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
         switch (args.Mode) {
             case EAddBlobMode::Write:
@@ -419,7 +419,7 @@ bool TIndexTabletActor::PrepareTx_AddBlob(
 {
     InitProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -38,7 +38,7 @@ public:
         TTransactionContext& tx,
         TTxIndexTablet::TAddBlob& args)
     {
-        TIndexTabletDatabase db(tx.DB);
+        TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
         switch (args.Mode) {
             case EAddBlobMode::Write:
@@ -419,7 +419,7 @@ bool TIndexTabletActor::PrepareTx_AddBlob(
 {
     InitProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -89,7 +89,7 @@ bool TIndexTabletActor::PrepareTx_AddData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     if (!ReadNode(db, args.NodeId, commitId, args.Node)) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -89,7 +89,7 @@ bool TIndexTabletActor::PrepareTx_AddData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     if (!ReadNode(db, args.NodeId, commitId, args.Node)) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -124,7 +124,7 @@ bool TIndexTabletActor::PrepareTx_AllocateData(
     args.NodeId = handle->GetNodeId();
     args.CommitId = GetCurrentCommitId();
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
         return false;
@@ -180,7 +180,7 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
     const bool needExtend = args.Node->Attrs.GetSize() < size &&
         !HasFlag(args.Flags, NProto::TAllocateDataRequest::F_KEEP_SIZE);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     // Here we should not check F_KEEP_SIZE OR'ed with F_PUNCH_HOLE, because
     // we did it in validation stage.

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -124,7 +124,7 @@ bool TIndexTabletActor::PrepareTx_AllocateData(
     args.NodeId = handle->GetNodeId();
     args.CommitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
         return false;
@@ -180,7 +180,7 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
     const bool needExtend = args.Node->Attrs.GetSize() < size &&
         !HasFlag(args.Flags, NProto::TAllocateDataRequest::F_KEEP_SIZE);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     // Here we should not check F_KEEP_SIZE OR'ed with F_PUNCH_HOLE, because
     // we did it in validation stage.

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
@@ -59,7 +59,7 @@ void TIndexTabletActor::ExecuteTx_CreateCheckpoint(
 {
     FILESTORE_VALIDATE_TX_ERROR(CreateCheckpoint, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
@@ -59,7 +59,7 @@ void TIndexTabletActor::ExecuteTx_CreateCheckpoint(
 {
     FILESTORE_VALIDATE_TX_ERROR(CreateCheckpoint, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -131,7 +131,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
         return true;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     // There could be two cases:
     // * access by parentId/name
@@ -237,7 +237,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         return RebootTabletOnCommitOverflow(ctx, "CreateHandle");
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     if (args.TargetNodeId == InvalidNodeId
             && (args.FollowerId.Empty() || args.IsNewFollowerNode))

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -131,7 +131,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
         return true;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     // There could be two cases:
     // * access by parentId/name
@@ -237,7 +237,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         return RebootTabletOnCommitOverflow(ctx, "CreateHandle");
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     if (args.TargetNodeId == InvalidNodeId
             && (args.FollowerId.Empty() || args.IsNewFollowerNode))

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -338,7 +338,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(CreateNode, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -435,7 +435,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -338,7 +338,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(CreateNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -435,7 +435,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -68,7 +68,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
 
     args.CommitId = checkpoint->GetCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     bool ready = true;
     switch (args.Mode) {
@@ -164,7 +164,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
     auto* checkpoint = FindCheckpoint(args.CheckpointId);
     TABLET_VERIFY(checkpoint);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     switch (args.Mode) {
         case EDeleteCheckpointMode::MarkCheckpointDeleted:

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -68,7 +68,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
 
     args.CommitId = checkpoint->GetCommitId();
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     bool ready = true;
     switch (args.Mode) {
@@ -164,7 +164,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
     auto* checkpoint = FindCheckpoint(args.CheckpointId);
     TABLET_VERIFY(checkpoint);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     switch (args.Mode) {
         case EDeleteCheckpointMode::MarkCheckpointDeleted:

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -71,7 +71,7 @@ bool TIndexTabletActor::PrepareTx_DestroyHandle(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
     if (!ReadNode(db, handle->GetNodeId(), commitId, args.Node)) {
         return false;
     }
@@ -93,7 +93,7 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
     auto* handle = FindHandle(args.Request.GetHandle());
     TABLET_VERIFY(handle);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
     DestroyHandle(db, handle);
 
     auto commitId = GenerateCommitId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -71,7 +71,7 @@ bool TIndexTabletActor::PrepareTx_DestroyHandle(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
     if (!ReadNode(db, handle->GetNodeId(), commitId, args.Node)) {
         return false;
     }
@@ -93,7 +93,7 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
     auto* handle = FindHandle(args.Request.GetHandle());
     TABLET_VERIFY(handle);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
     DestroyHandle(db, handle);
 
     auto commitId = GenerateCommitId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -252,7 +252,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
         args.SessionId.c_str(),
         args.SessionSeqNo);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     bool ready = true;
     auto commitId = GetCurrentCommitId();
@@ -282,7 +282,7 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
     TTransactionContext& tx,
     TTxIndexTablet::TDestroySession& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     auto* session = FindSession(args.SessionId);
     if (!session) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -252,7 +252,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
         args.SessionId.c_str(),
         args.SessionSeqNo);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     bool ready = true;
     auto commitId = GetCurrentCommitId();
@@ -282,7 +282,7 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
     TTransactionContext& tx,
     TTxIndexTablet::TDestroySession& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     auto* session = FindSession(args.SessionId);
     if (!session) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
@@ -61,7 +61,7 @@ bool TIndexTabletActor::PrepareTx_RemoveNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(RemoveNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -96,7 +96,7 @@ void TIndexTabletActor::ExecuteTx_RemoveNodeXAttr(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
@@ -61,7 +61,7 @@ bool TIndexTabletActor::PrepareTx_RemoveNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(RemoveNodeXAttr, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -96,7 +96,7 @@ void TIndexTabletActor::ExecuteTx_RemoveNodeXAttr(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -84,7 +84,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -269,7 +269,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
         return; // nothing to do
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -84,7 +84,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -269,7 +269,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
         return; // nothing to do
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -87,7 +87,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -123,7 +123,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
 {
     FILESTORE_VALIDATE_TX_ERROR(SetNodeAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -87,7 +87,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeAttr, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -123,7 +123,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
 {
     FILESTORE_VALIDATE_TX_ERROR(SetNodeAttr, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
@@ -67,7 +67,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -108,7 +108,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeXAttr(
 {
     FILESTORE_VALIDATE_TX_ERROR(SetNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
@@ -67,7 +67,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeXAttr, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -108,7 +108,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeXAttr(
 {
     FILESTORE_VALIDATE_TX_ERROR(SetNodeXAttr, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
@@ -309,7 +309,7 @@ void TIndexTabletActor::ExecuteTx_TruncateRange(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     ui64 commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
@@ -309,7 +309,7 @@ void TIndexTabletActor::ExecuteTx_TruncateRange(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     ui64 commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -275,7 +275,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(UnlinkNode, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -351,7 +351,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
 {
     FILESTORE_VALIDATE_TX_ERROR(UnlinkNode, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -275,7 +275,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(UnlinkNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -351,7 +351,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
 {
     FILESTORE_VALIDATE_TX_ERROR(UnlinkNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -306,7 +306,7 @@ bool TIndexTabletActor::PrepareTx_WriteBatch(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -404,7 +404,7 @@ void TIndexTabletActor::ExecuteTx_WriteBatch(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -306,7 +306,7 @@ bool TIndexTabletActor::PrepareTx_WriteBatch(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -404,7 +404,7 @@ void TIndexTabletActor::ExecuteTx_WriteBatch(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -197,7 +197,7 @@ bool TIndexTabletActor::PrepareTx_WriteData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
         return false;
@@ -224,7 +224,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -197,7 +197,7 @@ bool TIndexTabletActor::PrepareTx_WriteData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
         return false;
@@ -224,7 +224,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, &args.IndexStateRequests);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1792,9 +1792,9 @@ bool TIndexTabletDatabase::ReadOpLog(TVector<NProto::TOpLogEntry>& opLog)
 
 TIndexTabletDatabaseProxy::TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<TInMemoryIndexState::TIndexStateRequest>& requestLog)
+        TVector<TInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
     : TIndexTabletDatabase(database)
-    , RequestLog(requestLog)
+    , NodeUpdates(nodeUpdates)
 {}
 
 void TIndexTabletDatabaseProxy::WriteNode(
@@ -1803,7 +1803,7 @@ void TIndexTabletDatabaseProxy::WriteNode(
     const NProto::TNode& attrs)
 {
     TIndexTabletDatabase::WriteNode(nodeId, commitId, attrs);
-    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
         .NodeId = nodeId,
         .Row = {.CommitId = commitId, .Node = attrs}});
 }
@@ -1811,7 +1811,7 @@ void TIndexTabletDatabaseProxy::WriteNode(
 void TIndexTabletDatabaseProxy::DeleteNode(ui64 nodeId)
 {
     TIndexTabletDatabase::DeleteNode(nodeId);
-    RequestLog.emplace_back(
+    NodeUpdates.emplace_back(
         TInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId});
 }
 
@@ -1822,7 +1822,7 @@ void TIndexTabletDatabaseProxy::WriteNodeVer(
     const NProto::TNode& attrs)
 {
     TIndexTabletDatabase::WriteNodeVer(nodeId, minCommitId, maxCommitId, attrs);
-    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeVerRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeVerRequest{
         .NodesVerKey = {nodeId, minCommitId},
         .NodesVerRow = {.MaxCommitId = maxCommitId, .Node = attrs}});
 }
@@ -1830,7 +1830,7 @@ void TIndexTabletDatabaseProxy::WriteNodeVer(
 void TIndexTabletDatabaseProxy::DeleteNodeVer(ui64 nodeId, ui64 commitId)
 {
     TIndexTabletDatabase::DeleteNodeVer(nodeId, commitId);
-    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeVerRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TDeleteNodeVerRequest{
         .NodesVerKey{nodeId, commitId}});
 }
 
@@ -1842,7 +1842,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttr(
     ui64 version)
 {
     TIndexTabletDatabase::WriteNodeAttr(nodeId, commitId, name, value, version);
-    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
         .NodeAttrsKey = {nodeId, name},
         .NodeAttrsRow =
             {.CommitId = commitId, .Value = value, .Version = version}});
@@ -1851,7 +1851,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttr(
 void TIndexTabletDatabaseProxy::DeleteNodeAttr(ui64 nodeId, const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeAttr(nodeId, name);
-    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeAttrsRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TDeleteNodeAttrsRequest{
         .NodeAttrsKey = {nodeId, name}});
 }
 
@@ -1870,7 +1870,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttrVer(
         name,
         value,
         version);
-    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeAttrsVerRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeAttrsVerRequest{
         .NodeAttrsVerKey = {nodeId, name, minCommitId},
         .NodeAttrsVerRow =
             {.MaxCommitId = maxCommitId, .Value = value, .Version = version}});
@@ -1882,7 +1882,7 @@ void TIndexTabletDatabaseProxy::DeleteNodeAttrVer(
     const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeAttrVer(nodeId, commitId, name);
-    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeAttrsVerRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TDeleteNodeAttrsVerRequest{
         .NodeAttrsVerKey = {nodeId, name, commitId}});
 }
 
@@ -1901,7 +1901,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
         childNode,
         followerId,
         followerName);
-    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
         .NodeRefsKey = {nodeId, name},
         .NodeRefsRow = {
             .CommitId = commitId,
@@ -1913,7 +1913,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
 void TIndexTabletDatabaseProxy::DeleteNodeRef(ui64 nodeId, const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeRef(nodeId, name);
-    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeRefsRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TDeleteNodeRefsRequest{
         .NodeRefsKey = {nodeId, name}});
 }
 
@@ -1934,7 +1934,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRefVer(
         childNode,
         followerId,
         followerName);
-    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeRefsVerRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRefsVerRequest{
         .NodeRefsVerKey = {nodeId, name, minCommitId},
         .NodeRefsVerRow = {
             .MaxCommitId = maxCommitId,
@@ -1949,7 +1949,7 @@ void TIndexTabletDatabaseProxy::DeleteNodeRefVer(
     const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeRefVer(nodeId, commitId, name);
-    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeRefsVerRequest{
+    NodeUpdates.emplace_back(TInMemoryIndexState::TDeleteNodeRefsVerRequest{
         .NodeRefsVerKey = {nodeId, name, commitId}});
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1791,13 +1791,11 @@ bool TIndexTabletDatabase::ReadOpLog(TVector<NProto::TOpLogEntry>& opLog)
 ////////////////////////////////////////////////////////////////////////////////
 
 TIndexTabletDatabaseProxy::TIndexTabletDatabaseProxy(
-    NKikimr::NTable::TDatabase& database,
-    TVector<TInMemoryIndexState::TIndexStateRequest>* requestsLog)
+        NKikimr::NTable::TDatabase& database,
+        TVector<TInMemoryIndexState::TIndexStateRequest>& requestLog)
     : TIndexTabletDatabase(database)
-    , RequestsLog(requestsLog)
-{
-    Y_UNUSED(RequestsLog);
-}
+    , RequestLog(requestLog)
+{}
 
 void TIndexTabletDatabaseProxy::WriteNode(
     ui64 nodeId,
@@ -1805,7 +1803,7 @@ void TIndexTabletDatabaseProxy::WriteNode(
     const NProto::TNode& attrs)
 {
     TIndexTabletDatabase::WriteNode(nodeId, commitId, attrs);
-    RequestsLog->emplace_back(TInMemoryIndexState::TWriteNodeRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
         .NodeId = nodeId,
         .Row = {.CommitId = commitId, .Node = attrs}});
 }
@@ -1813,7 +1811,7 @@ void TIndexTabletDatabaseProxy::WriteNode(
 void TIndexTabletDatabaseProxy::DeleteNode(ui64 nodeId)
 {
     TIndexTabletDatabase::DeleteNode(nodeId);
-    RequestsLog->emplace_back(
+    RequestLog.emplace_back(
         TInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId});
 }
 
@@ -1824,7 +1822,7 @@ void TIndexTabletDatabaseProxy::WriteNodeVer(
     const NProto::TNode& attrs)
 {
     TIndexTabletDatabase::WriteNodeVer(nodeId, minCommitId, maxCommitId, attrs);
-    RequestsLog->emplace_back(TInMemoryIndexState::TWriteNodeVerRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeVerRequest{
         .NodesVerKey = {nodeId, minCommitId},
         .NodesVerRow = {.MaxCommitId = maxCommitId, .Node = attrs}});
 }
@@ -1832,7 +1830,7 @@ void TIndexTabletDatabaseProxy::WriteNodeVer(
 void TIndexTabletDatabaseProxy::DeleteNodeVer(ui64 nodeId, ui64 commitId)
 {
     TIndexTabletDatabase::DeleteNodeVer(nodeId, commitId);
-    RequestsLog->emplace_back(TInMemoryIndexState::TDeleteNodeVerRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeVerRequest{
         .NodesVerKey{nodeId, commitId}});
 }
 
@@ -1844,7 +1842,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttr(
     ui64 version)
 {
     TIndexTabletDatabase::WriteNodeAttr(nodeId, commitId, name, value, version);
-    RequestsLog->emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
         .NodeAttrsKey = {nodeId, name},
         .NodeAttrsRow =
             {.CommitId = commitId, .Value = value, .Version = version}});
@@ -1853,7 +1851,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttr(
 void TIndexTabletDatabaseProxy::DeleteNodeAttr(ui64 nodeId, const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeAttr(nodeId, name);
-    RequestsLog->emplace_back(TInMemoryIndexState::TDeleteNodeAttrsRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeAttrsRequest{
         .NodeAttrsKey = {nodeId, name}});
 }
 
@@ -1872,7 +1870,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttrVer(
         name,
         value,
         version);
-    RequestsLog->emplace_back(TInMemoryIndexState::TWriteNodeAttrsVerRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeAttrsVerRequest{
         .NodeAttrsVerKey = {nodeId, name, minCommitId},
         .NodeAttrsVerRow =
             {.MaxCommitId = maxCommitId, .Value = value, .Version = version}});
@@ -1884,7 +1882,7 @@ void TIndexTabletDatabaseProxy::DeleteNodeAttrVer(
     const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeAttrVer(nodeId, commitId, name);
-    RequestsLog->emplace_back(TInMemoryIndexState::TDeleteNodeAttrsVerRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeAttrsVerRequest{
         .NodeAttrsVerKey = {nodeId, name, commitId}});
 }
 
@@ -1903,7 +1901,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
         childNode,
         followerId,
         followerName);
-    RequestsLog->emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
         .NodeRefsKey = {nodeId, name},
         .NodeRefsRow = {
             .CommitId = commitId,
@@ -1915,7 +1913,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
 void TIndexTabletDatabaseProxy::DeleteNodeRef(ui64 nodeId, const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeRef(nodeId, name);
-    RequestsLog->emplace_back(TInMemoryIndexState::TDeleteNodeRefsRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeRefsRequest{
         .NodeRefsKey = {nodeId, name}});
 }
 
@@ -1936,7 +1934,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRefVer(
         childNode,
         followerId,
         followerName);
-    RequestsLog->emplace_back(TInMemoryIndexState::TWriteNodeRefsVerRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TWriteNodeRefsVerRequest{
         .NodeRefsVerKey = {nodeId, name, minCommitId},
         .NodeRefsVerRow = {
             .MaxCommitId = maxCommitId,
@@ -1951,7 +1949,7 @@ void TIndexTabletDatabaseProxy::DeleteNodeRefVer(
     const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeRefVer(nodeId, commitId, name);
-    RequestsLog->emplace_back(TInMemoryIndexState::TDeleteNodeRefsVerRequest{
+    RequestLog.emplace_back(TInMemoryIndexState::TDeleteNodeRefsVerRequest{
         .NodeRefsVerKey = {nodeId, name, commitId}});
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -99,8 +99,10 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // Nodes
     //
 
-    virtual void
-    WriteNode(ui64 nodeId, ui64 commitId, const NProto::TNode& attrs);
+    virtual void WriteNode(
+        ui64 nodeId,
+        ui64 commitId,
+        const NProto::TNode& attrs);
     virtual void DeleteNode(ui64 nodeId);
     virtual bool ReadNode(
         ui64 nodeId,
@@ -160,8 +162,10 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& value,
         ui64 version);
 
-    virtual void
-    DeleteNodeAttrVer(ui64 nodeId, ui64 commitId, const TString& name);
+    virtual void DeleteNodeAttrVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name);
 
     virtual bool ReadNodeAttrVer(
         ui64 nodeId,
@@ -220,8 +224,10 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& followerId,
         const TString& followerName);
 
-    virtual void
-    DeleteNodeRefVer(ui64 nodeId, ui64 commitId, const TString& name);
+    virtual void DeleteNodeRefVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name);
 
     virtual bool ReadNodeRefVer(
         ui64 nodeId,
@@ -494,7 +500,7 @@ class TIndexTabletDatabaseProxy: public TIndexTabletDatabase
 public:
     explicit TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<TInMemoryIndexState::TIndexStateRequest>* requestsLog);
+        TVector<TInMemoryIndexState::TIndexStateRequest>& requestLog);
 
     //
     // Nodes
@@ -582,7 +588,7 @@ public:
         const TString& name) override;
 
 private:
-    TVector<TInMemoryIndexState::TIndexStateRequest>* RequestsLog;
+    TVector<TInMemoryIndexState::TIndexStateRequest>& RequestLog;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -498,9 +498,9 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 class TIndexTabletDatabaseProxy: public TIndexTabletDatabase
 {
 public:
-    explicit TIndexTabletDatabaseProxy(
+    TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<TInMemoryIndexState::TIndexStateRequest>& requestLog);
+        TVector<TInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
 
     //
     // Nodes
@@ -588,7 +588,7 @@ public:
         const TString& name) override;
 
 private:
-    TVector<TInMemoryIndexState::TIndexStateRequest>& RequestLog;
+    TVector<TInMemoryIndexState::TIndexStateRequest>& NodeUpdates;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include "tablet_state_cache.h"
 #include "tablet_state_iface.h"
 
 #include <cloud/filestore/config/storage.pb.h>
@@ -98,9 +99,10 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // Nodes
     //
 
-    void WriteNode(ui64 nodeId, ui64 commitId, const NProto::TNode& attrs);
-    void DeleteNode(ui64 nodeId);
-    bool ReadNode(
+    virtual void
+    WriteNode(ui64 nodeId, ui64 commitId, const NProto::TNode& attrs);
+    virtual void DeleteNode(ui64 nodeId);
+    virtual bool ReadNode(
         ui64 nodeId,
         ui64 commitId,
         TMaybe<IIndexTabletDatabase::TNode>& node) override;
@@ -109,15 +111,15 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // Nodes_Ver
     //
 
-    void WriteNodeVer(
+    virtual void WriteNodeVer(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
         const NProto::TNode& attrs);
 
-    void DeleteNodeVer(ui64 nodeId, ui64 commitId);
+    virtual void DeleteNodeVer(ui64 nodeId, ui64 commitId);
 
-    bool ReadNodeVer(
+    virtual bool ReadNodeVer(
         ui64 nodeId,
         ui64 commitId,
         TMaybe<IIndexTabletDatabase::TNode>& node) override;
@@ -126,22 +128,22 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeAttrs
     //
 
-    void WriteNodeAttr(
+    virtual void WriteNodeAttr(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         const TString& value,
         ui64 version);
 
-    void DeleteNodeAttr(ui64 nodeId, const TString& name);
+    virtual void DeleteNodeAttr(ui64 nodeId, const TString& name);
 
-    bool ReadNodeAttr(
+    virtual bool ReadNodeAttr(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<IIndexTabletDatabase::TNodeAttr>& attr) override;
 
-    bool ReadNodeAttrs(
+    virtual bool ReadNodeAttrs(
         ui64 nodeId,
         ui64 commitId,
         TVector<IIndexTabletDatabase::TNodeAttr>& attrs) override;
@@ -150,7 +152,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeAttrs_Ver
     //
 
-    void WriteNodeAttrVer(
+    virtual void WriteNodeAttrVer(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -158,15 +160,16 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& value,
         ui64 version);
 
-    void DeleteNodeAttrVer(ui64 nodeId, ui64 commitId, const TString& name);
+    virtual void
+    DeleteNodeAttrVer(ui64 nodeId, ui64 commitId, const TString& name);
 
-    bool ReadNodeAttrVer(
+    virtual bool ReadNodeAttrVer(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<IIndexTabletDatabase::TNodeAttr>& attr) override;
 
-    bool ReadNodeAttrVers(
+    virtual bool ReadNodeAttrVers(
         ui64 nodeId,
         ui64 commitId,
         TVector<IIndexTabletDatabase::TNodeAttr>& attrs) override;
@@ -175,7 +178,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeRefs
     //
 
-    void WriteNodeRef(
+    virtual void WriteNodeRef(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
@@ -183,15 +186,15 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& followerId,
         const TString& followerName);
 
-    void DeleteNodeRef(ui64 nodeId, const TString& name);
+    virtual void DeleteNodeRef(ui64 nodeId, const TString& name);
 
-    bool ReadNodeRef(
+    virtual bool ReadNodeRef(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<IIndexTabletDatabase::TNodeRef>& ref) override;
 
-    bool ReadNodeRefs(
+    virtual bool ReadNodeRefs(
         ui64 nodeId,
         ui64 commitId,
         const TString& cookie,
@@ -199,7 +202,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui32 maxBytes,
         TString* next = nullptr) override;
 
-    bool PrechargeNodeRefs(
+    virtual bool PrechargeNodeRefs(
         ui64 nodeId,
         const TString& cookie,
         ui32 bytesToPrecharge) override;
@@ -208,7 +211,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeRefs_Ver
     //
 
-    void WriteNodeRefVer(
+    virtual void WriteNodeRefVer(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -217,15 +220,16 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& followerId,
         const TString& followerName);
 
-    void DeleteNodeRefVer(ui64 nodeId, ui64 commitId, const TString& name);
+    virtual void
+    DeleteNodeRefVer(ui64 nodeId, ui64 commitId, const TString& name);
 
-    bool ReadNodeRefVer(
+    virtual bool ReadNodeRefVer(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<IIndexTabletDatabase::TNodeRef>& ref) override;
 
-    bool ReadNodeRefVers(
+    virtual bool ReadNodeRefVers(
         ui64 nodeId,
         ui64 commitId,
         TVector<IIndexTabletDatabase::TNodeRef>& refs) override;
@@ -479,6 +483,106 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     void WriteOpLogEntry(const NProto::TOpLogEntry& entry);
     void DeleteOpLogEntry(ui64 entryId);
     bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// This is a proxy class that forwards all calls to the underlying
+// TIndexTabletDatabase, but also records all inode-relevant changes
+class TIndexTabletDatabaseProxy: public TIndexTabletDatabase
+{
+public:
+    explicit TIndexTabletDatabaseProxy(
+        NKikimr::NTable::TDatabase& database,
+        TVector<TInMemoryIndexState::TIndexStateRequest>* requestsLog);
+
+    //
+    // Nodes
+    //
+
+    void WriteNode(
+        ui64 nodeId,
+        ui64 commitId,
+        const NProto::TNode& attrs) override;
+
+    void DeleteNode(ui64 nodeId) override;
+
+    //
+    // Nodes_Ver
+    //
+
+    void WriteNodeVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const NProto::TNode& attrs) override;
+
+    void DeleteNodeVer(ui64 nodeId, ui64 commitId) override;
+
+    //
+    // NodeAttrs
+    //
+
+    void WriteNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        const TString& value,
+        ui64 version) override;
+
+    void DeleteNodeAttr(ui64 nodeId, const TString& name) override;
+
+    //
+    // NodeAttrs_Ver
+    //
+
+    void WriteNodeAttrVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const TString& name,
+        const TString& value,
+        ui64 version) override;
+
+    void DeleteNodeAttrVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name) override;
+
+    //
+    // NodeRefs
+    //
+
+    void WriteNodeRef(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        ui64 childNode,
+        const TString& followerId,
+        const TString& followerName) override;
+
+    void DeleteNodeRef(ui64 nodeId, const TString& name) override;
+
+    //
+    // NodeRefs_Ver
+    //
+
+    void WriteNodeRefVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const TString& name,
+        ui64 childNode,
+        const TString& followerId,
+        const TString& followerName) override;
+
+    void DeleteNodeRefVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name) override;
+
+private:
+    TVector<TInMemoryIndexState::TIndexStateRequest>* RequestsLog;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -143,28 +143,11 @@ private:
 
     THashMap<ui64, TNodeRow> Nodes;
 
-<<<<<<< HEAD
-    struct TWriteNodeRequest
-    {
-        ui64 NodeId;
-        TNodeRow Row;
-
-    struct TDeleteNodeRequest
-    {
-=======
-    struct TWriteNodeRequest {
-        ui64 NodeId;
-        TNodeRow Row;
-    };
-
-    struct TDeleteNodeRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        ui64 NodeId;
-    };
-
     //
     // Nodes_Ver
     //
+
+    struct TNodesVerKey
     {
         TNodesVerKey(ui64 nodeId, ui64 minCommitId)
             : NodeId(nodeId)
@@ -185,25 +168,6 @@ private:
     {
         ui64 MaxCommitId = 0;
         NProto::TNode Node;
-    };
-
-<<<<<<< HEAD
-    struct TWriteNodeVerRequest
-    {
-=======
-    struct TWriteNodeVerRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodesVerKey NodesVerKey;
-        TNodesVerRow NodesVerRow;
-    };
-
-<<<<<<< HEAD
-    struct TDeleteNodeVerRequest
-    {
-=======
-    struct TDeleteNodeVerRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodesVerKey NodesVerKey;
     };
 
     TMap<TNodesVerKey, TNodesVerRow> NodesVer;
@@ -243,25 +207,6 @@ private:
         ui64 Version = 0;
     };
 
-<<<<<<< HEAD
-    struct TWriteNodeAttrsRequest
-    {
-=======
-    struct TWriteNodeAttrsRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodeAttrsKey NodeAttrsKey;
-        TNodeAttrsRow NodeAttrsRow;
-    };
-
-<<<<<<< HEAD
-    struct TDeleteNodeAttrsRequest
-    {
-=======
-    struct TDeleteNodeAttrsRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodeAttrsKey NodeAttrsKey;
-    };
-
     THashMap<TNodeAttrsKey, TNodeAttrsRow, TNodeAttrsKeyHash> NodeAttrs;
 
     //
@@ -292,25 +237,6 @@ private:
         ui64 MaxCommitId = 0;
         TString Value;
         ui64 Version = 0;
-    };
-
-<<<<<<< HEAD
-    struct TWriteNodeAttrsVerRequest
-    {
-=======
-    struct TWriteNodeAttrsVerRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodeAttrsVerKey NodeAttrsVerKey;
-        TNodeAttrsVerRow NodeAttrsVerRow;
-    };
-
-<<<<<<< HEAD
-    struct TDeleteNodeAttrsVerRequest
-    {
-=======
-    struct TDeleteNodeAttrsVerRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodeAttrsVerKey NodeAttrsVerKey;
     };
 
     TMap<TNodeAttrsVerKey, TNodeAttrsVerRow> NodeAttrsVer;
@@ -351,25 +277,6 @@ private:
         TString FollowerName;
     };
 
-<<<<<<< HEAD
-    struct TWriteNodeRefsRequest
-    {
-=======
-    struct TWriteNodeRefsRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodeRefsKey NodeRefsKey;
-        TNodeRefsRow NodeRefsRow;
-    };
-
-<<<<<<< HEAD
-    struct TDeleteNodeRefsRequest
-    {
-=======
-    struct TDeleteNodeRefsRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-        TNodeRefsKey NodeRefsKey;
-    };
-
     THashMap<TNodeRefsKey, TNodeRefsRow, TNodeRefsKeyHash> NodeRefs;
 
     //
@@ -403,35 +310,74 @@ private:
         TString FollowerName;
     };
 
-<<<<<<< HEAD
+    TMap<TNodeRefsVerKey, TNodeRefsVerRow> NodeRefsVer;
+
+public:
+    struct TWriteNodeRequest
+    {
+        ui64 NodeId = 0;
+        TNodeRow Row;
+    };
+
+    struct TDeleteNodeRequest
+    {
+        ui64 NodeId = 0;
+    };
+
+    struct TWriteNodeVerRequest
+    {
+        TNodesVerKey NodesVerKey;
+        TNodesVerRow NodesVerRow;
+    };
+
+    struct TDeleteNodeVerRequest
+    {
+        TNodesVerKey NodesVerKey;
+    };
+
+    struct TWriteNodeAttrsRequest
+    {
+        TNodeAttrsKey NodeAttrsKey;
+        TNodeAttrsRow NodeAttrsRow;
+    };
+
+    struct TDeleteNodeAttrsRequest
+    {
+        TNodeAttrsKey NodeAttrsKey;
+    };
+
+    struct TWriteNodeAttrsVerRequest
+    {
+        TNodeAttrsVerKey NodeAttrsVerKey;
+        TNodeAttrsVerRow NodeAttrsVerRow;
+    };
+
+    struct TDeleteNodeAttrsVerRequest
+    {
+        TNodeAttrsVerKey NodeAttrsVerKey;
+    };
+
+    struct TWriteNodeRefsRequest
+    {
+        TNodeRefsKey NodeRefsKey;
+        TNodeRefsRow NodeRefsRow;
+    };
+
+    struct TDeleteNodeRefsRequest
+    {
+        TNodeRefsKey NodeRefsKey;
+    };
+
     struct TWriteNodeRefsVerRequest
     {
-=======
-    struct TWriteNodeRefsVerRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeRefsVerKey NodeRefsVerKey;
         TNodeRefsVerRow NodeRefsVerRow;
     };
 
-<<<<<<< HEAD
     struct TDeleteNodeRefsVerRequest
     {
-=======
-    struct TDeleteNodeRefsVerRequest {
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeRefsVerKey NodeRefsVerKey;
     };
-
-    TMap<TNodeRefsVerKey, TNodeRefsVerRow> NodeRefsVer;
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-public:
-=======
->>>>>>> de824e5dfa (add update/delete requests (no implementations))
-=======
-public:
->>>>>>> ba6e5d7060 (fix compile issue)
     using TIndexStateRequest = std::variant<
         TWriteNodeRequest,
         TDeleteNodeRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -143,6 +143,7 @@ private:
 
     THashMap<ui64, TNodeRow> Nodes;
 
+<<<<<<< HEAD
     struct TWriteNodeRequest
     {
         ui64 NodeId;
@@ -150,6 +151,14 @@ private:
 
     struct TDeleteNodeRequest
     {
+=======
+    struct TWriteNodeRequest {
+        ui64 NodeId;
+        TNodeRow Row;
+    };
+
+    struct TDeleteNodeRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         ui64 NodeId;
     };
 
@@ -178,14 +187,22 @@ private:
         NProto::TNode Node;
     };
 
+<<<<<<< HEAD
     struct TWriteNodeVerRequest
     {
+=======
+    struct TWriteNodeVerRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodesVerKey NodesVerKey;
         TNodesVerRow NodesVerRow;
     };
 
+<<<<<<< HEAD
     struct TDeleteNodeVerRequest
     {
+=======
+    struct TDeleteNodeVerRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodesVerKey NodesVerKey;
     };
 
@@ -226,14 +243,22 @@ private:
         ui64 Version = 0;
     };
 
+<<<<<<< HEAD
     struct TWriteNodeAttrsRequest
     {
+=======
+    struct TWriteNodeAttrsRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeAttrsKey NodeAttrsKey;
         TNodeAttrsRow NodeAttrsRow;
     };
 
+<<<<<<< HEAD
     struct TDeleteNodeAttrsRequest
     {
+=======
+    struct TDeleteNodeAttrsRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeAttrsKey NodeAttrsKey;
     };
 
@@ -269,14 +294,22 @@ private:
         ui64 Version = 0;
     };
 
+<<<<<<< HEAD
     struct TWriteNodeAttrsVerRequest
     {
+=======
+    struct TWriteNodeAttrsVerRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeAttrsVerKey NodeAttrsVerKey;
         TNodeAttrsVerRow NodeAttrsVerRow;
     };
 
+<<<<<<< HEAD
     struct TDeleteNodeAttrsVerRequest
     {
+=======
+    struct TDeleteNodeAttrsVerRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeAttrsVerKey NodeAttrsVerKey;
     };
 
@@ -318,14 +351,22 @@ private:
         TString FollowerName;
     };
 
+<<<<<<< HEAD
     struct TWriteNodeRefsRequest
     {
+=======
+    struct TWriteNodeRefsRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeRefsKey NodeRefsKey;
         TNodeRefsRow NodeRefsRow;
     };
 
+<<<<<<< HEAD
     struct TDeleteNodeRefsRequest
     {
+=======
+    struct TDeleteNodeRefsRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeRefsKey NodeRefsKey;
     };
 
@@ -362,20 +403,31 @@ private:
         TString FollowerName;
     };
 
+<<<<<<< HEAD
     struct TWriteNodeRefsVerRequest
     {
+=======
+    struct TWriteNodeRefsVerRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeRefsVerKey NodeRefsVerKey;
         TNodeRefsVerRow NodeRefsVerRow;
     };
 
+<<<<<<< HEAD
     struct TDeleteNodeRefsVerRequest
     {
+=======
+    struct TDeleteNodeRefsVerRequest {
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
         TNodeRefsVerKey NodeRefsVerKey;
     };
 
     TMap<TNodeRefsVerKey, TNodeRefsVerRow> NodeRefsVer;
 
+<<<<<<< HEAD
 public:
+=======
+>>>>>>> de824e5dfa (add update/delete requests (no implementations))
     using TIndexStateRequest = std::variant<
         TWriteNodeRequest,
         TDeleteNodeRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -425,9 +425,13 @@ private:
     TMap<TNodeRefsVerKey, TNodeRefsVerRow> NodeRefsVer;
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 public:
 =======
 >>>>>>> de824e5dfa (add update/delete requests (no implementations))
+=======
+public:
+>>>>>>> ba6e5d7060 (fix compile issue)
     using TIndexStateRequest = std::variant<
         TWriteNodeRequest,
         TDeleteNodeRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -147,7 +147,6 @@ private:
     {
         ui64 NodeId;
         TNodeRow Row;
-    };
 
     struct TDeleteNodeRequest
     {
@@ -157,8 +156,6 @@ private:
     //
     // Nodes_Ver
     //
-
-    struct TNodesVerKey
     {
         TNodesVerKey(ui64 nodeId, ui64 minCommitId)
             : NodeId(nodeId)

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -168,12 +168,6 @@ struct TSessionAware
 struct TIndexStateNodeUpdates
 {
     TVector<TInMemoryIndexState::TIndexStateRequest> NodeUpdates;
-
-protected:
-    void Clear()
-    {
-        NodeUpdates.clear();
-    }
 };
 
 struct TProfileAware {
@@ -519,7 +513,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             Nodes.clear();
         }
     };
@@ -548,7 +541,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
         }
     };
@@ -591,7 +583,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
 
             NodeIds.clear();
@@ -683,7 +674,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNodeId = InvalidNodeId;
@@ -729,7 +719,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -786,7 +775,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -934,7 +922,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
         }
@@ -1042,7 +1029,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             Version = 0;
             CommitId = InvalidCommitId;
             Node.Clear();
@@ -1143,7 +1129,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             Attr.Clear();
@@ -1199,7 +1184,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             ReadCommitId = InvalidCommitId;
             WriteCommitId = InvalidCommitId;
             TargetNodeId = InvalidNodeId;
@@ -1238,7 +1222,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             Node.Clear();
         }
     };
@@ -1411,7 +1394,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1461,7 +1443,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             NodeId = InvalidNodeId;
             Node.Clear();
         }
@@ -1494,7 +1475,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             WriteRanges.clear();
             Nodes.clear();
@@ -1532,7 +1512,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1582,7 +1561,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             TProfileAware::Clear();
 
             CommitId = InvalidCommitId;
@@ -1812,7 +1790,6 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateNodeUpdates::Clear();
             TProfileAware::Clear();
         }
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -165,14 +165,14 @@ struct TSessionAware
  * Thus, to guarantee consistency, they store all the changes applied to this
  * data in the request log.
  */
-struct TIndexStateRequestLog
+struct TIndexStateNodeUpdates
 {
-    TVector<TInMemoryIndexState::TIndexStateRequest> IndexStateRequests;
+    TVector<TInMemoryIndexState::TIndexStateRequest> NodeUpdates;
 
 protected:
     void Clear()
     {
-        IndexStateRequests.clear();
+        NodeUpdates.clear();
     }
 };
 
@@ -497,7 +497,7 @@ struct TTxIndexTablet
     // DestroySession
     //
 
-    struct TDestroySession: TIndexStateRequestLog
+    struct TDestroySession: TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const TString SessionId;
@@ -519,7 +519,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             Nodes.clear();
         }
     };
@@ -528,7 +528,7 @@ struct TTxIndexTablet
     // CreateCheckpoint
     //
 
-    struct TCreateCheckpoint: TIndexStateRequestLog
+    struct TCreateCheckpoint: TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const TString CheckpointId;
@@ -548,7 +548,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
         }
     };
@@ -557,7 +557,7 @@ struct TTxIndexTablet
     // DeleteCheckpoint
     //
 
-    struct TDeleteCheckpoint: TIndexStateRequestLog
+    struct TDeleteCheckpoint: TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const TString CheckpointId;
@@ -591,7 +591,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
 
             NodeIds.clear();
@@ -637,7 +637,7 @@ struct TTxIndexTablet
 
     struct TCreateNode
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 ParentNodeId;
@@ -683,7 +683,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNodeId = InvalidNodeId;
@@ -701,7 +701,7 @@ struct TTxIndexTablet
 
     struct TUnlinkNode
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TUnlinkNodeRequest Request;
@@ -729,7 +729,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -745,7 +745,7 @@ struct TTxIndexTablet
 
     struct TRenameNode
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 ParentNodeId;
@@ -786,7 +786,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -914,7 +914,7 @@ struct TTxIndexTablet
 
     struct TSetNodeAttr
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TSetNodeAttrRequest Request;
@@ -934,7 +934,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
         }
@@ -1016,7 +1016,7 @@ struct TTxIndexTablet
 
     struct TSetNodeXAttr
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TSetNodeXAttrRequest Request;
@@ -1042,7 +1042,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             Version = 0;
             CommitId = InvalidCommitId;
             Node.Clear();
@@ -1120,7 +1120,7 @@ struct TTxIndexTablet
 
     struct TRemoveNodeXAttr
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TRemoveNodeXAttrRequest Request;
@@ -1143,7 +1143,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             Attr.Clear();
@@ -1156,7 +1156,7 @@ struct TTxIndexTablet
 
     struct TCreateHandle
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 NodeId;
@@ -1199,7 +1199,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             ReadCommitId = InvalidCommitId;
             WriteCommitId = InvalidCommitId;
             TargetNodeId = InvalidNodeId;
@@ -1221,7 +1221,7 @@ struct TTxIndexTablet
 
     struct TDestroyHandle
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TDestroyHandleRequest Request;
@@ -1238,7 +1238,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             Node.Clear();
         }
     };
@@ -1383,7 +1383,7 @@ struct TTxIndexTablet
 
     struct TWriteData
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui32 WriteBlobThreshold;
@@ -1411,7 +1411,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1431,7 +1431,7 @@ struct TTxIndexTablet
 
     struct TAddData
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 Handle;
@@ -1461,7 +1461,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             NodeId = InvalidNodeId;
             Node.Clear();
         }
@@ -1471,7 +1471,7 @@ struct TTxIndexTablet
     // WriteBatch
     //
 
-    struct TWriteBatch: TIndexStateRequestLog
+    struct TWriteBatch: TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const bool SkipFresh;
@@ -1494,7 +1494,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             WriteRanges.clear();
             Nodes.clear();
@@ -1507,7 +1507,7 @@ struct TTxIndexTablet
 
     struct TAllocateData
         : TSessionAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 Handle;
@@ -1532,7 +1532,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1545,7 +1545,7 @@ struct TTxIndexTablet
 
     struct TAddBlob
         : TProfileAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const EAddBlobMode Mode;
@@ -1582,7 +1582,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             TProfileAware::Clear();
 
             CommitId = InvalidCommitId;
@@ -1794,7 +1794,7 @@ struct TTxIndexTablet
 
     struct TTruncateRange
         : TProfileAware
-        , TIndexStateRequestLog
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 NodeId;
@@ -1812,7 +1812,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateRequestLog::Clear();
+            TIndexStateNodeUpdates::Clear();
             TProfileAware::Clear();
         }
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -163,9 +163,9 @@ struct TSessionAware
 /**
  * @brief Transactions, derived from this class, may modify inode-related data.
  * Thus, to guarantee consistency, they store all the changes applied to this
- * data in the oplog.
+ * data in the request log.
  */
-struct TIndexStateOplog
+struct TIndexStateRequestLog
 {
     TVector<TInMemoryIndexState::TIndexStateRequest> IndexStateRequests;
 
@@ -497,7 +497,7 @@ struct TTxIndexTablet
     // DestroySession
     //
 
-    struct TDestroySession : TIndexStateOplog
+    struct TDestroySession: TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const TString SessionId;
@@ -519,7 +519,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             Nodes.clear();
         }
     };
@@ -528,7 +528,7 @@ struct TTxIndexTablet
     // CreateCheckpoint
     //
 
-    struct TCreateCheckpoint : TIndexStateOplog
+    struct TCreateCheckpoint: TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const TString CheckpointId;
@@ -548,7 +548,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
         }
     };
@@ -557,7 +557,7 @@ struct TTxIndexTablet
     // DeleteCheckpoint
     //
 
-    struct TDeleteCheckpoint : TIndexStateOplog
+    struct TDeleteCheckpoint: TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const TString CheckpointId;
@@ -591,7 +591,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
 
             NodeIds.clear();
@@ -635,7 +635,9 @@ struct TTxIndexTablet
     // CreateNode
     //
 
-    struct TCreateNode : TSessionAware, TIndexStateOplog
+    struct TCreateNode
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 ParentNodeId;
@@ -681,7 +683,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNodeId = InvalidNodeId;
@@ -697,7 +699,9 @@ struct TTxIndexTablet
     // UnlinkNode
     //
 
-    struct TUnlinkNode : TSessionAware, TIndexStateOplog
+    struct TUnlinkNode
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TUnlinkNodeRequest Request;
@@ -725,7 +729,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -739,7 +743,9 @@ struct TTxIndexTablet
     // RenameNode
     //
 
-    struct TRenameNode : TSessionAware, TIndexStateOplog
+    struct TRenameNode
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 ParentNodeId;
@@ -780,7 +786,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -906,7 +912,9 @@ struct TTxIndexTablet
     // SetNodeAttr
     //
 
-    struct TSetNodeAttr : TSessionAware, TIndexStateOplog
+    struct TSetNodeAttr
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TSetNodeAttrRequest Request;
@@ -926,7 +934,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
         }
@@ -1006,7 +1014,9 @@ struct TTxIndexTablet
     // SetNodeXAttr
     //
 
-    struct TSetNodeXAttr : TSessionAware, TIndexStateOplog
+    struct TSetNodeXAttr
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TSetNodeXAttrRequest Request;
@@ -1032,7 +1042,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             Version = 0;
             CommitId = InvalidCommitId;
             Node.Clear();
@@ -1108,7 +1118,9 @@ struct TTxIndexTablet
     // RemoveNodeXAttr
     //
 
-    struct TRemoveNodeXAttr : TSessionAware, TIndexStateOplog
+    struct TRemoveNodeXAttr
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TRemoveNodeXAttrRequest Request;
@@ -1131,7 +1143,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             Attr.Clear();
@@ -1142,7 +1154,9 @@ struct TTxIndexTablet
     // CreateHandle
     //
 
-    struct TCreateHandle : TSessionAware, TIndexStateOplog
+    struct TCreateHandle
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 NodeId;
@@ -1185,7 +1199,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             ReadCommitId = InvalidCommitId;
             WriteCommitId = InvalidCommitId;
             TargetNodeId = InvalidNodeId;
@@ -1205,7 +1219,9 @@ struct TTxIndexTablet
     // DestroyHandle
     //
 
-    struct TDestroyHandle : TSessionAware, TIndexStateOplog
+    struct TDestroyHandle
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TDestroyHandleRequest Request;
@@ -1222,7 +1238,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             Node.Clear();
         }
     };
@@ -1365,7 +1381,9 @@ struct TTxIndexTablet
     // WriteData
     //
 
-    struct TWriteData : TSessionAware, TIndexStateOplog
+    struct TWriteData
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui32 WriteBlobThreshold;
@@ -1393,7 +1411,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1411,7 +1429,9 @@ struct TTxIndexTablet
     // AddData
     //
 
-    struct TAddData : TSessionAware, TIndexStateOplog
+    struct TAddData
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 Handle;
@@ -1441,7 +1461,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             NodeId = InvalidNodeId;
             Node.Clear();
         }
@@ -1451,7 +1471,7 @@ struct TTxIndexTablet
     // WriteBatch
     //
 
-    struct TWriteBatch : TIndexStateOplog
+    struct TWriteBatch: TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const bool SkipFresh;
@@ -1474,7 +1494,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             WriteRanges.clear();
             Nodes.clear();
@@ -1485,7 +1505,9 @@ struct TTxIndexTablet
     // AllocateData
     //
 
-    struct TAllocateData : TSessionAware, TIndexStateOplog
+    struct TAllocateData
+        : TSessionAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 Handle;
@@ -1510,7 +1532,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1521,7 +1543,9 @@ struct TTxIndexTablet
     // AddBlob
     //
 
-    struct TAddBlob : TProfileAware, TIndexStateOplog
+    struct TAddBlob
+        : TProfileAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const EAddBlobMode Mode;
@@ -1558,7 +1582,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             TProfileAware::Clear();
 
             CommitId = InvalidCommitId;
@@ -1768,7 +1792,9 @@ struct TTxIndexTablet
     // TruncateRange
     //
 
-    struct TTruncateRange : TProfileAware, TIndexStateOplog
+    struct TTruncateRange
+        : TProfileAware
+        , TIndexStateRequestLog
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 NodeId;
@@ -1786,7 +1812,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
-            TIndexStateOplog::Clear();
+            TIndexStateRequestLog::Clear();
             TProfileAware::Clear();
         }
     };


### PR DESCRIPTION
No actual changes, just some preliminary refactoring. Add the proxy, mentioned in this comment: https://github.com/ydb-platform/nbs/pull/1478#issue-2366706946

All transactions that can modity index tables are provided with args.IndexStateRequests, a place to store all modifying requests made in this transaction

References #1146