### PR TITLE
issue-1657: handle "start nbd device" error

### DIFF
--- a/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
+#include <library/cpp/testing/common/network.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/core/future.h>
 
@@ -46,7 +47,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         // 4. Expect response with error
         // 5. Send start endpoint request with invalid device path again
         // 6. Expect response with error
-        const ui16 port = 8122;
+        const auto port = NTesting::GetFreePort();
         auto unixSocketPath = CreateGuidAsString();
         TEndpointProxyServerConfig serverConfig(
             port,

--- a/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
@@ -34,6 +34,13 @@ Y_UNIT_TEST_SUITE(TServerTest)
 {
     Y_UNIT_TEST(StartRequestShouldNotReturnAlreadyAfterFailure)
     {
+        // Test scenario:
+        // 1. Start endpoint proxy server
+        // 2. Start endpoint proxy client
+        // 3. Send start endpoint request with invalid device path
+        // 4. Expect response with error
+        // 5. Send start endpoint request with invalid device path again
+        // 6. Expect response with error
         const ui16 port = 8122;
         auto unixSocketPath = CreateGuidAsString();
         TEndpointProxyServerConfig serverConfig(

--- a/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
@@ -1,0 +1,96 @@
+#include "server.h"
+
+#include <cloud/blockstore/libs/endpoint_proxy/client/client.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/scheduler.h>
+#include <cloud/storage/core/libs/common/timer.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/core/future.h>
+
+#include <util/generic/guid.h>
+
+namespace NCloud::NBlockStore::NServer {
+
+namespace {
+std::shared_ptr<NProto::TStartProxyEndpointRequest> CreateStartRequest(
+    ui64 blocksCount,
+    ui32 blockSize,
+    TString unixSocketPath,
+    TString nbdDevice)
+{
+    auto startRequest = std::make_shared<NProto::TStartProxyEndpointRequest>();
+    startRequest->SetBlocksCount(blocksCount);
+    startRequest->SetBlockSize(blockSize);
+    startRequest->SetUnixSocketPath(std::move(unixSocketPath));
+    startRequest->SetNbdDevice(std::move(nbdDevice));
+    return startRequest;
+}
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TServerTest)
+{
+    Y_UNIT_TEST(StartRequestShouldNotReturnAlreadyAfterFailure)
+    {
+        const ui16 port = 8122;
+        auto unixSocketPath = CreateGuidAsString();
+        TEndpointProxyServerConfig serverConfig(
+            port,
+            0,
+            "",
+            "",
+            "",
+            unixSocketPath,
+            false,
+            "",
+            TDuration::Seconds(1));
+
+        auto server = CreateServer(
+            serverConfig,
+            CreateWallClockTimer(),
+            CreateScheduler(),
+            CreateLoggingService("server", TLogSettings{}));
+        UNIT_ASSERT(server);
+        server->Start();
+
+        NClient::TEndpointProxyClientConfig clientConfig;
+        clientConfig.Host = "127.0.0.1";
+        clientConfig.Port = port;
+        clientConfig.UnixSocketPath = unixSocketPath;
+        auto client = NClient::CreateClient(
+            clientConfig,
+            CreateScheduler(),
+            CreateWallClockTimer(),
+            CreateLoggingService("client", TLogSettings{}));
+        UNIT_ASSERT(client);
+        client->Start();
+
+        const ui64 blocksCount = 10000;
+        const ui32 blockSize = 4096;
+        const TString nbdDevice = "/dev/nbd9999";
+        auto resp1 = client
+                         ->StartProxyEndpoint(CreateStartRequest(
+                             blocksCount,
+                             blockSize,
+                             unixSocketPath,
+                             nbdDevice))
+                         .GetValueSync();
+        UNIT_ASSERT(HasError(resp1));
+
+        auto resp2 = client
+                         ->StartProxyEndpoint(CreateStartRequest(
+                             blocksCount,
+                             blockSize,
+                             unixSocketPath,
+                             nbdDevice))
+                         .GetValueSync();
+        UNIT_ASSERT(HasError(resp2));
+
+        client->Stop();
+        server->Stop();
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoint_proxy/server/ut/ya.make
+++ b/cloud/blockstore/libs/endpoint_proxy/server/ut/ya.make
@@ -4,9 +4,11 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
     proxy_storage_ut.cpp
+    server_ut.cpp
 )
 
 PEERDIR(
+    cloud/blockstore/libs/endpoint_proxy/client
 )
 
 END()

--- a/cloud/blockstore/libs/nbd/device.cpp
+++ b/cloud/blockstore/libs/nbd/device.cpp
@@ -203,32 +203,32 @@ void TDevice::ConnectDevice()
     STORAGE_DEBUG("NBD_SET_BLKSIZE " << sectorSize);
     int ret = ioctl(device, NBD_SET_BLKSIZE, sectorSize);
     if (ret < 0) {
-        ythrow TFileError() << "could not setup device block size";
+        ythrow TFileError() << "could not setup device block size: " << ret;
     }
 
     STORAGE_DEBUG("NBD_SET_SIZE_BLOCKS " << sectors);
     ret = ioctl(device, NBD_SET_SIZE_BLOCKS, sectors);
     if (ret < 0) {
-        ythrow TFileError() << "could not setup device blocks count";
+        ythrow TFileError() << "could not setup device blocks count: " << ret;
     }
 
     STORAGE_DEBUG("NBD_SET_FLAGS " << exportInfo.Flags);
     ret = ioctl(device, NBD_SET_FLAGS, exportInfo.Flags);
     if (ret < 0) {
-        ythrow TFileError() << "could not setup device flags";
+        ythrow TFileError() << "could not setup device flags: " << ret;
     }
 
     STORAGE_DEBUG("NBD_SET_SOCK " << static_cast<SOCKET>(Socket));
     ret = ioctl(device, NBD_SET_SOCK, static_cast<SOCKET>(Socket));
     if (ret < 0) {
-        ythrow TFileError() << "could not bind socket to device";
+        ythrow TFileError() << "could not bind socket to device: " << ret;
     }
 
     if (Timeout) {
         STORAGE_DEBUG("NBD_SET_TIMEOUT " << Timeout);
         ret = ioctl(device, NBD_SET_TIMEOUT, Timeout.Seconds());
         if (ret < 0) {
-            ythrow TFileError() << "could not set timeout to device";
+            ythrow TFileError() << "could not set timeout to device: " << ret;
         }
     }
 


### PR DESCRIPTION
1. return error if nbd device failed to start
2. cleanup server state after "nbd device start" failure
3. log ioctl device errors