### PR TITLE
Add aliases for disk manager admin commands

### DIFF
--- a/cloud/disk_manager/pkg/admin/filesystem.go
+++ b/cloud/disk_manager/pkg/admin/filesystem.go
@@ -346,7 +346,8 @@ func newFilesystemCmd(
 ) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use: "filesystem",
+		Use:     "filesystems",
+		Aliases: []string{"filesystem"},
 	}
 
 	cmd.AddCommand(

--- a/cloud/disk_manager/pkg/admin/placement_group.go
+++ b/cloud/disk_manager/pkg/admin/placement_group.go
@@ -335,7 +335,8 @@ func newPlacementGroupCmd(
 ) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use: "placement_group",
+		Use:     "placement_groups",
+		Aliases: []string{"placement_group"},
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
Added aliases for filesystem and placement_group commands (similarly to disks, tasks and other commands).