### PR TITLE
revert NodeExpandVolume implementation

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -1163,8 +1163,9 @@ func (s *nodeService) NodeExpandVolume(
 		return nil, err
 	}
 
-	_, err = s.nbsClient.RefreshEndpoint(ctx, &nbsapi.TRefreshEndpointRequest{
-		UnixSocketPath: unixSocketPath,
+	_, err = s.nbsClient.ResizeDevice(ctx, &nbsapi.TResizeDeviceRequest{
+		UnixSocketPath:    unixSocketPath,
+		DeviceSizeInBytes: newBlocksCount * uint64(resp.Volume.BlockSize),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Partially revert https://github.com/ydb-platform/nbs/pull/2006/files#diff-021fd610a4ef17348cd72682382ac75500e3207f4f055627a06300ba7c962f9e and use previous implementation of NodeExpandVolume  as we have not deployed new nbs.