### PR TITLE
issue-757: pass path as empty TMaybe<TString> instead of empty TString when registering node in Node Broker; spoil BS Controller config before restarting Kikimr after formatting static pdisks in local-emergency test (otherwise BS Controller would erase all the data from other non-static groups)

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -232,10 +232,11 @@ void TBootstrapYdb::InitKikimrService()
     };
 
     bool loadCmsConfigs = Configs->Options->LoadCmsConfigs;
-    if (loadCmsConfigs &&
-        (Configs->StorageConfig->GetHiveProxyFallbackMode() ||
-        Configs->StorageConfig->GetSSProxyFallbackMode()))
-    {
+    bool emergencyMode =
+        Configs->StorageConfig->GetHiveProxyFallbackMode() ||
+        Configs->StorageConfig->GetSSProxyFallbackMode();
+
+    if (loadCmsConfigs && emergencyMode) {
         STORAGE_INFO("Disable loading configs from CMS in emergency mode");
         loadCmsConfigs = false;
     }
@@ -250,6 +251,10 @@ void TBootstrapYdb::InitKikimrService()
         .LoadCmsConfigs = loadCmsConfigs,
         .Settings = std::move(settings)
     };
+
+    if (emergencyMode) {
+        registerOpts.SchemeShardDir = "";
+    }
 
     if (Configs->Options->LocationFile) {
         NProto::TLocation location;

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -1,4 +1,3 @@
-# import os
 import pytest
 
 import yatest.common as common

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -82,6 +82,8 @@ def __run_test(test_case):
     client.execute_action(action="BackupTabletBootInfos", input_bytes=str.encode(""))
 
     env.kikimr_cluster.format_static_pdisks()
+    # spoil config to prevent BS Controller from starting otherwise it will
+    # erase dynamic groups data
     env.kikimr_cluster.spoil_bs_controller_config()
     env.kikimr_cluster.restart_nodes()
 

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -82,15 +82,8 @@ def __run_test(test_case):
     client.execute_action(action="BackupPathDescriptions", input_bytes=str.encode(""))
     client.execute_action(action="BackupTabletBootInfos", input_bytes=str.encode(""))
 
-    static_pdisk_paths = []
-    for info in env.pdisks_info:
-        if info["pdisk_user_kind"] == 0:
-            static_pdisk_paths += [info["pdisk_path"]]
-    assert len(static_pdisk_paths) == 1
-
-    # Destroy static group in order to emulate emergency.
-    # TODO: survive outage of kikimr static tablets.
-    # os.remove(static_pdisk_paths[0])
+    env.kikimr_cluster.format_static_pdisks()
+    env.kikimr_cluster.spoil_bs_controller_config()
     env.kikimr_cluster.restart_nodes()
 
     env.nbs.storage_config_patches = [storage_config_with_emergency_mode(backups_folder)]

--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -223,6 +223,11 @@ struct TLegacyNodeRegistrant
     {
         NClient::TKikimr kikimr(CreateKikimrConfig(Options, nodeBrokerAddress));
 
+        TMaybe<TString> path;
+        if (Options.SchemeShardDir) {
+            path = Options.SchemeShardDir;
+        }
+
         auto registrant = kikimr.GetNodeRegistrant();
         auto result = registrant.SyncRegisterNode(
             Options.Domain,
@@ -231,8 +236,8 @@ struct TLegacyNodeRegistrant
             HostAddress,
             HostName,
             Location,
-            false, //request fixed node id
-            Options.SchemeShardDir);
+            false, // fixedNodeId
+            path);
 
         if (!result.IsSuccess()) {
             return MakeError(


### PR DESCRIPTION
#757 