### PR TITLE
issue-1657: use mount-utils to resize fs

### DIFF
--- a/cloud/blockstore/tests/csi_driver/test.py
+++ b/cloud/blockstore/tests/csi_driver/test.py
@@ -205,7 +205,7 @@ class NbsCsiDriverRunner:
             volume_id,
         )
 
-    def publish_volume(self, pod_id: str, volume_id: str, pod_name: str):
+    def publish_volume(self, pod_id: str, volume_id: str, pod_name: str, fs_type: str = ""):
         return self._node_run(
             "publishvolume",
             "--pod-id",
@@ -214,6 +214,8 @@ class NbsCsiDriverRunner:
             volume_id,
             "--pod-name",
             pod_name,
+            "--fs-type",
+            fs_type,
         )
 
     def unpublish_volume(self, pod_id: str, volume_id: str):
@@ -424,7 +426,8 @@ def test_csi_sanity_nbs_backend(mount_path, volume_access_type, vm_mode):
         cleanup_after_test(env)
 
 
-def test_node_volume_expand():
+@pytest.mark.parametrize('fs_type', ["ext4", "xfs"])
+def test_node_volume_expand(fs_type):
     env, run = init()
     try:
         volume_name = "example-disk"
@@ -433,7 +436,7 @@ def test_node_volume_expand():
         pod_id = "deadbeef"
         env.csi.create_volume(name=volume_name, size=volume_size)
         env.csi.stage_volume(volume_name)
-        env.csi.publish_volume(pod_id, volume_name, pod_name)
+        env.csi.publish_volume(pod_id, volume_name, pod_name, fs_type)
 
         new_volume_size = 2 * volume_size
         env.csi.expand_volume(pod_id, volume_name, new_volume_size)

--- a/cloud/blockstore/tools/csi_driver/client/main.go
+++ b/cloud/blockstore/tools/csi_driver/client/main.go
@@ -253,7 +253,7 @@ func newNodeStageVolumeCommand(endpoint *string) *cobra.Command {
 }
 
 func newPublishVolumeCommand(endpoint *string) *cobra.Command {
-	var volumeId, podId, stagingTargetPath, podName string
+	var volumeId, podId, stagingTargetPath, podName, fsType string
 	var readOnly bool
 	cmd := cobra.Command{
 		Use:   "publishvolume",
@@ -283,6 +283,7 @@ func newPublishVolumeCommand(endpoint *string) *cobra.Command {
 				"csi.storage.k8s.io/pod.name":                  podName,
 				"storage.kubernetes.io/csiProvisionerIdentity": "someIdentity",
 				"instanceId": "example-instance-id",
+				"fsType":     fsType,
 			}
 			accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
 
@@ -339,6 +340,13 @@ func newPublishVolumeCommand(endpoint *string) *cobra.Command {
 		false,
 		"volume is read only",
 	)
+	cmd.Flags().StringVar(
+		&fsType,
+		"fs-type",
+		"",
+		"filesystem type: ext4, xfs",
+	)
+
 	err := cmd.MarkFlagRequired("volume-id")
 	if err != nil {
 		log.Fatal(err)

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
@@ -9,4 +9,7 @@ type Interface interface {
 
 	IsFilesystemExisted(device string) (bool, error)
 	MakeFilesystem(device string, fsType string) ([]byte, error)
+
+	NeedResize(devicePath string, deviceMountPath string) (bool, error)
+	Resize(devicePath, deviceMountPath string) (bool, error)
 }

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
@@ -40,6 +40,16 @@ func (c *Mock) MakeFilesystem(device string, fsType string) ([]byte, error) {
 	return args.Get(0).([]byte), args.Error(1)
 }
 
+func (c *Mock) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	args := c.Called(devicePath, deviceMountPath)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (c *Mock) Resize(devicePath string, deviceMountPath string) (bool, error) {
+	args := c.Called(devicePath, deviceMountPath)
+	return args.Get(0).(bool), args.Error(1)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewMock() *Mock {

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/mounter.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/mounter.go
@@ -8,17 +8,20 @@ import (
 	"strings"
 
 	"k8s.io/mount-utils"
+	executils "k8s.io/utils/exec"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
 
 type mounter struct {
-	mnt mount.Interface
+	mnt  mount.Interface
+	exec executils.Interface
 }
 
 func NewMounter() Interface {
 	return &mounter{
-		mnt: mount.New(""),
+		mnt:  mount.New(""),
+		exec: executils.New(),
 	}
 }
 
@@ -76,4 +79,12 @@ func (m *mounter) MakeFilesystem(device string, fsType string) ([]byte, error) {
 
 	options = append(options, device)
 	return exec.Command("mkfs", options...).CombinedOutput()
+}
+
+func (m *mounter) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	return mount.NewResizeFs(m.exec).NeedResize(devicePath, deviceMountPath)
+}
+
+func (m *mounter) Resize(devicePath string, deviceMountPath string) (bool, error) {
+	return mount.NewResizeFs(m.exec).Resize(devicePath, deviceMountPath)
 }


### PR DESCRIPTION
issue: #1657

Use mount-utils.Resize to support resize of ext4 and xfs