### PR TITLE
Mount a volume encrypted with ENCRYPTION_AES_XTS without encryption

### DIFF
--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -788,7 +788,9 @@ private:
         const NProto::TVolume& volume)
     {
         const auto& desc = volume.GetEncryptionDesc();
-        if (desc.GetMode() == NProto::NO_ENCRYPTION) {
+        if (desc.GetMode() == NProto::NO_ENCRYPTION ||
+            desc.GetMode() == NProto::ENCRYPTION_AES_XTS)
+        {
             return MakeFuture<TResultOrError<IBlockStorePtr>>(Client);
         }
 

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -1261,7 +1261,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
         auto testClient = std::make_shared<TTestService>();
 
-        // Mount a volume with an unexpected encryption mode
+        // Mount a volume encrypted with ENCRYPTION_AES_XTS without encryption
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
                 UNIT_ASSERT(!request->HasEncryptionSpec());
@@ -1282,7 +1282,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
             auto response = MountVolume(*encryptionClient);
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_ARGUMENT, // Unexpected encryption mode
+                S_OK,   // It's OK to mount an encrypted disk without an
+                        // encryption key to make snapshot or fill from snapshot
                 response.GetError().GetCode(),
                 response.GetError());
         }


### PR DESCRIPTION
Зашифрованный диск нужно монтировать без указания ключа шифрования чтобы снять с него снимок, или наоборот налить из зашифрованного снимка шифрованный же диск.