### PR TITLE
fix: cleaning cloud-init artefacts

### DIFF
--- a/.github/scripts/github-runner.sh
+++ b/.github/scripts/github-runner.sh
@@ -25,6 +25,7 @@ function on_exit() {
 
     sudo rm -rf "/home/${USER_TO_CREATE}/.aws" /root/.aws/
     sudo rm -rf /var/lib/apt/lists/*
+    sudo cloud-init clean --logs
     sync
     exit "$exit_code"
 }


### PR DESCRIPTION
Somehow cloud-init left some artifacts that prevent consecutive config stages not to run.

Cleanup should fix the issue.