### PR TITLE
Handle migration partition non-retriable errors separately

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h
@@ -26,35 +26,41 @@ class TMirrorRequestActor final
     : public NActors::TActorBootstrapped<TMirrorRequestActor<TMethod>>
 {
 private:
+    using TBase = NActors::TActorBootstrapped<TMirrorRequestActor<TMethod>>;
+    using TResponseProto = typename TMethod::TResponse::ProtoRecordType;
+
     const TRequestInfoPtr RequestInfo;
-    const TVector<NActors::TActorId> Partitions;
+    const TVector<NActors::TActorId> LeaderPartitions;
+    const NActors::TActorId FollowerPartition;
     const typename TMethod::TRequest::ProtoRecordType Request;
     const TString DiskId;
     const NActors::TActorId ParentActorId;
     const ui64 NonreplicatedRequestCounter;
-    const bool ShouldProcessError;
 
     TVector<TCallContextPtr> ForkedCallContexts;
     ui32 Responses = 0;
-    typename TMethod::TResponse::ProtoRecordType Record;
-
-    using TBase = NActors::TActorBootstrapped<TMirrorRequestActor<TMethod>>;
+    TResponseProto LeadersCollectiveResponse;
+    TResponseProto FollowerResponse;
 
 public:
     TMirrorRequestActor(
         TRequestInfoPtr requestInfo,
-        TVector<NActors::TActorId> partitions,
+        TVector<NActors::TActorId> leaderPartitions,
+        NActors::TActorId followerPartition,
         typename TMethod::TRequest::ProtoRecordType request,
         TString diskId,
         NActors::TActorId parentActorId,
-        ui64 nonreplicatedRequestCounter,
-        bool shouldProcessError);
+        ui64 nonreplicatedRequestCounter);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
 private:
     void SendRequests(const NActors::TActorContext& ctx);
     void Done(const NActors::TActorContext& ctx);
+    size_t GetTotalPartitionCount() const;
+    void UpdateResponse(
+        const NActors::TActorId& sender,
+        TResponseProto&& response);
 
 private:
     STFUNC(StateWork);
@@ -77,19 +83,19 @@ private:
 template <typename TMethod>
 TMirrorRequestActor<TMethod>::TMirrorRequestActor(
         TRequestInfoPtr requestInfo,
-        TVector<NActors::TActorId> partitions,
+        TVector<NActors::TActorId> leaderPartitions,
+        NActors::TActorId followerPartition,
         typename TMethod::TRequest::ProtoRecordType request,
         TString diskId,
         NActors::TActorId parentActorId,
-        ui64 nonreplicatedRequestCounter,
-        bool shouldProcessError)
+        ui64 nonreplicatedRequestCounter)
     : RequestInfo(std::move(requestInfo))
-    , Partitions(std::move(partitions))
+    , LeaderPartitions(std::move(leaderPartitions))
+    , FollowerPartition(followerPartition)
     , Request(std::move(request))
     , DiskId(std::move(diskId))
     , ParentActorId(parentActorId)
     , NonreplicatedRequestCounter(nonreplicatedRequestCounter)
-    , ShouldProcessError(shouldProcessError)
 {}
 
 template <typename TMethod>
