### PR TITLE
nbd netlink refactoring part 2

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -183,7 +183,7 @@ message TServerConfig
     // NBD request timeout in seconds, only makes sense if using netlink
     optional uint32 NbdRequestTimeout = 112;
 
-    // NBD connection timeout in seconds, only makes sense if using netlink
+    // NBD connection timeout in seconds
     optional uint32 NbdConnectionTimeout = 113;
 
     // Endpoint Proxy unix socket path. Triggers proxy device factory usage

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -551,10 +551,13 @@ void TBootstrapBase::Init()
             EndpointProxyClient);
     }
 
+    // The only case we want kernel to retry requests is when the socket is dead
+    // due to nbd server restart. And since we can't configure ioctl device to
+    // use a new socket, request timeout effectively becomes connection timeout
     if (!nbdDeviceFactory) {
         nbdDeviceFactory = NBD::CreateDeviceFactory(
             Logging,
-            TDuration::Days(1));    // timeout
+            Configs->ServerConfig->GetNbdConnectionTimeout());  // timeout
     }
 
     EndpointManager = CreateEndpointManager(

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -631,15 +631,15 @@ struct TServer: IEndpointProxyServer
                 TDuration::Days(1),         // connection timeout
                 true);                      // reconfigure device if exists
         } else {
-            // For netlink devices we have to balance request timeout between
-            // time it takes to fail request for good and resend it if socket
-            // is dead due to proxy restart. We can't configure ioctl device
-            // to use a fresh socket, so there is no point configuring it
+            // The only case we want kernel to retry requests is when the socket
+            // is dead due to nbd server restart. And since we can't configure
+            // ioctl device to use a new socket, request timeout effectively
+            // becomes connection timeout
             ep.NbdDevice = NBD::CreateDevice(
                 Logging,
                 *ep.ListenAddress,
                 request.GetNbdDevice(),
-                TDuration::Days(1));    // request timeout
+                TDuration::Days(1));        // timeout
         }
 
         auto status = ep.NbdDevice->Start().ExtractValue();

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -64,11 +64,6 @@ public:
         nl_socket_free(Socket);
     }
 
-    operator nl_sock*() const
-    {
-        return Socket;
-    }
-
     int GetFamily() const
     {
         return Family;
@@ -78,6 +73,7 @@ public:
     void SetCallback(nl_cb_type type, F func)
     {
         auto arg = std::make_unique<TResponseHandler>(std::move(func));
+
         if (int err = nl_socket_modify_cb(
                 Socket,
                 type,
@@ -97,6 +93,20 @@ public:
             static_cast<TResponseHandler*>(arg));
 
         return (*func)(static_cast<genlmsghdr*>(nlmsg_data(nlmsg_hdr(msg))));
+    }
+
+    void Send(nl_msg* message)
+    {
+        if (int err = nl_send_auto(Socket, message); err < 0) {
+            throw TServiceError(E_FAIL)
+                << "send error: " << nl_geterror(err);
+        }
+        if (int err = nl_wait_for_ack(Socket)) {
+            // this is either recv error, or an actual error message received
+            // from the kernel
+            throw TServiceError(E_FAIL)
+                << "recv error: " << nl_geterror(err);
+        }
     }
 };
 
@@ -120,9 +130,7 @@ public:
 
     ~TNestedAttribute()
     {
-        if (Attribute) {
-            nla_nest_end(Message, Attribute);
-        }
+        nla_nest_end(Message, Attribute);
     }
 };
 
@@ -156,6 +164,11 @@ public:
         nlmsg_free(Message);
     }
 
