### PR TITLE
[Blockstore] disable topic_api_impl/ut for the undefined-behavior sanitizer

### DIFF
--- a/cloud/blockstore/libs/logbroker/topic_api_impl/ya.make
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/ya.make
@@ -18,4 +18,9 @@ PEERDIR(
 
 END()
 
+# see https://github.com/ydb-platform/ydb/issues/8170
+IF (SANITIZER_TYPE != "undefined")
+
 RECURSE_FOR_TESTS(ut)
+
+ENDIF()


### PR DESCRIPTION
Because of https://github.com/ydb-platform/ydb/issues/8170