### PR TITLE
issue-1657: resize nbd device

### DIFF
--- a/cloud/blockstore/apps/client/lib/factory.cpp
+++ b/cloud/blockstore/apps/client/lib/factory.cpp
@@ -31,6 +31,7 @@
 #include "query_available_storage.h"
 #include "read_blocks.h"
 #include "refresh_endpoint.h"
+#include "resize_device.h"
 #include "resize_volume.h"
 #include "resume_device.h"
 #include "start_endpoint.h"
@@ -84,6 +85,7 @@ struct THandlerFactory
         { "queryavailablestorage", NewQueryAvailableStorageCommand },
         { "readblocks", NewReadBlocksCommand },
         { "refreshendpoint", NewRefreshEndpointCommand },
+        { "resizedevice", NewResizeDeviceCommand },
         { "resizevolume", NewResizeVolumeCommand },
         { "restorevolume", NewRestoreVolumeCommand },
         { "resumedevice", NewResumeDeviceCommand },

--- a/cloud/blockstore/apps/client/lib/resize_device.cpp
+++ b/cloud/blockstore/apps/client/lib/resize_device.cpp
@@ -48,7 +48,7 @@ protected:
 
         STORAGE_DEBUG("Reading ResizeDevice request");
         auto request = std::make_shared<NProto::TResizeDeviceRequest>();
-         if (Proto) {
+        if (Proto) {
             ParseFromTextFormat(input, *request);
         } else {
             request->SetUnixSocketPath(UnixSocketPath);

--- a/cloud/blockstore/apps/client/lib/resize_device.cpp
+++ b/cloud/blockstore/apps/client/lib/resize_device.cpp
@@ -1,4 +1,5 @@
-#include "refresh_endpoint.h"
+#include "resize_device.h"
+
 
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
@@ -14,46 +15,50 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TRefreshEndpointCommand final
+class TResizeDeviceCommand final
     : public TCommand
 {
 private:
     TString UnixSocketPath;
+    ui64 DeviceSizeInBytes = 0;
 
 public:
-    TRefreshEndpointCommand(IBlockStorePtr client)
+    TResizeDeviceCommand(IBlockStorePtr client)
         : TCommand(std::move(client))
     {
         Opts.AddLongOption("socket", "unix socket path")
             .RequiredArgument("STR")
+            .Required()
             .StoreResult(&UnixSocketPath);
+
+        Opts.AddLongOption("device-size", "Device size in bytes")
+            .RequiredArgument("NUM")
+            .Required()
+            .StoreResult(&DeviceSizeInBytes);
     }
 
 protected:
     bool DoExecute() override
     {
-        if (!Proto && !CheckOpts()) {
-            return false;
-        }
-
         auto& input = GetInputStream();
         auto& output = GetOutputStream();
 
-        STORAGE_DEBUG("Reading RefreshEndpoint request");
-        auto request = std::make_shared<NProto::TRefreshEndpointRequest>();
-        if (Proto) {
+        STORAGE_DEBUG("Reading ResizeDevice request");
+        auto request = std::make_shared<NProto::TResizeDeviceRequest>();
+         if (Proto) {
             ParseFromTextFormat(input, *request);
         } else {
             request->SetUnixSocketPath(UnixSocketPath);
+            request->SetDeviceSizeInBytes(DeviceSizeInBytes);
         }
 
-        STORAGE_DEBUG("Sending RefreshEndpoint request");
+        STORAGE_DEBUG("Sending ResizeDevice request");
         const auto requestId = GetRequestId(*request);
-        auto result = WaitFor(ClientEndpoint->RefreshEndpoint(
+        auto result = WaitFor(ClientEndpoint->ResizeDevice(
             MakeIntrusive<TCallContext>(requestId),
             std::move(request)));
 
-        STORAGE_DEBUG("Received RefreshEndpoint response");
+        STORAGE_DEBUG("Received ResizeDevice response");
         if (Proto) {
             SerializeToTextFormat(result, output);
             return true;
@@ -67,26 +72,15 @@ protected:
         output << "OK" << Endl;
         return true;
     }
-
-private:
-    bool CheckOpts() const
-    {
-        if (!UnixSocketPath) {
-            STORAGE_ERROR("Unix socket path is required");
-            return false;
-        }
-
-        return true;
-    }
 };
 
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TCommandPtr NewRefreshEndpointCommand(IBlockStorePtr client)
+TCommandPtr NewResizeDeviceCommand(IBlockStorePtr client)
 {
-    return MakeIntrusive<TRefreshEndpointCommand>(std::move(client));
+    return MakeIntrusive<TResizeDeviceCommand>(std::move(client));
 }
 
 }   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/apps/client/lib/resize_device.cpp
+++ b/cloud/blockstore/apps/client/lib/resize_device.cpp
@@ -28,8 +28,8 @@ public:
     {
         Opts.AddLongOption(
                 "socket",
-                "unix socket path of the endpoint associated with the device "
-                "we are resizing")
+                "Unix socket path of the endpoint associated with the device "
+                "being resized")
             .RequiredArgument("STR")
             .Required()
             .StoreResult(&UnixSocketPath);

--- a/cloud/blockstore/apps/client/lib/resize_device.cpp
+++ b/cloud/blockstore/apps/client/lib/resize_device.cpp
@@ -26,7 +26,10 @@ public:
     TResizeDeviceCommand(IBlockStorePtr client)
         : TCommand(std::move(client))
     {
-        Opts.AddLongOption("socket", "unix socket path")
+        Opts.AddLongOption(
+                "socket",
+                "unix socket path of the endpoint associated with the device "
+                "we are resizing")
             .RequiredArgument("STR")
             .Required()
             .StoreResult(&UnixSocketPath);

--- a/cloud/blockstore/apps/client/lib/resize_device.h
+++ b/cloud/blockstore/apps/client/lib/resize_device.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "command.h"
+
+namespace NCloud::NBlockStore::NClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewResizeDeviceCommand(IBlockStorePtr client);
+
+}   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/apps/client/lib/ya.make
+++ b/cloud/blockstore/apps/client/lib/ya.make
@@ -38,6 +38,7 @@ SRCS(
     query_available_storage.cpp
     read_blocks.cpp
     refresh_endpoint.cpp
+    resize_device.cpp
     resize_volume.cpp
     resume_device.cpp
     start_endpoint.cpp

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
@@ -155,10 +155,10 @@ struct TResizeRequestContext
     std::unique_ptr<TReader> Reader;
 
     TResizeRequestContext(
-        grpc::CompletionQueue& cq,
-        std::shared_ptr<grpc::Channel> channel,
-        TRequest request,
-        TInstant now)
+            grpc::CompletionQueue& cq,
+            std::shared_ptr<grpc::Channel> channel,
+            TRequest request,
+            TInstant now)
         : TRequestContextImpl(cq, std::move(channel), std::move(request), now)
     {
         Reader = Service.AsyncResizeProxyDevice(&ClientContext, Request, &CQ);

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
@@ -145,6 +145,26 @@ struct TListRequestContext: TRequestContextImpl<
     }
 };
 
+struct TResizeRequestContext
+    : TRequestContextImpl<
+          NProto::TResizeProxyDeviceRequest,
+          NProto::TResizeProxyDeviceResponse>
+{
+    using TReader = grpc::ClientAsyncResponseReader<TResponse>;
+
+    std::unique_ptr<TReader> Reader;
+
+    TResizeRequestContext(
+        grpc::CompletionQueue& cq,
+        std::shared_ptr<grpc::Channel> channel,
+        TRequest request,
+        TInstant now)
+        : TRequestContextImpl(cq, std::move(channel), std::move(request), now)
+    {
+        Reader = Service.AsyncResizeProxyDevice(&ClientContext, Request, &CQ);
+    }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TEndpointProxyClient
@@ -297,6 +317,16 @@ struct TEndpointProxyClient
             Timer->Now());
     }
 
+    TFuture<NProto::TResizeProxyDeviceResponse> ResizeProxyDevice(
+        std::shared_ptr<NProto::TResizeProxyDeviceRequest> request) override
+    {
+        STORAGE_INFO("ResizeRequest: " << request->DebugString().Quote());
+
+        return RequestImpl<TResizeRequestContext>(
+            std::move(*request),
+            Timer->Now());
+    }
+
     void Loop()
     {
         STORAGE_INFO("Starting loop");
@@ -325,6 +355,13 @@ struct TEndpointProxyClient
                 dynamic_cast<TListRequestContext*>(&*requestContext);
             if (listRequestContext) {
                 FinishRequest(*listRequestContext, ok);
+                continue;
+            }
+
+            auto* resizeRequestContext =
+                dynamic_cast<TResizeRequestContext*>(&*requestContext);
+            if (resizeRequestContext) {
+                FinishRequest(*resizeRequestContext, ok);
                 continue;
             }
         }

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.h
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.h
@@ -27,6 +27,9 @@ struct IEndpointProxyClient: IStartable
 
     virtual TFuture<NProto::TListProxyEndpointsResponse> ListProxyEndpoints(
         std::shared_ptr<NProto::TListProxyEndpointsRequest> request) = 0;
+
+    virtual TFuture<NProto::TResizeProxyDeviceResponse> ResizeProxyDevice(
+        std::shared_ptr<NProto::TResizeProxyDeviceRequest> request) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
@@ -89,10 +89,13 @@ struct TProxyDevice: NBD::IDevice
             });
     }
 
