### PR TITLE
Calculate migration bandwidth in the base migration class

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -41,16 +41,19 @@ TNonreplicatedPartitionMigrationActor::TNonreplicatedPartitionMigrationActor(
     , SrcConfig(std::move(srcConfig))
     , Migrations(std::move(migrations))
     , RdmaClient(std::move(rdmaClient))
-    , TimeoutCalculator(
-          Config->GetMaxMigrationBandwidth(),
-          Config->GetExpectedDiskAgentSize(),
-          SrcConfig)
 {}
 
 void TNonreplicatedPartitionMigrationActor::OnBootstrap(
     const NActors::TActorContext& ctx)
 {
-    InitWork(ctx, CreateSrcActor(ctx), CreateDstActor(ctx));
+    InitWork(
+        ctx,
+        CreateSrcActor(ctx),
+        CreateDstActor(ctx),
+        std::make_unique<TMigrationTimeoutCalculator>(
+            Config->GetMaxMigrationBandwidth(),
+            Config->GetExpectedDiskAgentSize(),
+            SrcConfig));
 
     PrepareForMigration(ctx);
 }
@@ -72,21 +75,11 @@ bool TNonreplicatedPartitionMigrationActor::OnMessage(
         HFunc(
             TEvDiskRegistry::TEvFinishMigrationResponse,
             HandleFinishMigrationResponse);
-        HFunc(
-            TEvStatsServicePrivate::TEvRegisterTrafficSourceResponse,
-            TimeoutCalculator.HandleUpdateBandwidthLimit);
-        HFunc(NActors::TEvents::TEvWakeup, HandleWakeup);
         default:
             return false;
             break;
     }
     return true;
-}
-
-TDuration TNonreplicatedPartitionMigrationActor::CalculateMigrationTimeout(
-    TBlockRange64 range)
-{
-    return TimeoutCalculator.CalculateTimeout(range);
 }
 
 void TNonreplicatedPartitionMigrationActor::OnMigrationFinished(
@@ -228,16 +221,6 @@ NActors::TActorId TNonreplicatedPartitionMigrationActor::CreateDstActor(
             RdmaClient));
 }
 
-void TNonreplicatedPartitionMigrationActor::DoRegisterTrafficSource(
-    const NActors::TActorContext& ctx)
-{
-    if (MigrationFinished) {
-        return;
-    }
-    TimeoutCalculator.RegisterTrafficSource(ctx);
-    ctx.Schedule(RegisterBackgroundTrafficDuration, new TEvents::TEvWakeup());
-}
-
 void TNonreplicatedPartitionMigrationActor::HandleMigrationStateUpdated(
     const TEvVolume::TEvMigrationStateUpdated::TPtr& ev,
     const TActorContext& ctx)
@@ -310,16 +293,6 @@ void TNonreplicatedPartitionMigrationActor::HandlePreparePartitionMigrationRespo
     }
 
     StartWork(ctx);
