### PR TITLE
issue-1795: backpressure for LargeDeletionMarkers

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -420,4 +420,8 @@ message TStorageConfig
 
     // settings for ydb config dispatcher service.
     optional NCloud.NProto.TConfigDispatcherSettings ConfigDispatcherSettings = 393;
+
+    // If the number of blocks marked for deletion via large deletion markers
+    // exceeds this threshold, large truncate-like operations will be rejected.
+    optional uint64 LargeDeletionMarkersThresholdForBackpressure = 394;
 }

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -22,6 +22,7 @@ namespace NCloud::NFileStore{
     xxx(AsyncDestroyHandleFailed)                                              \
     xxx(DuplicateRequestId)                                                    \
     xxx(InvalidDupCacheEntry)                                                  \
+    xxx(GeneratedOrphanNode)                                                   \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -50,11 +50,12 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(MaxBlocksPerTruncateTx,             ui32,   0 /*TODO: 32GiB/4KiB*/    )\
     xxx(MaxTruncateTxInflight,              ui32,   10                        )\
                                                                                \
-    xxx(MaxFileBlocks,                          ui32,   300_GB / 4_KB         )\
-    xxx(LargeDeletionMarkersEnabled,            bool,   false                 )\
-    xxx(LargeDeletionMarkerBlocks,              ui64,   1_GB / 4_KB           )\
-    xxx(LargeDeletionMarkersThreshold,          ui64,   128_GB / 4_KB         )\
-    xxx(LargeDeletionMarkersCleanupThreshold,   ui64,   1_TB / 4_KB           )\
+    xxx(MaxFileBlocks,                                  ui32,   300_GB / 4_KB )\
+    xxx(LargeDeletionMarkersEnabled,                    bool,   false         )\
+    xxx(LargeDeletionMarkerBlocks,                      ui64,   1_GB / 4_KB   )\
+    xxx(LargeDeletionMarkersThreshold,                  ui64,   128_GB / 4_KB )\
+    xxx(LargeDeletionMarkersCleanupThreshold,           ui64,   1_TB / 4_KB   )\
+    xxx(LargeDeletionMarkersThresholdForBackpressure,   ui64,   10_TB / 4_KB  )\
                                                                                \
     xxx(CompactionRetryTimeout,             TDuration, TDuration::Seconds(1)  )\
     xxx(BlobIndexOpsPriority,                                                  \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -267,6 +267,7 @@ public:
     ui64 GetLargeDeletionMarkerBlocks() const;
     ui64 GetLargeDeletionMarkersThreshold() const;
     ui64 GetLargeDeletionMarkersCleanupThreshold() const;
+    ui64 GetLargeDeletionMarkersThresholdForBackpressure() const;
 
     bool GetMultipleStageRequestThrottlingEnabled() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -151,6 +151,8 @@ private:
         std::atomic<i64> NodesOpenForReadingBySingleSession{0};
         std::atomic<i64> NodesOpenForReadingByMultipleSessions{0};
 
+        std::atomic<i64> OrphanNodesCount{0};
+
         NMetrics::TDefaultWindowCalculator MaxUsedQuota{0};
         using TLatHistogram =
             NMetrics::THistogram<NMetrics::EHistUnit::HU_TIME_MICROSECONDS>;
@@ -216,7 +218,8 @@ private:
             const TChannelsStats& channelsStats,
             const TReadAheadCacheStats& readAheadStats,
             const TNodeIndexCacheStats& nodeIndexCacheStats,
-            const TNodeToSessionCounters& nodeToSessionCounters);
+            const TNodeToSessionCounters& nodeToSessionCounters,
+            const TMiscNodeStats& miscNodeStats);
     } Metrics;
 
     const IProfileLogPtr ProfileLog;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -199,11 +199,15 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
         if (args.CommitId == InvalidCommitId) {
             return RebootTabletOnCommitOverflow(ctx, "AllocateData");
         }
