### PR TITLE
[CSI driver] Implementation of staged mount for vhost block and FS volumes in VM mode

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -131,7 +131,7 @@ func newNodeService(
 }
 
 func (s *nodeService) NodeStageVolume(
-	ctx context.Context,
+	_ context.Context,
 	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 
 	log.Printf("csi.NodeStageVolumeRequest: %+v", req)
@@ -156,7 +156,7 @@ func (s *nodeService) NodeStageVolume(
 }
 
 func (s *nodeService) NodeUnstageVolume(
-	ctx context.Context,
+	_ context.Context,
 	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 
 	log.Printf("csi.NodeUnstageVolumeRequest: %+v", req)
@@ -292,8 +292,8 @@ func (s *nodeService) NodeUnpublishVolume(
 }
 
 func (s *nodeService) NodeGetCapabilities(
-	ctx context.Context,
-	req *csi.NodeGetCapabilitiesRequest,
+	_ context.Context,
+	_ *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
 
 	if s.vmMode {
@@ -308,8 +308,8 @@ func (s *nodeService) NodeGetCapabilities(
 }
 
 func (s *nodeService) NodeGetInfo(
-	ctx context.Context,
-	req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	_ context.Context,
+	_ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 
 	return &csi.NodeGetInfoResponse{
 		NodeId: s.nodeID,
@@ -723,7 +723,7 @@ func logVolume(volumeId string, format string, v ...any) {
 }
 
 func (s *nodeService) NodeGetVolumeStats(
-	ctx context.Context,
+	_ context.Context,
 	req *csi.NodeGetVolumeStatsRequest) (
 	*csi.NodeGetVolumeStatsResponse, error) {
 

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -361,6 +361,10 @@ func (s *nodeService) nodePublishDiskAsVhostSocket(
 		return fmt.Errorf("failed to start NBS endpoint: %w", err)
 	}
 
+	if err := s.createDummyImgFile(endpointDir); err != nil {
+		return err
+	}
+
 	return s.mountSocketDir(req)
 }
 
@@ -511,6 +515,10 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 		return fmt.Errorf("failed to start NFS endpoint: %w", err)
 	}
 
+	if err := s.createDummyImgFile(endpointDir); err != nil {
+		return err
+	}
+
 	return s.mountSocketDir(req)
 }
 
@@ -564,10 +572,6 @@ func (s *nodeService) nodeUnpublishVolume(
 func (s *nodeService) mountSocketDir(req *csi.NodePublishVolumeRequest) error {
 
 	endpointDir := filepath.Join(s.socketsDir, s.getPodId(req), req.VolumeId)
-
-	if err := s.createDummyImgFile(endpointDir); err != nil {
-		return err
-	}
 
 	targetPerm := os.FileMode(0775)
 	if err := os.MkdirAll(req.TargetPath, targetPerm); err != nil {

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -383,7 +383,7 @@ func (s *nodeService) nodePublishDiskAsFilesystem(
 		return err
 	}
 
-	if mnt.VolumeMountGroup != "" {
+	if mnt != nil && mnt.VolumeMountGroup != "" {
 		cmd := exec.Command("chown", "-R", ":"+mnt.VolumeMountGroup, req.TargetPath)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("failed to chown %s to %q: %w, output %q",

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -398,7 +398,7 @@ func (s *nodeService) nodePublishDiskAsVhostSocket(
 		return err
 	}
 
-	return s.mountSocketDir(req)
+	return s.mountSocketDir(endpointDir, req)
 }
 
 func (s *nodeService) nodeStageDiskAsVhostSocket(
@@ -597,7 +597,7 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 		return err
 	}
 
-	return s.mountSocketDir(req)
+	return s.mountSocketDir(endpointDir, req)
 }
 
 func (s *nodeService) nodeStageFileStoreAsVhostSocket(
@@ -633,7 +633,8 @@ func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 }
 
 func (s *nodeService) nodePublishStagedVhostSocket(req *csi.NodePublishVolumeRequest) error {
-	return s.mountSocketDir(req)
+	endpointDir := s.getEndpointDir(s.getInstanceOrPodId(req), req.VolumeId)
+	return s.mountSocketDir(endpointDir, req)
 }
 
 func (s *nodeService) nodeUnpublishVolume(
@@ -687,9 +688,7 @@ func (s *nodeService) getEndpointDir(instanceOrPodId string, volumeId string) st
 	return filepath.Join(s.socketsDir, instanceOrPodId, volumeId)
 }
 
-func (s *nodeService) mountSocketDir(req *csi.NodePublishVolumeRequest) error {
-
-	endpointDir := s.getEndpointDir(s.getInstanceOrPodId(req), req.VolumeId)
+func (s *nodeService) mountSocketDir(sourcePath string, req *csi.NodePublishVolumeRequest) error {
 
 	targetPerm := os.FileMode(0775)
 	if err := os.MkdirAll(req.TargetPath, targetPerm); err != nil {
@@ -705,7 +704,7 @@ func (s *nodeService) mountSocketDir(req *csi.NodePublishVolumeRequest) error {
 	}
 	err := s.mountIfNeeded(
 		req.VolumeId,
-		endpointDir,
+		sourcePath,
 		req.TargetPath,
 		"",
 		mountOptions)

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -705,6 +705,17 @@ func (s *nodeService) nodeUnpublishVolume(
 		return err
 	}
 
+	// In VM-mode for volumes that were staged we need just the unmount, so
+	// we could return here. Unfortunately we don't have enough information
+	// to know if this is a staged volume or a legacy one.
+	// Next StopEndpoint calls have no effect for staged volumes because their
+	// endpoints were started in socketsDir/instanceId/volumeId instead of
+	// socketsDir/podId/volumeId.
+	//
+	// When all VM disks are migrated to staged volumes we can enforce non-empty
+	// instanceId for new VM disks and add early return here:
+	// if s.vmMode { return nil }
+
 	// no other way to get podId from NodeUnpublishVolumeRequest
 	podId, err := s.parsePodId(req.TargetPath)
 	if err != nil {

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -525,7 +525,7 @@ func (s *nodeService) nodeUnpublishVolume(
 	}
 
 	// remove pod's folder if it's empty
-	os.Remove(filepath.Join(s.socketsDir, podId))
+	ignoreError(os.Remove(filepath.Join(s.socketsDir, podId)))
 	return nil
 }
 
@@ -542,7 +542,7 @@ func (s *nodeService) mountSocketDir(req *csi.NodePublishVolumeRequest) error {
 	if err != nil {
 		return fmt.Errorf("failed to create disk.img: %w", err)
 	}
-	file.Close()
+	ignoreError(file.Close())
 
 	targetPerm := os.FileMode(0775)
 	if err := os.MkdirAll(req.TargetPath, targetPerm); err != nil {
@@ -587,7 +587,7 @@ func (s *nodeService) mountBlockDevice(
 	if err != nil {
 		return fmt.Errorf("failed to create target file: %w", err)
 	}
-	file.Close()
+	ignoreError(file.Close())
 
 	mountOptions := []string{"bind"}
 	err = s.mountIfNeeded(volumeId, source, target, "", mountOptions)
@@ -925,3 +925,5 @@ func (s *nodeService) NodeExpandVolume(
 		CapacityBytes: int64(newBlocksCount * uint64(resp.Volume.BlockSize)),
 	}, nil
 }
+
+func ignoreError(_ error) {}

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -156,20 +156,19 @@ func (s *nodeService) NodeStageVolume(
 
 	if s.vmMode {
 		nfsBackend := (req.VolumeContext[backendVolumeContextKey] == "nfs")
-		instanceID := req.VolumeContext[instanceIDKey]
 
 		var err error
-		if instanceID != "" {
+		if instanceID := req.VolumeContext[instanceIDKey]; instanceID != "" {
 			if nfsBackend {
 				err = s.nodeStageFileStoreAsVhostSocket(ctx, instanceID, req.VolumeId)
 			} else {
 				err = s.nodeStageDiskAsVhostSocket(ctx, instanceID, req.VolumeId, req.VolumeContext)
 			}
-		}
 
-		if err != nil {
-			return nil, s.statusErrorf(codes.Internal,
-				"Failed to stage volume: %v", err)
+			if err != nil {
+				return nil, s.statusErrorf(codes.Internal,
+					"Failed to stage volume: %v", err)
+			}
 		}
 	}
 

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -750,7 +751,7 @@ func (s *nodeService) NodeGetVolumeStats(
 
 	mounted, err := s.mounter.IsMountPoint(req.VolumePath)
 	if err != nil {
-		if err == fs.ErrNotExist {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, s.statusError(
 				codes.NotFound,
 				"Mount point does not exist")

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	nbs "github.com/ydb-platform/nbs/cloud/blockstore/public/api/protos"
 	"github.com/ydb-platform/nbs/cloud/blockstore/tools/csi_driver/internal/driver/mocks"
-	"github.com/ydb-platform/nbs/cloud/blockstore/tools/csi_driver/internal/mounter"
+	csimounter "github.com/ydb-platform/nbs/cloud/blockstore/tools/csi_driver/internal/mounter"
 	nfs "github.com/ydb-platform/nbs/cloud/filestore/public/api/protos"
 )
 
@@ -28,7 +28,7 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 
 	nbsClient := mocks.NewNbsClientMock()
 	nfsClient := mocks.NewNfsEndpointClientMock()
-	mounter := mounter.NewMock()
+	mounter := csimounter.NewMock()
 
 	ctx := context.Background()
 	clientID := "testClientId"
@@ -201,7 +201,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	log.Printf("groupId: %s", groupId)
 
 	nbsClient := mocks.NewNbsClientMock()
-	mounter := mounter.NewMock()
+	mounter := csimounter.NewMock()
 
 	ipcType := nbs.EClientIpcType_IPC_NBD
 	nbdDeviceFile := filepath.Join(tempDir, "dev", "nbd3")
@@ -328,7 +328,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	tempDir := os.TempDir()
 
 	nbsClient := mocks.NewNbsClientMock()
-	mounter := mounter.NewMock()
+	mounter := csimounter.NewMock()
 
 	ipcType := nbs.EClientIpcType_IPC_NBD
 	nbdDeviceFile := filepath.Join(tempDir, "dev", "nbd3")
@@ -448,7 +448,7 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	tempDir := os.TempDir()
 
 	nbsClient := mocks.NewNbsClientMock()
-	mounter := mounter.NewMock()
+	mounter := csimounter.NewMock()
 
 	podID := "test-pod-id-13"
 	diskID := "test-disk-id-42"
@@ -510,7 +510,7 @@ func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 	tempDir := os.TempDir()
 
 	nbsClient := mocks.NewNbsClientMock()
-	mounter := mounter.NewMock()
+	mounter := csimounter.NewMock()
 
 	nbdDeviceFile := filepath.Join(tempDir, "dev", "nbd3")
 	err := os.MkdirAll(nbdDeviceFile, 0755)
@@ -564,7 +564,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 	tempDir := os.TempDir()
 
 	nbsClient := mocks.NewNbsClientMock()
-	mounter := mounter.NewMock()
+	mounter := csimounter.NewMock()
 
 	nbdDeviceFile := filepath.Join(tempDir, "dev", "nbd3")
 	err := os.MkdirAll(nbdDeviceFile, 0755)

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -210,7 +210,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 	}
 	stagingTargetPath := filepath.Join(tempDir, "testStagingTargetPath")
 	socketsDir := filepath.Join(tempDir, "sockets")
-	sourcePath := filepath.Join(socketsDir, stagingDirName, diskID)
+	sourcePath := filepath.Join(socketsDir, instanceID, diskID)
 	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	nbsSocketPath := filepath.Join(sourcePath, "nbs.sock")

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -335,6 +335,13 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 	})
 	require.NoError(t, err)
 
+	// TODO: enable check that target directory is deleted after fixing https://github.com/ydb-platform/nbs/issues/2120
+	// mock mounter should remove targetPath but if it does then TestGetVolumeStatCapabilitiesWithoutVmMode
+	// fails because it relies on other tests leaving target directory (it fails if launched alone)
+	//
+	//_, err = os.Stat(targetPath)
+	//assert.True(t, os.IsNotExist(err))
+
 	if backend == "nbs" {
 		nbsClient.On("StopEndpoint", ctx, &nbs.TStopEndpointRequest{
 			UnixSocketPath: nbsSocketPath,


### PR DESCRIPTION
Previously endpoints were started on NodePublish phase, this breaks hotplug of multiple disks to the same VM (causes recreation of endpoints when helpler pod chandges, and ends up in deadlock attemptiong to create new endpoint before the old wan was stopped).

This commit splits volume mount between NodeStage and NodePublish phases. So endpoint is started in NodeStage, and NodePublish just creates mount to requested pod. With this split change of hotplug pod doesn't cause endpoint stop (because it doesn't trigger NodeUnpublish) but intead results in remounts, avoiding deadlock and reconnects.

What is unclear:
- [x] ~should stage mount be implemented for other types (FS, nbd?)~
   Decided that only vhost endpoints (NBS and NFS) should use new scheme
- [x] ~how to get podId in NodeStage phase (from volume attributes?)~
   We don't use podId at all, use instead instanceId from volume attributes, if it is not provided then use old scheme
- [x] ~how to make tranfer from old scheme seamless~
   Volumes that have instanceId attrubute will use new scheme, others will continue using old scheme 
- [x] ~should we use separate stage directory or just use s.socketsDir~
   Grouped volumes in instanceId directories  

