### PR TITLE
Merge to stable-23-3: issue-757: move spoil_bs_controller_config and format_static_pdisks methods out from contrib/ydb (#2072)

### DIFF
--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
@@ -2,11 +2,9 @@
 
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/storage/api/public.h>
-#include <cloud/blockstore/libs/storage/partition/part_events_private.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
-using namespace NPartition;
 using namespace NActors;
 using namespace NKikimr;
 

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -35,6 +35,32 @@ def storage_config_with_emergency_mode(backups_folder):
     return storage
 
 
+# TODO(svartmetal): remove this when YDB learns not to erase dynamic groups
+# data after formatting of static pdisk
+def spoil_bs_controller_config(kikimr_cluster):
+    flat_bs_controller = [{
+        "info": {
+            "channels": [{
+                "channel": 0,
+                "channel_erasure_name": str(kikimr_cluster.config.static_erasure),
+                "history": [{
+                    "from_generation": 0,
+                    "group_id": 100500
+                }]
+            }]
+        }
+    }]
+    kikimr_cluster.config.yaml_config["system_tablets"]["flat_bs_controller"] = flat_bs_controller
+    kikimr_cluster.config.write_proto_configs(kikimr_cluster.config_path)
+
+
+def format_static_pdisks(kikimr_cluster):
+    for node_id in kikimr_cluster.config.all_node_ids():
+        for pdisk in kikimr_cluster.config.pdisks_info:
+            if pdisk["pdisk_user_kind"] == 0:
+                kikimr_cluster.nodes[node_id].format_pdisk(**pdisk)
+
+
 class TestCase(object):
 
     def __init__(self, name, config_path):
@@ -81,10 +107,10 @@ def __run_test(test_case):
     client.execute_action(action="BackupPathDescriptions", input_bytes=str.encode(""))
     client.execute_action(action="BackupTabletBootInfos", input_bytes=str.encode(""))
 
-    env.kikimr_cluster.format_static_pdisks()
+    format_static_pdisks(env.kikimr_cluster)
     # spoil config to prevent BS Controller from starting otherwise it will
     # erase dynamic groups data
-    env.kikimr_cluster.spoil_bs_controller_config()
+    spoil_bs_controller_config(env.kikimr_cluster)
     env.kikimr_cluster.restart_nodes()
 
     env.nbs.storage_config_patches = [storage_config_with_emergency_mode(backups_folder)]

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -494,30 +494,6 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
             os.symlink(udf_path, link_name)
         return self.__common_udfs_dir
 
-    # TODO(svartmetal): remove this when YDB learns not to erase dynamic groups
-    # data after formatting of static pdisks
-    def spoil_bs_controller_config(self):
-        flat_bs_controller = [{
-            "info": {
-                "channels": [{
-                    "channel": 0,
-                    "channel_erasure_name": str(self.__configurator.static_erasure),
-                    "history": [{
-                        "from_generation": 0,
-                        "group_id": 100500
-                    }]
-                }]
-            }
-        }]
-        self.__configurator.yaml_config["system_tablets"]["flat_bs_controller"] = flat_bs_controller
-        self.__write_configs()
-
-    def format_static_pdisks(self):
-        for node_id in self.__configurator.all_node_ids():
-            for pdisk in self.__configurator.pdisks_info:
-                if pdisk["pdisk_user_kind"] == 0:
-                    self.nodes[node_id].format_pdisk(**pdisk)
-
     def __format_disks(self, node_id):
         for pdisk in self.__configurator.pdisks_info:
             if pdisk['node_id'] != node_id:


### PR DESCRIPTION
* [Blockstore] partition/common/actor_read_blob.h should not include partition/part_events_private.h (#926)
* issue-757: move spoil_bs_controller_config and format_static_pdisks methods out from contrib/ydb (#2072)

#757 