### PR TITLE
Fix blockstore-vhost-server deadlock before execvp call

### DIFF
--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -266,9 +266,9 @@ struct TPipe
         R.Close();
 
         TFileHandle h {fd};
-        Y_SCOPE_EXIT(&h) { h.Release(); };
 
         h.LinkTo(W);
+        h.Release();
     }
 };
 
@@ -290,36 +290,40 @@ TChild SpawnChild(
 
     pid_t childPid = ::fork();
 
-    if (childPid == -1) {
-        int err = errno;
-        char buf[64] {};
-        ythrow TServiceError {MAKE_SYSTEM_ERROR(err)}
-            << "fork error: " << ::strerror_r(err, buf, sizeof(buf));
+    // WARNING: Don't make heap allocations here!
+    {
+        if (childPid == -1) {
+            int err = errno;
+            char buf[64]{};
+            ythrow TServiceError{MAKE_SYSTEM_ERROR(err)}
+                << "fork error: " << ::strerror_r(err, buf, sizeof(buf));
+        }
+
+        if (childPid) {
+            // Parent process.
+            return TChild{childPid, std::move(stdOut.R), std::move(stdErr.R)};
+        }
+
+        // child process
+
+        stdOut.LinkTo(STDOUT_FILENO);
+        stdErr.LinkTo(STDERR_FILENO);
+
+        // Last chance to figure out what's going on.
+        // freopen((TString("/tmp/out.") + ToString(::getpid())).c_str(), "w",
+        // stdout); freopen((TString("/tmp/err.") +
+        // ToString(::getpid())).c_str(), "w", stderr);
+
+        // Following "const_cast"s are safe:
+        // http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
+        qargs.push_back(const_cast<char*>(binaryPath.data()));
+        for (auto& arg: args) {
+            qargs.push_back(const_cast<char*>(arg.data()));
+        }
+        qargs.emplace_back();
+
+        ::execvp(binaryPath.c_str(), qargs.data());
     }
-
-    if (childPid) {
-        // Parent process.
-        return TChild {childPid, std::move(stdOut.R), std::move(stdErr.R)};
-    }
-
-    // child process
-
-    stdOut.LinkTo(STDOUT_FILENO);
-    stdErr.LinkTo(STDERR_FILENO);
-
-    // Last chance to figure out what's going on.
-    // freopen((TString("/tmp/out.") + ToString(::getpid())).c_str(), "w", stdout);
-    // freopen((TString("/tmp/err.") + ToString(::getpid())).c_str(), "w", stderr);
-
-    // Following "const_cast"s are safe:
-    // http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
-    qargs.push_back(const_cast<char*>(binaryPath.data()));
-    for (auto& arg: args) {
-        qargs.push_back(const_cast<char*>(arg.data()));
-    }
-    qargs.emplace_back();
-
-    ::execvp(binaryPath.c_str(), qargs.data());
 
     int err = errno;
     char buf[64] {};


### PR DESCRIPTION
Поймали вот такое зависание:
```
#0  0x00007f89aaa0e95d in syscall () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x000056004318b534 in AbslInternalSpinLockDelay_lts_20240116 (w=0x56005977c9c8 <tcmalloc::tcmalloc_internal::Static::transfer_cache_+1608>, value=9)
#2  0x000056004318b167 in absl::lts_20240116::base_internal::SpinLockDelay (w=0x9, value=128, loop=1, scheduling_mode=(unknown: 2246275520)) 
#3  absl::lts_20240116::base_internal::SpinLock::SlowLock (this=0x9) 
#4  0x0000560058b17e4a in absl::lts_20240116::base_internal::SpinLock::Lock (this=0x56005977c9c8 <tcmalloc::tcmalloc_internal::Static::transfer_cache_+1608>)
#5  absl::lts_20240116::base_internal::SpinLockHolder::SpinLockHolder (this=0x7f8985e36038, l=0x56005977c9c8 <tcmalloc::tcmalloc_internal::Static::transfer_cache_+1608>)
#6  tcmalloc::tcmalloc_internal::internal_transfer_cache::RingBufferTransferCache<tcmalloc::tcmalloc_internal::CentralFreeList, tcmalloc::tcmalloc_internal::TransferCacheManager>::RemoveRange (this=
    0x56005977c9c8 <tcmalloc::tcmalloc_internal::Static::transfer_cache_+1608>, size_class=128, batch=0x7f8985e36160, N=9) 
#7  0x0000560058b45e49 in tcmalloc::tcmalloc_internal::TransferCacheManager::RemoveRange (this=0xfffffffffffffe00, size_class=128, batch=0x7f8985e36160, n=-1432295075)
#8  tcmalloc::tcmalloc_internal::ThreadCache::FetchFromCentralCache (this=0x7f8985e371c0, cl=128, byte_size=9)
#9  0x0000560058b0b66b in tcmalloc::tcmalloc_internal::ThreadCache::AllocateSlow<&tcmalloc::tcmalloc_internal::TCMallocPolicy<tcmalloc::tcmalloc_internal::CppOomPolicy, tcmalloc::tcmalloc_internal::DefaultAlignPolicy, tcmalloc::tcmalloc_internal::InvokeHooksPolicy, tcmalloc::tcmalloc_internal::LocalNumaPartitionPolicy>::handle_oom> (this=0x56005977c9c8 <tcmalloc::tcmalloc_internal::Static::transfer_cache_+1608>, cl=128, allocated_size=9)
#10 0x000056004468970c in std::__y1::__libcpp_operator_new[abi:v160005]<unsigned long>(unsigned long) (__args=94559501011400) 
#11 std::__y1::__libcpp_allocate[abi:v160005](unsigned long, unsigned long) (__size=94559501011400, __align=8)
#12 std::__y1::allocator<char*>::allocate[abi:v160005](unsigned long) (__n=94559501011400, this=<optimized out>)
#13 std::__y1::__allocate_at_least[abi:v160005]<std::__y1::allocator<char*> >(std::__y1::allocator<char*>&, unsigned long) (__n=94559501011400, __alloc=...)
#14 std::__y1::__split_buffer<char*, std::__y1::allocator<char*>&>::__split_buffer (__cap=94559501011400, __a=..., this=<optimized out>, __start=<optimized out>)
#15 std::__y1::vector<char*, std::__y1::allocator<char*> >::reserve (this=0x9, __n=94559501011400) 
#16 0x000056004468892b in NCloud::NBlockStore::NServer::(anonymous namespace)::SpawnChild (binaryPath=..., args=...) 
#17 NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::StartProcess (this=0x14132f882e10) 
#18 0x0000560044686792 in NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::Start()::{lambda()#1}::operator()() const (this=0x11) 
#19 std::__y1::__invoke[abi:v160005]<NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::Start()::{lambda()#1}> (__f=...) 
#20 std::__y1::__thread_execute[abi:v160005]<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::Start()::{lambda()#1}>(std::__y1::tuple<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::Start()::{lambda()#1}>&, std::__y1::__tuple_indices<>) (
    __t=...) 
#21 std::__y1::__thread_proxy[abi:v160005]<std::__y1::tuple<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::Start()::{lambda()#1}> >(std::__y1::tuple<std::__y1::unique_ptr<std::__y1::__thread_struct, std::__y1::default_delete<std::__y1::__thread_struct> >, NCloud::NBlockStore::NServer::(anonymous namespace)::TEndpoint::Start()::{lambda()#1}>) (__vp=0x9)
#22 0x00007f89aaaf0609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#23 0x00007f89aaa15353 in clone () from /lib/x86_64-linux-gnu/libc.so.6
```