### PR TITLE
NBSDUTY-111: round up Timeout to seconds

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
@@ -75,6 +75,11 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostDeviceState(
     args.Error = std::move(result.Error);
     args.AffectedDisks = std::move(result.AffectedDisks);
     args.Timeout = result.Timeout;
+    // Round up to seconds because TActionResult::Timeout is specified in
+    // seconds
+    if (args.Timeout) {
+        args.Timeout = Max(args.Timeout, TDuration::Seconds(1));
+    }
 }
 
 void TDiskRegistryActor::CompleteUpdateCmsHostDeviceState(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
@@ -70,6 +70,12 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostState(
         args.DryRun,
         args.AffectedDisks,
         args.Timeout);
+
+    // Round up to seconds because TActionResult::Timeout is specified in
+    // seconds
+    if (args.Timeout) {
+        args.Timeout = Max(args.Timeout, TDuration::Seconds(1));
+    }
 }
 
 void TDiskRegistryActor::CompleteUpdateCmsHostState(


### PR DESCRIPTION
Fixes cases like this:
```
UpdateCmsHost result: Host=localhost Error=E_TRY_AGAIN time remaining: 0.025766s Timeout=0 AffectedDisks=[]
```