-        ZeroRange(
+        auto e = ZeroRange(
             db,
             args.NodeId,
             args.CommitId,
             TByteRange(args.Offset, minBorder - args.Offset, GetBlockSize()));
+        if (HasError(e)) {
+            args.Error = std::move(e);
+            return;
+        }
     }
 
     if (!needExtend) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -322,6 +322,8 @@ void TIndexTabletActor::TMetrics::Register(
         NodesOpenForReadingByMultipleSessions,
         EMetricType::MT_ABSOLUTE);
 
+    REGISTER_AGGREGATABLE_SUM(OrphanNodesCount, EMetricType::MT_ABSOLUTE);
+
     // Throttling
     REGISTER_LOCAL(MaxReadBandwidth, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(MaxWriteBandwidth, EMetricType::MT_ABSOLUTE);
@@ -400,7 +402,8 @@ void TIndexTabletActor::TMetrics::Update(
     const TChannelsStats& channelsStats,
     const TReadAheadCacheStats& readAheadStats,
     const TNodeIndexCacheStats& nodeIndexCacheStats,
-    const TNodeToSessionCounters& nodeToSessionCounters)
+    const TNodeToSessionCounters& nodeToSessionCounters,
+    const TMiscNodeStats& miscNodeStats)
 {
     const ui32 blockSize = fileSystem.GetBlockSize();
 
@@ -472,6 +475,8 @@ void TIndexTabletActor::TMetrics::Update(
         NodesOpenForReadingByMultipleSessions,
         nodeToSessionCounters.NodesOpenForReadingByMultipleSessions);
 
+    Store(OrphanNodesCount, miscNodeStats.OrphanNodesCount);
+
     BusyIdleCalc.OnUpdateStats();
 }
 
@@ -520,7 +525,8 @@ void TIndexTabletActor::RegisterStatCounters()
         CalculateChannelsStats(),
         CalculateReadAheadCacheStats(),
         CalculateNodeIndexCacheStats(),
-        GetNodeToSessionCounters());
+        GetNodeToSessionCounters(),
+        GetMiscNodeStats());
 
     Metrics.Register(fsId, storageMediaKind);
 }
