### PR TITLE
Revert "Making an explicit unsafe conversion from TBlockDataRef to IOutputStream::TPart (#1804)"

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -92,7 +92,7 @@ public:
 
     size_t GetRequestSize() const
     {
-        return NRdma::TProtoMessageSerializer::MessageByteSize(*Request, 0);
+        return Serializer->MessageByteSize(*Request, 0);
     }
 
     size_t GetResponseSize() const
@@ -107,11 +107,12 @@ public:
 
     size_t PrepareRequest(TStringBuf buffer)
     {
-        return NRdma::TProtoMessageSerializer::Serialize(
+        return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ReadBlocksRequest,
-            0,   // flags
-            *Request);
+            0, // flags
+            *Request,
+            TContIOVector(nullptr, 0));
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -187,7 +188,7 @@ public:
 
     size_t GetRequestSize() const
     {
-        return NRdma::TProtoMessageSerializer::MessageByteSize(
+        return Serializer->MessageByteSize(
             *Request,
             BlockSize * Request->BlocksCount);
     }
@@ -208,13 +209,12 @@ public:
         Y_ENSURE(guard);
 
         const auto& sglist = guard.Get();
-
-        return NRdma::TProtoMessageSerializer::SerializeWithData(
+        return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::WriteBlocksRequest,
             0, // flags
             *Request,
-            sglist);
+            TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -268,7 +268,7 @@ public:
 
     size_t GetRequestSize() const
     {
-        return NRdma::TProtoMessageSerializer::MessageByteSize(*Request, 0);
+        return Serializer->MessageByteSize(*Request, 0);
     }
 
     size_t GetResponseSize() const
@@ -283,11 +283,12 @@ public:
 
     size_t PrepareRequest(TStringBuf buffer)
     {
-        return NRdma::TProtoMessageSerializer::Serialize(
+        return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ZeroBlocksRequest,
-            0,   // flags
-            *Request);
+            0, // flags
+            *Request,
+            TContIOVector(nullptr, 0));
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/rdma/iface/protobuf.h
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.h
@@ -2,7 +2,6 @@
 
 #include "public.h"
 
-#include <cloud/storage/core/libs/common/block_data_ref.h>
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/generic/hash.h>
@@ -52,24 +51,16 @@ private:
     THashMap<ui32, IProtoFactoryPtr> Messages;
 
 public:
-    [[nodiscard]] static size_t MessageByteSize(
-        const TProtoMessage& proto,
-        size_t dataLen);
+    static size_t MessageByteSize(const TProtoMessage& proto, size_t dataLen);
 
     static size_t Serialize(
         TStringBuf buffer,
         ui32 msgId,
         ui32 flags,
-        const TProtoMessage& proto);
-
-    static size_t SerializeWithData(
-        TStringBuf buffer,
-        ui32 msgId,
-        ui32 flags,
         const TProtoMessage& proto,
-        TBlockDataRefSpan data);
+        TContIOVector data);
 
-    static size_t SerializeWithDataLength(
+    static size_t Serialize(
         TStringBuf buffer,
         ui32 msgId,
         ui32 flags,
@@ -84,7 +75,7 @@ public:
         TStringBuf Data;
     };
 
-    [[nodiscard]] TResultOrError<TParseResult> Parse(TStringBuf buffer) const;
+    TResultOrError<TParseResult> Parse(TStringBuf buffer) const;
 
 protected:
     template <typename T>

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -128,13 +128,15 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes =
-                    NRdma::TProtoMessageSerializer::SerializeWithData(
-                        req->ResponseBuffer,
-                        TBlockStoreProtocol::ReadDeviceBlocksResponse,
-                        0,   // flags
-                        response,
-                        sglist);
+                responseBytes = serializer->Serialize(
+                    req->ResponseBuffer,
+                    TBlockStoreProtocol::ReadDeviceBlocksResponse,
+                    0, // flags
+                    response,
+                    TContIOVector(
+                        (IOutputStream::TPart*)sglist.begin(),
+                        sglist.size()
+                    ));
 
                 break;
             }
@@ -164,11 +166,12 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
+                responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::WriteDeviceBlocksResponse,
-                    0,   // flags
-                    response);
+                    0, // flags
+                    response,
+                    TContIOVector(nullptr, 0));
 
                 break;
             }
@@ -194,11 +197,12 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     }
                 }
 
-                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
+                responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ZeroDeviceBlocksResponse,
-                    0,   // flags
-                    response);
+                    0, // flags
+                    response,
+                    TContIOVector(nullptr, 0));
 
                 break;
             }
@@ -227,11 +231,12 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     response.SetChecksum(checksum.GetValue());
                 }
 
-                responseBytes = NRdma::TProtoMessageSerializer::Serialize(
+                responseBytes = serializer->Serialize(
                     req->ResponseBuffer,
                     TBlockStoreProtocol::ChecksumDeviceBlocksResponse,
-                    0,   // flags
-                    response);
+                    0, // flags
+                    response,
+                    TContIOVector(nullptr, 0));
 
                 break;
             }

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -93,11 +93,12 @@ public:
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        return NRdma::TProtoMessageSerializer::Serialize(
+        return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            Proto);
+            Proto,
+            TContIOVector(nullptr, 0));
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -209,12 +210,12 @@ public:
             SetProtoFlag(flags, NRdma::RDMA_PROTO_FLAG_DATA_AT_THE_END);
         }
 
