### PR TITLE
Making an explicit unsafe conversion from TBlockDataRef to IOutputStream::TPart

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -111,7 +111,8 @@ public:
             buffer,
             TBlockStoreProtocol::ReadBlocksRequest,
             0,   // flags
-            *Request);
+            *Request,
+            {});
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -287,7 +288,8 @@ public:
             buffer,
             TBlockStoreProtocol::ZeroBlocksRequest,
             0,   // flags
-            *Request);
+            *Request,
+            {});
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -217,11 +217,12 @@ public:
 
         // 2. Ensure IOutputStream::TPart layout compatible with TBlockDataRef
         static_assert(sizeof(TBlockDataRef) == sizeof(IOutputStream::TPart));
+        static_assert(alignof(TBlockDataRef) == alignof(IOutputStream::TPart));
         // Can't get offset of private member :-(
-        // static_assert(0, offsetof(TBlockDataRef, Start));
+        // static_assert(0 == offsetof(TBlockDataRef, Start));
         static_assert(0 == offsetof(IOutputStream::TPart, buf));
         // Can't get offset of private member :-(
-        // static_assert(8, offsetof(TBlockDataRef, Length));
+        // static_assert(8 == offsetof(TBlockDataRef, Length));
         static_assert(8 == offsetof(IOutputStream::TPart, len));
 
         // 3. reinterpret_cast TBlockDataRef* to IOutputStream::TPart*

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -92,7 +92,7 @@ public:
 
     size_t GetRequestSize() const
     {
-        return Serializer->MessageByteSize(*Request, 0);
+        return NRdma::TProtoMessageSerializer::MessageByteSize(*Request, 0);
     }
 
     size_t GetResponseSize() const
@@ -187,7 +187,7 @@ public:
 
     size_t GetRequestSize() const
     {
-        return Serializer->MessageByteSize(
+        return NRdma::TProtoMessageSerializer::MessageByteSize(
             *Request,
             BlockSize * Request->BlocksCount);
     }
@@ -268,7 +268,7 @@ public:
 
     size_t GetRequestSize() const
     {
-        return Serializer->MessageByteSize(*Request, 0);
+        return NRdma::TProtoMessageSerializer::MessageByteSize(*Request, 0);
     }
 
     size_t GetResponseSize() const

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -111,8 +111,7 @@ public:
             buffer,
             TBlockStoreProtocol::ReadBlocksRequest,
             0,   // flags
-            *Request,
-            {});
+            *Request);
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -210,7 +209,7 @@ public:
 
         const auto& sglist = guard.Get();
 
-        return NRdma::TProtoMessageSerializer::Serialize(
+        return NRdma::TProtoMessageSerializer::SerializeWithData(
             buffer,
             TBlockStoreProtocol::WriteBlocksRequest,
             0, // flags
@@ -288,8 +287,7 @@ public:
             buffer,
             TBlockStoreProtocol::ZeroBlocksRequest,
             0,   // flags
-            *Request,
-            {});
+            *Request);
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -199,18 +199,16 @@ NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
         auto response = ExtractResponse(future);
 
         TaskQueue->ExecuteSimple([=] {
-            Y_UNUSED(buffer);
-
             auto guard = guardedSgList.Acquire();
             Y_ENSURE(guard);
 
             const auto& sglist = guard.Get();
-            size_t responseBytes = Serializer->Serialize(
+            size_t responseBytes = NRdma::TProtoMessageSerializer::Serialize(
                 out,
                 TBlockStoreProtocol::ReadBlocksResponse,
-                0, // flags
+                0,   // flags
                 response,
-                TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
+                sglist);
 
             Endpoint->SendResponse(context, responseBytes);
         });
@@ -247,12 +245,11 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
         TaskQueue->ExecuteSimple([=] {
             Y_UNUSED(guardedSgList);
 
-            size_t responseBytes = Serializer->Serialize(
+            size_t responseBytes = NRdma::TProtoMessageSerializer::Serialize(
                 out,
                 TBlockStoreProtocol::WriteBlocksResponse,
-                0, // flags
-                response,
-                TContIOVector(nullptr, 0));
+                0,   // flags
+                response);
 
             Endpoint->SendResponse(context, responseBytes);
         });
@@ -279,12 +276,11 @@ NProto::TError TRdmaEndpoint::HandleZeroBlocksRequest(
     future.Subscribe([=] (auto future) {
         auto response = ExtractResponse(future);
 
-        size_t responseBytes = Serializer->Serialize(
+        size_t responseBytes = NRdma::TProtoMessageSerializer::Serialize(
             out,
             TBlockStoreProtocol::ZeroBlocksResponse,
-            0, // flags
-            response,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            response);
 
         Endpoint->SendResponse(context, responseBytes);
     });

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -249,7 +249,8 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
                 out,
                 TBlockStoreProtocol::WriteBlocksResponse,
                 0,   // flags
-                response);
+                response,
+                {});
 
             Endpoint->SendResponse(context, responseBytes);
         });
