### PR TITLE
Always respond with E_REJECT when killing a volume tablet actor

### DIFF
--- a/cloud/blockstore/libs/storage/volume/multi_partition_requests.h
+++ b/cloud/blockstore/libs/storage/volume/multi_partition_requests.h
@@ -55,8 +55,6 @@ class TMultiPartitionRequestActor final
 {
 private:
     const TRequestInfoPtr RequestInfo;
-    const NActors::TActorId VolumeActorId;
-    const ui64 VolumeRequestId;
     const TBlockRange64 OriginalRange;
     const ui32 BlocksPerStripe;
     const ui32 BlockSize;
@@ -73,8 +71,6 @@ private:
 public:
     TMultiPartitionRequestActor(
         TRequestInfoPtr requestInfo,
-        NActors::TActorId volumeActorId,
-        ui64 volumeRequestId,
         TBlockRange64 originalRange,
         ui32 blocksPerStripe,
         ui32 blockSize,
@@ -277,8 +273,6 @@ private:
         MergeCommonFields(src, dst);
     }
 
-    void NotifyCompleted(const NActors::TActorContext& ctx);
-
     void ForkTraces(TCallContextPtr callContext)
     {
         auto& cc = RequestInfo->CallContext;
@@ -306,8 +300,6 @@ private:
 template <typename TMethod>
 TMultiPartitionRequestActor<TMethod>::TMultiPartitionRequestActor(
         TRequestInfoPtr requestInfo,
-        NActors::TActorId volumeActorId,
-        ui64 volumeRequestId,
         TBlockRange64 originalRange,
         ui32 blocksPerStripe,
         ui32 blockSize,
@@ -315,8 +307,6 @@ TMultiPartitionRequestActor<TMethod>::TMultiPartitionRequestActor(
         TVector<TPartitionRequest<TMethod>> partitionRequests,
         TRequestTraceInfo traceInfo)
     : RequestInfo(std::move(requestInfo))
-    , VolumeActorId(volumeActorId)
-    , VolumeRequestId(volumeRequestId)
     , OriginalRange(originalRange)
     , BlocksPerStripe(blocksPerStripe)
     , BlockSize(blockSize)
@@ -370,26 +360,6 @@ void TMultiPartitionRequestActor<TMethod>::Prepare(
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
-void TMultiPartitionRequestActor<TMethod>::NotifyCompleted(
-    const NActors::TActorContext& ctx)
-{
-    if constexpr (RequiresReadWriteAccess<TMethod>) {
-        using TEvent = TEvVolumePrivate::TEvMultipartitionWriteOrZeroCompleted;
-        auto ev = std::make_unique<TEvent>(
-            VolumeRequestId,
-            Record.GetError().GetCode());
-
-        NCloud::Send(
-            ctx,
-            VolumeActorId,
-            std::move(ev)
-        );
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-template <typename TMethod>
 void TMultiPartitionRequestActor<TMethod>::HandlePartitionResponse(
     const typename TMethod::TResponse::TPtr& ev,
     const NActors::TActorContext& ctx)
@@ -427,8 +397,6 @@ void TMultiPartitionRequestActor<TMethod>::HandlePartitionResponse(
 
         NCloud::Reply(ctx, *RequestInfo, std::move(response));
 
-        NotifyCompleted(ctx);
-
         TBase::Die(ctx);
     }
 }
@@ -456,8 +424,6 @@ void TMultiPartitionRequestActor<TMethod>::HandleUndelivery(
         RequestInfo->CallContext->RequestId);
 
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
-
-    NotifyCompleted(ctx);
 
     TBase::Die(ctx);
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1017,9 +1017,6 @@ STFUNC(TVolumeActor::StateWork)
         HFunc(TEvStatsService::TEvVolumePartCounters, HandlePartCounters);
         HFunc(TEvVolumePrivate::TEvPartStatsSaved, HandlePartStatsSaved);
         HFunc(
-            TEvVolumePrivate::TEvMultipartitionWriteOrZeroCompleted,
-            HandleMultipartitionWriteOrZeroCompleted);
-        HFunc(
             TEvVolumePrivate::TEvWriteOrZeroCompleted,
             HandleWriteOrZeroCompleted);
         HFunc(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -926,12 +926,9 @@ template <>
 void TVolumeActor::HandleCheckpointRequest<TCreateCheckpointMethod>(
     const TActorContext& ctx,
     const TCreateCheckpointMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
     bool isTraced,
     ui64 traceTs)
 {
-    Y_UNUSED(volumeRequestId);
-
     const auto& msg = *ev->Get();
 
     auto requestInfo = CreateRequestInfo<TCreateCheckpointMethod>(
@@ -962,12 +959,9 @@ template <>
 void TVolumeActor::HandleCheckpointRequest<TDeleteCheckpointMethod>(
     const TActorContext& ctx,
     const TDeleteCheckpointMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
     bool isTraced,
     ui64 traceTs)
 {
-    Y_UNUSED(volumeRequestId);
-
     const auto& msg = *ev->Get();
 
     auto requestInfo = CreateRequestInfo<TDeleteCheckpointMethod>(
@@ -991,12 +985,9 @@ template <>
 void TVolumeActor::HandleCheckpointRequest<TDeleteCheckpointDataMethod>(
     const TActorContext& ctx,
     const TDeleteCheckpointDataMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
     bool isTraced,
     ui64 traceTs)
 {
-    Y_UNUSED(volumeRequestId);
-
     const auto& msg = *ev->Get();
 
     auto requestInfo = CreateRequestInfo<TDeleteCheckpointDataMethod>(
@@ -1020,11 +1011,9 @@ template <>
 void TVolumeActor::HandleCheckpointRequest<TGetCheckpointStatusMethod>(
     const TActorContext& ctx,
     const TGetCheckpointStatusMethod::TRequest::TPtr& ev,
-    ui64 volumeRequestId,
     bool isTraced,
     ui64 traceTs)
 {
-    Y_UNUSED(volumeRequestId);
     Y_UNUSED(isTraced);
     Y_UNUSED(traceTs);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -34,9 +34,6 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
     if constexpr (IsWriteMethod<TMethod>) {
         if (State->GetTrackUsedBlocks() || State->HasCheckpointLight())
         {
-            auto requestInfo =
-                CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
-
             // TODO(drbasic)
             // For encrypted disk-registry based disks, we will continue to
             // write a map of encrypted blocks for a while.
@@ -56,7 +53,7 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
                 encryptedDiskRegistryBasedDisk || overlayDiskRegistryBasedDisk;
             NCloud::Register<TWriteAndMarkUsedActor<TMethod>>(
                 ctx,
-                std::move(requestInfo),
+                CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
                 std::move(msg->Record),
                 State->GetBlockSize(),
                 needReliableUsedBlockTracking,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -34,6 +34,8 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
     if constexpr (IsWriteMethod<TMethod>) {
         if (State->GetTrackUsedBlocks() || State->HasCheckpointLight())
         {
+            auto requestInfo =
+                CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
             // TODO(drbasic)
             // For encrypted disk-registry based disks, we will continue to
             // write a map of encrypted blocks for a while.
@@ -53,7 +55,7 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
                 encryptedDiskRegistryBasedDisk || overlayDiskRegistryBasedDisk;
             NCloud::Register<TWriteAndMarkUsedActor<TMethod>>(
                 ctx,
-                CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+                std::move(requestInfo),
                 std::move(msg->Record),
                 State->GetBlockSize(),
                 needReliableUsedBlockTracking,

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -206,7 +206,7 @@ struct TEvVolumePrivate
     };
 
     //
-    // MultipartitionWriteOrZeroCompleted & WriteOrZeroCompleted
+    // WriteOrZeroCompleted
     //
 
     struct TWriteOrZeroCompleted
@@ -320,7 +320,6 @@ struct TEvVolumePrivate
         EvRetryStartPartition,
         EvAcquireDiskIfNeeded,
         EvPartStatsSaved,
-        EvMultipartitionWriteOrZeroCompleted,
         EvWriteOrZeroCompleted,
         EvUpdateReadWriteClientInfo,
         EvRemoveExpiredVolumeParams,
@@ -361,11 +360,6 @@ struct TEvVolumePrivate
     using TEvPartStatsSaved = TRequestEvent<
         TPartStatsSaved,
         EvPartStatsSaved
-    >;
-
-    using TEvMultipartitionWriteOrZeroCompleted = TRequestEvent<
-        TMultipartitionWriteOrZeroCompleted,
-        EvMultipartitionWriteOrZeroCompleted
     >;
 
     using TEvWriteOrZeroCompleted = TRequestEvent<

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -8943,7 +8943,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(1u, updateUsedBlocksRequestCount);
     }
 
-    void DoShouldRejectRequestsWhenVolumesIsKilled(
+    void DoShouldRejectRequestsWhenVolumeIsKilled(
         bool multipartition,
         bool trackUsed)
     {
@@ -9021,22 +9021,22 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
     Y_UNIT_TEST(ShouldRejectRequestsWhenSinglePartitionVolumesIsKilled)
     {
-        DoShouldRejectRequestsWhenVolumesIsKilled(false, false);
+        DoShouldRejectRequestsWhenVolumeIsKilled(false, false);
     }
 
     Y_UNIT_TEST(ShouldRejectRequestsWhenMultiPartitionVolumesIsKilled)
     {
-        DoShouldRejectRequestsWhenVolumesIsKilled(true, false);
+        DoShouldRejectRequestsWhenVolumeIsKilled(true, false);
     }
 
     Y_UNIT_TEST(ShouldRejectRequestsWhenTrackUsedAndSinglePartitionVolumesIsKilled)
     {
-        DoShouldRejectRequestsWhenVolumesIsKilled(false, true);
+        DoShouldRejectRequestsWhenVolumeIsKilled(false, true);
     }
 
     Y_UNIT_TEST(ShouldRejectRequestsWhenTrackUsedAndMultiPartitionVolumesIsKilled)
     {
-        DoShouldRejectRequestsWhenVolumesIsKilled(true, true);
+        DoShouldRejectRequestsWhenVolumeIsKilled(true, true);
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -8942,6 +8942,102 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1u, updateUsedBlocksRequestCount);
     }
+
+    void DoShouldRejectRequestsWhenVolumesIsKilled(
+        bool multipartition,
+        bool trackUsed)
+    {
+        auto runtime = PrepareTestActorRuntime({});
+        const ui32 partitionCount = multipartition ? 2 : 1;
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_HYBRID,
+            7 * 1024,   // block count per partition
+            "vol0",
+            "cloud",
+            "folder",
+            partitionCount,                 // partition count
+            2,                              // blocksPerStripe
+            trackUsed ? "track-used" : ""   // tags
+        );
+        volume.WaitReady();
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+
+        volume.AddClient(clientInfo);
+
+        // Make the interceptor for WriteBlocks responses from the partition.
+        ui32 droppedResponseCount = 0;
+        auto dropPartitionResponses =
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() == TEvService::EvWriteBlocksResponse) {
+                ++droppedResponseCount;
+                return true;
+            }
+
+            return false;
+        };
+        auto oldFilter = runtime->SetEventFilter(dropPartitionResponses);
+
+        // Send write request.
+        volume.SendWriteBlocksRequest(
+            TBlockRange64::WithLength(0, 1024),
+            clientInfo.GetClientId(),
+            1);
+
+        // Waiting for the interception of all responses from the partitions.
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]()
+        {
+            return droppedResponseCount == partitionCount;
+        };
+        runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+        // Remove the responses interceptor.
+        runtime->SetEventFilter(oldFilter);
+
+        // Restarting the volume tablet. It must respond to requests that have
+        // not yet been completed.
+        volume.RebootTablet();
+
+        // Check response.
+        auto response = volume.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "Shutting down",
+            response->GetError().GetMessage());
+    }
+
+    Y_UNIT_TEST(ShouldRejectRequestsWhenSinglePartitionVolumesIsKilled)
+    {
+        DoShouldRejectRequestsWhenVolumesIsKilled(false, false);
+    }
+
+    Y_UNIT_TEST(ShouldRejectRequestsWhenMultiPartitionVolumesIsKilled)
+    {
+        DoShouldRejectRequestsWhenVolumesIsKilled(true, false);
+    }
+
+    Y_UNIT_TEST(ShouldRejectRequestsWhenTrackUsedAndSinglePartitionVolumesIsKilled)
+    {
+        DoShouldRejectRequestsWhenVolumesIsKilled(false, true);
+    }
+
+    Y_UNIT_TEST(ShouldRejectRequestsWhenTrackUsedAndMultiPartitionVolumesIsKilled)
+    {
+        DoShouldRejectRequestsWhenVolumesIsKilled(true, true);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
Раньше не всегда запросы, которые отправлялись в партишен, сохранялись в акторе вольюма в векторе VolumeRequests. Это работало только если паришен был один, и не происходило отслеживание записанных блоков.

Сейчас сохранение происходит во всех случаях. А значит, если таблетка вольюма умирает, то и E_REJECTED будет отправляться всегда https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/storage/volume/volume_actor.cpp#L531

Поведение стало консистентным.
