### PR TITLE
[merge to stable-23-3] Added prometheus format to user stats (#2193)

### DIFF
--- a/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
+++ b/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
@@ -11,6 +11,7 @@
 #include <library/cpp/monlib/dynamic_counters/encode.h>
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/monlib/encode/json/json.h>
+#include <library/cpp/monlib/encode/prometheus/prometheus.h>
 #include <library/cpp/monlib/encode/spack/spack_v1.h>
 #include <library/cpp/monlib/encode/text/text.h>
 
@@ -53,6 +54,11 @@ void TUserStatsActor::RegisterPages(const NActors::TActorContext& ctx)
             Path + "/user_stats/spack",
             [this] (IOutputStream& out) {
                 return OutputSpackPage(out);
+            }));
+        mon->Register(new TMonPageWrapper(
+            Path + "/user_stats/prometheus",
+            [this] (IOutputStream& out) {
+                return OutputPrometheusPage(out);
             }));
     }
 }
@@ -103,6 +109,23 @@ void TUserStatsActor::OutputSpackPage(IOutputStream& out) const
 
         for (auto&& provider : Providers) {
             provider->Append(TInstant::Now(), encoder.Get());
+        }
+    }
+    encoder->OnStreamEnd();
+}
+
+void TUserStatsActor::OutputPrometheusPage(IOutputStream& out) const
+{
+    out << NMonitoring::HTTPOKPROMETHEUS;
+
+    auto encoder = NMonitoring::EncoderPrometheus(&out, "name");
+
+    encoder->OnStreamBegin();
+    {
+        TReadGuard g{Lock};
+
+        for (auto&& provider : Providers) {
+            provider->Append(TInstant::Zero(), encoder.Get());
         }
     }
     encoder->OnStreamEnd();

--- a/cloud/storage/core/libs/user_stats/user_stats_actor.h
+++ b/cloud/storage/core/libs/user_stats/user_stats_actor.h
@@ -38,6 +38,7 @@ private:
 
     void OutputJsonPage(IOutputStream& out) const;
     void OutputSpackPage(IOutputStream& out) const;
+    void OutputPrometheusPage(IOutputStream& out) const;
 
 private:
     STFUNC(StateWork);


### PR DESCRIPTION
* Added prometheus format to user stats

* use "name" instead "sensor" for counter name

* remove timestamp

---------

Co-authored-by: Dmitry Razumov <dvrazumov@yandex-team.ru>