@@ -280,7 +281,8 @@ NProto::TError TRdmaEndpoint::HandleZeroBlocksRequest(
             out,
             TBlockStoreProtocol::ZeroBlocksResponse,
             0,   // flags
-            response);
+            response,
+            {});
 
         Endpoint->SendResponse(context, responseBytes);
     });

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -203,12 +203,13 @@ NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
             Y_ENSURE(guard);
 
             const auto& sglist = guard.Get();
-            size_t responseBytes = NRdma::TProtoMessageSerializer::Serialize(
-                out,
-                TBlockStoreProtocol::ReadBlocksResponse,
-                0,   // flags
-                response,
-                sglist);
+            size_t responseBytes =
+                NRdma::TProtoMessageSerializer::SerializeWithData(
+                    out,
+                    TBlockStoreProtocol::ReadBlocksResponse,
+                    0,   // flags
+                    response,
+                    sglist);
 
             Endpoint->SendResponse(context, responseBytes);
         });
@@ -249,8 +250,7 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
                 out,
                 TBlockStoreProtocol::WriteBlocksResponse,
                 0,   // flags
-                response,
-                {});
+                response);
 
             Endpoint->SendResponse(context, responseBytes);
         });
@@ -281,8 +281,7 @@ NProto::TError TRdmaEndpoint::HandleZeroBlocksRequest(
             out,
             TBlockStoreProtocol::ZeroBlocksResponse,
             0,   // flags
-            response,
-            {});
+            response);
 
         Endpoint->SendResponse(context, responseBytes);
     });

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -68,7 +68,7 @@ size_t TProtoMessageSerializer::Serialize(
         [](size_t acc, TBlockDataRef dataRef) { return acc + dataRef.Size(); });
 
     char* ptr = const_cast<char*>(buffer.data());
-    ptr += Serialize(buffer, msgId, flags, proto, dataLen);
+    ptr += SerializeWithDataLength(buffer, msgId, flags, proto, dataLen);
 
     if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
         ptr = const_cast<char*>(buffer.data()) + buffer.length() - dataLen;
@@ -87,7 +87,7 @@ size_t TProtoMessageSerializer::Serialize(
 }
 
 // static
