### PR TITLE
issue-1657: Skip perf profile to automatically recalculate quotes for resized volume

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -889,10 +889,9 @@ func (s *nodeService) NodeExpandVolume(
 
 	log.Printf("Resize volume id %v blocks count %v", req.VolumeId, newBlocksCount)
 	_, err = s.nbsClient.ResizeVolume(ctx, &nbsapi.TResizeVolumeRequest{
-		DiskId:             req.VolumeId,
-		BlocksCount:        newBlocksCount,
-		ConfigVersion:      resp.Volume.ConfigVersion,
-		PerformanceProfile: resp.Volume.PerformanceProfile,
+		DiskId:        req.VolumeId,
+		BlocksCount:   newBlocksCount,
+		ConfigVersion: resp.Volume.ConfigVersion,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Skip performance profile argument to automatically recalculate bw/iops quotes for resized volume