### PR TITLE
Implement (un)stage/(un)publish volume according csi spec for mount mode

### DIFF
--- a/cloud/blockstore/tests/csi_driver/test.py
+++ b/cloud/blockstore/tests/csi_driver/test.py
@@ -488,3 +488,54 @@ def test_publish_volume_twice_on_the_same_node():
         with called_process_error_logged():
             env.csi.delete_volume(volume_name)
         cleanup_after_test(env)
+
+
+def test_restart_kubelet_with_old_format_endpoint():
+    env, run = init()
+    try:
+        volume_name = "example-disk"
+        volume_size = 1024 ** 3
+        pod_name1 = "example-pod-1"
+        pod_id1 = "deadbeef1"
+        env.csi.create_volume(name=volume_name, size=volume_size)
+
+        # skip stage to create endpoint with old format
+        env.csi.publish_volume(pod_id1, volume_name, pod_name1)
+        env.csi.stage_volume(volume_name)
+        env.csi.publish_volume(pod_id1, volume_name, pod_name1)
+    except subprocess.CalledProcessError as e:
+        log_called_process_error(e)
+        raise
+    finally:
+        with called_process_error_logged():
+            env.csi.unpublish_volume(pod_id1, volume_name)
+        with called_process_error_logged():
+            env.csi.unstage_volume(volume_name)
+        with called_process_error_logged():
+            env.csi.delete_volume(volume_name)
+        cleanup_after_test(env)
+
+
+def test_restart_kubelet_with_new_format_endpoint():
+    env, run = init()
+    try:
+        volume_name = "example-disk"
+        volume_size = 1024 ** 3
+        pod_name1 = "example-pod-1"
+        pod_id1 = "deadbeef1"
+        env.csi.create_volume(name=volume_name, size=volume_size)
+        env.csi.stage_volume(volume_name)
+        env.csi.publish_volume(pod_id1, volume_name, pod_name1)
+        env.csi.stage_volume(volume_name)
+        env.csi.publish_volume(pod_id1, volume_name, pod_name1)
+    except subprocess.CalledProcessError as e:
+        log_called_process_error(e)
+        raise
+    finally:
+        with called_process_error_logged():
+            env.csi.unpublish_volume(pod_id1, volume_name)
+        with called_process_error_logged():
+            env.csi.unstage_volume(volume_name)
+        with called_process_error_logged():
+            env.csi.delete_volume(volume_name)
+        cleanup_after_test(env)

--- a/cloud/blockstore/tests/csi_driver/test.py
+++ b/cloud/blockstore/tests/csi_driver/test.py
@@ -462,8 +462,9 @@ def test_node_volume_expand():
         cleanup_after_test(env)
 
 
-def test_publish_volume_twice_on_the_same_node():
-    env, run = init(vm_mode=True)
+@pytest.mark.parametrize('vm_mode', [True, False])
+def test_publish_volume_twice_on_the_same_node(vm_mode):
+    env, run = init(vm_mode=vm_mode)
     try:
         volume_name = "example-disk"
         volume_size = 1024 ** 3

--- a/cloud/blockstore/tests/csi_driver/test.py
+++ b/cloud/blockstore/tests/csi_driver/test.py
@@ -499,9 +499,9 @@ def test_restart_kubelet_with_old_format_endpoint():
         pod_name1 = "example-pod-1"
         pod_id1 = "deadbeef1"
         env.csi.create_volume(name=volume_name, size=volume_size)
-
         # skip stage to create endpoint with old format
         env.csi.publish_volume(pod_id1, volume_name, pod_name1)
+        # run stage/publish again to simulate kubelet restart
         env.csi.stage_volume(volume_name)
         env.csi.publish_volume(pod_id1, volume_name, pod_name1)
     except subprocess.CalledProcessError as e:
@@ -527,6 +527,7 @@ def test_restart_kubelet_with_new_format_endpoint():
         env.csi.create_volume(name=volume_name, size=volume_size)
         env.csi.stage_volume(volume_name)
         env.csi.publish_volume(pod_id1, volume_name, pod_name1)