+    operator nl_msg*() const
+    {
+        return Message;
+    }
+
     template <typename T>
     void Put(int attribute, T data)
     {
@@ -169,20 +182,6 @@ public:
     {
         return TNestedAttribute(Message, attribute);
     }
-
-    void Send(nl_sock* socket)
-    {
-        if (int err = nl_send_auto(socket, Message); err < 0) {
-            throw TServiceError(E_FAIL)
-                << "send error: " << nl_geterror(err);
-        }
-        if (int err = nl_wait_for_ack(socket)) {
-            // this is either recv error, or an actual error message received
-            // from the kernel
-            throw TServiceError(E_FAIL)
-                << "recv error: " << nl_geterror(err);
-        }
-    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -195,26 +194,25 @@ private:
     const ILoggingServicePtr Logging;
     const TNetworkAddress ConnectAddress;
     const TString DeviceName;
-    const TDuration Timeout;
-    const TDuration DeadConnectionTimeout;
+    const TDuration RequestTimeout;
+    const TDuration ConnectionTimeout;
     const bool Reconfigure;
 
     TLog Log;
     IClientHandlerPtr Handler;
     TSocket Socket;
     ui32 DeviceIndex;
-    TAtomic ShouldStop = 0;
 
-    TPromise<NProto::TError> StartResult = NewPromise<NProto::TError>();
-    TPromise<NProto::TError> StopResult = NewPromise<NProto::TError>();
+    TPromise<NProto::TError> StartResult;
+    TPromise<NProto::TError> StopResult;
 
 public:
     TNetlinkDevice(
         ILoggingServicePtr logging,
         TNetworkAddress connectAddress,
         TString deviceName,
-        TDuration timeout,
-        TDuration deadConnectionTimeout,
+        TDuration requestTimeout,
+        TDuration connectionTimeout,
         bool reconfigure);
 
     ~TNetlinkDevice();
@@ -242,14 +240,14 @@ TNetlinkDevice::TNetlinkDevice(
         ILoggingServicePtr logging,
         TNetworkAddress connectAddress,
         TString deviceName,
-        TDuration timeout,
-        TDuration deadConnectionTimeout,
+        TDuration requestTimeout,
+        TDuration connectionTimeout,
         bool reconfigure)
     : Logging(std::move(logging))
     , ConnectAddress(std::move(connectAddress))
     , DeviceName(std::move(deviceName))
-    , Timeout(timeout)
-    , DeadConnectionTimeout(deadConnectionTimeout)
+    , RequestTimeout(requestTimeout)
+    , ConnectionTimeout(connectionTimeout)
     , Reconfigure(reconfigure)
 {
     Log = Logging->CreateLog("BLOCKSTORE_NBD");
@@ -262,6 +260,11 @@ TNetlinkDevice::~TNetlinkDevice()
 
 TFuture<NProto::TError> TNetlinkDevice::Start()
 {
+    if (StartResult.Initialized()) {
+        return StartResult.GetFuture();
+    }
+    StartResult = NewPromise<NProto::TError>();
+
     try {
         ParseIndex();
         ConnectSocket();
@@ -274,25 +277,19 @@ TFuture<NProto::TError> TNetlinkDevice::Start()
                 << "unable to configure " << DeviceName << ": " << e.what()));
     }
 
-    // will be set asynchronously in Connect > HandleStatus > DoConnect
     return StartResult.GetFuture();
 }
 
 TFuture<NProto::TError> TNetlinkDevice::Stop(bool deleteDevice)
 {
-    if (AtomicSwap(&ShouldStop, 1) == 1) {
+    if (StopResult.Initialized()) {
         return StopResult.GetFuture();
     }
-
-    if (!deleteDevice) {
-        StopResult.SetValue(MakeError(S_OK));
-        return StopResult.GetFuture();
-    }
+    StopResult = NewPromise<NProto::TError>();
 
     try {
-        Disconnect();
         DisconnectSocket();
-        StopResult.SetValue(MakeError(S_OK));
+        deleteDevice ? Disconnect() : StopResult.SetValue(MakeError(S_OK));
 
     } catch (const TServiceError& e) {
         StopResult.SetValue(MakeError(
@@ -319,7 +316,7 @@ TFuture<NProto::TError> TNetlinkDevice::Resize(ui64 deviceSizeInBytes)
             message.Put(NBD_SOCK_FD, static_cast<ui32>(Socket));
         }
 
-        message.Send(socket);
+        socket.Send(message);
 
     } catch (const TServiceError& e) {
         return MakeFuture(MakeError(
@@ -336,6 +333,7 @@ void TNetlinkDevice::ParseIndex()
     // accept dev/nbd* devices with prefix other than /
     TStringBuf l, r;
     TStringBuf(DeviceName).RSplit(NBD_DEVICE_SUFFIX, l, r);
+
     if (!TryFromString(r, DeviceIndex)) {
         throw TServiceError(E_ARGUMENT) << "unable to parse device index";
     }
@@ -379,7 +377,7 @@ void TNetlinkDevice::Connect()
 
     TNetlinkMessage message(socket.GetFamily(), NBD_CMD_STATUS);
     message.Put(NBD_ATTR_INDEX, DeviceIndex);
-    message.Send(socket);
+    socket.Send(message);
 }
 
 void TNetlinkDevice::Disconnect()
@@ -389,7 +387,8 @@ void TNetlinkDevice::Disconnect()
     TNetlinkSocket socket;
     TNetlinkMessage message(socket.GetFamily(), NBD_CMD_DISCONNECT);
     message.Put(NBD_ATTR_INDEX, DeviceIndex);
-    message.Send(socket);
+    socket.Send(message);
+    StopResult.SetValue(MakeError(S_OK));
 }
 
 void TNetlinkDevice::DoConnect(bool connected)
@@ -417,14 +416,14 @@ void TNetlinkDevice::DoConnect(bool connected)
             static_cast<ui64>(info.MinBlockSize));
         message.Put(NBD_ATTR_SERVER_FLAGS, static_cast<ui64>(info.Flags));
 
-        if (Timeout) {
-            message.Put(NBD_ATTR_TIMEOUT, Timeout.Seconds());
+        if (RequestTimeout) {
+            message.Put(NBD_ATTR_TIMEOUT, RequestTimeout.Seconds());
         }
 
-        if (DeadConnectionTimeout) {
+        if (ConnectionTimeout) {
             message.Put(
                 NBD_ATTR_DEAD_CONN_TIMEOUT,
-                DeadConnectionTimeout.Seconds());
+                ConnectionTimeout.Seconds());
         }
 
         {
@@ -433,7 +432,7 @@ void TNetlinkDevice::DoConnect(bool connected)
             message.Put(NBD_SOCK_FD, static_cast<ui32>(Socket));
         }
 
-        message.Send(socket);
+        socket.Send(message);
         StartResult.SetValue(MakeError(S_OK));
 
     } catch (const TServiceError& e) {
@@ -529,19 +528,19 @@ class TNetlinkDeviceFactory final
 {
 private:
     const ILoggingServicePtr Logging;
-    const TDuration Timeout;
-    const TDuration DeadConnectionTimeout;
+    const TDuration RequestTimeout;
+    const TDuration ConnectionTimeout;
     const bool Reconfigure;
 
 public:
     TNetlinkDeviceFactory(
             ILoggingServicePtr logging,
-            TDuration timeout,
-            TDuration deadConnectionTimeout,
+            TDuration requestTimeout,
+            TDuration connectionTimeout,
             bool reconfigure)
         : Logging(std::move(logging))
-        , Timeout(std::move(timeout))
-        , DeadConnectionTimeout(std::move(deadConnectionTimeout))
+        , RequestTimeout(requestTimeout)
+        , ConnectionTimeout(connectionTimeout)
         , Reconfigure(reconfigure)
     {}
 
@@ -558,8 +557,8 @@ public:
             Logging,
             connectAddress,
             std::move(deviceName),
-            Timeout,
-            DeadConnectionTimeout,
+            RequestTimeout,
+            ConnectionTimeout,
             Reconfigure);
     }
 };
@@ -572,29 +571,29 @@ IDevicePtr CreateNetlinkDevice(
     ILoggingServicePtr logging,
     TNetworkAddress connectAddress,
     TString deviceName,
-    TDuration timeout,
-    TDuration deadConnectionTimeout,
+    TDuration requestTimeout,
+    TDuration connectionTimeout,
     bool reconfigure)
 {
     return std::make_shared<TNetlinkDevice>(
         std::move(logging),
         std::move(connectAddress),
         std::move(deviceName),
-        timeout,
-        deadConnectionTimeout,
+        requestTimeout,
+        connectionTimeout,
         reconfigure);
 }
 
 IDeviceFactoryPtr CreateNetlinkDeviceFactory(
     ILoggingServicePtr logging,
-    TDuration timeout,
-    TDuration deadConnectionTimeout,
+    TDuration requestTimeout,
+    TDuration connectionTimeout,
     bool reconfigure)
 {
     return std::make_shared<TNetlinkDeviceFactory>(
         std::move(logging),
-        std::move(timeout),
-        std::move(deadConnectionTimeout),
+        requestTimeout,
+        connectionTimeout,
         reconfigure);
 }
 

--- a/cloud/blockstore/libs/nbd/netlink_device.h
+++ b/cloud/blockstore/libs/nbd/netlink_device.h
@@ -10,14 +10,14 @@ IDevicePtr CreateNetlinkDevice(
     ILoggingServicePtr logging,
     TNetworkAddress connectAddress,
     TString deviceName,
-    TDuration timeout,
-    TDuration deadConnectionTimeout,
+    TDuration requestTimeout,
+    TDuration connectionTimeout,
     bool reconfigure);
 
 IDeviceFactoryPtr CreateNetlinkDeviceFactory(
     ILoggingServicePtr logging,
-    TDuration timeout,
-    TDuration deadConnectionTimeout,
+    TDuration requestTimeout,
+    TDuration connectionTimeout,
     bool reconfigure);
 
 }   // namespace NCloud::NBlockStore::NBD

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -297,15 +297,19 @@ void TBootstrap::Start()
                 Logging,
                 listenAddress,
                 Options->ConnectDevice,
-                Options->Timeout,
-                Options->DeadConnectionTimeout,
+                Options->RequestTimeout,
+                Options->ConnectionTimeout,
                 Options->Reconfigure);
         } else {
+            // The only case we want kernel to retry requests is when the socket
+            // is dead due to nbd server restart. And since we can't configure
+            // ioctl device to use a new socket, request timeout effectively
+            // becomes connection timeout
             NbdDevice = CreateDevice(
                 Logging,
                 listenAddress,
                 Options->ConnectDevice,
-                Options->Timeout);
+                Options->ConnectionTimeout);
         }
         auto status = NbdDevice->Start().ExtractValue();
         if (HasError(status)) {

--- a/cloud/blockstore/tools/nbd/options.cpp
+++ b/cloud/blockstore/tools/nbd/options.cpp
@@ -192,23 +192,23 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("NUM")
         .StoreResult(&MaxInFlightBytes);
 
-    opts.AddLongOption("timeout", "request timeout")
+    opts.AddLongOption("request-timeout", "request timeout")
         .OptionalArgument("NUM")
         .Handler1T<TString>([this] (const auto& s) {
-            Timeout = TDuration::Parse(s);
+            RequestTimeout = TDuration::Parse(s);
             Y_ENSURE(
-                Timeout.MicroSeconds() % 1000000 == 0,
+                RequestTimeout.MicroSeconds() % 1000000 == 0,
                 "timeout should be a multiple of a second"
             );
         });
 
-    opts.AddLongOption("dead-connection-timeout", "dead connection timeout")
+    opts.AddLongOption("connection-timeout", "connection timeout")
         .OptionalArgument("NUM")
         .Handler1T<TString>([this] (const auto& s) {
-            DeadConnectionTimeout = TDuration::Parse(s);
+            ConnectionTimeout = TDuration::Parse(s);
             Y_ENSURE(
-                DeadConnectionTimeout.MicroSeconds() % 1000000 == 0,
-                "dead connection timeout should be a multiple of a second"
+                ConnectionTimeout.MicroSeconds() % 1000000 == 0,
+                "connection timeout should be a multiple of a second"
             );
         });
 

--- a/cloud/blockstore/tools/nbd/options.h
+++ b/cloud/blockstore/tools/nbd/options.h
@@ -70,8 +70,8 @@ struct TOptions
 
     bool UnalignedRequestsDisabled = false;
 
-    TDuration Timeout = TDuration::Days(1);
-    TDuration DeadConnectionTimeout = TDuration::Hours(1);
+    TDuration RequestTimeout = TDuration::Minutes(5);
+    TDuration ConnectionTimeout = TDuration::Hours(1);
 
     void Parse(int argc, char** argv);
 };


### PR DESCRIPTION
- rename Timeout -> RequestTimeout
- rename DeadConnectionTimeout -> ConnectionTimeout
- move Send method from TNetlinkMessage to TNetlinkSocket
- clarify comments regarding ioctl device timeout
- get rid of ShouldStop atomic
- close client socket regardless of deleteDevice flag
- replace hard-coded 1 day ioctl device timeout with connection timeout which serves the same purpose
- make Start idempotent