### PR TITLE
[Snapshot] get rid of non-valuable but possibly buggy optimization which saves 1 task update when dataplane task is almost finished; better logging

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
@@ -112,15 +112,12 @@ func (t *createSnapshotFromDiskTask) saveProgress(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	if t.state.Progress == 1 {
-		return nil
-	}
-
 	if t.state.ChunkCount != 0 {
 		t.state.Progress =
 			float64(t.state.MilestoneChunkIndex) / float64(t.state.ChunkCount)
 	}
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }
 
@@ -146,7 +143,7 @@ func (t *createSnapshotFromDiskTask) lockBaseSnapshot(
 	if diskParams.IsDiskRegistryBasedDisk {
 		logging.Info(
 			ctx,
-			"Performing full snapshot %v of disk %v because it is registry based",
+			"Performing full snapshot %v of disk %v because it is Disk Registry based",
 			snapshotMeta.ID,
 			t.request.SrcDisk.DiskId,
 		)

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_legacy_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_legacy_snapshot_task.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
 	"github.com/ydb-platform/nbs/cloud/tasks"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -183,14 +184,11 @@ func (t *createSnapshotFromLegacySnapshotTask) saveProgress(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	if t.state.Progress == 1 {
-		return nil
-	}
-
 	if t.state.ChunkCount != 0 {
 		t.state.Progress =
 			float64(t.state.MilestoneChunkIndex) / float64(t.state.ChunkCount)
 	}
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_snapshot_task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
 	"github.com/ydb-platform/nbs/cloud/tasks"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -127,14 +128,11 @@ func (t *createSnapshotFromSnapshotTask) saveProgress(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	if t.state.Progress == 1 {
-		return nil
-	}
-
 	if t.state.ChunkCount != 0 {
 		t.state.Progress =
 			float64(t.state.MilestoneChunkIndex) / float64(t.state.ChunkCount)
 	}
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/url"
 	"github.com/ydb-platform/nbs/cloud/tasks"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -204,14 +205,11 @@ func (t *createSnapshotFromURLTask) saveProgress(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	if t.state.Progress == 1 {
-		return nil
-	}
-
 	if t.state.ChunkCount != 0 {
 		t.state.Progress =
 			float64(t.state.MilestoneChunkIndex) / float64(t.state.ChunkCount)
 	}
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
@@ -144,6 +144,7 @@ func (t *replicateDiskTask) saveProgress(
 	t.state.SecondsRemaining = int64(bytesToReplicate / bytesPerSecond)
 	t.state.UpdatedAt = timestamppb.Now()
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/transfer_from_disk_to_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/transfer_from_disk_to_disk_task.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/nbs"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/protos"
 	"github.com/ydb-platform/nbs/cloud/tasks"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,14 +151,11 @@ func (t *transferFromDiskToDiskTask) saveProgress(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	if t.state.Progress == 1 {
-		return nil
-	}
-
 	if t.state.ChunkCount != 0 {
 		t.state.Progress =
 			float64(t.state.MilestoneChunkIndex) / float64(t.state.ChunkCount)
 	}
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/transfer_from_snapshot_to_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/transfer_from_snapshot_to_disk_task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
 	"github.com/ydb-platform/nbs/cloud/tasks"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -131,14 +132,11 @@ func (t *transferFromSnapshotToDiskTask) saveProgress(
 	execCtx tasks.ExecutionContext,
 ) error {
 
-	if t.state.Progress == 1 {
-		return nil
-	}
-
 	if t.state.ChunkCount != 0 {
 		t.state.Progress =
 			float64(t.state.MilestoneChunkIndex) / float64(t.state.ChunkCount)
 	}
 
+	logging.Debug(ctx, "saving state %+v", t.state)
 	return execCtx.SaveState(ctx)
 }


### PR DESCRIPTION
There is a very unlikely (but possible) scenario which results in the task state having `t.state.Progress == 1` and `t.state.MilestoneChunkIndex != t.state.ChunkCount` which may cause a live lock in nemesis tests with the task being restarted but not making progress.

Example:
https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build/10674745634/1/nebius-x86-64/test_data/actions-runner/_work/nbs/nbs/cloud/disk_manager/internal/pkg/facade/image_service_nemesis_test/test-results/image_service_nemesis_test/chunk2/testing_out_stuff/
`cloud/disk_manager/internal/pkg/facade/image_service_nemesis_test/image_service_nemesis_test.TestImageServiceCreateRawImageFromURL`

Unfortunately, this hypothesis cannot be proven due to the lack of logs