### PR TITLE
issue-1350: fixed ListNodes -> UnlinkNode -> GetNodeAttr race which lead to E_IO due to having empty node attrs in the listing results

### DIFF
--- a/cloud/filestore/libs/storage/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/model/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
 SRCS(
     block_buffer_ut.cpp
     range_ut.cpp
+    utils_ut.cpp
 )
 
 END()

--- a/cloud/filestore/libs/storage/model/utils.h
+++ b/cloud/filestore/libs/storage/model/utils.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <util/generic/algorithm.h>
 #include <util/generic/bitops.h>
+#include <util/generic/vector.h>
+
+#include <google/protobuf/repeated_ptr_field.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -24,6 +28,31 @@ inline ui32 ExtractShardNo(ui64 id)
 {
     const auto realBits = 56U;
     return id >> realBits;
+}
+
+template <typename T>
+void RemoveByIndices(
+    google::protobuf::RepeatedPtrField<T>& field,
+    TVector<ui32>& indices)
+{
+    Sort(indices);
+
+    int j = 0;
+    for (int i = static_cast<int>(indices[0]); i < field.size(); ++i) {
+        if (j < static_cast<int>(indices.size())
+                && i == static_cast<int>(indices[j]))
+        {
+            ++j;
+            continue;
+        }
+
+        field[i - j] = std::move(field[i]);
+    }
+
+    while (j) {
+        field.RemoveLast();
+        --j;
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/model/utils_ut.cpp
+++ b/cloud/filestore/libs/storage/model/utils_ut.cpp
@@ -1,0 +1,46 @@
+#include "utils.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+#include <util/string/join.h>
+
+#include <google/protobuf/repeated_ptr_field.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TUtilsTest)
+{
+    Y_UNIT_TEST(ShouldRemoveByIndices)
+    {
+        google::protobuf::RepeatedPtrField<TString> strings;
+        strings.Add("aaa");
+        strings.Add("bbb");
+        strings.Add("ccc");
+        strings.Add("ddd");
+        strings.Add("eee");
+
+        google::protobuf::RepeatedPtrField<TString> strings2;
+        strings2.Add("100");
+        strings2.Add("200");
+        strings2.Add("300");
+        strings2.Add("400");
+        strings2.Add("500");
+
+        TVector<ui32> indices{1, 4, 2};
+        RemoveByIndices(strings, indices);
+        RemoveByIndices(strings2, indices);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "aaa,ddd",
+            JoinRange(",", strings.begin(), strings.end()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "100,400",
+            JoinRange(",", strings2.begin(), strings2.end()));
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/model/ya.make
+++ b/cloud/filestore/libs/storage/model/ya.make
@@ -14,6 +14,8 @@ SRCS(
 
 PEERDIR(
     cloud/storage/core/libs/common
+
+    contrib/libs/protobuf
 )
 
 END()

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3831,20 +3831,62 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.CreateNode(
             headers,
             TCreateNodeArgs::File(RootNodeId, "file2"));
+        service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file3"));
+        service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file4"));
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(4, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL("file2", listNodesResponse.GetNames(1));
+        UNIT_ASSERT_VALUES_EQUAL("file3", listNodesResponse.GetNames(2));
+        UNIT_ASSERT_VALUES_EQUAL("file4", listNodesResponse.GetNames(3));
+        TVector<std::pair<ui64, TString>> nodes(4);
+        for (ui32 i = 0; i < 4; ++i) {
+            nodes[i] = {
+                listNodesResponse.GetNodes(i).GetId(),
+                listNodesResponse.GetNames(i)};
+            UNIT_ASSERT_VALUES_UNEQUAL(0, nodes[i].first);
+        }
 
         auto headers1 = headers;
         headers1.FileSystemId = shard1Id;
 
-        auto listNodesResponse = service.ListNodes(
+        listNodesResponse = service.ListNodes(
             headers1,
             shard1Id,
             RootNodeId)->Record;
 
-        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
-        const auto shard1NodeName = listNodesResponse.GetNames(0);
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NamesSize());
+        const auto shard1NodeName1 = listNodesResponse.GetNames(0);
+        const auto shard1NodeId1 = listNodesResponse.GetNodes(0).GetId();
+        const auto shard1NodeName2 = listNodesResponse.GetNames(1);
+
+        auto headers2 = headers;
+        headers2.FileSystemId = shard2Id;
+
+        listNodesResponse = service.ListNodes(
+            headers2,
+            shard2Id,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NamesSize());
+        const auto shard2NodeName1 = listNodesResponse.GetNames(0);
+        const auto shard2NodeName2 = listNodesResponse.GetNames(1);
 
         // "breaking" one node - deleting it directly from the shard
-        service.UnlinkNode(headers1, RootNodeId, shard1NodeName);
+        service.UnlinkNode(headers1, RootNodeId, shard1NodeName1);
+
+        EraseIf(nodes, [=] (const auto& node) {
+            return node.first == shard1NodeId1;
+        });
 
         // ListNodes should still succeed
         listNodesResponse = service.ListNodes(
@@ -3852,18 +3894,28 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             fsId,
             RootNodeId)->Record;
 
-        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NamesSize());
-        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
-        UNIT_ASSERT_VALUES_EQUAL("file2", listNodesResponse.GetNames(1));
-
-        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NodesSize());
-        // zero node id is expected - we failed to fetch attrs for this file
+        // unresolved nodes should be removed from the response
+        UNIT_ASSERT_VALUES_EQUAL(3, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL(
-            0,
+            nodes[0].second,
+            listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodes[1].second,
+            listNodesResponse.GetNames(1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodes[2].second,
+            listNodesResponse.GetNames(2));
+
+        UNIT_ASSERT_VALUES_EQUAL(3, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodes[0].first,
             listNodesResponse.GetNodes(0).GetId());
-        UNIT_ASSERT_VALUES_UNEQUAL(
-            0,
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodes[1].first,
             listNodesResponse.GetNodes(1).GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            nodes[2].first,
+            listNodesResponse.GetNodes(2).GetId());
 
         const auto counters =
             env.GetCounters()->FindSubgroup("component", "service");
@@ -3871,6 +3923,18 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         const auto counter =
             counters->GetCounter("AppCriticalEvents/NodeNotFoundInFollower");
         UNIT_ASSERT_EQUAL(1, counter->GetAtomic());
+
+        // "breaking" all nodes - ListNodes should fail with E_IO after this
+        service.UnlinkNode(headers1, RootNodeId, shard1NodeName2);
+        service.UnlinkNode(headers2, RootNodeId, shard2NodeName1);
+        service.UnlinkNode(headers2, RootNodeId, shard2NodeName2);
+
+        service.SendListNodesRequest(headers, fsId, RootNodeId);
+        auto response = service.RecvListNodesResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_IO,
+            response->GetError().GetCode(),
+            response->GetErrorReason());
     }
 
     Y_UNIT_TEST(ShouldNotFailListNodesUponGetAttrENOENT)
@@ -4001,7 +4065,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             destroyFileStoreResponse->GetErrorReason());
     }
 
-    Y_UNIT_TEST(DestroyDestroyedFileStoreShouldFail)
+    Y_UNIT_TEST(DestroyDestroyedFileStoreShouldNotFail)
     {
         TTestEnv env;
         env.CreateSubDomain("nfs");

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3997,9 +3997,12 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(
             names.size() / 2,
             listNodesResponse.NamesSize());
-        const ui32 idxToUnlink = 13;
-        const auto shard1NodeName = listNodesResponse.GetNames(idxToUnlink);
-        const ui64 unlinkedId = listNodesResponse.GetNodes(idxToUnlink).GetId();
+        const ui32 idxToUnlink1 = 13;
+        const ui32 idxToUnlink2 = 17;
+        const auto shard1NodeName1 = listNodesResponse.GetNames(idxToUnlink1);
+        const ui64 unlinkedId1 = listNodesResponse.GetNodes(idxToUnlink1).GetId();
+        const auto shard1NodeName2 = listNodesResponse.GetNames(idxToUnlink2);
+        const ui64 unlinkedId2 = listNodesResponse.GetNodes(idxToUnlink2).GetId();
 
         listNodesResponse = service.ListNodes(
             headers,
@@ -4014,18 +4017,25 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 listNodesResponse.GetNodes(i).GetId());
         }
 
-        service.UnlinkNode(headers1, RootNodeId, shard1NodeName);
+        service.UnlinkNode(headers1, RootNodeId, shard1NodeName1);
+        service.UnlinkNode(headers1, RootNodeId, shard1NodeName2);
 
         listNodesResponse = service.ListNodes(
             headers,
             fsId,
             RootNodeId)->Record;
 
+        for (auto id: {unlinkedId1, unlinkedId2}) {
+            auto idx = Find(ids, id) - ids.begin();
+            ids.erase(ids.begin() + idx);
+            names.erase(names.begin() + idx);
+        }
+
         UNIT_ASSERT_VALUES_EQUAL(names.size(), listNodesResponse.NamesSize());
         for (ui32 i = 0; i < names.size(); ++i) {
             UNIT_ASSERT_VALUES_EQUAL(names[i], listNodesResponse.GetNames(i));
             UNIT_ASSERT_VALUES_EQUAL(
-                ids[i] == unlinkedId ? InvalidNodeId : ids[i],
+                ids[i],
                 listNodesResponse.GetNodes(i).GetId());
         }
     }

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
@@ -19,16 +19,19 @@ using TBufferPtr = std::shared_ptr<TBuffer>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TDirectoryContent {
+struct TDirectoryContent
+{
     TBufferPtr Content = nullptr;
     size_t Offset = 0;
     size_t Size = 0;
 
-    const char* GetData() const {
+    const char* GetData() const
+    {
         return Content ? Content->Data() + Offset : nullptr;
     }
 
-    size_t GetSize() const {
+    size_t GetSize() const
+    {
         return Content ? Min(Size, Content->Size() - Offset) : 0;
     }
 };
@@ -47,7 +50,7 @@ public:
     const fuse_ino_t Index;
     TString Cookie;
 
-    TDirectoryHandle(fuse_ino_t ino)
+    explicit TDirectoryHandle(fuse_ino_t ino)
         : Index(ino)
     {}
 
@@ -113,13 +116,21 @@ public:
 
 namespace {
 
-bool CheckDirectoryHandle(fuse_req_t req, fuse_ino_t ino, std::shared_ptr<TDirectoryHandle> handle, TLog& Log, const char* funcName)
+////////////////////////////////////////////////////////////////////////////////
+
+bool CheckDirectoryHandle(
+    fuse_req_t req,
+    fuse_ino_t ino,
+    const TDirectoryHandle& handle,
+    TLog& Log,
+    const char* funcName)
 {
-    if (handle->Index != ino) {
+    if (handle.Index != ino) {
         STORAGE_ERROR("request #" << fuse_req_unique(req)
             << " consistency violation: " << funcName
-            << " (handle->Index != ino) : "  <<
-            "(" << handle->Index << " != " << ino << ")");
+            << " (handle.Index != ino) : "  <<
+            "(" << handle.Index << " != " << ino << ")");
+
         return false;
     }
     return true;
@@ -135,12 +146,16 @@ private:
     TBufferPtr Buffer;
 
 public:
-    TDirectoryBuilder(size_t size) noexcept
+    explicit TDirectoryBuilder(size_t size) noexcept
         : Buffer(std::make_shared<TBuffer>(size))
     {}
 
 #if defined(FUSE_VIRTIO)
-    void Add(fuse_req_t req, const TString& name, const fuse_entry_param& entry, size_t offset)
+    void Add(
+        fuse_req_t req,
+        const TString& name,
+        const fuse_entry_param& entry,
+        size_t offset)
     {
         size_t entrySize = fuse_add_direntry_plus(
             req,
@@ -161,7 +176,11 @@ public:
             offset + Buffer->Size());
     }
 #else
-    void Add(fuse_req_t req, const TString& name, const fuse_entry_param& entry, size_t offset)
+    void Add(
+        fuse_req_t req,
+        const TString& name,
+        const fuse_entry_param& entry,
+        size_t offset)
     {
         size_t entrySize = fuse_add_direntry(
             req,
@@ -262,7 +281,7 @@ void TFileSystem::ReadDir(
 
     Y_ABORT_UNLESS(handle);
 
-    if (!CheckDirectoryHandle(req, ino, handle, Log, __func__)) {
+    if (!CheckDirectoryHandle(req, ino, *handle, Log, __func__)) {
         ReplyError(*callContext, ErrorInvalidHandle(fi->fh), req, EBADF);
         return;
     }
@@ -294,7 +313,9 @@ void TFileSystem::ReadDir(
             const auto& response = future.GetValue();
             if (!CheckResponse(self, *callContext, req, response)) {
                 return;
-            } else if (response.NodesSize() != response.NamesSize()) {
+            }
+
+            if (response.NodesSize() != response.NamesSize()) {
                 STORAGE_ERROR("listnodes #" << fuse_req_unique(req)
                     << " names/nodes count mismatch");
 
@@ -368,7 +389,7 @@ void TFileSystem::ReleaseDir(
     with_lock (CacheLock) {
         auto it = DirectoryHandles.find(fi->fh);
         if (it != DirectoryHandles.end()) {
-            CheckDirectoryHandle(req, ino, it->second, Log, __func__);
+            CheckDirectoryHandle(req, ino, *it->second, Log, __func__);
             DirectoryHandles.erase(it);
         }
     }


### PR DESCRIPTION
In multitablet filestores we first send ListNodesRequest to the leader, then send GetNodeAttr / GetNodeAttrBatch requests to the followers where the files are stored. If an UnlinkNode request happens between these two steps, GetNodeAttr / GetNodeAttrBatch will return ENOENT. Our current code detects this but does nothing and sends empty node attr for such nodes to the layer above it (vfs_fuse) which detects this and responds to the client with E_IO errors. This PR removes such nodes from the ListNodesResponse. NodeNotFoundInFollower is reported only if such nodes are still present in the leader fs (checked via a bunch of GetNodeAttr requests to the leader). E_IO is returned only if the resulting ListNodesResponse is empty and all the nodes are "lost" (not found in the followers and at the same time the leader still has the entries for these nodes and those entries point to the same nodes in the followers).

#1350 