### PR TITLE
issue-1657: fix resize for netlink device

### DIFF
--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -257,12 +257,6 @@ public:
 
     NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override
     {
-        if (!StartResult.HasValue() || StartResult.GetValue().GetCode() != S_OK)
-        {
-            return NThreading::MakeFuture(
-                MakeError(E_FAIL, "Device is not open"));
-        }
-
         try {
             TNetlinkSocket socket;
             TNetlinkMessage message(socket.GetFamily(), NBD_CMD_RECONFIGURE);

--- a/cloud/blockstore/tests/python/lib/endpoint_proxy.py
+++ b/cloud/blockstore/tests/python/lib/endpoint_proxy.py
@@ -12,7 +12,7 @@ class EndpointProxy(Daemon):
         ]
 
         if with_netlink:
-            command += "--netlink"
+            command += ["--netlink"]
 
         super(EndpointProxy, self).__init__(
             commands=[command],


### PR DESCRIPTION
issue: #1657

1. fix proxy argument "--netlink" in e2e test
2. StartResult future doesn't contain any value as it was moved, so we need to remove this check and fail in message.Send