### PR TITLE
fix: revert wait_for_block_device_to_appear implementation

### DIFF
--- a/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/helpers.py
@@ -37,10 +37,9 @@ def wait_for_block_device_to_appear(
     disk_id: str,
     module_factory,
     ssh_key_path: str | None = None,
-):
-    device_name = f'/dev/disk/by-id/virtio-{disk_id}'
-    helpers = module_factory.make_helpers(False)
-    helpers.wait_for_block_device_to_appear(ip, device_name, ssh_key_path=ssh_key_path)
+) -> str:
+    device_to_id_mapper = VirtualDevicesToIdMapper(ip, module_factory, ssh_key_path)
+    return device_to_id_mapper.wait_for_disk_to_appear(disk_id)
 
 
 class VirtualDevicesToIdMapper:

--- a/cloud/disk_manager/test/acceptance/test_runner/lib/instance_policy.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/lib/instance_policy.py
@@ -74,7 +74,7 @@ class YcpNewInstancePolicy:
                 self._ycp.delete_instance(self._instance)
 
     @contextmanager
-    def attach_disk(self, disk: Ycp.Disk):
+    def attach_disk(self, disk: Ycp.Disk) -> str:
         # Temprorary disable autodetach to debug acceptance test failure
         with self._ycp.attach_disk(self._instance, disk, None, False):
             yield wait_for_block_device_to_appear(


### PR DESCRIPTION
revert to previous wait_for_block_device_to_appear implementation https://github.com/ydb-platform/nbs/commit/98ac178cc7fc1cf886f38dae7ae5367780629686#diff-536ed3f8ea3b7c4f96c4e0fa2c894a1ee506c2da759d2ee1c77a334199779477