### PR TITLE
[Disk Manager] tracing: add sampling of tasks generations

### DIFF
--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -55,5 +55,5 @@ message TasksConfig {
 
     // Needed for tracing.
     // Spans of tasks with greater generation id will not be sampled.
-    optional uint64 MaxSampledGeneration = 32 [default = 100];
+    optional uint64 MaxSampledTaskGeneration = 32 [default = 100];
 }

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -52,4 +52,8 @@ message TasksConfig {
     optional int64 MaxHangingTaskIDsToReport = 30 [default = 1000];
     // Number of missed estimated durations until task is considered hanging.
     optional uint64 MissedEstimatesUntilTaskIsHanging = 31 [default = 2];
+
+    // Needed for tracing.
+    // Spans of tasks with greater generation id will not be sampled.
+    optional uint64 MaxSampledGeneration = 32 [default = 100];
 }

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -340,7 +340,7 @@ type runnerForCancel struct {
 
 	hangingTaskTimeout                time.Duration
 	missedEstimatesUntilTaskIsHanging uint64
-	maxSampledGeneration              uint64 // TODO:_ maybe not use this limit for cancel?
+	maxSampledGeneration              uint64
 }
 
 func (r *runnerForCancel) receiveTask(

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -575,6 +575,7 @@ func lockAndExecuteTask(
 		sampleForTracing,
 		tracing.WithAttributes(
 			tracing.AttributeString("task_id", taskInfo.ID),
+			tracing.AttributeString("request_id", headers.GetRequestID(runCtx)),
 			tracing.AttributeInt64(
 				"generation_id",
 				int64(taskInfo.GenerationID),

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -572,7 +572,7 @@ func lockAndExecuteTask(
 	runCtx, span := tracing.StartSpanWithSampling(
 		runCtx,
 		fmt.Sprintf(taskInfo.TaskType),
-		taskInfo.GenerationID <= maxSampledTaskGeneration,
+		taskInfo.GenerationID <= maxSampledTaskGeneration, // sampled
 		tracing.WithAttributes(
 			tracing.AttributeString("task_id", taskInfo.ID),
 			tracing.AttributeString("request_id", headers.GetRequestID(runCtx)),

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -83,7 +83,7 @@ type runnerForRun struct {
 
 	hangingTaskTimeout                time.Duration
 	missedEstimatesUntilTaskIsHanging uint64
-	maxSampledTaskGeneration              uint64
+	maxSampledTaskGeneration          uint64
 }
 
 func (r *runnerForRun) receiveTask(
@@ -340,7 +340,7 @@ type runnerForCancel struct {
 
 	hangingTaskTimeout                time.Duration
 	missedEstimatesUntilTaskIsHanging uint64
-	maxSampledTaskGeneration              uint64
+	maxSampledTaskGeneration          uint64
 }
 
 func (r *runnerForCancel) receiveTask(
@@ -679,7 +679,7 @@ func startRunner(
 
 		hangingTaskTimeout:                hangingTaskTimeout,
 		missedEstimatesUntilTaskIsHanging: missedEstimatesUntilTaskIsHanging,
-		maxSampledTaskGeneration:              maxSampledTaskGeneration,
+		maxSampledTaskGeneration:          maxSampledTaskGeneration,
 	})
 
 	runnerForCancelMetrics := newRunnerMetrics(
@@ -701,7 +701,7 @@ func startRunner(
 
 		hangingTaskTimeout:                hangingTaskTimeout,
 		missedEstimatesUntilTaskIsHanging: missedEstimatesUntilTaskIsHanging,
-		maxSampledTaskGeneration:              maxSampledTaskGeneration,
+		maxSampledTaskGeneration:          maxSampledTaskGeneration,
 	})
 
 	return nil

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1276,6 +1276,7 @@ func TestTryExecutingTask(t *testing.T) {
 		taskInfo,
 		time.Hour,
 		2,
+		false,
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)
@@ -1336,6 +1337,7 @@ func TestTryExecutingTaskFailToPing(t *testing.T) {
 		taskInfo,
 		time.Hour,
 		2,
+		false,
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1276,7 +1276,7 @@ func TestTryExecutingTask(t *testing.T) {
 		taskInfo,
 		time.Hour,
 		2,
-		false,
+		100,
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)
@@ -1337,7 +1337,7 @@ func TestTryExecutingTaskFailToPing(t *testing.T) {
 		taskInfo,
 		time.Hour,
 		2,
-		false,
+		100,
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)

--- a/cloud/tasks/tracing/init.go
+++ b/cloud/tasks/tracing/init.go
@@ -41,7 +41,7 @@ func StartSpanWithSampling(
 	opts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 
-	opts = append(opts, WithAttributes(newShouldSampleAttribute(sampled)))
+	opts = append(opts, WithAttributes(newSampledAttribute(sampled)))
 	return StartSpan(ctx, spanName, opts...)
 }
 
@@ -71,8 +71,10 @@ func newTraceExporter(
 
 func newParentBasedSampler() sdktrace.Sampler {
 	rootSampler := newSampler()
-	// If the parent span is not sampled. then the child span also will not be sampled.
-	// If the parent span is sampled, then the rootSampler will make sampling decision.
+	// If a parent span is not sampled, then
+	// the child span will not be sampled also.
+	// If a parent span is sampled, then
+	// the rootSampler is used to make sampling decision about the child span.
 	return sdktrace.ParentBased(
 		rootSampler,
 		sdktrace.WithLocalParentSampled(rootSampler),

--- a/cloud/tasks/tracing/init.go
+++ b/cloud/tasks/tracing/init.go
@@ -41,7 +41,7 @@ func StartSpanWithSampling(
 	opts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 
-	opts = append(opts, WithAttributes(makeShouldSampleAttribute(sampled)))
+	opts = append(opts, WithAttributes(newShouldSampleAttribute(sampled)))
 	return StartSpan(ctx, spanName, opts...)
 }
 
@@ -70,11 +70,13 @@ func newTraceExporter(
 }
 
 func newParentBasedSampler() sdktrace.Sampler {
-	sampler := newSampler() // TODO:_ naming: sampler?
+	rootSampler := newSampler()
+	// If the parent span is not sampled. then the child span also will not be sampled.
+	// If the parent span is sampled, then the rootSampler will make sampling decision.
 	return sdktrace.ParentBased(
-		sampler,
-		sdktrace.WithLocalParentSampled(sampler),
-		sdktrace.WithRemoteParentSampled(sampler),
+		rootSampler,
+		sdktrace.WithLocalParentSampled(rootSampler),
+		sdktrace.WithRemoteParentSampled(rootSampler),
 	)
 }
 

--- a/cloud/tasks/tracing/init.go
+++ b/cloud/tasks/tracing/init.go
@@ -71,10 +71,9 @@ func newTraceExporter(
 
 func newParentBasedSampler() sdktrace.Sampler {
 	rootSampler := newSampler()
-	// If a parent span is not sampled, then
-	// the child span will not be sampled also.
-	// If a parent span is sampled, then
-	// the rootSampler is used to make sampling decision about the child span.
+	// If a parent span is not sampled, then the child span will not be sampled
+	// also. If a parent span is sampled, then the rootSampler is used to make
+	// sampling decision about the child span.
 	return sdktrace.ParentBased(
 		rootSampler,
 		sdktrace.WithLocalParentSampled(rootSampler),

--- a/cloud/tasks/tracing/sampling.go
+++ b/cloud/tasks/tracing/sampling.go
@@ -1,6 +1,5 @@
 package tracing
 
-// TODO:_ check style of imports
 import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -8,9 +7,8 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO:_ comments about how this option interfere with parents and maybe other options?
 const (
-	sampledAttributeKey = "should_sample" // TODO:_ naming: is name 'sampled' confusing?
+	sampledAttributeKey = "sampled"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -34,19 +32,20 @@ func (s *sampler) ShouldSample(
 }
 
 func (s *sampler) Description() string {
-	return "AAAAAAAAAA" // TODO:_ description
+	return "Basic cloud.tasks sampler. " +
+		"Uses attribute 'sampled' of the span for sampling decision."
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func makeShouldSampleAttribute(sampled bool) attribute.KeyValue { // TODO:_ naming: make?
+func newShouldSampleAttribute(sampled bool) attribute.KeyValue {
 	return attribute.Bool(sampledAttributeKey, sampled)
 }
 
 func hasShouldSampleAttribute(params sdktrace.SamplingParameters) bool {
 	for _, attr := range params.Attributes {
 		if attr.Key == sampledAttributeKey {
-			// TODO:_ ensure that this is bool?
 			return attr.Value.AsBool()
 		}
 	}

--- a/cloud/tasks/tracing/sampling.go
+++ b/cloud/tasks/tracing/sampling.go
@@ -25,7 +25,7 @@ func (s *sampler) ShouldSample(
 	params sdktrace.SamplingParameters,
 ) sdktrace.SamplingResult {
 
-	if !hasShouldSampleAttribute(params) {
+	if !hasSampledAttribute(params) {
 		return sdktrace.SamplingResult{Decision: sdktrace.Drop}
 	}
 	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
@@ -33,17 +33,16 @@ func (s *sampler) ShouldSample(
 
 func (s *sampler) Description() string {
 	return "Basic cloud.tasks sampler. " +
-		"Uses attribute 'sampled' of the span for sampling decision."
-
+		"Uses attribute 'sampled' of a span for sampling decision."
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func newShouldSampleAttribute(sampled bool) attribute.KeyValue {
+func newSampledAttribute(sampled bool) attribute.KeyValue {
 	return attribute.Bool(sampledAttributeKey, sampled)
 }
 
-func hasShouldSampleAttribute(params sdktrace.SamplingParameters) bool {
+func hasSampledAttribute(params sdktrace.SamplingParameters) bool {
 	for _, attr := range params.Attributes {
 		if attr.Key == sampledAttributeKey {
 			return attr.Value.AsBool()

--- a/cloud/tasks/tracing/sampling.go
+++ b/cloud/tasks/tracing/sampling.go
@@ -28,6 +28,7 @@ func (s *sampler) ShouldSample(
 	if !hasSampledAttribute(params) {
 		return sdktrace.SamplingResult{Decision: sdktrace.Drop}
 	}
+
 	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
 }
 
@@ -48,5 +49,6 @@ func hasSampledAttribute(params sdktrace.SamplingParameters) bool {
 			return attr.Value.AsBool()
 		}
 	}
+
 	return true
 }

--- a/cloud/tasks/tracing/sampling.go
+++ b/cloud/tasks/tracing/sampling.go
@@ -1,0 +1,54 @@
+package tracing
+
+// TODO:_ check style of imports
+import (
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+// TODO:_ comments about how this option interfere with parents and maybe other options?
+const (
+	sampledAttributeKey = "should_sample" // TODO:_ naming: is name 'sampled' confusing?
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type sampler struct{}
+
+func newSampler() sdktrace.Sampler {
+	return &sampler{}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func (s *sampler) ShouldSample(
+	params sdktrace.SamplingParameters,
+) sdktrace.SamplingResult {
+
+	if !hasShouldSampleAttribute(params) {
+		return sdktrace.SamplingResult{Decision: sdktrace.Drop}
+	}
+	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
+}
+
+func (s *sampler) Description() string {
+	return "AAAAAAAAAA" // TODO:_ description
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func makeShouldSampleAttribute(sampled bool) attribute.KeyValue { // TODO:_ naming: make?
+	return attribute.Bool(sampledAttributeKey, sampled)
+}
+
+func hasShouldSampleAttribute(params sdktrace.SamplingParameters) bool {
+	for _, attr := range params.Attributes {
+		if attr.Key == sampledAttributeKey {
+			// TODO:_ ensure that this is bool?
+			return attr.Value.AsBool()
+		}
+	}
+	return true
+}

--- a/cloud/tasks/tracing/ya.make
+++ b/cloud/tasks/tracing/ya.make
@@ -3,6 +3,7 @@ GO_LIBRARY()
 SRCS(
     attributes.go
     init.go
+    sampling.go
     tracing_context.go
 )
 


### PR DESCRIPTION
#1199

- spans for task generations with id <= MaxSampledGeneration will be sampled (i.e. these spans will be sent to backend). Spans for tasks generations with greater id will not be sapmpled

- added request_id attribute to task spans.