### PR TITLE
nbd netlink refactoring

### DIFF
--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -395,7 +395,6 @@ void TNetlinkDevice::DisconnectDevice()
 void TNetlinkDevice::DoConnectDevice(bool connected)
 {
     try {
-        /*
         auto command = NBD_CMD_CONNECT;
         if (connected) {
             if (!Reconfigure) {
@@ -406,9 +405,6 @@ void TNetlinkDevice::DoConnectDevice(bool connected)
         } else {
             STORAGE_INFO("connect " << DeviceName);
         }
-        */
-        Y_UNUSED(connected);
-        auto command = Reconfigure ? NBD_CMD_RECONFIGURE : NBD_CMD_CONNECT;
 
         TNetlinkSocket socket;
         TNetlinkMessage message(socket.GetFamily(), command);


### PR DESCRIPTION
- fix context leak when nl_socket_modify_cb fails
- use clojure instead of a static method as a socket callback
- move TNetlinkDevice methods outside of the class definition to reduce nesting
- use nl_send_auto + nl_wait_for_ack instead of nl_send_sync to differentiate between send and recv errors