@@ -111,7 +117,7 @@ void TMirrorRequestActor<TMethod>::Bootstrap(const NActors::TActorContext& ctx)
 template <typename TMethod>
 void TMirrorRequestActor<TMethod>::SendRequests(const NActors::TActorContext& ctx)
 {
-    for (const auto& actorId: Partitions) {
+    auto sendRequest = [&](const NActors::TActorId& actorId) {
         auto request = std::make_unique<typename TMethod::TRequest>();
         auto& callContext = *RequestInfo->CallContext;
         if (!callContext.LWOrbit.Fork(request->CallContext->LWOrbit)) {
@@ -134,14 +140,32 @@ void TMirrorRequestActor<TMethod>::SendRequests(const NActors::TActorContext& ct
         );
 
         ctx.Send(std::move(event));
+    };
+
+    for (const auto& actorId: LeaderPartitions) {
+        sendRequest(actorId);
+    }
+    if (FollowerPartition) {
+        sendRequest(FollowerPartition);
     }
 }
 
 template <typename TMethod>
 void TMirrorRequestActor<TMethod>::Done(const NActors::TActorContext& ctx)
 {
+    const bool hasFollower = FollowerPartition != NActors::TActorId();
+    const bool isFollowerResponseError =
+        hasFollower && HasError(FollowerResponse);
+    const bool isFollowerResponseFatal =
+        isFollowerResponseError &&
+        GetErrorKind(FollowerResponse.GetError()) == EErrorKind::ErrorFatal;
+
+    if (isFollowerResponseError && !isFollowerResponseFatal) {
+        UpdateResponse({}, std::move(FollowerResponse));
+    }
+
     auto response = std::make_unique<typename TMethod::TResponse>();
-    response->Record = std::move(Record);
+    response->Record = std::move(LeadersCollectiveResponse);
 
     auto& callContext = *RequestInfo->CallContext;
     for (auto& cc: ForkedCallContexts) {
@@ -156,16 +180,42 @@ void TMirrorRequestActor<TMethod>::Done(const NActors::TActorContext& ctx)
 
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 
-    using TCompletion =
-        TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted;
     auto completion =
-        std::make_unique<TCompletion>(
+        std::make_unique<TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted>(
             NonreplicatedRequestCounter,
-            RequestInfo->GetTotalCycles());
-
+            RequestInfo->GetTotalCycles(),
+            isFollowerResponseFatal);
     NCloud::Send(ctx, ParentActorId, std::move(completion));
 
     TBase::Die(ctx);
+}
+
+template <typename TMethod>
+size_t TMirrorRequestActor<TMethod>::GetTotalPartitionCount() const
+{
+    const bool hasFollower = FollowerPartition != NActors::TActorId();
+    return LeaderPartitions.size() + (hasFollower ? 1 : 0);
+}
+
+template <typename TMethod>
+void TMirrorRequestActor<TMethod>::UpdateResponse(
+    const NActors::TActorId& sender,
+    TResponseProto&& response)
+{
+    if (sender == FollowerPartition) {
+        FollowerResponse = std::move(response);
+        return;
+    }
+
+    const bool hasFollower = FollowerPartition != NActors::TActorId();
+
+    if (!hasFollower) {
+        ProcessMirrorActorError(*response.MutableError());
+    }
+
+    if (!HasError(LeadersCollectiveResponse)) {
+        LeadersCollectiveResponse = std::move(response);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -182,10 +232,12 @@ void TMirrorRequestActor<TMethod>::HandleUndelivery(
         DiskId.c_str(),
         TMethod::Name);
 
-    Record.MutableError()->CopyFrom(MakeError(E_REJECTED, TStringBuilder()
-        << TMethod::Name << " request undelivered to some nonrepl partitions"));
+    LeadersCollectiveResponse.MutableError()->CopyFrom(MakeError(
+        E_REJECTED,
+        TStringBuilder() << TMethod::Name
+                         << " request undelivered to some nonrepl partitions"));
 
-    if (++Responses < Partitions.size()) {
+    if (++Responses < GetTotalPartitionCount()) {
         return;
     }
 
@@ -207,15 +259,9 @@ void TMirrorRequestActor<TMethod>::HandleResponse(
             FormatError(msg->Record.GetError()).c_str());
     }
 
-    if (ShouldProcessError) {
-        ProcessMirrorActorError(*msg->Record.MutableError());
-    }
+    UpdateResponse(ev->Sender, std::move(msg->Record));
 
-    if (!HasError(Record)) {
-        Record = std::move(msg->Record);
-    }
-
-    if (++Responses < Partitions.size()) {
+    if (++Responses < GetTotalPartitionCount()) {
         return;
     }
 
@@ -229,7 +275,9 @@ void TMirrorRequestActor<TMethod>::HandlePoisonPill(
 {
     Y_UNUSED(ev);
 
-    Record.MutableError()->CopyFrom(MakeError(E_REJECTED, "Dead"));
+    LeadersCollectiveResponse.MutableError()->CopyFrom(
+        MakeError(E_REJECTED, "Dead"));
+
     Done(ctx);
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -78,12 +78,11 @@ void TMirrorPartitionActor::MirrorRequest(
         ctx,
         std::move(requestInfo),
         State.GetReplicaActors(),
+        TActorId{},
         std::move(msg->Record),
         State.GetReplicaInfos()[0].Config->GetName(),
         SelfId(),
-        requestIdentityKey,
-        true // shouldProcessError
-    );
+        requestIdentityKey);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -83,12 +83,15 @@ struct TEvNonreplPartitionPrivate
     {
         ui64 RequestCounter;
         ui64 TotalCycles;
+        bool FollowerGotNonretriableError;
 
         TWriteOrZeroCompleted(
                 ui64 requestCounter,
-                ui64 totalCycles)
+                ui64 totalCycles,
+                bool followerGotNonretriableError)
             : RequestCounter(requestCounter)
             , TotalCycles(totalCycles)
+            , FollowerGotNonretriableError(followerGotNonretriableError)
         {
         }
     };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -83,15 +83,15 @@ struct TEvNonreplPartitionPrivate
     {
         ui64 RequestCounter;
         ui64 TotalCycles;
-        bool FollowerGotNonretriableError;
+        bool FollowerGotNonRetriableError;
 
         TWriteOrZeroCompleted(
                 ui64 requestCounter,
                 ui64 totalCycles,
-                bool followerGotNonretriableError)
+                bool followerGotNonRetriableError)
             : RequestCounter(requestCounter)
             , TotalCycles(totalCycles)
-            , FollowerGotNonretriableError(followerGotNonretriableError)
+            , FollowerGotNonRetriableError(followerGotNonRetriableError)
         {
         }
     };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -92,7 +92,6 @@ void TNonreplicatedPartitionMigrationActor::OnMigrationFinished(
 void TNonreplicatedPartitionMigrationActor::OnMigrationError(
     const NActors::TActorContext& ctx)
 {
-    Y_UNUSED(ctx);
     LOG_ERROR(
         ctx,
         TBlockStoreComponents::PARTITION,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -93,6 +93,11 @@ void TNonreplicatedPartitionMigrationActor::OnMigrationError(
     const NActors::TActorContext& ctx)
 {
     Y_UNUSED(ctx);
+    LOG_ERROR(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Migration failed",
+        SrcConfig->GetName().c_str());
 }
 
 void TNonreplicatedPartitionMigrationActor::OnMigrationProgress(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -212,6 +212,8 @@ private:
     TDuration CalculateMigrationTimeout(TBlockRange64 range) const;
     void DoRegisterTrafficSource(const NActors::TActorContext& ctx);
 
+    void OnMigrationNonRetriableError(const NActors::TActorContext& ctx);
+
 private:
     STFUNC(StateWork);
     STFUNC(StateZombie);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -25,7 +25,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleWriteOrZeroCompleted(
         Y_DEBUG_ABORT_UNLESS(0);
     }
 
-    if (msg->FollowerGotNonretriableError) {
+    if (msg->FollowerGotNonRetriableError) {
         OnMigrationNonRetriableError(ctx);
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -391,7 +391,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         UNIT_ASSERT_VALUES_EQUAL(2, registerSourceCounter);
     }
 
-    Y_UNIT_TEST(ShouldNotFailRequestOnFollowerNonretriableError)
+    Y_UNIT_TEST(ShouldNotFailRequestOnFollowerNonRetriableError)
     {
         TTestBasicRuntime runtime;
 
@@ -429,7 +429,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         UNIT_ASSERT(followerPartition);
 
         // Now we will fail requests to the follower partition with an
-        // nonretriable error. Expect that the client's requests will be
+        // non-retriable error. Expect that the client's requests will be
         // executed successfully, since the leader partition response S_OK, but
         // the migration will be stopped due to errors of follower partition.
         size_t failedPartitionRequestCount = 0;


### PR DESCRIPTION
Класс TMirrorRequestActor используется для двух задач:
1. для записи в 3 реплики для ssd-io3 диска. В таком режиме он должен превращать все ошибки от реплик в "ретрабельные", так как рано или поздно диск агент поднимется и mirroro-3 диски ломаться не умеют.
2. для наливки нового девайса, в этом случае у него две реплики, одна из которой делается наливка, а вторая куда льем. В таком режиме мы не обрабатывали ошибки и могли отдать в клиента E_IO когда проблема была у новой, наливаемой при миграции реплики.

Здесь делается так, что явно указывается какая реплика является "follower". Если такой реплики нет, то все реплики равнозначные и работа идет по сценарию 1.
Если такая реплика есть, то у нас второй сценарий и поведение чуть меняется относительно того что было:
- если получили фатальную ошибку от наливаемой реплики, мы не отвечаем клиенту ошибкой, но при этом останавливаем миграцию.
- если получили не фатальную ошибку, то все остается как  было - отдаем ее клиенту, чтобы он повторил запрос. 