### PR TITLE
issue-1946: remove duplicated code

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -271,7 +271,7 @@ void TConfigInitializerYdb::ApplyStorageServiceConfig(const TString& text)
 
     if (ServerConfig && ServerConfig->GetServerConfig()) {
         NStorage::AdaptNodeRegistrationParams(
-            {},
+            {}, // overriddenNodeType is empty, is not passed in command line
             *ServerConfig->GetServerConfig(),
             storageConfig);
     }

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -61,7 +61,7 @@ void TConfigInitializerYdb::InitStorageConfig()
 
     if (ServerConfig && ServerConfig->GetServerConfig()) {
         NStorage::AdaptNodeRegistrationParams(
-            {},
+            {}, // overriddenNodeType, node type is not passed in cmd line
             *ServerConfig->GetServerConfig(),
             storageConfig);
     }
@@ -271,7 +271,7 @@ void TConfigInitializerYdb::ApplyStorageServiceConfig(const TString& text)
 
     if (ServerConfig && ServerConfig->GetServerConfig()) {
         NStorage::AdaptNodeRegistrationParams(
-            {}, // overriddenNodeType is empty, is not passed in command line
+            {}, // overriddenNodeType, node type is not passed in cmd line
             *ServerConfig->GetServerConfig(),
             storageConfig);
     }

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -59,7 +59,12 @@ void TConfigInitializerYdb::InitStorageConfig()
         ParseProtoTextFromFileRobust(Options->StorageConfig, storageConfig);
     }
 
-    AdaptNodeRegistrationParams(storageConfig);
+    if (ServerConfig && ServerConfig->GetServerConfig()) {
+        NStorage::AdaptNodeRegistrationParams(
+            {},
+            *ServerConfig->GetServerConfig(),
+            storageConfig);
+    }
 
     SetupStorageConfig(storageConfig);
 
@@ -264,7 +269,12 @@ void TConfigInitializerYdb::ApplyStorageServiceConfig(const TString& text)
     NProto::TStorageServiceConfig storageConfig;
     ParseProtoTextFromStringRobust(text, storageConfig);
 
-    AdaptNodeRegistrationParams(storageConfig);
+    if (ServerConfig && ServerConfig->GetServerConfig()) {
+        NStorage::AdaptNodeRegistrationParams(
+            {},
+            *ServerConfig->GetServerConfig(),
+            storageConfig);
+    }
 
     SetupStorageConfig(storageConfig);
 
@@ -387,40 +397,6 @@ void TConfigInitializerYdb::ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfi
             handler.second,
             this,
             config.GetNamedConfigs(it->second).GetConfig());
-    }
-}
-
-void TConfigInitializerYdb::AdaptNodeRegistrationParams(
-    NProto::TStorageServiceConfig& config)
-{
-    if (!ServerConfig || !ServerConfig->GetServerConfig()) {
-        return;
-    }
-
-    const auto* serverConfig = ServerConfig->GetServerConfig();
-
-    if (!config.GetNodeRegistrationMaxAttempts()) {
-        config.SetNodeRegistrationMaxAttempts(
-            serverConfig->GetNodeRegistrationMaxAttempts());
-    }
-
-    if (!config.GetNodeRegistrationTimeout()) {
-        config.SetNodeRegistrationTimeout(
-            serverConfig->GetNodeRegistrationTimeout());
-    }
-
-    if (!config.GetNodeRegistrationErrorTimeout()) {
-        config.SetNodeRegistrationErrorTimeout(
-            serverConfig->GetNodeRegistrationErrorTimeout());
-    }
-
-    if (!config.GetNodeRegistrationToken()) {
-        config.SetNodeRegistrationToken(
-            serverConfig->GetNodeRegistrationToken());
-    }
-
-    if (!config.GetNodeType()) {
-        config.SetNodeType(serverConfig->GetNodeType());
     }
 }
 

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.h
@@ -78,7 +78,6 @@ struct TConfigInitializerYdb final
 
 private:
     void SetupStorageConfig(NProto::TStorageServiceConfig& config) const;
