### PR TITLE
fix: acceptance test failure

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -37,9 +37,10 @@ def wait_for_block_device_to_appear(
     disk_id: str,
     module_factory,
     ssh_key_path: str | None = None,
-) -> str:
-    device_to_id_mapper = VirtualDevicesToIdMapper(ip, module_factory, ssh_key_path)
-    return device_to_id_mapper.wait_for_disk_to_appear(disk_id)
+):
+    device_name = f'/dev/disk/by-id/virtio-{disk_id}'
+    helpers = module_factory.make_helpers(False)
+    helpers.wait_for_block_device_to_appear(ip, device_name, ssh_key_path=ssh_key_path)
 
 
 class VirtualDevicesToIdMapper:

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/instance_policy.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/instance_policy.py
@@ -75,7 +75,8 @@ class YcpNewInstancePolicy:
 
     @contextmanager
     def attach_disk(self, disk: Ycp.Disk):
-        with self._ycp.attach_disk(self._instance, disk):
+        # Temprorary disable autodetach to debug acceptance test failure
+        with self._ycp.attach_disk(self._instance, disk, None, False):
             yield wait_for_block_device_to_appear(
                 self._instance.ip,
                 disk.id,


### PR DESCRIPTION
1. disable disk auto-detach to debug test after failure
2.  use wait_for_block_device_to_appear implementation from helpers