### PR TITLE
Adding a debug assert to debug the case when PostponeTsCycles is zero upon Advance()

### DIFF
--- a/cloud/storage/core/libs/common/context.cpp
+++ b/cloud/storage/core/libs/common/context.cpp
@@ -86,6 +86,7 @@ void TCallContextBase::Postpone(ui64 nowCycles)
     Y_DEBUG_ABORT_UNLESS(
         AtomicGet(PostponeTsCycles) == 0,
         "Request was not advanced.");
+    Y_DEBUG_ABORT_UNLESS(nowCycles > 0);
     AtomicSet(PostponeTsCycles, nowCycles);
 }
 


### PR DESCRIPTION
```
VERIFY failed (2024-10-01T09:10:30.509721Z): Request was not postponed.
  cloud/storage/core/libs/common/context.cpp:95
  Advance(): requirement start != 0 failed
2024-10-01T09:10:30.510683Z :BLOCKSTORE_PARTITION DEBUG: [72075186224037889] Complete ZeroBlocks (gen: 4, step: 8)
BackTrace(void**, unsigned long)+29 (0x36B9A42D)
FormatBackTrace(IOutputStream*)+32 (0x36B9A900)
PrintBackTrace()+17 (0x36B9A951)
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+995 (0x36BF67E3)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+418 (0x36BE9A62)
NCloud::TCallContextBase::Advance(unsigned long)+222 (0x3747BBEE)
??+0 (0x3862C5C2)
??+0 (0x3866C7A4)
??+0 (0x38665F69)
??+0 (0x38665EAD)
??+0 (0x38665D71)
??+0 (0x38665D15)
??+0 (0x38665CD5)
??+0 (0x38665CAD)
??+0 (0x38665119)
std::__y1::__function::__value_func<void ()>::operator()[abi:v15000]() const+50 (0x3599F6B2)
std::__y1::function<void ()>::operator()() const+21 (0x35997025)
??+0 (0x380BA749)
??+0 (0x380B88D3)
??+0 (0x380B79FE)
??+0 (0x36BF5346)
??+0 (0x36BFA1BD)
??+0 (0x7F6C61E3AAC3)
??+0 (0x7F6C61ECC850)
```