### PR TITLE
issue-1795: fixed TBlockDeletion application in FlushBytes - we should reset only the part of the block that describes the data, not the NodeId, BlockIndex, etc part

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -78,7 +78,7 @@ public:
         TABLET_VERIFY(!ApplyingByteLayer);
 
         if (BlockMinCommitId < deletion.CommitId) {
-            Block = {};
+            Block.Block = {};
         }
     }
 
@@ -90,6 +90,11 @@ public:
             const auto bytesOffset =
                 static_cast<ui64>(Block.BlockIndex) * BlockSize;
             Block.BytesMinCommitId = bytes.MinCommitId;
+            TABLET_VERIFY_C(
+                bytes.Offset - bytesOffset <= BlockSize,
+                "Bytes: " << bytes.Describe()
+                    << ", Block: " << Block.BlockIndex
+                    << ", BlockSize: " << BlockSize);
             Block.BlockBytes.Intervals.push_back({
                 IntegerCast<ui32>(bytes.Offset - bytesOffset),
                 TString(data)


### PR DESCRIPTION
#1795 