### PR TITLE
[NBS]: Fix some tests local teardown hangs

### DIFF
--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -160,7 +160,7 @@ class LocalLoadTest:
             try:
                 with open(yatest_common.output_path() + "/dmesg.txt", "w") as dmesg_output:
                     subprocess.run(
-                        ["sudo", "dmesg", "-T"],
+                        ["sudo", "-n", "dmesg", "-T"],
                         stdout=dmesg_output,
                         stderr=dmesg_output,
                         timeout=10


### PR DESCRIPTION
Do not ask for password in sudo. If user does not have NOPASSWD for sudo, just fail.