### PR TITLE
[Filestore]: partially revert #273: do not use pre-built ydbd for filestore tests, but build it from the current branch

### DIFF
--- a/cloud/filestore/tests/recipes/service-kikimr.inc
+++ b/cloud/filestore/tests/recipes/service-kikimr.inc
@@ -2,7 +2,7 @@ DEPENDS(
     cloud/filestore/apps/server
     cloud/filestore/tests/recipes/service-kikimr
 
-    cloud/storage/core/tools/testing/ydb/bin
+    contrib/ydb/apps/ydbd
 )
 
 IF (NFS_RESTART_INTERVAL)

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -35,7 +35,7 @@ def start(argv):
     parser.add_argument("--storage-config-patch", action="store", default=None)
     args = parser.parse_args(argv)
 
-    kikimr_binary_path = common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
+    kikimr_binary_path = common.binary_path("contrib/ydb/apps/ydbd/ydbd")
     if args.kikimr_package_path is not None:
         kikimr_binary_path = common.build_path("{}/Berkanavt/kikimr/bin/kikimr".format(args.kikimr_package_path))
 


### PR DESCRIPTION
Reverts #273