### PR TITLE
issue-1794: fixed use-after-free in fs search by alias, not making a new THashMap upon each alias search, removed incorrect TABLET_VERIFY in TIndexTabletActor::CompleteTx_CreateSession

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -294,7 +294,7 @@ const type& TStorageConfig::Get##name() const                                  \
 {                                                                              \
     return ProtoConfig.Get##name();                                            \
 }                                                                              \
-// FILESTORE_CONFIG_GETTER
+// FILESTORE_CONFIG_GETTER_REF
 
 FILESTORE_STORAGE_CONFIG_REF(FILESTORE_CONFIG_GETTER_REF)
 

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -240,7 +240,8 @@ public:
 
     const NProto::TStorageConfig& GetStorageConfigProto() const;
 
-    THashMap<TString, TString> GetFilestoreAliases() const;
+    const NProto::TStorageConfig::TFilestoreAliases& GetFilestoreAliases() const;
+    const TString* FindFileSystemIdByAlias(const TString& alias) const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -653,9 +653,10 @@ void TStorageServiceActor::HandleCreateSession(
 
     const auto& clientId = GetClientId(msg->Record);
     TString fileSystemId = msg->Record.GetFileSystemId();
-    auto it = StorageConfig->GetFilestoreAliases().find(fileSystemId);
-    if (it != StorageConfig->GetFilestoreAliases().end()) {
-        fileSystemId = it->second;
+    if (const auto* realId =
+            StorageConfig->FindFileSystemIdByAlias(fileSystemId))
+    {
+        fileSystemId = *realId;
     }
     const auto& checkpointId = msg->Record.GetCheckpointId();
     auto originFqdn = GetOriginFqdn(msg->Record);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -444,7 +444,19 @@ void TIndexTabletActor::CompleteTx_CreateSession(
     }
 
     auto* session = FindSession(args.SessionId);
-    TABLET_VERIFY(session);
+    if (!session) {
+        auto message = TStringBuilder() << "Session " << args.SessionId
+            << " destroyed during creation";
+        LOG_WARN(ctx, TFileStoreComponents::TABLET,
+            "%s %s",
+            LogTag.c_str(),
+            message.c_str());
+
+        auto response =
+            std::make_unique<TResponse>(MakeError(E_REJECTED, message));
+        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+        return;
+    }
 
     auto response = std::make_unique<TResponse>(args.Error);
     response->Record.SetSessionId(std::move(args.SessionId));

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
@@ -320,9 +320,8 @@ void TIndexTabletProxyActor::HandleRequest(
 
     TString fileSystemId = GetFileSystemId(*msg);
     // Some filestore names can point to another filestore, set by storage config
-    auto it = Config->GetFilestoreAliases().find(fileSystemId);
-    if (it != Config->GetFilestoreAliases().end()) {
-        fileSystemId = it->second;
+    if (const auto* realId = Config->FindFileSystemIdByAlias(fileSystemId)) {
+        fileSystemId = *realId;
     }
 
     TConnection& conn = CreateConnection(fileSystemId);


### PR DESCRIPTION
Fixes the following stuff:
* https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(asan)/10428632397/1/nebius-x86-64-asan/logs/cloud/filestore/libs/storage/service/ut/test-results/unittest/chunk6/testing_out_stuff/TStorageServiceTest.ShouldUseAliasesForRequestsForwarding.err
* https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/10428397589/1/nebius-x86-64-tsan/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/test-results/py3test/chunk4/testing_out_stuff/filestore-server.err

#1794 
#1350 