### PR TITLE
[Filestore] parse `TClientAppConfig`, not `TClientConfig` in filestore-client

### DIFF
--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -183,11 +183,12 @@ void TCommand::Init()
     Timer = CreateWallClockTimer();
     Scheduler = CreateScheduler();
 
-    NProto::TClientConfig config;
+    NProto::TClientAppConfig appConfig;
     if (NFs::Exists(ConfigFile)) {
-        ParseFromTextFormat(ConfigFile, config);
+        ParseFromTextFormat(ConfigFile, appConfig);
     }
 
+    auto& config = *appConfig.MutableClientConfig();
     if (ServerAddress) {
         config.SetHost(ServerAddress);
     }


### PR DESCRIPTION
Now filestore-client will fail if provided with a valid nfs-config.txt. Fixing error, introduced by #1687