-    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override
     {
-        Y_UNUSED(deviceSizeInBytes);
-        return MakeError(E_NOT_IMPLEMENTED);
+        auto request = std::make_shared<NProto::TResizeProxyDeviceRequest>();
+        request->SetUnixSocketPath(AddressString);
+        request->SetDeviceSizeInBytes(deviceSizeInBytes);
+        return Client->ResizeProxyDevice(std::move(request))
+            .Apply([](const auto& f) { return f.GetValue().GetError(); });
     }
 };
 

--- a/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
@@ -88,6 +88,12 @@ struct TProxyDevice: NBD::IDevice
                 return f.GetValue().GetError();
             });
     }
+
+    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    {
+        Y_UNUSED(deviceSizeInBytes);
+        return MakeError(E_NOT_IMPLEMENTED);
+    }
 };
 
 struct TProxyFactory: NBD::IDeviceFactory

--- a/cloud/blockstore/libs/endpoint_proxy/client/device_factory_ut.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/device_factory_ut.cpp
@@ -71,6 +71,15 @@ struct TTestEndpointProxyClient: NClient::IEndpointProxyClient
             TErrorResponse(E_NOT_IMPLEMENTED));
     }
 
+    TFuture<NProto::TResizeProxyDeviceResponse> ResizeProxyDevice(
+        std::shared_ptr<NProto::TResizeProxyDeviceRequest> request) override
+    {
+        Y_UNUSED(request);
+
+        return NThreading::MakeFuture<NProto::TResizeProxyDeviceResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED));
+    }
+
     void Start() override
     {}
 

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -146,8 +146,8 @@ struct TResizeRequestContext: TRequestContextBase
     grpc::ServerAsyncResponseWriter<NProto::TResizeProxyDeviceResponse> Writer;
 
     TResizeRequestContext(
-        NProto::TBlockStoreEndpointProxy::AsyncService& service,
-        grpc::ServerCompletionQueue& cq)
+            NProto::TBlockStoreEndpointProxy::AsyncService& service,
+            grpc::ServerCompletionQueue& cq)
         : Writer(&ServerContext)
     {
         service.RequestResizeProxyDevice(

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1577,6 +1577,26 @@ void TEndpointManager::DetachFileDevice(const TString& device)
     }
 }
 