+        # run stage/publish again to simulate kubelet restart
         env.csi.stage_volume(volume_name)
         env.csi.publish_volume(pod_id1, volume_name, pod_name1)
     except subprocess.CalledProcessError as e:

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -614,29 +614,20 @@ func (s *nodeService) nodePublishDiskAsFilesystem(
 		return s.nodePublishDiskAsFilesystemDeprecated(ctx, req)
 	}
 
-	mnt := req.VolumeCapability.GetMount()
-
-	fsType := req.VolumeContext["fsType"]
-	if mnt != nil && mnt.FsType != "" {
-		fsType = mnt.FsType
-	}
-	if fsType == "" {
-		fsType = "ext4"
-	}
-
 	targetPerm := os.FileMode(0775)
 	if err := os.MkdirAll(req.TargetPath, targetPerm); err != nil {
 		return fmt.Errorf("failed to create target directory: %w", err)
 	}
 
 	mountOptions := []string{"bind"}
+	mnt := req.VolumeCapability.GetMount()
 	if mnt != nil {
 		for _, flag := range mnt.MountFlags {
 			mountOptions = append(mountOptions, flag)
 		}
 	}
 
-	return s.mounter.Mount(req.StagingTargetPath, req.TargetPath, fsType, mountOptions)
+	return s.mounter.Mount(req.StagingTargetPath, req.TargetPath, "", mountOptions)
 }
 
 func (s *nodeService) nodeStageDiskAsFilesystem(

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -634,7 +634,12 @@ func (s *nodeService) nodePublishDiskAsFilesystem(
 		}
 	}
 