-size_t TProtoMessageSerializer::Serialize(
+size_t TProtoMessageSerializer::SerializeWithDataLength(
     TStringBuf buffer,
     ui32 msgId,
     ui32 flags,

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -59,6 +59,16 @@ size_t TProtoMessageSerializer::Serialize(
     TStringBuf buffer,
     ui32 msgId,
     ui32 flags,
+    const TProtoMessage& proto)
+{
+    return SerializeWithDataLength(buffer, msgId, flags, proto, 0);
+}
+
+// static
+size_t TProtoMessageSerializer::SerializeWithData(
+    TStringBuf buffer,
+    ui32 msgId,
+    ui32 flags,
     const TProtoMessage& proto,
     TBlockDataRefSpan data)
 {

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -59,23 +59,6 @@ size_t TProtoMessageSerializer::Serialize(
     TStringBuf buffer,
     ui32 msgId,
     ui32 flags,
-    const TProtoMessage& proto)
-{
-    char* ptr = const_cast<char*>(buffer.data());
-    ptr += Serialize(buffer, msgId, flags, proto, 0);
-
-    if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
-        ptr = const_cast<char*>(buffer.data()) + buffer.length();
-    }
-
-    return ptr - buffer.data();
-}
-
-// static
-size_t TProtoMessageSerializer::Serialize(
-    TStringBuf buffer,
-    ui32 msgId,
-    ui32 flags,
     const TProtoMessage& proto,
     TBlockDataRefSpan data)
 {

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -41,6 +41,7 @@ TProtoMessagePtr TProtoMessageSerializer::CreateProto(ui32 msgId) const
     return nullptr;
 }
 
+// static
 size_t TProtoMessageSerializer::MessageByteSize(
     const TProtoMessage& proto,
     size_t dataLen)
@@ -51,6 +52,23 @@ size_t TProtoMessageSerializer::MessageByteSize(
     Y_ENSURE(dataLen < RDMA_MAX_DATA_LEN, "attached data is too big");
 
     return NRdma::MessageByteSize(protoLen, dataLen);
+}
+
+// static
+size_t TProtoMessageSerializer::Serialize(
+    TStringBuf buffer,
+    ui32 msgId,
+    ui32 flags,
+    const TProtoMessage& proto)
+{
+    char* ptr = const_cast<char*>(buffer.data());
+    ptr += Serialize(buffer, msgId, flags, proto, 0);
+
+    if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
+        ptr = const_cast<char*>(buffer.data()) + buffer.length();
+    }
+
+    return ptr - buffer.data();
 }
 
 // static

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <cloud/storage/core/libs/common/block_data_ref.h>
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/generic/hash.h>
@@ -58,7 +59,7 @@ public:
         ui32 msgId,
         ui32 flags,
         const TProtoMessage& proto,
-        TContIOVector data);
+        TBlockDataRefSpan data = {});
 
     static size_t Serialize(
         TStringBuf buffer,
@@ -75,7 +76,7 @@ public:
         TStringBuf Data;
     };
 
-    TResultOrError<TParseResult> Parse(TStringBuf buffer) const;
+    [[nodiscard]] TResultOrError<TParseResult> Parse(TStringBuf buffer) const;
 
 protected:
     template <typename T>

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -60,6 +60,12 @@ public:
         TStringBuf buffer,
         ui32 msgId,
         ui32 flags,
+        const TProtoMessage& proto);
+
+    static size_t SerializeWithData(
+        TStringBuf buffer,
+        ui32 msgId,
+        ui32 flags,
         const TProtoMessage& proto,
         TBlockDataRefSpan data);
 

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -52,14 +52,22 @@ private:
     THashMap<ui32, IProtoFactoryPtr> Messages;
 
 public:
-    static size_t MessageByteSize(const TProtoMessage& proto, size_t dataLen);
+    [[nodiscard]] static size_t MessageByteSize(
+        const TProtoMessage& proto,
+        size_t dataLen);
+
+    static size_t Serialize(
+        TStringBuf buffer,
+        ui32 msgId,
+        ui32 flags,
+        const TProtoMessage& proto);
 
     static size_t Serialize(
         TStringBuf buffer,
         ui32 msgId,
         ui32 flags,
         const TProtoMessage& proto,
-        TBlockDataRefSpan data = {});
+        TBlockDataRefSpan data);
 
     static size_t Serialize(
         TStringBuf buffer,

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -63,7 +63,7 @@ public:
         const TProtoMessage& proto,
         TBlockDataRefSpan data);
 
