### PR TITLE
[Tasks] fix cloud/tasks/tests/tests.TestTryExecutingTask

### DIFF
--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1261,8 +1261,7 @@ func TestTryExecutingTask(t *testing.T) {
 	runner.On("lockTask", ctx, taskInfo).Return(state, nil)
 	task.On("Load", state.Request, state.State).Return(nil)
 	taskStorage.On("UpdateTask", mock.Anything, mock.MatchedBy(matchesState(t, state))).Return(state, nil).Maybe()
-	execCtx := newExecutionContext(task, taskStorage, state, time.Hour, 2)
-	runnerMetrics.On("OnExecutionStarted", execCtx)
+	runnerMetrics.On("OnExecutionStarted", mock.Anything)
 	runner.On("executeTask", mock.Anything, mock.Anything, task)
 	runnerMetrics.On("OnExecutionStopped")
 
@@ -1317,8 +1316,7 @@ func TestTryExecutingTaskFailToPing(t *testing.T) {
 		updateTaskErr,
 	).Once()
 
-	execCtx := newExecutionContext(task, taskStorage, state, time.Hour, 2)
-	runnerMetrics.On("OnExecutionStarted", execCtx)
+	runnerMetrics.On("OnExecutionStarted", mock.Anything)
 	runner.On("executeTask", mock.Anything, mock.Anything, task).Run(func(args mock.Arguments) {
 		// Wait for pingPeriod, so that the first ping has had a chance to run.
 		// TODO: This is bad.


### PR DESCRIPTION
https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/PR-check/11012514227/1/nebius-x86-64/logs/cloud/tasks/tests/test-results/tests/testing_out_stuff/stderr

```
Difference found in argument 0:

--- Expected
+++ Actual
@@ -1,2 +1,2 @@
-(*tasks.executionContext)(*tasks.executionContext<0xc00086a000>)
+(*tasks.executionContext)(*tasks.executionContext<0xc00086a200>)
 

Diff: 0: FAIL:  (*tasks.executionContext=*tasks.executionContext<0xc00086a200>) != (*tasks.executionContext=*tasks.executionContext<0xc00086a000>) [recovered]
```