### PR TITLE
issue-1350: increasing default IdleSessionTimeout to 1 hour - 5 minutes aren't enough if we deploy a bug which causes filestore-vhost to enter a crash loop or something like that, whereas 1 hour should be enough

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -28,7 +28,7 @@ using TAliasMap = THashMap<TString, TString>;
     xxx(PipeClientMaxRetryTime,        TDuration, TDuration::Seconds(4)       )\
                                                                                \
     xxx(EstablishSessionTimeout,       TDuration, TDuration::Seconds(30)      )\
-    xxx(IdleSessionTimeout,            TDuration, TDuration::Minutes(5)       )\
+    xxx(IdleSessionTimeout,            TDuration, TDuration::Hours(1)         )\
                                                                                \
     xxx(WriteBatchEnabled,             bool,      false                       )\
     xxx(WriteBatchTimeout,             TDuration, TDuration::MilliSeconds(0)  )\

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -275,7 +275,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         });
 
         Tablet->RebootTablet();
-        Tablet->AdvanceTime(TDuration::Minutes(10));
+        Tablet->AdvanceTime(TDuration::Hours(1));
         Tablet->CleanupSessions();
 
         Tablet->AdvanceTime(TDuration::Seconds(15));


### PR DESCRIPTION
#1350 