### PR TITLE
[merge-to-stable]: issue-1146: preliminary changes: refactor RO txs: allow them to run atop of IIndexTabletDatabase, issue-1146: apply cache upon RW TXs completion, add tests for its invalidation, issue-1993: resetting CurrentBackgroundBlobIndexOp if FlushBytes couldn't be enqueued due to Flush being already enqueued or running; enqueueing Flush and BlobIndexOp upon backpressure error; tracking BackpressurePeriod and rebooting tablets if this period is too long; added more backpressure info to monpage

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -47,6 +47,14 @@ enum EVolumePreemptionType
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+//
+//  !!!IMPORTANT!!!
+//  Even though StorageServiceConfig is usually stored in textual format, it may
+//  be overridden for some tablets and in this case it's stored in binary format
+//  in the tablet's localdb. So binary backward-compatibility should be
+//  maintained.
+//
+////////////////////////////////////////////////////////////////////////////////
 
 message TStorageServiceConfig
 {

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -17,6 +17,14 @@ enum EBlobIndexOpsPriority
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+//
+//  !!!IMPORTANT!!!
+//  Even though StorageConfig is usually stored in textual format, it may be
+//  overridden for some tablets and in this case it's stored in binary format
+//  in the tablet's localdb. So binary backward-compatibility should be
+//  maintained.
+//
+////////////////////////////////////////////////////////////////////////////////
 
 message TStorageConfig
 {
@@ -402,4 +410,10 @@ message TStorageConfig
     // uncontrollable behaviour change for production systems. TODO: gradually
     // enable this flag everywhere and make this behaviour the new default.
     optional bool UseMixedBlocksInsteadOfAliveBlocksInCompaction = 391;
+
+    // IndexTabletActor will suicide (and thus reboot) after observing
+    // consecutive backpressure errors for this period of time. Needed to
+    // automatically recover after various races that may happen during index
+    // tablet startup due to bugs.
+    optional uint32 MaxBackpressurePeriodBeforeSuicide = 392;   // in ms
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -170,7 +170,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\
     xxx(AttrTimeout,                     TDuration, TDuration::Zero()         )\
     xxx(MaxOutOfOrderCompactionMapLoadRequestsInQueue,  ui32,      5          )\
-    xxx(MaxBackpressureErrorsBeforeSuicide,             ui32,      1000       )\
+    xxx(MaxBackpressureErrorsBeforeSuicide, ui32,       1000                  )\
+    xxx(MaxBackpressurePeriodBeforeSuicide, TDuration,  TDuration::Minutes(10))\
                                                                                \
     xxx(NewLocalDBCompactionPolicyEnabled,              bool,      false      )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -204,6 +204,7 @@ public:
     bool GetConfigsDispatcherServiceEnabled() const;
 
     ui32 GetMaxBackpressureErrorsBeforeSuicide() const;
+    TDuration GetMaxBackpressurePeriodBeforeSuicide() const;
 
     TDuration GetGenerateBlobIdsReleaseCollectBarrierTimeout() const;
 

--- a/cloud/filestore/libs/storage/core/tablet.h
+++ b/cloud/filestore/libs/storage/core/tablet.h
@@ -243,7 +243,7 @@ protected:
         template <typename T, typename ...Args>                                \
         static void CompleteTx(T& target, Args&& ...args)                      \
         {                                                                      \
-            target.CompleteTx_##name(std::forward<Args>(args)...);             \
+            target.CompleteAndUpdateState(std::forward<Args>(args)...);        \
         }                                                                      \
     };                                                                         \
                                                                                \
@@ -260,6 +260,14 @@ protected:
     void CompleteTx_##name(                                                    \
         const NActors::TActorContext& ctx,                                     \
         ns::T##name& args);                                                    \
+                                                                               \
+    void CompleteAndUpdateState(                                               \
+        const NActors::TActorContext& ctx,                                     \
+        ns::T##name& args)                                                     \
+    {                                                                          \
+        UpdateInMemoryIndexState(args);                                        \
+        CompleteTx_##name(ctx, args);                                          \
+    }                                                                          \
 // FILESTORE_IMPLEMENT_RW_TRANSACTION
 
 // For RO transactions we allow to alternatively declare ValidateTx_, PrepareTx_
@@ -340,6 +348,7 @@ protected:
             CompleteTx_##name(ctx, args);                                      \
             return true;                                                       \
         }                                                                      \
+        args.Clear();                                                          \
         return false;                                                          \
     }                                                                          \
 // FILESTORE_IMPLEMENT_RO_TRANSACTION

