### PR TITLE
issue-2100: introduce cloud/storage/core/libs/ss_proxy lib - later it will be used to unify blockstore & filestore SS proxy common part

### DIFF
--- a/cloud/storage/core/libs/api/ss_proxy.cpp
+++ b/cloud/storage/core/libs/api/ss_proxy.cpp
@@ -1,0 +1,1 @@
+#include "ss_proxy.h"

--- a/cloud/storage/core/libs/api/ss_proxy.h
+++ b/cloud/storage/core/libs/api/ss_proxy.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/kikimr/components.h>
+#include <cloud/storage/core/libs/kikimr/events.h>
+
+#include <contrib/ydb/core/protos/flat_tx_scheme.pb.h>
+#include <contrib/ydb/core/protos/flat_scheme_op.pb.h>
+
+#include <contrib/ydb/library/actors/core/actorid.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define STORAGE_SS_PROXY_REQUESTS(xxx, ...)                                    \
+    xxx(DescribeScheme,     __VA_ARGS__)                                       \
+    xxx(ModifyScheme,       __VA_ARGS__)                                       \
+    xxx(WaitSchemeTx,       __VA_ARGS__)                                       \
+// STORAGE_SS_PROXY_REQUESTS
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TEvSSProxy
+{
+    //
+    // DescribeScheme
+    //
+
+    struct TDescribeSchemeRequest
+    {
+        const TString Path;
+
+        TDescribeSchemeRequest(TString path)
+            : Path(std::move(path))
+        {}
+    };
+
+    struct TDescribeSchemeResponse
+    {
+        const TString Path;
+        const NKikimrSchemeOp::TPathDescription PathDescription;
+
+        TDescribeSchemeResponse() = default;
+
+        TDescribeSchemeResponse(
+                TString path,
+                NKikimrSchemeOp::TPathDescription pathDescription)
+            : Path(std::move(path))
+            , PathDescription(std::move(pathDescription))
+        {}
+    };
+
+    //
+    // ModifyScheme
+    //
+
+    struct TModifySchemeRequest
+    {
+        const NKikimrSchemeOp::TModifyScheme ModifyScheme;
+
+        TModifySchemeRequest(
+                NKikimrSchemeOp::TModifyScheme modifyScheme)
+            : ModifyScheme(std::move(modifyScheme))
+        {}
+    };
+
+    struct TModifySchemeResponse
+    {
+        const ui64 SchemeShardTabletId;
+        const NKikimrScheme::EStatus Status;
+        const TString Reason;
+
+        TModifySchemeResponse(
+                ui64 schemeShardTabletId = 0,
+                NKikimrScheme::EStatus status = NKikimrScheme::StatusSuccess,
+                TString reason = TString())
+            : SchemeShardTabletId(schemeShardTabletId)
+            , Status(status)
+            , Reason(std::move(reason))
+        {}
+    };
+
+    //
+    // WaitSchemeTx
+    //
+
+    struct TWaitSchemeTxRequest
+    {
+        const ui64 SchemeShardTabletId;
+        const ui64 TxId;
+
+        TWaitSchemeTxRequest(
+                ui64 schemeShardTabletId,
+                ui64 txId)
+            : SchemeShardTabletId(schemeShardTabletId)
+            , TxId(txId)
+        {}
+    };
+
+    struct TWaitSchemeTxResponse
+    {
+    };
+
+    //
+    // Events declaration
+    //
+
+    enum EEvents
+    {
+        EvBegin = TStorageEvents::SS_PROXY_START,
+
+        EvDescribeSchemeRequest = EvBegin + 1,
+        EvDescribeSchemeResponse = EvBegin + 2,
+
+        EvModifySchemeRequest = EvBegin + 3,
+        EvModifySchemeResponse = EvBegin + 4,
+
+        EvWaitSchemeTxRequest = EvBegin + 5,
+        EvWaitSchemeTxResponse = EvBegin + 6,
+
+        EvEnd
+    };
+
+    static_assert(EvEnd < (int)TStorageEvents::SS_PROXY_END,
+        "EvEnd expected to be < TStorageEvents::SS_PROXY_END");
+
+    STORAGE_SS_PROXY_REQUESTS(STORAGE_DECLARE_EVENTS)
+};
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/api/ya.make
+++ b/cloud/storage/core/libs/api/ya.make
@@ -3,13 +3,16 @@ LIBRARY()
 SRCS(
     authorizer.cpp
     hive_proxy.cpp
+    ss_proxy.cpp
     user_stats.cpp
 )
 
 PEERDIR(
     cloud/storage/core/libs/kikimr
-    contrib/ydb/library/actors/core
+
     contrib/ydb/core/base
+
+    contrib/ydb/library/actors/core
 )
 
 END()

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
@@ -4,8 +4,8 @@
 
 #include "hive_proxy_events_private.h"
 
