### PR TITLE
Respond to HTTP requests while being in the deep idle state

### DIFF
--- a/cloud/blockstore/libs/disk_agent/bootstrap.h
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.h
@@ -11,10 +11,11 @@
 #include <cloud/blockstore/libs/service_local/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
 #include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/storage/core/libs/http/simple_http_server.h>
 
 #include <contrib/ydb/core/driver_lib/run/factories.h>
-
 #include <contrib/ydb/library/actors/util/should_continue.h>
+
 #include <library/cpp/logger/log.h>
 
 namespace NCloud::NBlockStore::NServer {
@@ -74,6 +75,7 @@ private:
     TProgramShouldContinue ShouldContinue;
     TVector<TString> PostponedCriticalEvents;
 
+    std::unique_ptr<NCloud::NStorage::TSimpleHttpServer> StubMonPageServer;
     bool Initialized = false;
 
 public:
@@ -94,6 +96,8 @@ private:
     void InitLWTrace();
     void InitProfileLog();
     bool InitKikimrService();
+
+    void InitHTTPServer();
 
     void InitRdmaServer(NRdma::TRdmaConfig& config);
 };

--- a/cloud/blockstore/libs/disk_agent/ya.make
+++ b/cloud/blockstore/libs/disk_agent/ya.make
@@ -21,6 +21,7 @@ PEERDIR(
     cloud/storage/core/libs/common
     cloud/storage/core/libs/daemon
     cloud/storage/core/libs/diagnostics
+    cloud/storage/core/libs/http
     cloud/storage/core/libs/version
 
     contrib/ydb/core/protos

--- a/cloud/blockstore/tests/python/lib/daemon.py
+++ b/cloud/blockstore/tests/python/lib/daemon.py
@@ -170,7 +170,7 @@ def start_nbs(config: NbsConfigurator, name='nbs-server'):
     return nbs
 
 
-def start_disk_agent(config: NbsConfigurator, name='disk-agent', wait_for_start=True):
+def start_disk_agent(config: NbsConfigurator, name='disk-agent'):
     exe_path = yatest_common.binary_path("cloud/blockstore/apps/disk_agent/diskagentd")
 
     cwd = get_unique_path_for_current_test(
@@ -190,7 +190,7 @@ def start_disk_agent(config: NbsConfigurator, name='disk-agent', wait_for_start=
     commands = [exe_path] + config.params
 
     agent = DiskAgent(
-        mon_port=(config.mon_port if wait_for_start else None),
+        mon_port=config.mon_port,
         server_port=config.server_port,
         commands=[commands],
         cwd=cwd,

--- a/cloud/storage/core/libs/http/simple_http_server.cpp
+++ b/cloud/storage/core/libs/http/simple_http_server.cpp
@@ -1,0 +1,62 @@
+#include "simple_http_server.h"
+
+namespace NCloud::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSimpleHttpServer::TRequest::TRequest(TString response)
+    : Response(std::move(response))
+{}
+
+TSimpleHttpServer::TRequest::~TRequest() = default;
+
+bool TSimpleHttpServer::TRequest::Reply(void* /*threadSpecificResource*/)
+{
+    if (!ProcessHeaders()) {
+        return true;
+    }
+
+    Output() << "HTTP/1.1 200 Ok\r\n"
+             << "Content-Length: " << Response.Size() << "\r\n"
+             << "Content-Type: text/html\r\n\r\n"
+             << Response;
+    Output().Finish();
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSimpleHttpServer::TSimpleHttpServer(ui16 port, TString response)
+    : Response(std::move(response))
+{
+    THttpServer::TOptions options;
+    options.Port = port;
+    options.nThreads = 1;
+    options.KeepAliveEnabled = false;
+    options.RejectExcessConnections = true;
+    Server = std::make_unique<THttpServer>(this, std::move(options));
+}
+
+TSimpleHttpServer::~TSimpleHttpServer()
+{
+    Server->Stop();
+    Server.reset();
+}
+
+bool TSimpleHttpServer::Start()
+{
+    return Server->Start();
+}
+
+void TSimpleHttpServer::Stop()
+{
+    Server->Stop();
+}
+
+TClientRequest* TSimpleHttpServer::CreateClient()
+{
+    return new TSimpleHttpServer::TRequest(Response);
+}
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/http/simple_http_server.h
+++ b/cloud/storage/core/libs/http/simple_http_server.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "library/cpp/http/server/http.h"
-#include "library/cpp/http/server/http_ex.h"
+#include <library/cpp/http/server/http.h>
+#include <library/cpp/http/server/http_ex.h>
 
 namespace NCloud::NStorage {
 
@@ -9,11 +9,8 @@ namespace NCloud::NStorage {
 
 // The most simple HTTP server. Listens to the port and responds with "Response"
 // with code 200.
-class TSimpleHttpServer: public THttpServer::ICallBack {
-private:
-    TString Response;
-    std::unique_ptr<THttpServer> Server;
-
+class TSimpleHttpServer: public THttpServer::ICallBack
+{
     class TRequest: public THttpClientRequestEx
     {
     private:
@@ -26,6 +23,10 @@ private:
         bool Reply(void* threadSpecificResource) override;
     };
 
+private:
+    TString Response;
+    std::unique_ptr<THttpServer> Server;
+
 public:
     TSimpleHttpServer(ui16 port, TString response);
     ~TSimpleHttpServer() override;
@@ -34,7 +35,6 @@ public:
     void Stop();
 
     TClientRequest* CreateClient() override;
-
 };
 
-}  // namespace NCloud::NStorage
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/http/simple_http_server.h
+++ b/cloud/storage/core/libs/http/simple_http_server.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "library/cpp/http/server/http.h"
+#include "library/cpp/http/server/http_ex.h"
+
+namespace NCloud::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The most simple HTTP server. Listens to the port and responds with "Response"
+// with code 200.
+class TSimpleHttpServer: public THttpServer::ICallBack {
+private:
+    TString Response;
+    std::unique_ptr<THttpServer> Server;
+
+    class TRequest: public THttpClientRequestEx
+    {
+    private:
+        TString Response;
+
+    public:
+        explicit TRequest(TString response);
+        ~TRequest() override;
+
+        bool Reply(void* threadSpecificResource) override;
+    };
+
+public:
+    TSimpleHttpServer(ui16 port, TString response);
+    ~TSimpleHttpServer() override;
+
+    bool Start();
+    void Stop();
+
+    TClientRequest* CreateClient() override;
+
+};
+
+}  // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/http/ya.make
+++ b/cloud/storage/core/libs/http/ya.make
@@ -1,0 +1,11 @@
+LIBRARY()
+
+SRCS(
+    simple_http_server.cpp
+)
+
+PEERDIR(
+    library/cpp/http/server
+)
+
+END()

--- a/cloud/storage/core/libs/ya.make
+++ b/cloud/storage/core/libs/ya.make
@@ -11,6 +11,7 @@ RECURSE(
     features
     grpc
     hive_proxy
+    http
     kikimr
     tablet
     throttling


### PR DESCRIPTION
Чтобы мониторинг не удивлялся что диск агент не отвечает на пинги в monport, я прикрутил простой http сервер