### PR TITLE
issue-2074: clean an unoccupied device if its configuration has been changed

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -62,6 +62,7 @@ namespace NCloud::NBlockStore {
     xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
     xxx(DiskRegistryPurgeHostError)                                            \
     xxx(DiskRegistryCleanupAgentConfigError)                                   \
+    xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -972,8 +972,6 @@ auto TDiskRegistryState::RegisterAgent(
                     << "Device configuration has changed: " << *oldConfig
                     << " -> " << d << ". Affected disk: " << diskId;
 
-                STORAGE_ERROR(message);
-
                 ReportDiskRegistryOccupiedDeviceConfigurationHasChanged(
                     message);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -971,6 +971,9 @@ auto TDiskRegistryState::RegisterAgent(
 
                 STORAGE_ERROR(message);
 
+                ReportDiskRegistryOccupiedDeviceConfigurationHasChanged(
+                    message);
+
                 SetDeviceErrorState(d, timestamp, std::move(message));
 
                 continue;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1268,10 +1268,6 @@ private:
         TDiskId& affectedDisk,
         TDuration& timeout);
 
-    bool IsChangeDestructive(
-        const NProto::TDeviceConfig& device,
-        const NProto::TDeviceConfig& oldConfig) const;
-
     void ResetMigrationStartTsIfNeeded(TDiskState& disk);
 
     struct TConfigUpdateEffect;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1268,9 +1268,9 @@ private:
         TDiskId& affectedDisk,
         TDuration& timeout);
 
-    NProto::TError CheckDestructiveConfigurationChange(
+    bool IsChangeDestructive(
         const NProto::TDeviceConfig& device,
-        const THashMap<TDeviceId, NProto::TDeviceConfig>& oldConfigs) const;
+        const NProto::TDeviceConfig& oldConfig) const;
 
     void ResetMigrationStartTsIfNeeded(TDiskState& disk);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -8677,7 +8677,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         });
 
         const auto agent1b = AgentConfig(1000, {
-            Device("dev-1", "uuid-1.2", "rack-1"),
+            Device("dev-2", "uuid-1.2", "rack-1"),
         });
 
         TDiskRegistryState state = TDiskRegistryStateBuilder()
@@ -11775,7 +11775,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyBytes->Val());
     }
 
-    Y_UNIT_TEST(ShouldDirtyDevicesWithNewSerialNumber)
+    Y_UNIT_TEST(ShouldCleanAvailableDevicesWithNewSerialNumber)
     {
         const TString oldSerialNumber = "OldSerialNumber";
         const TString newSerialNumber = "NewSerialNumber";

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -11775,11 +11775,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyBytes->Val());
     }
 
-    Y_UNIT_TEST(ShouldCleanAvailableDevicesWithNewSerialNumber)
+    Y_UNIT_TEST(ShouldCleanUnoccupiedDevicesWithNewSerialNumber)
     {
-        const TString oldSerialNumber = "OldSerialNumber";
-        const TString newSerialNumber = "NewSerialNumber";
-
         auto monitoring = CreateMonitoringServiceStub();
         auto rootGroup = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore");
@@ -11800,7 +11797,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         auto agentConfig = AgentConfig(1, {
             Device("NVMENBS01", "uuid-1.1"),
-            Device("NVMENBS01", "uuid-1.2"),
+            Device("NVMENBS02", "uuid-1.2"),
         });
 
         TDiskRegistryState state = TDiskRegistryStateBuilder()
@@ -11820,8 +11817,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 UNIT_ASSERT_VALUES_EQUAL(0, state.GetDirtyDevices().size());
             });
 
-        agentConfig.MutableDevices(0)->SetSerialNumber(oldSerialNumber);
-        agentConfig.MutableDevices(1)->SetSerialNumber(oldSerialNumber);
+        agentConfig.MutableDevices(0)->SetSerialNumber("SN-X-1");
+        agentConfig.MutableDevices(1)->SetSerialNumber("SN-Y-1");
+        agentConfig.MutableDevices(0)->SetPhysicalOffset(1000);
+        agentConfig.MutableDevices(1)->SetPhysicalOffset(1000);
 
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
@@ -11833,8 +11832,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 UNIT_ASSERT_VALUES_EQUAL(0, state.GetDirtyDevices().size());
             });
 
-        agentConfig.MutableDevices(0)->SetSerialNumber(newSerialNumber);
-        agentConfig.MutableDevices(1)->SetSerialNumber(newSerialNumber);
+        agentConfig.MutableDevices(0)->SetSerialNumber("SN-X-2");
+        agentConfig.MutableDevices(1)->SetSerialNumber("SN-Y-2");
 
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
@@ -11848,11 +11847,40 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 UNIT_ASSERT_VALUES_EQUAL(1, dd.size());
                 UNIT_ASSERT_VALUES_EQUAL("uuid-1.1", dd[0].GetDeviceUUID());
                 UNIT_ASSERT_VALUES_EQUAL(
-                    newSerialNumber,
+                    agentConfig.GetDevices(0).GetSerialNumber(),
                     dd[0].GetSerialNumber());
             });
 
         UNIT_ASSERT_VALUES_EQUAL(1, criticalEvents->Val());
+
+        // Change the PhysicalOffset for uuid-1.2
+        agentConfig.MutableDevices(1)->SetPhysicalOffset(42);
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                auto [r, error] = state.RegisterAgent(db, agentConfig, Now());
+
+                UNIT_ASSERT_SUCCESS(error);
+                UNIT_ASSERT_VALUES_EQUAL(0, r.AffectedDisks.size());
+            });
+
+        UNIT_ASSERT_VALUES_EQUAL(2, criticalEvents->Val());
+
+        // Change the SN for uuid-1.2 once more
+        agentConfig.MutableDevices(1)->SetSerialNumber("SN-Y-3");
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                auto [r, error] = state.RegisterAgent(db, agentConfig, Now());
+
+                UNIT_ASSERT_SUCCESS(error);
+                UNIT_ASSERT_VALUES_EQUAL(0, r.AffectedDisks.size());
+            });
+
+        // Crit event shouldn't be reported
+        UNIT_ASSERT_VALUES_EQUAL(2, criticalEvents->Val());
     }
 }
 


### PR DESCRIPTION
#2074

Only unoccupied devices are cleared, devices with user disks will still be put into error state without cleanup.