### PR TITLE
unstable-process: logging open sockets upon process start failure

### DIFF
--- a/cloud/storage/core/tools/testing/unstable-process/__main__.py
+++ b/cloud/storage/core/tools/testing/unstable-process/__main__.py
@@ -114,6 +114,7 @@ def main():
                     if process.poll() is not None:
                         if process.poll() in [0, 1, 100]:
                             logging.info(f'subprocess failed to start, code {process.poll()}')
+                            logging.info(os.system("ss -tpn"))
                             process = start_process()
                         else:
                             logging.fatal(f'unexpected exit code {process.poll()}')


### PR DESCRIPTION
Sometimes our tests fail because they attempt to start daemons on occupied ports. Happens especially often for nemesis tests due to daemon restarts - some other process may capture a port between the restarts. Adding more logging to detect the offending processes.