### PR TITLE
Add possibility to do lite reallocations

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1039,4 +1039,11 @@ message TStorageServiceConfig
 
     // settings for ydb config dispatcher service.
     optional NCloud.NProto.TConfigDispatcherSettings ConfigDispatcherSettings = 385;
+
+    // The volume actor will compare meta before and after reallocation and
+    // decide whether a lite reallocation is possible.
+    optional bool AllowLiteDiskReallocations = 386;
+
+    // Timeout between disks reallocations.
+    optional uint32 DiskRegistryDisksNotificationTimeout = 387;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -86,6 +86,7 @@ namespace NCloud::NBlockStore {
     xxx(DiskRegistryUnexpectedAffectedDisks)                                   \
     xxx(ReadBlockCountMismatch)                                                \
     xxx(CancelRoutineIsNotSet)                                                 \
+    xxx(FieldDescriptorNotFound)                                               \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -511,6 +511,8 @@ TDuration MSeconds(ui32 value)
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(IdleAgentDeployByCmsDelay,                      TDuration, Hours(1)      )\
+    xxx(AllowLiteDiskReallocations,                     bool,      false         )\
+    xxx(DiskRegistryDisksNotificationTimeout,           TDuration, Seconds(5)    )\
 
 
 // BLOCKSTORE_STORAGE_CONFIG_RW

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -596,6 +596,9 @@ public:
     TVector<TString> GetDestructionAllowedOnlyForDisksWithIdPrefixes() const;
 
     TDuration GetIdleAgentDeployByCmsDelay() const;
+    TDuration GetDiskRegistryDisksNotificationTimeout() const;
+
+    bool GetAllowLiteDiskReallocations() const;
 
     TString GetNodeRegistrationToken() const;
     ui32 GetNodeRegistrationMaxAttempts() const;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
@@ -232,7 +232,8 @@ void TDiskRegistryActor::ReallocateDisks(const TActorContext& ctx)
 
     auto request = std::make_unique<TEvDiskRegistryPrivate::TEvNotifyDisksRequest>();
 
-    auto deadline = Min(DisksNotificationStartTs, ctx.Now()) + TDuration::Seconds(5);
+    auto deadline = Min(DisksNotificationStartTs, ctx.Now()) +
+                    Config->GetDiskRegistryDisksNotificationTimeout();
     if (deadline > ctx.Now()) {
         LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
             "[%lu] Scheduled disks notification, now: %lu, deadline: %lu",

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -545,6 +545,12 @@ TVolumeClient::CreateUpdateShadowDiskStateRequest(
         processedBlockCount);
 }
 
+std::unique_ptr<TEvVolumePrivate::TEvReadMetaHistoryRequest>
+TVolumeClient::CreateReadMetaHistoryRequest()
+{
+    return std::make_unique<TEvVolumePrivate::TEvReadMetaHistoryRequest>();
+}
+
 void TVolumeClient::SendRemoteHttpInfo(
     const TString& params,
     HTTP_METHOD method)

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -457,7 +457,8 @@ public:
         TEvVolumePrivate::TEvUpdateShadowDiskStateRequest::EReason reason,
         ui64 processedBlockCount);
 
-    std::unique_ptr<TEvVolumePrivate::TEvReadMetaHistoryRequest> CreateReadMetaHistoryRequest();
+    std::unique_ptr<TEvVolumePrivate::TEvReadMetaHistoryRequest>
+    CreateReadMetaHistoryRequest();
 
     void SendRemoteHttpInfo(
         const TString& params,

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -457,6 +457,8 @@ public:
         TEvVolumePrivate::TEvUpdateShadowDiskStateRequest::EReason reason,
         ui64 processedBlockCount);
 
+    std::unique_ptr<TEvVolumePrivate::TEvReadMetaHistoryRequest> CreateReadMetaHistoryRequest();
+
     void SendRemoteHttpInfo(
         const TString& params,
         HTTP_METHOD method);

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -516,6 +516,10 @@ private:
         size_t recordCount,
         bool monRequest);
 