+NProto::TResizeDeviceResponse TEndpointManager::DoResizeDevice(
+    TCallContextPtr ctx,
+    std::shared_ptr<NProto::TResizeDeviceRequest> request)
+{
+    Y_UNUSED(ctx);
+    const auto& socketPath = request->GetUnixSocketPath();
+    const auto& deviceSize = request->GetDeviceSizeInBytes();
+
+    auto it = Endpoints.find(socketPath);
+    if (it == Endpoints.end()) {
+        return TErrorResponse(
+            S_FALSE,
+            TStringBuilder()
+                << "endpoint " << socketPath.Quote() << " not started");
+    }
+
+    auto ret = it->second.Device->Resize(deviceSize);
+    return TErrorResponse(ret);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TFuture<NProto::TStartEndpointResponse> TRestoringClient::StartEndpoint(

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1593,8 +1593,7 @@ NProto::TResizeDeviceResponse TEndpointManager::DoResizeDevice(
                 << "endpoint " << socketPath.Quote() << " not started");
     }
 
-    auto ret = it->second.Device->Resize(deviceSize);
-    return TErrorResponse(ret);
+    return TErrorResponse(it->second.Device->Resize(deviceSize));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1593,7 +1593,7 @@ NProto::TResizeDeviceResponse TEndpointManager::DoResizeDevice(
                 << "endpoint " << socketPath.Quote() << " not started");
     }
 
-    return TErrorResponse(it->second.Device->Resize(deviceSize));
+    return TErrorResponse(it->second.Device->Resize(deviceSize).GetValueSync());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1588,7 +1588,7 @@ NProto::TResizeDeviceResponse TEndpointManager::DoResizeDevice(
     auto it = Endpoints.find(socketPath);
     if (it == Endpoints.end()) {
         return TErrorResponse(
-            S_FALSE,
+            E_NOT_FOUND,
             TStringBuilder()
                 << "endpoint " << socketPath.Quote() << " not started");
     }

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -498,6 +498,16 @@ TFuture<NProto::TListEndpointsResponse> ListEndpoints(
         std::make_shared<NProto::TListEndpointsRequest>());
 }
 
+TFuture<NProto::TResizeDeviceResponse> ResizeDevice(
+    IEndpointManager& endpointManager, const TString& unixSocketPath, ui64 deviceSize)
+{
+    auto request = std::make_shared<NProto::TResizeDeviceRequest>();
+    request->SetUnixSocketPath(unixSocketPath);
+    request->SetDeviceSizeInBytes(deviceSize);
+    return endpointManager.ResizeDevice(
+        MakeIntrusive<TCallContext>(), request);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1834,6 +1844,61 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
             auto future = StopEndpoint(*manager, socketPath.GetPath());
             auto response = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT(!HasError(response));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldResizeDevice)
+    {
+        TTempDir dir;
+        auto socketPath = dir.Path() / "testSocket";
+        TString diskId = "testDiskId";
+        auto ipcType = NProto::IPC_GRPC;
+
+        TBootstrap bootstrap;
+        TMap<TString, NProto::TMountVolumeRequest> mountedVolumes;
+        bootstrap.Service = CreateTestService(mountedVolumes);
+
+        auto grpcListener =
+            CreateSocketEndpointListener(bootstrap.Logging, 16, MODE0660);
+        grpcListener->SetClientStorageFactory(CreateClientStorageFactoryStub());
+        bootstrap.EndpointListeners = {{NProto::IPC_GRPC, grpcListener}};
+
+        auto manager = CreateEndpointManager(bootstrap);
+        bootstrap.Start();
+
+        NProto::TStartEndpointRequest request;
+        SetDefaultHeaders(request);
+        request.SetUnixSocketPath(socketPath.GetPath());
+        request.SetDiskId(diskId);
+        request.SetClientId(TestClientId);
+        request.SetIpcType(ipcType);
+
+        socketPath.DeleteIfExists();
+        UNIT_ASSERT(!socketPath.Exists());
+
+        {
+            auto future = StartEndpoint(*manager, request);
+            auto response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(response), response.GetError());
+        }
+
+        const auto deviceSize = 1000u;
+        {
+            auto future =
+                ResizeDevice(*manager, "invalid/path/socket", deviceSize);
+            auto response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT(HasError(response));
+            const auto& resizeError = response.GetError();
+            UNIT_ASSERT_EQUAL_C(
+                E_NOT_FOUND,
+                resizeError.GetCode(),
+                resizeError.GetMessage());
+        }
+
+        {
+            auto future = ResizeDevice(*manager, socketPath, deviceSize);
+            auto response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(response), response.GetError());
         }
     }
 }

