### PR TITLE
issue-1993: resetting CurrentBackgroundBlobIndexOp if FlushBytes couldn't be enqueued due to Flush being already enqueued or running; enqueueing Flush and BlobIndexOp upon backpressure error; tracking BackpressurePeriod and rebooting tablets if this period is too long; added more backpressure info to monpage

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -47,6 +47,14 @@ enum EVolumePreemptionType
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+//
+//  !!!IMPORTANT!!!
+//  Even though StorageServiceConfig is usually stored in textual format, it may
+//  be overridden for some tablets and in this case it's stored in binary format
+//  in the tablet's localdb. So binary backward-compatibility should be
+//  maintained.
+//
+////////////////////////////////////////////////////////////////////////////////
 
 message TStorageServiceConfig
 {

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -17,6 +17,14 @@ enum EBlobIndexOpsPriority
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+//
+//  !!!IMPORTANT!!!
+//  Even though StorageConfig is usually stored in textual format, it may be
+//  overridden for some tablets and in this case it's stored in binary format
+//  in the tablet's localdb. So binary backward-compatibility should be
+//  maintained.
+//
+////////////////////////////////////////////////////////////////////////////////
 
 message TStorageConfig
 {
@@ -402,4 +410,10 @@ message TStorageConfig
     // uncontrollable behaviour change for production systems. TODO: gradually
     // enable this flag everywhere and make this behaviour the new default.
     optional bool UseMixedBlocksInsteadOfAliveBlocksInCompaction = 391;
+
+    // IndexTabletActor will suicide (and thus reboot) after observing
+    // consecutive backpressure errors for this period of time. Needed to
+    // automatically recover after various races that may happen during index
+    // tablet startup due to bugs.
+    optional uint32 MaxBackpressurePeriodBeforeSuicide = 392;   // in ms
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -170,7 +170,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\
     xxx(AttrTimeout,                     TDuration, TDuration::Zero()         )\
     xxx(MaxOutOfOrderCompactionMapLoadRequestsInQueue,  ui32,      5          )\
-    xxx(MaxBackpressureErrorsBeforeSuicide,             ui32,      1000       )\
+    xxx(MaxBackpressureErrorsBeforeSuicide, ui32,       1000                  )\
+    xxx(MaxBackpressurePeriodBeforeSuicide, TDuration,  TDuration::Minutes(10))\
                                                                                \
     xxx(NewLocalDBCompactionPolicyEnabled,              bool,      false      )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -204,6 +204,7 @@ public:
     bool GetConfigsDispatcherServiceEnabled() const;
 
     ui32 GetMaxBackpressureErrorsBeforeSuicide() const;
+    TDuration GetMaxBackpressurePeriodBeforeSuicide() const;
 
     TDuration GetGenerateBlobIdsReleaseCollectBarrierTimeout() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -359,9 +359,20 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
         EnqueueFlushIfNeeded(ctx);
         EnqueueBlobIndexOpIfNeeded(ctx);
 
-        if (CompactionStateLoadStatus.Finished &&
-            ++BackpressureErrorCount >=
-                Config->GetMaxBackpressureErrorsBeforeSuicide())
+        if (CompactionStateLoadStatus.Finished) {
+            if (!BackpressurePeriodStart) {
+                BackpressurePeriodStart = ctx.Now();
+            }
+
+            ++BackpressureErrorCount;
+        }
+
+        const auto backpressurePeriod = ctx.Now() - BackpressurePeriodStart;
+
+        if (BackpressureErrorCount >=
+                Config->GetMaxBackpressureErrorsBeforeSuicide()
+                || backpressurePeriod >=
+                Config->GetMaxBackpressurePeriodBeforeSuicide())
         {
             LOG_WARN(
                 ctx,
@@ -373,10 +384,18 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
             Suicide(ctx);
         }
 
+        EnqueueFlushIfNeeded(ctx);
+        EnqueueBlobIndexOpIfNeeded(ctx);
+
         return MakeError(
             E_REJECTED,
             TStringBuilder() << "rejected due to backpressure: " << message);
     }
+
+    // this request passed the backpressure check => tablet is not stuck
+    // anywhere, we can reset our backpressure error counter
+    BackpressureErrorCount = 0;
+    BackpressurePeriodStart = TInstant::Zero();
 
     return NProto::TError{};
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -359,15 +359,15 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
         EnqueueFlushIfNeeded(ctx);
         EnqueueBlobIndexOpIfNeeded(ctx);
 
+        TDuration backpressurePeriod;
         if (CompactionStateLoadStatus.Finished) {
             if (!BackpressurePeriodStart) {
                 BackpressurePeriodStart = ctx.Now();
             }
 
             ++BackpressureErrorCount;
+            backpressurePeriod = ctx.Now() - BackpressurePeriodStart;
         }
-
-        const auto backpressurePeriod = ctx.Now() - BackpressurePeriodStart;
 
         if (BackpressureErrorCount >=
                 Config->GetMaxBackpressureErrorsBeforeSuicide()

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -250,6 +250,7 @@ private:
     NProto::TStorageConfig StorageConfigOverride;
 
     ui32 BackpressureErrorCount = 0;
+    TInstant BackpressurePeriodStart;
 
     const NBlockCodecs::ICodec* BlobCodec;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -409,6 +409,7 @@ void TIndexTabletActor::EnqueueBlobIndexOpIfNeeded(const TActorContext& ctx)
             // Flush blocked since FlushBytes op rewrites some fresh blocks as
             // blobs
             if (!FlushState.Enqueue()) {
+                StartBackgroundBlobIndexOp();
                 CompleteBlobIndexOp();
                 if (!IsBlobIndexOpsQueueEmpty()) {
                     EnqueueBlobIndexOpIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -323,9 +323,6 @@ void TIndexTabletActor::HandleFlush(
             MakeError(S_FALSE, "nothing to flush"));
         FlushState.Complete();
 
-        // FlushBytes may need to be triggered
-        EnqueueBlobIndexOpIfNeeded(ctx);
-
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -323,6 +323,9 @@ void TIndexTabletActor::HandleFlush(
             MakeError(S_FALSE, "nothing to flush"));
         FlushState.Complete();
 
+        // FlushBytes may need to be triggered
+        EnqueueBlobIndexOpIfNeeded(ctx);
+
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1082,6 +1082,8 @@ void TIndexTabletActor::HandleHttpInfo_Default(
             }
             DIV_CLASS("alert") {
                 out << "Backpressure period start: " << BackpressurePeriodStart;
+            }
+            DIV_CLASS("alert") {
                 out << "Backpressure period: "
                     << (ctx.Now() - BackpressurePeriodStart);
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1068,9 +1068,19 @@ void TIndexTabletActor::HandleHttpInfo_Default(
             &message);
         TAG(TH3) { out << "Backpressure"; }
         if (!isWriteAllowed) {
-            out << "<div class='alert alert-danger'>" << "Write not allowed: " << message << "</div>";
+            DIV_CLASS("alert alert-danger") {
+                out << "Write NOT allowed: " << message;
+            }
         } else {
-            out << "<div class='alert'>Write allowed</div>";
+            DIV_CLASS("alert") {
+                out << "Write allowed: " << message;
+            }
+        }
+        DIV_CLASS("alert") {
+            out << "Backpressure errors: " << BackpressureErrorCount;
+        }
+        DIV_CLASS("alert") {
+            out << "Backpressure period: " << BackpressurePeriodStart;
         }
 
         TABLE_CLASS("table table-bordered") {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1076,11 +1076,15 @@ void TIndexTabletActor::HandleHttpInfo_Default(
                 out << "Write allowed: " << message;
             }
         }
-        DIV_CLASS("alert") {
-            out << "Backpressure errors: " << BackpressureErrorCount;
-        }
-        DIV_CLASS("alert") {
-            out << "Backpressure period: " << BackpressurePeriodStart;
+        if (BackpressurePeriodStart || BackpressureErrorCount) {
+            DIV_CLASS("alert") {
+                out << "Backpressure errors: " << BackpressureErrorCount;
+            }
+            DIV_CLASS("alert") {
+                out << "Backpressure period start: " << BackpressurePeriodStart;
+                out << "Backpressure period: "
+                    << (ctx.Now() - BackpressurePeriodStart);
+            }
         }
 
         TABLE_CLASS("table table-bordered") {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -105,10 +105,6 @@ void TIndexTabletActor::HandleWriteData(
         return;
     }
 
-    // this request passed the backpressure check => tablet is not stuck
-    // anywhere, we can reset our backpressure error counter
-    BackpressureErrorCount = 0;
-
     // either rejected or put into queue
     if (ThrottleIfNeeded<TEvService::TWriteDataMethod>(ev, ctx)) {
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2740,7 +2740,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT(poisonPillObserved);
     }
 
-    TABLET_TEST(ShouldAutomaticallyEnqueueFlushBytesAfterFlushShortcut)
+    TABLET_TEST(FlushBytesShouldReenqueueAfterAttemptToEnqueueItDuringFlush)
     {
         const auto block = tabletConfig.BlockSize;
 
@@ -2757,13 +2757,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         ui32 nodeIdx = env.CreateNode("nfs");
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
-        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
         tablet.InitSession("client", "session");
 
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         ui64 handle = CreateHandle(tablet, id);
-        tablet.WriteData(handle, 0, block, '0'); // 1 fresh block
-        tablet.WriteData(handle, 0, 1, '0'); // 1 fresh byte
 
         TAutoPtr<IEventHandle> flush;
         TAutoPtr<IEventHandle> flushBytesCompletion;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2672,7 +2672,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThresholdForBackpressure(999'999);
         storageConfig.SetFlushBytesThresholdForBackpressure(1_GB);
         storageConfig.SetFlushThresholdForBackpressure(block);
-        storageConfig.SetMaxBackpressureErrorsBeforeSuicide(2);
+        storageConfig.SetMaxBackpressureErrorsBeforeSuicide(999999);
+        storageConfig.SetMaxBackpressurePeriodBeforeSuicide(60'000); // 1m
 
         TTestEnv env({}, std::move(storageConfig));
         env.CreateSubDomain("nfs");
@@ -2714,6 +2715,20 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         });
 
         // backpressure due to FlushThresholdForBackpressure
+        // should not cause tablet reboot since the backpressure period hasn't
+        // passed yet
+        tablet.SendWriteDataRequest(handle, 0, block, '0');
+        {
+            auto response = tablet.RecvWriteDataResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        }
+
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(!poisonPillObserved);
+
+        env.GetRuntime().AdvanceCurrentTime(TDuration::Minutes(1));
+
+        // backpressure due to FlushThresholdForBackpressure
         // should cause tablet reboot
         tablet.SendWriteDataRequest(handle, 0, block, '0');
         {
@@ -2723,6 +2738,76 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT(poisonPillObserved);
+    }
+
+    TABLET_TEST(ShouldAutomaticallyEnqueueFlushBytesAfterFlushShortcut)
+    {
+        const auto block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1_GB);
+        storageConfig.SetCompactionThreshold(999'999);
+        storageConfig.SetCleanupThreshold(999'999);
+        storageConfig.SetFlushThreshold(2 * block);
+        storageConfig.SetFlushBytesThreshold(block);
+
+        TTestEnv env({}, std::move(storageConfig));
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+        tablet.WriteData(handle, 0, block, '0'); // 1 fresh block
+        tablet.WriteData(handle, 0, 1, '0'); // 1 fresh byte
+
+        TAutoPtr<IEventHandle> flush;
+        TAutoPtr<IEventHandle> flushBytesCompletion;
+
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvIndexTabletPrivate::EvFlushRequest: {
+                    UNIT_ASSERT(!flush);
+                    flush = event.Release();
+                    return true;
+                }
+
+                case TEvIndexTabletPrivate::EvFlushBytesCompleted: {
+                    UNIT_ASSERT(!flushBytesCompletion);
+                    flushBytesCompletion = event.Release();
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        // triggering Flush
+        tablet.WriteData(handle, 0, 2 * block, '0'); // 2 fresh blocks
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+        // Flush caught
+        UNIT_ASSERT(flush);
+
+        // triggering FlushBytes
+        // FlushBytes shouldn't get triggered since Flush is already enqueued
+        tablet.WriteData(handle, 0, block / 2, '0'); // fresh bytes
+        tablet.WriteData(handle, 0, block / 2, '0'); // fresh bytes
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        // releasing Flush
+        env.GetRuntime().Send(flush.Release(), 1 /* node index */);
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+        // FlushBytes should get enqueued and should successfully run and finish
+        UNIT_ASSERT(flushBytesCompletion);
     }
 
     TABLET_TEST(ShouldReadUnAligned)


### PR DESCRIPTION
~~No ut for now since the ut will be too cumbersome and the code in this PR seems to be pretty bulletproof.~~
No code is bulletproof =) Added uts

#1993 