-    static size_t Serialize(
+    static size_t SerializeWithDataLength(
         TStringBuf buffer,
         ui32 msgId,
         ui32 flags,

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -60,12 +60,6 @@ public:
         TStringBuf buffer,
         ui32 msgId,
         ui32 flags,
-        const TProtoMessage& proto);
-
-    static size_t Serialize(
-        TStringBuf buffer,
-        ui32 msgId,
-        ui32 flags,
         const TProtoMessage& proto,
         TBlockDataRefSpan data);
 

--- a/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
@@ -56,7 +56,9 @@ Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
         const TBlockDataRef part[1] = {
             TBlockDataRef(data.data(), data.length())};
 
-        size_t msgByteSize = serializer->MessageByteSize(proto, data.length());
+        size_t msgByteSize = NRdma::TProtoMessageSerializer::MessageByteSize(
+            proto,
+            data.length());
         TVector testedFlags{0U, RDMA_PROTO_FLAG_DATA_AT_THE_END};
         TVector testedBufferSizes{
             msgByteSize,

--- a/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
@@ -74,12 +74,13 @@ Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
 
                 auto buffer = TString::Uninitialized(bufferSize);
 
-                size_t serializedBytes = NRdma::TProtoMessageSerializer::Serialize(
-                    buffer,
-                    TBlockStoreProtocol::ReadBlocksRequest,
-                    flags,
-                    proto,
-                    part);
+                size_t serializedBytes =
+                    NRdma::TProtoMessageSerializer::SerializeWithData(
+                        buffer,
+                        TBlockStoreProtocol::ReadBlocksRequest,
+                        flags,
+                        proto,
+                        part);
 
                 if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
                     UNIT_ASSERT_VALUES_EQUAL(bufferSize, serializedBytes);

--- a/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
@@ -53,7 +53,8 @@ Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
         proto.SetDiskId("test");
 
         auto data = TString(1024, 'A');
-        IOutputStream::TPart part(data.data(), data.length());
+        const TBlockDataRef part[1] = {
+            TBlockDataRef(data.data(), data.length())};
 
         size_t msgByteSize = serializer->MessageByteSize(proto, data.length());
         TVector testedFlags{0U, RDMA_PROTO_FLAG_DATA_AT_THE_END};
@@ -71,12 +72,12 @@ Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
 
                 auto buffer = TString::Uninitialized(bufferSize);
 
-                size_t serializedBytes = serializer->Serialize(
+                size_t serializedBytes = NRdma::TProtoMessageSerializer::Serialize(
                     buffer,
                     TBlockStoreProtocol::ReadBlocksRequest,
                     flags,
                     proto,
-                    TContIOVector(&part, 1));
+                    part);
 
                 if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
                     UNIT_ASSERT_VALUES_EQUAL(bufferSize, serializedBytes);

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -128,15 +128,12 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes = serializer->Serialize(
+                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ReadDeviceBlocksResponse,
-                    0, // flags
+                    0,   // flags
                     response,
-                    TContIOVector(
-                        (IOutputStream::TPart*)sglist.begin(),
-                        sglist.size()
-                    ));
+                    sglist);
 
                 break;
             }
@@ -166,12 +163,11 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes = serializer->Serialize(
+                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::WriteDeviceBlocksResponse,
-                    0, // flags
-                    response,
-                    TContIOVector(nullptr, 0));
+                    0,   // flags
+                    response);
 
                 break;
             }
@@ -197,12 +193,11 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes = serializer->Serialize(
+                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ZeroDeviceBlocksResponse,
-                    0, // flags
-                    response,
-                    TContIOVector(nullptr, 0));
+                    0,   // flags
+                    response);
 
                 break;
             }
@@ -231,12 +226,11 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     response.SetChecksum(checksum.GetValue());
                 }
 
-                responseBytes = serializer->Serialize(
+                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
-                    0, // flags
-                    response,
-                    TContIOVector(nullptr, 0));
+                    0,   // flags
+                    response);
 
                 break;
             }

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -167,7 +167,8 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     req->ResponseBuffer,
                     TBlockStoreProtocol::WriteDeviceBlocksResponse,
                     0,   // flags
-                    response);
+                    response,
+                    {});
 
                 break;
             }
@@ -197,7 +198,8 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ZeroDeviceBlocksResponse,
                     0,   // flags
-                    response);
+                    response,
+                    {});
 
                 break;
             }