--- a/cloud/blockstore/libs/nbd/device.cpp
+++ b/cloud/blockstore/libs/nbd/device.cpp
@@ -116,19 +116,21 @@ public:
         return NThreading::MakeFuture(MakeError(S_OK));
     }
 
-    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override
     {
         if (!Device.IsOpen()) {
-            return MakeError(E_FAIL, "Device is not open");
+            return NThreading::MakeFuture(
+                MakeError(E_FAIL, "Device is not open"));
         }
 
         STORAGE_DEBUG("NBD_SET_SIZE " << deviceSizeInBytes);
         auto ret = ioctl(Device, NBD_SET_SIZE, deviceSizeInBytes);
         if (ret < 0) {
-            return MakeError(E_FAIL, "Could not setup device size");
+            return NThreading::MakeFuture(
+                MakeError(E_FAIL, "Could not setup device size"));
         }
 
-        return MakeError(S_OK);
+        return NThreading::MakeFuture(MakeError(S_OK));
     }
 
 private:
@@ -277,10 +279,10 @@ public:
         return NThreading::MakeFuture(MakeError(S_OK));
     }
 
-    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override
     {
         Y_UNUSED(deviceSizeInBytes);
-        return MakeError(S_OK);
+        return NThreading::MakeFuture(MakeError(S_OK));
     }
 };
 

--- a/cloud/blockstore/libs/nbd/device.cpp
+++ b/cloud/blockstore/libs/nbd/device.cpp
@@ -116,6 +116,21 @@ public:
         return NThreading::MakeFuture(MakeError(S_OK));
     }
 
+    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    {
+        if (!Device.IsOpen()) {
+            return MakeError(E_FAIL, "Device is not open");
+        }
+
+        STORAGE_DEBUG("NBD_SET_SIZE " << deviceSizeInBytes);
+        auto ret = ioctl(Device, NBD_SET_SIZE, deviceSizeInBytes);
+        if (ret < 0) {
+            return MakeError(E_FAIL, "Could not setup device size");
+        }
+
+        return MakeError(S_OK);
+    }
+
 private:
     void* ThreadProc() override
     {
@@ -260,6 +275,12 @@ public:
         Y_UNUSED(deleteDevice);
 
         return NThreading::MakeFuture(MakeError(S_OK));
+    }
+
+    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    {
+        Y_UNUSED(deviceSizeInBytes);
+        return MakeError(E_NOT_IMPLEMENTED);
     }
 };
 

--- a/cloud/blockstore/libs/nbd/device.cpp
+++ b/cloud/blockstore/libs/nbd/device.cpp
@@ -280,7 +280,7 @@ public:
     NProto::TError Resize(ui64 deviceSizeInBytes) override
     {
         Y_UNUSED(deviceSizeInBytes);
-        return MakeError(E_NOT_IMPLEMENTED);
+        return MakeError(S_OK);
     }
 };
 

--- a/cloud/blockstore/libs/nbd/device.h
+++ b/cloud/blockstore/libs/nbd/device.h
@@ -27,7 +27,8 @@ struct IDevice
     // stopped for technical reasons like service restart
     virtual NThreading::TFuture<NProto::TError> Stop(bool deleteDevice) = 0;
 
-    virtual NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) = 0;
+    virtual NThreading::TFuture<NProto::TError> Resize(
+        ui64 deviceSizeInBytes) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nbd/device.h
+++ b/cloud/blockstore/libs/nbd/device.h
@@ -27,7 +27,7 @@ struct IDevice
     // stopped for technical reasons like service restart
     virtual NThreading::TFuture<NProto::TError> Stop(bool deleteDevice) = 0;
 
-    virtual NProto::TError Resize(ui64 deviceSizeInBytes) = 0;
+    virtual NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nbd/device.h
+++ b/cloud/blockstore/libs/nbd/device.h
@@ -26,6 +26,8 @@ struct IDevice
     // cases when user explicitly asked us to stop the device and it being
     // stopped for technical reasons like service restart
     virtual NThreading::TFuture<NProto::TError> Stop(bool deleteDevice) = 0;
+
+    virtual NProto::TError Resize(ui64 deviceSizeInBytes) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -255,11 +255,12 @@ public:
         return StopResult.GetFuture();
     }
 
-    NProto::TError Resize(ui64 deviceSizeInBytes) override
+    NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override
     {
         if (!StartResult.HasValue() || StartResult.GetValue().GetCode() != S_OK)
         {
-            return MakeError(E_FAIL, "Device is not open");
+            return NThreading::MakeFuture(
+                MakeError(E_FAIL, "Device is not open"));
         }
 
         try {
@@ -277,13 +278,13 @@ public:
 
             message.Send(socket);
         } catch (const TServiceError& e) {
-            return MakeError(
+            return NThreading::MakeFuture(MakeError(
                 e.GetCode(),
-                TStringBuilder() << "unable to resize " << DeviceName << ": "
-                                 << e.what());
+                TStringBuilder()
+                    << "unable to resize " << DeviceName << ": " << e.what()));
         }
 
-        return MakeError(S_OK);
+        return NThreading::MakeFuture(MakeError(S_OK));
     }
 
 private:

--- a/cloud/blockstore/libs/service/auth_scheme.cpp
+++ b/cloud/blockstore/libs/service/auth_scheme.cpp
@@ -122,6 +122,7 @@ TPermissionList GetRequestPermissions(EBlockStoreRequest requestType)
         case EBlockStoreRequest::StopEndpoint:
         case EBlockStoreRequest::KickEndpoint:
         case EBlockStoreRequest::RefreshEndpoint:
+        case EBlockStoreRequest::ResizeDevice:
             return CreatePermissionList({EPermission::Update});
 
         case EBlockStoreRequest::ListEndpoints:

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -99,6 +99,7 @@ using TWriteBlocksLocalResponse = TWriteBlocksResponse;
     xxx(ListKeyrings,                       __VA_ARGS__)                       \
     xxx(DescribeEndpoint,                   __VA_ARGS__)                       \
     xxx(RefreshEndpoint,                    __VA_ARGS__)                       \
+    xxx(ResizeDevice,                       __VA_ARGS__)                       \
 // BLOCKSTORE_ENDPOINT_SERVICE
 
 #define BLOCKSTORE_GRPC_SERVICE(xxx, ...)                                      \

--- a/cloud/blockstore/libs/service/request_helpers.h
+++ b/cloud/blockstore/libs/service/request_helpers.h
@@ -314,6 +314,7 @@ constexpr bool IsControlRequest(EBlockStoreRequest requestType)
         case EBlockStoreRequest::DescribeEndpoint:
         case EBlockStoreRequest::RefreshEndpoint:
         case EBlockStoreRequest::QueryAgentsInfo:
+        case EBlockStoreRequest::ResizeDevice:
             return true;
         case EBlockStoreRequest::MAX:
             Y_DEBUG_ABORT_UNLESS(false);

--- a/cloud/blockstore/public/api/grpc/endpoint_proxy.proto
+++ b/cloud/blockstore/public/api/grpc/endpoint_proxy.proto
@@ -33,4 +33,11 @@ service TBlockStoreEndpointProxy
             body: "*"
         };
     }
+
+    rpc ResizeProxyDevice(TResizeProxyDeviceRequest) returns (TResizeProxyDeviceResponse) {
+        option (google.api.http) = {
+            post: "/resize_proxy_device"
+            body: "*"
+        };
+    }
 }

--- a/cloud/blockstore/public/api/grpc/service.proto
+++ b/cloud/blockstore/public/api/grpc/service.proto
@@ -254,6 +254,13 @@ service TBlockStoreService
         };
     }
 
+    rpc ResizeDevice(TResizeDeviceRequest) returns (TResizeDeviceResponse) {
+        option (google.api.http) = {
+            post: "/resize_device"
+            body: "*"
+        };
+    }
+
     //
     // Disk Registry config.
     //

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -332,3 +332,21 @@ message TListProxyEndpointsResponse
     // List of proxy endpoints.
     repeated TProxyEndpoint Endpoints = 2;
 }
+
+message TResizeDeviceRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // BlockStore unix-socket path.
+    string UnixSocketPath = 2;
+
+    // New size in bytes.
+    uint64 DeviceSizeInBytes = 3;
+}
+
+message TResizeDeviceResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -338,7 +338,7 @@ message TResizeDeviceRequest
     // Optional request headers.
     THeaders Headers = 1;
 
-    // BlockStore unix-socket path.
+    // Unix socket path of the endpoint associated with the device being resized
     string UnixSocketPath = 2;
 
     // New size in bytes.

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -350,3 +350,22 @@ message TResizeDeviceResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+
+message TResizeProxyDeviceRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Unix socket path of the endpoint associated with the device being resized
+    string UnixSocketPath = 2;
+
+    // New size in bytes.
+    uint64 DeviceSizeInBytes = 3;
+}
+
+message TResizeProxyDeviceResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}

--- a/cloud/blockstore/tests/csi_driver/test.py
+++ b/cloud/blockstore/tests/csi_driver/test.py
@@ -100,9 +100,6 @@ def init():
             input=script_input,
             text=True,
         )
-
-        logging.info("Stdout: %s", result.stdout)
-        logging.info("Stderr: %s", result.stderr)
         return result
     return env, run
 
@@ -249,6 +246,8 @@ def test_nbs_csi_driver_mounted_disk_protected_from_deletion():
             input=volume_name,
             code=1,
         )
+        logging.info("Stdout: %s", result.stdout)
+        logging.info("Stderr: %s", result.stderr)
         if result.returncode != 1:
             raise AssertionError("Destroyvolume must return exit code 1")
         assert "E_REJECTED" in result.stdout
@@ -318,14 +317,6 @@ def test_nbs_csi_driver_volume_stat():
         assert 2 == nodesUsage1["available"] - nodesUsage2["available"]
         assert 2 == nodesUsage2["used"] - nodesUsage1["used"]
 
-        try:
-            env.csi.unpublish_volume(pod_id, volume_name)
-        except subprocess.CalledProcessError as e:
-            log_called_process_error(e)
-        try:
-            env.csi.delete_volume(volume_name)
-        except subprocess.CalledProcessError as e:
-            log_called_process_error(e)
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)
         raise

--- a/cloud/blockstore/tests/csi_driver/test.py
+++ b/cloud/blockstore/tests/csi_driver/test.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pytest
 import subprocess
 import tempfile
 import time
@@ -47,9 +48,13 @@ class CsiLoadTest(LocalLoadTest):
         self.sockets_temporary_directory.cleanup()
 
 
-def init():
+def init(enableNetlink=True):
     server_config_patch = TServerConfig()
     server_config_patch.NbdEnabled = True
