### PR TITLE
minor filestore tweaks: 1. not reporting DescribeFileStoreError crit event if the error is retriable 2. decreased TIndexTabletTest_Data_Stress::ShouldTruncateAndAllocateFiles iteration count under asan

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -215,7 +215,9 @@ void TCreateSessionActor::HandleDescribeFileStoreResponse(
     const auto* msg = ev->Get();
 
     if (FAILED(msg->GetStatus())) {
-        ReportDescribeFileStoreError();
+        if (GetErrorKind(msg->GetError()) != EErrorKind::ErrorRetriable) {
+            ReportDescribeFileStoreError();
+        }
 
         Notify(ctx, msg->GetError(), false);
         Die(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -355,7 +355,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         const auto sanitizerType = GetEnv("SANITIZER_TYPE");
         // temporary logging
         Cerr << "sanitizer: " << sanitizerType << Endl;
-        THashSet<TString> slowSanitizers({"thread", "undefined"});
+        THashSet<TString> slowSanitizers({"thread", "undefined", "address"});
         const ui32 d = slowSanitizers.contains(sanitizerType) ? 20 : 1;
 
         PERFORM_TEST(5'000 / d);


### PR DESCRIPTION
subj