### PR TITLE
issue-2190: persistent table data structure

### DIFF
--- a/cloud/storage/core/libs/common/persistent_table.cpp
+++ b/cloud/storage/core/libs/common/persistent_table.cpp
@@ -1,0 +1,1 @@
+#include "persistent_table.h"

--- a/cloud/storage/core/libs/common/persistent_table.h
+++ b/cloud/storage/core/libs/common/persistent_table.h
@@ -1,0 +1,249 @@
+#pragma once
+
+#include <util/generic/list.h>
+#include <util/generic/vector.h>
+#include <util/system/file.h>
+#include <util/system/filemap.h>
+#include <util/system/yassert.h>
+
+#include <cstddef>
+#include <optional>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename H, typename R>
+class TPersistentTable
+{
+private:
+    struct Header
+    {
+        size_t HeaderSize;
+        size_t RecordSize;
+        size_t RecordCount;
+        H Data;
+    };
+
+    enum class ERecordState: ui8
+    {
+        Free = 0,
+        Allocated,
+        Stored,
+    };
+
+    struct Record
+    {
+        R Data;
+        ERecordState State;
+    };
+
+    TString FileName;
+    size_t RecordCount;
+    size_t NextFreeRecord;
+
+    std::unique_ptr<TFileMap> FileMap;
+    TList<ui64> FreeRecords;
+    Header* HeaderPtr = nullptr;
+    Record* RecordsPtr = nullptr;
+
+public:
+    static constexpr ui64 InvalidIndex = -1;
+
+    class TIterator
+    {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = R;
+        using difference_type = std::ptrdiff_t;
+        using pointer = R*;
+        using reference = R&;
+
+        TIterator(TPersistentTable& table, ui64 index)
+            : Index(index)
+            , Table(table)
+        {
+            SkipEmptyRecords();
+        }
+
+        bool operator==(const TIterator& other) const
+        {
+            return Index == other.Index;
+        }
+
+        bool operator!=(const TIterator& other) const
+        {
+            return !(*this == other);
+        }
+
+        TIterator& operator++()
+        {
+            ++Index;
+            SkipEmptyRecords();
+            return *this;
+        }
+
+        TIterator operator++(int)
+        {
+            auto tmp = *this;
+            ++*this;
+            return tmp;
+        }
+
+        R& operator*()
+        {
+            return Table.RecordsPtr[Index].Data;
+        }
+
+        R* operator->()
+        {
+            return &Table.RecordsPtr[Index].Data;
+        }
+
+        ui64 GetIndex() const
+        {
+            return Index;
+        }
+
+    private:
+        void SkipEmptyRecords()
+        {
+            while (Index < Table.RecordCount &&
+                   Table.RecordsPtr[Index].State != ERecordState::Stored)
+            {
+                ++Index;
+            }
+        }
+
+    private:
+        ui64 Index;
+        TPersistentTable& Table;
+    };
+
+    TIterator begin()
+    {
+        return TIterator(*this, 0);
+    }
+
+    TIterator end()
+    {
+        return TIterator(*this, RecordCount);
+    }
+
+public:
+    TPersistentTable(const TString& fileName, size_t initialRecordCount)
+        : FileName(fileName)
+        , RecordCount(initialRecordCount)
+    {
+        // if file doesn't exist create file with zeroed header
+        TFile file(FileName, OpenAlways | WrOnly);
+        if (file.GetLength() == 0) {
+            file.Resize(CalcFileSize(0));
+        }
+        file.Close();
+
+        FileMap = std::make_unique<TFileMap>(FileName, TMemoryMapCommon::oRdWr);
+        FileMap->Map(0, sizeof(Header));
+
+        auto* header = static_cast<Header*>(FileMap->Ptr());
+        if (header->RecordCount == 0) {
+            header->RecordCount = RecordCount;
+            header->HeaderSize = sizeof(Header);
+            header->RecordSize = sizeof(Record);
+        }
+
+        Y_ABORT_UNLESS(header->HeaderSize == sizeof(Header));
+        Y_ABORT_UNLESS(header->RecordSize == sizeof(Record));
+
+        RecordCount = header->RecordCount;
+
+        FileMap->ResizeAndRemap(0, CalcFileSize(RecordCount));
+        HeaderPtr = static_cast<Header*>(FileMap->Ptr());
+        RecordsPtr = static_cast<Record*>((void*)(HeaderPtr + 1));
+
+        CompactRecords();
+    }
+
+    H* HeaderData()
+    {
+        return &HeaderPtr->Data;
+    }
+
+    R* RecordData(ui64 index)
+    {
+        return &RecordsPtr[index].Data;
+    }
+
+    ui64 AllocRecord()
+    {
+        ui64 index = InvalidIndex;
+
+        if (!FreeRecords.empty()) {
+            index = FreeRecords.front();
+            FreeRecords.pop_front();
+        } else if (NextFreeRecord < RecordCount) {
+            index = NextFreeRecord++;
+        }
+
+        if (index != InvalidIndex) {
+            RecordsPtr[index].State = ERecordState::Allocated;
+        }
+
+        return index;
+    }
+
+    void StoreRecord(ui64 index)
+    {
+        Y_ABORT_UNLESS(index < RecordCount);
+        RecordsPtr[index].State = ERecordState::Stored;
+    }
+
+    void DeleteRecord(ui64 index)
+    {
+        Y_ABORT_UNLESS(index < RecordCount);
+        RecordsPtr[index].State = ERecordState::Free;
+        if (index + 1 == NextFreeRecord) {
+            NextFreeRecord--;
+        } else {
+            FreeRecords.push_back(index);
+        }
+    }
+
+    size_t CountRecords()
+    {
+        return std::distance(begin(), end());
+    }
+
+private:
+    size_t CalcFileSize(size_t recordCount)
+    {
+        return sizeof(Header) + recordCount * sizeof(Record);
+    }
+
+    void CompactRecords()
+    {
+        ui64 writeRecordIndex = 0;
+        ui64 readRecordIndex = 0;
+
+        while (readRecordIndex < RecordCount) {
+            if (RecordsPtr[readRecordIndex].State != ERecordState::Stored) {
+                readRecordIndex++;
+                continue;
+            }
+
+            if (writeRecordIndex != readRecordIndex) {
+                std::memcpy(
+                    &RecordsPtr[writeRecordIndex],
+                    &RecordsPtr[readRecordIndex],
+                    sizeof(Record));
+                RecordsPtr[readRecordIndex].State = ERecordState::Free;
+            }
+            writeRecordIndex++;
+            readRecordIndex++;
+        }
+
+        NextFreeRecord = writeRecordIndex;
+    }
+};
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/persistent_table_ut.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/folder/tempdir.h>
+#include <util/generic/list.h>
 #include <util/random/random.h>
 
 #include <iterator>