+    if enableNetlink:
+        server_config_patch.NbdNetlink = True
+        server_config_patch.NbdRequestTimeout = 120
+        server_config_patch.NbdConnectionTimeout = 120
     endpoints_dir = Path(common.output_path()) / f"endpoints-{hash(common.context.test_name)}"
     endpoints_dir.mkdir(exist_ok=True)
     server_config_patch.EndpointStorageType = EEndpointStorageType.ENDPOINT_STORAGE_FILE
@@ -100,6 +105,9 @@ def init():
             input=script_input,
             text=True,
         )
+
+        logging.info("Stdout: %s", result.stdout)
+        logging.info("Stderr: %s", result.stderr)
         return result
     return env, run
 
@@ -246,8 +254,6 @@ def test_nbs_csi_driver_mounted_disk_protected_from_deletion():
             input=volume_name,
             code=1,
         )
-        logging.info("Stdout: %s", result.stdout)
-        logging.info("Stderr: %s", result.stderr)
         if result.returncode != 1:
             raise AssertionError("Destroyvolume must return exit code 1")
         assert "E_REJECTED" in result.stdout
@@ -317,6 +323,14 @@ def test_nbs_csi_driver_volume_stat():
         assert 2 == nodesUsage1["available"] - nodesUsage2["available"]
         assert 2 == nodesUsage2["used"] - nodesUsage1["used"]
 
+        try:
+            env.csi.unpublish_volume(pod_id, volume_name)
+        except subprocess.CalledProcessError as e:
+            log_called_process_error(e)
+        try:
+            env.csi.delete_volume(volume_name)
+        except subprocess.CalledProcessError as e:
+            log_called_process_error(e)
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)
         raise
@@ -357,6 +371,78 @@ def test_csi_sanity_nbs_backend():
             capture_output=True,
             text=True,
         )
