### PR TITLE
[Disk Manager] Tracing: Add spans for tasks

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/interceptor.go
+++ b/cloud/disk_manager/internal/pkg/facade/interceptor.go
@@ -206,7 +206,7 @@ func (i *interceptor) intercept(
 		return nil, err
 	}
 
-	ctx = tracing.ExtractTracingContext(ctx)
+	ctx = tracing.GetTracingContext(ctx)
 	ctx, span := tracing.StartSpan(ctx, requestName)
 	defer span.End()
 

--- a/cloud/tasks/headers/headers.go
+++ b/cloud/tasks/headers/headers.go
@@ -10,33 +10,36 @@ import (
 
 func appendToIncomingContext(
 	ctx context.Context,
-	md grpc_metadata.MD,
+	metadata grpc_metadata.MD,
 ) context.Context {
 
-	existingMd, ok := grpc_metadata.FromIncomingContext(ctx)
+	existingMetadata, ok := grpc_metadata.FromIncomingContext(ctx)
 	if ok {
-		md = grpc_metadata.Join(existingMd, md)
+		metadata = grpc_metadata.Join(existingMetadata, metadata)
 	}
 
-	return grpc_metadata.NewIncomingContext(ctx, md)
+	return grpc_metadata.NewIncomingContext(ctx, metadata)
 }
 
 func appendToOutgoingContext(
 	ctx context.Context,
-	md grpc_metadata.MD,
+	metadata grpc_metadata.MD,
 ) context.Context {
 
-	existingMd, ok := grpc_metadata.FromOutgoingContext(ctx)
+	existingMetadata, ok := grpc_metadata.FromOutgoingContext(ctx)
 	if ok {
-		md = grpc_metadata.Join(existingMd, md)
+		metadata = grpc_metadata.Join(existingMetadata, metadata)
 	}
 
-	return grpc_metadata.NewOutgoingContext(ctx, md)
+	return grpc_metadata.NewOutgoingContext(ctx, metadata)
 }
 
 func Append(ctx context.Context, headers map[string]string) context.Context {
-	md := grpc_metadata.New(headers)
-	return appendToOutgoingContext(appendToIncomingContext(ctx, md), md)
+	metadata := grpc_metadata.New(headers)
+	return appendToOutgoingContext(
+		appendToIncomingContext(ctx, metadata),
+		metadata,
+	)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -46,15 +49,15 @@ func deleteFromIncomingContext(
 	headers map[string]string,
 ) context.Context {
 
-	existingMd, ok := grpc_metadata.FromIncomingContext(ctx)
+	existingMetadata, ok := grpc_metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ctx
 	}
 
 	for key := range headers {
-		existingMd.Delete(key)
+		existingMetadata.Delete(key)
 	}
-	return grpc_metadata.NewIncomingContext(ctx, existingMd)
+	return grpc_metadata.NewIncomingContext(ctx, existingMetadata)
 }
 
 func deleteFromOutgoingContext(
@@ -62,15 +65,15 @@ func deleteFromOutgoingContext(
 	headers map[string]string,
 ) context.Context {
 
-	existingMd, ok := grpc_metadata.FromOutgoingContext(ctx)
+	existingMetadata, ok := grpc_metadata.FromOutgoingContext(ctx)
 	if !ok {
 		return ctx
 	}
 
 	for key := range headers {
-		existingMd.Delete(key)
+		existingMetadata.Delete(key)
 	}
-	return grpc_metadata.NewOutgoingContext(ctx, existingMd)
+	return grpc_metadata.NewOutgoingContext(ctx, existingMetadata)
 }
 
 func Replace(ctx context.Context, headers map[string]string) context.Context {
@@ -86,7 +89,7 @@ func GetFromIncomingContext(
 	allowedKeys []string,
 ) map[string]string {
 
-	md, ok := grpc_metadata.FromIncomingContext(ctx)
+	metadata, ok := grpc_metadata.FromIncomingContext(ctx)
 	if !ok {
 		return map[string]string{}
 	}
@@ -94,7 +97,7 @@ func GetFromIncomingContext(
 	headers := make(map[string]string)
 
 	for _, key := range allowedKeys {
-		vals := md.Get(key)
+		vals := metadata.Get(key)
 		if len(vals) != 0 {
 			headers[key] = vals[0]
 		}

--- a/cloud/tasks/headers/headers.go
+++ b/cloud/tasks/headers/headers.go
@@ -41,6 +41,46 @@ func Append(ctx context.Context, headers map[string]string) context.Context {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+func deleteFromIncomingContext(
+	ctx context.Context,
+	headers map[string]string,
+) context.Context {
+
+	existingMd, ok := grpc_metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	for key := range headers {
+		existingMd.Delete(key)
+	}
+	return grpc_metadata.NewIncomingContext(ctx, existingMd)
+}
+
+func deleteFromOutgoingContext(
+	ctx context.Context,
+	headers map[string]string,
+) context.Context {
+
+	existingMd, ok := grpc_metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	for key := range headers {
+		existingMd.Delete(key)
+	}
+	return grpc_metadata.NewOutgoingContext(ctx, existingMd)
+}
+
+func Replace(ctx context.Context, headers map[string]string) context.Context {
+	ctx = deleteFromOutgoingContext(ctx, headers)
+	ctx = deleteFromIncomingContext(ctx, headers)
+	return Append(ctx, headers)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 func GetFromIncomingContext(
 	ctx context.Context,
 	allowedKeys []string,

--- a/cloud/tasks/headers/headers.go
+++ b/cloud/tasks/headers/headers.go
@@ -17,7 +17,6 @@ func appendToIncomingContext(
 	if ok {
 		metadata = grpc_metadata.Join(existingMetadata, metadata)
 	}
-
 	return grpc_metadata.NewIncomingContext(ctx, metadata)
 }
 
@@ -30,7 +29,6 @@ func appendToOutgoingContext(
 	if ok {
 		metadata = grpc_metadata.Join(existingMetadata, metadata)
 	}
-
 	return grpc_metadata.NewOutgoingContext(ctx, metadata)
 }
 
@@ -110,7 +108,6 @@ func GetFromIncomingContext(
 	if !ok {
 		return map[string]string{}
 	}
-
 	return getFromMetadata(metadata, allowedKeys)
 }
 
@@ -123,7 +120,6 @@ func GetFromOutgoingContext(
 	if !ok {
 		return map[string]string{}
 	}
-
 	return getFromMetadata(metadata, allowedKeys)
 }
 

--- a/cloud/tasks/headers/headers.go
+++ b/cloud/tasks/headers/headers.go
@@ -70,6 +70,8 @@ func GetTracingHeaders(ctx context.Context) map[string]string {
 		"x-operation-id",
 		"x-request-id",
 		"x-request-uid",
+		"traceparent",
+		"tracestate",
 	}
 	return GetFromIncomingContext(ctx, allowedKeys)
 }

--- a/cloud/tasks/headers/headers.go
+++ b/cloud/tasks/headers/headers.go
@@ -84,15 +84,10 @@ func Replace(ctx context.Context, headers map[string]string) context.Context {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func GetFromIncomingContext(
-	ctx context.Context,
+func getFromMetadata(
+	metadata grpc_metadata.MD,
 	allowedKeys []string,
 ) map[string]string {
-
-	metadata, ok := grpc_metadata.FromIncomingContext(ctx)
-	if !ok {
-		return map[string]string{}
-	}
 
 	headers := make(map[string]string)
 
@@ -104,6 +99,32 @@ func GetFromIncomingContext(
 	}
 
 	return headers
+}
+
+func GetFromIncomingContext(
+	ctx context.Context,
+	allowedKeys []string,
+) map[string]string {
+
+	metadata, ok := grpc_metadata.FromIncomingContext(ctx)
+	if !ok {
+		return map[string]string{}
+	}
+
+	return getFromMetadata(metadata, allowedKeys)
+}
+
+func GetFromOutgoingContext(
+	ctx context.Context,
+	allowedKeys []string,
+) map[string]string {
+
+	metadata, ok := grpc_metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return map[string]string{}
+	}
+
+	return getFromMetadata(metadata, allowedKeys)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/tasks/headers/headers_test.go
+++ b/cloud/tasks/headers/headers_test.go
@@ -1,0 +1,44 @@
+package headers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestHeaders(t *testing.T) {
+	ctx := context.Background()
+
+	keyA := "A"
+	keyB := "B"
+	keyC := "C"
+	keyD := "D"
+
+	checkContext := func(ctx context.Context, expected map[string]string) {
+		var keys []string
+		for key := range expected {
+			keys = append(keys, key)
+		}
+		keys = append(keys, "non_existing_key")
+
+		actualIncoming := GetFromIncomingContext(ctx, keys)
+		require.Equal(t, expected, actualIncoming)
+		actualOutgoing := GetFromOutgoingContext(ctx, keys)
+		require.Equal(t, expected, actualOutgoing)
+	}
+
+	checkContext(ctx, map[string]string{})
+
+	ctx = Append(ctx, map[string]string{keyA: "a", keyB: "b"})
+	checkContext(ctx, map[string]string{keyA: "a", keyB: "b"})
+	ctx = Append(ctx, map[string]string{keyB: "bb", keyC: "c"})
+	checkContext(ctx, map[string]string{keyA: "a", keyB: "b", keyC: "c"})
+
+	ctx = Replace(ctx, map[string]string{keyB: "bbb"})
+	checkContext(ctx, map[string]string{keyA: "a", keyB: "bbb", keyC: "c"})
+	ctx = Replace(ctx, map[string]string{keyD: "d"})
+	checkContext(ctx, map[string]string{keyA: "a", keyB: "bbb", keyC: "c"})
+}

--- a/cloud/tasks/headers/tests/ya.make
+++ b/cloud/tasks/headers/tests/ya.make
@@ -1,0 +1,3 @@
+GO_TEST_FOR(cloud/tasks/headers)
+
+END()

--- a/cloud/tasks/headers/ya.make
+++ b/cloud/tasks/headers/ya.make
@@ -4,4 +4,12 @@ SRCS(
     headers.go
 )
 
+GO_TEST_SRCS(
+    headers_test.go
+)
+
 END()
+
+RECURSE_FOR_TESTS(
+    tests
+)

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -552,6 +552,7 @@ func lockAndExecuteTask(
 	// All derived tasks should be pinned to the same storage folder.
 	runCtx = setStorageFolder(runCtx, taskState.StorageFolder)
 	runCtx = logging.WithCommonFields(runCtx)
+	runCtx = tracing.ExtractTracingContext(runCtx)
 
 	runCtx, span := tracing.StartSpan(
 		runCtx,
@@ -559,8 +560,7 @@ func lockAndExecuteTask(
 		trace.WithAttributes(
 			attribute.String("task_id", taskInfo.ID),
 			attribute.Int64("generation_id", int64(taskInfo.GenerationID)),
-			attribute.String("task_type", taskInfo.TaskType),
-			attribute.Bool("regular", taskState.Regular),
+			attribute.Bool("is_regular", taskState.Regular),
 		),
 	)
 	defer span.End()

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -550,7 +550,7 @@ func lockAndExecuteTask(
 	// All derived tasks should be pinned to the same storage folder.
 	runCtx = setStorageFolder(runCtx, taskState.StorageFolder)
 	runCtx = logging.WithCommonFields(runCtx)
-	runCtx = tracing.ExtractTracingContext(runCtx)
+	runCtx = tracing.GetTracingContext(runCtx)
 
 	runCtx, span := tracing.StartSpan(
 		runCtx,

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ydb-platform/nbs/cloud/tasks/metrics"
 	"github.com/ydb-platform/nbs/cloud/tasks/storage"
 	"github.com/ydb-platform/nbs/cloud/tasks/tracing"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -557,10 +555,13 @@ func lockAndExecuteTask(
 	runCtx, span := tracing.StartSpan(
 		runCtx,
 		fmt.Sprintf(taskInfo.TaskType),
-		trace.WithAttributes(
-			attribute.String("task_id", taskInfo.ID),
-			attribute.Int64("generation_id", int64(taskInfo.GenerationID)),
-			attribute.Bool("regular", taskState.Regular),
+		tracing.WithAttributes(
+			tracing.AttributeString("task_id", taskInfo.ID),
+			tracing.AttributeInt64(
+				"generation_id",
+				int64(taskInfo.GenerationID),
+			),
+			tracing.AttributeBool("regular", taskState.Regular),
 		),
 	)
 	defer span.End()

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -560,7 +560,7 @@ func lockAndExecuteTask(
 		trace.WithAttributes(
 			attribute.String("task_id", taskInfo.ID),
 			attribute.Int64("generation_id", int64(taskInfo.GenerationID)),
-			attribute.Bool("is_regular", taskState.Regular),
+			attribute.Bool("regular", taskState.Regular),
 		),
 	)
 	defer span.End()

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -66,7 +66,7 @@ func (s *scheduler) ScheduleZonalTask(
 	ctx = withComponentLoggingField(ctx)
 	logging.Info(ctx, "scheduling task %v", taskType)
 
-	ctx = tracing.InjectTracingContext(ctx)
+	ctx = tracing.SetTracingContext(ctx)
 
 	marshalledRequest, err := proto.Marshal(request)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *scheduler) ScheduleRegularTasks(
 			}
 
 			ctx = headers.SetIncomingRequestID(ctx, requestID.String())
-			ctx = tracing.InjectTracingContext(ctx)
+			ctx = tracing.SetTracingContext(ctx)
 			metadata := tasks_storage.NewMetadata(headers.GetTracingHeaders(ctx))
 
 			schedule := tasks_storage.TaskSchedule{

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -66,6 +66,8 @@ func (s *scheduler) ScheduleZonalTask(
 	ctx = withComponentLoggingField(ctx)
 	logging.Info(ctx, "scheduling task %v", taskType)
 
+	ctx = tracing.InjectTracingContext(ctx)
+
 	marshalledRequest, err := proto.Marshal(request)
 	if err != nil {
 		logging.Warn(
@@ -154,8 +156,6 @@ func (s *scheduler) ScheduleRegularTasks(
 			ctx = headers.SetIncomingRequestID(ctx, requestID.String())
 			ctx = tracing.InjectTracingContext(ctx)
 			metadata := tasks_storage.NewMetadata(headers.GetTracingHeaders(ctx))
-			// TODO:_ check that all is ok with x-request-id
-			// TODO:_ can we write some tests for this?
 
 			schedule := tasks_storage.TaskSchedule{
 				ScheduleInterval: schedule.ScheduleInterval,

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/tasks/metrics"
 	"github.com/ydb-platform/nbs/cloud/tasks/operation"
 	tasks_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
+	"github.com/ydb-platform/nbs/cloud/tasks/tracing"
 	grpc_codes "google.golang.org/grpc/codes"
 	grpc_status "google.golang.org/grpc/status"
 )
@@ -127,7 +128,7 @@ func (s *scheduler) ScheduleRegularTasks(
 		for {
 			select {
 			case <-ctx.Done():
-				logging.Info(ctx, "sheduling regular task %v stopped", taskType)
+				logging.Info(ctx, "scheduling regular task %v stopped", taskType)
 				return
 			case <-time.After(
 				common.RandomDuration(
@@ -150,9 +151,11 @@ func (s *scheduler) ScheduleRegularTasks(
 				continue
 			}
 
-			metadata := tasks_storage.NewMetadata(map[string]string{
-				"x-request-id": requestID.String(),
-			})
+			ctx = headers.SetIncomingRequestID(ctx, requestID.String())
+			ctx = tracing.InjectTracingContext(ctx)
+			metadata := tasks_storage.NewMetadata(headers.GetTracingHeaders(ctx))
+			// TODO:_ check that all is ok with x-request-id
+			// TODO:_ can we write some tests for this?
 
 			schedule := tasks_storage.TaskSchedule{
 				ScheduleInterval: schedule.ScheduleInterval,

--- a/cloud/tasks/tracing/attributes.go
+++ b/cloud/tasks/tracing/attributes.go
@@ -1,0 +1,33 @@
+package tracing
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func WithAttributes(
+	attributes ...attribute.KeyValue,
+) trace.SpanStartEventOption {
+
+	return trace.WithAttributes(attributes...)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func AttributeBool(key string, value bool) attribute.KeyValue {
+	return attribute.Bool(key, value)
+}
+
+func AttributeInt(key string, value int) attribute.KeyValue {
+	return attribute.Int(key, value)
+}
+
+func AttributeInt64(key string, value int64) attribute.KeyValue {
+	return attribute.Int64(key, value)
+}
+
+func AttributeString(key string, value string) attribute.KeyValue {
+	return attribute.String(key, value)
+}

--- a/cloud/tasks/tracing/tracing_context.go
+++ b/cloud/tasks/tracing/tracing_context.go
@@ -19,10 +19,7 @@ const (
 ////////////////////////////////////////////////////////////////////////////////
 
 // Extracts traceparent and tracestate headers from grpc metadata.
-func ExtractTracingContext(
-	ctx context.Context,
-) context.Context {
-
+func ExtractTracingContext(ctx context.Context) context.Context {
 	tracingContext := headers.GetFromIncomingContext(ctx, []string{
 		traceparentHeaderKey,
 		tracestateHeaderKey,
@@ -37,3 +34,26 @@ func ExtractTracingContext(
 	prop := otel.GetTextMapPropagator()
 	return prop.Extract(ctx, propagation.MapCarrier(tracingContext))
 }
+
+// Injects (appends) traceparent and tracestate headers to grpc metadata
+func InjectTracingContext(ctx context.Context) context.Context {
+	mapCarrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, mapCarrier)
+
+	tracingContextHeaders := make(map[string]string)
+
+	traceparent, ok := mapCarrier[traceparentHeaderKey]
+	if !ok {
+		return ctx
+	}
+	tracingContextHeaders[traceparentHeaderKey] = traceparent // TODO:_ or just pass mapCarrier to headers.Append?
+
+	tracestate, ok := mapCarrier[tracestateHeaderKey]
+	if ok {
+		tracingContextHeaders[tracestateHeaderKey] = tracestate
+	}
+
+	return headers.Append(ctx, tracingContextHeaders)
+}
+
+// TODO:_ add change for regular tasks

--- a/cloud/tasks/tracing/tracing_context.go
+++ b/cloud/tasks/tracing/tracing_context.go
@@ -56,6 +56,5 @@ func SetTracingContext(ctx context.Context) context.Context {
 	if ok {
 		tracingContextHeaders[tracestateHeaderKey] = tracestate
 	}
-
 	return headers.Replace(ctx, tracingContextHeaders)
 }

--- a/cloud/tasks/tracing/tracing_context.go
+++ b/cloud/tasks/tracing/tracing_context.go
@@ -18,8 +18,8 @@ const (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Extracts traceparent and tracestate headers from incoming grpc metadata.
-func ExtractTracingContext(ctx context.Context) context.Context {
+// Gets traceparent and tracestate headers from incoming grpc metadata.
+func GetTracingContext(ctx context.Context) context.Context {
 	tracingContext := headers.GetFromIncomingContext(ctx, []string{
 		traceparentHeaderKey,
 		tracestateHeaderKey,
@@ -35,11 +35,11 @@ func ExtractTracingContext(ctx context.Context) context.Context {
 	return prop.Extract(ctx, propagation.MapCarrier(tracingContext))
 }
 
-// Injects traceparent and tracestate headers to grpc metadata
+// Sets traceparent and tracestate headers in grpc metadata
 // (both incoming and outgoing).
 // If these fields are already present in grpc metadata,
 // their values will be overwritten.
-func InjectTracingContext(ctx context.Context) context.Context {
+func SetTracingContext(ctx context.Context) context.Context {
 	mapCarrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, mapCarrier)
 

--- a/cloud/tasks/tracing/ya.make
+++ b/cloud/tasks/tracing/ya.make
@@ -1,6 +1,7 @@
 GO_LIBRARY()
 
 SRCS(
+    attributes.go
     init.go
     tracing_context.go
 )


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1199

Traces will look like this (example for creating disk from snapshot):

```
<external span from grpc metadata>
    CreateDisk
        disks.CreateDiskFromSnapshot (gen 1)
        disks.CreateDiskFromSnapshot (gen 2)
            dataplane.TransferFromSnpashotToDisk (gen 1)
            dataplane.TransferFromSnpashotToDisk (gen 2)
        disks.CreateDiskFromSnapshot (gen 3)
```
    
Also, regular tasks will have their spans in separate traces.

For each task generation we start a new span. The disadvantage of this approach is huge amount of span if the task has many generations. Sampling can help here. I'm going to add sampling in next pull requests.