### PR TITLE
issue-1285: fix missing StartedTs initialization for requestInfo in `Compaction`

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -479,6 +479,7 @@ void TIndexTabletActor::HandleCompaction(
         ev->Sender,
         ev->Cookie,
         msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
 
     ExecuteTx<TCompaction>(
         ctx,


### PR DESCRIPTION
References #1285