@@ -230,7 +232,8 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
                     0,   // flags
-                    response);
+                    response,
+                    {});
 
                 break;
             }

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -128,12 +128,13 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
-                    req->ResponseBuffer,
-                    TBlockStoreProtocol::ReadDeviceBlocksResponse,
-                    0,   // flags
-                    response,
-                    sglist);
+                responseBytes =
+                    NRdma::TProtoMessageSerializer::SerializeWithData(
+                        req->ResponseBuffer,
+                        TBlockStoreProtocol::ReadDeviceBlocksResponse,
+                        0,   // flags
+                        response,
+                        sglist);
 
                 break;
             }
@@ -167,8 +168,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     req->ResponseBuffer,
                     TBlockStoreProtocol::WriteDeviceBlocksResponse,
                     0,   // flags
-                    response,
-                    {});
+                    response);
 
                 break;
             }
@@ -198,8 +198,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ZeroDeviceBlocksResponse,
                     0,   // flags
-                    response,
-                    {});
+                    response);
 
                 break;
             }
@@ -232,8 +231,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
                     0,   // flags
-                    response,
-                    {});
+                    response);
 
                 break;
             }

--- a/cloud/blockstore/libs/rdma_test/server_test_async.cpp
+++ b/cloud/blockstore/libs/rdma_test/server_test_async.cpp
@@ -138,12 +138,13 @@ public:
                 request,
                 SgListGetSize(sglist));
         wrapper->Serialized = TString(expectedSerializedSize, 0);
-        const size_t serializedSize = NRdma::TProtoMessageSerializer::Serialize(
-            wrapper->Serialized,
-            messageType,
-            0,   // flags
-            request,
-            sglist);
+        const size_t serializedSize =
+            NRdma::TProtoMessageSerializer::SerializeWithData(
+                wrapper->Serialized,
+                messageType,
+                0,   // flags
+                request,
+                sglist);
         UNIT_ASSERT(expectedSerializedSize >= serializedSize);
 
         // Prepare buffer for response message

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -93,12 +93,11 @@ public:
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        return Serializer->Serialize(
+        return NRdma::TProtoMessageSerializer::Serialize(
             buffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            Proto,
-            TContIOVector(nullptr, 0));
+            Proto);
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -210,12 +209,12 @@ public:
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        return Serializer->Serialize(
+        return NRdma::TProtoMessageSerializer::Serialize(
             buffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
             flags,
             Proto,
-            TContIOVector((IOutputStream::TPart*)sglist.data(), sglist.size()));
+            sglist);
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -295,12 +294,11 @@ public:
     {
         Y_UNUSED(isAlignedDataEnabled);
 
-        return Serializer->Serialize(
+        return NRdma::TProtoMessageSerializer::Serialize(
             buffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
-            0, // flags
-            Proto,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            Proto);
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -97,7 +97,8 @@ public:
             buffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            Proto);
+            Proto,
+            {});
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -298,7 +299,8 @@ public:
             buffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
             0,   // flags
-            Proto);
+            Proto,
+            {});
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -97,8 +97,7 @@ public:
             buffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            Proto,
