### PR TITLE
[merge to stable] issue-1285: fix missing StartedTs initialization for requestInfo in `Flush`, `CollectGarbage` and `Cleanup`, report readblob operation once event for multiple blobs in service sensors

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2031,9 +2031,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         {
             auto subgroup = counters->FindSubgroup("request", "ReadBlob");
             UNIT_ASSERT(subgroup);
-            // 1MB = 4 blobs of 256KB. Read is performed thrice
+            // Read is performed thrice
             UNIT_ASSERT_VALUES_EQUAL(
-                12,
+                3,
                 subgroup->GetCounter("Count")->GetAtomic());
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -70,6 +70,7 @@ void TIndexTabletActor::HandleCleanup(
         ev->Sender,
         ev->Cookie,
         msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
 
     ExecuteTx<TCleanup>(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -438,6 +438,7 @@ void TIndexTabletActor::HandleCollectGarbage(
         ev->Sender,
         ev->Cookie,
         msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
 
     auto channels = GetChannels(EChannelDataKind::Mixed);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -364,6 +364,7 @@ void TIndexTabletActor::HandleFlush(
         ev->Sender,
         ev->Cookie,
         msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
 
     AcquireCollectBarrier(commitId);
 


### PR DESCRIPTION
08b9327 cb2b10b