### PR TITLE
issue-652: do not acquire barriers from the past upon `FlushBytes`

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -664,11 +664,7 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
         }
     };
 
-    args.CollectCommitId = Max<ui64>();
-
-    for (const auto& bytes: args.Bytes) {
-        args.CollectCommitId = Min(args.CollectCommitId, bytes.MinCommitId);
-    }
+    args.CollectCommitId = GetCurrentCommitId();
 
     THashMap<TBlockLocation, TBlockWithBytes, TBlockLocationHash> blockMap;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -822,7 +822,7 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
     AcquireCollectBarrier(args.CommitId);
     // TODO(#1923): it may be problematic to acquire the barrier only upon
     // completion of the transaction, because blobs, that have been read at the
-    // prepare stage, may be tempered with by the time of the transaction
+    // prepare stage, may be tampered with by the time of the transaction
     // completion
 
     auto actor = std::make_unique<TFlushBytesActor>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -664,7 +664,10 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
         }
     };
 
-    args.CollectCommitId = GetCurrentCommitId();
+    args.CollectCommitId = GenerateCommitId();
+    if (args.CollectCommitId == InvalidCommitId) {
+        return RebootTabletOnCommitOverflow(ctx, "FlushBytes");
+    }
 
     THashMap<TBlockLocation, TBlockWithBytes, TBlockLocationHash> blockMap;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -410,7 +410,7 @@ struct TEvIndexTabletPrivate
     {
         const TCallContextPtr CallContext;
         const TSet<ui32> MixedBlocksRanges;
-        const ui64 CollectCommitId;
+        const ui64 CommitId;
         const ui64 ChunkId;
 
         TFlushBytesCompleted(
@@ -419,12 +419,12 @@ struct TEvIndexTabletPrivate
                 TDuration d,
                 TCallContextPtr callContext,
                 TSet<ui32> mixedBlocksRanges,
-                ui64 collectCommitId,
+                ui64 commitId,
                 ui64 chunkId)
             : TDataOperationCompleted(requestCount, requestBytes, d)
             , CallContext(std::move(callContext))
             , MixedBlocksRanges(std::move(mixedBlocksRanges))
-            , CollectCommitId(collectCommitId)
+            , CommitId(commitId)
             , ChunkId(chunkId)
         {
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1545,7 +1545,7 @@ struct TTxIndexTablet
         const ui64 ChunkId;
         const TVector<TBytes> Bytes;
 
-        ui64 CollectCommitId = InvalidCommitId;
+        ui64 CommitId = InvalidCommitId;
 
         // NOTE: should persist state across tx restarts
         TSet<ui32> MixedBlocksRanges;
@@ -1566,7 +1566,7 @@ struct TTxIndexTablet
         {
             TProfileAware::Clear();
 
-            CollectCommitId = InvalidCommitId;
+            CommitId = InvalidCommitId;
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5787,6 +5787,134 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
     }
 
+    TTestActorRuntimeBase::TEventFilter MakeCollectGarbageFilter(
+        ui64 keepCount,
+        ui64 doNotKeepCount)
+    {
+        return [keepCount, doNotKeepCount](auto& runtime, auto& event)
+        {
+            Y_UNUSED(runtime);
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvCollectGarbage: {
+                    auto* msg =
+                        event
+                            ->template Get<TEvBlobStorage::TEvCollectGarbage>();
+                    if (msg->Channel >= TIndexTabletSchema::DataChannel) {
+                        UNIT_ASSERT_VALUES_EQUAL(keepCount, msg->Keep->size());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            doNotKeepCount,
+                            msg->DoNotKeep->size());
+                    }
+                    break;
+                }
+            }
+            return false;
+        };
+    }
+
+    TABLET_TEST(FlushBytesShouldNotInterfereWithCollectGarbage)
+    {
+        const auto block = tabletConfig.BlockSize;
+        NProto::TStorageConfig storageConfig;
+
+        storageConfig.SetCompactionThreshold(999'999);
+        storageConfig.SetCleanupThreshold(999'999);
+        storageConfig.SetCollectGarbageThreshold(1_GB);
+        storageConfig.SetMinChannelCount(1);
+
+        // ensure that all blobs use the same channel
+        TTestEnv env(
+            {.ChannelCount = TIndexTabletSchema::DataChannel + 1},
+            std::move(storageConfig));
+
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+
+        auto handle = CreateHandle(tablet, id);
+
+        const int size = BlockGroupSize * block;
+        tablet.WriteData(handle, 0 * size, size, 'a');
+        tablet.WriteData(handle, 1 * size, size, 'b');
+        tablet.WriteData(handle, 2 * size, size, 'c');
+        tablet.WriteData(handle, 2 * size, 1_KB, 'f');
+        tablet.WriteData(handle, 0, size, 'd');
+
+        // File contents:
+        // [dddddd][bbbbbb][fcccccc]
+
+        auto& runtime = env.GetRuntime();
+
+        runtime.SetEventFilter(MakeCollectGarbageFilter(4, 0));
+        tablet.CollectGarbage();
+        // left to right: growth of commitId
+        //     new        new        new               new     |
+        // [    a    ][    b    ][    c    ][fresh][    d    ] |
+        //                                                     |
+        //                                            lastCollectCommitId
+
+        tablet.Cleanup(GetMixedRangeIndex(id, 0));
+        //   garbage                                           |
+        // [    a    ][    b    ][    c    ][fresh][    d    ] |
+        //                                                     |
+        //                                            lastCollectCommitId
+        // runtime.SetEventFilter(MakeCollectGarbageFilter(0, 1));
+
+        // during the FlushBytes (after the barrier is acquired):
+        //
+        //   garbage                           |               |
+        // [    a    ][    b    ][    c    ][fresh][    d    ] |
+        //                                     |               |
+        //                                  barrier   lastCollectCommitId
+        //
+        // in order to ensure the barrier is held for long enough time, we
+        // postpone the ReadBlob request, that is supposed to be sent during the
+        // FlushBytes
+
+        TAutoPtr<IEventHandle> readBlob;
+        runtime.SetEventFilter(
+            [&readBlob](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTabletPrivate::EvReadBlobRequest: {
+                        readBlob = event.Release();
+                        return true;
+                    }
+                }
+                return false;
+            });
+        tablet.SendFlushBytesRequest();
+        runtime.DispatchEvents(TDispatchOptions{
+            .CustomFinalCondition = [&]() -> bool
+            {
+                return readBlob.Get();
+            }});
+
+        runtime.SetEventFilter(MakeCollectGarbageFilter(0, 1));
+
+        // The following CollectGarbage is sent with collectCommitId equal to
+        // the minimal barrier, meaning that it will be less than the
+        // lastCollectCommitId
+
+        tablet.SendCollectGarbageRequest();
+        auto response = tablet.RecvCollectGarbageResponse();
+
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+        UNIT_ASSERT_C(
+            response->GetErrorReason().Contains("empty QuorumTracker"),
+            response->GetErrorReason());
+    }
+
     TABLET_TEST(ShouldNotCollectGarbageWithPreviousGeneration)
     {
         const auto block = tabletConfig.BlockSize;


### PR DESCRIPTION
References (and, hopefully, fixes) #652

The main problem is that FlushBytes acquires collect barrier, which is less than the last collect commit id:

---

1. Consider that there were the following sequence of writes:
```
Write(0,       256 KiB, 'a') -> Blob(commitId = 42)
Write(256 KiB, 256 KiB, 'b') -> Blob(commitId = 43)
Write(512 KiB, 1,       'f') -> FreshBytes(commitId = 44)
Write(0,       256 KiB, 'c') -> Blob(commitId = 45)
```
This will lead to the following file layout: `[ccccccc][bbbbbbb][f]`

2. After execution of the CollectGarbage, all three new blobs will get a KeepFlag and the last collect commit id will be equal to 44
```
CommitId:     41      42        43       44
            Blob(a) Blob(b) FreshBytes Blob(c)
                                          |
                                 LastCollectCommitId
```

3. After execution of the Cleanup operation, the first blob will be marked as garbage

4. Let us execute FlushBytes operation, It will acquire collect barrier, equal to the minimal commitId, associated with FreshBlobs:
https://github.com/ydb-platform/nbs/blob/836a5162f99b998582dc4b476a212619954bfa22/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp#L669-L671

After this acquisition there will be one barrier, equal to 43:
```
CommitId:     41      42        43       44
            Blob(a) Blob(b) FreshBytes Blob(c)
                                |         |
                             Barrier  LastCollectCommitId
```

5. When the next CollectGarbage operation is to be executed, it will choose 42 as a collectCommitId:

https://github.com/ydb-platform/nbs/blob/836a5162f99b998582dc4b476a212619954bfa22/cloud/filestore/libs/storage/tablet/model/garbage_queue.cpp#L227-L228

After it the CollectGarbage request with one new grabage will be sent, leading to a decrease in collectCommitIds sequence: 42 after 44