### PR TITLE
[Test]: Fix new auth test

### DIFF
--- a/cloud/filestore/tests/auth/lib/__init__.py
+++ b/cloud/filestore/tests/auth/lib/__init__.py
@@ -20,16 +20,17 @@ class TestFixture:
         self.folder_id = os.getenv("TEST_FOLDER_ID")
         access_service_port = os.getenv("ACCESS_SERVICE_PORT")
         access_service_control_port = os.getenv("ACCESS_SERVICE_CONTROL_PORT")
-        self.access_service = AccessService(
-            "localhost",
-            access_service_port,
-            access_service_control_port,
-        )
         if os.getenv("ACCESS_SERVICE_TYPE") == "new":
             self.access_service = NewAccessService(
                 "localhost",
                 int(access_service_port),
                 int(access_service_control_port),
+            )
+        else:
+            self.access_service = AccessService(
+                "localhost",
+                access_service_port,
+                access_service_control_port,
             )
         client_config = TClientAppConfig()
         client_config.ClientConfig.CopyFrom(TClientConfig())


### PR DESCRIPTION
New auth test failed in our internal CI (for some reason ya.make ignored test's depends and `cloud/storage/core/tools/testing/access_service/mock/accessservice-mock` was not found. I could not reproduce the issue even on the CI vm itself with CI vm's configuration, but just to be safe, there's an ironclad fix.