### PR TITLE
Fix local disks test

### DIFF
--- a/cloud/blockstore/tests/external_endpoint/multiple_endpoints.py
+++ b/cloud/blockstore/tests/external_endpoint/multiple_endpoints.py
@@ -186,7 +186,7 @@ def test_multiple_endpoints(nbs):
     create_vol0()
 
     # Start a lot of blockstore-vhost-server processes.
-    SOCKET_COUNT = 30
+    SOCKET_COUNT = 15
     for i in range(0, SOCKET_COUNT):
         socket = tempfile.NamedTemporaryFile()
         client.start_endpoint_async(


### PR DESCRIPTION
Тест падает, т.к. 30 процессов не могут стартовать. На 27-28 процессе не хватает IO:
```
2024-09-16T02:06:50.608236Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: VERIFY failed (2024-09-16T02:06:50.605952Z): io_setup
2024-09-16T02:06:50.608301Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json:   cloud/blockstore/vhost-server/backend_aio.cpp:179
2024-09-16T02:06:50.608307Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json:   Init(): requirement io_setup(BatchSize, &Io) >= 0 failed
2024-09-16T02:06:50.608312Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+663 (0xF3A327)
2024-09-16T02:06:50.608317Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+284 (0xF305BC)
2024-09-16T02:06:50.608323Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: ??+0 (0xDFDB2C)
2024-09-16T02:06:50.609413Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: ??+0 (0xE1F20C)
2024-09-16T02:06:50.611124Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: main+2735 (0xDFA51F)
2024-09-16T02:06:50.611150Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: ??+0 (0x7F937EBA6D90)
2024-09-16T02:06:50.611155Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: __libc_start_main+128 (0x7F937EBA6E40)
2024-09-16T02:06:50.611161Z :BLOCKSTORE_EXTERNAL_ENDPOINT ERROR: cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp:505: [/home/github/.ya/build/build_root/92ii/0029f8/r3tmp/tmpu1hii7w7-id] bad json: ??+0 (0xDD8029)
```