### PR TITLE
[Filestore] add information about backpressure to the monpage

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -405,6 +405,7 @@ private:
         const NProto::TSessionEvent& event);
 
     TBackpressureThresholds BuildBackpressureThresholds() const;
+    TBackpressureValues GetBackpressureValues() const;
 
     void ResetThrottlingPolicy();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1059,6 +1059,44 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         TAG(TH3) { out << "CompactionMap"; }
         DumpCompactionMap(out, TabletID(), GetCompactionMapStats(topSize));
 
+        const auto backpressureThresholds = BuildBackpressureThresholds();
+        const auto backpressureValues = GetBackpressureValues();
+        TString message;
+        bool isWriteAllowed = IsWriteAllowed(
+            backpressureThresholds,
+            backpressureValues,
+            &message);
+        TAG(TH3) { out << "Backpressure"; }
+        if (!isWriteAllowed) {
+            out << "<div class='alert alert-danger'>" << "Write not allowed: " << message << "</div>";
+        } else {
+            out << "<div class='alert'>Write allowed</div>";
+        }
+
+        TABLE_CLASS("table table-bordered") {
+            TABLEHEAD() {
+                TABLER() {
+                    TABLEH() { out << "Name"; }
+                    TABLEH() { out << "Value"; }
+                    TABLEH() { out << "Threshold"; }
+                }
+            }
+#define DUMP_BACKPRESSURE_FIELD(name)                                          \
+            TABLER() {                                                         \
+                TABLED() { out << #name; }                                     \
+                TABLED() { out << backpressureValues.name; }                   \
+                TABLED() { out << backpressureThresholds.name; }               \
+            }                                                                  \
+// DUMP_BACKPRESSURE_FIELD
+
+            DUMP_BACKPRESSURE_FIELD(Flush);
+            DUMP_BACKPRESSURE_FIELD(FlushBytes);
+            DUMP_BACKPRESSURE_FIELD(CompactionScore);
+            DUMP_BACKPRESSURE_FIELD(CleanupScore);
+
+#undef DUMP_BACKPRESSURE_FIELD
+        }
+
 #define DUMP_INFO_FIELD(info, name)                                            \
         TABLER() {                                                             \
             TABLED() { out << #name; }                                         \

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -714,8 +714,11 @@ public:
         }
     };
 
+    using TBackpressureValues = TBackpressureThresholds;
+
     bool IsWriteAllowed(
         const TBackpressureThresholds& thresholds,
+        const TBackpressureValues& values,
         TString* message) const;
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -238,31 +238,27 @@ bool TIndexTabletState::HasActiveTruncateOp(ui64 nodeId) const
 
 bool TIndexTabletState::IsWriteAllowed(
     const TIndexTabletState::TBackpressureThresholds& thresholds,
+    const TIndexTabletState::TBackpressureValues& values,
     TString* message) const
 {
-    const auto freshBlocksDataSize = GetFreshBlocksCount() * GetBlockSize();
-
-    if (freshBlocksDataSize >= thresholds.Flush) {
-        *message = TStringBuilder() << "freshBlocksDataSize: "
-            << freshBlocksDataSize;
+    if (values.Flush >= thresholds.Flush) {
+        *message = TStringBuilder() << "freshBlocksDataSize: " << values.Flush;
         return false;
     }
 
-    const auto freshBytesCount = GetFreshBytesCount();
-    if (freshBytesCount >= thresholds.FlushBytes) {
-        *message = TStringBuilder() << "freshBytesCount: " << freshBytesCount;
+    if (values.FlushBytes >= thresholds.FlushBytes) {
+        *message = TStringBuilder() << "freshBytesCount: " << values.FlushBytes;
         return false;
     }
 
-    const auto compactionScore = GetRangeToCompact().Score;
-    if (compactionScore >= thresholds.CompactionScore) {
-        *message = TStringBuilder() << "compactionScore: " << compactionScore;
+    if (values.CompactionScore >= thresholds.CompactionScore) {
+        *message = TStringBuilder()
+                   << "compactionScore: " << values.CompactionScore;
         return false;
     }
 
-    const auto cleanupScore = GetRangeToCleanup().Score;
-    if (cleanupScore >= thresholds.CleanupScore) {
-        *message = TStringBuilder() << "cleanupScore: " << cleanupScore;
+    if (values.CleanupScore >= thresholds.CleanupScore) {
+        *message = TStringBuilder() << "cleanupScore: " << values.CleanupScore;
         return false;
     }
 


### PR DESCRIPTION
Adding information about backpressure state to the monpage for better observability:

---

<img width="902" alt="image" src="https://github.com/user-attachments/assets/b6395ea7-dcff-4046-83d8-e9ed750b3c09">

---

<img width="921" alt="image" src="https://github.com/user-attachments/assets/5d14be34-6d03-474d-8f04-a9f126ccf8f1">
