### PR TITLE
[Filestore] fix incorrect auth header in GO SDK

### DIFF
--- a/cloud/filestore/public/sdk/go/client/credentials.go
+++ b/cloud/filestore/public/sdk/go/client/credentials.go
@@ -17,6 +17,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 const authHeader = "authorization"
+const authMethod = "Bearer"
 
 type ClientCredentials struct {
 	RootCertsFile      string
@@ -39,7 +40,7 @@ func (p *grpcTokenProvider) GetRequestMetadata(ctx context.Context, _ ...string)
 	if err != nil {
 		return nil, err
 	}
-	return map[string]string{authHeader: token}, nil
+	return map[string]string{authHeader: authMethod + " " + token}, nil
 }
 
 func (p *grpcTokenProvider) RequireTransportSecurity() bool {


### PR DESCRIPTION
Make it the same as in blockstore:

https://github.com/ydb-platform/nbs/blob/6bc430c0f113d0815ed730dd40bae40a1d2e52fc/cloud/blockstore/public/sdk/go/client/credentials.go#L23

https://github.com/ydb-platform/nbs/blob/6bc430c0f113d0815ed730dd40bae40a1d2e52fc/cloud/blockstore/public/sdk/go/client/credentials.go#L91