### PR TITLE
Fix Arcadia sync #2

### DIFF
--- a/cloud/storage/core/tests/recipes/access-service-new/__main__.py
+++ b/cloud/storage/core/tests/recipes/access-service-new/__main__.py
@@ -55,6 +55,7 @@ def start(argv):
     set_env("ACCESS_SERVICE_CONTROL_PORT", str(control_port))
     set_env("ACCESS_SERVICE_PID", str(access_service.pid))
 
+
 def stop(argv):
     logger.info("Shutdown new access-service")
 

--- a/cloud/storage/core/tools/testing/access_service_new/mock/main.go
+++ b/cloud/storage/core/tools/testing/access_service_new/mock/main.go
@@ -27,7 +27,7 @@ type Permission struct {
 
 type AccountConfig struct {
 	Permissions      []Permission `json:"permissions,omitempty"`
-	Id               string       `json:"id,omitempty"`
+	ID               string       `json:"id,omitempty"`
 	IsUnknownSubject bool         `json:"is_unknown_subject,omitempty"`
 	Token            string       `json:"token,omitempty"`
 }
@@ -103,7 +103,7 @@ func (t *accessServiceMock) Authorize(
 		account := &iamv1.Account{
 			Type: &iamv1.Account_UserAccount_{
 				UserAccount: &iamv1.Account_UserAccount{
-					Id: accountConfig.Id,
+					Id: accountConfig.ID,
 				},
 			},
 		}
@@ -159,7 +159,7 @@ func (t *accessServiceMock) Authenticate(
 		Account: &iamv1.Account{
 			Type: &iamv1.Account_UserAccount_{
 				UserAccount: &iamv1.Account_UserAccount{
-					Id: accountConfig.Id,
+					Id: accountConfig.ID,
 				},
 			},
 		},


### PR DESCRIPTION
> $S/cloud/storage/core/tools/testing/access_service_new/mock/main.go:30:2: "ST1003: struct field Id should be ID"
$S/cloud/storage/core/tools/testing/access_service_new/mock/main.go:30:2: "ST1003: if you believe this report is false positive, please silence it with //nolint:st1003 comment"

> cloud/storage/core/tests/recipes/access-service-new/__main__.py:58: [E302] expected 2 blank lines, found 1