### PR TITLE
issue-1657: resize device in "refresh endpoint" handler

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1203,6 +1203,13 @@ NProto::TRefreshEndpointResponse TEndpointManager::RefreshEndpointImpl(
         return TErrorResponse(getSessionError);
     }
 
+    auto error = it->second.Device->Resize(
+        sessionInfo.Volume.GetBlocksCount() *
+        sessionInfo.Volume.GetBlockSize()).GetValueSync();
+    if (HasError(error)) {
+        return TErrorResponse(error);
+    }
+
     const auto refreshError = listener->RefreshEndpoint(socketPath, sessionInfo.Volume);
     return TErrorResponse(refreshError);
 }

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -180,11 +180,9 @@ def test_resize_device(with_netlink, with_endpoint_proxy):
         assert result.returncode == 0
 
         result = run(
-            "resizedevice",
+            "refreshendpoint",
             "--socket",
-            socket_path,
-            "--device-size",
-            str(new_volume_size)
+            socket_path
         )
         assert result.returncode == 0
 

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -886,9 +886,8 @@ func (s *nodeService) NodeExpandVolume(
 		return nil, err
 	}
 
-	_, err = s.nbsClient.ResizeDevice(ctx, &nbsapi.TResizeDeviceRequest{
-		UnixSocketPath:    unixSocketPath,
-		DeviceSizeInBytes: newBlocksCount * uint64(resp.Volume.BlockSize),
+	_, err = s.nbsClient.RefreshEndpoint(ctx, &nbsapi.TRefreshEndpointRequest{
+		UnixSocketPath: unixSocketPath,
 	})
 
 	if err != nil {


### PR DESCRIPTION
issue: #1657

Discussion: https://github.com/ydb-platform/nbs/pull/1748#discussion_r1743430963

RefreshEndpoint was introduced to notify endpoints about new size of the volume: https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp#L66

 We can use it to resize nbd device instead of separate ResizeDevice method.

ResizeDevice will be removed in another PR.