### PR TITLE
Revert "issue-2100: make blockstore SS proxy error handling consistent with filestore SS proxy (to unlock the possibility of unification of the common part of these two implementations) (#2101)

### DIFF
--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -134,10 +134,18 @@ void TModifySchemeActor::HandleStatus(
                 break;
             }
 
+            ui32 errorCode = MAKE_SCHEMESHARD_ERROR(SchemeShardStatus);
+
+            if (SchemeShardStatus == NKikimrScheme::StatusMultipleModifications ||
+                SchemeShardStatus == NKikimrScheme::StatusNotAvailable)
+            {
+                errorCode = E_REJECTED;
+            }
+
             ReplyAndDie(
                 ctx,
                 MakeError(
-                    MAKE_SCHEMESHARD_ERROR(SchemeShardStatus),
+                    errorCode,
                     (TStringBuilder()
                         << NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).data()
                         << " failed with reason: "
@@ -178,8 +186,9 @@ void TModifySchemeActor::HandleStatus(
 
             ReplyAndDie(
                 ctx,
-                MakeError(MAKE_TXPROXY_ERROR(status), TStringBuilder()
-                    << "TxProxy failed: " << status));
+                TranslateTxProxyError(
+                    MakeError(MAKE_TXPROXY_ERROR(status), TStringBuilder()
+                        << "TxProxy failed: " << status)));
             break;
     }
 }


### PR DESCRIPTION
This reverts commit 227be9d7f957a60be1ab62735de3eed88e64250f which breaks two Disk Manager tests https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/PR-check/10998469280/1/nebius-x86-64/summary/ya-test.html#FAIL