### PR TITLE
issue-1657: confirm "destroy volume" in e2e test

### DIFF
--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -214,9 +214,8 @@ def test_resize_device(with_netlink, with_endpoint_proxy):
         )
 
         run(
-            "destroyvolume",
-            "--disk-id",
-            volume_name,
+            *("destroyvolume", "--disk-id", volume_name),
+            **{"input": volume_name},
         )
 
         result = common.execute(


### PR DESCRIPTION
blockstore client asks to type the disk name as a confirmation to remove it.