-    DoRegisterTrafficSource(ctx);
-}
-
-void TNonreplicatedPartitionMigrationActor::HandleWakeup(
-    const NActors::TEvents::TEvWakeup::TPtr& ev,
-    const NActors::TActorContext& ctx)
-{
-    Y_UNUSED(ev);
-
-    DoRegisterTrafficSource(ctx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -2,7 +2,6 @@
 
 #include "public.h"
 
-#include <cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -18,7 +17,6 @@ private:
     TNonreplicatedPartitionConfigPtr SrcConfig;
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> Migrations;
     NRdma::IClientPtr RdmaClient;
-    TMigrationTimeoutCalculator TimeoutCalculator;
 
     bool UpdatingMigrationState = false;
     bool MigrationFinished = false;
@@ -39,7 +37,6 @@ public:
     void OnBootstrap(const NActors::TActorContext& ctx) override;
     bool OnMessage(const NActors::TActorContext& ctx,
         TAutoPtr<NActors::IEventHandle>& ev) override;
-    TDuration CalculateMigrationTimeout(TBlockRange64 range) override;
     void OnMigrationProgress(
         const NActors::TActorContext& ctx,
         ui64 migrationIndex) override;
@@ -67,10 +64,6 @@ private:
 
     void HandlePreparePartitionMigrationResponse(
         const TEvVolume::TEvPreparePartitionMigrationResponse::TPtr& ev,
-        const NActors::TActorContext& ctx);
-
-    void HandleWakeup(
-        const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -108,7 +108,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleWakeup(
 {
     const auto* msg = ev->Get();
     switch (msg->Tag) {
-        case REGISTER_TRAFFIC_SOURCE:
+        case WR_REGISTER_TRAFFIC_SOURCE:
             DoRegisterTrafficSource(ctx);
             break;
         default:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -14,6 +14,7 @@
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
 #include <cloud/blockstore/libs/storage/partition_common/get_changed_blocks_companion.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
@@ -43,10 +44,6 @@ public:
     virtual bool OnMessage(
         const NActors::TActorContext& ctx,
         TAutoPtr<NActors::IEventHandle>& ev) = 0;
-
-    // Calculates the time during which a 4MB block should migrate.
-    [[nodiscard]] virtual TDuration
-    CalculateMigrationTimeout(TBlockRange64 range) = 0;
 
     // Notifies that a sufficiently large block of data has been migrated. The
     // size is determined by the settings.
@@ -96,6 +93,7 @@ private:
 
     NActors::TActorId SrcActorId;
     NActors::TActorId DstActorId;
+    std::unique_ptr<TMigrationTimeoutCalculator> TimeoutCalculator;
 
     TProcessingBlocks ProcessingBlocks;
     bool MigrationEnabled = false;
@@ -131,6 +129,14 @@ private:
     TDuration CpuUsage;
 
 protected:
+    // Derived class that wishes to handle wakeup messages should make its own
+    // enum which starts with `REASON_COUNT` value.
+    enum EWakeupReason {
+        REGISTER_TRAFFIC_SOURCE = 1,
+
+        REASON_COUNT
+    };
+
     // PoisonPill
     TPoisonPillHelper PoisonPillHelper;
 
@@ -156,7 +162,8 @@ public:
     void InitWork(
         const NActors::TActorContext& ctx,
         NActors::TActorId srcActorId,
-        NActors::TActorId dstActorId);
+        NActors::TActorId dstActorId,
+        std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator);
 
     // Called from the inheritor to start migration.
     void StartWork(const NActors::TActorContext& ctx);
@@ -180,6 +187,7 @@ protected:
 
 private:
     bool IsMigrationAllowed() const;
+    bool IsMigrationFinished() const;
     bool IsIoDepthLimitReached() const;
     bool OverlapsWithInflightWriteAndZero(TBlockRange64 range) const;
 
@@ -198,6 +206,10 @@ private:
         const NActors::TActorContext& ctx,
         TBlockRange64 migratedRange);
     void NotifyMigrationFinishedIfNeeded(const NActors::TActorContext& ctx);
+
+    // Calculates the time during which a 4MB block should migrate.
+    TDuration CalculateMigrationTimeout(TBlockRange64 range) const;
+    void DoRegisterTrafficSource(const NActors::TActorContext& ctx);
 
 private:
     STFUNC(StateWork);
@@ -225,6 +237,10 @@ private:
 
     void HandleUpdateCounters(
         const TEvNonreplPartitionPrivate::TEvUpdateCounters::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleWakeup(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandlePoisonPill(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -130,11 +130,12 @@ private:
 
 protected:
     // Derived class that wishes to handle wakeup messages should make its own
-    // enum which starts with `REASON_COUNT` value.
-    enum EWakeupReason {
-        REGISTER_TRAFFIC_SOURCE = 1,
+    // enum which starts with `WR_REASON_COUNT` value.
+    enum EWakeupReason
+    {
+        WR_REGISTER_TRAFFIC_SOURCE = 1,
 
-        REASON_COUNT
+        WR_REASON_COUNT
     };
 
     // PoisonPill

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -319,8 +319,7 @@ void TNonreplicatedPartitionMigrationCommonActor::
 void TNonreplicatedPartitionMigrationCommonActor::
     NotifyMigrationFinishedIfNeeded(const TActorContext& ctx)
 {
-    if (!IsMigrationFinished())
-    {
+    if (!IsMigrationFinished()) {
         return;
     }
 
@@ -352,7 +351,7 @@ void TNonreplicatedPartitionMigrationCommonActor::DoRegisterTrafficSource(
     TimeoutCalculator->RegisterTrafficSource(ctx);
     ctx.Schedule(
         RegisterBackgroundTrafficDuration,
-        new TEvents::TEvWakeup(REGISTER_TRAFFIC_SOURCE));
+        new TEvents::TEvWakeup(WR_REGISTER_TRAFFIC_SOURCE));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -29,7 +29,7 @@ void TNonreplicatedPartitionMigrationCommonActor::InitWork(
     SrcActorId = srcActorId;
     DstActorId = dstActorId;
     TimeoutCalculator = std::move(timeoutCalculator);
-    Y_DEBUG_ABORT_UNLESS(TimeoutCalculator);
+    STORAGE_CHECK_PRECONDITION(TimeoutCalculator);
 
     PoisonPillHelper.TakeOwnership(ctx, SrcActorId);
     PoisonPillHelper.TakeOwnership(ctx, DstActorId);
@@ -337,7 +337,7 @@ TDuration
 TNonreplicatedPartitionMigrationCommonActor::CalculateMigrationTimeout(
     TBlockRange64 range) const
 {
-    Y_DEBUG_ABORT_UNLESS(TimeoutCalculator);
+    STORAGE_CHECK_PRECONDITION(TimeoutCalculator);
     return TimeoutCalculator->CalculateTimeout(range);
 }
 
@@ -348,7 +348,7 @@ void TNonreplicatedPartitionMigrationCommonActor::DoRegisterTrafficSource(
         return;
     }
 
-    Y_DEBUG_ABORT_UNLESS(TimeoutCalculator);
+    STORAGE_CHECK_PRECONDITION(TimeoutCalculator);
     TimeoutCalculator->RegisterTrafficSource(ctx);
     ctx.Schedule(
         RegisterBackgroundTrafficDuration,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -23,10 +23,13 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 void TNonreplicatedPartitionMigrationCommonActor::InitWork(
     const NActors::TActorContext& ctx,
     NActors::TActorId srcActorId,
-    NActors::TActorId dstActorId)
+    NActors::TActorId dstActorId,
+    std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator)
 {
     SrcActorId = srcActorId;
     DstActorId = dstActorId;
+    TimeoutCalculator = std::move(timeoutCalculator);
+    Y_DEBUG_ABORT_UNLESS(TimeoutCalculator);
 
     PoisonPillHelper.TakeOwnership(ctx, SrcActorId);
     PoisonPillHelper.TakeOwnership(ctx, DstActorId);
@@ -42,6 +45,7 @@ void TNonreplicatedPartitionMigrationCommonActor::StartWork(
     const NActors::TActorContext& ctx)
 {
     MigrationEnabled = true;
+    DoRegisterTrafficSource(ctx);
     ScheduleRangeMigration(ctx);
 }
 
@@ -99,6 +103,12 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
 bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationAllowed() const
 {
     return SrcActorId && DstActorId && MigrationEnabled;
+}
+
+bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationFinished() const
+{
+    return !ProcessingBlocks.IsProcessing() && MigrationsInProgress.empty() &&
+           DeferredMigrations.empty();
 }
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsIoDepthLimitReached() const
@@ -309,8 +319,7 @@ void TNonreplicatedPartitionMigrationCommonActor::
 void TNonreplicatedPartitionMigrationCommonActor::
     NotifyMigrationFinishedIfNeeded(const TActorContext& ctx)
 {
-    if (ProcessingBlocks.IsProcessing() || !MigrationsInProgress.empty() ||
-        !DeferredMigrations.empty())
+    if (!IsMigrationFinished())
     {
         return;
     }
@@ -322,6 +331,28 @@ TString TNonreplicatedPartitionMigrationCommonActor::GetChangedBlocks(
     TBlockRange64 range) const
 {
     return ChangedRangesMap.GetChangedBlocks(range);
+}
+
+TDuration
+TNonreplicatedPartitionMigrationCommonActor::CalculateMigrationTimeout(
+    TBlockRange64 range) const
+{
+    Y_DEBUG_ABORT_UNLESS(TimeoutCalculator);
+    return TimeoutCalculator->CalculateTimeout(range);
+}
+
+void TNonreplicatedPartitionMigrationCommonActor::DoRegisterTrafficSource(
+    const TActorContext& ctx)
+{
+    if (!IsMigrationAllowed() || IsMigrationFinished()) {
+        return;
+    }
+
+    Y_DEBUG_ABORT_UNLESS(TimeoutCalculator);
+    TimeoutCalculator->RegisterTrafficSource(ctx);
+    ctx.Schedule(
+        RegisterBackgroundTrafficDuration,
+        new TEvents::TEvWakeup(REGISTER_TRAFFIC_SOURCE));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -338,9 +369,7 @@ void TNonreplicatedPartitionMigrationCommonActor::ScheduleRangeMigration(
         return;
     }
 
-    auto delayBetweenMigrations =
-        MigrationOwner->CalculateMigrationTimeout(*nextRange);
-
+    const auto delayBetweenMigrations = CalculateMigrationTimeout(*nextRange);
     const auto deadline = LastRangeMigrationStartTs + delayBetweenMigrations;
 
     if (ctx.Now() >= deadline) {

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -892,7 +892,7 @@ void TShadowDiskActor::SchedulePeriodicalReAcquire(const TActorContext& ctx)
 {
     ctx.Schedule(
         Config->GetClientRemountPeriod(),
-        new TEvents::TEvWakeup(EShadowDiskWakeupReason::REACQUIRE));
+        new TEvents::TEvWakeup(EShadowDiskWakeupReason::SDWR_REACQUIRE));
 }
 
 void TShadowDiskActor::SetErrorState(const NActors::TActorContext& ctx)
@@ -1129,9 +1129,8 @@ bool TShadowDiskActor::HandleWakeup(
     const NActors::TEvents::TEvWakeup::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    auto reason = static_cast<EShadowDiskWakeupReason>(ev->Get()->Tag);
-    switch (reason) {
-        case EShadowDiskWakeupReason::REACQUIRE:
+    switch (ev->Get()->Tag) {
+        case EShadowDiskWakeupReason::SDWR_REACQUIRE:
             AcquireShadowDisk(ctx, EAcquireReason::PeriodicalReAcquire);
             SchedulePeriodicalReAcquire(ctx);
             return true;

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -18,12 +18,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class EWakeupReason
-{
-    Reacquire,
-    RegisterBandwidth,
-};
-
 TString MakeShadowDiskClientId(
     const TString& sourceDiskClientId,
     bool readOnlyMount)
@@ -111,7 +105,7 @@ public:
     TAcquireShadowDiskActor(
         TStorageConfigPtr config,
         TString shadowDiskId,
-        const TDevices& shadowDiskDevices,
+        TDevices shadowDiskDevices,
         TShadowDiskActor::EAcquireReason acquireReason,
         bool readOnlyMount,
         bool areWritesToSourceBlocked,
@@ -174,7 +168,7 @@ private:
 TAcquireShadowDiskActor::TAcquireShadowDiskActor(
         TStorageConfigPtr config,
         TString shadowDiskId,
-        const TDevices& shadowDiskDevices,
+        TDevices shadowDiskDevices,
         TShadowDiskActor::EAcquireReason acquireReason,
         bool readOnlyMount,
         bool areWritesToSourceBlocked,
@@ -193,7 +187,7 @@ TAcquireShadowDiskActor::TAcquireShadowDiskActor(
     , RwClientId(std::move(rwClientId))
     , MountSeqNumber(mountSeqNumber)
     , Generation(generation)
-    , ShadowDiskDevices(shadowDiskDevices)
+    , ShadowDiskDevices(std::move(shadowDiskDevices))
     , RetryDelayProvider(
           areWritesToSourceBlocked
               ? config->GetMinAcquireShadowDiskRetryDelayWhenBlocked()
@@ -633,16 +627,12 @@ bool TShadowDiskActor::OnMessage(
         HFunc(
             TEvVolume::TEvDiskRegistryBasedPartitionCounters,
             HandleShadowDiskCounters);
-        HFunc(NActors::TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvVolume::TEvReacquireDisk, HandleReacquireDisk);
         HFunc(TEvVolume::TEvRdmaUnavailable, HandleRdmaUnavailable);
         HFunc(
             TEvVolumePrivate::TEvUpdateShadowDiskStateResponse,
             HandleUpdateShadowDiskStateResponse);
         HFunc(TEvService::TEvGetChangedBlocksRequest, HandleGetChangedBlocks);
-        HFunc(
-            TEvStatsServicePrivate::TEvRegisterTrafficSourceResponse,
-            HandleUpdateBandwidthLimit);
 
         // Read request.
         HFunc(
@@ -678,6 +668,12 @@ bool TShadowDiskActor::OnMessage(
                 ctx);
         }
 
+        case NActors::TEvents::TEvWakeup::EventType: {
+            return HandleWakeup(
+                *reinterpret_cast<NActors::TEvents::TEvWakeup::TPtr*>(&ev),
+                ctx);
+        }
+
         default:
             // Message processing by the base class is required.
             return false;
@@ -686,16 +682,6 @@ bool TShadowDiskActor::OnMessage(
     // We get here if we have processed an incoming message. And its processing
     // by the base class is not required.
     return true;
-}
-
-TDuration TShadowDiskActor::CalculateMigrationTimeout(TBlockRange64 range)
-{
-    STORAGE_CHECK_PRECONDITION(TimeoutCalculator);
-
-    if (TimeoutCalculator) {
-        return TimeoutCalculator->CalculateTimeout(range);
-    }
-    return TDuration::Seconds(1);
 }
 
 void TShadowDiskActor::OnMigrationProgress(
@@ -844,11 +830,6 @@ void TShadowDiskActor::CreateShadowDiskConfig()
         false,                 // maxTimedOutDeviceStateDurationOverridden
         true                   // useSimpleMigrationBandwidthLimiter
     );
-
-    TimeoutCalculator.emplace(
-        Config->GetMaxShadowDiskFillBandwidth(),
-        Config->GetExpectedDiskAgentSize(),
-        DstConfig);
 }
 
 void TShadowDiskActor::CreateShadowDiskPartitionActor(
@@ -883,13 +864,15 @@ void TShadowDiskActor::CreateShadowDiskPartitionActor(
 
         // Ready to fill shadow disk with data.
         State = EActorState::Preparing;
-        DoRegisterTrafficSource(ctx);
-
-        TNonreplicatedPartitionMigrationCommonActor::InitWork(
+        InitWork(
             ctx,
             SrcActorId,
-            DstActorId);
-        TNonreplicatedPartitionMigrationCommonActor::StartWork(ctx);
+            DstActorId,
+            std::make_unique<TMigrationTimeoutCalculator>(
+                Config->GetMaxShadowDiskFillBandwidth(),
+                Config->GetExpectedDiskAgentSize(),
+                DstConfig));
+        StartWork(ctx);
 
         // Persist state.
         NCloud::Send(
@@ -909,24 +892,7 @@ void TShadowDiskActor::SchedulePeriodicalReAcquire(const TActorContext& ctx)
 {
     ctx.Schedule(
         Config->GetClientRemountPeriod(),
-        new TEvents::TEvWakeup(static_cast<ui64>(EWakeupReason::Reacquire)));
-}
-
-void TShadowDiskActor::DoRegisterTrafficSource(
-    const NActors::TActorContext& ctx)
-{
-    if (State != EActorState::Preparing) {
-        return;
-    }
-
-    if (TimeoutCalculator) {
-        TimeoutCalculator->RegisterTrafficSource(ctx);
-    }
-
-    ctx.Schedule(
-        RegisterBackgroundTrafficDuration,
-        new TEvents::TEvWakeup(
-            static_cast<ui64>(EWakeupReason::RegisterBandwidth)));
+        new TEvents::TEvWakeup(EShadowDiskWakeupReason::REACQUIRE));
 }
 
 void TShadowDiskActor::SetErrorState(const NActors::TActorContext& ctx)
@@ -1108,7 +1074,6 @@ void TShadowDiskActor::HandleUpdateShadowDiskStateResponse(
                     << ", processed block count: " << msg->ProcessedBlockCount);
             if (State != EActorState::Preparing) {
                 State = EActorState::Preparing;
-                DoRegisterTrafficSource(ctx);
             }
             STORAGE_CHECK_PRECONDITION(Acquired());
         } break;
@@ -1160,21 +1125,19 @@ void TShadowDiskActor::HandleShadowDiskCounters(
     ForwardMessageToActor(ev, ctx, VolumeActorId);
 }
 
-void TShadowDiskActor::HandleWakeup(
+bool TShadowDiskActor::HandleWakeup(
     const NActors::TEvents::TEvWakeup::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    auto reason = static_cast<EWakeupReason>(ev->Get()->Tag);
-
+    auto reason = static_cast<EShadowDiskWakeupReason>(ev->Get()->Tag);
     switch (reason) {
-        case EWakeupReason::Reacquire: {
+        case EShadowDiskWakeupReason::REACQUIRE:
             AcquireShadowDisk(ctx, EAcquireReason::PeriodicalReAcquire);
             SchedulePeriodicalReAcquire(ctx);
-        } break;
-        case EWakeupReason::RegisterBandwidth: {
-            DoRegisterTrafficSource(ctx);
-        } break;
+            return true;
     }
+
+    return false;
 }
 
 void TShadowDiskActor::HandleRdmaUnavailable(
@@ -1296,16 +1259,6 @@ void TShadowDiskActor::HandleGetChangedBlocks(
     response->Record.SetMask(GetChangedBlocks(range));
 
     NCloud::Reply(ctx, *ev, std::move(response));
-}
-
-void TShadowDiskActor::HandleUpdateBandwidthLimit(
-    const TEvStatsServicePrivate::TEvRegisterTrafficSourceResponse::
-        TPtr& ev,
-    const NActors::TActorContext& ctx)
-{
-    if (TimeoutCalculator) {
-        TimeoutCalculator->HandleUpdateBandwidthLimit(ev, ctx);
-    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -137,7 +137,8 @@ public:
 private:
     enum EShadowDiskWakeupReason
     {
-        REACQUIRE = TNonreplicatedPartitionMigrationCommonActor::REASON_COUNT,
+        SDWR_REACQUIRE =
+            TNonreplicatedPartitionMigrationCommonActor::WR_REASON_COUNT,
     };
 
     void AcquireShadowDisk(


### PR DESCRIPTION
Related to #3

Вношу `TMigrationTimeoutCalculator` внтурь базового класса миграций `TNonreplicatedPartitionMigrationCommonActor`. 
Изменения логики нет.