### PR TITLE
fix: remove NodeGetVolumeStats entry log

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -726,8 +726,6 @@ func (s *nodeService) NodeGetVolumeStats(
 	req *csi.NodeGetVolumeStatsRequest) (
 	*csi.NodeGetVolumeStatsResponse, error) {
 
-	log.Printf("csi.NodeGetVolumeStats: %+v", req)
-
 	if req.VolumeId == "" {
 		return nil, s.statusError(
 			codes.InvalidArgument,


### PR DESCRIPTION
Kubernetes can trigger NodeGetVolumeStats each minute and it causes a lot of spam in our logs.