### PR TITLE
issue-1657: duplicate socket

### DIFF
--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -176,7 +176,11 @@ struct TClientStorage: NStorage::NServer::IClientStorage
     {
         Y_UNUSED(source);
 
-        grpc::AddInsecureChannelFromFd(&Server, clientSocket);
+        auto fileHandle = TFileHandle(clientSocket);
+        auto dupSocket = fileHandle.Duplicate();
+        fileHandle.Release();
+
+        grpc::AddInsecureChannelFromFd(&Server, dupSocket);
     }
 
     void RemoveClient(const TSocketHolder& clientSocket) override


### PR DESCRIPTION
grpc::AddInsecureChannelFromFd takes ownership of closing socket. We need to duplicate socket to avoid calling close twice. 