### PR TITLE
issue-1657: resize pvc with nbsd-lightweight and minikube

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -221,6 +221,8 @@ message TNullServiceConfig
 message TLocalServiceConfig
 {
     optional string DataDir = 1;
+    // Shutdown timeout (in milliseconds).
+    optional uint32 ShutdownTimeout = 2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -302,7 +302,10 @@ public:
         volume.SetDiskId(dataPath);
         return StorageProvider->CreateStorage(volume, clientId, accessMode)
             .Apply(
-                [this, mountedVolume, clientId, accessMode](const auto& future)
+                [mountedVolume,
+                 clientId,
+                 accessMode,
+                 shutdownTimeout = StorageShutdownTimeout](const auto& future)
                 {
                     auto storage = future.GetValue();
                     if (!storage) {
@@ -317,7 +320,7 @@ public:
                         clientId,
                         accessMode,
                         std::move(storage),
-                        StorageShutdownTimeout);
+                        shutdownTimeout);
 
                     NProto::TMountVolumeResponse response;
                     response.SetSessionId(session->SessionId);

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -436,7 +436,7 @@ struct TLocalServiceBase
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const ui32 kDefaultStorageShutdownTimeoutInMilliseconds = 60000;
+constexpr auto DefaultStorageShutdownTimeout = TDuration::Minutes(1);
 
 class TLocalService final
     : public TLocalServiceBase
@@ -453,10 +453,9 @@ public:
         : DiscoveryService(std::move(discoveryService))
         , VolumeManager(
               config.GetDataDir(),
-              TDuration::MilliSeconds(
-                  config.HasShutdownTimeout()
-                      ? config.GetShutdownTimeout()
-                      : kDefaultStorageShutdownTimeoutInMilliseconds),
+              config.HasShutdownTimeout()
+                  ? TDuration::MilliSeconds(config.GetShutdownTimeout())
+                  : DefaultStorageShutdownTimeout,
               std::move(storageProvider))
     {}
 

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -171,7 +171,7 @@ struct TMountedVolume
             auto volume = Volume;
             volume.SetDiskId(dataPath);
             for (auto& [_, session]: Sessions) {
-                // nbd-lightweit was implemented for test purposes and
+                // nbsd-lightweight was implemented for test purposes and
                 // CreateStorage implementation is sync. It is safe to
                 // call CreateStorage under the lock.
                 auto storage = storageProvider

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -229,23 +229,22 @@ public:
         }
         with_lock (mountedVolume->SessionLock) {
             mountedVolume->Volume = volume;
-            for (auto& session: mountedVolume->Sessions) {
+            for (auto& [_, session]: mountedVolume->Sessions) {
                 auto dataPath = MakeDataPath(volume.GetDiskId());
                 volume.SetDiskId(dataPath);
-                session.second->Storage = StorageProvider
-                                              ->CreateStorage(
-                                                  volume,
-                                                  session.second->ClientId,
-                                                  session.second->AccessMode)
-                                              .GetValueSync();
-                session.second->StorageAdapter =
-                    std::make_unique<TStorageAdapter>(
-                        session.second->Storage,
-                        volume.GetBlockSize(),
-                        true,
-                        0,
-                        TDuration::Zero(),
-                        StorageShutdownTimeout);
+                session->Storage = StorageProvider
+                                       ->CreateStorage(
+                                           volume,
+                                           session->ClientId,
+                                           session->AccessMode)
+                                       .GetValueSync();
+                session->StorageAdapter = std::make_unique<TStorageAdapter>(
+                    session->Storage,
+                    volume.GetBlockSize(),
+                    true,
+                    0,
+                    TDuration::Zero(),
+                    StorageShutdownTimeout);
             }
         }
     }

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -404,7 +404,7 @@ struct TLocalServiceBase
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const ui32 kDefaultStorageShutdownTimeoutInMiliseconds = 60000;
+const ui32 kDefaultStorageShutdownTimeoutInMilliseconds = 60000;
 
 class TLocalService final
     : public TLocalServiceBase
@@ -424,7 +424,7 @@ public:
               TDuration::MilliSeconds(
                   config.HasShutdownTimeout()
                       ? config.GetShutdownTimeout()
-                      : kDefaultStorageShutdownTimeoutInMiliseconds),
+                      : kDefaultStorageShutdownTimeoutInMilliseconds),
               std::move(storageProvider))
     {}
 

--- a/cloud/blockstore/tools/csi_driver/deploy/example/pvc-fs.yaml
+++ b/cloud/blockstore/tools/csi_driver/deploy/example/pvc-fs.yaml
@@ -10,5 +10,5 @@ spec:
     requests:
       storage: 1Gi
     limits:
-      storage: 1Gi
+      storage: 10Gi
   storageClassName: nbs-csi-sc

--- a/cloud/blockstore/tools/csi_driver/deploy/manifests/4-storageclass.yaml
+++ b/cloud/blockstore/tools/csi_driver/deploy/manifests/4-storageclass.yaml
@@ -5,3 +5,4 @@ metadata:
   name: nbs-csi-sc
 provisioner: nbs.csi.nebius.ai
 volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/cloud/blockstore/tools/csi_driver/deploy/manifests/5-csi-deployment.yaml
+++ b/cloud/blockstore/tools/csi_driver/deploy/manifests/5-csi-deployment.yaml
@@ -95,6 +95,33 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.11.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--leader-election"
+            - "--http-endpoint=:8081"
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "250m"
+          ports:
+            - containerPort: 8081
+              name: http-endpoint
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-nbs-driver
           image: nbs-csi-driver:latest
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
issue: #1657

Support pvc resize with minikube/nbsd-lightweight

1. Update minikube manifests:
 - Add csi-resizer sidecar to csi controller
 - Allow to expand volume
 - Increase pvc storage limit as it is not possible to expand volume beyond the limit
2. Fix volume resize in nbsd-lightweight. Old blocks count value was cached in several places: mounted volume, storage and storage adapter. Fixed by recreating storage/storage adapter.
 