+    except subprocess.CalledProcessError as e:
+        log_called_process_error(e)
+        raise
+    finally:
+        cleanup_after_test(env)
+
+
+@pytest.mark.parametrize('enableNetlink', [True, False])
+def test_resize_device(enableNetlink):
+    env, run = init(enableNetlink)
+    volume_name = "example-disk"
+    block_size = 4096
+    volume_size = 10000 * block_size
+    pod_name = "example-pod"
+    pod_id = "deadbeef"
+    nbd_device = "/dev/nbd0"
+    try:
+        env.csi.create_volume(name=volume_name, size=volume_size)
+        env.csi.publish_volume(pod_id, volume_name, pod_name)
+
+        result = common.execute(
+            ["blockdev", "--getsize64", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+
+        assert result.returncode == 0
+        disk_size = int(result.stdout)
+        assert volume_size == disk_size
+
+        new_volume_size = 2 * volume_size
+        result = run(
+            "resizevolume",
+            "--disk-id",
+            volume_name,
+            "--blocks-count",
+            str(new_volume_size // block_size)
+        )
+        assert result.returncode == 0
+
+        socket_path = Path(env.sockets_temporary_directory.name)
+        result = run(
+            "resizedevice",
+            "--socket",
+            socket_path / pod_id / volume_name / "nbs.sock",
+            "--device-size",
+            str(new_volume_size)
+        )
+        assert result.returncode == 0
+
+        result = common.execute(
+            ["blockdev", "--getsize64", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+
+        assert result.returncode == 0
+        disk_size = int(result.stdout)
+        assert new_volume_size == disk_size
+
+        result = common.execute(
+            ["resize2fs", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        assert result.returncode == 0
+
+        try:
+            env.csi.unpublish_volume(pod_id, volume_name)
+        except subprocess.CalledProcessError as e:
+            log_called_process_error(e)
+        try:
+            env.csi.delete_volume(volume_name)
+        except subprocess.CalledProcessError as e:
+            log_called_process_error(e)
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)
         raise

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -111,7 +111,7 @@ def log_called_process_error(exc):
 
 
 @pytest.mark.parametrize('with_netlink,with_endpoint_proxy',
-                         [(True, True), (True, True), (True, False), (True, False)])
+                         [(True, False), (True, True), (False, False), (False, True)])
 def test_resize_device(with_netlink, with_endpoint_proxy):
     env, run = init(with_netlink, with_endpoint_proxy)
     volume_name = "example-disk"

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -161,6 +161,14 @@ def test_resize_device(with_netlink, with_endpoint_proxy):
             stderr=subprocess.STDOUT)
         assert result.returncode == 0
 
+        mount_dir = Path("/tmp/mount")
+        mount_dir.mkdir(parents=True, exist_ok=True)
+        result = common.execute(
+            ["mount", nbd_device, str(mount_dir)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        assert result.returncode == 0
+
         new_volume_size = 2 * volume_size
         result = run(
             "resizevolume",
@@ -210,5 +218,10 @@ def test_resize_device(with_netlink, with_endpoint_proxy):
             "--disk-id",
             volume_name,
         )
+
+        result = common.execute(
+            ["umount", str(mount_dir)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
 
         cleanup_after_test(env)

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -1,0 +1,204 @@
+import logging
+import pytest
+import subprocess
+import tempfile
+
+from pathlib import Path
+
+import yatest.common as common
+
+import contrib.ydb.tests.library.common.yatest_common as yatest_common
+from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
+from cloud.blockstore.config.client_pb2 import TClientConfig, TClientAppConfig
+from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
+from cloud.blockstore.tests.python.lib.test_base import (
+    thread_count
+)
+from cloud.storage.core.protos.endpoints_pb2 import (
+    EEndpointStorageType,
+)
+
+from google.protobuf.text_format import MessageToString
+
+
+BINARY_PATH = common.binary_path("cloud/blockstore/apps/client/blockstore-client")
+
+
+def init(withNetlink=True):
+    server_config_patch = TServerConfig()
+    server_config_patch.NbdEnabled = True
+    if withNetlink:
+        server_config_patch.NbdNetlink = True
+        server_config_patch.NbdRequestTimeout = 120
+        server_config_patch.NbdConnectionTimeout = 120
+    endpoints_dir = Path(common.output_path()) / f"endpoints-{hash(common.context.test_name)}"
+    endpoints_dir.mkdir(exist_ok=True)
+    server_config_patch.EndpointStorageType = EEndpointStorageType.ENDPOINT_STORAGE_FILE
+    server_config_patch.EndpointStorageDir = str(endpoints_dir)
+    server_config_patch.AllowAllRequestsViaUDS = True
+    # We run inside qemu, so do not need to cleanup
+    temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+    logging.info("Created temporary dir %s", temp_dir.name)
+    sockets_dir = Path(temp_dir.name)
+    server_config_patch.UnixSocketPath = str(sockets_dir / "grpc.sock")
+    server_config_patch.VhostEnabled = False
+    server_config_patch.NbdDevicePrefix = "/dev/nbd"
+    server = TServerAppConfig()
+    server.ServerConfig.CopyFrom(server_config_patch)
+    server.ServerConfig.ThreadsCount = thread_count()
+    server.ServerConfig.StrictContractValidation = True
+    server.KikimrServiceConfig.CopyFrom(TKikimrServiceConfig())
+    subprocess.check_call(["modprobe", "nbd"], timeout=20)
+    env = LocalLoadTest(
+        endpoint="",
+        server_app_config=server,
+        storage_config_patches=None,
+        use_in_memory_pdisks=True)
+
+    client_config_path = Path(yatest_common.output_path()) / "client-config.txt"
+    client_config = TClientAppConfig()
+    client_config.ClientConfig.CopyFrom(TClientConfig())
+    client_config.ClientConfig.RetryTimeout = 1
+    client_config.ClientConfig.Host = "localhost"
+    client_config.ClientConfig.InsecurePort = env.nbs_port
+    client_config_path.write_text(MessageToString(client_config))
+
+    def run(*args, **kwargs):
+        args = [BINARY_PATH, *args, "--config", str(client_config_path)]
+        script_input = kwargs.get("input")
+        if script_input is not None:
+            script_input = script_input + "\n"
+
+        logging.info("running command: %s" % args)
+        result = subprocess.run(
+            args,
+            cwd=kwargs.get("cwd"),
+            check=False,
+            capture_output=True,
+            input=script_input,
+            text=True,
+        )
+
+        logging.info("Stdout: %s", result.stdout)
+        logging.info("Stderr: %s", result.stderr)
+        return result
+    return env, run
+
+
+def cleanup_after_test(env: LocalLoadTest):
+    if env is None:
+        return
+    env.tear_down()
+
+
+def log_called_process_error(exc):
+    logging.error(
+        "Failed %s, stdout: %s, stderr: %s",
+        str(exc.args),
+        exc.stderr,
+        exc.stdout,
+        exc_info=exc,
+    )
+
+
+@pytest.mark.parametrize('withNetlink', [True, False])
+def test_resize_device(withNetlink):
+    env, run = init(withNetlink)
+    volume_name = "example-disk"
+    block_size = 4096
+    blocks_count = 10000
+    volume_size = blocks_count * block_size
+    nbd_device = "/dev/nbd0"
+    socket_path = "/tmp/nbd.sock"
+    try:
+        result = run(
+            "createvolume",
+            "--disk-id",
+            volume_name,
+            "--blocks-count",
+            str(blocks_count),
+            "--block-size",
+            str(block_size),
+        )
+        assert result.returncode == 0
+
+        result = run(
+            "startendpoint",
+            "--disk-id",
+            volume_name,
+            "--socket",
+            socket_path,
+            "--ipc-type",
+            "nbd",
+            "--persistent",
+            "--nbd-device",
+            nbd_device
+        )
+        assert result.returncode == 0
+
+        result = common.execute(
+            ["blockdev", "--getsize64", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+
+        assert result.returncode == 0
+        disk_size = int(result.stdout)
+        assert volume_size == disk_size
+
+        result = common.execute(
+            ["mkfs", "-t", "ext4", "-E", "nodiscard", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        assert result.returncode == 0
+
+        new_volume_size = 2 * volume_size
+        result = run(
+            "resizevolume",
+            "--disk-id",
+            volume_name,
+            "--blocks-count",
+            str(new_volume_size // block_size)
+        )
+        assert result.returncode == 0
+
+        result = run(
+            "resizedevice",
+            "--socket",
+            socket_path,
+            "--device-size",
+            str(new_volume_size)
+        )
+        assert result.returncode == 0
+
+        result = common.execute(
+            ["blockdev", "--getsize64", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+
+        assert result.returncode == 0
+        disk_size = int(result.stdout)
+        assert new_volume_size == disk_size
+
+        result = common.execute(
+            ["resize2fs", nbd_device],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        assert result.returncode == 0
+
+    except subprocess.CalledProcessError as e:
+        log_called_process_error(e)
+        raise
+    finally:
+        run(
+            "stopendpoint",
+            "--socket",
+            socket_path,
+        )
+
+        run(
+            "destroyvolume",
+            "--disk-id",
+            volume_name,
+        )
+
+        cleanup_after_test(env)

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -111,7 +111,7 @@ def log_called_process_error(exc):
 
 
 @pytest.mark.parametrize('with_netlink,with_endpoint_proxy',
-                         [(True, True), (False, True), (True, False), (False, False)])
+                         [(True, True), (True, True), (True, False), (True, False)])
 def test_resize_device(with_netlink, with_endpoint_proxy):
     env, run = init(with_netlink, with_endpoint_proxy)
     volume_name = "example-disk"

--- a/cloud/blockstore/tests/e2e-tests/ya.make
+++ b/cloud/blockstore/tests/e2e-tests/ya.make
@@ -1,0 +1,35 @@
+PY3TEST()
+
+SIZE(MEDIUM)
+TIMEOUT(600)
+REQUIREMENTS(
+    cpu:4
+    ram:16
+)
+
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    cloud/blockstore/apps/client
+    cloud/blockstore/apps/disk_agent
+    cloud/blockstore/apps/endpoint_proxy
+    cloud/blockstore/apps/server
+    contrib/ydb/apps/ydbd
+)
+
+PEERDIR(
+    cloud/blockstore/config
+    cloud/blockstore/tests/python/lib
+    cloud/storage/core/protos
+    contrib/ydb/core/protos
+    contrib/ydb/tests/library
+)
+SET_APPEND(QEMU_INVOKE_TEST YES)
+SET_APPEND(QEMU_VIRTIO none)
+SET_APPEND(QEMU_ENABLE_KVM True)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/blockstore/tests/python/lib/endpoint_proxy.py
+++ b/cloud/blockstore/tests/python/lib/endpoint_proxy.py
@@ -1,0 +1,30 @@
+from contrib.ydb.tests.library.harness.daemon import Daemon
+import contrib.ydb.tests.library.common.yatest_common as yatest_common
+
+
+class EndpointProxy(Daemon):
+
+    def __init__(self, working_dir, unix_socket_path, with_netlink):
+        command = [yatest_common.binary_path(
+            "cloud/blockstore/apps/endpoint_proxy/blockstore-endpoint-proxy")]
+        command += [
+            "--unix-socket-path", unix_socket_path
+        ]
+
+        if with_netlink:
+            command += "--netlink"
+
+        super(EndpointProxy, self).__init__(
+            command=command,
+            cwd=working_dir,
+            timeout=180)
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, type, value, tb):
+        self.stop()
+
+    @property
+    def pid(self):
+        return super(EndpointProxy, self).daemon.process.pid

--- a/cloud/blockstore/tests/python/lib/endpoint_proxy.py
+++ b/cloud/blockstore/tests/python/lib/endpoint_proxy.py
@@ -1,4 +1,4 @@
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.storage.core.tools.common.python.daemon import Daemon
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 
@@ -15,9 +15,9 @@ class EndpointProxy(Daemon):
             command += "--netlink"
 
         super(EndpointProxy, self).__init__(
-            command=command,
+            commands=[command],
             cwd=working_dir,
-            timeout=180)
+            service_name="blockstore-endpoint-proxy")
 
     def __enter__(self):
         self.start()

--- a/cloud/blockstore/tests/python/lib/ya.make
+++ b/cloud/blockstore/tests/python/lib/ya.make
@@ -24,6 +24,7 @@ PY_SRCS(
     config.py
     daemon.py
     disk_agent_runner.py
+    endpoint_proxy.py
     endpoints.py
     loadtest_env.py
     nbs_http_proxy.py

--- a/cloud/blockstore/tests/ya.make
+++ b/cloud/blockstore/tests/ya.make
@@ -10,6 +10,7 @@ RECURSE(
     cms
     csi_driver
     external_endpoint
+    e2e-tests
     fio
     functional
     fuzzing

--- a/cloud/blockstore/tools/http_proxy/main_test.go
+++ b/cloud/blockstore/tools/http_proxy/main_test.go
@@ -521,6 +521,16 @@ func (s *mockBlockstoreServer) QueryAgentsInfo(
 	return res, args.Error(1)
 }
 
+func (s *mockBlockstoreServer) ResizeDevice(
+	ctx context.Context,
+	req *blockstore_protos.TResizeDeviceRequest,
+) (*blockstore_protos.TResizeDeviceResponse, error) {
+
+	args := s.Called(ctx, req)
+	res, _ := args.Get(0).(*blockstore_protos.TResizeDeviceResponse)
+	return res, args.Error(1)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func runMockBlockstoreServer(

--- a/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
+++ b/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
@@ -320,6 +320,14 @@ func (n nbsService) QueryAgentsInfo(
 	panic("implement me")
 }
 
+func (n nbsService) ResizeDevice(
+	ctx context.Context,
+	request *protos.TResizeDeviceRequest,
+) (*protos.TResizeDeviceResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (n nbsService) ExecuteAction(
 	ctx context.Context,
 	request *protos.TExecuteActionRequest,


### PR DESCRIPTION
issue: #1657

ResizeDevice command allows to resize mounted filesystem without restarting endpoint.

```
blockstore-client resizevolume --disk-id test-volume-12 --blocks-count 524288
blockstore-client resizedevice --sock /tmp/nbd12.sock --device-size 2147483648
resize2fs /dev/nbd12
```
