### PR TITLE
issue-1350: restoring follower sessions after follower restarts

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2942,8 +2942,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
             env.GetRuntime().Send(
                 new IEventHandle(
-                    leaderActorId,
-                    leaderActorId,
+                    leaderActorId, // recipient
+                    TActorId(), // sender
                     new TRequest(),
                     0, // flags
                     0),
@@ -2951,7 +2951,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         }
 
         env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
-
         // waiting for idle session expiration
         // sending the event manually since registration observers which enable
         // scheduling for actors are reset upon tablet reboot
@@ -2964,8 +2963,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
             env.GetRuntime().Send(
                 new IEventHandle(
-                    actorId,
-                    actorId,
+                    actorId, // recipient
+                    TActorId(), // sender
                     new TRequest(),
                     0, // flags
                     0),

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -49,7 +49,7 @@ NActors::TActorId TSubSessions::UpdateSubSession(
     if (!readOnly) {
         MaxSeenRwSeqNo = std::max(MaxSeenRwSeqNo, seqNo);
     }
-    auto subsession = FindIf(
+    auto* subsession = FindIf(
         SubSessions,
         [&] (const auto& subsession) {
             return subsession.SeqNo == seqNo;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -225,6 +225,7 @@ private:
     NKikimr::TTabletCountersWithTxTypes* Counters = nullptr;
     bool UpdateCountersScheduled = false;
     bool UpdateLeakyBucketCountersScheduled = false;
+    bool SyncSessionsScheduled = false;
     bool CleanupSessionsScheduled = false;
 
     TDeque<NActors::IEventHandlePtr> WaitReadyRequests;
@@ -303,7 +304,14 @@ private:
         TThrottlingPolicy::EOpType opType,
         TDuration time);
 
+    void ScheduleSyncSessions(const NActors::TActorContext& ctx);
     void ScheduleCleanupSessions(const NActors::TActorContext& ctx);
+    void CreateSessionsInFollowers(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo,
+        NProtoPrivate::TCreateSessionRequest request,
+        std::unique_ptr<TEvIndexTablet::TEvCreateSessionResponse> response,
+        TVector<TString> followerIds);
     void RestartCheckpointDestruction(const NActors::TActorContext& ctx);
 
     template <typename TMethod>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
@@ -1,5 +1,8 @@
 #include "tablet_actor.h"
 
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -8,6 +11,218 @@ using namespace NActors;
 using namespace NKikimr;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSyncFollowerSessionsActor final
+    : public TActorBootstrapped<TSyncFollowerSessionsActor>
+{
+private:
+    const TString LogTag;
+    const TActorId Tablet;
+    const TString FileSystemId;
+    const TVector<TString> FollowerIds;
+    const TRequestInfoPtr RequestInfo;
+
+    NProto::TError Error;
+    TMap<TString, TEvIndexTabletPrivate::TFollowerSessionsInfo> Follower2Info;
+
+public:
+    TSyncFollowerSessionsActor(
+        TString logTag,
+        TActorId tablet,
+        TString fileSystemId,
+        TVector<TString> followerIds,
+        TRequestInfoPtr requestInfo);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void DescribeSessions(const TActorContext& ctx);
+    void HandleDescribeSessionsResponse(
+        const TEvIndexTablet::TEvDescribeSessionsResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void SyncFollowerSessions(
+        const TActorContext& ctx,
+        const TString& followerId,
+        NProtoPrivate::TDescribeSessionsResponse response);
+    void HandleSyncFollowerSessionsResponse(
+        const TEvIndexTabletPrivate::TEvSyncFollowerSessionsResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSyncFollowerSessionsActor::TSyncFollowerSessionsActor(
+        TString logTag,
+        TActorId tablet,
+        TString fileSystemId,
+        TVector<TString> followerIds,
+        TRequestInfoPtr requestInfo)
+    : LogTag(std::move(logTag))
+    , Tablet(tablet)
+    , FileSystemId(std::move(fileSystemId))
+    , FollowerIds(std::move(followerIds))
+    , RequestInfo(std::move(requestInfo))
+{}
+
+void TSyncFollowerSessionsActor::Bootstrap(const TActorContext& ctx)
+{
+    DescribeSessions(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TSyncFollowerSessionsActor::DescribeSessions(const TActorContext& ctx)
+{
+    ui32 cookie = 0;
+    for (const auto& followerId: FollowerIds) {
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvDescribeSessionsRequest>();
+        request->Record.SetFileSystemId(followerId);
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s Sending DescribeSessionsRequest to follower %s",
+            LogTag.c_str(),
+            followerId.c_str());
+
+        ctx.Send(
+            MakeIndexTabletProxyServiceId(),
+            request.release(),
+            {}, // flags
+            cookie++);
+    }
+}
+
+void TSyncFollowerSessionsActor::HandleDescribeSessionsResponse(
+    const TEvIndexTablet::TEvDescribeSessionsResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    TABLET_VERIFY(ev->Cookie < FollowerIds.size());
+    const auto& followerId = FollowerIds[ev->Cookie];
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET_WORKER,
+        "%s[%s] sessions described: %lu (error %s)",
+        LogTag.c_str(),
+        followerId.c_str(),
+        msg->Record.SessionsSize(),
+        FormatError(msg->GetError()).c_str());
+
+    if (HasError(msg->GetError())) {
+        Error = msg->GetError();
+        Follower2Info[followerId] = {};
+
+        if (Follower2Info.size() == FollowerIds.size()) {
+            ReplyAndDie(ctx);
+        }
+    } else {
+        SyncFollowerSessions(ctx, followerId, std::move(msg->Record));
+    }
+}
+
+void TSyncFollowerSessionsActor::SyncFollowerSessions(
+    const TActorContext& ctx,
+    const TString& followerId,
+    NProtoPrivate::TDescribeSessionsResponse response)
+{
+    using TRequest = TEvIndexTabletPrivate::TEvSyncFollowerSessionsRequest;
+    auto request = std::make_unique<TRequest>();
+    request->FollowerId = followerId;
+    request->Sessions = std::move(response);
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s Sending SyncFollowerSessionsRequest for follower %s",
+        LogTag.c_str(),
+        followerId.c_str());
+
+    ctx.Send(Tablet, request.release());
+}
+
+void TSyncFollowerSessionsActor::HandleSyncFollowerSessionsResponse(
+    const TEvIndexTabletPrivate::TEvSyncFollowerSessionsResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET_WORKER,
+        "%s[%s] sessions synced: %lu (error %s)",
+        LogTag.c_str(),
+        msg->Info.FollowerId.c_str(),
+        msg->Info.SessionCount,
+        FormatError(msg->GetError()).c_str());
+
+    if (HasError(msg->GetError())) {
+        Error = msg->GetError();
+    }
+
+    Follower2Info[msg->Info.FollowerId] = std::move(msg->Info);
+    if (Follower2Info.size() == FollowerIds.size()) {
+        ReplyAndDie(ctx);
+    }
+}
+
+void TSyncFollowerSessionsActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    Error = MakeError(E_REJECTED, "tablet is shutting down");
+    ReplyAndDie(ctx);
+}
+
+void TSyncFollowerSessionsActor::ReplyAndDie(const TActorContext& ctx)
+{
+    {
+        // notify tablet
+        using TCompletion = TEvIndexTabletPrivate::TEvSyncSessionsCompleted;
+        auto response = std::make_unique<TCompletion>(Error);
+        for (auto& x: Follower2Info) {
+            response->FollowerSessionsInfos.push_back(std::move(x.second));
+        }
+        NCloud::Send(ctx, Tablet, std::move(response));
+    }
+
+    if (RequestInfo->Sender != Tablet) {
+        // reply to caller
+        using TResponse = TEvIndexTabletPrivate::TEvSyncSessionsResponse;
+        auto response = std::make_unique<TResponse>(Error);
+        NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    }
+
+    Die(ctx);
+}
+
+STFUNC(TSyncFollowerSessionsActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvIndexTablet::TEvDescribeSessionsResponse,
+            HandleDescribeSessionsResponse);
+
+        HFunc(
+            TEvIndexTabletPrivate::TEvSyncFollowerSessionsResponse,
+            HandleSyncFollowerSessionsResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            break;
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -155,6 +370,84 @@ STFUNC(TCleanupSessionsActor::StateWork)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TIndexTabletActor::ScheduleSyncSessions(const TActorContext& ctx)
+{
+    if (!SyncSessionsScheduled) {
+        ctx.Schedule(
+            // TODO: make a separate config setting
+            Config->GetIdleSessionTimeout() / 3,
+            new TEvIndexTabletPrivate::TEvSyncSessionsRequest());
+        SyncSessionsScheduled = true;
+    }
+}
+
+void TIndexTabletActor::HandleSyncSessions(
+    const TEvIndexTabletPrivate::TEvSyncSessionsRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (ev->Sender == ctx.SelfID) {
+        SyncSessionsScheduled = false;
+    }
+
+    TVector<TString> followerIds;
+    for (const auto& followerId: GetFileSystem().GetFollowerFileSystemIds()) {
+        followerIds.push_back(followerId);
+    }
+
+    if (followerIds.empty()) {
+        using TResponse = TEvIndexTabletPrivate::TEvSyncSessionsResponse;
+        if (ev->Sender != ctx.SelfID) {
+            auto response = std::make_unique<TResponse>();
+            NCloud::Reply(ctx, *ev, std::move(response));
+        }
+
+        ScheduleSyncSessions(ctx);
+        return;
+    }
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+
+    auto actor = std::make_unique<TSyncFollowerSessionsActor>(
+        LogTag,
+        ctx.SelfID,
+        GetFileSystemId(),
+        std::move(followerIds),
+        std::move(requestInfo));
+
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
+}
+
+void TIndexTabletActor::HandleSyncSessionsCompleted(
+    const TEvIndexTabletPrivate::TEvSyncSessionsCompleted::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s SyncSessions completed (%s)",
+        LogTag.c_str(),
+        FormatError(msg->GetError()).c_str());
+
+    for (const auto& followerSessionsInfo: msg->FollowerSessionsInfos) {
+        LOG_INFO(ctx, TFileStoreComponents::TABLET,
+            "%s Synced %lu sessions for follower %s",
+            LogTag.c_str(),
+            followerSessionsInfo.SessionCount,
+            followerSessionsInfo.FollowerId.c_str());
+    }
+
+    WorkerActors.erase(ev->Sender);
+    ScheduleSyncSessions(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TIndexTabletActor::ScheduleCleanupSessions(const TActorContext& ctx)
 {
     if (!CleanupSessionsScheduled) {
@@ -178,8 +471,11 @@ void TIndexTabletActor::HandleCleanupSessions(
     auto sessions = GetTimeoutedSessions(ctx.Now());
     if (!sessions) {
         // nothing to do
-        auto response = std::make_unique<TEvIndexTabletPrivate::TEvCleanupSessionsResponse>();
-        NCloud::Reply(ctx, *ev, std::move(response));
+        using TResponse = TEvIndexTabletPrivate::TEvCleanupSessionsResponse;
+        if (ev->Sender != ctx.SelfID) {
+            auto response = std::make_unique<TResponse>();
+            NCloud::Reply(ctx, *ev, std::move(response));
+        }
 
         ScheduleCleanupSessions(ctx);
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
@@ -388,10 +388,12 @@ void TIndexTabletActor::HandleSyncSessions(
 
     if (followerIds.empty()) {
         using TResponse = TEvIndexTabletPrivate::TEvSyncSessionsResponse;
-        if (ev->Sender != ctx.SelfID) {
-            auto response = std::make_unique<TResponse>();
-            NCloud::Reply(ctx, *ev, std::move(response));
-        }
+        auto response = std::make_unique<TResponse>();
+        NCloud::Reply(ctx, *ev, std::move(response));
+
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+            "%s SyncSessions dud",
+            LogTag.c_str());
 
         ScheduleSyncSessions(ctx);
         return;
@@ -459,10 +461,8 @@ void TIndexTabletActor::HandleCleanupSessions(
     if (sessions.empty()) {
         // nothing to do
         using TResponse = TEvIndexTabletPrivate::TEvCleanupSessionsResponse;
-        if (ev->Sender != ctx.SelfID) {
-            auto response = std::make_unique<TResponse>();
-            NCloud::Reply(ctx, *ev, std::move(response));
-        }
+        auto response = std::make_unique<TResponse>();
+        NCloud::Reply(ctx, *ev, std::move(response));
 
         ScheduleCleanupSessions(ctx);
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -1,6 +1,7 @@
 #include "tablet_actor.h"
 
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <util/string/join.h>
 
@@ -114,9 +115,10 @@ private:
     const TString LogTag;
     const TRequestInfoPtr RequestInfo;
     const NProtoPrivate::TCreateSessionRequest Request;
-    const google::protobuf::RepeatedPtrField<TString> FollowerIds;
-    std::unique_ptr<TEvIndexTablet::TEvCreateSessionResponse> Response;
-    int CreatedSessions = 0;
+    const TVector<TString> FollowerIds;
+    using TResponse = TEvIndexTablet::TEvCreateSessionResponse;
+    std::unique_ptr<TResponse> Response;
+    ui32 CreatedSessions = 0;
 
     NProto::TProfileLogRequestInfo ProfileLogRequest;
 
@@ -125,7 +127,7 @@ public:
         TString logTag,
         TRequestInfoPtr requestInfo,
         NProtoPrivate::TCreateSessionRequest request,
-        google::protobuf::RepeatedPtrField<TString> followerIds,
+        TVector<TString> followerIds,
         std::unique_ptr<TEvIndexTablet::TEvCreateSessionResponse> response);
 
     void Bootstrap(const TActorContext& ctx);
@@ -154,7 +156,7 @@ TCreateFollowerSessionsActor::TCreateFollowerSessionsActor(
         TString logTag,
         TRequestInfoPtr requestInfo,
         NProtoPrivate::TCreateSessionRequest request,
-        google::protobuf::RepeatedPtrField<TString> followerIds,
+        TVector<TString> followerIds,
         std::unique_ptr<TEvIndexTablet::TEvCreateSessionResponse> response)
     : LogTag(std::move(logTag))
     , RequestInfo(std::move(requestInfo))
@@ -236,13 +238,19 @@ void TCreateFollowerSessionsActor::ReplyAndDie(
     const TActorContext& ctx,
     const NProto::TError& error)
 {
-    if (HasError(error)) {
-        // TODO(#1350): properly rollback session creation in the leader tablet
-        // and in the followers
-        Response =
-            std::make_unique<TEvIndexTablet::TEvCreateSessionResponse>(error);
+    if (RequestInfo) {
+        if (HasError(error)) {
+            // TODO(#1350): properly rollback session creation in the leader
+            // tablet and in the followers
+            Response = std::make_unique<TResponse>(error);
+        }
+
+        if (Response) {
+            NCloud::Reply(ctx, *RequestInfo, std::move(Response));
+        } else {
+            Y_DEBUG_ABORT_UNLESS(0);
+        }
     }
-    NCloud::Reply(ctx, *RequestInfo, std::move(Response));
 
     Die(ctx);
 }
@@ -287,7 +295,7 @@ void TIndexTabletActor::HandleCreateSession(
     ExecuteTx<TCreateSession>(
         ctx,
         std::move(requestInfo),
-        msg->Record);
+        std::move(msg->Record));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -445,7 +453,10 @@ void TIndexTabletActor::CompleteTx_CreateSession(
     Convert(GetFileSystem(), fileStore);
     FillFeatures(*Config, fileStore);
 
-    const auto& followerIds = GetFileSystem().GetFollowerFileSystemIds();
+    TVector<TString> followerIds;
+    for (const auto& followerId: GetFileSystem().GetFollowerFileSystemIds()) {
+        followerIds.push_back(followerId);
+    }
     if (followerIds.empty()) {
         LOG_INFO(ctx, TFileStoreComponents::TABLET,
             "%s CreateSession completed (%s)",
@@ -457,17 +468,66 @@ void TIndexTabletActor::CompleteTx_CreateSession(
     }
 
     LOG_INFO(ctx, TFileStoreComponents::TABLET,
-        "%s CreateSession completed - local (%s)"
-        ", creating follower sessions (%s)",
+        "%s CreateSession completed - local (%s)",
         LogTag.c_str(),
-        FormatError(args.Error).c_str(),
-        JoinSeq(",", GetFileSystem().GetFollowerFileSystemIds()).c_str());
+        FormatError(args.Error).c_str());
+
+    CreateSessionsInFollowers(
+        ctx,
+        std::move(args.RequestInfo),
+        std::move(args.Request),
+        std::move(response),
+        std::move(followerIds));
+}
+
+void TIndexTabletActor::HandleSyncFollowerSessions(
+    const TEvIndexTabletPrivate::TEvSyncFollowerSessionsRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    THashSet<TString> filter;
+    for (auto& s: *ev->Get()->Sessions.MutableSessions()) {
+        filter.insert(*s.MutableSessionId());
+    }
+    TEvIndexTabletPrivate::TFollowerSessionsInfo info;
+    info.FollowerId = std::move(ev->Get()->FollowerId);
+    for (auto& request: BuildCreateSessionRequests(filter)) {
+        CreateSessionsInFollowers(
+            ctx,
+            nullptr, // requestInfo
+            std::move(request),
+            nullptr, // response
+            {info.FollowerId});
+
+        ++info.SessionCount;
+    }
+
+    using TResponse = TEvIndexTabletPrivate::TEvSyncFollowerSessionsResponse;
+    auto response = std::make_unique<TResponse>();
+    response->Info = std::move(info);
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+void TIndexTabletActor::CreateSessionsInFollowers(
+    const NActors::TActorContext& ctx,
+    TRequestInfoPtr requestInfo,
+    NProtoPrivate::TCreateSessionRequest request,
+    std::unique_ptr<TEvIndexTablet::TEvCreateSessionResponse> response,
+    TVector<TString> followerIds)
+{
+    TString logTag = TStringBuilder() << LogTag
+        << " s=" << request.GetHeaders().GetSessionId()
+        << " c=" << request.GetHeaders().GetClientId();
+
+    LOG_INFO(ctx, TFileStoreComponents::TABLET,
+        "%s Creating follower sessions (%s)",
+        logTag.c_str(),
+        JoinSeq(",", followerIds).c_str());
 
     auto actor = std::make_unique<TCreateFollowerSessionsActor>(
-        LogTag,
-        args.RequestInfo,
-        args.Request,
-        followerIds,
+        std::move(logTag),
+        std::move(requestInfo),
+        std::move(request),
+        std::move(followerIds),
         std::move(response));
 
     auto actorId = NCloud::Register(ctx, std::move(actor));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -293,6 +293,7 @@ void TIndexTabletActor::CompleteTx_LoadState(
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Scheduling startup events");
+    ScheduleSyncSessions(ctx);
     ScheduleCleanupSessions(ctx);
     RestartCheckpointDestruction(ctx);
     EnqueueCollectGarbageIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -11,6 +11,7 @@
 #include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/blob.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
 
@@ -25,6 +26,7 @@ namespace NCloud::NFileStore::NStorage {
 #define FILESTORE_TABLET_REQUESTS_PRIVATE_ASYNC(xxx, ...)                      \
     xxx(Compaction,                             __VA_ARGS__)                   \
     xxx(CollectGarbage,                         __VA_ARGS__)                   \
+    xxx(SyncSessions,                        __VA_ARGS__)                      \
     xxx(CleanupSessions,                        __VA_ARGS__)                   \
     xxx(DeleteCheckpoint,                       __VA_ARGS__)                   \
     xxx(DumpCompactionRange,                    __VA_ARGS__)                   \
@@ -46,6 +48,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ZeroRange,                              __VA_ARGS__)                   \
     xxx(FilterAliveNodes,                       __VA_ARGS__)                   \
     xxx(GenerateCommitId,                       __VA_ARGS__)                   \
+    xxx(SyncFollowerSessions,                   __VA_ARGS__)                   \
 // FILESTORE_TABLET_REQUESTS_PRIVATE
 
 #define FILESTORE_TABLET_REQUESTS_PRIVATE(xxx, ...)                            \
@@ -184,6 +187,40 @@ struct TEvIndexTabletPrivate
             , CommitId(commitId)
         {
         }
+    };
+
+    //
+    // SyncSessions
+    //
+
+    struct TFollowerSessionsInfo
+    {
+        TString FollowerId;
+        ui32 SessionCount = 0;
+    };
+
+    struct TSyncSessionsRequest
+    {
+    };
+
+    struct TSyncSessionsResponse
+    {
+    };
+
+    struct TSyncSessionsCompleted
+    {
+        TVector<TFollowerSessionsInfo> FollowerSessionsInfos;
+    };
+
+    struct TSyncFollowerSessionsRequest
+    {
+        TString FollowerId;
+        NProtoPrivate::TDescribeSessionsResponse Sessions;
+    };
+
+    struct TSyncFollowerSessionsResponse
+    {
+        TFollowerSessionsInfo Info;
     };
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -26,7 +26,7 @@ namespace NCloud::NFileStore::NStorage {
 #define FILESTORE_TABLET_REQUESTS_PRIVATE_ASYNC(xxx, ...)                      \
     xxx(Compaction,                             __VA_ARGS__)                   \
     xxx(CollectGarbage,                         __VA_ARGS__)                   \
-    xxx(SyncSessions,                        __VA_ARGS__)                      \
+    xxx(SyncSessions,                           __VA_ARGS__)                   \
     xxx(CleanupSessions,                        __VA_ARGS__)                   \
     xxx(DeleteCheckpoint,                       __VA_ARGS__)                   \
     xxx(DumpCompactionRange,                    __VA_ARGS__)                   \

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -544,6 +544,10 @@ public:
         TIndexTabletDatabase& db,
         const TSessionHistoryEntry& entry, size_t maxEntryCount);
 
+    using TCreateSessionRequests =
+        TVector<NProtoPrivate::TCreateSessionRequest>;
+    TCreateSessionRequests BuildCreateSessionRequests(
+        const THashSet<TString>& filter) const;
     TVector<TMonSessionInfo> GetActiveSessions() const;
     TSessionsStats CalculateSessionsStats() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -429,6 +429,32 @@ void TIndexTabletState::AddSessionHistoryEntry(
     }
 }
 
+TIndexTabletState::TCreateSessionRequests
+TIndexTabletState::BuildCreateSessionRequests(
+    const THashSet<TString>& filter) const
+{
+    TCreateSessionRequests requests;
+    for (const auto& s: Impl->Sessions) {
+        if (filter.contains(s.GetSessionId())) {
+            continue;
+        }
+
+        NProtoPrivate::TCreateSessionRequest request;
+        request.MutableHeaders()->SetSessionId(s.GetSessionId());
+        request.MutableHeaders()->SetClientId(s.GetClientId());
+        // FileSystemId is deliberately not set
+        request.SetCheckpointId(s.GetCheckpointId());
+        // being explicit about our intentions
+        request.SetReadOnly(false);
+        // we are passing SessionId, no need for the restore flag
+        request.SetRestoreClientSession(false);
+        request.SetMountSeqNumber(s.GetMaxRwSeqNo());
+
+        requests.push_back(std::move(request));
+    }
+    return requests;
+}
+
 TVector<TMonSessionInfo> TIndexTabletState::GetActiveSessions() const
 {
     TVector<TMonSessionInfo> sessions;

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -424,21 +424,22 @@ struct TTxIndexTablet
 
     struct TCreateSession
     {
-        const TRequestInfoPtr RequestInfo;
-        const NProtoPrivate::TCreateSessionRequest Request;
+        /* const */ TRequestInfoPtr RequestInfo;
+        /* const */ NProtoPrivate::TCreateSessionRequest Request;
 
         NProto::TError Error;
         TString SessionId;
 
         TCreateSession(
                 TRequestInfoPtr requestInfo,
-                const NProtoPrivate::TCreateSessionRequest& request)
+                NProtoPrivate::TCreateSessionRequest request)
             : RequestInfo(std::move(requestInfo))
-            , Request(request)
+            , Request(std::move(request))
         {}
 
         void Clear()
         {
+            Error.Clear();
             SessionId.clear();
         }
     };

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -110,7 +110,8 @@ public:
             NKikimr::TTestActorRuntime& runtime,
             ui32 nodeIdx,
             ui64 tabletId,
-            const TFileSystemConfig& config = {})
+            const TFileSystemConfig& config = {},
+            bool updateConfig = true)
         : Runtime(runtime)
         , NodeIdx(nodeIdx)
         , TabletId(tabletId)
@@ -120,7 +121,9 @@ public:
         ReconnectPipe();
 
         WaitReady();
-        UpdateConfig(config);
+        if (updateConfig) {
+            UpdateConfig(config);
+        }
     }
 
     TIndexTabletClient& WithSessionSeqNo(ui64 seqNo)


### PR DESCRIPTION
There is an object called "session" which corresponds to an active FS endpoint of a single VM - the session object stores that VM's locks and open file descriptors (file handles). A session exists in the leader tablet for each VM that has this FS attached and a session exists for each shard tablet as well. If a tablet restarts, it restores all sessions from persistent storage and launches a 5 minute timer waiting for a heartbeat (TCreateSessionRequest) from the client - if the heartbeat doesn't arrive, the session is deleted. If the leader restarts, each client reestablishes the connection to the leader and sends that heartbeat which causes all sessions - in the leader and in the shards - to be renewed. But if a shard restarts, the session in the shard won't receive a heartbeat until either the leader restarts or the client issues a request (any request) to that shard. If a client doesn't issue any requests to some shard within 5 minutes from the shard's restart, its session is deleted and all file descriptors for that client are closed causing subsequent EBADFs (E_FS_BADHANDLE).

The leader now regularly describes follower sessions. If some sessions are not found in some follower, the leader recreates those sessions in that follower. Session sync period is equal to IdleSessionTimeout / 3. I will make a separate config setting for this timeout in my next PR.

#1350 