### PR TITLE
libnl: fixed ub

### DIFF
--- a/contrib/restricted/libnl/ChangeLog.patch
+++ b/contrib/restricted/libnl/ChangeLog.patch
@@ -1,0 +1,14 @@
+diff --git a/contrib/restricted/libnl/lib/socket.c b/contrib/restricted/libnl/lib/socket.c
+index b0a6530113..b4417e08de 100644
+--- a/contrib/restricted/libnl/lib/socket.c
++++ b/contrib/restricted/libnl/lib/socket.c
+@@ -111,7 +111,7 @@ static uint32_t generate_local_port(void)
+                        nl_write_unlock(&port_map_lock);
+
+                        /* ensure we don't return zero. */
+-                       pid = pid + (n << 22);
++                       pid = pid + (uint32_t(n) << 22);
+                        return pid ? pid : 1024;
+                }
+        }
+

--- a/contrib/restricted/libnl/ChangeLog.patch
+++ b/contrib/restricted/libnl/ChangeLog.patch
@@ -7,7 +7,7 @@ index b0a6530113..b4417e08de 100644
 
                         /* ensure we don't return zero. */
 -                       pid = pid + (n << 22);
-+                       pid = pid + (uint32_t(n) << 22);
++                       pid = pid + ((uint32_t)n << 22);
                         return pid ? pid : 1024;
                 }
         }

--- a/contrib/restricted/libnl/lib/socket.c
+++ b/contrib/restricted/libnl/lib/socket.c
@@ -111,7 +111,7 @@ static uint32_t generate_local_port(void)
 			nl_write_unlock(&port_map_lock);
 
 			/* ensure we don't return zero. */
-			pid = pid + (n << 22);
+			pid = pid + (uint32_t(n) << 22);
 			return pid ? pid : 1024;
 		}
 	}

--- a/contrib/restricted/libnl/lib/socket.c
+++ b/contrib/restricted/libnl/lib/socket.c
@@ -111,7 +111,7 @@ static uint32_t generate_local_port(void)
 			nl_write_unlock(&port_map_lock);
 
 			/* ensure we don't return zero. */
-			pid = pid + (uint32_t(n) << 22);
+			pid = pid + ((uint32_t)n << 22);
 			return pid ? pid : 1024;
 		}
 	}


### PR DESCRIPTION
```
/actions-runner/_work/nbs/nbs/contrib/restricted/libnl/lib/socket.c:114:19: runtime error: left shift of 545 by 22 places cannot be represented in type 'int'
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0xf0 has a premature terminator entry at offset 0x100
warning: address range table at offset 0x6a0 has a premature terminator entry at offset 0x6b0
warning: address range table at offset 0x6d0 has a premature terminator entry at offset 0x6e0
    #0 0x4a52963 in generate_local_port /actions-runner/_work/nbs/nbs/contrib/restricted/libnl/lib/socket.c:114:19
    #1 0x4a52326 in _nl_socket_set_local_port_no_release /actions-runner/_work/nbs/nbs/contrib/restricted/libnl/lib/socket.c:346:10
    #2 0x4a774fc in nl_connect /actions-runner/_work/nbs/nbs/contrib/restricted/libnl/lib/nl.c:143:11
    #3 0x4a4dd16 in NCloud::NBlockStore::NBD::(anonymous namespace)::TNetlinkSocket::TNetlinkSocket() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/nbd/netlink_device.cpp:43:23
    #4 0x4a4d68a in NCloud::NBlockStore::NBD::(anonymous namespace)::TNetlinkDevice::Resize(unsigned long) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/nbd/netlink_device.cpp:261:28
    #5 0x3eb73d3 in NCloud::NBlockStore::NServer::(anonymous namespace)::TServer::DoProcessRequest /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:827:38
    #6 0x3eb73d3 in NCloud::NBlockStore::NServer::(anonymous namespace)::TServer::ProcessRequest(NCloud::NBlockStore::NServer::(anonymous namespace)::TResizeRequestContext*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:863:17
    #7 0x3ea38c7 in NCloud::NBlockStore::NServer::(anonymous namespace)::TServer::Loop /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:456:17
    #8 0x3ea38c7 in NCloud::NBlockStore::NServer::(anonymous namespace)::TServer::Start()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:886:13
    #9 0x3ea38c7 in std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:885:45) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #10 0x3ea38c7 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:885:45) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #11 0x3ea38c7 in std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:885:45), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/endpoint_proxy/server/server.cpp:885:45)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #12 0x3ea38c7 in std::__y1::__function::__func<NCloud::NBlockStore::NServer::(anonymous namespace)::TServer::Start()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NServer::(anonymous namespace)::TServer::Start()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12
    #13 0x3711b3d in std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12
    #14 0x3711b3d in (anonymous namespace)::TThreadFactoryFuncObj::DoExecute() /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:61:13
    #15 0x37123d8 in IThreadFactory::IThreadAble::Execute /actions-runner/_work/nbs/nbs/util/thread/factory.h:15:13
    #16 0x37123d8 in (anonymous namespace)::TSystemThreadFactory::TPoolThread::ThreadProc(void*) /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:36:41
    #17 0x2030f24 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20
    #18 0x7f5bbfe5d608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8608) (BuildId: f5b7b9b3efe01ef7aec691dc8f4e272c518f8cdf)
    #19 0x7f5bbfd82132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132) (BuildId: e678fe54a5d2c2092f8e47eb0b33105e380f7340)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /actions-runner/_work/nbs/nbs/contrib/restricted/libnl/lib/socket.c:114:19 in 
```