### PR TITLE
Fix invalid range request duplicates cache poisoning

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -655,6 +655,20 @@ void TVolumeActor::ForwardRequest(
     }
 
     /*
+     *  Validation of the request blocks range
+     */
+    if constexpr (IsReadOrWriteMethod<TMethod>) {
+        const auto range = BuildRequestBlockRange(*msg, State->GetBlockSize());
+        if (!CheckReadWriteBlockRange(range)) {
+            replyError(MakeError(
+                E_ARGUMENT,
+                TStringBuilder()
+                    << "invalid block range " << DescribeRange(range)));
+            return;
+        }
+    }
+
+    /*
      *  Processing overlapping writes. Overlapping writes should not be sent
      *  to the underlying (storage) layer.
      */
@@ -705,19 +719,6 @@ void TVolumeActor::ForwardRequest(
         }
     }
 
-    /*
-     *  Validation of the request blocks range
-     */
-    if constexpr (IsReadOrWriteMethod<TMethod>) {
-        const auto range = BuildRequestBlockRange(*msg, State->GetBlockSize());
-        if (!CheckReadWriteBlockRange(range)) {
-            replyError(MakeError(
-                E_ARGUMENT,
-                TStringBuilder()
-                    << "invalid block range " << DescribeRange(range)));
-            return;
-        }
-    }
 
     /*
      *  Passing the request to the underlying (storage) layer.

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -8246,7 +8246,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         // WriteBlocks
         {
             auto request = volume.CreateWriteBlocksRequest(
-                TBlockRange64::WithLength(2048, 1024),
+                TBlockRange64::WithLength(1500, 1024),
                 clientInfo.GetClientId(),
                 1
             );
@@ -8254,6 +8254,17 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             auto response = volume.RecvWriteBlocksResponse();
             UNIT_ASSERT(response);
             UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, response->GetStatus());
+        }
+
+        // Writing to a valid range that is covered by the range of the
+        // previously rejected request should be successful.
+        {
+            auto response = volume.WriteBlocks(
+                TBlockRange64::WithLength(1500, 500),
+                clientInfo.GetClientId(),
+                1);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
         }
 
         // WriteBlocksLocal


### PR DESCRIPTION
При реализации https://github.com/ydb-platform/nbs/pull/1475
был сделан баг, что запрос сохранялся в кэше для отслеживания повторных запросов, но не удалялся оттуда.
Перенес отклонение запроса выше, до его помещения в кэш DuplicateWriteAndZeroRequests