-#include <cloud/storage/core/libs/kikimr/helpers.h>
 #include <cloud/storage/core/libs/api/hive_proxy.h>
+#include <cloud/storage/core/libs/kikimr/helpers.h>
 
 #include <contrib/ydb/core/base/hive.h>
 #include <contrib/ydb/core/mind/local.h>

--- a/cloud/storage/core/libs/kikimr/components.h
+++ b/cloud/storage/core/libs/kikimr/components.h
@@ -15,6 +15,7 @@ namespace NCloud {
 
 #define STORAGE_ACTORS(xxx)                                                    \
     xxx(HIVE_PROXY)                                                            \
+    xxx(SS_PROXY)                                                              \
 // STORAGE_ACTORS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/ss_proxy/public.h
+++ b/cloud/storage/core/libs/ss_proxy/public.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor.cpp
@@ -1,0 +1,100 @@
+#include "ss_proxy_actor.h"
+
+namespace NCloud::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NSchemeShard;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSSProxyActor::TSSProxyActor(
+        int logComponent,
+        TString schemeShardDir,
+        NKikimr::NTabletPipe::TClientConfig pipeClientConfig)
+    : TActor(&TThis::StateWork)
+    , LogComponent(logComponent)
+    , SchemeShardDir(schemeShardDir)
+    , ClientCache(NTabletPipe::CreateUnboundedClientCache(pipeClientConfig))
+{}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TSSProxyActor::HandleConnect(
+    TEvTabletPipe::TEvClientConnected::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    if (!ClientCache->OnConnect(ev)) {
+        auto error = MakeKikimrError(msg->Status, TStringBuilder()
+            << "Connect to schemeshard " << msg->TabletId << " failed");
+
+        OnConnectionError(ctx, error, msg->TabletId);
+    }
+}
+
+void TSSProxyActor::HandleDisconnect(
+    TEvTabletPipe::TEvClientDestroyed::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    ClientCache->OnDisconnect(ev);
+
+    auto error = MakeError(E_REJECTED, TStringBuilder()
+        << "Disconnected from schemeshard " << msg->TabletId);
+
+    OnConnectionError(ctx, error, msg->TabletId);
+}
+
+void TSSProxyActor::OnConnectionError(
+    const TActorContext& ctx,
+    const NProto::TError& error,
+    ui64 schemeShard)
+{
+    Y_UNUSED(error);
+
+    // SchemeShard is a tablet, so it should eventually get up
+    // Re-send all outstanding requests
+    if (auto* state = SchemeShardStates.FindPtr(schemeShard)) {
+        for (const auto& kv : state->TxToRequests) {
+            ui64 txId = kv.first;
+            SendWaitTxRequest(ctx, schemeShard, txId);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TSSProxyActor::HandleRequests(STFUNC_SIG)
+{
+    switch (ev->GetTypeRewrite()) {
+        STORAGE_SS_PROXY_REQUESTS(STORAGE_HANDLE_REQUEST, TEvSSProxy)
+
+        default:
+            return false;
+    }
+
+    return true;
+}
+
+STFUNC(TSSProxyActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvTabletPipe::TEvClientConnected, HandleConnect);
+        HFunc(TEvTabletPipe::TEvClientDestroyed, HandleDisconnect);
+
+        HFunc(TEvSchemeShard::TEvNotifyTxCompletionRegistered, HandleTxRegistered);
+        HFunc(TEvSchemeShard::TEvNotifyTxCompletionResult, HandleTxResult);
+
+        default:
+            if (!HandleRequests(ev)) {
+                HandleUnexpectedEvent(ev, LogComponent);
+            }
+            break;
+    }
+}
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor.h
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/api/ss_proxy.h>
+#include <cloud/storage/core/libs/kikimr/helpers.h>
+
+#include <contrib/ydb/core/tablet/tablet_pipe_client_cache.h>
+#include <contrib/ydb/core/tx/schemeshard/schemeshard.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/deque.h>
+
+namespace NCloud::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSSProxyActor final
+    : public NActors::TActor<TSSProxyActor>
+{
+public:
+    struct TRequestInfo
+    {
+        NActors::TActorId Sender;
+        ui64 Cookie = 0;
+
+        TRequestInfo() = default;
+        TRequestInfo(const TRequestInfo&) = default;
+        TRequestInfo& operator=(const TRequestInfo&) = default;
+
+        TRequestInfo(NActors::TActorId sender, ui64 cookie)
+            : Sender(sender)
+            , Cookie(cookie)
+        {}
+    };
+
+private:
+    struct TSchemeShardState
+    {
+        NActors::TActorId ReplyProxy;
+        THashMap<ui64, TDeque<TRequestInfo>> TxToRequests;
+    };
+
+private:
+    const int LogComponent;
+    const TString SchemeShardDir;
+
+    std::unique_ptr<NKikimr::NTabletPipe::IClientCache> ClientCache;
+    THashMap<ui64, TSchemeShardState> SchemeShardStates;
+
+public:
+    TSSProxyActor(
+        int logComponent,
+        TString schemeShardDir,
+        NKikimr::NTabletPipe::TClientConfig pipeClientConfig);
+
+private:
+    void SendWaitTxRequest(
+        const NActors::TActorContext& ctx,
+        ui64 schemeShard,
+        ui64 txId);
+
+    void OnConnectionError(
+        const NActors::TActorContext& ctx,
+        const NProto::TError& error,
+        ui64 schemeShard);
+
+private:
+    void HandleConnect(
+        NKikimr::TEvTabletPipe::TEvClientConnected::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleDisconnect(
+        NKikimr::TEvTabletPipe::TEvClientDestroyed::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleTxRegistered(
+        const NKikimr::NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionRegistered::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleTxResult(
+        const NKikimr::NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    bool HandleRequests(STFUNC_SIG);
+
+    STORAGE_SS_PROXY_REQUESTS(STORAGE_IMPLEMENT_REQUEST, TEvSSProxy)
+
+    STFUNC(StateWork);
+};
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -1,0 +1,153 @@
+#include "ss_proxy_actor.h"
+
+#include <contrib/ydb/core/tx/tx_proxy/proxy.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+namespace NCloud::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NSchemeShard;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDescribeSchemeActor final
+    : public TActorBootstrapped<TDescribeSchemeActor>
+{
+private:
+    const int LogComponent;
+    const TSSProxyActor::TRequestInfo RequestInfo;
+
+    const TString SchemeShardDir;
+    const TString Path;
+
+public:
+    TDescribeSchemeActor(
+        int logComponent,
+        TSSProxyActor::TRequestInfo requestInfo,
+        TString schemeShardDir,
+        TString path);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void DescribeScheme(const TActorContext& ctx);
+
+    bool HandleError(const TActorContext& ctx, const NProto::TError& error);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        std::unique_ptr<TEvSSProxy::TEvDescribeSchemeResponse> response);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleDescribeSchemeResult(
+        const TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDescribeSchemeActor::TDescribeSchemeActor(
+        int logComponent,
+        TSSProxyActor::TRequestInfo requestInfo,
+        TString schemeShardDir,
+        TString path)
+    : LogComponent(logComponent)
+    , RequestInfo(std::move(requestInfo))
+    , SchemeShardDir(std::move(schemeShardDir))
+    , Path(std::move(path))
+{}
+
+void TDescribeSchemeActor::Bootstrap(const TActorContext& ctx)
+{
+    DescribeScheme(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TDescribeSchemeActor::DescribeScheme(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvTxUserProxy::TEvNavigate>();
+    request->Record.MutableDescribePath()->SetPath(Path);
+    request->Record.SetDatabaseName(SchemeShardDir);
+
+    NCloud::Send(ctx, MakeTxProxyID(), std::move(request));
+}
+
+bool TDescribeSchemeActor::HandleError(
+    const TActorContext& ctx,
+    const NProto::TError& error)
+{
+    if (FAILED(error.GetCode())) {
+        ReplyAndDie(
+            ctx,
+            std::make_unique<TEvSSProxy::TEvDescribeSchemeResponse>(error));
+        return true;
+    }
+    return false;
+}
+
+void TDescribeSchemeActor::ReplyAndDie(
+    const TActorContext& ctx,
+    std::unique_ptr<TEvSSProxy::TEvDescribeSchemeResponse> response)
+{
+    NCloud::Reply(ctx, RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDescribeSchemeActor::HandleDescribeSchemeResult(
+    const TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    const auto& record = msg->GetRecord();
+
+    if (HandleError(ctx, MakeSchemeShardError(record.GetStatus(), record.GetReason()))) {
+        return;
+    }
+
+    auto response = std::make_unique<TEvSSProxy::TEvDescribeSchemeResponse>(
+        record.GetPath(),
+        record.GetPathDescription());
+
+    ReplyAndDie(ctx, std::move(response));
+}
+
+STFUNC(TDescribeSchemeActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvSchemeShard::TEvDescribeSchemeResult, HandleDescribeSchemeResult);
+
+        default:
+            HandleUnexpectedEvent(ev, LogComponent);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TSSProxyActor::HandleDescribeScheme(
+    const TEvSSProxy::TEvDescribeSchemeRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    NCloud::Register(
+        ctx,
+        std::make_unique<TDescribeSchemeActor>(
+            LogComponent,
+            TRequestInfo(ev->Sender, ev->Cookie),
+            SchemeShardDir,
+            msg->Path));
+}
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -1,0 +1,270 @@
+#include "ss_proxy_actor.h"
+
+#include <contrib/ydb/core/tx/tx_proxy/proxy.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+namespace NCloud::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NSchemeShard;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError GetErrorFromPreconditionFailed(const NProto::TError& error)
+{
+    NProto::TError result = error;
+    const auto& msg = error.GetMessage();
+
+    if (msg.Contains("Wrong version in")) {
+        // ConfigVersion is different from current one in SchemeShard
+        // return E_ABORTED to client to read
+        // updated config (Stat FS) and issue new request
+        result.SetCode(E_ABORTED);
+        result.SetMessage("Config version mismatch");
+    } else if (msg.Contains("path version mistmach")) {
+        // Just path version mismatch. Return E_REJECTED
+        // so durable client will retry request
+        result.SetCode(E_REJECTED);
+    }
+
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TModifySchemeActor final
+    : public TActorBootstrapped<TModifySchemeActor>
+{
+private:
+    const int LogComponent;
+    const TSSProxyActor::TRequestInfo RequestInfo;
+    const TActorId Owner;
+    const NKikimrSchemeOp::TModifyScheme ModifyScheme;
+
+    ui64 TxId = 0;
+    ui64 SchemeShardTabletId = 0;
+    NKikimrScheme::EStatus SchemeShardStatus = NKikimrScheme::StatusSuccess;
+    TString SchemeShardReason;
+
+public:
+    TModifySchemeActor(
+        int logComponent,
+        TSSProxyActor::TRequestInfo requestInfo,
+        const TActorId& owner,
+        NKikimrSchemeOp::TModifyScheme modifyScheme);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleStatus(
+        const TEvTxUserProxy::TEvProposeTransactionStatus::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleTxDone(
+        const TEvSSProxy::TEvWaitSchemeTxResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        NProto::TError error = NProto::TError());
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TModifySchemeActor::TModifySchemeActor(
+        int logComponent,
+        TSSProxyActor::TRequestInfo requestInfo,
+        const TActorId& owner,
+        NKikimrSchemeOp::TModifyScheme modifyScheme)
+    : LogComponent(logComponent)
+    , RequestInfo(std::move(requestInfo))
+    , Owner(owner)
+    , ModifyScheme(std::move(modifyScheme))
+{}
+
+void TModifySchemeActor::Bootstrap(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
+
+    auto* tx = request->Record.MutableTransaction();
+    tx->MutableModifyScheme()->CopyFrom(ModifyScheme);
+
+    NCloud::Send(ctx, MakeTxProxyID(), std::move(request));
+
+    Become(&TThis::StateWork);
+}
+
+void TModifySchemeActor::HandleStatus(
+    const TEvTxUserProxy::TEvProposeTransactionStatus::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto& record = ev->Get()->Record;
+
+    TxId = record.GetTxId();
+    SchemeShardTabletId = record.GetSchemeShardTabletId();
+    SchemeShardStatus = (NKikimrScheme::EStatus) record.GetSchemeShardStatus();
+    SchemeShardReason = record.GetSchemeShardReason();
+
+    auto status = (TEvTxUserProxy::TEvProposeTransactionStatus::EStatus) record.GetStatus();
+    switch (status) {
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete:
+            LOG_DEBUG(ctx, LogComponent,
+                "Request %s with TxId# %lu completed immediately",
+                NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
+                TxId);
+
+            ReplyAndDie(ctx);
+            break;
+
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress: {
+            LOG_DEBUG(ctx, LogComponent,
+                "Request %s with TxId# %lu in progress, waiting for completion",
+                NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
+                TxId);
+
+            auto request = std::make_unique<TEvSSProxy::TEvWaitSchemeTxRequest>(
+                SchemeShardTabletId,
+                TxId);
+
+            NCloud::Send(ctx, Owner, std::move(request));
+            break;
+        }
+
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecError:
+            LOG_DEBUG(ctx, LogComponent,
+                "Request %s with TxId# %lu failed with status %s",
+                NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
+                TxId,
+                NKikimrScheme::EStatus_Name(SchemeShardStatus).c_str());
+
+            if (SchemeShardStatus == NKikimrScheme::StatusMultipleModifications &&
+                (record.GetPathCreateTxId() != 0 || record.GetPathDropTxId() != 0))
+            {
+                ui64 txId = record.GetPathCreateTxId() != 0 ? record.GetPathCreateTxId() : record.GetPathDropTxId();
+                LOG_DEBUG(ctx, LogComponent,
+                    "Waiting for a different TxId# %lu", txId);
+
+                auto request = std::make_unique<TEvSSProxy::TEvWaitSchemeTxRequest>(
+                    SchemeShardTabletId,
+                    txId);
+
+                NCloud::Send(ctx, Owner, std::move(request));
+                break;
+            }
+
+            ReplyAndDie(
+                ctx,
+                MakeError(
+                    MAKE_SCHEMESHARD_ERROR(SchemeShardStatus),
+                    (TStringBuilder()
+                        << NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str()
+                        << " failed with reason: "
+                        << (SchemeShardReason.empty() ?
+                            NKikimrScheme::EStatus_Name(SchemeShardStatus).c_str()
+                            :SchemeShardReason))));
+            break;
+
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError:
+            if (SchemeShardStatus == NKikimrScheme::StatusPathDoesNotExist) {
+                LOG_DEBUG(ctx, LogComponent,
+                    "Request %s failed to resolve parent path",
+                    NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str());
+
+                ReplyAndDie(
+                    ctx,
+                    MakeError(
+                        MAKE_SCHEMESHARD_ERROR(SchemeShardStatus),
+                        (TStringBuilder()
+                            << NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str()
+                            << " failed with reason: "
+                            << (SchemeShardReason.empty() ?
+                                NKikimrScheme::EStatus_Name(SchemeShardStatus).c_str()
+                                                          :SchemeShardReason))));
+                break;
+            }
+
+            /* fall through */
+
+        default:
+            LOG_DEBUG(ctx, LogComponent,
+                "Request %s to tx_proxy failed with code %u",
+                NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
+                status);
+
+            ReplyAndDie(
+                ctx,
+                MakeError(MAKE_TXPROXY_ERROR(status), TStringBuilder()
+                    << "TxProxy failed: " << status));
+            break;
+    }
+}
+
+void TModifySchemeActor::HandleTxDone(
+    const TEvSSProxy::TEvWaitSchemeTxResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    LOG_DEBUG(ctx, LogComponent,
+        "TModifySchemeActor received TEvWaitSchemeTxResponse");
+
+    ReplyAndDie(ctx, msg->GetError());
+}
+
+void TModifySchemeActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TError error)
+{
+    if (SchemeShardStatus == NKikimrScheme::StatusPreconditionFailed) {
+        error = GetErrorFromPreconditionFailed(error);
+    }
+
+    auto response = std::make_unique<TEvSSProxy::TEvModifySchemeResponse>(
+        error,
+        SchemeShardTabletId,
+        SchemeShardStatus,
+        SchemeShardReason);
+
+    NCloud::Reply(ctx, RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+STFUNC(TModifySchemeActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvTxUserProxy::TEvProposeTransactionStatus, HandleStatus);
+        HFunc(TEvSSProxy::TEvWaitSchemeTxResponse, HandleTxDone);
+
+        default:
+            HandleUnexpectedEvent(ev, LogComponent);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TSSProxyActor::HandleModifyScheme(
+    const TEvSSProxy::TEvModifySchemeRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    NCloud::Register(
+        ctx,
+        std::make_unique<TModifySchemeActor>(
+            LogComponent,
+            TRequestInfo(ev->Sender, ev->Cookie),
+            ctx.SelfID,
+            msg->ModifyScheme));
+}
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_waitschemetx.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_waitschemetx.cpp
@@ -1,0 +1,169 @@
+#include "ss_proxy_actor.h"
+
+namespace NCloud::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NSchemeShard;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TReplyProxyActor final
+    : public TActor<TReplyProxyActor>
+{
+private:
+    const int LogComponent;
+    const TActorId Owner;
+    const ui64 TabletId;
+
+public:
+    TReplyProxyActor(
+            int logComponent,
+            const TActorId& owner,
+            const ui64 tabletId)
+        : TActor(&TThis::StateWork)
+        , LogComponent(logComponent)
+        , Owner(owner)
+        , TabletId(tabletId)
+    {}
+
+private:
+    STFUNC(StateWork);
+
+    void Handle(
+        const TEvSchemeShard::TEvNotifyTxCompletionRegistered::TPtr& ev,
+        const TActorContext& ctx);
+
+    void Handle(
+        const TEvSchemeShard::TEvNotifyTxCompletionResult::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TReplyProxyActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvSchemeShard::TEvNotifyTxCompletionRegistered, Handle);
+        HFunc(TEvSchemeShard::TEvNotifyTxCompletionResult, Handle);
+
+        default:
+            HandleUnexpectedEvent(ev, LogComponent);
+            break;
+    }
+}
+
+void TReplyProxyActor::Handle(
+    const TEvSchemeShard::TEvNotifyTxCompletionRegistered::TPtr& ev,
+    const TActorContext& ctx)
+{
+    // Send response to owner with the correct cookie
+    ctx.Send(Owner, ev->Release().Release(), 0, TabletId);
+}
+
+void TReplyProxyActor::Handle(
+    const TEvSchemeShard::TEvNotifyTxCompletionResult::TPtr& ev,
+    const TActorContext& ctx)
+{
+    // Send response to owner with the correct cookie
+    ctx.Send(Owner, ev->Release().Release(), 0, TabletId);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TSSProxyActor::HandleWaitSchemeTx(
+    const TEvSSProxy::TEvWaitSchemeTxRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    auto& state = SchemeShardStates[msg->SchemeShardTabletId];
+    auto& requests = state.TxToRequests[msg->TxId];
+
+    requests.emplace_back(TRequestInfo(ev->Sender, ev->Cookie));
+
+    if (requests.size() == 1) {
+        // This is the first request for this tabletId/txId
+        SendWaitTxRequest(ctx, msg->SchemeShardTabletId, msg->TxId);
+    }
+}
+
+void TSSProxyActor::SendWaitTxRequest(
+    const TActorContext& ctx,
+    ui64 schemeShard,
+    ui64 txId)
+{
+    auto& state = SchemeShardStates[schemeShard];
+    if (!state.ReplyProxy) {
+        LOG_DEBUG(ctx, LogComponent,
+            "Creating reply proxy actor for schemeshard %lu",
+            schemeShard);
+
+        state.ReplyProxy = NCloud::Register(
+            ctx,
+            std::make_unique<TReplyProxyActor>(
+                LogComponent,
+                ctx.SelfID,
+                schemeShard));
+    }
+
+    LOG_DEBUG(ctx, LogComponent,
+        "Sending NotifyTxCompletion to %lu for txId# %lu",
+        schemeShard,
+        txId);
+
+    TActorId clientId = ClientCache->Prepare(ctx, schemeShard);
+    NTabletPipe::SendData(
+        ctx.MakeFor(state.ReplyProxy),
+        clientId,
+        new TEvSchemeShard::TEvNotifyTxCompletion(txId));
+}
+
+void TSSProxyActor::HandleTxRegistered(
+    const TEvSchemeShard::TEvNotifyTxCompletionRegistered::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ui64 schemeShard = ev->Cookie;
+
+    const auto* msg = ev->Get();
+    ui64 txId = msg->Record.GetTxId();
+
+    LOG_DEBUG(ctx, LogComponent,
+        "Received NotifyTxCompletionRegistered from %lu for txId# %lu",
+        schemeShard,
+        txId);
+}
+
+void TSSProxyActor::HandleTxResult(
+    const TEvSchemeShard::TEvNotifyTxCompletionResult::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ui64 schemeShard = ev->Cookie;
+    auto& state = SchemeShardStates[schemeShard];
+
+    const auto* msg = ev->Get();
+    ui64 txId = msg->Record.GetTxId();
+
+    LOG_DEBUG(ctx, LogComponent,
+        "Received NotifyTxCompletionResult from %lu for txId# %lu",
+        schemeShard,
+        txId);
+
+    auto it = state.TxToRequests.find(txId);
+    if (it != state.TxToRequests.end()) {
+        for (const auto& request : it->second) {
+            NCloud::Reply(
+                ctx,
+                request,
+                std::make_unique<TEvSSProxy::TEvWaitSchemeTxResponse>());
+        }
+        state.TxToRequests.erase(it);
+    }
+}
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ya.make
+++ b/cloud/storage/core/libs/ss_proxy/ya.make
@@ -1,0 +1,22 @@
+LIBRARY()
+
+SRCS(
+    ss_proxy_actor.cpp
+    ss_proxy_actor_describescheme.cpp
+    ss_proxy_actor_modifyscheme.cpp
+    ss_proxy_actor_waitschemetx.cpp
+)
+
+PEERDIR(
+    cloud/storage/core/libs/api
+    cloud/storage/core/libs/kikimr
+
+    contrib/ydb/core/base
+    contrib/ydb/core/tablet
+    contrib/ydb/core/tx/schemeshard
+    contrib/ydb/core/tx/tx_proxy
+
+    contrib/ydb/library/actors/core
+)
+
+END()

--- a/cloud/storage/core/libs/ya.make
+++ b/cloud/storage/core/libs/ya.make
@@ -13,6 +13,7 @@ RECURSE(
     hive_proxy
     http
     kikimr
+    ss_proxy
     tablet
     throttling
     uds


### PR DESCRIPTION
Copy-pasted (and reworked) from https://github.com/ydb-platform/nbs/tree/9c55e94fe6c15e716bd540f03bc17a9abd579828/cloud/filestore/libs/storage/ss_proxy