### PR TITLE
issue-2100: make GetErrorFromPreconditionFailed function (of blockstore SS proxy) look the same as the corresponding function of filestore SS proxy

### DIFF
--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor.cpp
@@ -166,9 +166,7 @@ NProto::TError GetErrorFromPreconditionFailed(const NProto::TError& error)
     NProto::TError result = error;
     const auto& msg = error.GetMessage();
 
-    if (msg.Contains("Wrong version in VolumeConfig") ||
-        msg.Contains("Wrong version in Assign Volume"))
-    {
+    if (msg.Contains("Wrong version in")) {
         // ConfigVersion is different from current one in SchemeShard
         // return E_ABORTED to client to read
         // updated config (StatVolume) and issue new request

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -20,7 +20,7 @@ NProto::TError GetErrorFromPreconditionFailed(const NProto::TError& error)
     NProto::TError result = error;
     const auto& msg = error.GetMessage();
 
-    if (msg.Contains("Wrong version in config")) {
+    if (msg.Contains("Wrong version in")) {
         // ConfigVersion is different from current one in SchemeShard
         // return E_ABORTED to client to read
         // updated config (Stat FS) and issue new request


### PR DESCRIPTION
Follow-up for work started at #2101.

There are three possible error messages:
* `Wrong version in VolumeConfig` (blockstore)
* `Wrong version in Assign Volume` (blockstore)
* `Wrong version in config` (filestore)

We may use just `Wrong version in` in order to unify all of these messages.

#2100 