### PR TITLE
Reject request with invalid size

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1027,4 +1027,7 @@ message TStorageServiceConfig
 
     // Node type
     optional string NodeType = 384;
+
+    // Max Read/Write/Zero request size
+    optional uint32 MaxRequestSize = 385;
 }

--- a/cloud/blockstore/libs/service/request_helpers.cpp
+++ b/cloud/blockstore/libs/service/request_helpers.cpp
@@ -86,12 +86,10 @@ ui32 CalculateWriteRequestBlockCount(
     const NProto::TWriteBlocksRequest& request,
     const ui32 blockSize)
 {
-    ui32 bytes = 0;
-    for (const auto& buffer: request.GetBlocks().GetBuffers()) {
-        bytes += buffer.Size();
-    }
+    auto bytes = CalculateBytesCount(request, blockSize);
+
     if (bytes % blockSize) {
-        Y_ABORT("bytes %u not divisible by blockSize %u", bytes, blockSize);
+        Y_ABORT("bytes %lu not divisible by blockSize %u", bytes, blockSize);
     }
 
     return bytes / blockSize;

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -508,6 +508,7 @@ TDuration MSeconds(ui32 value)
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(IdleAgentDeployByCmsDelay,                      TDuration, Hours(1)      )\
+    xxx(MaxRequestSize,                                 ui32,      32_MB         )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -604,6 +604,8 @@ public:
     TString GetNodeRegistrationRootCertsFile() const;
     TCertificate GetNodeRegistrationCert() const;
     TString GetNodeType() const;
+
+    ui32 GetMaxRequestSize() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stats.cpp
@@ -28,6 +28,8 @@ EDeviceHealthStatus GetHealthStatus(EWellKnownResultCodes code)
     switch (code) {
         case EWellKnownResultCodes::S_OK:
             return EDeviceHealthStatus::Healthy;
+        case EWellKnownResultCodes::E_ARGUMENT:
+        case EWellKnownResultCodes::E_CANCELLED:
         case EWellKnownResultCodes::E_REJECTED:
             return EDeviceHealthStatus::Unknown;
         default:

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -876,6 +876,7 @@ void CheckVolumeSendsStatsEvenIfPartitionsAreDead(
 void CheckRebuildMetadata(ui32 partCount, ui32 blocksPerStripe)
 {
     NProto::TStorageServiceConfig config;
+    config.SetMaxRequestSize(128_MB);
     config.SetMinChannelCount(4);
     auto runtime = PrepareTestActorRuntime(config);
 


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/2000
Сделал валидацию размера данных в запросе.
У нас несколько мест где ограничивается размер
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/client/config.cpp#L55
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/service_local/storage_aio.cpp#L482
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp#L45
https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/service/device_handler.cpp#L137

Вынес в настройку и задал по дефолту как в дискагенте. Это не должно поменять текущее поведение.