-            {});
+            Proto);
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -210,7 +209,7 @@ public:
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        return NRdma::TProtoMessageSerializer::Serialize(
+        return NRdma::TProtoMessageSerializer::SerializeWithData(
             buffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
             flags,
@@ -299,8 +298,7 @@ public:
             buffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
             0,   // flags
-            Proto,
-            {});
+            Proto);
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -604,11 +604,11 @@ private:
                 requestDetails.DataBuffer.size());
             bytes = requestDetails.Out.size();
         } else {
-            TStackVec<IOutputStream::TPart> parts;
+            TStackVec<TBlockDataRef> parts;
             parts.reserve(blocks.BuffersSize());
 
             for (const auto& buffer: blocks.GetBuffers()) {
-                parts.emplace_back(TStringBuf(buffer));
+                parts.emplace_back(TBlockDataRef(buffer.data(), buffer.size()));
             }
 
             bytes = NRdma::TProtoMessageSerializer::Serialize(
@@ -616,7 +616,7 @@ private:
                 TBlockStoreProtocol::ReadDeviceBlocksResponse,
                 flags,
                 proto,
-                TContIOVector(parts.data(), parts.size()));
+                parts);
         }
 
         if (auto ep = Endpoint.lock()) {
@@ -747,9 +747,8 @@ private:
         size_t bytes = NRdma::TProtoMessageSerializer::Serialize(
             requestDetails.Out,
             TBlockStoreProtocol::WriteDeviceBlocksResponse,
-            0, // flags
-            proto,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            proto);
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);
@@ -868,9 +867,8 @@ private:
         size_t bytes = NRdma::TProtoMessageSerializer::Serialize(
             requestDetails.Out,
             TBlockStoreProtocol::ZeroDeviceBlocksResponse,
-            0, // flags
-            proto,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            proto);
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);
@@ -948,9 +946,8 @@ private:
         size_t bytes = NRdma::TProtoMessageSerializer::Serialize(
             requestDetails.Out,
             TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
-            0, // flags
-            proto,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            proto);
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -611,7 +611,7 @@ private:
                 parts.emplace_back(TBlockDataRef(buffer.data(), buffer.size()));
             }
 
-            bytes = NRdma::TProtoMessageSerializer::Serialize(
+            bytes = NRdma::TProtoMessageSerializer::SerializeWithData(
                 requestDetails.Out,
                 TBlockStoreProtocol::ReadDeviceBlocksResponse,
                 flags,
@@ -748,8 +748,7 @@ private:
             requestDetails.Out,
             TBlockStoreProtocol::WriteDeviceBlocksResponse,
             0,   // flags
-            proto,
-            {});
+            proto);
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);
@@ -869,8 +868,7 @@ private:
             requestDetails.Out,
             TBlockStoreProtocol::ZeroDeviceBlocksResponse,
             0,   // flags
-            proto,
-            {});
+            proto);
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);
@@ -949,8 +947,7 @@ private:
             requestDetails.Out,
             TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
             0,   // flags
-            proto,
-            {});
+            proto);
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -748,7 +748,8 @@ private:
             requestDetails.Out,
             TBlockStoreProtocol::WriteDeviceBlocksResponse,
             0,   // flags
-            proto);
+            proto,
+            {});
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);
@@ -868,7 +869,8 @@ private:
             requestDetails.Out,
             TBlockStoreProtocol::ZeroDeviceBlocksResponse,
             0,   // flags
-            proto);
+            proto,
+            {});
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);
@@ -947,7 +949,8 @@ private:
             requestDetails.Out,
             TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
             0,   // flags
-            proto);
+            proto,
+            {});
 
         if (auto ep = Endpoint.lock()) {
             ep->SendResponse(requestDetails.Context, bytes);

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -596,7 +596,7 @@ private:
 
         if (requestDetails.DataBuffer.size()) {
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
-            NRdma::TProtoMessageSerializer::Serialize(
+            NRdma::TProtoMessageSerializer::SerializeWithDataLength(
                 requestDetails.Out,
                 TBlockStoreProtocol::ReadDeviceBlocksResponse,
                 flags,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h
@@ -88,7 +88,7 @@ public:
     }
 
 public:
-    void BuildNextRequest(TVector<IOutputStream::TPart>* parts)
+    void BuildNextRequest(TSgList* sglist)
     {
         Y_ABORT_UNLESS(CurrentDeviceIdx < DeviceRequests.size());
 
@@ -96,10 +96,8 @@ public:
         for (ui32 i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
             const ui32 rem = Buffer().size() - CurrentOffsetInBuffer;
             Y_ABORT_UNLESS(rem >= BlockSize);
-            parts->push_back({
-                Buffer().data() + CurrentOffsetInBuffer,
-                BlockSize
-            });
+            sglist->push_back(
+                {Buffer().data() + CurrentOffsetInBuffer, BlockSize});
             CurrentOffsetInBuffer += BlockSize;
             if (CurrentOffsetInBuffer == Buffer().size()) {
                 CurrentOffsetInBuffer = 0;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -289,7 +289,8 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            deviceRequest);
+            deviceRequest,
+            {});
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -289,8 +289,7 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            deviceRequest,
-            {});
+            deviceRequest);
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -289,8 +289,7 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            deviceRequest,
-            TContIOVector(nullptr, 0));
+            deviceRequest);
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -211,8 +211,6 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
         SelfId(),
         requestId);
 
