### PR TITLE
[Filestore] merge-to-stable: allowing FS size decrease with a Force flag, Fix incorrect format string in service_actor_getnodeattr.cpp

### DIFF
--- a/cloud/filestore/apps/client/lib/resize.cpp
+++ b/cloud/filestore/apps/client/lib/resize.cpp
@@ -15,6 +15,7 @@ private:
     const TPerformanceProfileParams PerformanceProfileParams;
 
     ui64 BlocksCount = 0;
+    bool Force = false;
 
 public:
     TResizeCommand()
@@ -24,6 +25,10 @@ public:
             .Required()
             .RequiredArgument("NUM")
             .StoreResult(&BlocksCount);
+
+        Opts.AddLongOption("force")
+            .StoreTrue(&Force)
+            .Help("force flag allows to decrease the size of the file store");
     }
 
     bool Execute() override
@@ -33,6 +38,7 @@ public:
         auto request = std::make_shared<NProto::TResizeFileStoreRequest>();
         request->SetFileSystemId(FileSystemId);
         request->SetBlocksCount(BlocksCount);
+        request->SetForce(Force);
 
         PerformanceProfileParams.FillRequest(*request);
 

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -112,7 +112,7 @@ void TGetNodeAttrActor::GetNodeAttrInFollower(const TActorContext& ctx)
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::SERVICE,
-        "[%s] Executing GetNodeAttr in follower for %lu, %s, %s",
+        "[%s] Executing GetNodeAttr in follower for %lu, %s",
         LogTag.c_str(),
         GetNodeAttrRequest.GetNodeId(),
         GetNodeAttrRequest.GetName().Quote().c_str());

--- a/cloud/filestore/tests/client/canondata/result.json
+++ b/cloud/filestore/tests/client/canondata/result.json
@@ -20,6 +20,9 @@
     "test.test_multitablet_ls": {
         "uri": "file://test.test_multitablet_ls/results.txt"
     },
+    "test.test_resize": {
+        "uri": "file://test.test_resize/results.txt"
+    },
     "test.test_stat": {
         "uri": "file://test.test_stat/results.txt"
     },

--- a/cloud/filestore/tests/client/canondata/test.test_resize/results.txt
+++ b/cloud/filestore/tests/client/canondata/test.test_resize/results.txt
@@ -1,0 +1,1 @@
+resize failed as expected

--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -264,6 +264,29 @@ def test_partial_set_node_attr():
     assert stat["Mode"] == new_stat["Mode"]
 
 
+def test_resize():
+    client, results_path = __init_test()
+    out = client.create(
+        "fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT
+    )
+
+    out += client.resize("fs0", 2 * BLOCKS_COUNT)
+
+    try:
+        client.resize("fs0", BLOCKS_COUNT)
+    except Exception:
+        out += b'resize failed as expected'
+
+    out += client.resize("fs0", BLOCKS_COUNT, force=True)
+    out += client.destroy("fs0")
+
+    with open(results_path, "wb") as results_file:
+        results_file.write(out)
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret
+
+
 def test_multitablet_ls():
     client, results_path = __init_test()
 

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -77,6 +77,19 @@ class NfsCliClient:
 
         return pid
 
+    def resize(self, fs, blk_count, force=False):
+        cmd = [
+            self.__binary_path, "resize",
+            "--filesystem", fs,
+            "--blocks-count", str(blk_count),
+        ] + self.__cmd_opts()
+
+        if force:
+            cmd.append("--force")
+
+        logger.info("resizing nfs: " + " ".join(cmd))
+        return common.execute(cmd).stdout
+
     def list_filestores(self):
         cmd = [
             self.__binary_path, "listfilestores",


### PR DESCRIPTION
541968c8db244fe903dd398d9d70b66019c27786
f30724825fd2324eeab68e1ba5dacd767c62c8a8