### PR TITLE
issue-2033: additional check for CreateHandle DupCache entries to avoid replying with old responses to new requests with reused request ids (which may happen due to bugs in the client)

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -20,6 +20,7 @@ namespace NCloud::NFileStore{
     xxx(NodeNotFoundInFollower)                                                \
     xxx(NotEnoughResultsInGetNodeAttrBatchResponses)                           \
     xxx(AsyncDestroyHandleFailed)                                              \
+    xxx(DuplicateRequestId)                                                    \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -155,7 +155,7 @@ public:
 
     ui64 GenerateDupCacheEntryId()
     {
-        return LastDupCacheEntryId++;
+        return ++LastDupCacheEntryId;
     }
 
     void LoadDupCacheEntry(NProto::TDupCacheEntry entry)

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -58,11 +58,12 @@ using TSessionLockMultiMap = THashMultiMap<ui64, TSessionLock*>;
 
 struct TDupCacheEntry: NProto::TDupCacheEntry
 {
-    bool Commited = false;
+    bool Committed = false;
+    bool Dropped = false;
 
-    TDupCacheEntry(const NProto::TDupCacheEntry& proto, bool commited)
+    TDupCacheEntry(const NProto::TDupCacheEntry& proto, bool committed)
         : NProto::TDupCacheEntry(proto)
-        , Commited(commited)
+        , Committed(committed)
     {}
 };
 
@@ -112,7 +113,7 @@ public:
         return SubSessions.IsValid();
     }
 
-    bool HasSeqNo(ui64 seqNo)
+    bool HasSeqNo(ui64 seqNo) const
     {
         return SubSessions.HasSeqNo(seqNo);
     }
@@ -177,6 +178,21 @@ public:
         return nullptr;
     }
 
+    void DropDupEntry(ui64 requestId)
+    {
+        if (!requestId) {
+            return;
+        }
+
+        auto it = DupCache.find(requestId);
+        if (it == DupCache.end()) {
+            return;
+        }
+
+        it->second->Dropped = true;
+        DupCache.erase(it);
+    }
+
     TDupCacheEntry* AccessDupEntry(ui64 requestId)
     {
         if (!requestId) {
@@ -191,12 +207,12 @@ public:
         return nullptr;
     }
 
-    void AddDupCacheEntry(NProto::TDupCacheEntry proto, bool commited)
+    void AddDupCacheEntry(NProto::TDupCacheEntry proto, bool committed)
     {
         Y_ABORT_UNLESS(proto.GetRequestId());
         Y_ABORT_UNLESS(proto.GetEntryId());
 
-        DupCacheEntries.emplace_back(std::move(proto), commited);
+        DupCacheEntries.emplace_back(std::move(proto), committed);
 
         auto& entry = DupCacheEntries.back();
         auto [_, inserted] = DupCache.emplace(entry.GetRequestId(), &entry);
@@ -206,7 +222,7 @@ public:
     void CommitDupCacheEntry(ui64 requestId)
     {
         if (auto it = DupCache.find(requestId); it != DupCache.end()) {
-            it->second->Commited = true;
+            it->second->Committed = true;
         }
     }
 
@@ -217,7 +233,8 @@ public:
         }
 
         auto entry = DupCacheEntries.front();
-        DupCache.erase(entry.GetRequestId());
+        const auto erased = DupCache.erase(entry.GetRequestId());
+        Y_DEBUG_ABORT_UNLESS(erased || entry.Dropped);
         DupCacheEntries.pop_front();
 
         return entry.GetEntryId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -295,6 +295,7 @@ void TIndexTabletActor::HandleCreateNode(
         GetDupCacheEntry(e, response->Record);
         if (response->Record.GetNode().GetId() == 0) {
             // it's an external node which is not yet created in follower
+            // this check is needed for the case of leader reboot
             *response->Record.MutableError() = MakeError(
                 E_REJECTED,
                 "node not yet created in follower");

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -844,14 +844,15 @@ void TIndexTabletState::GetDupCacheEntry(                                      \
     const TDupCacheEntry* entry,                                               \
     NProto::T##name##Response& response)                                       \
 {                                                                              \
-    if (entry->Commited && entry->Has##name()) {                               \
+    if (entry->Committed && entry->Has##name()) {                              \
         response = entry->Get##name();                                         \
-    } else if (!entry->Commited) {                                             \
+    } else if (!entry->Committed) {                                            \
         *response.MutableError() = ErrorDuplicate();                           \
     } else if (!entry->Has##name()) {                                          \
         *response.MutableError() = MakeError(                                  \
             E_ARGUMENT, TStringBuilder() << "invalid request dup cache type: " \
                 << entry->ShortUtf8DebugString().Quote());                     \
+        ReportDuplicateRequestId(response.GetError().GetMessage());            \
     }                                                                          \
 }                                                                              \
 // FILESTORE_IMPLEMENT_DUPCACHE


### PR DESCRIPTION
#2033 