### PR TITLE
Make the date-time format consistent in logs

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -433,7 +433,6 @@ void TCommand::Init()
     const auto& monConfig = ClientConfig->GetMonitoringConfig();
 
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
 
     if (logConfig.HasLogLevel()) {
         logSettings.FiltrationLevel = static_cast<ELogPriority>(

--- a/cloud/blockstore/libs/client/bench/main.cpp
+++ b/cloud/blockstore/libs/client/bench/main.cpp
@@ -31,10 +31,11 @@ struct TBootstrap
 {
     const ui32 BlockSize = 4*1024;
 
-    ILoggingServicePtr Logging = CreateLoggingService("console", {
-        .FiltrationLevel = TLOG_ERR,
-        .UseLocalTimestamps = true,
-    });
+    ILoggingServicePtr Logging = CreateLoggingService(
+        "console",
+        {
+            .FiltrationLevel = TLOG_ERR,
+        });
     TClientAppConfigPtr Config = std::make_shared<TClientAppConfig>();
     ITimerPtr Timer = CreateWallClockTimer();
     ISchedulerPtr Scheduler = CreateScheduler();

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -201,10 +201,7 @@ void TBootstrapBase::ParseOptions(int argc, char** argv)
 
 void TBootstrapBase::Init()
 {
-    TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
-
-    BootstrapLogging = CreateLoggingService("console", logSettings);
+    BootstrapLogging = CreateLoggingService("console", TLogSettings{});
     Log = BootstrapLogging->CreateLog("BLOCKSTORE_SERVER");
     SetCriticalEventsLog(Log);
     Configs->Log = Log;
@@ -702,7 +699,6 @@ void TBootstrapBase::InitDbgConfigs()
     Configs->InitSpdkEnvConfig();
 
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
     logSettings.FiltrationLevel =
         static_cast<ELogPriority>(Configs->GetLogDefaultLevel());
 

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -197,10 +197,7 @@ void TBootstrap::ParseOptions(int argc, char** argv)
 
 void TBootstrap::Init()
 {
-    TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
-
-    BootstrapLogging = CreateLoggingService("console", logSettings);
+    BootstrapLogging = CreateLoggingService("console", TLogSettings{});
     Log = BootstrapLogging->CreateLog("BLOCKSTORE_SERVER");
     STORAGE_INFO("NBS server version: " << GetFullVersionString());
 

--- a/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
@@ -16,9 +16,7 @@ void TBootstrap::ParseOptions(int argc, char** argv)
 
 void TBootstrap::Init()
 {
-    TLogSettings logSettings;
     Scheduler = CreateScheduler();
-    logSettings.UseLocalTimestamps = true;
     Server = CreateServer({
         static_cast<ui16>(Options.ServerPort),
         static_cast<ui16>(Options.SecureServerPort),
@@ -32,7 +30,7 @@ void TBootstrap::Init()
     },
     CreateWallClockTimer(),
     Scheduler,
-    CreateLoggingService("console", logSettings));
+    CreateLoggingService("console", TLogSettings{}));
 }
 
 void TBootstrap::Start()

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api_ut.cpp
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api_ut.cpp
@@ -70,10 +70,11 @@ struct TFixture
     std::optional<NYdb::TDriver> Driver;
     std::optional<NYdb::NTopic::TTopicClient> Client;
 
-    ILoggingServicePtr Logging = CreateLoggingService("console", {
-        .FiltrationLevel = TLOG_DEBUG,
-        .UseLocalTimestamps = true
-    });
+    ILoggingServicePtr Logging = CreateLoggingService(
+        "console",
+        {
+            .FiltrationLevel = TLOG_DEBUG,
+        });
 
     void SetUp(NUnitTest::TTestContext& /*context*/) override
     {
@@ -222,9 +223,7 @@ Y_UNIT_TEST_SUITE(TLogbrokerTest)
 
     void ShouldHandleErrorImpl(TLogbrokerConfigPtr config)
     {
-        auto logging = CreateLoggingService("console", TLogSettings  {
-            .UseLocalTimestamps = true
-        });
+        auto logging = CreateLoggingService("console", TLogSettings{});
 
         auto service = CreateTopicAPIService(config, logging);
         service->Start();

--- a/cloud/blockstore/libs/nbd/bench/bootstrap.cpp
+++ b/cloud/blockstore/libs/nbd/bench/bootstrap.cpp
@@ -112,7 +112,6 @@ TBootstrap::~TBootstrap()
 void TBootstrap::Init()
 {
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
     logSettings.FiltrationLevel = Options->FiltrationLevel;
 
     Logging = CreateLoggingService("console", logSettings);

--- a/cloud/blockstore/tests/fuzzing/common/starter.cpp
+++ b/cloud/blockstore/tests/fuzzing/common/starter.cpp
@@ -77,10 +77,7 @@ TStarter* TStarter::GetStarter(
 TStarter::TStarter(NServer::TBootstrapBase& bootstrap)
     : Bootstrap(bootstrap)
 {
-    TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
-
-    FuzzerLogging = CreateLoggingService("console", logSettings);
+    FuzzerLogging = CreateLoggingService("console", TLogSettings{});
     Log = FuzzerLogging->CreateLog("BLOCKSTORE_FUZZER");
 }
 
@@ -223,4 +220,3 @@ int TStarter::Run(const ui8* data, size_t size)
 }
 
 }   // namespace NCloud::NBlockStore::NFuzzing
-

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -126,7 +126,6 @@ void TBootstrap::Init()
     const auto& monConfig = ClientConfig->GetMonitoringConfig();
 
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
 
     if (logConfig.HasLogLevel()) {
         logSettings.FiltrationLevel = static_cast<ELogPriority>(

--- a/cloud/blockstore/tools/testing/eternal_tests/checkpoint-validator/bin/main.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/checkpoint-validator/bin/main.cpp
@@ -14,9 +14,7 @@ class TApp
 public:
     TApp()
     {
-        TLogSettings settings;
-        settings.UseLocalTimestamps = true;
-        Logging = CreateLoggingService("console", settings);
+        Logging = CreateLoggingService("console", TLogSettings{});
         Logging->Start();
         Log = Logging->CreateLog("MAIN");
     }

--- a/cloud/blockstore/tools/testing/eternal_tests/checkpoint-validator/lib/validator_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/checkpoint-validator/lib/validator_ut.cpp
@@ -13,9 +13,7 @@ bool RunTest(
     ui64 iterations,
     TMaybe<ui32> brokenBlockIdx)
 {
-    TLogSettings settings;
-    settings.UseLocalTimestamps = true;
-    auto logging = CreateLoggingService("console", settings);
+    auto logging = CreateLoggingService("console", TLogSettings{});
     logging->Start();
     Y_DEFER {
         logging->Stop();

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -49,9 +49,7 @@ private:
 
 void TTest::InitLogger()
 {
-    TLogSettings settings;
-    settings.UseLocalTimestamps = true;
-    Logging = CreateLoggingService("console", settings);
+    Logging = CreateLoggingService("console", TLogSettings{});
     Logging->Start();
     Log = Logging->CreateLog("ETERNAL_MAIN");
 }

--- a/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
@@ -165,7 +165,6 @@ void TBootstrap::Init()
     const auto& monConfig = ClientConfig->GetMonitoringConfig();
 
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
 
     if (logConfig.HasLogLevel()) {
         logSettings.FiltrationLevel = static_cast<ELogPriority>(

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -156,7 +156,6 @@ bool TCommand::WaitForI(const TFuture<void>& future)
 
 void TCommand::Init()
 {
-    LogSettings.UseLocalTimestamps = true;
     if (!VerboseLevel.empty()) {
         auto level = GetLogLevel(VerboseLevel);
         Y_ENSURE(level, "unknown log level: " << VerboseLevel.Quote());

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -104,9 +104,7 @@ TBootstrapCommon::TBootstrapCommon(
     , ModuleFactories(std::move(moduleFactories))
     , UserCounters(std::move(userCounters))
 {
-    TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
-    BootstrapLogging = CreateLoggingService("console", logSettings);
+    BootstrapLogging = CreateLoggingService("console", TLogSettings{});
     BootstrapLogging->Start();
 
     Log = BootstrapLogging->CreateLog(logComponent);
@@ -242,7 +240,6 @@ void TBootstrapCommon::InitDiagnostics()
 {
     if (!ActorSystem) {
         TLogSettings logSettings;
-        logSettings.UseLocalTimestamps = true;
 
         if (Configs->Options->VerboseLevel) {
             auto level = GetLogLevel(Configs->Options->VerboseLevel);

--- a/cloud/filestore/tools/testing/loadtest/bin/bootstrap.cpp
+++ b/cloud/filestore/tools/testing/loadtest/bin/bootstrap.cpp
@@ -154,7 +154,6 @@ void TBootstrap::Stop()
 void TBootstrap::InitDbgConfig()
 {
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
 
     if (Options->VerboseLevel) {
         auto level = GetLogLevel(Options->VerboseLevel);

--- a/cloud/storage/core/tools/analytics/cpu-wait-monitor/main.cpp
+++ b/cloud/storage/core/tools/analytics/cpu-wait-monitor/main.cpp
@@ -56,10 +56,8 @@ int main(int argc, const char** argv)
 {
     TOptions options(argc, argv);
 
-    NCloud::TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
-
-    auto logging = NCloud::CreateLoggingService("console", logSettings);
+    auto logging =
+        NCloud::CreateLoggingService("console", NCloud::TLogSettings{});
     auto Log = logging->CreateLog(options.ComponentName);
     auto monitoring = NCloud::CreateMonitoringServiceStub();
     auto statsFetcher = NCloud::NStorage::CreateCgroupStatsFetcher(

--- a/cloud/vm/blockstore/bootstrap.cpp
+++ b/cloud/vm/blockstore/bootstrap.cpp
@@ -100,7 +100,6 @@ void TBootstrap::Init()
     const auto& monConfig = ClientConfig->GetMonitoringConfig();
 
     TLogSettings logSettings;
-    logSettings.UseLocalTimestamps = true;
     logSettings.SuppressNewLine = true;   // host will do it for us
 
     if (logConfig.HasLogLevel()) {


### PR DESCRIPTION
Сейчас в логах формат времени может отличаться:
2024-08-28-14-10-22:BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/daemon/common/bootstrap.cpp:855: Started Monitoring
2024-08-28T07:10:22.059462Z:BLOCKSTORE_DISK_REGISTRY_PROXY INFO: Tablet client: 72075186224037888 (remote: [50000:7408084243596560056:8189])

В первом случае, когда время выглядит как «2024-08-28-14-10-22», это записано через BootstrapLogging https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/daemon/common/bootstrap.cpp#L207

Во втором случае строки были записаны через логгер, созданный из Logging и выглядят как "2024-08-28T07:10:22.059462Z"
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/daemon/common/bootstrap.cpp#L709

Несмотря на то, что оба раза было выставлено UseLocalTimestamps = true;, во втором случае его переопределила настройка из конфига, переданного через параметр --log-file при запуске, и это произошло в 
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/storage/init/common/actorsystem.cpp#L104
или https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/libs/storage/init/actorsystem.cpp#L408

В конфигах у нас ничего не задано, и применяется дефолт — false.

Получается, что в логах строки в разных форматах, что неудобно. 
Есть предложение поменять в коде все logSettings.UseLocalTimestamps = true; на false,
чтобы в логах все было одинаково. 
Есть какие-то соображения, по которым в логи нужно писать в формате «2024-08-28-14-10-22»?
Кроме того, в таком формате не получается отслеживать миллисекунды, что не дает нам точно понять тайминги запуска сервиса.