-	err := s.mounter.Mount(req.StagingTargetPath, req.TargetPath, "", mountOptions)
+	err := s.mountIfNeeded(
+		req.VolumeId,
+		req.StagingTargetPath,
+		req.TargetPath,
+		"",
+		mountOptions)
 	if err != nil {
 		return err
 	}

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -206,7 +206,7 @@ func (s *nodeService) NodeStageVolume(
 		} else {
 			if nfsBackend {
 				return nil, s.statusError(codes.InvalidArgument,
-					"FileStore can't be mounted to container as a filesystem")
+					"NFS mounts are only supported in VM mode")
 			} else {
 				err = s.nodeStageDiskAsFilesystem(ctx, req)
 			}

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -218,7 +218,7 @@ func (s *nodeService) NodeStageVolume(
 
 	if err != nil {
 		return nil, s.statusErrorf(codes.Internal,
-			"Failed to publish volume: %v", err)
+			"Failed to stage volume: %v", err)
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -902,7 +902,7 @@ func (s *nodeService) nodeUnstageVolume(
 
 	mounted, _ := s.mounter.IsMountPoint(req.StagingTargetPath)
 	if !mounted {
-		//Fallback to previous implementation for already mounted volumes to
+		// Fallback to previous implementation for already mounted volumes to
 		// stop endpoint in nodeUnpublishVolume
 		// Must be removed after migration of all endpoints to the new format
 		return nil
@@ -956,7 +956,7 @@ func (s *nodeService) nodeUnpublishVolume(
 	// because the endpoint's backend service is unknown here.
 	// When we miss we get S_FALSE/S_ALREADY code (err == nil).
 
-	//Fallback to previous implementation for already mounted volumes to
+	// Fallback to previous implementation for already mounted volumes to
 	// stop endpoint in nodeUnpublishVolume.
 	// Must be removed after migration of all endpoints to the new format
 	if s.nbsClient != nil {
@@ -1374,7 +1374,7 @@ func (s *nodeService) NodeExpandVolume(
 	nbdDevicePath := ""
 	unixSocketPath := ""
 	for _, endpoint := range listEndpointsResp.Endpoints {
-		//Fallback to previous implementation for already mounted volumes
+		// Fallback to previous implementation for already mounted volumes
 		// Must be removed after migration of all endpoints to the new format
 		if endpoint.UnixSocketPath == unixSocketPathOld {
 			nbdDevicePath = endpoint.GetNbdDeviceFile()

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -862,6 +862,11 @@ func (s *nodeService) nodeUnstageVolume(
 	ctx context.Context,
 	req *csi.NodeUnstageVolumeRequest) error {
 
+	mounted, _ := s.mounter.IsMountPoint(req.StagingTargetPath)
+	if !mounted {
+		return nil
+	}
+
 	if err := s.mounter.CleanupMountPoint(req.StagingTargetPath); err != nil {
 		return err
 	}

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -747,7 +747,7 @@ func (s *nodeService) nodePublishDiskAsBlockDevice(
 			mountOptions = append(mountOptions, flag)
 		}
 	}
-	return s.mounter.Mount(req.StagingTargetPath, req.TargetPath, "", mountOptions)
+	return s.mountBlockDevice(req.VolumeId, req.StagingTargetPath, req.TargetPath)
 }
 
 func (s *nodeService) startNbsEndpointForNBD(

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -616,6 +616,8 @@ func (s *nodeService) nodePublishDiskAsFilesystem(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest) error {
 
+	// Fallback to previous implementation for already mounted volumes
+	// Must be removed after migration of all endpoints to the new format
 	mounted, _ := s.mounter.IsMountPoint(req.StagingTargetPath)
 	if !mounted {
 		return s.nodePublishDiskAsFilesystemDeprecated(ctx, req)
@@ -900,6 +902,9 @@ func (s *nodeService) nodeUnstageVolume(
 
 	mounted, _ := s.mounter.IsMountPoint(req.StagingTargetPath)
 	if !mounted {
+		//Fallback to previous implementation for already mounted volumes to
+		// stop endpoint in nodeUnpublishVolume
+		// Must be removed after migration of all endpoints to the new format
 		return nil
 	}
 
@@ -951,6 +956,9 @@ func (s *nodeService) nodeUnpublishVolume(
 	// because the endpoint's backend service is unknown here.
 	// When we miss we get S_FALSE/S_ALREADY code (err == nil).
 
+	//Fallback to previous implementation for already mounted volumes to
+	// stop endpoint in nodeUnpublishVolume.
+	// Must be removed after migration of all endpoints to the new format
 	if s.nbsClient != nil {
 		_, err := s.nbsClient.StopEndpoint(ctx, &nbsapi.TStopEndpointRequest{
 			UnixSocketPath: filepath.Join(endpointDir, nbsSocketName),
@@ -1366,6 +1374,8 @@ func (s *nodeService) NodeExpandVolume(
 	nbdDevicePath := ""
 	unixSocketPath := ""
 	for _, endpoint := range listEndpointsResp.Endpoints {
+		//Fallback to previous implementation for already mounted volumes
+		// Must be removed after migration of all endpoints to the new format
 		if endpoint.UnixSocketPath == unixSocketPathOld {
 			nbdDevicePath = endpoint.GetNbdDeviceFile()
 			unixSocketPath = unixSocketPathOld

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -398,13 +398,13 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	clientID := "testClientId"
 	podID := "test-pod-id-13"
 	diskID := "test-disk-id-42"
-	actualClientId := "testClientId-testNodeId"
+	actualClientId := "testClientId-v2/testNodeId"
 	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	stagingTargetPath := "testStagingTargetPath"
 	socketsDir := filepath.Join(tempDir, "sockets")
 	sourcePath := filepath.Join(socketsDir, nodeID, diskID)
-	socketPath := filepath.Join(socketsDir, nodeID, diskID, "nbs.sock")
+	socketPath := filepath.Join(socketsDir, "v2", nodeID, diskID, "nbs.sock")
 	deprecatedSocketPath := filepath.Join(socketsDir, podID, diskID, "nbs.sock")
 
 	nodeService := newNodeService(

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -398,13 +398,13 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	clientID := "testClientId"
 	podID := "test-pod-id-13"
 	diskID := "test-disk-id-42"
-	actualClientId := "testClientId-v2/testNodeId"
+	actualClientId := "testClientId-testNodeId"
 	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	stagingTargetPath := "testStagingTargetPath"
 	socketsDir := filepath.Join(tempDir, "sockets")
 	sourcePath := filepath.Join(socketsDir, nodeID, diskID)
-	socketPath := filepath.Join(socketsDir, "v2", nodeID, diskID, "nbs.sock")
+	socketPath := filepath.Join(socketsDir, nodeID, diskID, "nbs.sock")
 	deprecatedSocketPath := filepath.Join(socketsDir, podID, diskID, "nbs.sock")
 
 	nodeService := newNodeService(

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -473,6 +473,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	mockCallIsMountPoint.Unset()
 
 	mounter.On("IsMountPoint", stagingTargetPath).Return(true, nil)
+	mounter.On("IsMountPoint", targetPath).Return(false, nil)
 
 	mounter.On("Mount", stagingTargetPath, targetPath, "", []string{"bind"}).Return(nil)
 

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -829,9 +829,13 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 	_, err := nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 		VolumeId:          diskID,
 		StagingTargetPath: "testStagingTargetPath",
-		VolumeCapability:  &csi.VolumeCapability{},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Block{
+				Block: &csi.VolumeCapability_BlockVolume{},
+			},
+		},
 	})
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// NodePublishVolume without access mode should fail
 	_, err = nodeService.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -403,8 +403,8 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	stagingTargetPath := "testStagingTargetPath"
 	socketsDir := filepath.Join(tempDir, "sockets")
-	sourcePath := filepath.Join(socketsDir, nodeID, diskID)
-	socketPath := filepath.Join(socketsDir, nodeID, diskID, "nbs.sock")
+	sourcePath := filepath.Join(socketsDir, diskID)
+	socketPath := filepath.Join(socketsDir, diskID, "nbs.sock")
 	deprecatedSocketPath := filepath.Join(socketsDir, podID, diskID, "nbs.sock")
 
 	nodeService := newNodeService(

--- a/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
+++ b/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
@@ -1,0 +1,61 @@
+Current CSI Driver implementation violates CSI specification in terms of stage/publish/unstage/unpublish volumes.
+At this moment StageVolume step is completely ignored and start endpoint/mounting volumes happens at PublishVolume step.
+As a result CSI Driver doesn't support ReadWriteOnce access mode in the correct way and only one pod on the same node can mount the volume,
+however it should be allowed to mount the same volume into multiple pods on the same node.
+
+According to CSI Driver specification:
+
+NodeStageVolume should mount the volume to the staging path
+NodePublishVolume should mount the volume to the target path
+NodeUnpublishVolume should unmount the volume from the target path
+NodeUnstageVolume should unmount the volume from the staging path
+As we already have current implementation of CSI Driver in production clusters we need to handle migration
+from existing implementation of mounting volumes(only NodePublishVolune/NodeUnpublishVolume is implemented)
+to the new implementation.
+
+The tricky part here is using different UnixSocketPath/InstanceId/ClientId
+for already bounded volumes and "new" volumes.
+
+Current format of UnixSocketPath: socketsDir/podId/volumeId
+New format of UnixSocketPath: socketsDir/nodeId/volumeId
+
+Current format of InstanceId: podId
+New format of InstanceId: nodeId
+
+Current format of ClientId: clientID-podId
+New format of ClientId: clientID-nodeId
+
+Possible scenarios:
+
+--------
+1. Volume was staged and published
+2. CSI Driver was updated
+3. Volume was unpublished and unstaged <- here we should handle unpublish with old unix socket path
+--------
+1. Volume was staged and published
+2. CSI Driver was updated
+3. Kubelet restart was happened
+4. CSI Driver received stage and publish for the same volume again <- here we should handle stage/publish with old unix socket path
+--------
+1. CSI Driver was updated
+2. Volume was staged and published
+3. endpoint should be start with new unix socket path
+4. Volume was unpublished and unstaged
+5. UnstageVolume should stop endpoint with new unix socket path
+--------
+1. CSI Driver was updated
+2. Volume was staged and published on the node #1 with RWO access mode
+3. Staging volume on the node #2
+4. StageVolume on the node #2 should return error
+
+
+Migration is splitted for differnt modes
+VM mode: https://github.com/ydb-platform/nbs/pull/1982
+Mount mode: https://github.com/ydb-platform/nbs/pull/2195
+Block mode: is not implemented yet
+
+After migration of all volumes to the new endpoints we can remove backward compatibility
+with old format of endpoints.
+
+External links/Documentation:
+https://github.com/container-storage-interface/spec/blob/master/spec.md#node-service-rpc

--- a/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
+++ b/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
@@ -17,7 +17,7 @@ The tricky part here is using different UnixSocketPath/InstanceId/ClientId
 for already bounded volumes and "new" volumes.
 
 Current format of UnixSocketPath: socketsDir/podId/volumeId
-New format of UnixSocketPath: socketsDir/nodeId/volumeId
+New format of UnixSocketPath: socketsDir/volumeId
 
 Current format of InstanceId: podId
 New format of InstanceId: nodeId

--- a/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
+++ b/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
@@ -52,7 +52,7 @@ Possible scenarios:
 Migration is splitted for differnt modes
 VM mode: https://github.com/ydb-platform/nbs/pull/1982
 Mount mode: https://github.com/ydb-platform/nbs/pull/2195
-Block mode: is not implemented yet
+Block mode: https://github.com/ydb-platform/nbs/pull/2269
 
 After migration of all volumes to the new endpoints we can remove backward compatibility
 with old format of endpoints.

--- a/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
+++ b/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
@@ -34,12 +34,12 @@ Possible scenarios:
 --------
 1. Volume was staged and published
 2. CSI Driver was updated
-3. Kubelet restart was happened
+3. Kubelet restart happened
 4. CSI Driver received stage and publish for the same volume again <- here we should handle stage/publish with old unix socket path
 --------
 1. CSI Driver was updated
 2. Volume was staged and published
-3. endpoint should be start with new unix socket path
+3. endpoint should start with new unix socket path
 4. Volume was unpublished and unstaged
 5. UnstageVolume should stop endpoint with new unix socket path
 --------


### PR DESCRIPTION
Problem:
-------

CSI Driver implementation violates CSI specification in terms of stage/publish/unstage/unpublish volumes.
At this moment StageVolume step is completely ignored and start endpoint/mounting volumes happens at PublishVolume step. As a result CSI Driver doesn't support ReadWriteOnce access mode in the correct way and only one pod on the same node can mount the volume, however it should be allowed to mount the same volume into multiple pods on the same node.

According to CSI Driver specification:
1. NodeStageVolume should mount the volume to the staging path
2. NodePublishVolume should mount the volume to the target path
3. NodeUnpublishVolume should unmount the volume from the target path
4. NodeUnstageVolume should unmount the volume from the staging path


As we already have current implementation of CSI Driver in production clusters we need to handle migration from existing implementation of mounting volumes(only NodePublishVolume/NodeUnpublishVolume is implemented) to the new implementation.

The tricky part here is using different UnixSocketPath/InstanceId/ClientId for already bounded volumes and "new" volumes.
Current format of UnixSocketPath: `socketsDir/podId/volumeId`
New format of UnixSocketPath: `socketsDir/nodeId/volumeId`

Current format of InstanceId: `podId`
New format of InstanceId: `nodeId`

Current format of ClientId: `clientID-podId`
New format of ClientId: `clientID-nodeId`

Possible scenarios:
-------
1. Volume was staged and published
2. CSI Driver was updated
3. Volume was unpublished and unstaged <- here we should handle unpublish with old unix socket path
------
1. Volume was staged and published
2. CSI Driver was updated
3. Kubelet restart had happened
4. CSI Driver received stage and publish for the same volume again <- here we should handle stage/publish with old unix socket path
------
1. CSI Driver was updated
2. Volume was staged and published
3.  endpoint should be start with new unix socket path
4. Volume was unpublished and unstaged
5. UnstageVolume should stop endpoint with new unix socket path
------
1. CSI Driver was updated
2. Volume was staged and published on the node1 with RWO access mode
3. Staging volume on the node2
6. StageVolume on the node2 should return error


Migration is splitted for differnt modes
VM mode: https://github.com/ydb-platform/nbs/pull/1982
Mount mode: https://github.com/ydb-platform/nbs/pull/2195
Block mode: https://github.com/ydb-platform/nbs/pull/2269

After migration of all volumes to the new endpoints we can remove backward compatibility
with old format of endpoints.


External links/documentation
-------
https://github.com/container-storage-interface/spec/blob/master/spec.md#node-service-rpc
