### PR TITLE
fix issues found by coverity

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -40,7 +40,6 @@ public:
     TGetNodeAttrActor(
         TRequestInfoPtr requestInfo,
         NProto::TGetNodeAttrRequest getNodeAttrRequest,
-        TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
         bool multiTabletForwardingEnabled);
@@ -73,13 +72,12 @@ private:
 TGetNodeAttrActor::TGetNodeAttrActor(
         TRequestInfoPtr requestInfo,
         NProto::TGetNodeAttrRequest getNodeAttrRequest,
-        TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
         bool multiTabletForwardingEnabled)
     : RequestInfo(std::move(requestInfo))
     , GetNodeAttrRequest(std::move(getNodeAttrRequest))
-    , LogTag(std::move(logTag))
+    , LogTag(GetNodeAttrRequest.GetFileSystemId())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
     , MultiTabletForwardingEnabled(multiTabletForwardingEnabled)
@@ -269,7 +267,6 @@ void TStorageServiceActor::HandleGetNodeAttr(
     auto actor = std::make_unique<TGetNodeAttrActor>(
         std::move(requestInfo),
         std::move(msg->Record),
-        msg->Record.GetFileSystemId(),
         session->RequestStats,
         ProfileLog,
         multiTabletForwardingEnabled);

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -47,7 +47,6 @@ public:
     TListNodesActor(
         TRequestInfoPtr requestInfo,
         NProto::TListNodesRequest listNodesRequest,
-        TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
         bool multiTabletForwardingEnabled,
@@ -89,14 +88,13 @@ private:
 TListNodesActor::TListNodesActor(
         TRequestInfoPtr requestInfo,
         NProto::TListNodesRequest listNodesRequest,
-        TString logTag,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
         bool multiTabletForwardingEnabled,
         bool getNodeAttrBatchEnabled)
     : RequestInfo(std::move(requestInfo))
     , ListNodesRequest(std::move(listNodesRequest))
-    , LogTag(std::move(logTag))
+    , LogTag(ListNodesRequest.GetFileSystemId())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
     , MultiTabletForwardingEnabled(multiTabletForwardingEnabled)
@@ -510,7 +508,6 @@ void TStorageServiceActor::HandleListNodes(
     auto actor = std::make_unique<TListNodesActor>(
         std::move(requestInfo),
         std::move(msg->Record),
-        msg->Record.GetFileSystemId(),
         session->RequestStats,
         ProfileLog,
         multiTabletForwardingEnabled,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -633,8 +633,9 @@ void TIndexTabletActor::HandleForcedOperation(
     }
 
     using TResponse = TEvIndexTablet::TEvForcedOperationResponse;
+    auto code = e.GetCode();
     auto response = std::make_unique<TResponse>(std::move(e));
-    if (e.GetCode() == S_OK) {
+    if (code == S_OK) {
         TVector<ui32> ranges;
         if (mode == EMode::DeleteZeroCompactionRanges) {
             const auto& zeroRanges = RangesWithEmptyCompactionScore;


### PR DESCRIPTION
Fix issues found by coverity:

service_actor_getnodeattr.cpp - use of moved object
service_actor_listnodes.cpp - use of moved object
tablet_actor.cpp - use after move