### PR TITLE
io_setup may return EAGAIN - it should be retried (for a reasonable time interval)

### DIFF
--- a/cloud/storage/core/libs/aio/service.cpp
+++ b/cloud/storage/core/libs/aio/service.cpp
@@ -49,7 +49,7 @@ public:
     {
         int code = 0;
         int iterations = 0;
-        const int maxIterations = 100;
+        const int maxIterations = 1000;
         const auto waitTime = TDuration::MilliSeconds(100);
         while (iterations < maxIterations) {
             ++iterations;

--- a/cloud/storage/core/libs/aio/service.cpp
+++ b/cloud/storage/core/libs/aio/service.cpp
@@ -4,6 +4,7 @@
 #include <cloud/storage/core/libs/common/file_io_service.h>
 #include <cloud/storage/core/libs/common/thread.h>
 
+#include <util/stream/file.h>
 #include <util/string/builder.h>
 #include <util/system/file.h>
 #include <util/system/thread.h>
@@ -55,7 +56,10 @@ public:
             ++iterations;
             code = io_setup(nr, &Context);
             if (code == -EAGAIN) {
-                Cerr << "retrying EAGAIN from io_setup" << Endl;
+                const auto aioMaxNr =
+                    TIFStream("/proc/sys/fs/aio-max-nr").ReadLine();
+                Cerr << "retrying EAGAIN from io_setup, aio-max-nr: "
+                    << aioMaxNr << Endl;
                 Sleep(waitTime);
             } else {
                 break;

--- a/cloud/storage/core/libs/aio/service.cpp
+++ b/cloud/storage/core/libs/aio/service.cpp
@@ -56,10 +56,12 @@ public:
             ++iterations;
             code = io_setup(nr, &Context);
             if (code == -EAGAIN) {
+                const auto aioNr =
+                    TIFStream("/proc/sys/fs/aio-nr").ReadLine();
                 const auto aioMaxNr =
                     TIFStream("/proc/sys/fs/aio-max-nr").ReadLine();
-                Cerr << "retrying EAGAIN from io_setup, aio-max-nr: "
-                    << aioMaxNr << Endl;
+                Cerr << "retrying EAGAIN from io_setup, aio-nr/max: "
+                    << aioNr << "/" << aioMaxNr << Endl;
                 Sleep(waitTime);
             } else {
                 break;

--- a/cloud/storage/core/libs/aio/service_ut.cpp
+++ b/cloud/storage/core/libs/aio/service_ut.cpp
@@ -12,7 +12,9 @@
 #include <util/generic/array_ref.h>
 #include <util/generic/scope.h>
 #include <util/generic/size_literals.h>
+#include <util/stream/file.h>
 #include <util/system/file.h>
+#include <util/thread/factory.h>
 
 namespace NCloud {
 
@@ -80,6 +82,31 @@ Y_UNIT_TEST_SUITE(TAioTest)
         for (char val: buffer) {
             UNIT_ASSERT_VALUES_EQUAL('X', val);
         }
+    }
+
+    Y_UNIT_TEST(ShouldRetryIoSetupErrors)
+    {
+        const auto eventCountLimit =
+            FromString<size_t>(TIFStream("/proc/sys/fs/aio-max-nr").ReadLine());
+        const auto service1EventCount = eventCountLimit / 2;
+        auto service1 = CreateAIOService(service1EventCount);
+        auto promise1 = NThreading::NewPromise<void>();
+        auto promise2 = NThreading::NewPromise<void>();
+        SystemThreadFactory()->Run([&] () {
+            promise1.SetValue();
+
+            const auto service2EventCount =
+                eventCountLimit - service1EventCount + 1;
+            // should cause EAGAIN from io_setup until service1 is destroyed
+            auto service2 = CreateAIOService(service2EventCount);
+            Y_UNUSED(service2);
+            promise2.SetValue();
+        });
+
+        promise1.GetFuture().GetValueSync();
+        Sleep(TDuration::Seconds(1));
+        service1.reset();
+        promise2.GetFuture().GetValue(TDuration::Seconds(5));
     }
 }
 


### PR DESCRIPTION
Fixing the following thing which may happen in our CI:
https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/10481521148/1/nebius-x86-64/test_data/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-mirror/test-results/py3test/chunk4/testing_out_stuff/test.py__test_load[mirror3-resync]/stderr_pz3my8rw

```
VERIFY failed (2024-08-21T03:55:52.806960Z): unable to initialize context: Resource temporarily unavailable
  cloud/storage/core/libs/aio/service.cpp:53
  TAsyncIOContext(): requirement ret == 0 failed
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+663 (0x1044B4F7)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+284 (0x1044178C)
NCloud::CreateAIOService(unsigned long)+207 (0x116F9F9F)
NCloud::NBlockStore::NServer::TBootstrapYdb::InitKikimrService()+12864 (0x1B084D20)
NCloud::NBlockStore::NServer::TBootstrapBase::Init()+2250 (0x10F9775A)
int NCloud::DoMain<NCloud::NBlockStore::NServer::TBootstrapYdb>(NCloud::NBlockStore::NServer::TBootstrapYdb&, int, char**)+47 (0x1032C1DF)
main+991 (0x1032C04F)
??+0 (0x7F5C1E8D1D90)
__libc_start_main+128 (0x7F5C1E8D1E40)
??+0 (0xF8B2029)
```