-    auto* serializer = TBlockStoreProtocol::Serializer();
-
     struct TDeviceRequestInfo
     {
         NRdma::IClientEndpointPtr Endpoint;
@@ -238,7 +236,7 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
         auto [req, err] = ep->AllocateRequest(
             requestContext,
             std::move(dc),
-            serializer->MessageByteSize(deviceRequest, 0),
+            NRdma::TProtoMessageSerializer::MessageByteSize(deviceRequest, 0),
             4_KB);
 
         if (HasError(err)) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -255,12 +255,11 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
             return;
         }
 
-        serializer->Serialize(
+        NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ChecksumDeviceBlocksRequest,
-            0, // flags
-            deviceRequest,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            deviceRequest);
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -257,7 +257,8 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
             req->RequestBuffer,
             TBlockStoreProtocol::ChecksumDeviceBlocksRequest,
             0,   // flags
-            deviceRequest);
+            deviceRequest,
+            {});
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -257,8 +257,7 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
             req->RequestBuffer,
             TBlockStoreProtocol::ChecksumDeviceBlocksRequest,
             0,   // flags
-            deviceRequest,
-            {});
+            deviceRequest);
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -287,7 +287,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        NRdma::TProtoMessageSerializer::Serialize(
+        NRdma::TProtoMessageSerializer::SerializeWithData(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
             flags,
@@ -435,7 +435,7 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        NRdma::TProtoMessageSerializer::Serialize(
+        NRdma::TProtoMessageSerializer::SerializeWithData(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
             flags,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -226,12 +226,11 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
             return;
         }
 
-        serializer->Serialize(
+        NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
-            0, // flags
-            deviceRequest,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            deviceRequest);
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -228,8 +228,7 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
             req->RequestBuffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
             0,   // flags
-            deviceRequest,
-            {});
+            deviceRequest);
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -177,8 +177,6 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         SelfId(),
         requestId);
 
-    auto* serializer = TBlockStoreProtocol::Serializer();
-
     struct TDeviceRequestInfo
     {
         NRdma::IClientEndpointPtr Endpoint;
@@ -209,7 +207,7 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         auto [req, err] = ep->AllocateRequest(
             requestContext,
             nullptr,
-            serializer->MessageByteSize(deviceRequest, 0),
+            NRdma::TProtoMessageSerializer::MessageByteSize(deviceRequest, 0),
             4_KB);
 
         if (HasError(err)) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -228,7 +228,8 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
             req->RequestBuffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
             0,   // flags
-            deviceRequest);
+            deviceRequest,
+            {});
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -75,7 +75,7 @@ public:
         auto [req, err] = endpoint.AllocateRequest(
             handler,
             nullptr,
-            Serializer->MessageByteSize(*Request, 0),
+            NRdma::TProtoMessageSerializer::MessageByteSize(*Request, 0),
             MAX_PROTO_SIZE + dataSize);
 
         if (HasError(err)) {
@@ -162,7 +162,7 @@ public:
         auto [req, err] = endpoint.AllocateRequest(
             std::move(handler),
             nullptr,
-            Serializer->MessageByteSize(*Request, dataSize),
+            NRdma::TProtoMessageSerializer::MessageByteSize(*Request, dataSize),
             MAX_PROTO_SIZE);
 
         if (HasError(err)) {

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -86,7 +86,8 @@ public:
             req->RequestBuffer,
             TBlockStoreProtocol::ReadBlocksRequest,
             0,   // flags
-            *Request);
+            *Request,
+            {});
 
         return std::move(req);
     }

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -86,8 +86,7 @@ public:
             req->RequestBuffer,
             TBlockStoreProtocol::ReadBlocksRequest,
             0,   // flags