@@ -566,7 +572,8 @@ void TIndexTabletActor::HandleUpdateCounters(
         CalculateChannelsStats(),
         CalculateReadAheadCacheStats(),
         CalculateNodeIndexCacheStats(),
-        GetNodeToSessionCounters());
+        GetNodeToSessionCounters(),
+        GetMiscNodeStats());
     SendMetricsToExecutor(ctx);
 
     UpdateCountersScheduled = false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -309,12 +309,16 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
     } else if (args.FollowerId.Empty()
         && HasFlag(args.Flags, NProto::TCreateHandleRequest::E_TRUNCATE))
     {
-        Truncate(
+        auto e = Truncate(
             db,
             args.TargetNodeId,
             args.WriteCommitId,
             args.TargetNode->Attrs.GetSize(),
             0);
+        if (HasError(e)) {
+            args.Error = std::move(e);
+            return;
+        }
 
         auto attrs = CopyAttrs(args.TargetNode->Attrs, E_CM_CMTIME);
         attrs.SetSize(0);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -104,11 +104,19 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
     if (args.Node->Attrs.GetLinks() == 0 &&
         !HasOpenHandles(args.Node->NodeId))
     {
-        RemoveNode(
+        auto e = RemoveNode(
             db,
             *args.Node,
             args.Node->MinCommitId,
             commitId);
+
+        if (HasError(e)) {
+            WriteOrphanNode(db, TStringBuilder()
+                << "DestroyHandle: " << args.SessionId
+                << ", Handle: " << args.Request.GetHandle()
+                << ", RemoveNode: " << args.Node->NodeId
+                << ", Error: " << FormatError(e), args.Node->NodeId);
+        }
     }
 
     EnqueueTruncateIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -308,11 +308,18 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
 
         auto it = args.Nodes.find(nodeId);
         if (it != args.Nodes.end() && !HasOpenHandles(nodeId)) {
-            RemoveNode(
+            auto e = RemoveNode(
                 db,
                 *it,
                 it->MinCommitId,
                 commitId);
+
+            if (HasError(e)) {
+                WriteOrphanNode(db, TStringBuilder()
+                    << "DestroySession: " << args.SessionId
+                    << ", RemoveNode: " << nodeId
+                    << ", Error: " << FormatError(e), nodeId);
+            }
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -112,6 +112,7 @@ bool TIndexTabletActor::PrepareTx_LoadState(
         db.ReadSessionHistoryEntries(args.SessionHistory),
         db.ReadOpLog(args.OpLog),
         db.ReadLargeDeletionMarkers(args.LargeDeletionMarkers),
+        db.ReadOrphanNodes(args.OrphanNodeIds),
     };
 
     bool ready = std::accumulate(
@@ -231,9 +232,16 @@ void TIndexTabletActor::CompleteTx_LoadState(
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Initializing tablet state");
-    LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
-        LogTag << " Read " << args.LargeDeletionMarkers.size()
-        << " large deletion markers");
+    if (args.LargeDeletionMarkers) {
+        LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+            LogTag << " Read " << args.LargeDeletionMarkers.size()
+            << " large deletion markers");
+    }
+    if (args.OrphanNodeIds) {
+        LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+            LogTag << " Read " << args.OrphanNodeIds.size()
+            << " orphan nodes");
+    }
 
     LoadState(
         Executor()->Generation(),
@@ -242,6 +250,7 @@ void TIndexTabletActor::CompleteTx_LoadState(
         args.FileSystemStats,
         args.TabletStorageInfo,
         args.LargeDeletionMarkers,
+        args.OrphanNodeIds,
         config);
     UpdateLogTag();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -142,11 +142,18 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
                 nodeId,
                 it->Attrs.GetSize());
 
-            RemoveNode(
+            auto e = RemoveNode(
                 db,
                 *it,
                 it->MinCommitId,
                 commitId);
+
+            if (HasError(e)) {
+                WriteOrphanNode(db, TStringBuilder()
+                    << "DestroySession: " << args.SessionId
+                    << ", RemoveNode: " << nodeId
+                    << ", Error: " << FormatError(e), nodeId);
+            }
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -167,12 +167,17 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
         attrs.SetCTime(update.GetCTime());
     }
     if (HasFlag(flags, NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE)) {
-        Truncate(
+        auto e = Truncate(
             db,
             args.NodeId,
             args.CommitId,
             attrs.GetSize(),
             update.GetSize());
+
+        if (HasError(e)) {
+            args.Error = e;
+            return;
+        }
 
         attrs.SetSize(update.GetSize());
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -383,13 +383,18 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
 
         db.WriteOpLogEntry(args.OpLogEntry);
     } else {
-        UnlinkNode(
+        auto e = UnlinkNode(
             db,
             args.ParentNodeId,
             args.Name,
             *args.ChildNode,
             args.ChildRef->MinCommitId,
             args.CommitId);
+
+        if (HasError(e)) {
+            args.Error = std::move(e);
+            return;
+        }
     }
 
     auto* session = FindSession(args.SessionId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
@@ -84,7 +84,7 @@ void TIndexTabletActor::ExecuteTx_ZeroRange(
         args.Range.Length,
         args.ProfileLogRequest);
 
-    ZeroRange(db, args.NodeId, commitId, args.Range);
+    args.Error = ZeroRange(db, args.NodeId, commitId, args.Range);
 }
 
 void TIndexTabletActor::CompleteTx_ZeroRange(
@@ -100,12 +100,15 @@ void TIndexTabletActor::CompleteTx_ZeroRange(
         ProfileLog);
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ZeroRange %lu %s completed",
+        "%s ZeroRange %lu %s completed: %s",
         LogTag.c_str(),
         args.NodeId,
-        args.Range.Describe().c_str());
+        args.Range.Describe().c_str(),
+        FormatError(args.Error).Quote().c_str());
 
-    auto response = std::make_unique<TEvIndexTabletPrivate::TEvZeroRangeResponse>();
+    auto response =
+        std::make_unique<TEvIndexTabletPrivate::TEvZeroRangeResponse>(
+            std::move(args.Error));
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 
     EnqueueCollectGarbageIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1405,6 +1405,49 @@ bool TIndexTabletDatabase::ReadLargeDeletionMarkers(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// OrphanNodes
+
+void TIndexTabletDatabase::WriteOrphanNode(ui64 nodeId)
+{
+    using TTable = TIndexTabletSchema::OrphanNodes;
+
+    Table<TTable>()
+        .Key(nodeId)
+        .Update();
+}
+
+void TIndexTabletDatabase::DeleteOrphanNode(ui64 nodeId)
+{
+    using TTable = TIndexTabletSchema::OrphanNodes;
+
+    Table<TTable>()
+        .Key(nodeId)
+        .Delete();
+}
+
+bool TIndexTabletDatabase::ReadOrphanNodes(TVector<ui64>& nodeIds)
+{
+    using TTable = TIndexTabletSchema::OrphanNodes;
+
+    auto it = Table<TTable>()
+        .Select();
+
+    if (!it.IsReady()) {
+        return false;   // not ready
+    }
+
+    while (it.IsValid()) {
+        nodeIds.emplace_back(it.GetValue<TTable::NodeId>());
+
+        if (!it.Next()) {
+            return false;   // not ready
+        }
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // NewBlobs
 
 void TIndexTabletDatabase::WriteNewBlob(const TPartialBlobId& blobId)

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -428,6 +428,14 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     bool ReadLargeDeletionMarkers(TVector<TDeletionMarker>& deletionMarkers);
 
     //
+    // OrphanNodes
+    //
+
+    void WriteOrphanNode(ui64 nodeId);
+    void DeleteOrphanNode(ui64 nodeId);
+    bool ReadOrphanNodes(TVector<ui64>& nodeIds);
+
+    //
     // NewBlobs
     //
 

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -533,6 +533,19 @@ struct TIndexTabletSchema
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;
     };
 
+    struct OrphanNodes: TTableSchema<27>
+    {
+        struct NodeId       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
+
+        using TKey = TableKey<NodeId>;
+
+        using TColumns = TableColumns<
+            NodeId
+        >;
+
+        using StoragePolicy = TStoragePolicy<IndexChannel>;
+    };
+
     using TTables = SchemaTables<
         FileSystem,
         Sessions,
@@ -559,7 +572,8 @@ struct TIndexTabletSchema
         TruncateQueue,
         SessionHistory,
         OpLog,
-        LargeDeletionMarkers
+        LargeDeletionMarkers,
+        OrphanNodes
     >;
 
     using TSettings = SchemaSettings<

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -143,6 +143,11 @@ struct TNodeToSessionCounters
     i64 NodesOpenForReadingByMultipleSessions{0};
 };
 
+struct TMiscNodeStats
+{
+    i64 OrphanNodesCount{0};
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TIndexTabletState
@@ -171,6 +176,7 @@ private:
     /*const*/ ui64 LargeDeletionMarkerBlocks = 0;
     /*const*/ ui64 LargeDeletionMarkersThreshold = 0;
     /*const*/ ui64 LargeDeletionMarkersCleanupThreshold = 0;
+    /*const*/ ui64 LargeDeletionMarkersThresholdForBackpressure = 0;
 
     bool StateLoaded = false;
 
@@ -190,6 +196,7 @@ public:
         const NProto::TFileSystemStats& fileSystemStats,
         const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
         const TVector<TDeletionMarker>& largeDeletionMarkers,
+        const TVector<ui64>& orphanNodeIds,
         const TThrottlerConfig& throttlerConfig);
 
     bool IsStateLoaded() const
@@ -274,6 +281,8 @@ public:
     {
         return NodeToSessionCounters;
     }
+
+    TMiscNodeStats GetMiscNodeStats() const;
 
     const NProto::TFileStorePerformanceProfile& GetPerformanceProfile() const;
 
@@ -380,13 +389,13 @@ public:
         const NProto::TNode& attrs,
         const NProto::TNode& prevAttrs);
 
-    void RemoveNode(
+    [[nodiscard]] NProto::TError RemoveNode(
         TIndexTabletDatabase& db,
         const IIndexTabletDatabase::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId);
 
-    void UnlinkNode(
+    [[nodiscard]] NProto::TError UnlinkNode(
         TIndexTabletDatabase& db,
         ui64 parentNodeId,
         const TString& name,
@@ -422,6 +431,11 @@ public:
 
     bool HasBlocksLeft(
         ui32 blocks) const;
+
+    void WriteOrphanNode(
+        TIndexTabletDatabase& db,
+        const TString& message,
+        ui64 nodeId);
 
 private:
     void UpdateUsedBlocksCount(
@@ -1197,7 +1211,7 @@ public:
     void AddTruncate(TIndexTabletDatabase& db, ui64 nodeId, TByteRange range);
     void DeleteTruncate(TIndexTabletDatabase& db, ui64 nodeId);
 
-    void Truncate(
+    [[nodiscard]] NProto::TError Truncate(
         TIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
@@ -1210,7 +1224,7 @@ public:
     // - aligns up range in the tail;
     // - deletes all blocks in NEW range;
     // - writes fresh bytes (zeroes) on unaligned head, if range.Offset != 0.
-    void TruncateRange(
+    [[nodiscard]] NProto::TError TruncateRange(
         TIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
@@ -1220,14 +1234,14 @@ public:
     // resizing the node. This function:
     // - writes fresh bytes (zeroes) on unaligned head, if any;
     // - writes fresh bytes (zeroes) on unaligned tail, if any.
-    void ZeroRange(
+    [[nodiscard]] NProto::TError ZeroRange(
         TIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         TByteRange range);
 
 private:
-    void DeleteRange(
+    [[nodiscard]] NProto::TError DeleteRange(
         TIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -59,6 +59,7 @@ struct TIndexTabletState::TImpl
     TReadAheadCache ReadAheadCache;
     TNodeIndexCache NodeIndexCache;
     TInMemoryIndexState InMemoryIndexState;
+    TSet<ui64> OrphanNodeIds;
 
     TCheckpointStore Checkpoints;
     TChannels Channels;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -98,12 +98,27 @@ void TIndexTabletState::UpdateNode(
     InvalidateNodeIndexCache(nodeId);
 }
 
-void TIndexTabletState::RemoveNode(
+NProto::TError TIndexTabletState::RemoveNode(
     TIndexTabletDatabase& db,
     const IIndexTabletDatabase::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId)
 {
+    // SymLinks have size (equal to TargetPath) but store no real data so there
+    // is no need to write deletion markers upon SymLink removal
+    if (!node.Attrs.GetSymLink()) {
+        auto e = Truncate(
+            db,
+            node.NodeId,
+            maxCommitId,
+            node.Attrs.GetSize(),
+            0);
+
+        if (HasError(e)) {
+            return e;
+        }
+    }
+
     db.DeleteNode(node.NodeId);
     DecrementUsedNodesCount(db);
 
@@ -116,21 +131,12 @@ void TIndexTabletState::RemoveNode(
         AddCheckpointNode(db, checkpointId, node.NodeId);
     }
 
-    // SymLinks have size (equal to TargetPath) but store no real data so there
-    // is no need to write deletion markers upon SymLink removal
-    if (!node.Attrs.GetSymLink()) {
-        Truncate(
-            db,
-            node.NodeId,
-            maxCommitId,
-            node.Attrs.GetSize(),
-            0);
-    }
-
     InvalidateNodeIndexCache(node.NodeId);
+
+    return {};
 }
 
-void TIndexTabletState::UnlinkNode(
+NProto::TError TIndexTabletState::UnlinkNode(
     TIndexTabletDatabase& db,
     ui64 parentNodeId,
     const TString& name,
@@ -148,11 +154,15 @@ void TIndexTabletState::UnlinkNode(
             attrs,
             node.Attrs);
     } else {
-        RemoveNode(
+        auto e = RemoveNode(
             db,
             node,
             minCommitId,
             maxCommitId);
+
+        if (HasError(e)) {
+            return e;
+        }
     }
 
     RemoveNodeRef(
@@ -165,6 +175,8 @@ void TIndexTabletState::UnlinkNode(
         "", // followerId
         "" // followerName
     );
+
+    return {};
 }
 
 void TIndexTabletState::UnlinkExternalNode(
@@ -230,6 +242,16 @@ void TIndexTabletState::RewriteNode(
     }
 
     InvalidateNodeIndexCache(nodeId);
+}
+
+void TIndexTabletState::WriteOrphanNode(
+    TIndexTabletDatabase& db,
+    const TString& message,
+    ui64 nodeId)
+{
+    ReportGeneratedOrphanNode(message);
+    db.WriteOrphanNode(nodeId);
+    Impl->OrphanNodeIds.insert(nodeId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -170,7 +170,8 @@ struct TIndexStateNodeUpdates
     TVector<TInMemoryIndexState::TIndexStateRequest> NodeUpdates;
 };
 
-struct TProfileAware {
+struct TProfileAware
+{
     NProto::TProfileLogRequestInfo ProfileLogRequest;
 
     explicit TProfileAware(EFileStoreSystemRequest requestType) noexcept
@@ -308,6 +309,7 @@ struct TTxIndexTablet
         TVector<NProto::TSessionHistoryEntry> SessionHistory;
         TVector<NProto::TOpLogEntry> OpLog;
         TVector<TDeletionMarker> LargeDeletionMarkers;
+        TVector<ui64> OrphanNodeIds;
 
         NProto::TError Error;
 
@@ -331,6 +333,7 @@ struct TTxIndexTablet
             SessionHistory.clear();
             OpLog.clear();
             LargeDeletionMarkers.clear();
+            OrphanNodeIds.clear();
         }
     };
 
@@ -1778,6 +1781,8 @@ struct TTxIndexTablet
         const ui64 NodeId;
         const TByteRange Range;
 
+        NProto::TError Error;
+
         TTruncateRange(
                 TRequestInfoPtr requestInfo,
                 ui64 nodeId,
@@ -1791,6 +1796,7 @@ struct TTxIndexTablet
         void Clear()
         {
             TProfileAware::Clear();
+            Error.Clear();
         }
     };
 
@@ -1826,6 +1832,8 @@ struct TTxIndexTablet
         const ui64 NodeId;
         const TByteRange Range;
 
+        NProto::TError Error;
+
         TZeroRange(
                 TRequestInfoPtr requestInfo,
                 ui64 nodeId,
@@ -1839,6 +1847,7 @@ struct TTxIndexTablet
         void Clear()
         {
             TProfileAware::Clear();
+            Error.Clear();
         }
     };
 


### PR DESCRIPTION
Backpressure is enabled if LargeDeletionMarkerCount >= LargeDeletionMarkersThresholdForBackpressure.
The operations that directly generate LargeDeletionMarkers will be rejected:
* UnlinkNode
* Truncate
* SetNodeAttr
* ZeroRange
* AllocateData
* CreateHandle

The operations that may delete a node as a side effect will generate OrphanNodes and raise an AppCriticalEvent:
* DestroySession
* DestroyHandle
* RenameNode
* ResetSession

#1795 