-    void AdaptNodeRegistrationParams(NProto::TStorageServiceConfig& config);
 
     void ApplyDiagnosticsConfig(const TString& text);
     void ApplyDiscoveryServiceConfig(const TString& text);

--- a/cloud/blockstore/libs/disk_agent/config_initializer.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.cpp
@@ -139,7 +139,12 @@ void TConfigInitializer::InitStorageConfig()
         ParseProtoTextFromFileRobust(Options->StorageConfig, storageConfig);
     }
 
-    AdaptNodeRegistrationParams(storageConfig);
+    if (ServerConfig && ServerConfig->GetServerConfig()) {
+        NStorage::AdaptNodeRegistrationParams(
+            Options->NodeType,
+            *ServerConfig->GetServerConfig(),
+            storageConfig);
+    }
 
     if (Options->SchemeShardDir) {
         storageConfig.SetSchemeShardDir(GetFullSchemeShardDir());
@@ -383,7 +388,12 @@ void TConfigInitializer::ApplyStorageServiceConfig(const TString& text)
     NProto::TStorageServiceConfig storageConfig;
     ParseProtoTextFromStringRobust(text, storageConfig);
 
-    AdaptNodeRegistrationParams(storageConfig);
+    if (ServerConfig && ServerConfig->GetServerConfig()) {
+        NStorage::AdaptNodeRegistrationParams(
+            Options->NodeType,
+            *ServerConfig->GetServerConfig(),
+            storageConfig);
+    }
 
     storageConfig.SetServiceVersionInfo(GetFullVersionString());
     StorageConfig = std::make_shared<NStorage::TStorageConfig>(
@@ -462,44 +472,6 @@ void TConfigInitializer::ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& 
             handler.second,
             this,
             config.GetNamedConfigs(it->second).GetConfig());
-    }
-}
-
-void TConfigInitializer::AdaptNodeRegistrationParams(
-    NProto::TStorageServiceConfig& config)
-{
-    if (!ServerConfig || !ServerConfig->GetServerConfig()) {
-        return;
-    }
-
-    const auto* serverConfig = ServerConfig->GetServerConfig();
-
-    if (!config.GetNodeRegistrationMaxAttempts()) {
-        config.SetNodeRegistrationMaxAttempts(
-            serverConfig->GetNodeRegistrationMaxAttempts());
-    }
-
-    if (!config.GetNodeRegistrationTimeout()) {
-        config.SetNodeRegistrationTimeout(
-            serverConfig->GetNodeRegistrationTimeout());
-    }
-
-    if (!config.GetNodeRegistrationErrorTimeout()) {
-        config.SetNodeRegistrationErrorTimeout(
-            serverConfig->GetNodeRegistrationErrorTimeout());
-    }
-
-    if (!config.GetNodeRegistrationToken()) {
-        config.SetNodeRegistrationToken(
-            serverConfig->GetNodeRegistrationToken());
-    }
-
-    if (Options->NodeType) {
-        config.SetNodeType(Options->NodeType);
-    }
-
-    if (!config.GetNodeType()) {
-        config.SetNodeType(serverConfig->GetNodeType());
     }
 }
 

--- a/cloud/blockstore/libs/disk_agent/config_initializer.h
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.h
@@ -61,7 +61,6 @@ struct TConfigInitializer
 
 private:
     TString GetFullSchemeShardDir() const;
