### PR TITLE
issue-1795: LargeDeletionMarkers

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -371,4 +371,18 @@ message TStorageConfig
     optional uint32 NodeRegistrationMaxAttempts = 381;
     optional uint32 NodeRegistrationTimeout = 382;   // in ms
     optional uint32 NodeRegistrationErrorTimeout = 383;  // in ms
+
+    // Max block count per file.
+    optional uint64 MaxFileBlocks = 384;
+    // Enables the usage of large deletion markers (needed for efficient
+    // truncate ops on large files).
+    optional bool LargeDeletionMarkersEnabled = 385;
+    // Sets max block count per single large deletion marker.
+    optional uint64 LargeDeletionMarkerBlocks = 386;
+    // Truncate and allocate ops that exceed this threshold will lead to large
+    // deletion marker generation.
+    optional uint64 LargeDeletionMarkersThreshold = 387;
+    // If the number of blocks marked for deletion via large deletion markers
+    // exceeds this threshold, Cleanup will be triggered.
+    optional uint64 LargeDeletionMarkersCleanupThreshold = 388;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -59,7 +59,7 @@ message TStorageConfig
 
     // The size of data (in bytes) in the fresh bytes table that triggers
     // flushing.
-    optional uint32 FlushBytesThreshold = 14;
+    optional uint64 FlushBytesThreshold = 14;
 
     // Size of allocation unit for HDD drives (in GiB).
     optional uint32 AllocationUnitHDD = 15;
@@ -143,7 +143,7 @@ message TStorageConfig
     optional uint32 FlushThresholdForBackpressure = 59;
     optional uint32 CleanupThresholdForBackpressure = 60;
     optional uint32 CompactionThresholdForBackpressure = 61;
-    optional uint32 FlushBytesThresholdForBackpressure = 62;
+    optional uint64 FlushBytesThresholdForBackpressure = 62;
 
     // Threshold for blob size in bytes.
     optional uint32 MaxBlobSize = 63;

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -373,7 +373,9 @@ message TStorageConfig
     optional uint32 NodeRegistrationErrorTimeout = 383;  // in ms
 
     // Max block count per file.
-    optional uint64 MaxFileBlocks = 384;
+    // uint32 is chosen deliberately - using values that exceed 2^32 - 1 or even
+    // 2^31 (which is 8TiB for a 4KiB block) should be thoroughly tested anyway
+    optional uint32 MaxFileBlocks = 384;
     // Enables the usage of large deletion markers (needed for efficient
     // truncate ops on large files).
     optional bool LargeDeletionMarkersEnabled = 385;

--- a/cloud/filestore/libs/service/filestore.h
+++ b/cloud/filestore/libs/service/filestore.h
@@ -34,7 +34,6 @@ constexpr ui32 MaxLink = NProto::E_FS_LIMITS_LINK;
 constexpr ui32 MaxName = NProto::E_FS_LIMITS_NAME;
 constexpr ui32 MaxPath = NProto::E_FS_LIMITS_PATH;
 constexpr ui32 MaxSymlink = NProto::E_FS_LIMITS_SYMLINK;
-constexpr ui64 MaxFileBlocks = static_cast<ui32>(NProto::E_FS_LIMITS_FILEBLOCKS);
 constexpr ui64 MaxNodes = static_cast<ui32>(NProto::E_FS_LIMITS_INODES);
 constexpr ui64 MaxXAttrName = NProto::E_FS_LIMITS_XATTR_NAME;
 constexpr ui64 MaxXAttrValue = NProto::E_FS_LIMITS_XATTR_VALUE;

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -48,6 +48,13 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(LoadedCompactionRangesPerTx,        ui32,   10 * 1024 * 1024          )\
     xxx(MaxBlocksPerTruncateTx,             ui32,   0 /*TODO: 32GiB/4KiB*/    )\
     xxx(MaxTruncateTxInflight,              ui32,   10                        )\
