### PR TITLE
Reapply monlib bugfixes (lost while merging ydb-24-1)

### DIFF
--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder.cpp
@@ -109,13 +109,11 @@ namespace NMonitoring {
                 Y_ENSURE(!name.Empty(), "trying to write metric with empty name");
 
                 char ch = name[0];
-                if (NPrometheus::IsValidMetricNameStart(ch)) {
-                    Out_->Write(ch);
-                } else {
+                if (!NPrometheus::IsValidMetricNameStart(ch)) {
                     Out_->Write('_');
                 }
 
-                for (size_t i = 1, len = name.length(); i < len; i++) {
+                for (size_t i = 0, len = name.length(); i < len; i++) {
                     ch = name[i];
                     if (NPrometheus::IsValidMetricNameContinuation(ch)) {
                         Out_->Write(ch);

--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
@@ -411,4 +411,89 @@ two{labels="l2", project="solomon", } 42 1500000000000
 
 )");
     }
+
+    Y_UNIT_TEST(FirstCharacterShouldNotBeReplaced) 
+    {
+        auto result = EncodeToString([](IMetricEncoder* e) {
+            e->OnStreamBegin();
+            const TVector<std::pair<TString, double>> sensors = {
+                {"0", 0.0},
+                {"50", 50.0},
+                {"90", 90.0},
+                {"99", 99.0},
+                {"100", 100},
+                {"012345", 123.45},
+                {"abc0123", 123.0},
+                {"0123abc", 123.0},
+                };
+
+            for (const auto& [name, value]: sensors) {
+                e->OnMetricBegin(EMetricType::COUNTER);
+                {
+                    e->OnLabelsBegin();
+                    e->OnLabel("sensor", name);
+                    e->OnLabelsEnd();
+                }
+                e->OnDouble(TInstant::Zero(), value);
+                e->OnMetricEnd();
+            }
+            e->OnStreamEnd();
+        });
+
+        UNIT_ASSERT_STRINGS_EQUAL(result,
+R"(# TYPE _0 counter
+_0 0
+# TYPE _50 counter
+_50 50
+# TYPE _90 counter
+_90 90
+# TYPE _99 counter
+_99 99
+# TYPE _100 counter
+_100 100
+# TYPE _012345 counter
+_012345 123.45
+# TYPE abc0123 counter
+abc0123 123
+# TYPE _0123abc counter
+_0123abc 123
+
+)");
+    }
+
+    Y_UNIT_TEST(InvalidCharactersShouldBeReplaced)
+    {
+        auto result = EncodeToString([](IMetricEncoder* e) {
+            e->OnStreamBegin();
+            const TVector<std::pair<TString, double>> sensors = {
+                {"abc/def", 1.0},
+                {"a+-*/=&{}()|bc", 0.1},
+                {"0.0", 0.0},
+                {"99.9", 99.9}};
+
+            for (const auto& [name, value]: sensors) {
+                e->OnMetricBegin(EMetricType::COUNTER);
+                {
+                    e->OnLabelsBegin();
+                    e->OnLabel("sensor", name);
+                    e->OnLabelsEnd();
+                }
+                e->OnDouble(TInstant::Zero(), value);
+                e->OnMetricEnd();
+            }
+            e->OnStreamEnd();
+        });
+
+        UNIT_ASSERT_STRINGS_EQUAL(result,
+R"(# TYPE abc_def counter
+abc_def 1
+# TYPE a___________bc counter
+a___________bc 0.1
+# TYPE _0_0 counter
+_0_0 0
+# TYPE _99_9 counter
+_99_9 99.9
+
+)");
+    }
 }

--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
@@ -412,8 +412,7 @@ two{labels="l2", project="solomon", } 42 1500000000000
 )");
     }
 
-    Y_UNIT_TEST(FirstCharacterShouldNotBeReplaced) 
-    {
+    Y_UNIT_TEST(FirstCharacterShouldNotBeReplaced) {
         auto result = EncodeToString([](IMetricEncoder* e) {
             e->OnStreamBegin();
             const TVector<std::pair<TString, double>> sensors = {
@@ -461,8 +460,7 @@ _0123abc 123
 )");
     }
 
-    Y_UNIT_TEST(InvalidCharactersShouldBeReplaced)
-    {
+    Y_UNIT_TEST(InvalidCharactersShouldBeReplaced) {
         auto result = EncodeToString([](IMetricEncoder* e) {
             e->OnStreamBegin();
             const TVector<std::pair<TString, double>> sensors = {
@@ -495,5 +493,23 @@ _0_0 0
 _99_9 99.9
 
 )");
+    }
+
+    Y_UNIT_TEST(ShouldNotFailOnMetricWithoutSensorLabel) {
+        auto result = EncodeToString([](IMetricEncoder* e) {
+            e->OnStreamBegin();
+            e->OnStreamEnd();
+            { // no values
+                e->OnMetricBegin(EMetricType::GAUGE);
+                {
+                    e->OnLabelsBegin();
+                    e->OnLabel("name", "cpuUsage");
+                    e->OnLabelsEnd();
+                }
+                e->OnInt64(TInstant::Zero(), 0);
+                e->OnMetricEnd();
+            }
+        });
+        UNIT_ASSERT_STRINGS_EQUAL(result, "\n");
     }
 }


### PR DESCRIPTION
- Don't erase first numerical character in sensor name in prometheus format (#1094)
- Removed assert on metrics without sensor label (prometheus format) (#1102)