-            *Request,
-            {});
+            *Request);
 
         return std::move(req);
     }
@@ -174,7 +173,7 @@ public:
         Y_ABORT_UNLESS(guard);
 
         const auto& sglist = guard.Get();
-        NRdma::TProtoMessageSerializer::Serialize(
+        NRdma::TProtoMessageSerializer::SerializeWithData(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteBlocksRequest,
             0,   // flags

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -82,12 +82,11 @@ public:
             return err;
         }
 
-        Serializer->Serialize(
+        NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadBlocksRequest,
-            0, // flags
-            *Request,
-            TContIOVector(nullptr, 0));
+            0,   // flags
+            *Request);
 
         return std::move(req);
     }
@@ -174,12 +173,12 @@ public:
         Y_ABORT_UNLESS(guard);
 
         const auto& sglist = guard.Get();
-        Serializer->Serialize(
+        NRdma::TProtoMessageSerializer::Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::WriteBlocksRequest,
-            0, // flags
+            0,   // flags
             *Request,
-            TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
+            sglist);
 
         return std::move(req);
     }

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -157,12 +157,13 @@ private:
                 Y_ABORT_UNLESS(guard);
 
                 const auto& sglist = guard.Get();
-                size_t responseBytes = Serializer->Serialize(
-                    out,
-                    TBlockStoreProtocol::ReadBlocksResponse,
-                    0, // flags
-                    response,
-                    TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
+                size_t responseBytes =
+                    NRdma::TProtoMessageSerializer::Serialize(
+                        out,
+                        TBlockStoreProtocol::ReadBlocksResponse,
+                        0,   // flags
+                        response,
+                        sglist);
 
                 Endpoint->SendResponse(context, responseBytes);
             });
@@ -197,12 +198,12 @@ private:
             TaskQueue->ExecuteSimple([=] {
                 Y_UNUSED(guardedSgList);
 
-                size_t responseBytes = Serializer->Serialize(
-                    out,
-                    TBlockStoreProtocol::WriteBlocksResponse,
-                    0, // flags
-                    response,
-                    TContIOVector(nullptr, 0));
+                size_t responseBytes =
+                    NRdma::TProtoMessageSerializer::Serialize(
+                        out,
+                        TBlockStoreProtocol::WriteBlocksResponse,
+                        0,   // flags
+                        response);
 
                 Endpoint->SendResponse(context, responseBytes);
             });

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -203,7 +203,8 @@ private:
                         out,
                         TBlockStoreProtocol::WriteBlocksResponse,
                         0,   // flags
-                        response);
+                        response,
+                        {});
 
                 Endpoint->SendResponse(context, responseBytes);
             });

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -158,7 +158,7 @@ private:
 
                 const auto& sglist = guard.Get();
                 size_t responseBytes =
-                    NRdma::TProtoMessageSerializer::Serialize(
+                    NRdma::TProtoMessageSerializer::SerializeWithData(
                         out,
                         TBlockStoreProtocol::ReadBlocksResponse,
                         0,   // flags
@@ -203,8 +203,7 @@ private:
                         out,
                         TBlockStoreProtocol::WriteBlocksResponse,
                         0,   // flags
-                        response,
-                        {});
+                        response);
 
                 Endpoint->SendResponse(context, responseBytes);
             });

--- a/cloud/storage/core/libs/common/block_data_ref.h
+++ b/cloud/storage/core/libs/common/block_data_ref.h
@@ -7,6 +7,8 @@
 #include <util/generic/string.h>
 #include <util/stream/output.h>
 
+#include <span>
+
 namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,6 +91,8 @@ public:
         return ComputeHash(TStringBuf(Start, Length));
     }
 };
+
+using TBlockDataRefSpan = std::span<const TBlockDataRef>;
 
 }   // namespace NCloud
 


### PR DESCRIPTION
Убираю замаскированное небезопасное преобразование в виде с-style cast 