+                                                                               \
+    xxx(MaxFileBlocks,                          ui64,   300_GB / 4_KB         )\
+    xxx(LargeDeletionMarkersEnabled,            bool,   false                 )\
+    xxx(LargeDeletionMarkerBlocks,              ui64,   1_GB / 4_KB           )\
+    xxx(LargeDeletionMarkersThreshold,          ui64,   128_GB / 4_KB         )\
+    xxx(LargeDeletionMarkersCleanupThreshold,   ui64,   10_TB / 4_KB          )\
+                                                                               \
     xxx(CompactionRetryTimeout,             TDuration, TDuration::Seconds(1)  )\
     xxx(BlobIndexOpsPriority,                                                  \
             NProto::EBlobIndexOpsPriority,                                     \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -53,7 +53,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(LargeDeletionMarkersEnabled,            bool,   false                 )\
     xxx(LargeDeletionMarkerBlocks,              ui64,   1_GB / 4_KB           )\
     xxx(LargeDeletionMarkersThreshold,          ui64,   128_GB / 4_KB         )\
-    xxx(LargeDeletionMarkersCleanupThreshold,   ui64,   10_TB / 4_KB          )\
+    xxx(LargeDeletionMarkersCleanupThreshold,   ui64,   1_TB / 4_KB           )\
                                                                                \
     xxx(CompactionRetryTimeout,             TDuration, TDuration::Seconds(1)  )\
     xxx(BlobIndexOpsPriority,                                                  \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -49,7 +49,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(MaxBlocksPerTruncateTx,             ui32,   0 /*TODO: 32GiB/4KiB*/    )\
     xxx(MaxTruncateTxInflight,              ui32,   10                        )\
                                                                                \
-    xxx(MaxFileBlocks,                          ui64,   300_GB / 4_KB         )\
+    xxx(MaxFileBlocks,                          ui32,   300_GB / 4_KB         )\
     xxx(LargeDeletionMarkersEnabled,            bool,   false                 )\
     xxx(LargeDeletionMarkerBlocks,              ui64,   1_GB / 4_KB           )\
     xxx(LargeDeletionMarkersThreshold,          ui64,   128_GB / 4_KB         )\

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -43,7 +43,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(GarbageCompactionThresholdAverage,  ui32,   20                        )\
     xxx(NewCompactionEnabled,               bool,   false                     )\
     xxx(CollectGarbageThreshold,            ui32,   4_MB                      )\
-    xxx(FlushBytesThreshold,                ui32,   4_MB                      )\
+    xxx(FlushBytesThreshold,                ui64,   4_MB                      )\
     xxx(MaxDeleteGarbageBlobsPerTx,         ui32,   16384                     )\
     xxx(LoadedCompactionRangesPerTx,        ui32,   10 * 1024 * 1024          )\
     xxx(MaxBlocksPerTruncateTx,             ui32,   0 /*TODO: 32GiB/4KiB*/    )\
@@ -63,7 +63,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(FlushThresholdForBackpressure,      ui32,      128_MB                 )\
     xxx(CleanupThresholdForBackpressure,    ui32,      32768                  )\
     xxx(CompactionThresholdForBackpressure, ui32,      200                    )\
-    xxx(FlushBytesThresholdForBackpressure, ui32,      128_MB                 )\
+    xxx(FlushBytesThresholdForBackpressure, ui64,      128_MB                 )\
                                                                                \
     xxx(HDDSystemChannelPoolKind,      TString,   "rot"                       )\
     xxx(HDDLogChannelPoolKind,         TString,   "rot"                       )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -261,6 +261,12 @@ public:
 
     ui32 GetChannelFreeSpaceThreshold() const;
     ui32 GetChannelMinFreeSpace() const;
+
+    ui64 GetMaxFileBlocks() const;
+    bool GetLargeDeletionMarkersEnabled() const;
+    ui64 GetLargeDeletionMarkerBlocks() const;
+    ui64 GetLargeDeletionMarkersThreshold() const;
+    ui64 GetLargeDeletionMarkersCleanupThreshold() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -82,14 +82,14 @@ public:
     ui32 GetGarbageCompactionThresholdAverage() const;
     bool GetNewCompactionEnabled() const;
     ui32 GetCollectGarbageThreshold() const;
-    ui32 GetFlushBytesThreshold() const;
+    ui64 GetFlushBytesThreshold() const;
     ui32 GetMaxDeleteGarbageBlobsPerTx() const;
     ui32 GetLoadedCompactionRangesPerTx() const;
 
     ui32 GetFlushThresholdForBackpressure() const;
     ui32 GetCleanupThresholdForBackpressure() const;
     ui32 GetCompactionThresholdForBackpressure() const;
-    ui32 GetFlushBytesThresholdForBackpressure() const;
+    ui64 GetFlushBytesThresholdForBackpressure() const;
 
     TString GetHDDSystemChannelPoolKind() const;
     TString GetHDDLogChannelPoolKind() const;

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -262,7 +262,7 @@ public:
     ui32 GetChannelFreeSpaceThreshold() const;
     ui32 GetChannelMinFreeSpace() const;
 
-    ui64 GetMaxFileBlocks() const;
+    ui32 GetMaxFileBlocks() const;
     bool GetLargeDeletionMarkersEnabled() const;
     ui64 GetLargeDeletionMarkerBlocks() const;
     ui64 GetLargeDeletionMarkersThreshold() const;

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -150,7 +150,7 @@ NProto::TError ValidateXAttrValue(const TString& name, const TString& value)
     return {};
 }
 
-NProto::TError ValidateRange(TByteRange byteRange, ui32 maxFileBlocks)
+NProto::TError ValidateRange(TByteRange byteRange, ui64 maxFileBlocks)
 {
     if (!byteRange.Length) {
         return ErrorInvalidArgument();

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -150,13 +150,13 @@ NProto::TError ValidateXAttrValue(const TString& name, const TString& value)
     return {};
 }
 
-NProto::TError ValidateRange(TByteRange byteRange)
+NProto::TError ValidateRange(TByteRange byteRange, ui32 maxFileBlocks)
 {
     if (!byteRange.Length) {
         return ErrorInvalidArgument();
     }
 
-    if (byteRange.LastBlock() + 1 > MaxFileBlocks) {
+    if (byteRange.LastBlock() + 1 > maxFileBlocks) {
         return ErrorFileTooBig();
     }
 

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -150,7 +150,7 @@ NProto::TError ValidateXAttrValue(const TString& name, const TString& value)
     return {};
 }
 
-NProto::TError ValidateRange(TByteRange byteRange, ui64 maxFileBlocks)
+NProto::TError ValidateRange(TByteRange byteRange, ui32 maxFileBlocks)
 {
     if (!byteRange.Length) {
         return ErrorInvalidArgument();

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -131,7 +131,7 @@ NProto::ELockType ConvertToImpl(ELockMode source, TTag<NProto::ELockType>);
 NProto::TError ValidateNodeName(const TString& name);
 NProto::TError ValidateXAttrName(const TString& name);
 NProto::TError ValidateXAttrValue(const TString& name, const TString& value);
-NProto::TError ValidateRange(TByteRange byteRange, ui32 maxFileBlocks);
+NProto::TError ValidateRange(TByteRange byteRange, ui64 maxFileBlocks);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -131,7 +131,7 @@ NProto::ELockType ConvertToImpl(ELockMode source, TTag<NProto::ELockType>);
 NProto::TError ValidateNodeName(const TString& name);
 NProto::TError ValidateXAttrName(const TString& name);
 NProto::TError ValidateXAttrValue(const TString& name, const TString& value);
-NProto::TError ValidateRange(TByteRange byteRange);
+NProto::TError ValidateRange(TByteRange byteRange, ui32 maxFileBlocks);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -131,7 +131,7 @@ NProto::ELockType ConvertToImpl(ELockMode source, TTag<NProto::ELockType>);
 NProto::TError ValidateNodeName(const TString& name);
 NProto::TError ValidateXAttrName(const TString& name);
 NProto::TError ValidateXAttrValue(const TString& name, const TString& value);
-NProto::TError ValidateRange(TByteRange byteRange, ui64 maxFileBlocks);
+NProto::TError ValidateRange(TByteRange byteRange, ui32 maxFileBlocks);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/model/alloc.h
+++ b/cloud/filestore/libs/storage/tablet/model/alloc.h
@@ -18,6 +18,7 @@ enum class EAllocatorTag
     ReadAheadCache,
     NodeIndexCache,
     InMemoryNodeIndexCache,
+    LargeBlocks,
 
     Max
 };

--- a/cloud/filestore/libs/storage/tablet/model/block.h
+++ b/cloud/filestore/libs/storage/tablet/model/block.h
@@ -71,6 +71,21 @@ struct TBlockDataRef: TBlock
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TBlockDeletion
+{
+    ui64 NodeId = 0;
+    ui32 BlockIndex = 0;
+    ui64 CommitId = 0;
+
+    TBlockDeletion(ui64 nodeId, ui32 blockIndex, ui64 commitId)
+        : NodeId(nodeId)
+        , BlockIndex(blockIndex)
+        , CommitId(commitId)
+    {}
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TBytes
 {
     ui64 NodeId = 0;
@@ -245,6 +260,16 @@ struct IMixedBlockVisitor
         const TBlock& block,
         const TPartialBlobId& blobId,
         ui32 blobOffset) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ILargeBlockVisitor
+{
+    virtual ~ILargeBlockVisitor() = default;
+
+    virtual void Accept(
+        const TBlockDeletion& marker) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/deletion_markers.h
+++ b/cloud/filestore/libs/storage/tablet/model/deletion_markers.h
@@ -38,6 +38,8 @@ struct TDeletionMarker
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// TODO(#1923): support checkpoints in TDeletionMarkers. Right now the
+// implementation simply overwrites older commitIds with newer ones.
 
 class TDeletionMarkers
 {

--- a/cloud/filestore/libs/storage/tablet/model/deletion_markers.h
+++ b/cloud/filestore/libs/storage/tablet/model/deletion_markers.h
@@ -35,6 +35,11 @@ struct TDeletionMarker
             && BlockIndex == other.BlockIndex
             && BlockCount == other.BlockCount;
     }
+
+    bool IsValid() const
+    {
+        return CommitId != InvalidCommitId && BlockCount > 0;
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -23,8 +23,8 @@ struct TSegmentWithHoles
         auto lo = End2Start.upper_bound(start);
         auto hi = End2Start.upper_bound(end);
         std::pair<ui64, ui64> newLo;
-        if (lo != End2Start.end()) {
-            newLo = {lo->first, Max(lo->first, start)};
+        if (lo != End2Start.end() && lo->second < start) {
+            newLo = {lo->second, start};
         }
 
         if (hi != End2Start.end() && hi->second < end) {

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -139,6 +139,10 @@ struct TLargeBlocks::TImpl
 
                 ++rangeIt;
             }
+
+            if (update && it->second.empty()) {
+                NodeId2Markers.erase(it);
+            }
         }
     }
 };

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -133,7 +133,6 @@ struct TLargeBlocks::TImpl
                     rangeIt->Marker.NodeId,
                     b,
                     rangeIt->Marker.CommitId});
-
             }
 
             if (update) {

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -1,0 +1,54 @@
+#include "large_blocks.h"
+
+#include "alloc.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TLargeBlocks::TImpl
+{
+    // TODO
+
+    IAllocator* Alloc;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLargeBlocks::TLargeBlocks(IAllocator* alloc)
+    : Impl(new TImpl{alloc})
+{}
+
+TLargeBlocks::~TLargeBlocks() = default;
+
+void TLargeBlocks::AddDeletionMarker(TDeletionMarker deletionMarker)
+{
+    Y_UNUSED(deletionMarker);
+    // TODO
+}
+
+void TLargeBlocks::ApplyDeletionMarkers(TVector<TBlock>& blocks) const
+{
+    Y_UNUSED(blocks);
+    // TODO
+}
+
+void TLargeBlocks::ApplyAndUpdateDeletionMarkers(TVector<TBlock>& blocks)
+{
+    Y_UNUSED(blocks);
+    // TODO
+}
+
+TVector<TDeletionMarker> TLargeBlocks::ExtractProcessedDeletionMarkers()
+{
+    // TODO
+    return {};
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -149,6 +149,22 @@ void TLargeBlocks::ApplyAndUpdateDeletionMarkers(TVector<TBlock>& blocks)
     Impl->Apply(blocks, true);
 }
 
+TDeletionMarker TLargeBlocks::GetOne() const
+{
+    const TDeletionMarker invalid(0, InvalidCommitId, 0, 0);
+    if (Impl->NodeId2Markers.empty()) {
+        return invalid;
+    }
+
+    const auto& markers = Impl->NodeId2Markers.begin()->second;
+    Y_DEBUG_ABORT_UNLESS(!markers.empty());
+    if (markers.empty()) {
+        return invalid;
+    }
+
+    return markers.begin()->Marker;
+}
+
 TVector<TDeletionMarker> TLargeBlocks::ExtractProcessedDeletionMarkers()
 {
     auto res = std::move(Impl->ProcessedMarkers);

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.h
@@ -25,7 +25,8 @@ public:
     void AddDeletionMarker(TDeletionMarker deletionMarker);
 
     // applies the deletion markers to the provided blocks
-    void ApplyDeletionMarkers(TVector<TBlock>& blocks) const;
+    // returns true if at least one of the blocks was affected
+    bool ApplyDeletionMarkers(TVector<TBlock>& blocks) const;
     // marks the corresponding parts of the stored deletion markers as processed
     void MarkProcessed(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.h
@@ -26,16 +26,27 @@ public:
 
     // applies the deletion markers to the provided blocks
     void ApplyDeletionMarkers(TVector<TBlock>& blocks) const;
-    // applies the deletion markers to the provided blocks AND marks the
-    // corresponding parts of the deletion markers as processed
-    void ApplyAndUpdateDeletionMarkers(TVector<TBlock>& blocks);
+    // marks the corresponding parts of the stored deletion markers as processed
+    void MarkProcessed(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount);
 
     // returns one of the deletion markers which haven't been fully processed
-    // yet - no assumptions should be made regarding which marker it is
+    // yet
     TDeletionMarker GetOne() const;
     // returns deletion markers which are not needed anymore and can be safely
     // deleted
     TVector<TDeletionMarker> ExtractProcessedDeletionMarkers();
+
+    // iterates the deletion subset that satisfies the provided filters
+    void FindBlocks(
+        ILargeBlockVisitor& visitor,
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount) const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "public.h"
+
+#include "block.h"
+#include "deletion_markers.h"
+
+#include <util/generic/vector.h>
+#include <util/memory/alloc.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLargeBlocks
+{
+private:
+    struct TImpl;
+    std::unique_ptr<TImpl> Impl;
+
+public:
+    explicit TLargeBlocks(IAllocator* allocator);
+    ~TLargeBlocks();
+
+    void AddDeletionMarker(TDeletionMarker deletionMarker);
+
+    void ApplyDeletionMarkers(TVector<TBlock>& blocks) const;
+    void ApplyAndUpdateDeletionMarkers(TVector<TBlock>& blocks);
+
+    TVector<TDeletionMarker> ExtractProcessedDeletionMarkers();
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.h
@@ -24,9 +24,17 @@ public:
 
     void AddDeletionMarker(TDeletionMarker deletionMarker);
 
+    // applies the deletion markers to the provided blocks
     void ApplyDeletionMarkers(TVector<TBlock>& blocks) const;
+    // applies the deletion markers to the provided blocks AND marks the
+    // corresponding parts of the deletion markers as processed
     void ApplyAndUpdateDeletionMarkers(TVector<TBlock>& blocks);
 
+    // returns one of the deletion markers which haven't been fully processed
+    // yet - no assumptions should be made regarding which marker it is
+    TDeletionMarker GetOne() const;
+    // returns deletion markers which are not needed anymore and can be safely
+    // deleted
     TVector<TDeletionMarker> ExtractProcessedDeletionMarkers();
 };
 

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks_ut.cpp
@@ -1,0 +1,110 @@
+#include "large_blocks.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+#include <util/generic/vector.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLargeBlocksTest)
+{
+    Y_UNIT_TEST(ShouldTrackDeletionMarkers)
+    {
+        const ui64 nodeId1 = 111;
+
+        const ui64 l = 1_GB / 4_KB;
+        const ui64 rem = 128_MB / 4_KB;
+        const ui32 blobBlocks = 4_MB / 4_KB;
+
+        TLargeBlocks lb(TDefaultAllocator::Instance());
+
+        ui64 commitId = 1;
+        TVector<TVector<TBlock>> blobs;
+        ui64 blockIndex = 0;
+        while (blockIndex < 2 * l + rem) {
+            ++commitId;
+            auto& blob = blobs.emplace_back();
+            for (ui32 i = 0; i < blobBlocks; ++i) {
+                blob.emplace_back(
+                    nodeId1,
+                    blockIndex++,
+                    commitId,
+                    InvalidCommitId);
+            }
+        }
+
+        lb.AddDeletionMarker({nodeId1, ++commitId, 0, l});
+        lb.AddDeletionMarker({nodeId1, commitId, l, l});
+        lb.AddDeletionMarker({nodeId1, commitId, 2 * l, rem});
+
+        lb.ApplyDeletionMarkers(blobs[0]);
+        for (auto& block: blobs[0]) {
+            UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
+            block.MaxCommitId = InvalidCommitId;
+        }
+
+        auto processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
+
+        for (ui32 i = 0; i < l / blobBlocks; ++i) {
+            lb.ApplyDeletionMarkers(blobs[i]);
+            for (auto& block: blobs[i]) {
+                UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
+                block.MaxCommitId = InvalidCommitId;
+            }
+        }
+
+        processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
+
+        lb.ApplyAndUpdateDeletionMarkers(blobs[0]);
+        for (const auto& block: blobs[0]) {
+            UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
+        }
+
+        for (ui32 i = 0; i < l / blobBlocks; ++i) {
+            processed = lb.ExtractProcessedDeletionMarkers();
+            UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
+            lb.ApplyAndUpdateDeletionMarkers(blobs[i]);
+            for (const auto& block: blobs[i]) {
+                UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
+            }
+        }
+
+        processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(1, processed.size());
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, processed[0].NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(0, processed[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, processed[0].BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(commitId, processed[0].CommitId);
+
+        for (ui32 i = l / blobBlocks; i < (2 * l + rem) / blobBlocks; ++i) {
+            lb.ApplyAndUpdateDeletionMarkers(blobs[i]);
+            for (const auto& block: blobs[i]) {
+                UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
+            }
+        }
+
+        processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(2, processed.size());
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, processed[0].NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(l, processed[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, processed[0].BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(commitId, processed[0].CommitId);
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, processed[1].NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(2 * l, processed[1].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(rem, processed[1].BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(commitId, processed[1].CommitId);
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks_ut.cpp
@@ -15,9 +15,9 @@ struct TVisitor: ILargeBlockVisitor
 {
     TVector<TBlockDeletion> Deletions;
 
-    void Accept(const TBlockDeletion& block) override
+    void Accept(const TBlockDeletion& deletion) override
     {
-        Deletions.push_back(block);
+        Deletions.push_back(deletion);
     }
 };
 
@@ -65,17 +65,21 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         UNIT_ASSERT_VALUES_EQUAL(commitId, one.CommitId);
 
         // simulating writes
-        lb.ApplyDeletionMarkers(blobs[0]);
+        UNIT_ASSERT(lb.ApplyDeletionMarkers(blobs[0]));
         for (auto& block: blobs[0]) {
             UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
-            block.MaxCommitId = InvalidCommitId;
         }
 
         auto processed = lb.ExtractProcessedDeletionMarkers();
         UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
 
         for (ui32 i = 0; i < l / blobBlocks; ++i) {
-            lb.ApplyDeletionMarkers(blobs[i]);
+            const bool affected = lb.ApplyDeletionMarkers(blobs[i]);
+            if (i) {
+                UNIT_ASSERT(affected);
+            } else {
+                UNIT_ASSERT(!affected);
+            }
             for (auto& block: blobs[i]) {
                 UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
                 block.MaxCommitId = InvalidCommitId;
@@ -119,7 +123,7 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
 
         // simulating Cleanup ops
-        lb.ApplyDeletionMarkers(blobs[0]);
+        UNIT_ASSERT(lb.ApplyDeletionMarkers(blobs[0]));
         for (const auto& block: blobs[0]) {
             UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
         }
@@ -128,7 +132,12 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         for (ui32 i = 0; i < l / blobBlocks; ++i) {
             processed = lb.ExtractProcessedDeletionMarkers();
             UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
-            lb.ApplyDeletionMarkers(blobs[i]);
+            const bool affected = lb.ApplyDeletionMarkers(blobs[i]);
+            if (i) {
+                UNIT_ASSERT(affected);
+            } else {
+                UNIT_ASSERT(!affected);
+            }
             for (const auto& block: blobs[i]) {
                 UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
             }
@@ -154,7 +163,7 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         UNIT_ASSERT_VALUES_EQUAL(commitId, one.CommitId);
 
         for (ui32 i = l / blobBlocks; i < (2 * l + rem) / blobBlocks; ++i) {
-            lb.ApplyDeletionMarkers(blobs[i]);
+            UNIT_ASSERT(lb.ApplyDeletionMarkers(blobs[i]));
             for (const auto& block: blobs[i]) {
                 UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
             }
@@ -182,6 +191,109 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
 
         one = lb.GetOne();
         UNIT_ASSERT(!one.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldWorkWithCommitIdsAndNodeIdsProperly)
+    {
+        const ui64 nodeId1 = 111;
+        const ui64 nodeId2 = 222;
+
+        const ui64 l = 1_GB / 4_KB;
+
+        TLargeBlocks lb(TDefaultAllocator::Instance());
+
+        TVector<TBlock> blocks{
+            {nodeId1, 1024, 10001, InvalidCommitId},
+            {nodeId1, 1025, 10005, InvalidCommitId},
+            {nodeId1, 1026, 10007, InvalidCommitId},
+            {nodeId1, 1027, 10006, InvalidCommitId},
+            {nodeId1, 1060, 10008, InvalidCommitId},
+            {nodeId2, 10240, 10002, InvalidCommitId},
+            {nodeId2, 10241, 10002, InvalidCommitId},
+            {nodeId2, 10242, 10012, InvalidCommitId},
+        };
+
+        // simulating large truncate ops
+        lb.AddDeletionMarker({nodeId1, 10002, 100, l});
+        lb.AddDeletionMarker({nodeId1, 10007, 1026, l});
+
+        auto one = lb.GetOne();
+        UNIT_ASSERT(one.IsValid());
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, one.NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(100, one.BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, one.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(10002, one.CommitId);
+
+        // simulating writes
+        UNIT_ASSERT(lb.ApplyDeletionMarkers(blocks));
+        // affected by marker1
+        UNIT_ASSERT_VALUES_EQUAL(10002, blocks[0].MaxCommitId);
+        // not affected by marker1 due to marker commitId not being newer than
+        // block commitId
+        // not affected by marker2 due to non-overlapping ranges
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocks[1].MaxCommitId);
+        // not affected by marker1 and marker2 due to marker commitId not being
+        // newer than block commitId
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocks[2].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(10007, blocks[3].MaxCommitId);
+        // not affected by marker1 and marker2 due to marker commitId not being
+        // newer than block commitId
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocks[4].MaxCommitId);
+        // the following 3 are not affected because there are no markers for
+        // nodeId2
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocks[5].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocks[6].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocks[7].MaxCommitId);
+
+        UNIT_ASSERT(!lb.ApplyDeletionMarkers(blocks));
+
+        auto processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
+
+        // simulating reads
+        TVisitor visitor;
+        ui32 visitIndex = 10000;
+        lb.AddDeletionMarker({nodeId2, 10003, visitIndex, l});
+        lb.FindBlocks(visitor, nodeId2, 10002, visitIndex, 241);
+        UNIT_ASSERT_VALUES_EQUAL(0, visitor.Deletions.size());
+        lb.FindBlocks(visitor, nodeId2, 10003, visitIndex, 241);
+        UNIT_ASSERT_VALUES_EQUAL(241, visitor.Deletions.size());
+        for (ui32 i = 0; i < visitor.Deletions.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                visitIndex + i,
+                visitor.Deletions[i].BlockIndex);
+            UNIT_ASSERT_VALUES_EQUAL(10003, visitor.Deletions[i].CommitId);
+            UNIT_ASSERT_VALUES_EQUAL(nodeId2, visitor.Deletions[i].NodeId);
+        }
+
+        for (auto& block: blocks) {
+            block.MaxCommitId = InvalidCommitId;
+        }
+
+        // simulating Cleanup ops
+        lb.MarkProcessed(nodeId1, 10009, 100, 1024);
+
+        processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(0, processed.size());
+
+        lb.MarkProcessed(nodeId1, 10009, 1124, 100 + l - 1124);
+
+        processed = lb.ExtractProcessedDeletionMarkers();
+        UNIT_ASSERT_VALUES_EQUAL(1, processed.size());
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, processed[0].NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(100, processed[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, processed[0].BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(10002, processed[0].CommitId);
+
+        one = lb.GetOne();
+        UNIT_ASSERT(one.IsValid());
+        // TLargeBlocks::TImpl contains a THashMap for NodeIds inside it so
+        // actually it's not guaranteed that nodeId2 deletion marker will be
+        // returned (and not nodeId1 deletion marker)
+        UNIT_ASSERT_VALUES_EQUAL(nodeId2, one.NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(visitIndex, one.BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, one.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(10003, one.CommitId);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks_ut.cpp
@@ -46,6 +46,13 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         lb.AddDeletionMarker({nodeId1, commitId, l, l});
         lb.AddDeletionMarker({nodeId1, commitId, 2 * l, rem});
 
+        auto one = lb.GetOne();
+        UNIT_ASSERT(one.IsValid());
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, one.NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(0, one.BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, one.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(commitId, one.CommitId);
+
         lb.ApplyDeletionMarkers(blobs[0]);
         for (auto& block: blobs[0]) {
             UNIT_ASSERT_VALUES_EQUAL(commitId, block.MaxCommitId);
@@ -87,6 +94,13 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         UNIT_ASSERT_VALUES_EQUAL(l, processed[0].BlockCount);
         UNIT_ASSERT_VALUES_EQUAL(commitId, processed[0].CommitId);
 
+        one = lb.GetOne();
+        UNIT_ASSERT(one.IsValid());
+        UNIT_ASSERT_VALUES_EQUAL(nodeId1, one.NodeId);
+        UNIT_ASSERT_VALUES_EQUAL(l, one.BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(l, one.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(commitId, one.CommitId);
+
         for (ui32 i = l / blobBlocks; i < (2 * l + rem) / blobBlocks; ++i) {
             lb.ApplyAndUpdateDeletionMarkers(blobs[i]);
             for (const auto& block: blobs[i]) {
@@ -104,6 +118,9 @@ Y_UNIT_TEST_SUITE(TLargeBlocksTest)
         UNIT_ASSERT_VALUES_EQUAL(2 * l, processed[1].BlockIndex);
         UNIT_ASSERT_VALUES_EQUAL(rem, processed[1].BlockCount);
         UNIT_ASSERT_VALUES_EQUAL(commitId, processed[1].CommitId);
+
+        one = lb.GetOne();
+        UNIT_ASSERT(!one.IsValid());
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.cpp
@@ -272,7 +272,9 @@ void TMixedBlocks::ApplyDeletionMarkers(
     range->DeletionMarkers.Apply(MakeArrayRef(blocks));
 }
 
-TVector<TMixedBlobMeta> TMixedBlocks::ApplyDeletionMarkers(ui32 rangeId) const
+TVector<TMixedBlobMeta> TMixedBlocks::ApplyDeletionMarkers(
+    ui32 rangeId,
+    bool returnAll) const
 {
     const auto* range = Impl->Ranges.FindPtr(rangeId);
     Y_ABORT_UNLESS(range);
@@ -282,7 +284,9 @@ TVector<TMixedBlobMeta> TMixedBlocks::ApplyDeletionMarkers(ui32 rangeId) const
     for (const auto& blob: range->Blobs) {
         auto blocks = blob.BlockList.DecodeBlocks();
 
-        if (range->DeletionMarkers.Apply(MakeArrayRef(blocks)) > 0) {
+        if (range->DeletionMarkers.Apply(MakeArrayRef(blocks)) > 0
+                || returnAll)
+        {
             result.emplace_back(blob.BlobId, std::move(blocks));
         }
     }

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -56,6 +56,9 @@ public:
         const IBlockLocation2RangeIndex& hasher,
         TVector<TBlock>& blocks) const;
 
+    // returnAll flag causes this function to return metas for all the blobs
+    // that are indexed in this range - not just the blobs that are affected by
+    // the applied markers
     TVector<TMixedBlobMeta> ApplyDeletionMarkers(
         ui32 rangeId,
         bool returnAll) const;

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -56,7 +56,9 @@ public:
         const IBlockLocation2RangeIndex& hasher,
         TVector<TBlock>& blocks) const;
 
-    TVector<TMixedBlobMeta> ApplyDeletionMarkers(ui32 rangeId) const;
+    TVector<TMixedBlobMeta> ApplyDeletionMarkers(
+        ui32 rangeId,
+        bool returnAll) const;
 
     TVector<TMixedBlobMeta> GetBlobsForCompaction(ui32 rangeId) const;
 

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -26,7 +26,7 @@ public:
 
     bool IsLoaded(ui32 rangeId) const;
 
-    void RefRange(ui32 ragneId);
+    void RefRange(ui32 rangeId);
     void UnRefRange(ui32 rangeId);
 
     bool AddBlocks(

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -56,12 +56,17 @@ public:
         const IBlockLocation2RangeIndex& hasher,
         TVector<TBlock>& blocks) const;
 
-    // returnAll flag causes this function to return metas for all the blobs
-    // that are indexed in this range - not just the blobs that are affected by
-    // the applied markers
-    TVector<TMixedBlobMeta> ApplyDeletionMarkers(
-        ui32 rangeId,
-        bool returnAll) const;
+    TVector<TMixedBlobMeta> ApplyDeletionMarkers(ui32 rangeId) const;
+
+    struct TDeletionMarkerApplicationResult
+    {
+        TMixedBlobMeta BlobMeta;
+        bool Affected = false;
+    };
+
+    // returns metas for all blobs belonging to this range
+    TVector<TDeletionMarkerApplicationResult> ApplyDeletionMarkersAndGetMetas(
+        ui32 rangeId) const;
 
     TVector<TMixedBlobMeta> GetBlobsForCompaction(ui32 rangeId) const;
 

--- a/cloud/filestore/libs/storage/tablet/model/sparse_segment.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/sparse_segment.cpp
@@ -1,0 +1,35 @@
+#include "sparse_segment.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSparseSegment::TSparseSegment(IAllocator* alloc, ui64 start, ui64 end)
+    : Ranges(alloc)
+{
+    Ranges.emplace(TRange{start, end});
+}
+
+void TSparseSegment::PunchHole(ui64 start, ui64 end)
+{
+    auto lo = Ranges.upper_bound(start);
+    auto hi = Ranges.upper_bound(end);
+    TRange newLo;
+    if (lo != Ranges.end() && lo->Start < start) {
+        newLo = {lo->Start, start};
+    }
+
+    if (hi != Ranges.end() && hi->Start < end) {
+        const_cast<TRange&>(*hi).Start = end;
+    }
+
+    while (lo != hi) {
+        lo = Ranges.erase(lo);
+    }
+
+    if (newLo.Start < newLo.End) {
+        Ranges.emplace(newLo);
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/sparse_segment.h
+++ b/cloud/filestore/libs/storage/tablet/model/sparse_segment.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/alloc.h>
+
+#include <util/generic/set.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSparseSegment
+{
+private:
+    struct TRange
+    {
+        ui64 Start = 0;
+        ui64 End = 0;
+    };
+
+    struct TRangeLess
+    {
+        using is_transparent = void;
+
+        bool operator()(const auto& lhs, const auto& rhs) const
+        {
+            return GetEnd(lhs) < GetEnd(rhs);
+        }
+
+        static ui64 GetEnd(const TRange& r)
+        {
+            return r.End;
+        }
+
+        static ui64 GetEnd(ui64 end)
+        {
+            return end;
+        }
+    };
+
+    TSet<TRange, TRangeLess, TStlAllocator> Ranges;
+
+public:
+    TSparseSegment(IAllocator* alloc, ui64 start, ui64 end);
+
+public:
+    void PunchHole(ui64 start, ui64 end);
+    bool Empty() const
+    {
+        return Ranges.empty();
+    }
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/sparse_segment_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/sparse_segment_ut.cpp
@@ -1,0 +1,52 @@
+#include "sparse_segment.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TSparseSegmentTest)
+{
+    Y_UNIT_TEST(ShouldPunchHoles)
+    {
+        TSparseSegment segment(TDefaultAllocator::Instance(), 0, 100);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(10, 20);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(5, 15);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(30, 75);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(75, 99);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(20, 30);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(99, 100);
+        UNIT_ASSERT(!segment.Empty());
+        segment.PunchHole(0, 5);
+        UNIT_ASSERT(segment.Empty());
+        segment.PunchHole(0, 111);
+        UNIT_ASSERT(segment.Empty());
+
+        TSparseSegment segment2(TDefaultAllocator::Instance(), 100, 200);
+        UNIT_ASSERT(!segment2.Empty());
+        segment2.PunchHole(95, 222);
+        UNIT_ASSERT(segment2.Empty());
+
+        TSparseSegment segment3(TDefaultAllocator::Instance(), 100, 200);
+        UNIT_ASSERT(!segment3.Empty());
+        segment3.PunchHole(100, 120);
+        UNIT_ASSERT(!segment3.Empty());
+        segment3.PunchHole(120, 140);
+        UNIT_ASSERT(!segment3.Empty());
+        segment3.PunchHole(140, 160);
+        UNIT_ASSERT(!segment3.Empty());
+        segment3.PunchHole(160, 180);
+        UNIT_ASSERT(!segment3.Empty());
+        segment3.PunchHole(180, 200);
+        UNIT_ASSERT(segment3.Empty());
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ut/ya.make
@@ -17,6 +17,7 @@ SRCS(
     operation_ut.cpp
     range_locks_ut.cpp
     read_ahead_ut.cpp
+    sparse_segment_ut.cpp
     split_range_ut.cpp
     throttling_policy_ut.cpp
 )

--- a/cloud/filestore/libs/storage/tablet/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ut/ya.make
@@ -10,6 +10,7 @@ SRCS(
     fresh_blocks_ut.cpp
     fresh_bytes_ut.cpp
     garbage_queue_ut.cpp
+    large_blocks_ut.cpp
     mixed_blocks_ut.cpp
     node_index_cache_ut.cpp
     node_session_stat_ut.cpp

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -23,6 +23,7 @@ SRCS(
     fresh_bytes.cpp
     garbage_queue.cpp
     group_by.cpp
+    large_blocks.cpp
     mixed_blocks.cpp
     node_index_cache.cpp
     node_session_stat.cpp

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -30,6 +30,7 @@ SRCS(
     operation.cpp
     range_locks.cpp
     read_ahead.cpp
+    sparse_segment.cpp
     split_range.cpp
     throttler_logger.cpp
     throttling_policy.cpp

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -76,6 +76,7 @@ message TFileSystemStats
     uint64 FreshBytesCount = 209;
     uint64 AttrsUsedBytesCount = 210;
     uint64 DeletedFreshBytesCount = 211;
+    uint64 LargeDeletionMarkersCount = 212;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -329,7 +329,8 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
     const TRequest& request,
     const TByteRange& range)
 {
-    if (auto error = ValidateRange(range); HasError(error)) {
+    auto error = ValidateRange(range, Config->GetMaxFileBlocks());
+    if (HasError(error)) {
         return error;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -461,6 +461,7 @@ TCompactionInfo TIndexTabletActor::GetCompactionInfo() const
 
 TCleanupInfo TIndexTabletActor::GetCleanupInfo() const
 {
+    // TODO: take LargeDeletionMarkers into account
     auto [cleanupRangeId, cleanupScore] = GetRangeToCleanup();
     const auto& stats = GetFileSystemStats();
     const auto compactionStats = GetCompactionMapStats(0);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -473,8 +473,8 @@ TCleanupInfo TIndexTabletActor::GetCleanupInfo() const
         avgCleanupScore >= Config->GetCleanupThresholdAverage();
     bool isPriority = false;
 
-    if (auto priorityRangeId = NextPriorityRangeIdForCleanup()) {
-        cleanupRangeId = *priorityRangeId;
+    if (auto priorityRange = NextPriorityRangeForCleanup()) {
+        cleanupRangeId = priorityRange->RangeId;
         cleanupScore = Max<ui32>();
         isPriority = true;
     }
@@ -487,7 +487,7 @@ TCleanupInfo TIndexTabletActor::GetCleanupInfo() const
         avgCleanupScore,
         Config->GetLargeDeletionMarkersThreshold(),
         GetLargeDeletionMarkersCount(),
-        GetPriorityRangeIdCount(),
+        GetPriorityRangeCount(),
         isPriority,
         Config->GetNewCleanupEnabled(),
         cleanupScore >= Config->GetCleanupThreshold()

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -114,6 +114,7 @@ private:
         std::atomic<i64> MixedBytesCount{0};
         std::atomic<i64> MixedBlobsCount{0};
         std::atomic<i64> DeletionMarkersCount{0};
+        std::atomic<i64> LargeDeletionMarkersCount{0};
         std::atomic<i64> GarbageQueueSize{0};
         std::atomic<i64> GarbageBytesCount{0};
         std::atomic<i64> FreshBlocksCount{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -199,9 +199,6 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
         if (args.CommitId == InvalidCommitId) {
             return RebootTabletOnCommitOverflow(ctx, "AllocateData");
         }
-        // TODO: We should not use this range request because tx size
-        // is limited. Need some generic process range mechanism after
-        // NBS-2979
         ZeroRange(
             db,
             args.NodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -102,7 +102,7 @@ void TIndexTabletActor::ExecuteTx_Cleanup(
     TIndexTabletDatabase db(tx.DB);
 
     args.ProcessedDeletionMarkerCount =
-        CleanupMixedBlockDeletions(db, args.RangeId, args.ProfileLogRequest);
+        CleanupBlockDeletions(db, args.RangeId, args.ProfileLogRequest);
 }
 
 void TIndexTabletActor::CompleteTx_Cleanup(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -56,9 +56,13 @@ void TIndexTabletActor::HandleCleanup(
     }
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s Cleanup started (range: #%u)",
+        "%s Cleanup started (range: #%u, priority queue size: %u"
+        ", large marker count: %lu / large cleanup threshold: %lu)",
         LogTag.c_str(),
-        msg->RangeId);
+        msg->RangeId,
+        GetPriorityRangeCount(),
+        GetLargeDeletionMarkersCount(),
+        Config->GetLargeDeletionMarkersCleanupThreshold());
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -285,6 +285,9 @@ void TIndexTabletActor::TMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(MixedBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(MixedBlobsCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(DeletionMarkersCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        LargeDeletionMarkersCount,
+        EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(GarbageQueueSize, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(GarbageBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(FreshBlocksCount, EMetricType::MT_ABSOLUTE);
@@ -407,6 +410,7 @@ void TIndexTabletActor::TMetrics::Update(
     Store(MixedBytesCount, stats.GetMixedBlocksCount() * blockSize);
     Store(MixedBlobsCount, stats.GetMixedBlobsCount());
     Store(DeletionMarkersCount, stats.GetDeletionMarkersCount());
+    Store(LargeDeletionMarkersCount, stats.GetLargeDeletionMarkersCount());
     Store(GarbageQueueSize, stats.GetGarbageQueueSize());
     Store(GarbageBytesCount, stats.GetGarbageBlocksCount() * blockSize);
     Store(FreshBlocksCount, stats.GetFreshBlocksCount());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -25,6 +25,7 @@ namespace {
 class TReadBlockVisitor final
     : public IFreshBlockVisitor
     , public IMixedBlockVisitor
+    , public ILargeBlockVisitor
     , public IFreshBytesVisitor
 {
 private:
@@ -69,6 +70,15 @@ public:
             ref.BlobId = blobId;
             ref.BlobOffset = blobOffset;
             Block.Block = std::move(ref);
+        }
+    }
+
+    void Accept(const TBlockDeletion& block) override
+    {
+        TABLET_VERIFY(!ApplyingByteLayer);
+
+        if (BlockMinCommitId < block.CommitId) {
+            Block = {};
         }
     }
 
@@ -712,6 +722,13 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
             1);
 
         FindMixedBlocks(
+            visitor,
+            bytes.NodeId,
+            args.ReadCommitId,
+            blockIndex,
+            1);
+
+        FindLargeBlocks(
             visitor,
             bytes.NodeId,
             args.ReadCommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -73,11 +73,11 @@ public:
         }
     }
 
-    void Accept(const TBlockDeletion& block) override
+    void Accept(const TBlockDeletion& deletion) override
     {
         TABLET_VERIFY(!ApplyingByteLayer);
 
-        if (BlockMinCommitId < block.CommitId) {
+        if (BlockMinCommitId < deletion.CommitId) {
             Block = {};
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -93,7 +93,6 @@ bool TIndexTabletActor::PrepareTx_LoadState(
 
     TIndexTabletDatabase db(tx.DB);
 
-    // TODO: load LargeBlocks
     std::initializer_list<bool> results = {
         db.ReadFileSystem(args.FileSystem),
         db.ReadFileSystemStats(args.FileSystemStats),
@@ -111,7 +110,8 @@ bool TIndexTabletActor::PrepareTx_LoadState(
         db.ReadTruncateQueue(args.TruncateQueue),
         db.ReadStorageConfig(args.StorageConfig),
         db.ReadSessionHistoryEntries(args.SessionHistory),
-        db.ReadOpLog(args.OpLog)
+        db.ReadOpLog(args.OpLog),
+        db.ReadLargeDeletionMarkers(args.LargeDeletionMarkers),
     };
 
     bool ready = std::accumulate(
@@ -231,6 +231,9 @@ void TIndexTabletActor::CompleteTx_LoadState(
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Initializing tablet state");
+    LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+        LogTag << " Read " << args.LargeDeletionMarkers.size()
+        << " large deletion markers");
 
     LoadState(
         Executor()->Generation(),
@@ -238,6 +241,7 @@ void TIndexTabletActor::CompleteTx_LoadState(
         args.FileSystem,
         args.FileSystemStats,
         args.TabletStorageInfo,
+        args.LargeDeletionMarkers,
         config);
     UpdateLogTag();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -93,6 +93,7 @@ bool TIndexTabletActor::PrepareTx_LoadState(
 
     TIndexTabletDatabase db(tx.DB);
 
+    // TODO: load LargeBlocks
     std::initializer_list<bool> results = {
         db.ReadFileSystem(args.FileSystem),
         db.ReadFileSystemStats(args.FileSystemStats),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1103,6 +1103,10 @@ void TIndexTabletActor::HandleHttpInfo_Default(
             DUMP_INFO_FIELD(cleanupInfo, Score);
             DUMP_INFO_FIELD(cleanupInfo, RangeId);
             DUMP_INFO_FIELD(cleanupInfo, AverageScore);
+            DUMP_INFO_FIELD(cleanupInfo, LargeDeletionMarkersThreshold);
+            DUMP_INFO_FIELD(cleanupInfo, LargeDeletionMarkerCount);
+            DUMP_INFO_FIELD(cleanupInfo, PriorityRangeIdCount);
+            DUMP_INFO_FIELD(cleanupInfo, IsPriority);
             DUMP_INFO_FIELD(cleanupInfo, NewCleanupEnabled);
             DUMP_INFO_FIELD(cleanupInfo, ShouldCleanup);
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -234,15 +234,15 @@ public:
         }
     }
 
-    void Accept(const TBlockDeletion& block) override
+    void Accept(const TBlockDeletion& deletion) override
     {
         TABLET_VERIFY(!ApplyingByteLayer);
 
-        ui32 blockOffset = block.BlockIndex - Args.ActualRange().FirstBlock();
+        ui32 blockOffset = deletion.BlockIndex - Args.ActualRange().FirstBlock();
         TABLET_VERIFY(blockOffset < Args.ActualRange().BlockCount());
 
         auto& prev = Args.Blocks[blockOffset];
-        if (prev.MinCommitId < block.CommitId) {
+        if (prev.MinCommitId < deletion.CommitId) {
             prev = {};
             Args.Buffer->ClearBlock(blockOffset);
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -15,17 +15,19 @@ namespace {
 
 NProto::TError ValidateRequest(
     const NProto::TSetNodeAttrRequest& request,
-    ui32 blockSize)
+    ui32 blockSize,
+    ui32 maxFileBlocks)
 {
     if (request.GetNodeId() == InvalidNodeId || request.GetFlags() == 0) {
         return ErrorInvalidArgument();
     }
 
-    if (HasFlag(request.GetFlags(), NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE) &&
+    const auto setSize = NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE;
+    if (HasFlag(request.GetFlags(), setSize) &&
         request.GetUpdate().GetSize() > 0)
     {
         TByteRange range(0, request.GetUpdate().GetSize(), blockSize);
-        if (range.BlockCount() > MaxFileBlocks) {
+        if (range.BlockCount() > maxFileBlocks) {
             return ErrorFileTooBig();
         }
     }
@@ -57,7 +59,10 @@ void TIndexTabletActor::HandleSetNodeAttr(
     }
 
     auto validator = [&] (const NProto::TSetNodeAttrRequest& request) {
-        return ValidateRequest(request, GetBlockSize());
+        return ValidateRequest(
+            request,
+            GetBlockSize(),
+            Config->GetMaxFileBlocks());
     };
 
     if (!AcceptRequest<TEvService::TSetNodeAttrMethod>(ev, ctx, validator)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -455,6 +455,7 @@ void TIndexTabletActor::CompleteTx_UnlinkNode(
     }
 
     RemoveTransaction(*args.RequestInfo);
+    EnqueueBlobIndexOpIfNeeded(ctx);
 
     auto response =
         std::make_unique<TEvService::TEvUnlinkNodeResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -21,18 +21,19 @@ namespace NCloud::NFileStore::NStorage {
     xxx(UsedLocksCount,         __VA_ARGS__)                                   \
     xxx(UsedBlocksCount,        __VA_ARGS__)                                   \
                                                                                \
-    xxx(FreshBlocksCount,       __VA_ARGS__)                                   \
-    xxx(MixedBlocksCount,       __VA_ARGS__)                                   \
-    xxx(MixedBlobsCount,        __VA_ARGS__)                                   \
-    xxx(DeletionMarkersCount,   __VA_ARGS__)                                   \
-    xxx(GarbageQueueSize,       __VA_ARGS__)                                   \
-    xxx(GarbageBlocksCount,     __VA_ARGS__)                                   \
-    xxx(CheckpointNodesCount,   __VA_ARGS__)                                   \
-    xxx(CheckpointBlocksCount,  __VA_ARGS__)                                   \
-    xxx(CheckpointBlobsCount,   __VA_ARGS__)                                   \
-    xxx(FreshBytesCount,        __VA_ARGS__)                                   \
-    xxx(DeletedFreshBytesCount, __VA_ARGS__)                                   \
-    xxx(LastCollectCommitId,    __VA_ARGS__)                                   \
+    xxx(FreshBlocksCount,           __VA_ARGS__)                               \
+    xxx(MixedBlocksCount,           __VA_ARGS__)                               \
+    xxx(MixedBlobsCount,            __VA_ARGS__)                               \
+    xxx(DeletionMarkersCount,       __VA_ARGS__)                               \
+    xxx(GarbageQueueSize,           __VA_ARGS__)                               \
+    xxx(GarbageBlocksCount,         __VA_ARGS__)                               \
+    xxx(CheckpointNodesCount,       __VA_ARGS__)                               \
+    xxx(CheckpointBlocksCount,      __VA_ARGS__)                               \
+    xxx(CheckpointBlobsCount,       __VA_ARGS__)                               \
+    xxx(FreshBytesCount,            __VA_ARGS__)                               \
+    xxx(DeletedFreshBytesCount,     __VA_ARGS__)                               \
+    xxx(LastCollectCommitId,        __VA_ARGS__)                               \
+    xxx(LargeDeletionMarkersCount,  __VA_ARGS__)                               \
 // FILESTORE_TABLET_STATS
 
 #define FILESTORE_TABLET_SIMPLE_COUNTERS(xxx)                                  \

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -37,18 +37,19 @@ namespace NCloud::NFileStore::NStorage {
     xxx(UsedLocksCount,         __VA_ARGS__)                                   \
     xxx(UsedBlocksCount,        __VA_ARGS__)                                   \
                                                                                \
-    xxx(FreshBlocksCount,       __VA_ARGS__)                                   \
-    xxx(MixedBlocksCount,       __VA_ARGS__)                                   \
-    xxx(MixedBlobsCount,        __VA_ARGS__)                                   \
-    xxx(DeletionMarkersCount,   __VA_ARGS__)                                   \
-    xxx(GarbageQueueSize,       __VA_ARGS__)                                   \
-    xxx(GarbageBlocksCount,     __VA_ARGS__)                                   \
-    xxx(CheckpointNodesCount,   __VA_ARGS__)                                   \
-    xxx(CheckpointBlocksCount,  __VA_ARGS__)                                   \
-    xxx(CheckpointBlobsCount,   __VA_ARGS__)                                   \
-    xxx(FreshBytesCount,        __VA_ARGS__)                                   \
-    xxx(AttrsUsedBytesCount,    __VA_ARGS__)                                   \
-    xxx(DeletedFreshBytesCount, __VA_ARGS__)                                   \
+    xxx(FreshBlocksCount,           __VA_ARGS__)                               \
+    xxx(MixedBlocksCount,           __VA_ARGS__)                               \
+    xxx(MixedBlobsCount,            __VA_ARGS__)                               \
+    xxx(DeletionMarkersCount,       __VA_ARGS__)                               \
+    xxx(GarbageQueueSize,           __VA_ARGS__)                               \
+    xxx(GarbageBlocksCount,         __VA_ARGS__)                               \
+    xxx(CheckpointNodesCount,       __VA_ARGS__)                               \
+    xxx(CheckpointBlocksCount,      __VA_ARGS__)                               \
+    xxx(CheckpointBlobsCount,       __VA_ARGS__)                               \
+    xxx(FreshBytesCount,            __VA_ARGS__)                               \
+    xxx(AttrsUsedBytesCount,        __VA_ARGS__)                               \
+    xxx(DeletedFreshBytesCount,     __VA_ARGS__)                               \
+    xxx(LargeDeletionMarkersCount,  __VA_ARGS__)                               \
 // FILESTORE_FILESYSTEM_STATS
 
 #define FILESTORE_DUPCACHE_REQUESTS(xxx, ...)                                  \
@@ -408,6 +409,23 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     bool ReadDeletionMarkers(
         ui32 rangeId,
         TVector<TDeletionMarker>& deletionMarkers);
+
+    //
+    // LargeDeletionMarkers
+    //
+
+    void WriteLargeDeletionMarkers(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount);
+
+    void DeleteLargeDeletionMarker(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex);
+
+    bool ReadLargeDeletionMarkers(TVector<TDeletionMarker>& deletionMarkers);
 
     //
     // NewBlobs

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -452,6 +452,65 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
                 toString(chunk));
         });
     }
+
+    Y_UNIT_TEST(ShouldStoreLargeDeletionMarkers)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&] (TIndexTabletDatabase db) {
+            db.InitSchema(false);
+        });
+
+        using TEntries = TVector<TDeletionMarker>;
+        TEntries entries = {
+            {1, 100500, 1024, 1024 * 1024},
+            {4, 100501, 20 * 1024 * 1024, 5 * 1024 * 1024},
+            {10, 100502, 100 * 1024 * 1024, 100 * 1024 * 1024},
+        };
+
+        executor.WriteTx([&] (TIndexTabletDatabase db) {
+            for (const auto& entry: entries) {
+                db.WriteLargeDeletionMarkers(
+                    entry.NodeId,
+                    entry.CommitId,
+                    entry.BlockIndex,
+                    entry.BlockCount);
+            }
+        });
+
+        auto toString = [] (const TEntries& v) {
+            TStringBuilder sb;
+            for (ui32 i = 0; i < v.size(); ++i) {
+                if (i) {
+                    sb << " ";
+                }
+                sb << v[i].NodeId
+                    << ",@" << v[i].CommitId
+                    << "," << v[i].BlockIndex
+                    << "," << v[i].BlockCount;
+            }
+            return sb;
+        };
+
+        executor.ReadTx([&] (TIndexTabletDatabase db) {
+            TVector<TDeletionMarker> markers;
+            UNIT_ASSERT(db.ReadLargeDeletionMarkers(markers));
+            UNIT_ASSERT_VALUES_EQUAL(toString(entries), toString(markers));
+        });
+
+        executor.WriteTx([&] (TIndexTabletDatabase db) {
+            db.DeleteLargeDeletionMarker(
+                entries.back().NodeId,
+                entries.back().CommitId,
+                entries.back().BlockIndex);
+            entries.pop_back();
+        });
+
+        executor.ReadTx([&] (TIndexTabletDatabase db) {
+            TVector<TDeletionMarker> markers;
+            UNIT_ASSERT(db.ReadLargeDeletionMarkers(markers));
+            UNIT_ASSERT_VALUES_EQUAL(toString(entries), toString(markers));
+        });
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -59,6 +59,8 @@ struct TIndexTabletSchema
 
         struct DeletedFreshBytesCount
             : Column<24, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct LargeDeletionMarkersCount
+            : Column<25, NKikimr::NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<Id>;
 
@@ -86,7 +88,8 @@ struct TIndexTabletSchema
             UsedBlocksCount,
             AttrsUsedBytesCount,
             StorageConfig,
-            DeletedFreshBytesCount
+            DeletedFreshBytesCount,
+            LargeDeletionMarkersCount
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
@@ -510,6 +513,26 @@ struct TIndexTabletSchema
         using StoragePolicy = TStoragePolicy<IndexChannel>;
     };
 
+    struct LargeDeletionMarkers: TTableSchema<26>
+    {
+        struct NodeId       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct CommitId     : Column<2, NKikimr::NScheme::NTypeIds::Uint64> {};
+        struct BlockIndex   : Column<3, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct BlocksCount  : Column<4, NKikimr::NScheme::NTypeIds::Uint32> {};
+
+        using TKey = TableKey<NodeId, CommitId, BlockIndex>;
+
+        using TColumns = TableColumns<
+            NodeId,
+            CommitId,
+            BlockIndex,
+            BlocksCount
+        >;
+
+        using StoragePolicy = TStoragePolicy<IndexChannel>;
+        using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;
+    };
+
     using TTables = SchemaTables<
         FileSystem,
         Sessions,
@@ -535,7 +558,8 @@ struct TIndexTabletSchema
         TabletStorageInfo,
         TruncateQueue,
         SessionHistory,
-        OpLog
+        OpLog,
+        LargeDeletionMarkers
     >;
 
     using TSettings = SchemaSettings<

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -97,6 +97,10 @@ void TIndexTabletState::LoadState(
     ChannelMinFreeSpace = config.GetChannelMinFreeSpace() / 100.;
     ChannelFreeSpaceThreshold = config.GetChannelFreeSpaceThreshold() / 100.;
 
+    LargeDeletionMarkersEnabled = config.GetLargeDeletionMarkersEnabled();
+    LargeDeletionMarkerBlocks = config.GetLargeDeletionMarkerBlocks();
+    LargeDeletionMarkersThreshold = config.GetLargeDeletionMarkersThreshold();
+
     FileSystem.CopyFrom(fileSystem);
     FileSystemStats.CopyFrom(fileSystemStats);
     TabletStorageInfo.CopyFrom(tabletStorageInfo);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -100,6 +100,8 @@ void TIndexTabletState::LoadState(
     LargeDeletionMarkersEnabled = config.GetLargeDeletionMarkersEnabled();
     LargeDeletionMarkerBlocks = config.GetLargeDeletionMarkerBlocks();
     LargeDeletionMarkersThreshold = config.GetLargeDeletionMarkersThreshold();
+    LargeDeletionMarkersCleanupThreshold =
+        config.GetLargeDeletionMarkersCleanupThreshold();
 
     FileSystem.CopyFrom(fileSystem);
     FileSystemStats.CopyFrom(fileSystemStats);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -82,6 +82,7 @@ void TIndexTabletState::LoadState(
     const NProto::TFileSystem& fileSystem,
     const NProto::TFileSystemStats& fileSystemStats,
     const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
+    const TVector<TDeletionMarker>& largeDeletionMarkers,
     const TThrottlerConfig& throttlerConfig)
 {
     Generation = generation;
@@ -122,6 +123,9 @@ void TIndexTabletState::LoadState(
         config.GetInMemoryIndexCacheNodeAttrsVerCapacity(),
         config.GetInMemoryIndexCacheNodeRefsCapacity(),
         config.GetInMemoryIndexCacheNodeRefsVerCapacity());
+    for (const auto& deletionMarker: largeDeletionMarkers) {
+        Impl->LargeBlocks.AddDeletionMarker(deletionMarker);
+    }
 }
 
 void TIndexTabletState::UpdateConfig(

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -845,7 +845,7 @@ public:
         ui32 blocksCount);
 
     // returns processed deletion marker count
-    ui32 CleanupMixedBlockDeletions(
+    ui32 CleanupBlockDeletions(
         TIndexTabletDatabase& db,
         ui32 rangeId,
         NProto::TProfileLogRequestInfo& profileLogRequest);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -155,6 +155,9 @@ private:
     /*const*/ ui32 SessionHistoryEntryCount = 0;
     /*const*/ double ChannelMinFreeSpace = 0;
     /*const*/ double ChannelFreeSpaceThreshold = 1;
+    /*const*/ bool LargeDeletionMarkersEnabled = false;
+    /*const*/ ui64 LargeDeletionMarkerBlocks = 0;
+    /*const*/ ui64 LargeDeletionMarkersThreshold = 0;
 
     bool StateLoaded = false;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -95,6 +95,10 @@ struct TCleanupInfo
     const ui32 Score;
     const ui32 RangeId;
     const double AverageScore;
+    const ui64 LargeDeletionMarkersThreshold;
+    const ui64 LargeDeletionMarkerCount;
+    const ui32 PriorityRangeIdCount;
+    const bool IsPriority;
     const bool NewCleanupEnabled;
     const bool ShouldCleanup;
 
@@ -104,6 +108,10 @@ struct TCleanupInfo
             ui32 score,
             ui32 rangeId,
             double averageScore,
+            ui64 largeDeletionMarkersThreshold,
+            ui64 largeDeletionMarkerCount,
+            ui32 priorityRangeIdCount,
+            bool isPriority,
             bool newCleanupEnabled,
             bool shouldCleanup)
         : Threshold(threshold)
@@ -111,6 +119,10 @@ struct TCleanupInfo
         , Score(score)
         , RangeId(rangeId)
         , AverageScore(averageScore)
+        , LargeDeletionMarkersThreshold(largeDeletionMarkersThreshold)
+        , LargeDeletionMarkerCount(largeDeletionMarkerCount)
+        , PriorityRangeIdCount(priorityRangeIdCount)
+        , IsPriority(isPriority)
         , NewCleanupEnabled(newCleanupEnabled)
         , ShouldCleanup(shouldCleanup)
     {
@@ -988,6 +1000,9 @@ public:
 
     TBlobIndexOpQueue BlobIndexOps;
 
+private:
+    mutable TDeque<ui32> PriorityRangeIdsForCleanup;
+
     //
     // Compaction map
     //
@@ -998,6 +1013,8 @@ public:
     TCompactionStats GetCompactionStats(ui32 rangeId) const;
     TCompactionCounter GetRangeToCompact() const;
     TCompactionCounter GetRangeToCleanup() const;
+    TMaybe<ui32> NextPriorityRangeIdForCleanup() const;
+    ui32 GetPriorityRangeIdCount() const;
 
     TCompactionMapStats GetCompactionMapStats(ui32 topSize) const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -173,6 +173,7 @@ public:
         const NProto::TFileSystem& fileSystem,
         const NProto::TFileSystemStats& fileSystemStats,
         const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
+        const TVector<TDeletionMarker>& largeDeletionMarkers,
         const TThrottlerConfig& throttlerConfig);
 
     bool IsStateLoaded() const

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -170,6 +170,7 @@ private:
     /*const*/ bool LargeDeletionMarkersEnabled = false;
     /*const*/ ui64 LargeDeletionMarkerBlocks = 0;
     /*const*/ ui64 LargeDeletionMarkersThreshold = 0;
+    /*const*/ ui64 LargeDeletionMarkersCleanupThreshold = 0;
 
     bool StateLoaded = false;
 
@@ -897,6 +898,18 @@ private:
     TRebaseResult RebaseMixedBlocks(TVector<TBlock>& blocks) const;
 
     //
+    // LargeBlocks
+    //
+
+public:
+    void FindLargeBlocks(
+        ILargeBlockVisitor& visitor,
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount) const;
+
+    //
     // Garbage
     //
 
@@ -1000,8 +1013,16 @@ public:
 
     TBlobIndexOpQueue BlobIndexOps;
 
+    struct TPriorityRange
+    {
+        ui64 NodeId = 0;
+        ui32 BlockIndex = 0;
+        ui32 BlockCount = 0;
+        ui32 RangeId = 0;
+    };
+
 private:
-    mutable TDeque<ui32> PriorityRangeIdsForCleanup;
+    mutable TDeque<TPriorityRange> PriorityRangesForCleanup;
 
     //
     // Compaction map
@@ -1013,8 +1034,8 @@ public:
     TCompactionStats GetCompactionStats(ui32 rangeId) const;
     TCompactionCounter GetRangeToCompact() const;
     TCompactionCounter GetRangeToCleanup() const;
-    TMaybe<ui32> NextPriorityRangeIdForCleanup() const;
-    ui32 GetPriorityRangeIdCount() const;
+    TMaybe<TPriorityRange> NextPriorityRangeForCleanup() const;
+    ui32 GetPriorityRangeCount() const;
 
     TCompactionMapStats GetCompactionMapStats(ui32 topSize) const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1193,9 +1193,9 @@ TCompactionCounter TIndexTabletState::GetRangeToCleanup() const
 TMaybe<TIndexTabletState::TPriorityRange>
 TIndexTabletState::NextPriorityRangeForCleanup() const
 {
-    const auto t = LargeDeletionMarkersCleanupThreshold;
     if (PriorityRangesForCleanup.empty()
-            && GetLargeDeletionMarkersCount() >= t)
+            && GetLargeDeletionMarkersCount()
+                >= LargeDeletionMarkersCleanupThreshold)
     {
         auto one = Impl->LargeBlocks.GetOne();
         SplitRange(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -861,6 +861,7 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
         Impl->MixedBlocks.ApplyDeletionMarkersAndGetMetas(rangeId);
 
     ui64 removedBlobs = 0;
+    TVector<TMixedBlobMeta> updatedBlobs;
     for (auto& blob: affectedBlobs) {
         const bool affected =
             Impl->LargeBlocks.ApplyDeletionMarkers(blob.BlobMeta.Blocks);
@@ -884,6 +885,8 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
         if (!written) {
             ++removedBlobs;
         }
+
+        updatedBlobs.emplace_back(std::move(blob.BlobMeta));
     }
 
     if (PriorityRangesForCleanup) {
@@ -900,7 +903,7 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
         }
     }
 
-    AddBlobsInfo(GetBlockSize(), affectedBlobs, profileLogRequest);
+    AddBlobsInfo(GetBlockSize(), updatedBlobs, profileLogRequest);
 
     auto deletionMarkers = Impl->MixedBlocks.ExtractDeletionMarkers(rangeId);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -857,7 +857,7 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
     ui32 rangeId,
     NProto::TProfileLogRequestInfo& profileLogRequest)
 {
-    auto affectedBlobs = Impl->MixedBlocks.ApplyDeletionMarkers(rangeId);
+    auto affectedBlobs = Impl->MixedBlocks.ApplyDeletionMarkers(rangeId, true);
 
     ui64 removedBlobs = 0;
     for (auto& blob: affectedBlobs) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -13,6 +13,7 @@
 #include <cloud/filestore/libs/storage/tablet/model/fresh_blocks.h>
 #include <cloud/filestore/libs/storage/tablet/model/fresh_bytes.h>
 #include <cloud/filestore/libs/storage/tablet/model/garbage_queue.h>
+#include <cloud/filestore/libs/storage/tablet/model/large_blocks.h>
 #include <cloud/filestore/libs/storage/tablet/model/mixed_blocks.h>
 #include <cloud/filestore/libs/storage/tablet/model/node_index_cache.h>
 #include <cloud/filestore/libs/storage/tablet/model/range_locks.h>
@@ -51,6 +52,7 @@ struct TIndexTabletState::TImpl
     TFreshBytes FreshBytes;
     TFreshBlocks FreshBlocks;
     TMixedBlocks MixedBlocks;
+    TLargeBlocks LargeBlocks;
     TCompactionMap CompactionMap;
     TGarbageQueue GarbageQueue;
     TTruncateQueue TruncateQueue;
@@ -69,6 +71,7 @@ struct TIndexTabletState::TImpl
         : FreshBytes(registry.GetAllocator(EAllocatorTag::FreshBytes))
         , FreshBlocks(registry.GetAllocator(EAllocatorTag::FreshBlocks))
         , MixedBlocks(registry.GetAllocator(EAllocatorTag::BlobMetaMap))
+        , LargeBlocks(registry.GetAllocator(EAllocatorTag::LargeBlocks))
         , CompactionMap(registry.GetAllocator(EAllocatorTag::CompactionMap))
         , GarbageQueue(registry.GetAllocator(EAllocatorTag::GarbageQueue))
         , ReadAheadCache(registry.GetAllocator(EAllocatorTag::ReadAheadCache))

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -307,6 +307,7 @@ struct TTxIndexTablet
         TMaybe<NProto::TStorageConfig> StorageConfig;
         TVector<NProto::TSessionHistoryEntry> SessionHistory;
         TVector<NProto::TOpLogEntry> OpLog;
+        TVector<TDeletionMarker> LargeDeletionMarkers;
 
         NProto::TError Error;
 
@@ -329,6 +330,7 @@ struct TTxIndexTablet
             StorageConfig.Clear();
             SessionHistory.clear();
             OpLog.clear();
+            LargeDeletionMarkers.clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1217,7 +1217,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         ui32 nodeIdx = env.CreateNode("nfs");
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
-        tabletConfig.BlockCount = MaxFileBlocks * 2;
+        tabletConfig.BlockCount = GetDefaultMaxFileBlocks() * 2;
         TIndexTabletClient tablet(
             env.GetRuntime(),
             nodeIdx,
@@ -1245,21 +1245,21 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         tablet.WriteData(
             handle,
-            (MaxFileBlocks - 1) * block,
+            (GetDefaultMaxFileBlocks() - 1) * block,
             block,
             '5');
         UNIT_ASSERT_VALUES_EQUAL(
             GetNodeAttrs(tablet, id).GetSize(),
-            MaxFileBlocks * block);
+            GetDefaultMaxFileBlocks() * block);
 
         tablet.AssertWriteDataFailed(
             handle,
-            MaxFileBlocks * block,
+            GetDefaultMaxFileBlocks() * block,
             1_KB,
             '6');
         UNIT_ASSERT_VALUES_EQUAL(
             GetNodeAttrs(tablet, id).GetSize(),
-            MaxFileBlocks * block);
+            GetDefaultMaxFileBlocks() * block);
     }
 
     TABLET_TEST(ShouldTrackUsedBlocks)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5977,7 +5977,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(
                 2 * blobSize / block,
                 stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetGarbageBlocksCount());
+            // 2 new blobs
+            UNIT_ASSERT_VALUES_EQUAL(2 * blobSize, stats.GetGarbageQueueSize());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
         }
 
@@ -5994,11 +5995,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 (3_TB - 1_GB) / block,
                 stats.GetLargeDeletionMarkersCount());
             UNIT_ASSERT_VALUES_EQUAL(
-                2 * blobSize / block,
-                stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(
                 blobSize / block,
-                stats.GetGarbageBlocksCount());
+                stats.GetMixedBlocksCount());
+            // 2 new blobs + 1 garbage blob
+            UNIT_ASSERT_VALUES_EQUAL(3 * blobSize, stats.GetGarbageQueueSize());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5346,7 +5346,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     TABLET_TEST(ShouldTrimFreshBytesDeletionMarkersForLargeFiles)
     {
         NProto::TStorageConfig storageConfig;
-        storageConfig.SetFlushBytesThreshold(1_GB);
+        storageConfig.SetFlushBytesThreshold(100_GB + 1);
 
         TTestEnv env({}, std::move(storageConfig));
         auto registry = env.GetRegistry();
@@ -5373,8 +5373,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBytesCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetDeletedFreshBytesCount(), 100_GB);
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBytesCount());
+            UNIT_ASSERT_VALUES_EQUAL(100_GB, stats.GetDeletedFreshBytesCount());
         }
 
         tablet.FlushBytes();
@@ -5382,8 +5382,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBytesCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetDeletedFreshBytesCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBytesCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeletedFreshBytesCount());
         }
 
         {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5977,6 +5977,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(
                 2 * blobSize / block,
                 stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetGarbageBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
         }
 
@@ -5988,13 +5989,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         {
             auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetDeletionMarkersCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 (3_TB - 1_GB) / block,
                 stats.GetLargeDeletionMarkersCount());
             UNIT_ASSERT_VALUES_EQUAL(
-                blobSize / block,
+                2 * blobSize / block,
                 stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobSize / block,
+                stats.GetGarbageBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5862,6 +5862,143 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(1, perGenerationCounter);
     }
 
+    TABLET_TEST(ShouldTruncateLargeFiles)
+    {
+        const auto block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetMaxFileBlocks(2_TB / block);
+        storageConfig.SetLargeDeletionMarkersEnabled(true);
+        storageConfig.SetLargeDeletionMarkerBlocks(1_GB / block);
+        storageConfig.SetLargeDeletionMarkersThreshold(128_GB / block);
+        storageConfig.SetLargeDeletionMarkersCleanupThreshold(3_TB / block);
+        const auto blobSize = 2 * block;
+        storageConfig.SetWriteBlobThreshold(blobSize);
+
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        tabletConfig.BlockCount = 10_TB / block;
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        tablet.WriteData(handle, 0, block, '1');
+        UNIT_ASSERT_VALUES_EQUAL(block, GetNodeAttrs(tablet, id).GetSize());
+
+        TSetNodeAttrArgs args(id);
+        args.SetFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
+        args.SetSize(1_TB);
+        tablet.SetNodeAttr(args);
+        UNIT_ASSERT_VALUES_EQUAL(1_TB, GetNodeAttrs(tablet, id).GetSize());
+
+        // writing some data at the beginning of the file
+        tablet.WriteData(handle, blobSize, blobSize, '2');
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(blobSize, '2'),
+            ReadData(tablet, handle, blobSize, blobSize));
+
+        // writing some data at the end of the file
+        tablet.WriteData(handle, 1_TB - blobSize, blobSize, '3');
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(blobSize, '3'),
+            ReadData(tablet, handle, blobSize, 1_TB - blobSize));
+
+        // downsizing the file and increasing its size back to 1_TB again
+        args.SetSize(512_GB);
+        tablet.SetNodeAttr(args);
+        UNIT_ASSERT_VALUES_EQUAL(512_GB, GetNodeAttrs(tablet, id).GetSize());
+
+        args.SetSize(1_TB);
+        tablet.SetNodeAttr(args);
+        UNIT_ASSERT_VALUES_EQUAL(1_TB, GetNodeAttrs(tablet, id).GetSize());
+
+        // data at the end of the file should've been erased
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(blobSize, 0),
+            ReadData(tablet, handle, blobSize, 1_TB - blobSize));
+
+        // data at the beginning should still be present
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(block, '1'),
+            ReadData(tablet, handle, block));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(blobSize, '2'),
+            ReadData(tablet, handle, blobSize, blobSize));
+
+        tablet.DestroyHandle(handle);
+
+        // deleting the file
+        // after this point we should have 512_GB + 1_TB of deletion markers
+        tablet.UnlinkNode(RootNodeId, "test", false);
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                (1_TB + 512_GB) / block,
+                stats.GetLargeDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                2 * blobSize / block,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+        }
+
+        // let's create a new file
+        auto id2 =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        TSetNodeAttrArgs args2(id2);
+        args2.SetFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
+        args2.SetSize(1_TB + 512_GB);
+        tablet.SetNodeAttr(args2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1_TB + 512_GB,
+            GetNodeAttrs(tablet, id2).GetSize());
+
+        // deletion marker-related stats shouldn't have changed
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                (1_TB + 512_GB) / block,
+                stats.GetLargeDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                2 * blobSize / block,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+        }
+
+        // but after unlinking the file Cleanup op should start running
+        tablet.UnlinkNode(RootNodeId, "test", false);
+
+        // so here all large deletion markers should've been cleaned up and
+        // the corresponding mixed blobs should've been deleted
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                (3_TB - 1_GB) / block,
+                stats.GetLargeDeletionMarkersCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobSize / block,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+        }
+    }
+
 #undef TABLET_TEST
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -256,7 +256,7 @@ struct TEnvironment
     {
         static auto hasher = CreateRangeIdHasher(RangeIdHasherType);
 
-        const TByteRange maxFileBlocks(0, MaxFileBlocks, BlockSize);
+        const TByteRange maxFileBlocks(0, GetDefaultMaxFileBlocks(), BlockSize);
 
         TVector<ui32> rangeIds;
         SplitRange(

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_truncate.cpp
@@ -113,7 +113,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Truncate)
         UNIT_ASSERT_VALUES_EQUAL(GetNodeAttrs(tablet, id).GetSize(), 0);
         UNIT_ASSERT_VALUES_EQUAL(ReadData(tablet, handle, 8_KB), TString());
 
-        args.SetSize(MaxFileBlocks * DefaultBlockSize + 1);
+        args.SetSize(GetDefaultMaxFileBlocks() * DefaultBlockSize + 1);
         tablet.AssertSetNodeAttrFailed(args);
 
         args.SetSize(18_KB);

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -35,6 +35,12 @@ constexpr ui32 DefaultChannelCount = 7;
 
 void CheckForkJoin(const NLWTrace::TShuttleTrace& trace, bool forkRequired);
 
+inline auto GetDefaultMaxFileBlocks()
+{
+    static const auto VALUE = TStorageConfig().GetMaxFileBlocks();
+    return VALUE;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TTestEnvConfig

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -37,7 +37,10 @@ void CheckForkJoin(const NLWTrace::TShuttleTrace& trace, bool forkRequired);
 
 inline auto GetDefaultMaxFileBlocks()
 {
-    static const auto VALUE = TStorageConfig().GetMaxFileBlocks();
+    // casting to ui64 is convenient here since some tests use the result of
+    // this function to do some arithmetic which may yield values outside of the
+    // ui32 domain
+    static const ui64 VALUE = TStorageConfig().GetMaxFileBlocks();
     return VALUE;
 }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -120,6 +120,7 @@ message TStorageStats
     uint64 UsedCompactionRanges = 111;
     uint64 LastCollectCommitId = 112;
     uint64 DeletedFreshBytesCount = 113;
+    uint64 LargeDeletionMarkersCount = 114;
 
     // channel stats
     uint64 TabletChannelCount = 1000;

--- a/cloud/filestore/public/api/protos/const.proto
+++ b/cloud/filestore/public/api/protos/const.proto
@@ -76,9 +76,6 @@ enum EFilestoreLimits
     // Maximum length of extended attribute value.
     E_FS_LIMITS_XATTR_VALUE = 65536;
 
-    // Until NBS-2979 it's limited to 300GB
-    E_FS_LIMITS_FILEBLOCKS = 78643200;
-
     // Maximum number of inodes.
     E_FS_LIMITS_INODES = -2; // 0xFFFFFFFE
 };

--- a/doc/filestore/design/storage/tablet/background_ops.md
+++ b/doc/filestore/design/storage/tablet/background_ops.md
@@ -1,0 +1,90 @@
+# Background ops in Filestore Tablet
+
+Since the data is stored in immutable blobs, we need some background operations whose main jobs would be:
+* data compaction - making the data that is logically local (e.g. adjacent blocks in a single file) be physically local (stored in the same blob) - makes read requests faster, makes index smaller
+* garbage collection - finding and rewriting all blobs the data in which is logically overwritten by a write request upon every write request is expensive, so each write is actually "blind" - it only writes new data and the data that gets overwritten is usually detected and processed later - in background
+
+The main background ops are:
+* Compaction
+* Cleanup
+* Flush
+* FlushBytes
+* CollectGarbage
+
+These operations are triggered based on various statistics - MaxBlobsPerRange, MaxDeletionsPerRange, etc.
+Ops are triggered when the related statistics are higher than some threshold. The thresholds are specified in TStorageServiceConfig (usually contained in a file named nfs-storage.txt).
+If the values of some statistics are way too high, new WriteData / GenerateBlobIds requests get rejected (receive E_REJECTED error) - so-called "Backpressure" logic.
+Backpressure is needed in order not to degrade into a state when the amount of garbage and/or size of the index is so big that it becomes unmanageable - e.g. localdb transactions start to hit size limits, localdb overall starts to be too slow, the overall amount of garbage becomes unreasonably high, etc.
+
+## Compaction
+
+Goals:
+* make [MixedIndex](data_index.md#mixedblocks) as small as possible
+* rewrite data to improve data locality
+* get rid of overwritten data
+
+What is does:
+* selects MixedIndex range with the most blobs in it, scans that range to extract blocklists and blobs
+* rewrites the blocks from that range throwing away the overwritten blocks, generates new blobs in the same range
+
+Is triggered:
+* either when blob count in some range exceeds some threshold
+* or when average garbage percentage per range exceeds some threshold
+
+## Cleanup
+
+Goals:
+* minimize DeletionMarker count
+* get rid of blobs containing only overwritten data
+
+What it does:
+* selects MixedIndex range with the most DeletionMarkers in it
+* OR selects MixedIndex range from the so-called PriorityRangesForCleanup queue which is filled if the number of LargeDeletionMarkers (which are global, not local to one of the ranges) is too big
+* applies DeletionMarkers from this range to blob BlockLists in this range
+* deletes the processed DeletionMarkers (both Mixed and Large) from the index
+
+Is triggered:
+* either when DeletionMarker count in some range exceeds some threshold
+* or when average deletion marker count per range exceeds some threshold
+* or if LargeDeletionMarker count exceeds some threshold
+
+## Flush
+
+Goals:
+* rewrite [FreshBlocks](data_index.md#freshblocks) as larger MixedBlobs
+* trim FreshBlocks
+
+What it does:
+* reads FreshBlocks, groups them into larger blobs
+* writes those blobs (via WriteBlob requests) and adds them to the index (via AddBlob requests)
+
+Is triggered:
+* when the total size of FreshBlocks exceeds some threshold
+
+## FlushBytes
+
+Goals:
+* apply [FreshBytes](data_index.md#freshbytes) to the blobs with which those byte ranges intersect
+* trim FreshBytes
+
+What it does:
+* takes some ranges from FreshBytes (usually all ranges)
+* scans MixedIndex to find the blobs with which those ranges intersect
+* reads those blobs, writes the corresponding FreshBytes on top of them, writes the results as new blobs (similar to Compaction)
+
+Is triggered:
+* when the total size of FreshBytes exceeds some threshold
+
+## CollectGarbage
+
+Goals:
+* move GC barriers in BlobStorage groups
+* set Keep / DontKeep flags for blobs
+
+What it does:
+* reads GarbageBlobs and NewBlobs from the queue, deduplicates them
+* calculates barrier values per group, sends EvCollectGarbage requests
+* calls DeleteGarbage op which cleans up GarbageQueue
+
+Is triggered:
+* when GarbageQueueSize (size of the blobs in GarbageQueue, i.e. GarbageBlobs + NewBlobs) exceeds some threshold

--- a/doc/filestore/design/storage/tablet/data_index.md
+++ b/doc/filestore/design/storage/tablet/data_index.md
@@ -1,4 +1,4 @@
-# Data index in Filestore
+# Data index in Filestore Tablet
 
 Data index is represented by the following layers:
 * FreshBytes layer - used for unaligned writes (predominantly smaller than BlockSize)

--- a/doc/filestore/design/storage/tablet/data_index.md
+++ b/doc/filestore/design/storage/tablet/data_index.md
@@ -33,3 +33,7 @@ This layer is planned for use with large files. For simplicity the code is going
 * Each large DeletionMarker will describe a range of up to 1GiB
 * Large DeletionMarkers will be generated only upon large (> 128GiB) truncate ops.
 * Cleanup operation will keep track of the number of large DeletionMarkers and will start applying and trimming them if their total number becomes too big (e.g. greater than, say, 2 ^ 20).
+
+## Deletions
+* Small (`deletedBlockCount < LargeDeletionMarkersThreshold`) deletions are propagated to all layers except the LargeBlocks layer
+* Large deletions are propagated to the FreshBlocks, FreshBytes and LargeBlocks layers which means that the LargeBlocks layer MUST be visited AFTER the MixedBlocks layer


### PR DESCRIPTION
Superficially described here: https://github.com/ydb-platform/nbs/blob/main/doc/filestore/design/storage/tablet/data_index.md. A bit more details can be found here: [doc/filestore/design/storage/tablet/background_ops.md](https://github.com/ydb-platform/nbs/pull/1907/files#diff-b79411fe4d44eea64b1ac29003b344d07ee1c19f47fe77834f37fa86a025ea15) (this PR).

What I'm doing here is basically tracking large truncates / range deletions in a separate LargeBlocks layer. LargeDeletionMarkers don't belong to any MixedIndex range - they are global and are loaded into memory upon tablet startup. The default behaviour shouldn't change. I also made MaxFileBlocks configurable (leaving the default value the same as it used to be - 300GiB / 4KiB). 

#1795 