### PR TITLE
tablet stresstest should have less iterations under ubsan - otherwise we hit the timeout

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -9,6 +9,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/hash_set.h>
 #include <util/generic/size_literals.h>
 #include <util/system/env.h>
 
@@ -354,7 +355,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         const auto sanitizerType = GetEnv("SANITIZER_TYPE");
         // temporary logging
         Cerr << "sanitizer: " << sanitizerType << Endl;
-        const ui32 d = sanitizerType == "thread" ? 20 : 1;
+        THashSet<TString> slowSanitizers({"thread", "undefined"});
+        const ui32 d = slowSanitizers.contains(sanitizerType) ? 20 : 1;
 
         PERFORM_TEST(5'000 / d);
         PERFORM_TEST(1'000 / d);


### PR DESCRIPTION
see https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(ubsan)/10370766577/1/nebius-x86-64-ubsan/logs/cloud/filestore/libs/storage/tablet/ut_stress/test-results/unittest/chunk0/testing_out_stuff/TIndexTabletTest_Data_Stress.ShouldTruncateAndAllocateFiles.err