-        return NRdma::TProtoMessageSerializer::SerializeWithData(
+        return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::WriteDeviceBlocksRequest,
             flags,
             Proto,
-            sglist);
+            TContIOVector((IOutputStream::TPart*)sglist.data(), sglist.size()));
     }
 
     void HandleResponse(TStringBuf buffer) override
@@ -294,11 +295,12 @@ public:
     {
         Y_UNUSED(isAlignedDataEnabled);
 
-        return NRdma::TProtoMessageSerializer::Serialize(
+        return Serializer->Serialize(
             buffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
-            0,   // flags
-            Proto);
+            0, // flags
+            Proto,
+            TContIOVector(nullptr, 0));
     }
 
     void HandleResponse(TStringBuf buffer) override

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h
@@ -88,7 +88,7 @@ public:
     }
 
 public:
-    void BuildNextRequest(TSgList* sglist)
+    void BuildNextRequest(TVector<IOutputStream::TPart>* parts)
     {
         Y_ABORT_UNLESS(CurrentDeviceIdx < DeviceRequests.size());
 
@@ -96,8 +96,10 @@ public:
         for (ui32 i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
             const ui32 rem = Buffer().size() - CurrentOffsetInBuffer;
             Y_ABORT_UNLESS(rem >= BlockSize);
-            sglist->push_back(
-                {Buffer().data() + CurrentOffsetInBuffer, BlockSize});
+            parts->push_back({
+                Buffer().data() + CurrentOffsetInBuffer,
+                BlockSize
+            });
             CurrentOffsetInBuffer += BlockSize;
             if (CurrentOffsetInBuffer == Buffer().size()) {
                 CurrentOffsetInBuffer = 0;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -289,7 +289,8 @@ NProto::TError TNonreplicatedPartitionRdmaActor::SendReadRequests(
             req->RequestBuffer,
             TBlockStoreProtocol::ReadDeviceBlocksRequest,
             flags,
-            deviceRequest);
+            deviceRequest,
+            TContIOVector(nullptr, 0));
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -177,6 +177,8 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         SelfId(),
         requestId);
 
+    auto* serializer = TBlockStoreProtocol::Serializer();
+
     struct TDeviceRequestInfo
     {
         NRdma::IClientEndpointPtr Endpoint;
@@ -207,7 +209,7 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         auto [req, err] = ep->AllocateRequest(
             requestContext,
             nullptr,
-            NRdma::TProtoMessageSerializer::MessageByteSize(deviceRequest, 0),
+            serializer->MessageByteSize(deviceRequest, 0),
             4_KB);
 
         if (HasError(err)) {
@@ -224,11 +226,12 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
             return;
         }
 
-        NRdma::TProtoMessageSerializer::Serialize(
+        serializer->Serialize(
             req->RequestBuffer,
             TBlockStoreProtocol::ZeroDeviceBlocksRequest,
-            0,   // flags
-            deviceRequest);
+            0, // flags
+            deviceRequest,
+            TContIOVector(nullptr, 0));
 
         requests.push_back({std::move(ep), std::move(req)});
     }

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -157,13 +157,12 @@ private:
                 Y_ABORT_UNLESS(guard);
 
                 const auto& sglist = guard.Get();
-                size_t responseBytes =
-                    NRdma::TProtoMessageSerializer::SerializeWithData(
-                        out,
-                        TBlockStoreProtocol::ReadBlocksResponse,
-                        0,   // flags
-                        response,
-                        sglist);
+                size_t responseBytes = Serializer->Serialize(
+                    out,
+                    TBlockStoreProtocol::ReadBlocksResponse,
+                    0, // flags
+                    response,
+                    TContIOVector((IOutputStream::TPart*)sglist.begin(), sglist.size()));
 
                 Endpoint->SendResponse(context, responseBytes);
             });
@@ -198,12 +197,12 @@ private:
             TaskQueue->ExecuteSimple([=] {
                 Y_UNUSED(guardedSgList);
 
-                size_t responseBytes =
-                    NRdma::TProtoMessageSerializer::Serialize(
-                        out,
-                        TBlockStoreProtocol::WriteBlocksResponse,
-                        0,   // flags
-                        response);
+                size_t responseBytes = Serializer->Serialize(
+                    out,
+                    TBlockStoreProtocol::WriteBlocksResponse,
+                    0, // flags
+                    response,
+                    TContIOVector(nullptr, 0));
 
                 Endpoint->SendResponse(context, responseBytes);
             });

--- a/cloud/storage/core/libs/common/block_data_ref.h
+++ b/cloud/storage/core/libs/common/block_data_ref.h
@@ -7,8 +7,6 @@
 #include <util/generic/string.h>
 #include <util/stream/output.h>
 
-#include <span>
-
 namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -91,8 +89,6 @@ public:
         return ComputeHash(TStringBuf(Start, Length));
     }
 };
-
-using TBlockDataRefSpan = std::span<const TBlockDataRef>;
 
 }   // namespace NCloud
 


### PR DESCRIPTION


This reverts commit ef663fbdcdd15872ca5adf2f94115dc0dcecde35.