### PR TITLE
Added possibility to report histograms as single-counter as well as multiple-counters in TRequestCounters::TStatCounters

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -470,7 +470,10 @@ void TCommand::Init()
         false);
     *versionCounter = 1;
 
-    RequestStats = CreateClientRequestStats(clientGroup, Timer);
+    RequestStats = CreateClientRequestStats(
+        clientGroup,
+        Timer,
+        EHistogramCounterOption::ReportMultipleCounters);
 
     VolumeStats = CreateVolumeStats(
         Monitoring,

--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -203,4 +203,10 @@ message TDiagnosticsConfig
 
     // Monitoring data necessary for link generation on monpages.
     optional TMonitoringUrlData MonitoringUrlData = 47;
+
+    // Report histogram as a set of manually created counters
+    optional bool ReportHistogramAsMultipleCounters = 48;
+
+    // Report histogram as a single counter (THistogramCounter)
+    optional bool ReportHistogramAsSingleCounter = 49;
 }

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -277,7 +277,10 @@ void TBootstrapBase::Init()
     }
     PostponedCriticalEvents.clear();
 
-    RequestStats = CreateServerRequestStats(serverGroup, Timer);
+    RequestStats = CreateServerRequestStats(
+        serverGroup,
+        Timer,
+        Configs->DiagnosticsConfig->GetHistogramCounterOptions());
 
     if (!VolumeStats) {
         VolumeStats = CreateVolumeStats(

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -51,6 +51,8 @@ namespace {
     xxx(Mirror2SSDDowntimeThreshold,         TDuration,       TDuration::Seconds(5)                     )\
     xxx(Mirror3SSDDowntimeThreshold,         TDuration,       TDuration::Seconds(5)                     )\
     xxx(LocalSSDDowntimeThreshold,           TDuration,       TDuration::Seconds(5)                     )\
+    xxx(ReportHistogramAsMultipleCounters,   bool,            true                                      )\
+    xxx(ReportHistogramAsSingleCounter,      bool,            false                                     )\
 // BLOCKSTORE_DIAGNOSTICS_CONFIG
 
 #define BLOCKSTORE_DIAGNOSTICS_DECLARE_CONFIG(name, type, value)               \
@@ -173,6 +175,19 @@ TRequestThresholds TDiagnosticsConfig::GetRequestThresholds() const
 {
     return ConvertValue<TRequestThresholds>(
         DiagnosticsConfig.GetRequestThresholds());
+}
+
+EHistogramCounterOptions TDiagnosticsConfig::GetHistogramCounterOptions() const
+{
+    EHistogramCounterOptions histogramCounterOptions;
+    if (GetReportHistogramAsMultipleCounters()) {
+        histogramCounterOptions |=
+            EHistogramCounterOption::ReportMultipleCounters;
+    }
+    if (GetReportHistogramAsSingleCounter()) {
+        histogramCounterOptions |= EHistogramCounterOption::ReportSingleCounter;
+    }
+    return histogramCounterOptions;
 }
 
 void TDiagnosticsConfig::Dump(IOutputStream& out) const

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/config/diagnostics.pb.h>
 
+#include "cloud/storage/core/libs/diagnostics/histogram_counter_options.h"
 #include <cloud/storage/core/libs/diagnostics/trace_reader.h>
 
 #include <util/generic/string.h>
@@ -146,7 +147,11 @@ public:
     TDuration GetMirror3SSDDowntimeThreshold() const;
     TDuration GetMirror2SSDDowntimeThreshold() const;
     TDuration GetLocalSSDDowntimeThreshold() const;
+    bool GetReportHistogramAsMultipleCounters() const;
+    bool GetReportHistogramAsSingleCounter() const;
+
     TRequestThresholds GetRequestThresholds() const;
+    EHistogramCounterOptions GetHistogramCounterOptions() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/blockstore/libs/diagnostics/request_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/request_stats.cpp
@@ -192,38 +192,55 @@ public:
     TRequestStats(
             TDynamicCountersPtr counters,
             bool isServerSide,
-            ITimerPtr timer)
+            ITimerPtr timer,
+            EHistogramCounterOptions histogramCounterOptions)
         : Counters(std::move(counters))
         , IsServerSide(isServerSide)
-        , Total(MakeRequestCounters(timer,
+        , Total(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::AddSpecialCounters))
-        , TotalSSD(MakeRequestCounters(timer,
+                TRequestCounters::EOption::AddSpecialCounters,
+            histogramCounterOptions))
+        , TotalSSD(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
-        , TotalHDD(MakeRequestCounters(timer,
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
+        , TotalHDD(MakeRequestCounters(
+            timer,
+                TRequestCounters::EOption::ReportDataPlaneHistogram |
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
+        , TotalSSDNonrepl(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
-        , TotalSSDNonrepl(MakeRequestCounters(timer,
+                TRequestCounters::EOption::AddSpecialCounters |
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
+        , TotalSSDMirror2(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::AddSpecialCounters |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
-        , TotalSSDMirror2(MakeRequestCounters(timer,
+                TRequestCounters::EOption::AddSpecialCounters |
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
+        , TotalSSDMirror3(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::AddSpecialCounters |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
-        , TotalSSDMirror3(MakeRequestCounters(timer,
+                TRequestCounters::EOption::AddSpecialCounters |
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
+        , TotalSSDLocal(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::AddSpecialCounters |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
-        , TotalSSDLocal(MakeRequestCounters(timer,
+                TRequestCounters::EOption::AddSpecialCounters |
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
+        , TotalHDDNonrepl(MakeRequestCounters(
+            timer,
             TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::AddSpecialCounters |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
-        , TotalHDDNonrepl(MakeRequestCounters(timer,
-            TRequestCounters::EOption::ReportDataPlaneHistogram |
-            TRequestCounters::EOption::AddSpecialCounters |
-            TRequestCounters::EOption::OnlyReadWriteRequests))
+                TRequestCounters::EOption::AddSpecialCounters |
+                TRequestCounters::EOption::OnlyReadWriteRequests,
+            histogramCounterOptions))
     {
         Total.Register(*Counters);
 
@@ -650,22 +667,26 @@ struct TRequestStatsStub final
 
 IRequestStatsPtr CreateClientRequestStats(
     TDynamicCountersPtr counters,
-    ITimerPtr timer)
+    ITimerPtr timer,
+    EHistogramCounterOptions histogramCounterOptions)
 {
     return std::make_shared<TRequestStats>(
         std::move(counters),
         false,
-        std::move(timer));
+        std::move(timer),
+        histogramCounterOptions);
 }
 
 IRequestStatsPtr CreateServerRequestStats(
     TDynamicCountersPtr counters,
-    ITimerPtr timer)
+    ITimerPtr timer,
+    EHistogramCounterOptions histogramCounterOptions)
 {
     return std::make_shared<TRequestStats>(
         std::move(counters),
         true,
-        std::move(timer));
+        std::move(timer),
+        histogramCounterOptions);
 }
 
 IRequestStatsPtr CreateRequestStatsStub()

--- a/cloud/blockstore/libs/diagnostics/request_stats.h
+++ b/cloud/blockstore/libs/diagnostics/request_stats.h
@@ -75,10 +75,12 @@ struct IRequestStats
 
 IRequestStatsPtr CreateClientRequestStats(
     NMonitoring::TDynamicCountersPtr counters,
-    ITimerPtr timer);
+    ITimerPtr timer,
+    EHistogramCounterOptions histogramCounterOptions);
 IRequestStatsPtr CreateServerRequestStats(
     NMonitoring::TDynamicCountersPtr counters,
-    ITimerPtr timer);
+    ITimerPtr timer,
+    EHistogramCounterOptions histogramCounterOptions);
 IRequestStatsPtr CreateRequestStatsStub();
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/request_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/request_stats_ut.cpp
@@ -63,7 +63,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto requestStats = CreateServerRequestStats(
             monitoring->GetCounters(),
-            CreateWallClockTimer());
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters);
 
         auto totalCounters = monitoring
             ->GetCounters()
@@ -228,7 +229,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto requestStats = CreateServerRequestStats(
             monitoring->GetCounters(),
-            CreateWallClockTimer());
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters);
 
         auto totalCounters =
             monitoring->GetCounters()->GetSubgroup("request", "WriteBlocks");
@@ -316,7 +318,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto requestStats = CreateServerRequestStats(
             monitoring->GetCounters(),
-            CreateWallClockTimer());
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters);
 
         auto totalCounters = monitoring
             ->GetCounters()
@@ -427,7 +430,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto requestStats = CreateServerRequestStats(
             monitoring->GetCounters(),
-            CreateWallClockTimer());
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters);
 
         auto totalCounters = monitoring
             ->GetCounters()
@@ -523,7 +527,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto requestStats = CreateServerRequestStats(
             monitoring->GetCounters(),
-            CreateWallClockTimer());
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters);
 
         auto totalCounters = monitoring
             ->GetCounters()
@@ -591,7 +596,8 @@ Y_UNIT_TEST_SUITE(TRequestStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto requestStats = CreateServerRequestStats(
             monitoring->GetCounters(),
-            CreateWallClockTimer());
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters);
 
         unsigned int totalShots = 0;
         auto shoot = [&] (auto mediaKind, unsigned int count) {

--- a/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
@@ -142,7 +142,10 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             std::make_shared<TDiagnosticsConfig>(),
             monitoring,
             CreateProfileLogStub(),
-            CreateServerRequestStats(serverGroup,timer),
+            CreateServerRequestStats(
+                serverGroup,
+                timer,
+                EHistogramCounterOption::ReportMultipleCounters),
             std::move(volumeStats)
         );
 
@@ -209,7 +212,10 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             std::make_shared<TDiagnosticsConfig>(),
             monitoring,
             CreateProfileLogStub(),
-            CreateServerRequestStats(serverGroup,timer),
+            CreateServerRequestStats(
+                serverGroup,
+                timer,
+                EHistogramCounterOption::ReportMultipleCounters),
             std::move(volumeStats)
         );
 
@@ -242,7 +248,10 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             std::make_shared<TDiagnosticsConfig>(),
             monitoring,
             CreateProfileLogStub(),
-            CreateServerRequestStats(serverGroup,timer),
+            CreateServerRequestStats(
+                serverGroup,
+                timer,
+                EHistogramCounterOption::ReportMultipleCounters),
             std::move(volumeStats)
         );
 
@@ -323,7 +332,10 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             std::make_shared<TDiagnosticsConfig>(),
             monitoring,
             CreateProfileLogStub(),
-            CreateServerRequestStats(serverGroup, timer),
+            CreateServerRequestStats(
+                serverGroup,
+                timer,
+                EHistogramCounterOption::ReportMultipleCounters),
             std::move(volumeStats)
         );
 

--- a/cloud/blockstore/libs/diagnostics/stats_helpers.cpp
+++ b/cloud/blockstore/libs/diagnostics/stats_helpers.cpp
@@ -9,7 +9,8 @@ namespace NCloud::NBlockStore {
 
 TRequestCounters MakeRequestCounters(
     ITimerPtr timer,
-    TRequestCounters::EOptions options)
+    TRequestCounters::EOptions options,
+    EHistogramCounterOptions histogramCounterOptions)
 {
     return TRequestCounters(
         std::move(timer),
@@ -24,7 +25,8 @@ TRequestCounters MakeRequestCounters(
             const auto bt = static_cast<EBlockStoreRequest>(t);
             return IsNonLocalReadWriteRequest(bt);
         },
-        options
+        options,
+        histogramCounterOptions
     );
 }
 

--- a/cloud/blockstore/libs/diagnostics/stats_helpers.h
+++ b/cloud/blockstore/libs/diagnostics/stats_helpers.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/storage/core/libs/diagnostics/request_counters.h>
+#include <cloud/storage/core/libs/diagnostics/histogram_counter_options.h>
 
 namespace NCloud::NBlockStore {
 
@@ -10,6 +11,7 @@ namespace NCloud::NBlockStore {
 
 TRequestCounters MakeRequestCounters(
     ITimerPtr timer,
-    TRequestCounters::EOptions options);
+    TRequestCounters::EOptions options,
+    EHistogramCounterOptions histogramCounterOptions);
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -270,12 +270,14 @@ public:
     TVolumeInfo(
             std::shared_ptr<TVolumeInfoBase> volumeBase,
             ITimerPtr timer,
-            TRealInstanceId realInstanceId)
+            TRealInstanceId realInstanceId,
+            EHistogramCounterOptions histogramCounterOptions)
         : VolumeBase(std::move(volumeBase))
         , RealInstanceId(std::move(realInstanceId))
         , RequestCounters(MakeRequestCounters(
             std::move(timer),
-            GetRequestCountersOptions(*VolumeBase)))
+            GetRequestCountersOptions(*VolumeBase),
+            histogramCounterOptions))
     {}
 
     const NProto::TVolume& GetInfo() const override
@@ -858,7 +860,8 @@ private:
         auto info = std::make_shared<TVolumeInfo>(
             volumeBase,
             Timer,
-            realInstanceId);
+            realInstanceId,
+            DiagnosticsConfig->GetHistogramCounterOptions());
 
         if (!Counters) {
             InitCounters();

--- a/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
@@ -124,7 +124,10 @@ struct TFixture
             std::make_shared<TDiagnosticsConfig>(),
             Monitoring,
             CreateProfileLogStub(),
-            CreateServerRequestStats(serverGroup, Timer),
+            CreateServerRequestStats(
+                serverGroup,
+                Timer,
+                EHistogramCounterOption::ReportMultipleCounters),
             std::move(volumeStats)
         );
 

--- a/cloud/blockstore/libs/service_local/compound_storage_ut.cpp
+++ b/cloud/blockstore/libs/service_local/compound_storage_ut.cpp
@@ -176,7 +176,10 @@ IStoragePtr CreateTestStorage(
         std::make_shared<TDiagnosticsConfig>(),
         monitoring,
         CreateProfileLogStub(),
-        CreateServerRequestStats(serverGroup, CreateWallClockTimer()),
+        CreateServerRequestStats(
+            serverGroup,
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters),
         CreateVolumeStatsStub());
 
     return CreateCompoundStorage(
@@ -700,7 +703,10 @@ Y_UNIT_TEST_SUITE(TCompoundStorageTest)
             std::make_shared<TDiagnosticsConfig>(),
             monitoring,
             CreateProfileLogStub(),
-            CreateServerRequestStats(serverGroup, CreateWallClockTimer()),
+            CreateServerRequestStats(
+                serverGroup,
+                CreateWallClockTimer(),
+                EHistogramCounterOption::ReportMultipleCounters),
             CreateVolumeStatsStub());
 
         auto storage = CreateCompoundStorage(

--- a/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
@@ -247,7 +247,10 @@ IStoragePtr CreateSpdkStorage(
         std::make_shared<TDiagnosticsConfig>(),
         monitoring,
         CreateProfileLogStub(),
-        CreateServerRequestStats(serverGroup, CreateWallClockTimer()),
+        CreateServerRequestStats(
+            serverGroup,
+            CreateWallClockTimer(),
+            EHistogramCounterOption::ReportMultipleCounters),
         CreateVolumeStatsStub());
 
     auto storageProvider = CreateSpdkStorageProvider(

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -386,7 +386,10 @@ void TBootstrap::InitControlClient()
 
     auto clientGroup = rootGroup->GetSubgroup("component", "client");
 
-    RequestStats = CreateClientRequestStats(clientGroup, Timer);
+    RequestStats = CreateClientRequestStats(
+        clientGroup,
+        Timer,
+        EHistogramCounterOption::ReportMultipleCounters);
 
     VolumeStats = CreateVolumeStats(
         Monitoring,

--- a/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
@@ -210,7 +210,10 @@ void TBootstrap::Init()
         false);
     *versionCounter = 1;
 
-    RequestStats = CreateClientRequestStats(clientGroup, Timer);
+    RequestStats = CreateClientRequestStats(
+        clientGroup,
+        Timer,
+        EHistogramCounterOption::ReportMultipleCounters);
 
     VolumeStats = CreateVolumeStats(
         Monitoring,

--- a/cloud/filestore/config/diagnostics.proto
+++ b/cloud/filestore/config/diagnostics.proto
@@ -99,8 +99,8 @@ message TDiagnosticsConfig
     optional TMonitoringUrlData MonitoringUrlData = 22;
 
     // Report histogram as a set of manually created counters
-    optional bool ReportHistogramAsMultipleCounters = 48;
+    optional bool ReportHistogramAsMultipleCounters = 23;
 
     // Report histogram as a single counter (THistogramCounter)
-    optional bool ReportHistogramAsSingleCounter = 49;
+    optional bool ReportHistogramAsSingleCounter = 24;
 }

--- a/cloud/filestore/config/diagnostics.proto
+++ b/cloud/filestore/config/diagnostics.proto
@@ -97,4 +97,10 @@ message TDiagnosticsConfig
 
     // Monitoring data necessary for link generation on monpages.
     optional TMonitoringUrlData MonitoringUrlData = 22;
+
+    // Report histogram as a set of manually created counters
+    optional bool ReportHistogramAsMultipleCounters = 48;
+
+    // Report histogram as a single counter (THistogramCounter)
+    optional bool ReportHistogramAsSingleCounter = 49;
 }

--- a/cloud/filestore/config/diagnostics.proto
+++ b/cloud/filestore/config/diagnostics.proto
@@ -99,8 +99,8 @@ message TDiagnosticsConfig
     optional TMonitoringUrlData MonitoringUrlData = 22;
 
     // Report histogram as a set of manually created counters
-    optional bool ReportHistogramAsMultipleCounters = 23;
+    optional bool ReportHistogramAsMultipleCounters = 24;
 
     // Report histogram as a single counter (THistogramCounter)
-    optional bool ReportHistogramAsSingleCounter = 24;
+    optional bool ReportHistogramAsSingleCounter = 25;
 }

--- a/cloud/filestore/libs/diagnostics/config.cpp
+++ b/cloud/filestore/libs/diagnostics/config.cpp
@@ -35,6 +35,8 @@ namespace {
     xxx(PostponeTimePredictorMaxTime,    TDuration, TDuration::Minutes(1)     )\
     xxx(PostponeTimePredictorPercentage, double,    0.0                       )\
     xxx(MonitoringUrlData,               TMonitoringUrlData,  {}              )\
+    xxx(ReportHistogramAsMultipleCounters,  bool,            true             )\
+    xxx(ReportHistogramAsSingleCounter,     bool,            false            )\
 // FILESTORE_DIAGNOSTICS_CONFIG
 
 #define FILESTORE_DIAGNOSTICS_DECLARE_CONFIG(name, type, value)                \
@@ -101,6 +103,19 @@ TRequestThresholds TDiagnosticsConfig::GetRequestThresholds() const
 {
     return ConvertValue<TRequestThresholds>(
         DiagnosticsConfig.GetRequestThresholds());
+}
+
+EHistogramCounterOptions TDiagnosticsConfig::GetHistogramCounterOptions() const
+{
+    EHistogramCounterOptions histogramCounterOptions;
+    if (GetReportHistogramAsMultipleCounters()) {
+        histogramCounterOptions |=
+            EHistogramCounterOption::ReportMultipleCounters;
+    }
+    if (GetReportHistogramAsSingleCounter()) {
+        histogramCounterOptions |= EHistogramCounterOption::ReportSingleCounter;
+    }
+    return histogramCounterOptions;
 }
 
 void TDiagnosticsConfig::Dump(IOutputStream& out) const

--- a/cloud/filestore/libs/diagnostics/config.h
+++ b/cloud/filestore/libs/diagnostics/config.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/filestore/config/diagnostics.pb.h>
+#include "cloud/storage/core/libs/diagnostics/histogram_counter_options.h"
 #include <cloud/storage/core/libs/diagnostics/trace_reader.h>
 
 #include <util/datetime/base.h>
@@ -65,6 +66,10 @@ public:
     double GetPostponeTimePredictorPercentage() const;
 
     TMonitoringUrlData GetMonitoringUrlData() const;
+
+    bool GetReportHistogramAsMultipleCounters() const;
+    bool GetReportHistogramAsSingleCounter() const;
+    EHistogramCounterOptions GetHistogramCounterOptions() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/storage/core/libs/diagnostics/histogram_counter_options.h
+++ b/cloud/storage/core/libs/diagnostics/histogram_counter_options.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <util/generic/flags.h>
+
+namespace NCloud {
+
+enum class EHistogramCounterOption {
+    ReportSingleCounter     = (1 << 0),
+    ReportMultipleCounters  = (1 << 1),
+};
+
+Y_DECLARE_FLAGS(EHistogramCounterOptions, EHistogramCounterOption);
+Y_DECLARE_OPERATORS_FOR_FLAGS(EHistogramCounterOptions);
+
+}   // namespace NCloud
+

--- a/cloud/storage/core/libs/diagnostics/histogram_types.h
+++ b/cloud/storage/core/libs/diagnostics/histogram_types.h
@@ -101,5 +101,10 @@ struct TKbSizeBuckets
     static TVector<TString> MakeNames();
 };
 
+template<class TBucketsType>
+inline TVector<double> ConvertToHistBounds(const TBucketsType& buckets) {
+    return {buckets.begin(), std::prev(buckets.end())};
+}
+
 }   // namespace NCloud
 

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -36,7 +36,7 @@ struct THistBase
     THistogramPtr Hist;
     std::array<TDynamicCounters::TCounterPtr, TDerived::BUCKETS_COUNT> Counters;
 
-    explicit THistBase(EHistogramCounterOptions counterOptions = {})
+    explicit THistBase(EHistogramCounterOptions counterOptions)
         : HistBounds(ConvertToHistBounds(TDerived::Buckets))
         , CounterOptions(counterOptions)
         , Hist(
@@ -296,8 +296,8 @@ struct TRequestCounters::TStatCounters
     TAtomic FullyInitialized = false;
 
     explicit TStatCounters(
-        ITimerPtr timer,
-        EHistogramCounterOptions histogramCounterOptions)
+            ITimerPtr timer,
+            EHistogramCounterOptions histogramCounterOptions)
         : SizeHist(histogramCounterOptions)
         , TimeHist(histogramCounterOptions)
         , TimeHistUnaligned(histogramCounterOptions)

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -30,65 +30,69 @@ namespace {
 template <typename TDerived>
 struct THistBase
 {
-    struct TBucket
+    const TBucketBounds HistBounds;
+    const EHistogramCounterOptions CounterOptions;
+
+    THistogramPtr Hist;
+    std::array<TDynamicCounters::TCounterPtr, TDerived::BUCKETS_COUNT> Counters;
+
+    explicit THistBase(EHistogramCounterOptions counterOptions = {})
+        : HistBounds(ConvertToHistBounds(TDerived::Buckets))
+        , CounterOptions(counterOptions)
+        , Hist(
+            new THistogramCounter(NMonitoring::ExplicitHistogram(HistBounds)))
     {
-        double Value;
-        TDynamicCounters::TCounterPtr Counter;
-
-        TBucket(double value = 0)
-            : Value(value)
-            , Counter(new TCounterForPtr(true))
-        {}
-    };
-
-    std::array<TBucket, TDerived::BUCKETS_COUNT> Buckets;
-
-    THistBase()
-    {
-        std::copy(
-            TDerived::Buckets.begin(),
-            TDerived::Buckets.end(),
-            Buckets.begin());
+        std::fill(Counters.begin(), Counters.end(), new TCounterForPtr(true));
     }
 
     void Register(
         TDynamicCounters& counters,
+        const TString& name,
         TCountableBase::EVisibility vis = TCountableBase::EVisibility::Public)
     {
-        const auto names = TDerived::MakeNames();
-        for (size_t i = 0; i < Buckets.size(); ++i) {
-            Buckets[i].Counter = counters.GetCounter(names[i], true, vis);
+        auto subgroup = MakeVisibilitySubgroup(
+            counters,
+            "histogram",
+            name,
+            vis);
+        if (CounterOptions & EHistogramCounterOption::ReportSingleCounter) {
+            Hist = subgroup->GetHistogram(name,
+                NMonitoring::ExplicitHistogram(HistBounds),
+                true,
+                vis);
+        }
+        if (CounterOptions & EHistogramCounterOption::ReportMultipleCounters) {
+            const auto names = TDerived::MakeNames();
+            for (size_t i = 0; i < Counters.size(); ++i) {
+                Counters[i] = subgroup->GetCounter(names[i], true, vis);
+            }
         }
     }
 
-    void Increment(double value, ui64 count = 1)
+    void Increment(double value, ui64 count)
     {
-        auto comparer = [] (const TBucket& bucket, double value) {
-            return bucket.Value < value;
-        };
+        Hist->Collect(value, count);
 
         auto it = LowerBound(
-            Buckets.begin(),
-            Buckets.end(),
-            value,
-            comparer);
+            TDerived::Buckets.begin(),
+            TDerived::Buckets.end(),
+            value);
         STORAGE_VERIFY(
-            it != Buckets.end(),
+            it != TDerived::Buckets.end(),
             "Bucket",
             value);
-
-        it->Counter->Add(count);
+        size_t index = std::distance(TDerived::Buckets.begin(), it);
+        Counters[index]->Add(count);
     }
 
     TVector<TBucketInfo> GetBuckets() const
     {
-        TVector<TBucketInfo> result(Reserve(Buckets.size()));
-        for (const auto& bucket: Buckets) {
-            result.emplace_back(
-                bucket.Value,
-                bucket.Counter->Val());
-        }
+        const auto snapshot = Hist->Snapshot();
 
+        TVector<TBucketInfo> result(snapshot->Count());
+        for (size_t i = 0; i < snapshot->Count(); ++i) {
+            result.emplace_back(snapshot->UpperBound(i), snapshot->Value(i));
+        }
         return result;
     }
 };
@@ -98,6 +102,11 @@ struct THistBase
 struct TTimeHist
     : public THistBase<TRequestMsTimeBuckets>
 {
+    explicit TTimeHist(EHistogramCounterOptions counterOptions)
+        : THistBase(counterOptions)
+    {
+    }
+
     void Increment(TDuration requestTime, ui64 count = 1)
     {
         THistBase::Increment(requestTime.MicroSeconds() / 1000., count);
@@ -109,6 +118,11 @@ struct TTimeHist
 struct TSizeHist
     : public THistBase<TKbSizeBuckets>
 {
+    explicit TSizeHist(EHistogramCounterOptions counterOptions)
+        : THistBase(counterOptions)
+    {
+    }
+
     void Increment(double requestBytes, ui64 count = 1)
     {
         THistBase::Increment(requestBytes / 1024, count);
@@ -281,8 +295,17 @@ struct TRequestCounters::TStatCounters
     TMutex FullInitLock;
     TAtomic FullyInitialized = false;
 
-    explicit TStatCounters(ITimerPtr timer)
-        : MaxTimeCalc(timer)
+    explicit TStatCounters(
+        ITimerPtr timer,
+        EHistogramCounterOptions histogramCounterOptions)
+        : SizeHist(histogramCounterOptions)
+        , TimeHist(histogramCounterOptions)
+        , TimeHistUnaligned(histogramCounterOptions)
+        , ExecutionTimeHist(histogramCounterOptions)
+        , ExecutionTimeHistUnaligned(histogramCounterOptions)
+        , RequestCompletionTimeHist(histogramCounterOptions)
+        , PostponedTimeHist(histogramCounterOptions)
+        , MaxTimeCalc(timer)
         , MaxTotalTimeCalc(timer)
         , MaxSizeCalc(timer)
         , MaxInProgressCalc(timer)
@@ -363,12 +386,10 @@ struct TRequestCounters::TStatCounters
             if (ReportDataPlaneHistogram) {
                 auto unalignedClassGroup = counters.GetSubgroup("sizeclass", "Unaligned");
 
-                SizeHist.Register(*counters.GetSubgroup("histogram", "Size"));
-                TimeHistUnaligned.Register(*unalignedClassGroup->GetSubgroup("histogram", "Time"));
-                ExecutionTimeHist.Register(
-                    *counters.GetSubgroup("histogram", "ExecutionTime"));
-                ExecutionTimeHistUnaligned.Register(
-                    *unalignedClassGroup->GetSubgroup("histogram", "ExecutionTime"));
+                SizeHist.Register(counters, "Size");
+                TimeHistUnaligned.Register(*unalignedClassGroup, "Time");
+                ExecutionTimeHist.Register(counters, "ExecutionTime");
+                ExecutionTimeHistUnaligned.Register(*unalignedClassGroup, "ExecutionTime");
             } else {
                 SizePercentiles.Register(*counters.GetSubgroup("percentiles", "Size"));
                 ExecutionTimePercentiles.Register(
@@ -382,24 +403,13 @@ struct TRequestCounters::TStatCounters
                 ? TCountableBase::EVisibility::Public
                 : TCountableBase::EVisibility::Private;
 
-            PostponedTimeHist.Register(*MakeVisibilitySubgroup(
-                counters,
-                "histogram",
-                "ThrottlerDelay",
-                visibleHistogram), visibleHistogram);
-
-            TimeHist.Register(*MakeVisibilitySubgroup(
-                counters,
-                "histogram",
-                "Time",
-                visibleHistogram), visibleHistogram);
+            PostponedTimeHist.Register(counters, "ThrottlerDelay", visibleHistogram);
+            TimeHist.Register(counters, "Time", visibleHistogram);
 
             // Always enough only percentiles.
-            RequestCompletionTimeHist.Register(*MakeVisibilitySubgroup(
-                    counters,
-                    "histogram",
-                    "RequestCompletionTime",
-                    TCountableBase::EVisibility::Private),
+            RequestCompletionTimeHist.Register(
+                counters,
+                "RequestCompletionTime",
                 TCountableBase::EVisibility::Private);
             RequestCompletionTimePercentiles.Register(
                 *counters.GetSubgroup("percentiles", "RequestCompletionTime"));
@@ -418,9 +428,7 @@ struct TRequestCounters::TStatCounters
             FastPathHits = counters.GetCounter("FastPathHits", true);
         } else {
             if (ReportControlPlaneHistogram) {
-                TimeHist.Register(*counters.GetSubgroup(
-                    "histogram",
-                    "Time"));
+                TimeHist.Register(counters, "Time");
             } else {
                 TimePercentiles.Register(
                     *counters.GetSubgroup("percentiles", "Time"));
@@ -688,7 +696,8 @@ TRequestCounters::TRequestCounters(
         ui32 requestCount,
         std::function<TString(TRequestType)> requestType2Name,
         std::function<bool(TRequestType)> isReadWriteRequestType,
-        EOptions options)
+        EOptions options,
+        EHistogramCounterOptions histogramCounterOptions)
     : RequestType2Name(std::move(requestType2Name))
     , IsReadWriteRequestType(std::move(isReadWriteRequestType))
     , Options(options)
@@ -699,7 +708,7 @@ TRequestCounters::TRequestCounters(
 
     CountersByRequest.reserve(requestCount);
     for (ui32 i = 0; i < requestCount; ++i) {
-        CountersByRequest.emplace_back(timer);
+        CountersByRequest.emplace_back(timer, histogramCounterOptions);
     }
 }
 

--- a/cloud/storage/core/libs/diagnostics/request_counters.h
+++ b/cloud/storage/core/libs/diagnostics/request_counters.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/histogram_counter_options.h>
 
 #include <util/datetime/base.h>
 #include <util/generic/flags.h>
@@ -55,7 +56,8 @@ public:
         ui32 requestCount,
         std::function<TString(TRequestType)> requestType2Name,
         std::function<bool(TRequestType)> isReadWriteRequestType,
-        EOptions options = {});
+        EOptions options,
+        EHistogramCounterOptions histogramCounterOptions);
     ~TRequestCounters();
 
     void Register(NMonitoring::TDynamicCounters& counters);

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -741,7 +741,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
             { 1_KB, TDuration::MilliSeconds(100000), TDuration::Zero() },
         });
 
-        const TMap<uint64_t, uint64_t> expectedHistogramValues = {
+        const TMap<size_t, uint64_t> expectedHistogramValues = {
             { 19, 1 }, // 1000ms
             { 20, 2 }, // 2000ms
             { 22, 1 }, // 10000ms
@@ -759,10 +759,10 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
         const auto snapshot = histogram->Snapshot();
         UNIT_ASSERT_VALUES_EQUAL(snapshot->Count(), TRequestMsTimeBuckets::Buckets.size());
-        for (size_t i = 0; i < snapshot->Count(); i++) {
-            auto expectedValue = expectedHistogramValues.contains(i) ?
-                expectedHistogramValues[i] : 0;
-            UNIT_ASSERT_VALUES_EQUAL(snapshot->Value(i), expectedValue);
+        for (size_t bucketId = 0; bucketId < snapshot->Count(); bucketId++) {
+            auto expectedValue = expectedHistogramValues.contains(bucketId) ?
+                expectedHistogramValues.at(bucketId) : 0;
+            UNIT_ASSERT_VALUES_EQUAL(snapshot->Value(bucketId), expectedValue);
         }
     }
 

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/timer.h>
+#include "cloud/storage/core/libs/diagnostics/histogram_types.h"
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -96,24 +97,32 @@ auto IsReadWriteRequest(TRequestCounters::TRequestType t)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-auto MakeRequestCounters(TRequestCounters::EOption options = {})
+auto MakeRequestCounters(
+    TRequestCounters::EOption options = {},
+    EHistogramCounterOptions histogramCounterOptions =
+        EHistogramCounterOption::ReportMultipleCounters)
 {
     return TRequestCounters(
         CreateWallClockTimer(),
         2,
         RequestType2Name,
         IsReadWriteRequest,
-        options);
+        options,
+        histogramCounterOptions);
 }
 
-auto MakeRequestCountersPtr(TRequestCounters::EOption options = {})
+auto MakeRequestCountersPtr(
+    TRequestCounters::EOption options = {},
+    EHistogramCounterOptions histogramCounterOptions =
+        EHistogramCounterOption::ReportMultipleCounters)
 {
     return std::make_shared<TRequestCounters>(
         CreateWallClockTimer(),
         2,
         RequestType2Name,
         IsReadWriteRequest,
-        options);
+        options,
+        histogramCounterOptions);
 }
 
 }   // namespace
@@ -668,6 +677,127 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
             UNIT_ASSERT_VALUES_EQUAL(time->Val(), 2);
         }
+    }
+
+    Y_UNIT_TEST(ShouldReportHistogramAsMultipleSensors)
+    {
+        auto warmupTimer = GetCyclesPerMillisecond();
+        Y_UNUSED(warmupTimer);
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = MakeRequestCountersPtr(
+            TRequestCounters::EOption::ReportDataPlaneHistogram,
+            EHistogramCounterOption::ReportMultipleCounters);
+        counters->Register(*monitoring->GetCounters());
+
+        AddRequestStats(*counters, WriteRequestType, {
+            { 1_KB, TDuration::MilliSeconds(800), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(1500), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(2000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(8000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(36000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(100000), TDuration::Zero() },
+        });
+
+        TMap<TString, uint64_t> expectedHistogramValues;
+        for (const auto& bucketName : TRequestMsTimeBuckets::MakeNames()) {
+            expectedHistogramValues[bucketName] = 0;
+        }
+        expectedHistogramValues["1000ms"] = 1;
+        expectedHistogramValues["2000ms"] = 2;
+        expectedHistogramValues["10000ms"] = 1;
+        expectedHistogramValues["Inf"] = 2;
+
+        counters->UpdateStats();
+        const auto group = monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "WriteBlocks")
+            ->GetSubgroup("histogram", "Time");
+
+        for (const auto& [name, value]: expectedHistogramValues) {
+            const auto counter = group->FindCounter(name);
+            UNIT_ASSERT(counter);
+            UNIT_ASSERT_VALUES_EQUAL(counter->Val(), value);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldReportHistogramAsSingleSensor)
+    {
+        auto warmupTimer = GetCyclesPerMillisecond();
+        Y_UNUSED(warmupTimer);
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = MakeRequestCountersPtr(
+            TRequestCounters::EOption::ReportDataPlaneHistogram,
+            EHistogramCounterOption::ReportSingleCounter);
+        counters->Register(*monitoring->GetCounters());
+
+        AddRequestStats(*counters, WriteRequestType, {
+            { 1_KB, TDuration::MilliSeconds(800), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(1500), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(2000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(8000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(36000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(100000), TDuration::Zero() },
+        });
+
+        const TMap<uint64_t, uint64_t> expectedHistogramValues = {
+            { 19, 1 }, // 1000ms
+            { 20, 2 }, // 2000ms
+            { 22, 1 }, // 10000ms
+            { 24, 2 }, // Inf
+        };
+
+        counters->UpdateStats();
+
+        const auto histogram = monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "WriteBlocks")
+            ->GetSubgroup("histogram", "Time")
+            ->FindHistogram("Time");
+        UNIT_ASSERT(histogram);
+
+        const auto snapshot = histogram->Snapshot();
+        UNIT_ASSERT_VALUES_EQUAL(snapshot->Count(), TRequestMsTimeBuckets::Buckets.size());
+        for (size_t i = 0; i < snapshot->Count(); i++) {
+            auto expectedValue = expectedHistogramValues.contains(i) ?
+                expectedHistogramValues[i] : 0;
+            UNIT_ASSERT_VALUES_EQUAL(snapshot->Value(i), expectedValue);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldNotReportHistogramIfOptionIsNotSet)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = MakeRequestCountersPtr(
+            TRequestCounters::EOption::ReportDataPlaneHistogram,
+            {});
+        counters->Register(*monitoring->GetCounters());
+
+        AddRequestStats(*counters, WriteRequestType, {
+            { 1_KB, TDuration::MilliSeconds(800), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(1500), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(2000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(8000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(36000), TDuration::Zero() },
+            { 1_KB, TDuration::MilliSeconds(100000), TDuration::Zero() },
+        });
+
+        auto counter = monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "WriteBlocks")
+            ->GetSubgroup("histogram", "Time")
+            ->FindCounter("1ms");
+
+        UNIT_ASSERT(!counter);
+
+        auto histogram = monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "WriteBlocks")
+            ->GetSubgroup("histogram", "Time")
+            ->FindHistogram("Time");
+
+        UNIT_ASSERT(!histogram);
     }
 }
 

--- a/cloud/vm/blockstore/bootstrap.cpp
+++ b/cloud/vm/blockstore/bootstrap.cpp
@@ -160,7 +160,10 @@ void TBootstrap::Init()
         false);
     *versionCounter = 1;
 
-    RequestStats = CreateClientRequestStats(clientGroup, Timer);
+    RequestStats = CreateClientRequestStats(
+        clientGroup,
+        Timer,
+        EHistogramCounterOption::ReportMultipleCounters);
 
     VolumeStats = CreateVolumeStats(
         Monitoring,


### PR DESCRIPTION
This pull request adds options to report histograms as either single or multiple counters, providing more flexibility in how monitoring data is collected and reported. Single historgram counter with "le" label makes it possible to calculate quantiles in Grafana monitoring system.

There are a several places in project that report histograms, this PR changes only some of them (specifically `THistBase` class).

The main changes: 
* Added new configuration options `ReportHistogramAsMultipleCounters` and `ReportHistogramAsSingleCounter` to the diagnostics configuration files (diagnostics.proto) and support them in NBS and Filestore
* Updated the `THistBase`, `TRequestCounters` and other related classes to handle the new histogram counter options
* Added unit tests to verify the new histogram reporting functionality

`THistBase` is used by `TRequestCounters`:
```
TRequestCounters
  TRequestCounters::TStatCounters
    TTimeHist : public THistBase
    TSizeHist : public THistBase
```
`TRequestCounters` is used by `TVolumeStats` and `TRequestStats`
```
TVolumeStats
  TVolumeInfo
    TRequestCounters
TRequestStats
  TRequestCounters  
```
