### PR TITLE
[Disk Manager] return detailed error with aborted status on wrong etag

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
@@ -94,7 +94,6 @@ func (t *createSnapshotFromURLTask) Run(
 	}
 
 	if t.state.ETag != source.ETag() {
-		// TODO: NBS-4002: use AbortedError here.
 		return url_common.NewWrongETagError(
 			"task with id %v has wrong ETag, expected %v, actual %v",
 			selfTaskID,

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/url"
+	url_common "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/url/common"
 	"github.com/ydb-platform/nbs/cloud/tasks"
-	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
 
@@ -95,7 +95,7 @@ func (t *createSnapshotFromURLTask) Run(
 
 	if t.state.ETag != source.ETag() {
 		// TODO: NBS-4002: use AbortedError here.
-		return errors.NewNonRetriableErrorf(
+		return url_common.NewWrongETagError(
 			"task with id %v has wrong ETag, expected %v, actual %v",
 			selfTaskID,
 			t.state.ETag,

--- a/cloud/disk_manager/internal/pkg/dataplane/url/common/errors.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/common/errors.go
@@ -41,3 +41,14 @@ func NewSourceForbiddenError(format string, args ...interface{}) error {
 		},
 	)
 }
+
+func NewWrongETagError(format string, args ...interface{}) error {
+	return errors.NewDetailedError(
+		fmt.Errorf(format, args...),
+		&errors.ErrorDetails{
+			Code:     error_codes.Aborted,
+			Message:  "url source data was changed during image creation",
+			Internal: false,
+		},
+	)
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/url/common/errors.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/common/errors.go
@@ -47,7 +47,7 @@ func NewWrongETagError(format string, args ...interface{}) error {
 		fmt.Errorf(format, args...),
 		&errors.ErrorDetails{
 			Code:     error_codes.Aborted,
-			Message:  "url source data was changed during image creation",
+			Message:  "data from url source changed during image creation",
 			Internal: false,
 		},
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/url/common/errors.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/common/errors.go
@@ -47,7 +47,7 @@ func NewWrongETagError(format string, args ...interface{}) error {
 		fmt.Errorf(format, args...),
 		&errors.ErrorDetails{
 			Code:     error_codes.Aborted,
-			Message:  "data from url source changed during image creation",
+			Message:  "data from url source was changed during image creation",
 			Internal: false,
 		},
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/url/common/http_client.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/common/http_client.go
@@ -265,8 +265,7 @@ func (c *httpClient) body(
 	}
 
 	if resp.Header.Get("Etag") != etag {
-		// TODO: NBS-4002: use AbortedError here.
-		return nil, errors.NewNonRetriableErrorf(
+		return nil, NewWrongETagError(
 			"wrong ETag: requested %v, actual %v",
 			etag,
 			resp.Header.Get("Etag"),


### PR DESCRIPTION
Wrong ETag error occurs during creation image from url if data from source url changed during image creation. This error shoudl not be internal.