### PR TITLE
[Blockstore] ignore TEvRegisterTrafficSourceResponse in StateZombie

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -248,6 +248,8 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateZombie)
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
         IgnoreFunc(TEvVolume::TEvDiskRegistryBasedPartitionCounters);
 
+        IgnoreFunc(TEvStatsServicePrivate::TEvRegisterTrafficSourceResponse);
+
         IgnoreFunc(TEvents::TEvPoisonPill);
         IgnoreFunc(NActors::TEvents::TEvWakeup);
         HFunc(TEvents::TEvPoisonTaken, PoisonPillHelper.HandlePoisonTaken);


### PR DESCRIPTION
Relates to #1303

```
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+663 (0x104974F7)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+284 (0x1048D78C)
NCloud::HandleUnexpectedEvent(TAutoPtr<NActors::IEventHandle, TDelete>&, int)+158 (0x20893AAE)
2024-09-02T16:48:26.465900Z :BLOCKSTORE_PARTITION DEBUG: [vol0] Range [8192..9215] migrated
2024-09-02T16:48:26.465930Z :BLOCKSTORE_PARTITION DEBUG: [vol0] Schedule migrating next range after "0.150000s"
NCloud::NBlockStore::NStorage::TNonreplicatedPartitionMigrationCommonActor::StateZombie(TAutoPtr<NActors::IEventHandle, TDelete>&)+573 (0x208E3A7D)
NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::THTSwapMailbox>(NActors::TMailboxTable::THTSwapMailbox*, unsigned int, bool)+2578 (0x10F6CE42)
??+0 (0x10F64F45)
NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)+424 (0x10F64928)
NActors::TExecutorThread::ThreadProc()+188 (0x10F657FC)
??+0 (0x1049896C)
??+0 (0x7FA887EDFAC3)
??+0 (0x7FA887F71850)
```