### PR TITLE
Don't mark devices as broken on non io-related errors

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stats.cpp
@@ -28,6 +28,8 @@ EDeviceHealthStatus GetHealthStatus(EWellKnownResultCodes code)
     switch (code) {
         case EWellKnownResultCodes::S_OK:
             return EDeviceHealthStatus::Healthy;
+        case EWellKnownResultCodes::E_ARGUMENT:
+        case EWellKnownResultCodes::E_CANCELLED:
         case EWellKnownResultCodes::E_REJECTED:
             return EDeviceHealthStatus::Unknown;
         default:


### PR DESCRIPTION
Если запрос отклоняется на стороне диска агента с этими ошибками, это уводит девайс в состоянии IO_ERROR.
Сделал чтобы некоторые типы ошибок не помечали девайс как сломанный. 