--- a/cloud/filestore/libs/storage/core/tablet.h
+++ b/cloud/filestore/libs/storage/core/tablet.h
@@ -219,13 +219,14 @@ protected:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define FILESTORE_IMPLEMENT_TRANSACTION(name, ns)                              \
+#define FILESTORE_IMPLEMENT_RW_TRANSACTION(name, ns)                           \
     struct T##name                                                             \
     {                                                                          \
         using TArgs = ns::T##name;                                             \
                                                                                \
         static constexpr const char* Name = #name;                             \
         static constexpr NKikimr::TTxType TxType = TCounters::TX_##name;       \
+        static constexpr bool IsReadOnly = false;                              \
                                                                                \
         template <typename T, typename ...Args>                                \
         static bool PrepareTx(T& target, Args&& ...args)                       \
@@ -259,6 +260,88 @@ protected:
     void CompleteTx_##name(                                                    \
         const NActors::TActorContext& ctx,                                     \
         ns::T##name& args);                                                    \
-// FILESTORE_IMPLEMENT_TRANSACTION
+// FILESTORE_IMPLEMENT_RW_TRANSACTION
+
+// For RO transactions we allow to alternatively declare ValidateTx_, PrepareTx_
+// and CompleteTx_, where Validate and PrepareTx are two stages of Prepare (one
+// not using, and one using db). CompleteTx is the same for all other
+// transactions. ValidateTx is expected to return false if Execute is to be
+// executed, and true if it is not.
+//
+// Unlike FILESTORE_IMPLEMENT_RW_TRANSACTION, this macro allows to define
+// operations that can both run atop of the LocalDB and other implementations
+// of the database. Thus, signature of ExecuteTx_ is a bit more lax.
+//
+// This macro also provides TryExecuteTx function that will run the whole
+// transaction and call CompleteTx_ if it was successful.
+#define FILESTORE_IMPLEMENT_RO_TRANSACTION(name, ns, dbType, dbIfaceType)      \
+    struct T##name                                                             \
+    {                                                                          \
+        using TArgs = ns::T##name;                                             \
+                                                                               \
+        static constexpr const char* Name = #name;                             \
+        static constexpr NKikimr::TTxType TxType = TCounters::TX_##name;       \
+        static constexpr bool IsReadOnly = true;                               \
+                                                                               \
+        template <typename T, typename ...Args>                                \
+        static bool PrepareTx(                                                 \
+            T& target,                                                         \
+            const NActors::TActorContext& ctx,                                 \
+            NKikimr::NTabletFlatExecutor::TTransactionContext& tx,             \
+            Args&& ...args)                                                    \
+        {                                                                      \
+            if (target.ValidateTx_##name(ctx, std::forward<Args>(args)...)) {  \
+                dbType db(tx.DB);                                              \
+                return target.PrepareTx_##name(                                \
+                    ctx, db, std::forward<Args>(args)...);                     \
+            }                                                                  \
+            return true;                                                       \
+        }                                                                      \
+                                                                               \
+        template <typename T, typename ...Args>                                \
+        static void ExecuteTx(                                                 \
+            T& target,                                                         \
+            const NActors::TActorContext& ctx,                                 \
+            NKikimr::NTabletFlatExecutor::TTransactionContext& tx,             \
+            Args&& ...args)                                                    \
+        {                                                                      \
+            Y_UNUSED(target, ctx, tx, std::forward<Args>(args)...);            \
+        }                                                                      \
+                                                                               \
+        template <typename T, typename ...Args>                                \
+        static void CompleteTx(                                                \
+            T& target,                                                         \
+            const NActors::TActorContext& ctx,                                 \
+            Args&& ...args)                                                    \
+        {                                                                      \
+            target.CompleteTx_##name(ctx, std::forward<Args>(args)...);        \
+        }                                                                      \
+    };                                                                         \
+                                                                               \
+    bool ValidateTx_##name(                                                    \
+        const NActors::TActorContext& ctx,                                     \
+        ns::T##name& args);                                                    \
+                                                                               \
+    bool PrepareTx_##name(                                                     \
+        const NActors::TActorContext& ctx,                                     \
+        dbIfaceType& db,                                                       \
+        ns::T##name& args);                                                    \
+                                                                               \
+    void CompleteTx_##name(                                                    \
+        const NActors::TActorContext& ctx,                                     \
+        ns::T##name& args);                                                    \
+                                                                               \
+    bool TryExecuteTx(                                                         \
+        const NActors::TActorContext& ctx,                                     \
+        dbIfaceType& db,                                                       \
+        ns::T##name& args)                                                     \
+    {                                                                          \
+        if (!ValidateTx_##name(ctx, args) || PrepareTx_##name(ctx, db, args)) {\
+            CompleteTx_##name(ctx, args);                                      \
+            return true;                                                       \
+        }                                                                      \
+        return false;                                                          \
+    }                                                                          \
+// FILESTORE_IMPLEMENT_RO_TRANSACTION
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -258,6 +258,7 @@ private:
     NProto::TStorageConfig StorageConfigOverride;
 
     ui32 BackpressureErrorCount = 0;
+    TInstant BackpressurePeriodStart;
 
     const NBlockCodecs::ICodec* BlobCodec;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -89,7 +89,7 @@ bool TIndexTabletActor::PrepareTx_AddData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabase db(tx.DB);
 
     if (!ReadNode(db, args.NodeId, commitId, args.Node)) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
@@ -67,10 +67,11 @@ void TIndexTabletActor::HandleChangeStorageConfig(
     AddTransaction<TEvIndexTablet::TChangeStorageConfigMethod>(*requestInfo);
 
     const auto* msg = ev->Get();
-    ExecuteTx(ctx, CreateTx<TChangeStorageConfig>(
-        requestInfo,
+    ExecuteTx<TChangeStorageConfig>(
+        ctx,
+        std::move(requestInfo),
         msg->Record.GetStorageConfig(),
-        msg->Record.GetMergeWithStorageConfigFromTabletDB()));
+        msg->Record.GetMergeWithStorageConfigFromTabletDB());
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -409,6 +409,7 @@ void TIndexTabletActor::EnqueueBlobIndexOpIfNeeded(const TActorContext& ctx)
             // Flush blocked since FlushBytes op rewrites some fresh blocks as
             // blobs
             if (!FlushState.Enqueue()) {
+                StartBackgroundBlobIndexOp();
                 CompleteBlobIndexOp();
                 if (!IsBlobIndexOpsQueueEmpty()) {
                     EnqueueBlobIndexOpIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -279,6 +279,15 @@ void TIndexTabletActor::TMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(
         NodeIndexCacheNodeCount,
         EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateROCacheHitCount,
+        EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateROCacheMissCount,
+        EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateRWCount,
+        EMetricType::MT_DERIVATIVE);
 
     REGISTER_AGGREGATABLE_SUM(FreshBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(DeletedFreshBytesCount, EMetricType::MT_ABSOLUTE);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
@@ -78,6 +78,7 @@ void TIndexTabletActor::CompleteTx_CreateCheckpoint(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateCheckpoint& args)
 {
+    // TODO(#1146) checkpoint-related tables are not yet supported
     RemoveTransaction(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvCreateCheckpointResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -249,6 +249,7 @@ void TIndexTabletActor::CompleteTx_DeleteCheckpoint(
     const TActorContext& ctx,
     TTxIndexTablet::TDeleteCheckpoint& args)
 {
+    // TODO(#1146) checkpoint-related tables are not yet supported
     RemoveTransaction(*args.RequestInfo);
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -100,9 +100,8 @@ void TIndexTabletActor::HandleGetNodeAttr(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TIndexTabletActor::PrepareTx_GetNodeAttr(
+bool TIndexTabletActor::ValidateTx_GetNodeAttr(
     const TActorContext& ctx,
-    TTransactionContext& tx,
     TTxIndexTablet::TGetNodeAttr& args)
 {
     Y_UNUSED(ctx);
@@ -116,16 +115,24 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttr(
             args.ClientId,
             args.SessionId,
             args.SessionSeqNo);
-        return true;
+        return false;
     }
 
     args.CommitId = GetReadCommitId(session->GetCheckpointId());
     if (args.CommitId == InvalidCommitId) {
         args.Error = ErrorInvalidCheckpoint(session->GetCheckpointId());
-        return true;
+        return false;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    return true;
+}
+
+bool TIndexTabletActor::PrepareTx_GetNodeAttr(
+    const NActors::TActorContext& ctx,
+    IIndexTabletDatabase& db,
+    TTxIndexTablet::TGetNodeAttr& args)
+{
+    Y_UNUSED(ctx);
 
     // There could be two cases:
     // * access by parentId/name
@@ -180,16 +187,6 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttr(
     TABLET_VERIFY(args.TargetNode);
 
     return true;
-}
-
-void TIndexTabletActor::ExecuteTx_GetNodeAttr(
-    const TActorContext& ctx,
-    TTransactionContext& tx,
-    TTxIndexTablet::TGetNodeAttr& args)
-{
-    Y_UNUSED(ctx);
-    Y_UNUSED(tx);
-    Y_UNUSED(args);
 }
 
 void TIndexTabletActor::CompleteTx_GetNodeAttr(
@@ -292,9 +289,8 @@ void TIndexTabletActor::HandleGetNodeAttrBatch(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
+bool TIndexTabletActor::ValidateTx_GetNodeAttrBatch(
     const TActorContext& ctx,
-    TTransactionContext& tx,
     TTxIndexTablet::TGetNodeAttrBatch& args)
 {
     Y_UNUSED(ctx);
@@ -308,16 +304,24 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
             args.ClientId,
             args.SessionId,
             args.SessionSeqNo);
-        return true;
+        return false;
     }
 
     args.CommitId = GetReadCommitId(session->GetCheckpointId());
     if (args.CommitId == InvalidCommitId) {
         args.Error = ErrorInvalidCheckpoint(session->GetCheckpointId());
-        return true;
+        return false;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    return true;
+}
+
+bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
+    const NActors::TActorContext& ctx,
+    IIndexTabletDatabase& db,
+    TTxIndexTablet::TGetNodeAttrBatch& args)
+{
+    Y_UNUSED(ctx);
 
     // validate parent node exists
     const bool readParent =
@@ -410,16 +414,6 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
     }
 
     return true;
-}
-
-void TIndexTabletActor::ExecuteTx_GetNodeAttrBatch(
-    const TActorContext& ctx,
-    TTransactionContext& tx,
-    TTxIndexTablet::TGetNodeAttrBatch& args)
-{
-    Y_UNUSED(ctx);
-    Y_UNUSED(tx);
-    Y_UNUSED(args);
 }
 
 void TIndexTabletActor::CompleteTx_GetNodeAttrBatch(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
@@ -52,9 +52,8 @@ void TIndexTabletActor::HandleGetNodeXAttr(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TIndexTabletActor::PrepareTx_GetNodeXAttr(
+bool TIndexTabletActor::ValidateTx_GetNodeXAttr(
     const TActorContext& ctx,
-    TTransactionContext& tx,
     TTxIndexTablet::TGetNodeXAttr& args)
 {
     Y_UNUSED(ctx);
@@ -68,16 +67,24 @@ bool TIndexTabletActor::PrepareTx_GetNodeXAttr(
             args.ClientId,
             args.SessionId,
             args.SessionSeqNo);
-        return true;
+        return false;
     }
 
     args.CommitId = GetReadCommitId(session->GetCheckpointId());
     if (args.CommitId == InvalidCommitId) {
         args.Error = ErrorInvalidCheckpoint(session->GetCheckpointId());
-        return true;
+        return false;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    return true;
+}
+
+bool TIndexTabletActor::PrepareTx_GetNodeXAttr(
+    const TActorContext& ctx,
+    IIndexTabletDatabase& db,
+    TTxIndexTablet::TGetNodeXAttr& args)
+{
+    Y_UNUSED(ctx);
 
     // validate target node exists
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
@@ -102,16 +109,6 @@ bool TIndexTabletActor::PrepareTx_GetNodeXAttr(
     }
 
     return true;
-}
-
-void TIndexTabletActor::ExecuteTx_GetNodeXAttr(
-    const TActorContext& ctx,
-    TTransactionContext& tx,
-    TTxIndexTablet::TGetNodeXAttr& args)
-{
-    Y_UNUSED(ctx);
-    Y_UNUSED(tx);
-    Y_UNUSED(args);
 }
 
 void TIndexTabletActor::CompleteTx_GetNodeXAttr(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
@@ -48,9 +48,8 @@ void TIndexTabletActor::HandleListNodeXAttr(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TIndexTabletActor::PrepareTx_ListNodeXAttr(
+bool TIndexTabletActor::ValidateTx_ListNodeXAttr(
     const TActorContext& ctx,
-    TTransactionContext& tx,
     TTxIndexTablet::TListNodeXAttr& args)
 {
     Y_UNUSED(ctx);
@@ -64,16 +63,24 @@ bool TIndexTabletActor::PrepareTx_ListNodeXAttr(
             args.ClientId,
             args.SessionId,
             args.SessionSeqNo);
-        return true;
+        return false;
     }
 
     args.CommitId = GetReadCommitId(session->GetCheckpointId());
     if (args.CommitId == InvalidCommitId) {
         args.Error = ErrorInvalidCheckpoint(session->GetCheckpointId());
-        return true;
+        return false;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    return true;
+}
+
+bool TIndexTabletActor::PrepareTx_ListNodeXAttr(
+    const TActorContext& ctx,
+    IIndexTabletDatabase& db,
+    TTxIndexTablet::TListNodeXAttr& args)
+{
+    Y_UNUSED(ctx);
 
     // validate target node exists
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
@@ -92,16 +99,6 @@ bool TIndexTabletActor::PrepareTx_ListNodeXAttr(
     }
 
     return true;
-}
-
-void TIndexTabletActor::ExecuteTx_ListNodeXAttr(
-    const TActorContext& ctx,
-    TTransactionContext& tx,
-    TTxIndexTablet::TListNodeXAttr& args)
-{
-    Y_UNUSED(ctx);
-    Y_UNUSED(tx);
-    Y_UNUSED(args);
 }
 
 void TIndexTabletActor::CompleteTx_ListNodeXAttr(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1066,9 +1066,25 @@ void TIndexTabletActor::HandleHttpInfo_Default(
             &message);
         TAG(TH3) { out << "Backpressure"; }
         if (!isWriteAllowed) {
-            out << "<div class='alert alert-danger'>" << "Write not allowed: " << message << "</div>";
+            DIV_CLASS("alert alert-danger") {
+                out << "Write NOT allowed: " << message;
+            }
         } else {
-            out << "<div class='alert'>Write allowed</div>";
+            DIV_CLASS("alert") {
+                out << "Write allowed: " << message;
+            }
+        }
+        if (BackpressurePeriodStart || BackpressureErrorCount) {
+            DIV_CLASS("alert") {
+                out << "Backpressure errors: " << BackpressureErrorCount;
+            }
+            DIV_CLASS("alert") {
+                out << "Backpressure period start: " << BackpressurePeriodStart;
+            }
+            DIV_CLASS("alert") {
+                out << "Backpressure period: "
+                    << (ctx.Now() - BackpressurePeriodStart);
+            }
         }
 
         TABLE_CLASS("table table-bordered") {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resolvepath.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resolvepath.cpp
@@ -53,27 +53,26 @@ void TIndexTabletActor::HandleResolvePath(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TIndexTabletActor::PrepareTx_ResolvePath(
+bool TIndexTabletActor::ValidateTx_ResolvePath(
     const TActorContext& ctx,
-    TTransactionContext& tx,
     TTxIndexTablet::TResolvePath& args)
 {
     // TODO
     Y_UNUSED(ctx);
-    Y_UNUSED(tx);
     Y_UNUSED(args);
 
     return true;
 }
 
-void TIndexTabletActor::ExecuteTx_ResolvePath(
+bool TIndexTabletActor::PrepareTx_ResolvePath(
     const TActorContext& ctx,
-    TTransactionContext& tx,
+    IIndexTabletDatabase& db,
     TTxIndexTablet::TResolvePath& args)
 {
     Y_UNUSED(ctx);
-    Y_UNUSED(tx);
+    Y_UNUSED(db);
     Y_UNUSED(args);
+    return true;
 }
 
 void TIndexTabletActor::CompleteTx_ResolvePath(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -105,10 +105,6 @@ void TIndexTabletActor::HandleWriteData(
         return;
     }
 
-    // this request passed the backpressure check => tablet is not stuck
-    // anywhere, we can reset our backpressure error counter
-    BackpressureErrorCount = 0;
-
     // either rejected or put into queue
     if (ThrottleIfNeeded<TEvService::TWriteDataMethod>(ev, ctx)) {
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1279,6 +1279,8 @@ public:
         const TString& name,
         const NProto::TNodeAttr& result);
     TNodeIndexCacheStats CalculateNodeIndexCacheStats() const;
+
+    IIndexTabletDatabase& AccessInMemoryIndexState();
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -161,7 +161,7 @@ private:
     NProto::TFileSystem FileSystem;
     NProto::TFileSystemStats FileSystemStats;
     NCloud::NProto::TTabletStorageInfo TabletStorageInfo;
-    TNodeToSessionCounters NodeToSessionCounters; 
+    TNodeToSessionCounters NodeToSessionCounters;
 
     /*const*/ ui32 TruncateBlocksThreshold = 0;
     /*const*/ ui32 SessionHistoryEntryCount = 0;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1281,6 +1281,8 @@ public:
     TNodeIndexCacheStats CalculateNodeIndexCacheStats() const;
 
     IIndexTabletDatabase& AccessInMemoryIndexState();
+    void UpdateInMemoryIndexState(
+        TVector<TInMemoryIndexState::TIndexStateRequest> nodeUpdates);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -561,4 +561,11 @@ TNodeIndexCacheStats TIndexTabletState::CalculateNodeIndexCacheStats() const
     return Impl->NodeIndexCache.GetStats();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+IIndexTabletDatabase& TIndexTabletState::AccessInMemoryIndexState()
+{
+    return Impl->InMemoryIndexState;
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -568,4 +568,10 @@ IIndexTabletDatabase& TIndexTabletState::AccessInMemoryIndexState()
     return Impl->InMemoryIndexState;
 }
 
+void TIndexTabletState::UpdateInMemoryIndexState(
+    TVector<TInMemoryIndexState::TIndexStateRequest> nodeUpdates)
+{
+    Impl->InMemoryIndexState.UpdateState(nodeUpdates);
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -64,7 +64,20 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define FILESTORE_TABLET_TRANSACTIONS(xxx, ...)                                \
+// read-only transactions can be executed atop of an in-memory cache
+#define FILESTORE_TABLET_INDEX_RO_TRANSACTIONS(xxx, ...)                       \
+    xxx(ResolvePath,                        __VA_ARGS__)                       \
+    xxx(AccessNode,                         __VA_ARGS__)                       \
+    xxx(ListNodes,                          __VA_ARGS__)                       \
+    xxx(ReadLink,                           __VA_ARGS__)                       \
+                                                                               \
+    xxx(GetNodeAttr,                        __VA_ARGS__)                       \
+    xxx(GetNodeAttrBatch,                   __VA_ARGS__)                       \
+    xxx(GetNodeXAttr,                       __VA_ARGS__)                       \
+    xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
+// FILESTORE_TABLET_RO_TRANSACTIONS
+
+#define FILESTORE_TABLET_RW_TRANSACTIONS(xxx, ...)                             \
     xxx(InitSchema,                         __VA_ARGS__)                       \
     xxx(LoadState,                          __VA_ARGS__)                       \
     xxx(LoadCompactionMapChunk,             __VA_ARGS__)                       \
@@ -79,20 +92,12 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateCheckpoint,                   __VA_ARGS__)                       \
     xxx(DeleteCheckpoint,                   __VA_ARGS__)                       \
                                                                                \
-    xxx(ResolvePath,                        __VA_ARGS__)                       \
     xxx(CreateNode,                         __VA_ARGS__)                       \
     xxx(UnlinkNode,                         __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
-    xxx(AccessNode,                         __VA_ARGS__)                       \
-    xxx(ListNodes,                          __VA_ARGS__)                       \
-    xxx(ReadLink,                           __VA_ARGS__)                       \
                                                                                \
     xxx(SetNodeAttr,                        __VA_ARGS__)                       \
-    xxx(GetNodeAttr,                        __VA_ARGS__)                       \
-    xxx(GetNodeAttrBatch,                   __VA_ARGS__)                       \
     xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
-    xxx(GetNodeXAttr,                       __VA_ARGS__)                       \
-    xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
     xxx(RemoveNodeXAttr,                    __VA_ARGS__)                       \
                                                                                \
     xxx(CreateHandle,                       __VA_ARGS__)                       \
@@ -126,6 +131,11 @@ namespace NCloud::NFileStore::NStorage {
                                                                                \
     xxx(DeleteOpLogEntry,                   __VA_ARGS__)                       \
     xxx(CommitNodeCreationInFollower,       __VA_ARGS__)                       \
+// FILESTORE_TABLET_RW_TRANSACTIONS
+
+#define FILESTORE_TABLET_TRANSACTIONS(xxx, ...)                                \
+    FILESTORE_TABLET_INDEX_RO_TRANSACTIONS(xxx, __VA_ARGS__)                   \
+    FILESTORE_TABLET_RW_TRANSACTIONS(xxx, __VA_ARGS__)                         \
 // FILESTORE_TABLET_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1413,9 +1413,7 @@ struct TTxIndexTablet
     // AddData
     //
 
-    struct TAddData
-        : TSessionAware
-        , TIndexStateNodeUpdates
+    struct TAddData: TSessionAware
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 Handle;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
@@ -3,7 +3,7 @@
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
 
-#include <contrib/ydb/core/base/counters.h>
+#include <ydb/core/base/counters.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
@@ -1,0 +1,676 @@
+#include "tablet.h"
+
+#include <cloud/filestore/libs/storage/testlib/tablet_client.h>
+#include <cloud/filestore/libs/storage/testlib/test_env.h>
+
+#include <contrib/ydb/core/base/counters.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTxStats
+{
+    i64 ROCacheHitCount = 0;
+    i64 ROCacheMissCount = 0;
+    i64 RWCount = 0;
+};
+
+TTxStats GetTxStats(TTestEnv& env, TIndexTabletClient& tablet)
+{
+    TTxStats stats;
+    TTestRegistryVisitor visitor;
+
+    tablet.SendRequest(tablet.CreateUpdateCounters());
+    env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+    env.GetRegistry()->Visit(TInstant::Zero(), visitor);
+
+    visitor.ValidateExpectedCountersWithPredicate({
+        {{{"filesystem", "test"},
+          {"sensor", "InMemoryIndexStateROCacheHitCount"}},
+         [&stats](i64 value)
+         {
+             stats.ROCacheHitCount = value;
+             return true;
+         }},
+        {{{"filesystem", "test"},
+          {"sensor", "InMemoryIndexStateROCacheMissCount"}},
+         [&stats](i64 value)
+         {
+             stats.ROCacheMissCount = value;
+             return true;
+         }},
+        {{{"filesystem", "test"}, {"sensor", "InMemoryIndexStateRWCount"}},
+         [&stats](i64 value)
+         {
+             stats.RWCount = value;
+             return true;
+         }},
+    });
+    return stats;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesCache)
+{
+    Y_UNIT_TEST(ShouldUpdateAndEvictCacheUponCreateNode)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+        // Create node should have populated the cache, thus the next
+        // GetNodeAttr should not trigger a transaction.
+        {
+            auto node =
+                tablet.GetNodeAttr(RootNodeId, "test")->Record.GetNode();
+            UNIT_ASSERT_VALUES_EQUAL(id, node.GetId());
+            UNIT_ASSERT(node.GetType() == NProto::E_REGULAR_NODE);
+        }
+
+        // The following GetNodeAttr should not produce a transaction either, as
+        // the requested node is already in the cache.
+        {
+            auto node = tablet.GetNodeAttr(RootNodeId, "")->Record.GetNode();
+            UNIT_ASSERT_VALUES_EQUAL(RootNodeId, node.GetId());
+            UNIT_ASSERT(node.GetType() == NProto::E_DIRECTORY_NODE);
+        }
+
+        // Now the Nodes table has two entries: Root and test.
+        // The NodeRefs table has one entry: Root -> test.
+        //
+        // Creating another node should evict the first one from the cache
+        tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test2"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            id,
+            tablet.GetNodeAttr(RootNodeId, "test")->Record.GetNode().GetId());
+        // ListNodes can not be performed using in-memory cache
+        tablet.ListNodes(RootNodeId);
+
+        // Two out of three GetNodeAttr calls should have been performed using
+        // the cache. ListNodes is a cache miss also.
+        auto statsAfter = GetTxStats(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(2, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    // Note: this test does not check the cache eviction policy, as cache size
+    // changes are not expected upon node rename
+    Y_UNIT_TEST(ShouldUpdateCacheUponRenameNode)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(3);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(2);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"));
+        // RO transaction, cache hit
+        auto ctime =
+            tablet.GetNodeAttr(RootNodeId, "")->Record.GetNode().GetCTime();
+
+        // Upon rename node the wall clock time is used to update the ctime, so
+        // until this is replaced with ctx.Now, we need to perform sleep, not
+        // tablet.AdvanceTime
+        Sleep(TDuration::Seconds(2));
+
+        // RW transaction, Nodes table has 2 entries: Root and test2, NodeRefs
+        // has 1 entry: Root -> test2
+        tablet.RenameNode(RootNodeId, "test", RootNodeId, "test2");
+
+        // RO transaction, cache hit
+        auto newCtime =
+            tablet.GetNodeAttr(RootNodeId, "")->Record.GetNode().GetCTime();
+        UNIT_ASSERT_GT(newCtime, ctime);
+
+        // GetNodeAttr of a non-existing node can not be performed using the
+        // cache, this is a RO transaction, cache miss
+        tablet.AssertGetNodeAttrFailed(RootNodeId, "test");
+
+        // Two out of three should have been performed using the cache
+        auto statsAfter = GetTxStats(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(2, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponUnlinkNode)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(3);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(3);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id1 =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test1"));
+        auto id2 =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test2"));
+
+        // Both nodes are in the cache. RO transaction, cache hit
+        tablet.GetNodeAttr(id1, "");
+        tablet.GetNodeAttr(id2, "");
+        tablet.GetNodeAttr(RootNodeId, "test1");
+        tablet.GetNodeAttr(RootNodeId, "test2");
+
+        // RW transactions, cache should be updated and nodes should be removed
+        tablet.UnlinkNode(RootNodeId, "test1", false);
+        tablet.UnlinkNode(RootNodeId, "test2", false);
+
+        // All four requests should have been performed without the cache
+        tablet.AssertGetNodeAttrFailed(id1, "");
+        tablet.AssertGetNodeAttrFailed(id2, "");
+        tablet.AssertGetNodeAttrFailed(RootNodeId, "test1");
+        tablet.AssertGetNodeAttrFailed(RootNodeId, "test2");
+
+        // Four out of eight GetNodeAttr calls should have been performed using
+        // the cache. Other four are cache misses and should have failed
+        auto statsAfter = GetTxStats(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(4, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponDestroySession)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(2);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+        auto handle = tablet.CreateHandle(id, TCreateHandleArgs::RDWR);
+
+        // Cache hit
+        tablet.GetNodeAttr(id, "")->Record.GetNode();
+
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        // Should work as there is an existing handle
+        tablet.GetNodeAttr(id, "");
+
+        // Upon session destruction the node should be removed from the cache as
+        // well as the localDB
+        tablet.DestroySession();
+
+        tablet.InitSession("client", "session2");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_FS_NOENT,
+            tablet.AssertGetNodeAttrFailed(id, "")->GetError().GetCode());
+
+        auto statsAfter = GetTxStats(env, tablet);
+        // First two GetNodeAttr calls should have been performed with the cache
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        // Last GetNodeAttr call should have been a cache miss as it is not
+        // supposed to be present in the cache
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        // CreateNode, CreateHandle, UnlinkNode, DestroySession and InitSession
+        // are RW txs
+        UNIT_ASSERT_VALUES_EQUAL(5, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponSetNodeAttr)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+
+        // RW transaction, updates cache
+        tablet.SetNodeAttr(TSetNodeAttrArgs(id).SetSize(77));
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            77,
+            tablet.GetNodeAttr(id, "")->Record.GetNode().GetSize());
+
+        auto statsAfter = GetTxStats(env, tablet);
+        // The only one GetNodeAttr call should have been performed with the
+        // cache
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        // There was no cache misses
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        // CreateNode and SetNodeAttr are RW txs
+        UNIT_ASSERT_VALUES_EQUAL(2, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponSetNodeXAttr)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        storageConfig.SetInMemoryIndexCacheNodeAttrsCapacity(2);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+
+        // RW transaction, updates cache
+        tablet.SetNodeXAttr(id, "user.test", "value");
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            "value",
+            tablet.GetNodeXAttr(id, "user.test")->Record.GetValue());
+
+        // RW transaction, updates cache
+        tablet.SetNodeXAttr(id, "user.test", "value2");
+        // RW transaction, updates cache
+        tablet.SetNodeXAttr(id, "user.test2", "value");
+
+        // RO transactions, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            "value2",
+            tablet.GetNodeXAttr(id, "user.test")->Record.GetValue());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "value",
+            tablet.GetNodeXAttr(id, "user.test2")->Record.GetValue());
+
+        // RW transaction, evicts the cache
+        tablet.SetNodeXAttr(id, "user.test3", "value");
+
+        // RO transaction, cache miss
+        UNIT_ASSERT_VALUES_EQUAL(
+            "value",
+            tablet.GetNodeXAttr(id, "user.test2")->Record.GetValue());
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(5, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponRemoveNodeXAttr)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        storageConfig.SetInMemoryIndexCacheNodeAttrsCapacity(2);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+
+        // RW transaction, updates cache
+        tablet.SetNodeXAttr(id, "user.test", "value");
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            "value",
+            tablet.GetNodeXAttr(id, "user.test")->Record.GetValue());
+
+        // RW transaction, updates cache
+        tablet.RemoveNodeXAttr(id, "user.test");
+
+        // RO transaction, cache miss
+        UNIT_ASSERT_VALUES_EQUAL(
+            MAKE_FILESTORE_ERROR(NProto::E_FS_NOXATTR),
+            tablet.AssertGetNodeXAttrFailed(id, "user.test")
+                ->GetError()
+                .GetCode());
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(3, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponWriteAndCreateHandle)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+        // RW transaction
+        auto handle = tablet.CreateHandle(id, TCreateHandleArgs::RDWR)
+                          ->Record.GetHandle();
+        // RW transaction, updates file size
+        tablet.WriteData(handle, 0, 99, '0');
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            99,
+            tablet.GetNodeAttr(id, "")->Record.GetNode().GetSize());
+
+        // RW transaction, updates cache
+        tablet.CreateHandle(
+            id,
+            "",
+            TCreateHandleArgs::CREATE | TCreateHandleArgs::TRUNC);
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            tablet.GetNodeAttr(id, "")->Record.GetNode().GetSize());
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(4, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponDestroyHandle)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+        // RW transaction, updates cache
+        auto handle = tablet.CreateHandle(id, TCreateHandleArgs::RDWR)
+                          ->Record.GetHandle();
+
+        // RW transaction, updates cache
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        // RO transaction, cache hit
+        tablet.GetNodeAttr(id, "");
+        // RW transaction, updates cache
+        tablet.DestroyHandle(handle);
+        // RO transaction, cache miss
+        tablet.AssertGetNodeAttrFailed(id, "");
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(4, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponAddBlob)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+        // RW transaction, updates cache
+        auto handle = tablet.CreateHandle(id, TCreateHandleArgs::RDWR)
+                          ->Record.GetHandle();
+
+        // explicitly write data to blob storage
+        const auto dataSize = DefaultBlockSize * BlockGroupSize;
+        NKikimr::TLogoBlobID blobId;
+        ui64 commitId = 0;
+        {
+            auto gbi = tablet
+                           .GenerateBlobIds(
+                               id,
+                               handle,
+                               /* offset */ 0,
+                               /* length */ dataSize)
+                           ->Record;
+            UNIT_ASSERT_VALUES_EQUAL(1, gbi.BlobsSize());
+            commitId = gbi.GetCommitId();
+
+            blobId = LogoBlobIDFromLogoBlobID(gbi.GetBlobs(0).GetBlobId());
+            auto evPut = std::make_unique<TEvBlobStorage::TEvPut>(
+                blobId,
+                TString(dataSize, 'x'),
+                TInstant::Max(),
+                NKikimrBlobStorage::UserData);
+            NKikimr::TActorId proxy =
+                MakeBlobStorageProxyID(gbi.GetBlobs(0).GetBSGroupId());
+            auto evPutSender =
+                env.GetRuntime().AllocateEdgeActor(proxy.NodeId());
+            env.GetRuntime().Send(CreateEventForBSProxy(
+                evPutSender,
+                proxy,
+                evPut.release(),
+                blobId.Cookie()));
+        }
+
+        // RW transaction, updates cache, subsequently calls AddData
+        tablet.AddData(
+            id,
+            handle,
+            /* offset */ 0,
+            /* length */ dataSize,
+            TVector<NKikimr::TLogoBlobID>{blobId},
+            commitId,
+            /* unaligned parts */ TVector<NProtoPrivate::TFreshDataRange>{});
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            dataSize,
+            tablet.GetNodeAttr(id, "")->Record.GetNode().GetSize());
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(4, statsAfter.RWCount - statsBefore.RWCount);
+    }
+
+    Y_UNIT_TEST(ShouldUpdateCacheUponAllocateData)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        TTestEnv env({}, storageConfig);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // RW transaction, populates the cache
+        auto id = tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, "test"))
+                      ->Record.GetNode()
+                      .GetId();
+        // RW transaction, updates cache
+        auto handle = tablet.CreateHandle(id, TCreateHandleArgs::RDWR)
+                          ->Record.GetHandle();
+
+        auto newSize = DefaultBlockSize * BlockGroupSize;
+        // RW transaction, updates cache
+        tablet.AllocateData(
+            handle,
+            0,
+            newSize,
+            ProtoFlag(NProto::TAllocateDataRequest::F_ZERO_RANGE));
+
+        // RO transaction, cache hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            newSize,
+            tablet.GetNodeAttr(id, "")->Record.GetNode().GetSize());
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(3, statsAfter.RWCount - statsBefore.RWCount);
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/ut/CMakeLists.darwin-x86_64.txt
+++ b/cloud/filestore/libs/storage/tablet/ut/CMakeLists.darwin-x86_64.txt
@@ -37,6 +37,7 @@ target_sources(cloud-filestore-libs-storage-tablet-ut PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_channels.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_checkpoints.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp

--- a/cloud/filestore/libs/storage/tablet/ut/CMakeLists.linux-aarch64.txt
+++ b/cloud/filestore/libs/storage/tablet/ut/CMakeLists.linux-aarch64.txt
@@ -40,6 +40,7 @@ target_sources(cloud-filestore-libs-storage-tablet-ut PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_channels.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_checkpoints.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp

--- a/cloud/filestore/libs/storage/tablet/ut/CMakeLists.linux-x86_64.txt
+++ b/cloud/filestore/libs/storage/tablet/ut/CMakeLists.linux-x86_64.txt
@@ -41,6 +41,7 @@ target_sources(cloud-filestore-libs-storage-tablet-ut PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_channels.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_checkpoints.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp

--- a/cloud/filestore/libs/storage/tablet/ut/CMakeLists.windows-x86_64.txt
+++ b/cloud/filestore/libs/storage/tablet/ut/CMakeLists.windows-x86_64.txt
@@ -30,6 +30,7 @@ target_sources(cloud-filestore-libs-storage-tablet-ut PRIVATE
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+  ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_channels.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_checkpoints.cpp
   ${CMAKE_SOURCE_DIR}/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp

--- a/cloud/filestore/libs/storage/tablet/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ut/ya.make
@@ -9,6 +9,7 @@ SRCS(
     subsessions_ut.cpp
     tablet_database_ut.cpp
     tablet_ut.cpp
+    tablet_ut_cache.cpp
     tablet_ut_channels.cpp
     tablet_ut_checkpoints.cpp
     tablet_ut_data.cpp

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
@@ -8,4 +8,8 @@ PreferredBlockSizeMultiplier: 64
 MultiTabletForwardingEnabled: true
 GetNodeAttrBatchEnabled: true
 UnalignedThreeStageWriteEnabled: true
+InMemoryIndexCacheEnabled: true
+InMemoryIndexCacheNodesCapacity: 10
+InMemoryIndexCacheNodeRefsCapacity: 10
+InMemoryIndexCacheNodeAttrsCapacity: 10
 UseMixedBlocksInsteadOfAliveBlocksInCompaction: true


### PR DESCRIPTION
be41d7a60bfa3c02b539f4f7568db0b78da666b8 
29342e9657974e77fd9dd770678cb8bf3ca176b5
aaa15e0
44cd61672757e3d4d71b794f5f593e570bce7131