+    void ProcessReadMetaHistory(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo);
+
     bool CheckAllocationResult(
         const NActors::TActorContext& ctx,
         const TDevices& devices,

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -516,10 +516,6 @@ private:
         size_t recordCount,
         bool monRequest);
 
-    void ProcessReadMetaHistory(
-        const NActors::TActorContext& ctx,
-        TRequestInfoPtr requestInfo);
-
     bool CheckAllocationResult(
         const NActors::TActorContext& ctx,
         const TDevices& devices,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -122,8 +122,9 @@ std::unique_ptr<MessageDifferencer> CreateNodeIdChangeDifferencer()
         ReportFieldDescriptorNotFound(
             TStringBuilder()
             << "Lite reallocation is impossible. nodeIdDescriptor = "
-            << nodeIdDescriptor
-            << "; rdmaPortDescriptor = " << rdmaPortDescriptor);
+            << static_cast<const void*>(nodeIdDescriptor)
+            << "; rdmaPortDescriptor = "
+            << static_cast<const void*>(rdmaPortDescriptor));
         return nullptr;
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -16,6 +16,8 @@ using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
+using MessageDifferencer = google::protobuf::util::MessageDifferencer;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -106,6 +108,50 @@ bool ValidateDevices(
     }
 
     return ok;
+}
+
+std::unique_ptr<MessageDifferencer> CreateNodeIdChangeDifferencer()
+{
+    // These are two fields that will change during disk agent blue-green
+    // deploy.
+    const auto* nodeIdDescriptor =
+        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("NodeId");
+    const auto* rdmaPortDescriptor =
+        NProto::TRdmaEndpoint::GetDescriptor()->FindFieldByName("Port");
+    Y_DEBUG_ABORT_UNLESS(nodeIdDescriptor);
+    Y_DEBUG_ABORT_UNLESS(rdmaPortDescriptor);
+
+    auto diff = std::make_unique<MessageDifferencer>();
+    diff->IgnoreField(nodeIdDescriptor);
+    diff->IgnoreField(rdmaPortDescriptor);
+    diff->set_float_comparison(
+        MessageDifferencer::FloatComparison::APPROXIMATE);
+    diff->set_message_field_comparison(
+        MessageDifferencer::MessageFieldComparison::EQUAL);
+    return diff;
+}
+
+NProto::TVolumeMeta CreateNewMeta(
+    const NProto::TVolumeMeta& oldMeta,
+    TTxVolume::TUpdateDevices& args)
+{
+    auto newMeta = oldMeta;
+    *newMeta.MutableDevices() = std::move(args.Devices);
+    *newMeta.MutableMigrations() = std::move(args.Migrations);
+    newMeta.ClearReplicas();
+    for (auto& devices: args.Replicas) {
+        auto* replica = newMeta.AddReplicas();
+        *replica->MutableDevices() = std::move(devices);
+    }
+    newMeta.ClearFreshDeviceIds();
+    for (auto& freshDeviceId: args.FreshDeviceIds) {
+        *newMeta.AddFreshDeviceIds() = std::move(freshDeviceId);
+    }
+    newMeta.SetIOMode(args.IOMode);
+    newMeta.SetIOModeTs(args.IOModeTs.MicroSeconds());
+    newMeta.SetMuteIOErrors(args.MuteIOErrors);
+
+    return newMeta;
 }
 
 }   // namespace
