### PR TITLE
Refactor volume request handling

### DIFF
--- a/cloud/blockstore/libs/storage/core/forward_helpers.h
+++ b/cloud/blockstore/libs/storage/core/forward_helpers.h
@@ -37,6 +37,17 @@ template <typename TMethod>
 constexpr bool IsReadOrWriteMethod =
     IsReadMethod<TMethod> || IsWriteMethod<TMethod>;
 
+template <typename T>
+constexpr bool IsDescribeBlocksMethod =
+    std::is_same_v<T, TEvVolume::TDescribeBlocksMethod>;
+
+template <typename TMethod>
+constexpr bool IsCheckpointMethod =
+    std::is_same_v<TMethod, TEvService::TCreateCheckpointMethod> ||
+    std::is_same_v<TMethod, TEvService::TDeleteCheckpointMethod> ||
+    std::is_same_v<TMethod, TEvVolume::TDeleteCheckpointDataMethod> ||
+    std::is_same_v<TMethod, TEvService::TGetCheckpointStatusMethod>;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -366,10 +366,42 @@ TBlockRange64 BuildRequestBlockRange(
     const TEvService::TEvZeroBlocksRequest& request,
     const ui32 blockSize)
 {
-    Y_UNUSED(blockSize);
     return TBlockRange64::WithLength(
         request.Record.GetStartIndex(),
         CalculateWriteRequestBlockCount(request.Record, blockSize));
+}
+
+TBlockRange64 BuildRequestBlockRange(
+    const TEvVolume::TEvDescribeBlocksRequest& request,
+    const ui32 blockSize)
+{
+    Y_UNUSED(blockSize);
+
+    return TBlockRange64::WithLength(
+        request.Record.GetStartIndex(),
+        request.Record.GetBlocksCount());
+}
+
+TBlockRange64 BuildRequestBlockRange(
+    const TEvService::TEvGetChangedBlocksRequest& request,
+    const ui32 blockSize)
+{
+    Y_UNUSED(blockSize);
+
+    return TBlockRange64::WithLength(
+        request.Record.GetStartIndex(),
+        request.Record.GetBlocksCount());
+}
+
+TBlockRange64 BuildRequestBlockRange(
+    const TEvVolume::TEvCompactRangeRequest& request,
+    const ui32 blockSize)
+{
+    Y_UNUSED(blockSize);
+
+    return TBlockRange64::WithLength(
+        request.Record.GetStartIndex(),
+        request.Record.GetBlocksCount());
 }
 
 TBlockRange64 BuildRequestBlockRange(

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/kikimr/events.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
 #include <util/generic/string.h>
@@ -199,6 +200,18 @@ TBlockRange64 BuildRequestBlockRange(
 
 TBlockRange64 BuildRequestBlockRange(
     const TEvService::TEvZeroBlocksRequest& request,
+    const ui32 blockSize);
+
+TBlockRange64 BuildRequestBlockRange(
+    const TEvVolume::TEvDescribeBlocksRequest& request,
+    const ui32 blockSize);
+
+TBlockRange64 BuildRequestBlockRange(
+    const TEvService::TEvGetChangedBlocksRequest& request,
+    const ui32 blockSize);
+
+TBlockRange64 BuildRequestBlockRange(
+    const TEvVolume::TEvCompactRangeRequest& request,
     const ui32 blockSize);
 
 TBlockRange64 BuildRequestBlockRange(

--- a/cloud/blockstore/libs/storage/volume/partition_requests.h
+++ b/cloud/blockstore/libs/storage/volume/partition_requests.h
@@ -51,24 +51,7 @@ bool ToPartitionRequests(
     const ui32 blocksPerStripe,
     const typename TMethod::TRequest::TPtr& ev,
     TVector<TPartitionRequest<TMethod>>* requests,
-    TBlockRange64* blockRange)
-{
-    Y_UNUSED(blockSize);
-    Y_UNUSED(blocksPerStripe);
-    Y_UNUSED(ev);
-    Y_UNUSED(requests);
-    Y_UNUSED(blockRange);
-
-    Y_ABORT_UNLESS(!partitions.empty());
-    STORAGE_VERIFY_C(
-        false,
-        NCloud::TWellKnownEntityTypes::DISK,
-        partitions[0].PartitionConfig.GetDiskId(),
-        TStringBuilder() << "ToPartitionRequests not implemented for "
-            << TMethod::Name);
-
-    return false;
-}
+    TBlockRange64* blockRange);
 
 template <typename TMethod>
 ui32 InitPartitionRequest(
@@ -204,8 +187,6 @@ bool ToPartitionRequests<TEvService::TReadBlocksMethod>(
     TVector<TPartitionRequest<TEvService::TReadBlocksMethod>>* requests,
     TBlockRange64* blockRange)
 {
-    Y_UNUSED(blockSize);
-
     const auto& proto = ev->Get()->Record;
 
     *blockRange = BuildRequestBlockRange(*ev->Get(), blockSize);
@@ -408,14 +389,10 @@ bool ToPartitionRequests<TEvVolume::TDescribeBlocksMethod>(
     TVector<TPartitionRequest<TEvVolume::TDescribeBlocksMethod>>* requests,
     TBlockRange64* blockRange)
 {
-    Y_UNUSED(blockSize);
-
     const auto& proto = ev->Get()->Record;
 
-    *blockRange = TBlockRange64::WithLength(
-        proto.GetStartIndex(),
-        proto.GetBlocksCount()
-    );
+    *blockRange = BuildRequestBlockRange(*ev->Get(), blockSize);
+
     requests->resize(CalculateRequestCount(
         blocksPerStripe,
         *blockRange,
@@ -447,14 +424,10 @@ bool ToPartitionRequests<TEvService::TGetChangedBlocksMethod>(
     TVector<TPartitionRequest<TEvService::TGetChangedBlocksMethod>>* requests,
     TBlockRange64* blockRange)
 {
-    Y_UNUSED(blockSize);
-
     const auto& proto = ev->Get()->Record;
 
-    *blockRange = TBlockRange64::WithLength(
-        proto.GetStartIndex(),
-        proto.GetBlocksCount()
-    );
+    *blockRange = BuildRequestBlockRange(*ev->Get(), blockSize);
+
     requests->resize(CalculateRequestCount(
         blocksPerStripe,
         *blockRange,
@@ -514,14 +487,10 @@ bool ToPartitionRequests<TEvVolume::TCompactRangeMethod>(
     TVector<TPartitionRequest<TEvVolume::TCompactRangeMethod>>* requests,
     TBlockRange64* blockRange)
 {
-    Y_UNUSED(blockSize);
-
     const auto& proto = ev->Get()->Record;
 
-    *blockRange = TBlockRange64::WithLength(
-        proto.GetStartIndex(),
-        proto.GetBlocksCount()
-    );
+    *blockRange = BuildRequestBlockRange(*ev->Get(), blockSize);
+
     requests->resize(CalculateRequestCount(
         blocksPerStripe,
         *blockRange,
@@ -658,6 +627,32 @@ bool ToPartitionRequests<TEvVolume::TGetScanDiskStatusMethod>(
         ev,
         requests,
         blockRange);
+}
+
+template <>
+bool ToPartitionRequests<TEvVolume::TGetUsedBlocksMethod>(
+    const TPartitionInfoList& partitions,
+    const ui32 blockSize,
+    const ui32 blocksPerStripe,
+    const TEvVolume::TGetUsedBlocksMethod::TRequest::TPtr& ev,
+    TVector<TPartitionRequest<TEvVolume::TGetUsedBlocksMethod>>* requests,
+    TBlockRange64* blockRange)
+{
+    Y_UNUSED(blockSize);
+    Y_UNUSED(blocksPerStripe);
+    Y_UNUSED(ev);
+    Y_UNUSED(requests);
+    Y_UNUSED(blockRange);
+
+    Y_ABORT_UNLESS(!partitions.empty());
+    STORAGE_VERIFY_C(
+        false,
+        NCloud::TWellKnownEntityTypes::DISK,
+        partitions[0].PartitionConfig.GetDiskId(),
+        TStringBuilder() << "ToPartitionRequests not implemented for "
+                            "TEvVolume::TGetUsedBlocksMethod");
+
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -132,19 +132,19 @@ class TVolumeActor final
 
     struct TVolumeRequest
     {
-        using TCancelRoutine = std::function<void(
+        using TCancelRoutine = void(
             const NActors::TActorContext& ctx,
             NActors::TActorId caller,
             ui64 callerCookie,
             TCallContext& callContext,
-            NProto::TError error)>;
+            NProto::TError error);
 
         NActors::TActorId Caller;
         ui64 CallerCookie;
         TCallContextPtr CallContext;
         TCallContextPtr ForkedContext;
         ui64 ReceiveTime;
-        TCancelRoutine CancelRoutine;
+        TCancelRoutine* CancelRoutine;
 
         TVolumeRequest(
                 const NActors::TActorId& caller,
@@ -158,7 +158,7 @@ class TVolumeActor final
             , CallContext(std::move(callContext))
             , ForkedContext(std::move(forkedContext))
             , ReceiveTime(receiveTime)
-            , CancelRoutine(std::move(cancelRoutine))
+            , CancelRoutine(cancelRoutine)
         {}
 
         void CancelRequest(

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -837,7 +837,15 @@ private:
         const ui64 volumeRequestId);
 
     template <typename TMethod>
-    bool HandleRequest(
+    bool HandleMultipartitionVolumeRequest(
+        const NActors::TActorContext& ctx,
+        const typename TMethod::TRequest::TPtr& ev,
+        ui64 volumeRequestId,
+        bool isTraced,
+        ui64 traceTs);
+
+    template <typename TMethod>
+    void HandleCheckpointRequest(
         const NActors::TActorContext& ctx,
         const typename TMethod::TRequest::TPtr& ev,
         ui64 volumeRequestId,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -920,7 +920,7 @@ void TVolumeActor::ReplyErrorOnNormalGetChangedBlocksRequestForDiskRegistryBased
 }
 
 template <>
-bool TVolumeActor::HandleRequest<TCreateCheckpointMethod>(
+void TVolumeActor::HandleCheckpointRequest<TCreateCheckpointMethod>(
     const TActorContext& ctx,
     const TCreateCheckpointMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
@@ -953,11 +953,10 @@ bool TVolumeActor::HandleRequest<TCreateCheckpointMethod>(
         {std::move(requestInfo), isTraced, traceTs}});
 
     ProcessCheckpointRequests(ctx);
-    return true;
 }
 
 template <>
-bool TVolumeActor::HandleRequest<TDeleteCheckpointMethod>(
+void TVolumeActor::HandleCheckpointRequest<TDeleteCheckpointMethod>(
     const TActorContext& ctx,
     const TDeleteCheckpointMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
@@ -983,11 +982,10 @@ bool TVolumeActor::HandleRequest<TDeleteCheckpointMethod>(
         {std::move(requestInfo), isTraced, traceTs}});
 
     ProcessCheckpointRequests(ctx);
-    return true;
 }
 
 template <>
-bool TVolumeActor::HandleRequest<TDeleteCheckpointDataMethod>(
+void TVolumeActor::HandleCheckpointRequest<TDeleteCheckpointDataMethod>(
     const TActorContext& ctx,
     const TDeleteCheckpointDataMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
@@ -1013,11 +1011,10 @@ bool TVolumeActor::HandleRequest<TDeleteCheckpointDataMethod>(
         {std::move(requestInfo), isTraced, traceTs}});
 
     ProcessCheckpointRequests(ctx);
-    return true;
 }
 
 template <>
-bool TVolumeActor::HandleRequest<TGetCheckpointStatusMethod>(
+void TVolumeActor::HandleCheckpointRequest<TGetCheckpointStatusMethod>(
     const TActorContext& ctx,
     const TGetCheckpointStatusMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
@@ -1052,11 +1049,10 @@ bool TVolumeActor::HandleRequest<TGetCheckpointStatusMethod>(
         reply(
             MakeError(E_NOT_FOUND, "Checkpoint not found"),
             NProto::ECheckpointStatus::ERROR);
-        return true;
+        return;
     }
 
     reply(MakeError(S_OK), GetCheckpointStatus(*checkpoint));
-    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -27,48 +27,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-constexpr bool IsDescribeBlocksMethod =
-    std::is_same_v<T, TEvVolume::TDescribeBlocksMethod>;
-
-////////////////////////////////////////////////////////////////////////////////
-
-template <typename TMethod>
-bool CanForwardToPartition(ui32 partitionCount)
-{
-    return partitionCount <= 1;
-}
-
-template <>
-bool CanForwardToPartition<TEvService::TCreateCheckpointMethod>(ui32 partitionCount)
-{
-    Y_UNUSED(partitionCount);
-    return false;
-}
-
-template <>
-bool CanForwardToPartition<TEvService::TDeleteCheckpointMethod>(ui32 partitionCount)
-{
-    Y_UNUSED(partitionCount);
-    return false;
-}
-
-template <>
-bool CanForwardToPartition<TEvVolume::TDeleteCheckpointDataMethod>(ui32 partitionCount)
-{
-    Y_UNUSED(partitionCount);
-    return false;
-}
-
-template <>
-bool CanForwardToPartition<TEvService::TGetCheckpointStatusMethod>(ui32 partitionCount)
-{
-    Y_UNUSED(partitionCount);
-    return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 Y_HAS_MEMBER(SetThrottlerDelay);
 
 template <typename TResponse>
@@ -106,14 +64,16 @@ void RejectVolumeRequest(
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
-bool TVolumeActor::HandleRequest(
+bool TVolumeActor::HandleMultipartitionVolumeRequest(
     const TActorContext& ctx,
     const typename TMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
     bool isTraced,
     ui64 traceTs)
 {
+    static_assert(!IsCheckpointMethod<TMethod>);
     Y_ABORT_UNLESS(!State->GetDiskRegistryBasedPartitionActor());
+    Y_ABORT_UNLESS(State->GetPartitions().size() > 1);
 
     const auto blocksPerStripe =
         State->GetMeta().GetVolumeConfig().GetBlocksPerStripe();
@@ -135,19 +95,16 @@ bool TVolumeActor::HandleRequest(
         return false;
     }
 
-    // Should always forward request via TPartitionRequestActor for
-    // DescribeBlocks method and multi-partitioned volume.
-    if (State->GetPartitions().size() == 1 ||
-        (partitionRequests.size() == 1 && !IsDescribeBlocksMethod<TMethod>))
-    {
+    // For DescribeBlocks should always forward request to
+    // TPartitionRequestActor
+    if (partitionRequests.size() == 1 && !IsDescribeBlocksMethod<TMethod>) {
         ev->Get()->Record = std::move(partitionRequests.front().Event->Record);
         SendRequestToPartition<TMethod>(
             ctx,
             ev,
             volumeRequestId,
             partitionRequests.front().PartitionId,
-            traceTs
-        );
+            traceTs);
 
         return true;
     }
@@ -185,45 +142,6 @@ bool TVolumeActor::HandleRequest(
 
     return true;
 }
-
-// Do NOT remove this forward declaration of template method
-// TVolumeActor::HandleRequest<> specializations!
-// Specialization defined in 'volume_actor_checkpoint.cpp'. Without this forward
-// declaration, a template implementation will be generated, and the linker will
-// not use specialization defined in 'volume_actor_checkpoint.cpp' translation
-// unit.
-
-template<>
-bool TVolumeActor::HandleRequest<TEvService::TCreateCheckpointMethod>(
-    const TActorContext& ctx,
-    const TEvService::TCreateCheckpointMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
-    bool isTraced,
-    ui64 traceTs);
-
-template<>
-bool TVolumeActor::HandleRequest<TEvService::TDeleteCheckpointMethod>(
-    const TActorContext& ctx,
-    const TEvService::TDeleteCheckpointMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
-    bool isTraced,
-    ui64 traceTs);
-
-template<>
-bool TVolumeActor::HandleRequest<TEvVolume::TDeleteCheckpointDataMethod>(
-    const TActorContext& ctx,
-    const TEvVolume::TDeleteCheckpointDataMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
-    bool isTraced,
-    ui64 traceTs);
-
-template<>
-bool TVolumeActor::HandleRequest<TEvService::TGetCheckpointStatusMethod>(
-    const TActorContext& ctx,
-    const TEvService::TGetCheckpointStatusMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
-    bool isTraced,
-    ui64 traceTs);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -809,9 +727,18 @@ void TVolumeActor::ForwardRequest(
     /*
      *  Passing the request to the underlying (storage) layer.
      */
-    if (CanForwardToPartition<TMethod>(State->GetPartitions().size())) {
+
+    const bool isSinglePartitionVolume = State->GetPartitions().size() <= 1;
+    if constexpr (IsCheckpointMethod<TMethod>) {
+        HandleCheckpointRequest<TMethod>(ctx, ev, volumeRequestId, isTraced, now);
+    } else if (isSinglePartitionVolume) {
         SendRequestToPartition<TMethod>(ctx, ev, volumeRequestId, 0, now);
-    } else if (!HandleRequest<TMethod>(ctx, ev, volumeRequestId, isTraced, now))
+    } else if (!HandleMultipartitionVolumeRequest<TMethod>(
+                   ctx,
+                   ev,
+                   volumeRequestId,
+                   isTraced,
+                   now))
     {
         WriteAndZeroRequestsInFlight.RemoveRequest(volumeRequestId);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -44,7 +44,7 @@ void StoreThrottlerDelay(TResponse& response, TDuration delay)
 template <typename TMethod>
 void RejectVolumeRequest(
     const TActorContext& ctx,
-    const NActors::TActorId& caller,
+    NActors::TActorId caller,
     ui64 callerCookie,
     TCallContext& callContext,
     NProto::TError error)


### PR DESCRIPTION
1. отделяю обработку сообщений про чекпоинты в отдельный шаблонный метод. 
2. добавляю новых перегрузок для BuildRequestBlockRange
3. убираю дефолтную реализацию шаблона ToPartitionRequests.
4. переименовываю HandleRequest в HandleMultipartitionVolumeRequest, так как он зовется только для мультипартиционных вольюмов
