### PR TITLE
issue-2100: make blockstore SS proxy error handling consistent with filestore SS proxy

### DIFF
--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor.cpp
@@ -18,17 +18,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const THashSet<ui32> RetriableTxProxyErrors {
-    NKikimr::NTxProxy::TResultStatus::ProxyNotReady,
-    NKikimr::NTxProxy::TResultStatus::ProxyShardNotAvailable,
-    NKikimr::NTxProxy::TResultStatus::ProxyShardTryLater,
-    NKikimr::NTxProxy::TResultStatus::ProxyShardOverloaded,
-    NKikimr::NTxProxy::TResultStatus::ExecTimeout,
-    NKikimr::NTxProxy::TResultStatus::ExecResultUnavailable
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 std::unique_ptr<NTabletPipe::IClientCache> CreateTabletPipeClientCache(
     const TStorageConfig& config)
 {
@@ -180,20 +169,6 @@ NProto::TError GetErrorFromPreconditionFailed(const NProto::TError& error)
         result.SetCode(E_REJECTED);
     }
     return result;
-}
-
-NProto::TError TranslateTxProxyError(NProto::TError error)
-{
-    if (FACILITY_FROM_CODE(error.GetCode()) != FACILITY_TXPROXY) {
-        return error;
-    }
-
-    auto status =
-        static_cast<NKikimrScheme::EStatus>(STATUS_FROM_CODE(error.GetCode()));
-    if (RetriableTxProxyErrors.count(status)) {
-        error.SetCode(E_REJECTED);
-    }
-    return error;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -134,18 +134,10 @@ void TModifySchemeActor::HandleStatus(
                 break;
             }
 
-            ui32 errorCode = MAKE_SCHEMESHARD_ERROR(SchemeShardStatus);
-
-            if (SchemeShardStatus == NKikimrScheme::StatusMultipleModifications ||
-                SchemeShardStatus == NKikimrScheme::StatusNotAvailable)
-            {
-                errorCode = E_REJECTED;
-            }
-
             ReplyAndDie(
                 ctx,
                 MakeError(
-                    errorCode,
+                    MAKE_SCHEMESHARD_ERROR(SchemeShardStatus),
                     (TStringBuilder()
                         << NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).data()
                         << " failed with reason: "
@@ -186,9 +178,8 @@ void TModifySchemeActor::HandleStatus(
 
             ReplyAndDie(
                 ctx,
-                TranslateTxProxyError(
-                    MakeError(MAKE_TXPROXY_ERROR(status), TStringBuilder()
-                        << "TxProxy failed: " << status)));
+                MakeError(MAKE_TXPROXY_ERROR(status), TStringBuilder()
+                    << "TxProxy failed: " << status));
             break;
     }
 }


### PR DESCRIPTION
To unlock the possibility of unification of the common part of these two implementations. 
Finally, we are going to move the common part to `cloud/storage` and add `PathDescriptionBackup` implementation on top of it - in order to re-use that for Filestore disaster recovery feature

#2100 