### PR TITLE
Resize the shadow disk when the size of the source disk changes

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -2010,7 +2010,7 @@ NProto::TError TDiskRegistryState::AllocateDisk(
     auto& disk = Disks[params.DiskId];
     auto error = ValidateAllocateDiskParams(disk, params);
 
-    auto originalDiskSize = GetDiskSize(params.DiskId);
+    auto originalBlockCount = GetDiskBlockCount(params.DiskId);
 
     if (HasError(error)) {
         if (disk.Devices.empty() && !disk.ReplicaCount) {
@@ -2027,8 +2027,8 @@ NProto::TError TDiskRegistryState::AllocateDisk(
             : AllocateSimpleDisk(now, db, params, {}, disk, result);
 
     // If disk size changed reallocate checkpoints too.
-    if (!HasError(allocateError) && originalDiskSize &&
-        originalDiskSize != GetDiskSize(params.DiskId))
+    if (!HasError(allocateError) && originalBlockCount &&
+        originalBlockCount != GetDiskBlockCount(params.DiskId))
     {
         ReallocateCheckpointByDisk(now, db, params.DiskId);
     }
@@ -7268,7 +7268,8 @@ TVector<NProto::TAgentInfo> TDiskRegistryState::QueryAgentsInfo() const
     return ret;
 }
 
-std::optional<ui64> TDiskRegistryState::GetDiskSize(const TDiskId& diskId) const
+std::optional<ui64> TDiskRegistryState::GetDiskBlockCount(
+    const TDiskId& diskId) const
 {
     TDiskInfo diskInfo;
     auto error = GetDiskInfo(diskId, diskInfo);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1263,7 +1263,7 @@ private:
     TResultOrError<TConfigUpdateEffect> CalcConfigUpdateEffect(
         const NProto::TDiskRegistryConfig& newConfig) const;
 
-    std::optional<ui64> GetDiskSize(const TDiskId& diskId) const;
+    std::optional<ui64> GetDiskBlockCount(const TDiskId& diskId) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1125,6 +1125,10 @@ private:
     void DeleteCheckpointByDisk(
         TDiskRegistryDatabase& db,
         const TDiskId& diskId);
+    void ReallocateCheckpointByDisk(
+        TInstant now,
+        TDiskRegistryDatabase& db,
+        const TDiskId& diskId);
 
     void ForgetDevices(
         TDiskRegistryDatabase& db,
@@ -1258,6 +1262,8 @@ private:
     struct TConfigUpdateEffect;
     TResultOrError<TConfigUpdateEffect> CalcConfigUpdateEffect(
         const NProto::TDiskRegistryConfig& newConfig) const;
+
+    std::optional<ui64> GetDiskSize(const TDiskId& diskId) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
Когда происходит изменение диска нужно изменить и размер теневого диска тоже, чтобы если в этот момент идет миграция, то записи пользователей могли проходить, а не падать с ошибкой E_ARGUMENT, что приводит к поломке NRD и залипанию mirror-диска.
Т.е. фикс чинит проблему, когда пользователь изменил размер диска в процессе создания снимка.