@@ -63,7 +64,7 @@ struct TReferenceImplementation
         }
 
         UNIT_ASSERT_VALUES_EQUAL(NextFreeRecord, index);
-        NextFreeRecord++;
+        ++NextFreeRecord;
     }
 
     void DeleteRecord(ui64 index)
@@ -106,8 +107,7 @@ struct TReferenceImplementation
         ui64 index = 0;
         TMap<ui64, ui64> newRecords;
         for (auto& [_, val]: Records) {
-            newRecords[index] = val;
-            index++;
+            newRecords[index++] = val;
         }
 
         Records = std::move(newRecords);
@@ -166,11 +166,11 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
             UNIT_ASSERT_VALUES_EQUAL(recordValues.size(), table.CountRecords());
 
             auto it = table.begin();
-            for (ui64 index = 0; index < recordValues.size(); index++) {
+            for (ui64 index = 0; index < recordValues.size(); ++index) {
                 UNIT_ASSERT_VALUES_EQUAL(index, it.GetIndex());
                 UNIT_ASSERT_VALUES_EQUAL(index, it->Index);
                 UNIT_ASSERT_VALUES_EQUAL(recordValues[index], it->Val);
-                it++;
+                ++it;
             }
         }
     }
@@ -184,7 +184,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
 
         {
             TPersistentTable<THeader, TRecord> table(tablePath, tableSize);
-            for (auto i = 0; i < tableSize; i++) {
+            for (auto i = 0; i < tableSize; ++i) {
                 auto index = table.AllocRecord();
                 UNIT_ASSERT_VALUES_UNEQUAL(table.InvalidIndex, index);
             }
@@ -239,7 +239,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
             }
 
             TVector<ui64> newRecordData;
-            for (ui64 index = 0; index < recordValues.size(); index++) {
+            for (ui64 index = 0; index < recordValues.size(); ++index) {
                 if (index % 2 == 0) {
                     newRecordData.push_back(recordValues[index]);
                 } else {
@@ -252,7 +252,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
         {
             TPersistentTable<THeader, TRecord> table(tablePath, 32);
             ui64 index = 0;
-            for (auto it = table.begin(); it != table.end(); index++, it++) {
+            for (auto it = table.begin(); it != table.end(); ++index, ++it) {
                 UNIT_ASSERT_LT(index, recordValues.size());
                 UNIT_ASSERT_VALUES_EQUAL(index, it.GetIndex());
                 UNIT_ASSERT_VALUES_EQUAL(recordValues[index], it->Val);
@@ -305,7 +305,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
         {
             TTable table(tablePath, 32);
             ui64 index = 0;
-            for (auto it = table.begin(); it != table.end(); index++, it++) {
+            for (auto it = table.begin(); it != table.end(); ++index, ++it) {
                 UNIT_ASSERT_LT(index, recordValues.size());
                 UNIT_ASSERT_VALUES_EQUAL(index, it.GetIndex());
                 UNIT_ASSERT_VALUES_EQUAL(recordValues[index], it->Val);
@@ -326,7 +326,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
         {
             TTable table(tablePath, 32);
             ui64 index = 0;
-            for (auto it = table.begin(); it != table.end(); index++, it++) {
+            for (auto it = table.begin(); it != table.end(); ++index, ++it) {
                 UNIT_ASSERT_LT(index, recordValues.size());
                 UNIT_ASSERT_VALUES_EQUAL(index, it.GetIndex());
                 UNIT_ASSERT_VALUES_EQUAL(recordValues[index], it->Val);
@@ -346,16 +346,16 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
             TPersistentTable<THeader, TRecord> table(tablePath, tableSize);
             UNIT_ASSERT_VALUES_EQUAL(table.CountRecords(), 0);
 
-            for (auto i = 0; i < tableSize; i++) {
+            for (auto i = 0; i < tableSize; ++i) {
                 auto index = table.AllocRecord();
                 UNIT_ASSERT_VALUES_UNEQUAL(table.InvalidIndex, index);
                 UNIT_ASSERT_VALUES_EQUAL(table.CountRecords(), index + 1);
             }
 
             ui32 deletedRecords = 0;
-            for (auto i = 0; i < tableSize; i++) {
+            for (auto i = 0; i < tableSize; ++i) {
                 if (i % 2 == 0) {
-                    deletedRecords++;
+                    ++deletedRecords;
                     table.DeleteRecord(i);
                     UNIT_ASSERT_VALUES_EQUAL(
                         table.CountRecords(),

--- a/cloud/storage/core/libs/common/persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/persistent_table_ut.cpp
@@ -1,0 +1,172 @@
+#include "persistent_table.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/folder/tempdir.h>
+
+#include <iterator>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct THeader
+{
+    ui64 Val;
+};
+
+struct TRecord
+{
+    ui64 Index;
+    ui64 Val;
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TPersistentTableTest)
+{
+    Y_UNIT_TEST(ShouldPersistHeader)
+    {
+        TTempDir dir;
+        auto tablePath = dir.Path() / "table";
+        TVector<ui64> headerValues = {123, 567, 99, 4};
+
+        for (auto& val: headerValues) {
+            {
+                TPersistentTable<THeader, TRecord> table(tablePath, 32);
+                auto* header = table.HeaderData();
+                header->Val = val;
+            }
+
+            {
+                TPersistentTable<THeader, TRecord> table(tablePath, 32);
+                auto* header = table.HeaderData();
+                UNIT_ASSERT_VALUES_EQUAL(val, header->Val);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldPersistRecords)
+    {
+        TTempDir dir;
+        auto tablePath = dir.Path() / "table";
+
+        TVector<ui64> recordValues = {1, 344, 67, 68, 56};
+
+        {
+            TPersistentTable<THeader, TRecord> table(tablePath, 32);
+            for (auto& val: recordValues) {
+                auto index = table.AllocRecord();
+                auto* record = table.RecordData(index);
+                record->Val = val;
+                record->Index = index;
+                table.StoreRecord(index);
+            }
+        }
+
+        {
+            TPersistentTable<THeader, TRecord> table(tablePath, 32);
+            UNIT_ASSERT_VALUES_EQUAL(recordValues.size(), table.CountRecords());
+
+            auto it = table.begin();
+            for (ui64 index = 0; index < recordValues.size(); index++) {
+                UNIT_ASSERT_VALUES_EQUAL(index, it.GetIndex());
+                UNIT_ASSERT_VALUES_EQUAL(index, it->Index);
+                UNIT_ASSERT_VALUES_EQUAL(recordValues[index], it->Val);
+                it++;
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldLimitAllocatedRecords)
+    {
+        TTempDir dir;
+        auto tablePath = dir.Path() / "table";
+
+        auto tableSize = 32;
+
+        {
+            TPersistentTable<THeader, TRecord> table(tablePath, tableSize);
+            for (auto i = 0; i < tableSize; i++) {
+                auto index = table.AllocRecord();
+                UNIT_ASSERT_VALUES_UNEQUAL(table.InvalidIndex, index);
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(table.InvalidIndex, table.AllocRecord());
+            table.DeleteRecord(0);
+            UNIT_ASSERT_VALUES_UNEQUAL(table.InvalidIndex, table.AllocRecord());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldReuseDeletedRecords)
+    {
+        TTempDir dir;
+        auto tablePath = dir.Path() / "table";
+
+        TVector<ui64> recordValues = {1, 344, 67, 68, 56};
+        {
+            TPersistentTable<THeader, TRecord> table(tablePath, 32);
+            for (auto& data: recordValues) {
+                auto index = table.AllocRecord();
+                table.RecordData(index)->Val = data;
+                table.StoreRecord(index);
+            }
+
+            table.DeleteRecord(1);
+            table.DeleteRecord(3);
+
+            auto index = table.AllocRecord();
+            UNIT_ASSERT_VALUES_EQUAL(1, index);
+
+            index = table.AllocRecord();
+            UNIT_ASSERT_VALUES_EQUAL(3, index);
+
+            index = table.AllocRecord();
+            UNIT_ASSERT_VALUES_EQUAL(recordValues.size(), index);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCompactRecord)
+    {
+        TTempDir dir;
+        auto tablePath = dir.Path() / "table";
+
+        TVector<ui64> recordValues = {1, 344, 67, 68, 56};
+        {
+            TPersistentTable<THeader, TRecord> table(tablePath, 32);
+            for (auto& data: recordValues) {
+                auto index = table.AllocRecord();
+                table.RecordData(index)->Index = index;
+                table.RecordData(index)->Val = data;
+                table.StoreRecord(index);
+            }
+
+            TVector<ui64> newRecordData;
+            for (ui64 index = 0; index < recordValues.size(); index++) {
+                if (index % 2 == 0) {
+                    newRecordData.push_back(recordValues[index]);
+                } else {
+                    table.DeleteRecord(index);
+                }
+            }
+            recordValues = std::move(newRecordData);
+        }
+
+        {
+            TPersistentTable<THeader, TRecord> table(tablePath, 32);
+            ui64 index = 0;
+            for (auto it = table.begin(); it != table.end(); index++, it++) {
+                UNIT_ASSERT_LT(index, recordValues.size());
+                UNIT_ASSERT_VALUES_EQUAL(index, it.GetIndex());
+                UNIT_ASSERT_VALUES_EQUAL(recordValues[index], it->Val);
+            }
+            UNIT_ASSERT_VALUES_EQUAL(index, recordValues.size());
+        }
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/persistent_table_ut.cpp
@@ -64,7 +64,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
                 auto* record = table.RecordData(index);
                 record->Val = val;
                 record->Index = index;
-                table.StoreRecord(index);
+                table.CommitRecord(index);
             }
         }
 
@@ -113,7 +113,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
             for (auto& data: recordValues) {
                 auto index = table.AllocRecord();
                 table.RecordData(index)->Val = data;
-                table.StoreRecord(index);
+                table.CommitRecord(index);
             }
 
             table.DeleteRecord(1);
@@ -142,7 +142,7 @@ Y_UNIT_TEST_SUITE(TPersistentTableTest)
                 auto index = table.AllocRecord();
                 table.RecordData(index)->Index = index;
                 table.RecordData(index)->Val = data;
-                table.StoreRecord(index);
+                table.CommitRecord(index);
             }
 
             TVector<ui64> newRecordData;

--- a/cloud/storage/core/libs/common/ut/ya.make
+++ b/cloud/storage/core/libs/common/ut/ya.make
@@ -24,6 +24,7 @@ SRCS(
     file_io_service_ut.cpp
     guarded_sglist_ut.cpp
     history_ut.cpp
+    persistent_table_ut.cpp
     ring_buffer_ut.cpp
     scheduler_ut.cpp
     scoped_handle_ut.cpp

--- a/cloud/storage/core/libs/common/ya.make
+++ b/cloud/storage/core/libs/common/ya.make
@@ -19,6 +19,7 @@ SRCS(
     helpers.cpp
     history.cpp
     media.cpp
+    persistent_table.cpp
     proto_helpers.cpp
     random.cpp
     ring_buffer.cpp


### PR DESCRIPTION
Implementation of records table on top of memory mapped file.

This will be used to recover inodes and file descriptors in later PRs

#2190 