-    void AdaptNodeRegistrationParams(NProto::TStorageServiceConfig& config);
 
     void SetupMonitoringConfig(NKikimrConfig::TMonitoringConfig& monConfig) const;
     void SetupLogConfig(NKikimrConfig::TLogConfig& logConfig) const;

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -959,11 +959,10 @@ const NProto::TStorageServiceConfig& TStorageConfig::GetStorageConfigProto() con
 }
 
 void AdaptNodeRegistrationParams(
-    const TString& nodeType,
-    const NCloud::NBlockStore::NProto::TServerConfig& serverConfig,
+    const TString& overriddenNodeType,
+    const NProto::TServerConfig& serverConfig,
     NProto::TStorageServiceConfig& storageConfig)
 {
-
     if (!storageConfig.GetNodeRegistrationMaxAttempts()) {
         storageConfig.SetNodeRegistrationMaxAttempts(
             serverConfig.GetNodeRegistrationMaxAttempts());
@@ -984,8 +983,8 @@ void AdaptNodeRegistrationParams(
             serverConfig.GetNodeRegistrationToken());
     }
 
-    if (nodeType) {
-        storageConfig.SetNodeType(nodeType);
+    if (overriddenNodeType) {
+        storageConfig.SetNodeType(overriddenNodeType);
     }
 
     if (!storageConfig.GetNodeType()) {

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -958,4 +958,39 @@ const NProto::TStorageServiceConfig& TStorageConfig::GetStorageConfigProto() con
     return Impl->StorageServiceConfig;
 }
 
+void AdaptNodeRegistrationParams(
+    const TString& nodeType,
+    const NCloud::NBlockStore::NProto::TServerConfig& serverConfig,
+    NProto::TStorageServiceConfig& storageConfig)
+{
+
+    if (!storageConfig.GetNodeRegistrationMaxAttempts()) {
+        storageConfig.SetNodeRegistrationMaxAttempts(
+            serverConfig.GetNodeRegistrationMaxAttempts());
+    }
+
+    if (!storageConfig.GetNodeRegistrationTimeout()) {
+        storageConfig.SetNodeRegistrationTimeout(
+            serverConfig.GetNodeRegistrationTimeout());
+    }
+
+    if (!storageConfig.GetNodeRegistrationErrorTimeout()) {
+        storageConfig.SetNodeRegistrationErrorTimeout(
+            serverConfig.GetNodeRegistrationErrorTimeout());
+    }
+
+    if (!storageConfig.GetNodeRegistrationToken()) {
+        storageConfig.SetNodeRegistrationToken(
+            serverConfig.GetNodeRegistrationToken());
+    }
+
+    if (nodeType) {
+        storageConfig.SetNodeType(nodeType);
+    }
+
+    if (!storageConfig.GetNodeType()) {
+        storageConfig.SetNodeType(serverConfig.GetNodeType());
+    }
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 
+#include <cloud/blockstore/config/server.pb.h>
 #include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/storage/core/libs/features/features_config.h>
 #include <cloud/storage/core/protos/media.pb.h>
@@ -609,5 +610,10 @@ public:
 ui64 GetAllocationUnit(
     const TStorageConfig& config,
     NCloud::NProto::EStorageMediaKind mediaKind);
+
+void AdaptNodeRegistrationParams(
+    const TString& nodeType,
+    const NCloud::NBlockStore::NProto::TServerConfig serverConfig,
+    NProto::TStorageServiceConfig& storageConfig);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -2,7 +2,6 @@
 
 #include "public.h"
 
-
 #include <cloud/blockstore/config/server.pb.h>
 #include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/storage/core/libs/features/features_config.h>
@@ -612,8 +611,8 @@ ui64 GetAllocationUnit(
     NCloud::NProto::EStorageMediaKind mediaKind);
 
 void AdaptNodeRegistrationParams(
-    const TString& nodeType,
-    const NCloud::NBlockStore::NProto::TServerConfig& serverConfig,
+    const TString& overriddenNodeType,
+    const NProto::TServerConfig& serverConfig,
     NProto::TStorageServiceConfig& storageConfig);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -613,7 +613,7 @@ ui64 GetAllocationUnit(
 
 void AdaptNodeRegistrationParams(
     const TString& nodeType,
-    const NCloud::NBlockStore::NProto::TServerConfig serverConfig,
+    const NCloud::NBlockStore::NProto::TServerConfig& serverConfig,
     NProto::TStorageServiceConfig& storageConfig);
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
Пока что вынес код AdaptNodeRegistrationParams чтобы убрать копипасту . Изначальная задумка была вообще унести bootstrap код диск-агента в libs/daemon, но посмотрев на то что лежит там, я уже не уверен что это стоит вообще делать. В libs/daemon все же лежит код который так или иначе относится к различным вариантам nbsd, а disk-agent это все-таки немного другое и если его переновить туда же то рефакторить придется довольно много