@@ -464,49 +510,58 @@ void TVolumeActor::ExecuteUpdateDevices(
     TTransactionContext& tx,
     TTxVolume::TUpdateDevices& args)
 {
-    Y_UNUSED(ctx);
     Y_ABORT_UNLESS(State);
+    const auto& oldMeta = State->GetMeta();
+    auto newMeta = CreateNewMeta(oldMeta, args);
 
-    auto newMeta = State->GetMeta();
-    *newMeta.MutableDevices() = std::move(args.Devices);
-    *newMeta.MutableMigrations() = std::move(args.Migrations);
-    newMeta.ClearReplicas();
-    for (auto& devices: args.Replicas) {
-        auto* replica = newMeta.AddReplicas();
-        *replica->MutableDevices() = std::move(devices);
+    Y_DEBUG_ABORT_UNLESS(State->IsDiskRegistryMediaKind());
+    if (Config->GetAllowLiteDiskReallocations()) {
+        auto differencer = CreateNodeIdChangeDifferencer();
+
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "\noldmeta = %s; \nnewmeta = %s",
+            oldMeta.DebugString().c_str(),
+            newMeta.DebugString().c_str());
+        args.LiteReallocation = differencer->Compare(oldMeta, newMeta);
     }
-    newMeta.ClearFreshDeviceIds();
-    for (auto& freshDeviceId: args.FreshDeviceIds) {
-        *newMeta.AddFreshDeviceIds() = std::move(freshDeviceId);
-    }
-    newMeta.SetIOMode(args.IOMode);
-    newMeta.SetIOModeTs(args.IOModeTs.MicroSeconds());
-    newMeta.SetMuteIOErrors(args.MuteIOErrors);
-
-    // TODO: reset MigrationIndex here and in UpdateVolumeConfig only if our
-    // migration or fresh device lists have changed
-    // NBS-1988
-    newMeta.SetMigrationIndex(0);
-
-    TVolumeMetaHistoryItem metaHistoryItem{ctx.Now(), newMeta};
 
     TVolumeDatabase db(tx.DB);
+    if (!args.LiteReallocation) {
+        // TODO: reset MigrationIndex here and in UpdateVolumeConfig only if our
+        // migration or fresh device lists have changed
+        // NBS-1988
+        newMeta.SetMigrationIndex(0);
+
+        TVolumeMetaHistoryItem metaHistoryItem{ctx.Now(), newMeta};
+        db.WriteMetaHistory(State->GetMetaHistory().size(), metaHistoryItem);
+        State->AddMetaHistory(std::move(metaHistoryItem));
+    }
+
     db.WriteMeta(newMeta);
-    db.WriteMetaHistory(State->GetMetaHistory().size(), metaHistoryItem);
     State->ResetMeta(std::move(newMeta));
-    State->AddMetaHistory(std::move(metaHistoryItem));
 }
 
 void TVolumeActor::CompleteUpdateDevices(
     const TActorContext& ctx,
     TTxVolume::TUpdateDevices& args)
 {
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "[%lu] Devices has been updated. DiskId: %s LiteReallocation: %d",
+        TabletID(),
+        State->GetDiskId().c_str(),
+        args.LiteReallocation);
+
     if (auto actorId = State->GetDiskRegistryBasedPartitionActor()) {
         if (!args.RequestInfo) {
             WaitForPartitions.emplace_back(actorId, nullptr);
         } else {
-            auto requestInfo = std::move(args.RequestInfo);
-            auto reply = [=] (const auto& ctx, auto error) {
+            auto reply =
+                [requestInfo = args.RequestInfo](const auto& ctx, auto error)
+            {
                 using TResponse = TEvVolumePrivate::TEvUpdateDevicesResponse;
 
                 NCloud::Reply(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_read_history.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_read_history.cpp
@@ -112,4 +112,3 @@ void TVolumeActor::CompleteReadHistory(
 }
 
 }   // namespace NCloud::NBlockStore::NStorage
-

--- a/cloud/blockstore/libs/storage/volume/volume_actor_read_meta_history.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_read_meta_history.cpp
@@ -2,7 +2,6 @@
 
 #include "volume_database.h"
 
-// #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
@@ -13,8 +12,6 @@ using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
-LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void TVolumeActor::HandleReadMetaHistory(
@@ -24,14 +21,6 @@ void TVolumeActor::HandleReadMetaHistory(
     auto* msg = ev->Get();
     auto requestInfo =
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
-
-    ProcessReadMetaHistory(ctx, std::move(requestInfo));
-}
-
-void TVolumeActor::ProcessReadMetaHistory(
-    const NActors::TActorContext& ctx,
-    TRequestInfoPtr requestInfo)
-{
     AddTransaction(*requestInfo);
 
     ExecuteTx<TReadMetaHistory>(ctx, std::move(requestInfo));

--- a/cloud/blockstore/libs/storage/volume/volume_actor_read_meta_history.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_read_meta_history.cpp
@@ -1,0 +1,75 @@
+#include "volume_actor.h"
+
+#include "volume_database.h"
+
+// #include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+#include <cloud/blockstore/libs/storage/core/request_info.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TVolumeActor::HandleReadMetaHistory(
+    const TEvVolumePrivate::TEvReadMetaHistoryRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+
+    ProcessReadMetaHistory(ctx, std::move(requestInfo));
+}
+
+void TVolumeActor::ProcessReadMetaHistory(
+    const NActors::TActorContext& ctx,
+    TRequestInfoPtr requestInfo)
+{
+    AddTransaction(*requestInfo);
+
+    ExecuteTx<TReadMetaHistory>(ctx, std::move(requestInfo));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TVolumeActor::PrepareReadMetaHistory(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxVolume::TReadMetaHistory& args)
+{
+    Y_UNUSED(ctx);
+
+    TVolumeDatabase db(tx.DB);
+    return db.ReadMetaHistory(args.MetaHistory);
+}
+
+void TVolumeActor::ExecuteReadMetaHistory(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxVolume::TReadMetaHistory& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+}
+
+void TVolumeActor::CompleteReadMetaHistory(
+    const TActorContext& ctx,
+    TTxVolume::TReadMetaHistory& args)
+{
+    auto response =
+        std::make_unique<TEvVolumePrivate::TEvReadMetaHistoryResponse>();
+    response->MetaHistory = std::move(args.MetaHistory);
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+
+    RemoveTransaction(*args.RequestInfo);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -24,6 +24,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(UpdateDevices,                      __VA_ARGS__)                       \
     xxx(UpdateCheckpointRequest,            __VA_ARGS__)                       \
     xxx(UpdateShadowDiskState,              __VA_ARGS__)                       \
+    xxx(ReadMetaHistory,                    __VA_ARGS__)                       \
 // BLOCKSTORE_VOLUME_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -116,6 +117,19 @@ struct TEvVolumePrivate
     struct TReadHistoryResponse
     {
         TVector<THistoryLogItem> History;
+    };
+
+    //
+    // ReadMetaHistory
+    //
+
+    struct TReadMetaHistoryRequest
+    {
+    };
+
+    struct TReadMetaHistoryResponse
+    {
+        TVector<TVolumeMetaHistoryItem> MetaHistory;
     };
 
     //

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -40,6 +40,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(UpdateVolumeParams,             __VA_ARGS__)                           \
     xxx(DeleteVolumeParams,             __VA_ARGS__)                           \
     xxx(ChangeStorageConfig,            __VA_ARGS__)                           \
+    xxx(ReadMetaHistory,                __VA_ARGS__)                           \
 // BLOCKSTORE_VOLUME_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,6 +151,8 @@ struct TTxVolume
         NProto::EVolumeIOMode IOMode;
         TInstant IOModeTs;
         bool MuteIOErrors;
+
+        bool LiteReallocation = false;
 
         TUpdateDevices(
                 TDevices devices,
@@ -365,6 +368,26 @@ struct TTxVolume
         void Clear()
         {
             OutdatedHistory.clear();
+        }
+    };
+
+    //
+    // Read Meta History
+    //
+
+    struct TReadMetaHistory
+    {
+        const TRequestInfoPtr RequestInfo;
+
+        TVector<TVolumeMetaHistoryItem> MetaHistory;
+
+        explicit TReadMetaHistory(TRequestInfoPtr requestInfo)
+            : RequestInfo(std::move(requestInfo))
+        {}
+
+        void Clear()
+        {
+            MetaHistory.clear();
         }
     };
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -5013,6 +5013,110 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldDoLiteReallocations)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        const auto expectedBlockCount = DefaultDeviceBlockSize * DefaultDeviceBlockCount
+            / DefaultBlockSize;
+        const auto expectedDeviceCount = 3;
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            expectedBlockCount);
+
+        NProto::TStorageServiceConfig patch;
+        patch.SetAllowLiteDiskReallocations(true);
+        volume.ChangeStorageConfig(std::move(patch));
+        volume.WaitReady();
+
+        {
+            // Meta history should contain a single item.
+            auto metaHistory = volume.ReadMetaHistory();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, metaHistory->Error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(1, metaHistory->MetaHistory.size());
+        }
+
+        {
+            auto stat = volume.StatVolume();
+            const auto& devices = stat->Record.GetVolume().GetDevices();
+            UNIT_ASSERT_VALUES_EQUAL(1, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedBlockCount,
+                devices[0].GetBlockCount());
+        }
+
+        {
+            auto sender = runtime->AllocateEdgeActor();
+
+            auto request = std::make_unique<TEvDiskRegistry::TEvAllocateDiskRequest>();
+            request->Record.SetDiskId("vol0");
+            request->Record.SetBlockSize(DefaultBlockSize);
+            request->Record.SetBlocksCount(expectedDeviceCount * expectedBlockCount);
+
+            runtime->Send(new IEventHandle(
+                MakeDiskRegistryProxyServiceId(),
+                sender,
+                request.release()));
+        }
+
+        volume.ReallocateDisk();
+
+        ui32 oldNodeId = 0;
+        {
+            auto stat = volume.StatVolume();
+            const auto& devices = stat->Record.GetVolume().GetDevices();
+            UNIT_ASSERT_VALUES_EQUAL(expectedDeviceCount, devices.size());
+            oldNodeId = devices[0].GetNodeId();
+        }
+
+        {
+            // No lite reallocation, since device count was changed. Meta
+            // history contains 2 items now.
+            auto metaHistory = volume.ReadMetaHistory();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, metaHistory->Error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(2, metaHistory->MetaHistory.size());
+        }
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvDiskRegistry::EvAllocateDiskResponse: {
+                        auto* msg = event->Get<
+                            TEvDiskRegistry::TEvAllocateDiskResponse>();
+                        for (auto& device: *msg->Record.MutableDevices()) {
+                            device.SetNodeId(device.GetNodeId() + 1);
+                        }
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        volume.ReallocateDisk();
+        {
+            auto stat = volume.StatVolume();
+            const auto& devices = stat->Record.GetVolume().GetDevices();
+            UNIT_ASSERT_VALUES_EQUAL(expectedDeviceCount, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL(oldNodeId + 1, devices[0].GetNodeId());
+        }
+
+        {
+            // Lite reallocation happened. Meta history still contains 2 items.
+            auto metaHistory = volume.ReadMetaHistory();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, metaHistory->Error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(2, metaHistory->MetaHistory.size());
+        }
+    }
+
     Y_UNIT_TEST(ShouldRejectAllocateDiskResponseWithInvalidDeviceSizes)
     {
         auto runtime = PrepareTestActorRuntime();

--- a/cloud/blockstore/libs/storage/volume/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ya.make
@@ -20,6 +20,7 @@ SRCS(
     volume_actor_monitoring_removeclient.cpp
     volume_actor_monitoring.cpp
     volume_actor_read_history.cpp
+    volume_actor_read_meta_history.cpp
     volume_actor_reallocatedisk.cpp
     volume_actor_removeclient.cpp
     volume_actor_reset_seqnumber.cpp


### PR DESCRIPTION
#2145

В случае реалокации диска во время blue-green диск агента, теперь не пишется история и не сбрасывается индекс миграции. 

Возможно в будущем доделаю, чтобы partition вообще не рестартовал. Но по-простому там не получилось.

