### PR TITLE
issue-757: don't load configs from CMS in emergency mode

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -233,8 +233,8 @@ void TBootstrapYdb::InitKikimrService()
 
     bool loadCmsConfigs = Configs->Options->LoadCmsConfigs;
     if (loadCmsConfigs &&
-        Configs->StorageConfig->GetHiveProxyFallbackMode() ||
-        Configs->StorageConfig->GetSSProxyFallbackMode())
+        (Configs->StorageConfig->GetHiveProxyFallbackMode() ||
+        Configs->StorageConfig->GetSSProxyFallbackMode()))
     {
         STORAGE_INFO("Disable loading configs from CMS in emergency mode");
         loadCmsConfigs = false;

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -231,6 +231,15 @@ void TBootstrapYdb::InitKikimrService()
         .NodeType = Configs->StorageConfig->GetNodeType(),
     };
 
+    bool loadCmsConfigs = Configs->Options->LoadCmsConfigs;
+    if (loadCmsConfigs &&
+        Configs->StorageConfig->GetHiveProxyFallbackMode() ||
+        Configs->StorageConfig->GetSSProxyFallbackMode())
+    {
+        STORAGE_INFO("Disable loading configs from CMS in emergency mode");
+        loadCmsConfigs = false;
+    }
+
     NCloud::NStorage::TRegisterDynamicNodeOptions registerOpts {
         .Domain = Configs->Options->Domain,
         .SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir(),
@@ -238,7 +247,7 @@ void TBootstrapYdb::InitKikimrService()
         .NodeBrokerPort = Configs->Options->NodeBrokerPort,
         .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl,
         .InterconnectPort = Configs->Options->InterconnectPort,
-        .LoadCmsConfigs = Configs->Options->LoadCmsConfigs,
+        .LoadCmsConfigs = loadCmsConfigs,
         .Settings = std::move(settings)
     };
 

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -67,6 +67,7 @@ def __run_test(test_case):
             dict(name="dynamic_storage_pool:2", kind="ssd", pdisk_user_kind=1)
         ],
         bs_cache_file_path=backups_folder + "/bs_cache.txt",
+        load_configs_from_cms=False,
     )
 
     client = CreateClient(env.endpoint)

--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -51,6 +51,7 @@ class LocalLoadTest:
             kikimr_binary_path=None,
             with_endpoint_proxy=False,
             with_netlink=False,
+            load_configs_from_cms=True,
     ):
 
         self.__endpoint = endpoint
@@ -76,6 +77,9 @@ class LocalLoadTest:
         if run_kikimr:
             self.kikimr_cluster.start()
             kikimr_port = list(self.kikimr_cluster.nodes.values())[0].port
+        else:
+            # makes sense only when Kikimr is running
+            load_configs_from_cms = False
 
         self.__devices = []
 
@@ -107,7 +111,7 @@ class LocalLoadTest:
             discovery_config=discovery_config,
             restart_interval=restart_interval,
             dynamic_storage_pools=dynamic_storage_pools,
-            load_configs_from_cms=run_kikimr,
+            load_configs_from_cms=load_configs_from_cms,
             features_config_patch=features_config_patch,
             grpc_trace=grpc_trace,
             rack=rack)


### PR DESCRIPTION
#757 