### PR TITLE
get rid of some arcadia string functions

### DIFF
--- a/cloud/blockstore/libs/diagnostics/block_digest_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/block_digest_ut.cpp
@@ -25,7 +25,7 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
 
         TString str("asd");
         str.resize(4_KB);
-        TBlockDataRef blockData(str.Data(), str.Size());
+        TBlockDataRef blockData(str.data(), str.size());
         UNIT_ASSERT(gen->ShouldProcess(0, 1, 4_KB));
         UNIT_ASSERT(gen->ComputeDigest(0, blockData));
         UNIT_ASSERT(gen->ShouldProcess(offset + 300, 1, 4_KB));
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
         auto check = [&] () {
             TString str(bytes, sizeof(x));
             str.resize(4_KB);
-            TBlockDataRef blockData(str.Data(), str.Size());
+            TBlockDataRef blockData(str.data(), str.size());
             auto digest = gen->ComputeDigest(0, blockData);
             UNIT_ASSERT(digest.Defined());
             UNIT_ASSERT_VALUES_EQUAL(x, *digest);
@@ -85,7 +85,7 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
 
         TString str("asd");
         str.resize(4_KB);
-        TBlockDataRef blockData(str.Data(), str.Size());
+        TBlockDataRef blockData(str.data(), str.size());
         UNIT_ASSERT(!gen->ComputeDigest(0, blockData));
         UNIT_ASSERT(!gen->ComputeDigest(512, blockData));
         UNIT_ASSERT(!gen->ComputeDigest(513, blockData));

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -584,10 +584,10 @@ TFuture<NProto::TZeroBlocksResponse> TEncryptionClient::ZeroBlocks(
     }
 
     STORAGE_VERIFY(
-        BlockSize <= ZeroBlock.Size(),
+        BlockSize <= ZeroBlock.size(),
         TWellKnownEntityTypes::DISK,
         request->GetDiskId());
-    TBlockDataRef zeroDataRef(ZeroBlock.Data(), BlockSize);
+    TBlockDataRef zeroDataRef(ZeroBlock.data(), BlockSize);
     TSgList zeroSgList(request->GetBlocksCount(), zeroDataRef);
     TGuardedSgList guardedSgList(std::move(zeroSgList));
 

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -350,7 +350,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
                 for (size_t i = 0; i < sglist.size(); ++i) {
                     UNIT_ASSERT(storageBlocks[i].size() == sglist[i].Size());
-                    auto* dst = const_cast<char*>(storageBlocks[i].Data());
+                    auto* dst = const_cast<char*>(storageBlocks[i].data());
                     auto* src = sglist[i].Data();
                     memcpy(dst, src, sglist[i].Size());
                 }
@@ -449,7 +449,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 for (size_t i = 0; i < sglist.size(); ++i) {
                     size_t n = i + wRequest->GetStartIndex();
                     UNIT_ASSERT(storageBlocks[n].size() == sglist[i].Size());
-                    auto* dst = const_cast<char*>(storageBlocks[n].Data());
+                    auto* dst = const_cast<char*>(storageBlocks[n].data());
                     auto* src = sglist[i].Data();
                     memcpy(dst, src, sglist[i].Size());
                 }

--- a/cloud/blockstore/libs/encryption/encryption_key.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_key.cpp
@@ -234,7 +234,7 @@ TEncryptionKey::TEncryptionKey(TString key)
 
 TEncryptionKey::~TEncryptionKey()
 {
-    SecureZero(Key.begin(), Key.Size());
+    SecureZero(Key.begin(), Key.size());
 }
 
 const TString& TEncryptionKey::GetKey() const

--- a/cloud/blockstore/libs/encryption/encryption_test.h
+++ b/cloud/blockstore/libs/encryption/encryption_test.h
@@ -20,7 +20,7 @@ public:
             const TString& filePath = "test_key_file")
         : File(filePath, EOpenModeFlag::CreateAlways | EOpenModeFlag::RdWr)
     {
-        File.Write(key.Data(), key.Size());
+        File.Write(key.data(), key.size());
         File.Flush();
         File.Close();
     }

--- a/cloud/blockstore/libs/encryption/encryptor.cpp
+++ b/cloud/blockstore/libs/encryption/encryptor.cpp
@@ -64,7 +64,7 @@ private:
 public:
     explicit TAesXtsEncryptor(TStringBuf key)
     {
-        memcpy(Key, key.Data(), Min<ui32>(key.size(), EVP_MAX_KEY_LENGTH));
+        memcpy(Key, key.data(), Min<ui32>(key.size(), EVP_MAX_KEY_LENGTH));
     }
 
     ~TAesXtsEncryptor() override

--- a/cloud/blockstore/libs/nbd/binary_writer.h
+++ b/cloud/blockstore/libs/nbd/binary_writer.h
@@ -37,7 +37,7 @@ public:
 
     void Write(TStringBuf buffer)
     {
-        Write(buffer.Data(), buffer.Size());
+        Write(buffer.data(), buffer.size());
     }
 
     void Write(const TBuffer& buffer)

--- a/cloud/blockstore/libs/nbd/protocol.cpp
+++ b/cloud/blockstore/libs/nbd/protocol.cpp
@@ -80,11 +80,11 @@ void TRequestWriter::WriteClientHello(ui32 flags)
 
 void TRequestWriter::WriteOption(ui32 option, TStringBuf optionData)
 {
-    Y_DEBUG_ABORT_UNLESS(optionData.Size() <= NBD_MAX_OPTION_SIZE);
+    Y_DEBUG_ABORT_UNLESS(optionData.size() <= NBD_MAX_OPTION_SIZE);
 
     Write<ui64>(NBD_OPTS_MAGIC);
     Write<ui32>(option);
-    Write<ui32>(optionData.Size());
+    Write<ui32>(optionData.size());
     Write(optionData);
 
     Flush();
@@ -148,12 +148,12 @@ void TRequestWriter::WriteOptionReply(
     ui32 type,
     TStringBuf replyData)
 {
-    Y_DEBUG_ABORT_UNLESS(replyData.Size() <= NBD_MAX_OPTION_SIZE);
+    Y_DEBUG_ABORT_UNLESS(replyData.size() <= NBD_MAX_OPTION_SIZE);
 
     Write<ui64>(NBD_REP_MAGIC);
     Write<ui32>(option);
     Write<ui32>(type);
-    Write<ui32>(replyData.Size());
+    Write<ui32>(replyData.size());
     Write(replyData);
 
     Flush();
@@ -177,7 +177,7 @@ void TRequestWriter::WriteRequest(
     Write<ui32>(request.Length);
 
     if (request.Type == NBD_CMD_WRITE) {
-        Y_DEBUG_ABORT_UNLESS(requestData.Size() == request.Length);
+        Y_DEBUG_ABORT_UNLESS(requestData.size() == request.Length);
         Write(requestData);
     } else {
         Y_DEBUG_ABORT_UNLESS(!requestData);
@@ -274,16 +274,16 @@ void TRequestWriter::WriteStructuredError(
     ui32 error,
     TStringBuf message)
 {
-    Y_DEBUG_ABORT_UNLESS(message.Size() <= NBD_MAX_BUFFER_SIZE);
+    Y_DEBUG_ABORT_UNLESS(message.size() <= NBD_MAX_BUFFER_SIZE);
 
     Write<ui32>(NBD_STRUCTURED_REPLY_MAGIC);
     Write<ui16>(NBD_REPLY_FLAG_DONE);
     Write<ui16>(NBD_REPLY_TYPE_ERROR);
     Write<ui64>(handle);
-    Write<ui32>(sizeof(TStructuredError) + message.Size());
+    Write<ui32>(sizeof(TStructuredError) + message.size());
 
     Write<ui32>(error);
-    Write<ui16>(message.Size());
+    Write<ui16>(message.size());
     Write(message);
 
     Flush();

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -164,7 +164,7 @@ private:
             << " SEND OptionReply"
             << " option:" << option
             << " type:" << type
-            << " length:" << replyData.Size());
+            << " length:" << replyData.size());
         out.WriteOptionReply(option, type, replyData);
     }
 

--- a/cloud/blockstore/libs/nbd/utils_ut.cpp
+++ b/cloud/blockstore/libs/nbd/utils_ut.cpp
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TUtilsTest)
         createPidFile(path / "nbd0" / "pid");
         createPidFile(path / "nbd1" / "pid");
 
-        UNIT_ASSERT(FindFreeNbdDevice(path.GetPath()).Empty());
+        UNIT_ASSERT(FindFreeNbdDevice(path.GetPath()).empty());
 
         (path / "nbd2").MkDir();
 

--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -1184,7 +1184,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                     UNIT_ASSERT_VALUES_EQUAL(block.size(), blockSize);
                     UNIT_ASSERT_VALUES_EQUAL(
                         TString(blockSize, content),
-                        block.Data());
+                        block.data());
                 }
 
                 return MakeFuture<NProto::TWriteBlocksResponse>();
@@ -1217,7 +1217,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         {
             TString buffer(blocksCount * blockSize + overheadSize, 0);
-            auto sglist = TSgList{{buffer.Data(), buffer.Size()}};
+            auto sglist = TSgList{{buffer.data(), buffer.size()}};
 
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetBlocksCount(blocksCount);
@@ -1230,7 +1230,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
             const auto& response = future.GetValue(TDuration::Seconds(5));
 
-            for (size_t i = 0; i < buffer.Size(); ++i) {
+            for (size_t i = 0; i < buffer.size(); ++i) {
                 UNIT_ASSERT_VALUES_EQUAL(
                     i < blocksCount * blockSize ? content : 0,
                     buffer[i]);
@@ -1240,12 +1240,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         {
             TString buffer(blocksCount * blockSize + overheadSize, 0);
-            memset(const_cast<char*>(buffer.Data()), content, blocksCount * blockSize);
+            memset(const_cast<char*>(buffer.data()), content, blocksCount * blockSize);
 
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             request->BlocksCount = blocksCount;
             request->BlockSize = blockSize;
-            request->Sglist = TGuardedSgList({{buffer.Data(), buffer.Size()}});
+            request->Sglist = TGuardedSgList({{buffer.data(), buffer.size()}});
 
             auto future = endpoint->WriteBlocksLocal(
                 MakeIntrusive<TCallContext>(),

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -615,10 +615,10 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
 
             TSgList src(
                 request->GetBlocksCount(),
-                TBlockDataRef(zeroBlock.Data(), zeroBlock.Size()));
+                TBlockDataRef(zeroBlock.data(), zeroBlock.size()));
 
             TBlockDataRef dst(
-                device.Data() + request->GetStartIndex() * blockSize,
+                device.data() + request->GetStartIndex() * blockSize,
                 src.size() * blockSize);
 
             auto bytesCount = SgListCopy(src, dst);
@@ -638,7 +638,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             UNIT_ASSERT(request->GetStartIndex() + request->BlocksCount <= deviceBlocksCount);
 
             TBlockDataRef dst(
-                device.Data() + request->GetStartIndex() * blockSize,
+                device.data() + request->GetStartIndex() * blockSize,
                 request->BlocksCount * blockSize);
 
             auto guard = request->Sglist.Acquire();
@@ -661,7 +661,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             UNIT_ASSERT(request->GetStartIndex() + request->GetBlocksCount() <= deviceBlocksCount);
 
             TBlockDataRef src(
-                device.Data() + request->GetStartIndex() * blockSize,
+                device.data() + request->GetStartIndex() * blockSize,
                 request->GetBlocksCount() * blockSize);
 
             NProto::TReadBlocksLocalResponse response;

--- a/cloud/blockstore/libs/service/request_helpers.cpp
+++ b/cloud/blockstore/libs/service/request_helpers.cpp
@@ -76,7 +76,7 @@ ui64 CalculateBytesCount(
 
     ui64 bytesInBuffers = 0;
     for (const auto& buffer: request.GetBlocks().GetBuffers()) {
-        bytesInBuffers += buffer.Size();
+        bytesInBuffers += buffer.size();
     }
     return bytesInBuffers;
 }
@@ -88,7 +88,7 @@ ui32 CalculateWriteRequestBlockCount(
 {
     ui32 bytes = 0;
     for (const auto& buffer: request.GetBlocks().GetBuffers()) {
-        bytes += buffer.Size();
+        bytes += buffer.size();
     }
     if (bytes % blockSize) {
         Y_ABORT("bytes %u not divisible by blockSize %u", bytes, blockSize);

--- a/cloud/blockstore/libs/service/storage_ut.cpp
+++ b/cloud/blockstore/libs/service/storage_ut.cpp
@@ -450,14 +450,14 @@ Y_UNIT_TEST_SUITE(TStorageTest)
             data.resize(requestByteCount, 0);
             for (ui64 offset = 0; offset < data.size(); offset += blockSize) {
                 std::memset(
-                    const_cast<char*>(data.Data() + offset),
+                    const_cast<char*>(data.data() + offset),
                     offset / blockSize,
                     blockSize);
             }
 
             auto guard = request->Sglist.Acquire();
             UNIT_ASSERT(guard);
-            SgListCopy(TBlockDataRef{data.data(), data.Size()}, guard.Get());
+            SgListCopy(TBlockDataRef{data.data(), data.size()}, guard.Get());
 
             NProto::TReadBlocksLocalResponse r;
             *r.MutableError() = MakeError(S_OK);
@@ -537,7 +537,7 @@ Y_UNIT_TEST_SUITE(TStorageTest)
             auto guard = request->Sglist.Acquire();
             UNIT_ASSERT(guard);
             SgListCopy(
-                TBlockDataRef{blocks.data(), blocks.Size()},
+                TBlockDataRef{blocks.data(), blocks.size()},
                 guard.Get());
 
             NProto::TReadBlocksLocalResponse r;

--- a/cloud/blockstore/libs/storage/api/public.h
+++ b/cloud/blockstore/libs/storage/api/public.h
@@ -30,7 +30,7 @@ inline TStringBuf GetBrokenDataMarker()
             : Magic(4096, '0')
         {
             TFastRng64 rng(1337);
-            for (ui32 i = 0; i < Magic.Size(); i += 8) {
+            for (ui32 i = 0; i < Magic.size(); i += 8) {
                 ui64 x = rng.GenRand();
                 ui8* bytes = reinterpret_cast<ui8*>(&x);
                 memcpy(Magic.begin() + i, bytes, 8);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -3471,7 +3471,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                 TString(blockSize, 'X'));
 
             for (const auto& block : blocks) {
-                checksum.Extend(block.Data(), block.Size());
+                checksum.Extend(block.data(), block.size());
             }
 
             WriteDeviceBlocks(runtime, diskAgent, uuids[0], 0, sglist, clientId);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -739,7 +739,7 @@ TFuture<NProto::TChecksumDeviceBlocksResponse> TDiskAgentState::Checksum(
             } else {
                 TBlockChecksum checksum;
                 for (const auto& buffer : data.GetBlocks().GetBuffers()) {
-                    checksum.Extend(buffer.Data(), buffer.Size());
+                    checksum.Extend(buffer.data(), buffer.size());
                 }
                 response.SetChecksum(checksum.GetValue());
             }

--- a/cloud/blockstore/libs/storage/disk_agent/hash_table_storage.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/hash_table_storage.cpp
@@ -79,11 +79,11 @@ struct THashTableStorage final
         while (b < e) {
             auto data = Blocks.FindPtr(b);
             auto& target = sglist[b - request->GetStartIndex()];
-            if (!data || data->Empty()) {
+            if (!data || data->empty()) {
                 memset(const_cast<char*>(target.Data()), 0, target.Size());
             } else {
                 Y_ABORT_UNLESS(target.Size() == BlockSize);
-                memcpy(const_cast<char*>(target.Data()), data->Data(), BlockSize);
+                memcpy(const_cast<char*>(target.Data()), data->data(), BlockSize);
             }
 
             ++b;

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
@@ -307,7 +307,7 @@ NCloud::NProto::TError TDeviceClient::AccessDevice(
     if (!acquired) {
         TStringBuilder allReaders;
         for (const auto& reader: deviceState->ReaderSessions) {
-            bool isFirst = allReaders.Empty();
+            bool isFirst = allReaders.empty();
             allReaders << reader.Id.Quote();
             if (!isFirst) {
                 allReaders << ", ";

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -939,7 +939,7 @@ private:
 
         TBlockChecksum checksum;
         for (const auto& buffer: blocks.GetBuffers()) {
-            checksum.Extend(buffer.Data(), buffer.Size());
+            checksum.Extend(buffer.data(), buffer.size());
         }
         proto.SetChecksum(checksum.GetValue());
 

--- a/cloud/blockstore/libs/storage/partition/model/block_index.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/block_index.cpp
@@ -75,8 +75,8 @@ TBlockIndex::~TBlockIndex()
     for (const auto& block: Impl->Blocks) {
         if (block.Content) {
             IAllocator::TBlock alloc{
-                const_cast<char*>(block.Content.Data()),
-                block.Content.Size()
+                const_cast<char*>(block.Content.data()),
+                block.Content.size()
             };
             Impl->Allocator->Release(alloc);
         }
@@ -94,9 +94,9 @@ bool TBlockIndex::AddBlock(
 
     TStringBuf content;
     if (blockContent) {
-        auto alloc = Impl->Allocator->Allocate(blockContent.Size());
-        std::memcpy(alloc.Data, blockContent.Data(), blockContent.Size());
-        content = {static_cast<const char*>(alloc.Data), blockContent.Size()};
+        auto alloc = Impl->Allocator->Allocate(blockContent.size());
+        std::memcpy(alloc.Data, blockContent.data(), blockContent.size());
+        content = {static_cast<const char*>(alloc.Data), blockContent.size()};
     }
 
     std::tie(it, inserted) = Impl->Blocks.emplace(
@@ -106,8 +106,8 @@ bool TBlockIndex::AddBlock(
 
     if (!inserted && content) {
         IAllocator::TBlock alloc{
-            const_cast<char*>(content.Data()),
-            content.Size()
+            const_cast<char*>(content.data()),
+            content.size()
         };
         Impl->Allocator->Release(alloc);
     }
@@ -125,8 +125,8 @@ bool TBlockIndex::RemoveBlock(ui32 blockIndex, ui64 commitId, bool isStoredInDb)
 
         if (it->Content) {
             IAllocator::TBlock alloc{
-                const_cast<char*>(it->Content.Data()),
-                it->Content.Size()
+                const_cast<char*>(it->Content.data()),
+                it->Content.size()
             };
             Impl->Allocator->Release(alloc);
         }

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -261,7 +261,7 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
     {
         TStringBuilder sb;
         for (const auto channel: channels) {
-            if (sb.Size()) {
+            if (sb.size()) {
                 sb << ", ";
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1701,8 +1701,8 @@ void CompleteRangeCompaction(
 
                 // fresh block will be written
                 blobContent.AddBlock({
-                    mark.BlockContent.Data(),
-                    mark.BlockContent.Size()
+                    mark.BlockContent.data(),
+                    mark.BlockContent.size()
                 });
 
                 if (args.ChecksumsEnabled) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -447,7 +447,7 @@ public:
                     std::move(Checksums));
             }
 
-            BlobContent.AddBlock({block.Content.Data(), block.Content.Size()});
+            BlobContent.AddBlock({block.Content.data(), block.Content.size()});
             Blocks.emplace_back(
                 block.Meta.BlockIndex,
                 block.Meta.CommitId,

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -145,8 +145,8 @@ IEventBasePtr CreateReadBlocksResponse(
         for (const auto blockIndex: xrange(readRange)) {
             const auto& blockContent = response->Record.GetBlocks().GetBuffers(blockIndex - readRange.Start);
             TBlockDataRef blockData = TBlockDataRef::CreateZeroBlock(blockSize);
-            if (!blockContent.Empty()) {
-                blockData = TBlockDataRef(blockContent.Data(), blockContent.Size());
+            if (!blockContent.empty()) {
+                blockData = TBlockDataRef(blockContent.data(), blockContent.size());
             }
             const auto digest = blockDigestGenerator.ComputeDigest(
                 blockIndex,
@@ -698,8 +698,8 @@ public:
 
         if (Args.MarkBlock(block.Meta.BlockIndex, block.Meta.CommitId, TFreshMark())) {
             TBlockDataRef blockData = TBlockDataRef::CreateZeroBlock(BlockSize);
-            if (!block.Content.Empty()) {
-                blockData = TBlockDataRef(block.Content.Data(), block.Content.Size());
+            if (!block.Content.empty()) {
+                blockData = TBlockDataRef(block.Content.data(), block.Content.size());
             }
             if (!Args.ReadHandler->SetBlock(
                     block.Meta.BlockIndex,

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblob.cpp
@@ -144,20 +144,20 @@ void TWriteBlobActor::SendPutRequest(const TActorContext& ctx)
     }
 
     STORAGE_VERIFY(
-        !blobContent.Empty(),
+        !blobContent.empty(),
         TWellKnownEntityTypes::TABLET,
         TabletId);
 
     if (Request->BlockSizeForChecksums) {
         STORAGE_VERIFY(
-            blobContent.Size() % Request->BlockSizeForChecksums == 0,
+            blobContent.size() % Request->BlockSizeForChecksums == 0,
             TWellKnownEntityTypes::TABLET,
             TabletId);
 
         ui32 offset = 0;
-        while (offset < blobContent.Size()) {
+        while (offset < blobContent.size()) {
             BlockChecksums.push_back(ComputeDefaultDigest({
-                blobContent.Data() + offset,
+                blobContent.data() + offset,
                 Request->BlockSizeForChecksums}));
 
             offset += Request->BlockSizeForChecksums;
@@ -342,7 +342,7 @@ void TPartitionActor::HandleWriteBlob(
             out.ReserveAndResize(BlobCodec->MaxCompressedLength(blobContent));
             const size_t sz = BlobCodec->Compress(blobContent, out.begin());
             auto& counters = PartCounters->Cumulative;
-            counters.UncompressedBytesWritten.Increment(blobContent.Size());
+            counters.UncompressedBytesWritten.Increment(blobContent.size());
             counters.CompressedBytesWritten.Increment(sz);
         }
     }

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -128,9 +128,9 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
             auto zero = GetBlockContent(0);
             auto one = GetBlockContent(1);
             auto two = GetBlockContent(2);
-            db.WriteFreshBlock(0, commitId, {zero.Data(), zero.Size()});
-            db.WriteFreshBlock(1, commitId, {one.Data(), one.Size()});
-            db.WriteFreshBlock(2, commitId, {two.Data(), two.Size()});
+            db.WriteFreshBlock(0, commitId, {zero.data(), zero.size()});
+            db.WriteFreshBlock(1, commitId, {one.data(), one.size()});
+            db.WriteFreshBlock(2, commitId, {two.data(), two.size()});
         });
 
         executor.WriteTx([&] (TPartitionDatabase db) {

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -547,13 +547,13 @@ public:
         TStringBuf blockContent)
     {
         TSgList sglist;
-        sglist.resize(writeRange.Size(), {blockContent.Data(), blockContent.Size()});
+        sglist.resize(writeRange.Size(), {blockContent.data(), blockContent.size()});
 
         auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
         request->Record.SetStartIndex(writeRange.Start);
         request->Record.Sglist = TGuardedSgList(std::move(sglist));
         request->Record.BlocksCount = writeRange.Size();
-        request->Record.BlockSize = blockContent.Size() / writeRange.Size();
+        request->Record.BlockSize = blockContent.size() / writeRange.size();
         return request;
     }
 
@@ -614,7 +614,7 @@ public:
         TStringBuf buffer,
         const TString& checkpointId = {})
     {
-        return CreateReadBlocksLocalRequest(blockIndex, TGuardedSgList{{TBlockDataRef(buffer.Data(), buffer.Size())}}, checkpointId);
+        return CreateReadBlocksLocalRequest(blockIndex, TGuardedSgList{{TBlockDataRef(buffer.data(), buffer.size())}}, checkpointId);
     }
 
     std::unique_ptr<TEvService::TEvReadBlocksLocalRequest> CreateReadBlocksLocalRequest(

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -553,7 +553,7 @@ public:
         request->Record.SetStartIndex(writeRange.Start);
         request->Record.Sglist = TGuardedSgList(std::move(sglist));
         request->Record.BlocksCount = writeRange.Size();
-        request->Record.BlockSize = blockContent.size() / writeRange.size();
+        request->Record.BlockSize = blockContent.size() / writeRange.Size();
         return request;
     }
 

--- a/cloud/blockstore/libs/storage/partition2/model/block_index.cpp
+++ b/cloud/blockstore/libs/storage/partition2/model/block_index.cpp
@@ -54,8 +54,8 @@ TBlockIndex::~TBlockIndex()
     for (const auto& block: Impl->Blocks) {
         if (block.Content) {
             IAllocator::TBlock alloc{
-                const_cast<char*>(block.Content.Data()),
-                block.Content.Size()
+                const_cast<char*>(block.Content.data()),
+                block.Content.size()
             };
             Impl->Allocator->Release(alloc);
         }
@@ -73,9 +73,9 @@ bool TBlockIndex::AddBlock(
 
     TStringBuf content;
     if (blockContent) {
-        auto alloc = Impl->Allocator->Allocate(blockContent.Size());
-        std::memcpy(alloc.Data, blockContent.Data(), blockContent.Size());
-        content = {static_cast<const char*>(alloc.Data), blockContent.Size()};
+        auto alloc = Impl->Allocator->Allocate(blockContent.size());
+        std::memcpy(alloc.Data, blockContent.data(), blockContent.size());
+        content = {static_cast<const char*>(alloc.Data), blockContent.size()};
     }
 
     std::tie(it, inserted) = Impl->Blocks.emplace(
@@ -97,8 +97,8 @@ bool TBlockIndex::RemoveBlock(ui32 blockIndex, ui64 minCommitId)
     if (it != Impl->Blocks.end()) {
         if (it->Content) {
             IAllocator::TBlock alloc{
-                const_cast<char*>(it->Content.Data()),
-                it->Content.Size()
+                const_cast<char*>(it->Content.data()),
+                it->Content.size()
             };
             Impl->Allocator->Release(alloc);
         }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -218,7 +218,7 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
     {
         TStringBuilder sb;
         for (const auto channel: channels) {
-            if (sb.Size()) {
+            if (sb.size()) {
                 sb << ", ";
             }
 

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_flush.cpp
@@ -345,7 +345,7 @@ public:
         }
 
         Blocks.push_back(block);
-        BlobContent.AddBlock({blockContent.Data(), blockContent.Size()});
+        BlobContent.AddBlock({blockContent.data(), blockContent.size()});
 
         if (Blocks.size() == MaxBlocksInBlob) {
             Flush();

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
@@ -237,8 +237,8 @@ void TReadBlobActor::HandleGetResult(
                     Y_ABORT_UNLESS(block.Data());
                     memcpy(
                         const_cast<char*>(block.Data()),
-                        marker.Data(),
-                        Min(block.Size(), marker.Size())
+                        marker.data(),
+                        Min(block.Size(), marker.size())
                     );
                     ++sglistIndex;
 
@@ -253,8 +253,8 @@ void TReadBlobActor::HandleGetResult(
                         Y_ABORT_UNLESS(block.Data());
                         memcpy(
                             const_cast<char*>(block.Data()),
-                            marker.Data(),
-                            Min(block.Size(), marker.Size())
+                            marker.data(),
+                            Min(block.Size(), marker.size())
                         );
 
                         ++sglistIndex;

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblocks.cpp
@@ -129,8 +129,8 @@ IEventBasePtr CreateReadBlocksResponse(
         for (const auto blockIndex: xrange(readRange)) {
             const auto& blockContent = response->Record.GetBlocks().GetBuffers(blockIndex - readRange.Start);
             TBlockDataRef blockData = TBlockDataRef::CreateZeroBlock(blockSize);
-            if (!blockContent.Empty()) {
-                blockData = TBlockDataRef(blockContent.Data(), blockContent.Size());
+            if (!blockContent.empty()) {
+                blockData = TBlockDataRef(blockContent.data(), blockContent.size());
             }
             const auto digest = blockDigestGenerator.ComputeDigest(
                 blockIndex,
@@ -723,8 +723,8 @@ public:
     {
         if (AddBlock(block, {}, 0, 0)) {
             TBlockDataRef blockData = TBlockDataRef::CreateZeroBlock(BlockSize);
-            if (!blockContent.Empty()) {
-                blockData = TBlockDataRef(blockContent.Data(), blockContent.Size());
+            if (!blockContent.empty()) {
+                blockData = TBlockDataRef(blockContent.data(), blockContent.size());
             }
             Args.ReadHandler->SetBlock(
                 block.BlockIndex,

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
@@ -128,7 +128,7 @@ void TWriteBlobActor::SendPutRequest(const TActorContext& ctx)
         blobContent = std::move(std::get<TString>(Request->Data));
     }
 
-    Y_ABORT_UNLESS(!blobContent.Empty());
+    Y_ABORT_UNLESS(!blobContent.empty());
 
     auto request = std::make_unique<TEvBlobStorage::TEvPut>(
         MakeBlobId(TabletId, Request->BlobId),

--- a/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
@@ -258,8 +258,8 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             auto block2 = TBlock(2, commitId, InvalidCommitId, false);
             auto one = GetBlockContent(1);
             auto two = GetBlockContent(2);
-            state.WriteFreshBlock(block1, {one.Data(), one.Size()});
-            state.WriteFreshBlock(block2, {two.Data(), two.Size()});
+            state.WriteFreshBlock(block1, {one.data(), one.size()});
+            state.WriteFreshBlock(block2, {two.data(), two.size()});
         };
 
         {
@@ -309,8 +309,8 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             auto one = GetBlockContent(1);
             auto two = GetBlockContent(2);
 
-            state.WriteFreshBlock(block1, {one.Data(), one.Size()});
-            state.WriteFreshBlock(block2, {two.Data(), two.Size()});
+            state.WriteFreshBlock(block1, {one.data(), one.size()});
+            state.WriteFreshBlock(block2, {two.data(), two.size()});
         };
 
         ui64 commitId2 = state.GenerateCommitId();
@@ -328,8 +328,8 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             auto oneone = GetBlockContent(11);
             auto twotwo = GetBlockContent(22);
 
-            state.WriteFreshBlock(block1, {oneone.Data(), oneone.Size()});
-            state.WriteFreshBlock(block2, {twotwo.Data(), twotwo.Size()});
+            state.WriteFreshBlock(block1, {oneone.data(), oneone.size()});
+            state.WriteFreshBlock(block2, {twotwo.data(), twotwo.size()});
         }
 
         {
@@ -390,8 +390,8 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             auto one = GetBlockContent(1);
             auto two = GetBlockContent(2);
 
-            state.WriteFreshBlock(block1, {one.Data(), one.Size()});
-            state.WriteFreshBlock(block2, {two.Data(), two.Size()});
+            state.WriteFreshBlock(block1, {one.data(), one.size()});
+            state.WriteFreshBlock(block2, {two.data(), two.size()});
         };
 
         ui64 commitId2 = state.GenerateCommitId();
@@ -405,8 +405,8 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             auto one = GetBlockContent(11);
             auto two = GetBlockContent(22);
 
-            state.WriteFreshBlock(block1, {one.Data(), one.Size()});
-            state.WriteFreshBlock(block2, {two.Data(), two.Size()});
+            state.WriteFreshBlock(block1, {one.data(), one.size()});
+            state.WriteFreshBlock(block2, {two.data(), two.size()});
         }
 
         {

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -523,13 +523,13 @@ public:
         TStringBuf blockContent)
     {
         TSgList sglist;
-        sglist.resize(writeRange.Size(), {blockContent.Data(), blockContent.Size()});
+        sglist.resize(writeRange.Size(), {blockContent.data(), blockContent.size()});
 
         auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
         request->Record.SetStartIndex(writeRange.Start);
         request->Record.Sglist = TGuardedSgList(std::move(sglist));
         request->Record.BlocksCount = writeRange.Size();
-        request->Record.BlockSize = blockContent.Size() / writeRange.Size();
+        request->Record.BlockSize = blockContent.size() / writeRange.Size();
         return request;
     }
 
@@ -596,7 +596,7 @@ public:
     {
         return CreateReadBlocksLocalRequest(
             TBlockRange32::MakeOneBlock(blockIndex),
-            {TBlockDataRef(buffer.Data(), buffer.Size())},
+            {TBlockDataRef(buffer.data(), buffer.size())},
             checkpointId);
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -264,7 +264,7 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksResponse(
         auto& destBuffer =
             destBuffers[blockRange.Start + i - Request.GetStartIndex()];
         destBuffer.swap(srcBuffer);
-        if (destBuffer.Empty()) {
+        if (destBuffer.empty()) {
             STORAGE_CHECK_PRECONDITION(SkipVoidBlocksToOptimizeNetworkTransfer);
             destBuffer.resize(blockSize, 0);
             ++VoidBlockCount;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -323,13 +323,13 @@ void TNonreplicatedPartitionActor::HandleWriteBlocks(
     };
 
     for (const auto& buffer: msg->Record.GetBlocks().GetBuffers()) {
-        if (buffer.Size() % PartConfig->GetBlockSize() != 0) {
+        if (buffer.size() % PartConfig->GetBlockSize() != 0) {
             replyError(
                 ctx,
                 *requestInfo,
                 E_ARGUMENT,
                 TStringBuilder() << "buffer not divisible by blockSize: "
-                    << buffer.Size() << " % " << PartConfig->GetBlockSize()
+                    << buffer.size() << " % " << PartConfig->GetBlockSize()
                     << " != 0");
             return;
         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
@@ -90,14 +90,14 @@ public:
         ui64 offset = 0;
         ui64 b = 0;
         bool isAllZeroes = CheckVoidBlocks;
-        while (offset < result.Data.Size()) {
+        while (offset < result.Data.size()) {
             ui64 targetBlock = dr.StartIndexOffset + b;
             Y_ABORT_UNLESS(targetBlock < static_cast<ui64>(blocks.size()));
             ui64 bytes =
-                Min(result.Data.Size() - offset, blocks[targetBlock].Size());
+                Min(result.Data.size() - offset, blocks[targetBlock].size());
             Y_ABORT_UNLESS(bytes);
 
-            char* dst = const_cast<char*>(blocks[targetBlock].Data());
+            char* dst = const_cast<char*>(blocks[targetBlock].data());
             const char* src = result.Data.data() + offset;
 
             if (isAllZeroes) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
@@ -87,11 +87,11 @@ public:
             ui64 offset = 0;
             ui64 b = 0;
             bool isAllZeroes = CheckVoidBlocks;
-            while (offset < result.Data.Size()) {
+            while (offset < result.Data.size()) {
                 ui64 targetBlock = dr.StartIndexOffset + b;
                 Y_ABORT_UNLESS(targetBlock < data.size());
                 ui64 bytes =
-                    Min(result.Data.Size() - offset, data[targetBlock].Size());
+                    Min(result.Data.size() - offset, data[targetBlock].Size());
                 Y_ABORT_UNLESS(bytes);
 
                 char* dst = const_cast<char*>(data[targetBlock].Data());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -188,13 +188,13 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
     };
 
     for (const auto& buffer: msg->Record.GetBlocks().GetBuffers()) {
-        if (buffer.Size() % PartConfig->GetBlockSize() != 0) {
+        if (buffer.size() % PartConfig->GetBlockSize() != 0) {
             replyError(
                 ctx,
                 *requestInfo,
                 E_ARGUMENT,
                 TStringBuilder() << "buffer not divisible by blockSize: "
-                    << buffer.Size() << " % " << PartConfig->GetBlockSize()
+                    << buffer.size() << " % " << PartConfig->GetBlockSize()
                     << " != 0");
             return;
         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
@@ -671,7 +671,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionRdmaTest)
 
         TString data(blockRange.Size() * DefaultBlockSize, 'A');
         TBlockChecksum checksum;
-        checksum.Extend(data.Data(), data.Size());
+        checksum.Extend(data.data(), data.size());
 
         {
             auto response = client.ChecksumBlocks(blockRange);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -578,7 +578,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
 
         TString data(blockRange.Size() * DefaultBlockSize, 'A');
         TBlockChecksum checksum;
-        checksum.Extend(data.Data(), data.Size());
+        checksum.Extend(data.data(), data.size());
 
         {
             auto response = client.ChecksumBlocks(blockRange);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
@@ -153,7 +153,7 @@ void TResyncRangeActor::WriteReplicaBlocks(const TActorContext& ctx, int idx)
     headers->SetClientId(std::move(clientId));
 
     for (const auto blockIndex: xrange(Range)) {
-        auto* data = Buffer.Get().Data() + (blockIndex - Range.Start) * BlockSize;
+        auto* data = Buffer.Get().data() + (blockIndex - Range.Start) * BlockSize;
 
         const auto digest = BlockDigestGenerator->ComputeDigest(
             blockIndex,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -549,7 +549,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
             ui64 index = 1024 + i;
             TString data(DefaultBlockSize, 'A');
             ui64 digest = *env.BlockDigestGenerator->ComputeDigest(
-                index, TBlockDataRef(data.Data(), data.Size()));
+                index, TBlockDataRef(data.data(), data.size()));
 
             UNIT_ASSERT_VALUES_EQUAL(index, response->AffectedBlockInfos[i].BlockIndex);
             UNIT_ASSERT_VALUES_EQUAL(digest, response->AffectedBlockInfos[i].Checksum);

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
@@ -119,7 +119,7 @@ void TWaitDependentDisksToSwitchNodeActor::Bootstrap(const TActorContext& ctx)
         return;
     }
 
-    if (Request.GetAgentId().Empty()) {
+    if (Request.GetAgentId().empty()) {
         HandleError(ctx, MakeError(E_ARGUMENT, "Empty AgentId"));
         return;
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create.cpp
@@ -178,7 +178,7 @@ void TCreateVolumeActor::CreateVolume(const TActorContext& ctx)
                 Request.GetBlocksCount(),
                 volumeParams.BlockSize,
                 Request.GetIsSystem(),
-                !Request.GetBaseDiskId().Empty()
+                !Request.GetBaseDiskId().empty()
             );
         }
         volumeParams.PartitionsCount = partitionsInfo.PartitionsCount;

--- a/cloud/blockstore/libs/storage/service/service_actor_describe_model.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_describe_model.cpp
@@ -33,7 +33,7 @@ void TServiceActor::HandleDescribeVolumeModel(
         request.GetBlocksCount(),
         request.GetBlockSize(),
         request.GetIsSystem(),
-        !request.GetBaseDiskId().Empty()
+        !request.GetBaseDiskId().empty()
     );
 
     TVolumeParams volumeParams;

--- a/cloud/blockstore/libs/storage/testlib/disk_agent_mock.h
+++ b/cloud/blockstore/libs/storage/testlib/disk_agent_mock.h
@@ -293,7 +293,7 @@ private:
                 } else {
                     buf = &zeroBlock;
                 }
-                checksum.Extend(buf->Data(), buf->Size());
+                checksum.Extend(buf->data(), buf->size());
             }
         }
 

--- a/cloud/blockstore/libs/storage/volume/actors/read_and_clear_empty_blocks_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_and_clear_empty_blocks_actor_ut.cpp
@@ -84,7 +84,7 @@ Y_UNIT_TEST_SUITE(TForwardReadTests)
         const auto& fullBuffers = fullResponse->Record.GetBlocks().GetBuffers();
         const auto& unencrypted =
             fullResponse->Record.GetUnencryptedBlockMask();
-        UNIT_ASSERT_EQUAL(0, unencrypted.Size());
+        UNIT_ASSERT_EQUAL(0, unencrypted.size());
 
         // Check that the blocks marked as unused are filled with zeros.
         for (int i = 0; i < fullBuffers.size(); ++i) {

--- a/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay_ut.cpp
@@ -105,7 +105,7 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
 
         const auto& fullBuffers = fullResponse->Record.GetBlocks().GetBuffers();
         for (int i = 0; i < fullBuffers.size(); ++i) {
-            UNIT_ASSERT_EQUAL(fullBuffers[i].Size(), blockSize);
+            UNIT_ASSERT_EQUAL(fullBuffers[i].size(), blockSize);
             UNIT_ASSERT_EQUAL(memcmp(
                 fullBuffers[i].data(),
                 TString(blockSize, i).data(),
@@ -582,7 +582,7 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
 
         const auto& fullBuffers = fullResponse->Record.GetBlocks().GetBuffers();
         for (int i = 0; i < fullBuffers.size(); ++i) {
-            UNIT_ASSERT_EQUAL(fullBuffers[i].Size(), blockSize);
+            UNIT_ASSERT_EQUAL(fullBuffers[i].size(), blockSize);
             UNIT_ASSERT_EQUAL(memcmp(
                 fullBuffers[i].data(),
                 TString(blockSize, i).data(),

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -22,7 +22,7 @@ TString MakeShadowDiskClientId(
     const TString& sourceDiskClientId,
     bool readOnlyMount)
 {
-    if (readOnlyMount || sourceDiskClientId.Empty()) {
+    if (readOnlyMount || sourceDiskClientId.empty()) {
         return TString(ShadowDiskClientId);
     }
     return sourceDiskClientId;

--- a/cloud/blockstore/libs/storage/volume/model/merge.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/merge.cpp
@@ -92,7 +92,7 @@ void SplitFreshBlockRangeFromRelativeToGlobalIndices(
     const ui32 startIndex = srcRange.GetStartIndex();
     ui32 blocksCount = 0;
 
-    const char* srcRangePtr = srcRange.GetBlocksContent().Data();
+    const char* srcRangePtr = srcRange.GetBlocksContent().data();
     while (blocksCount < srcRange.GetBlocksCount()) {
         const auto index = RelativeToGlobalIndex(
             blocksPerStripe,

--- a/cloud/blockstore/libs/storage/volume/multi_partition_requests.cpp
+++ b/cloud/blockstore/libs/storage/volume/multi_partition_requests.cpp
@@ -112,8 +112,8 @@ bool ToPartitionRequests<TEvService::TWriteBlocksMethod>(
 
     ui32 bufferSize = 0;
     for (const auto& buffer: buffers) {
-        Y_ABORT_UNLESS(bufferSize == 0 || bufferSize == buffer.Size());
-        bufferSize = buffer.Size();
+        Y_ABORT_UNLESS(bufferSize == 0 || bufferSize == buffer.size());
+        bufferSize = buffer.size();
     }
 
     *blockRange = BuildRequestBlockRange(*ev->Get(), blockSize);

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -355,7 +355,7 @@ TString TVolumeActor::GetVolumeStatusString(TVolumeActor::EStatus status) const
     switch (status)
     {
         case TVolumeActor::STATUS_ONLINE: {
-            return State->GetLocalMountClientId().Empty() ?
+            return State->GetLocalMountClientId().empty() ?
                 "Online":
                 "Online (preempted)";
         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -531,7 +531,7 @@ void TVolumeActor::OnClientListUpdate(const NActors::TActorContext& ctx)
     if (StartMode != EVolumeStartMode::MOUNTED) {
         auto request = std::make_unique<TEvService::TEvVolumeMountStateChanged>(
             State->GetDiskId(),
-            !State->GetLocalMountClientId().Empty());
+            !State->GetLocalMountClientId().empty());
         NCloud::Send(ctx, MakeStorageServiceId(), std::move(request));
     }
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1463,7 +1463,7 @@ void TVolumeActor::CompleteUpdateCheckpointRequest(
     const bool needToCreateShadowActor =
         request.ReqType == ECheckpointRequestType::Create &&
         request.ShadowDiskState != EShadowDiskState::Error &&
-        !request.ShadowDiskId.Empty() &&
+        !request.ShadowDiskId.empty() &&
         !State->GetCheckpointStore().HasShadowActor(request.CheckpointId);
 
     if (needToDestroyShadowActor || needToCreateShadowActor) {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -29,7 +29,7 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
     const auto* msg = ev->Get();
 
     const bool overlayDiskRegistryBasedDisk =
-        State->IsDiskRegistryMediaKind() && !State->GetBaseDiskId().Empty();
+        State->IsDiskRegistryMediaKind() && !State->GetBaseDiskId().empty();
 
     if constexpr (IsWriteMethod<TMethod>) {
         if (State->GetTrackUsedBlocks() || State->HasCheckpointLight())

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -553,7 +553,7 @@ void TVolumeActor::HandleHttpInfo_Default(
     const char* storageConfigTab = inactiveTab;
     const char* rawVolumeConfigTab = inactiveTab;
 
-    if (tabName.Empty() || tabName == overviewTabName) {
+    if (tabName.empty() || tabName == overviewTabName) {
         overviewTab = activeTab;
     } else if (tabName == historyTabName) {
         historyTab = activeTab;

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -244,7 +244,7 @@ void TVolumeState::Reset()
         if (Meta.GetDevices().size()) {
             CreatePartitionStatInfo(GetDiskId(), 0);
         }
-        const bool overlay = !GetBaseDiskId().Empty();
+        const bool overlay = !GetBaseDiskId().empty();
         // TODO(drbasic)
         // For encrypted disk-registry based disks, we will continue to
         // write a map of encrypted blocks for a while.

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -4896,7 +4896,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             auto blockContent = GetBlockContent(1);
 
             TSgList sglist;
-            sglist.resize(range.Size(), {blockContent.Data(), blockContent.Size()});
+            sglist.resize(range.Size(), {blockContent.data(), blockContent.size()});
             TGuardedSgList glist(std::move(sglist));
 
             auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
@@ -6176,7 +6176,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             TSgList sglist;
             sglist.resize(
                 range.Size(),
-                {blockContent.Data(), blockContent.Size()}
+                {blockContent.data(), blockContent.size()}
             );
             TGuardedSgList glist(std::move(sglist));
 
@@ -6401,7 +6401,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             TSgList sglist;
             sglist.resize(
                 range.Size(),
-                {blockContent.Data(), blockContent.Size()}
+                {blockContent.data(), blockContent.size()}
             );
             TGuardedSgList glist(std::move(sglist));
 

--- a/cloud/blockstore/libs/validation/validation.cpp
+++ b/cloud/blockstore/libs/validation/validation.cpp
@@ -15,7 +15,7 @@ struct TCrcDigestCalculator final
     {
         Y_UNUSED(blockIndex);
 
-        return Crc32c(block.Data(), block.Size());
+        return Crc32c(block.data(), block.size());
     }
 };
 

--- a/cloud/blockstore/libs/vhost/server_ut_stress.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut_stress.cpp
@@ -162,7 +162,7 @@ void SendRandomRequest(ITestVhostDevice& device)
     ui64 length = dist3(eng) * 1024;
 
     TString buffer(length, '0');
-    auto sglist = TSgList{ TBlockDataRef(buffer.Data(), buffer.Size()) };
+    auto sglist = TSgList{ TBlockDataRef(buffer.data(), buffer.size()) };
 
     auto future = device.SendTestRequest(type, from, length, std::move(sglist));
     future.Apply([holder = std::move(buffer)] (const auto& f) {

--- a/cloud/blockstore/tools/testing/bad-guest/lib/io.cpp
+++ b/cloud/blockstore/tools/testing/bad-guest/lib/io.cpp
@@ -60,12 +60,12 @@ public:
     {
         ui64 sz = 0;
         for (const auto& data: datas) {
-            sz = Max(sz, data.Size());
+            sz = Max(sz, data.size());
         }
         sz = AlignUp<ui64>(sz);
         TAlignedBuffer buffer(sz, BlockSize);
         const auto offset = blockIndex * BlockSize;
-        memcpy(buffer.AlignedPtr, datas[0].Data(), datas[0].Size());
+        memcpy(buffer.AlignedPtr, datas[0].data(), datas[0].size());
 
         auto f = AsyncIO.Write(File, buffer.AlignedPtr, sz, offset);
         // corrupting the data buffer that we have just sent to the storage
@@ -74,7 +74,7 @@ public:
         ui32 i = 0;
         while (!f.HasValue()) {
             const auto& data = datas[++i % datas.size()];
-            memcpy(buffer.AlignedPtr, data.Data(), data.Size());
+            memcpy(buffer.AlignedPtr, data.data(), data.size());
         }
 
         Y_ABORT_UNLESS(f.GetValue() == sz);

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -231,7 +231,7 @@ void TStorageServiceActor::HandleCreateHandle(
 {
     auto* msg = ev->Get();
 
-    if (msg->Record.GetName().Empty()) {
+    if (msg->Record.GetName().empty()) {
         // handle creation by NodeId can be handled directly by the shard
         ForwardRequestToShard<TEvService::TCreateHandleMethod>(
             ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -160,7 +160,7 @@ void TGetNodeAttrActor::HandleGetNodeAttrResponse(
         msg->Record.GetNode().GetShardNodeName().Quote().c_str());
 
     if (!MultiTabletForwardingEnabled
-            || msg->Record.GetNode().GetShardFileSystemId().Empty())
+            || msg->Record.GetNode().GetShardFileSystemId().empty())
     {
         ReplyAndDie(ctx, std::move(msg->Record));
         return;
@@ -231,7 +231,7 @@ void TStorageServiceActor::HandleGetNodeAttr(
 {
     auto* msg = ev->Get();
 
-    if (msg->Record.GetName().Empty()) {
+    if (msg->Record.GetName().empty()) {
         // handle creation by NodeId can be handled directly by the shard
         ForwardRequestToShard<TEvService::TGetNodeAttrMethod>(
             ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -164,7 +164,7 @@ void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
         const auto& node = Response.GetNodes(i);
         if (node.GetShardFileSystemId()) {
             auto& batch = batches[node.GetShardFileSystemId()];
-            if (batch.Record.GetHeaders().GetSessionId().Empty()) {
+            if (batch.Record.GetHeaders().GetSessionId().empty()) {
                 batch.Record.MutableHeaders()->CopyFrom(ListNodesRequest.GetHeaders());
                 batch.Record.SetFileSystemId(node.GetShardFileSystemId());
                 batch.Record.SetNodeId(RootNodeId);

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -172,7 +172,7 @@ TString DescribeResponseDebugString(
     // we need to clear user data first
     for (auto& freshRange: *response.MutableFreshDataRanges()) {
         freshRange.SetContent(
-            Sprintf("Content size: %lu", freshRange.GetContent().Size()));
+            Sprintf("Content size: %lu", freshRange.GetContent().size()));
     }
 
     return response.DebugString();
@@ -190,7 +190,7 @@ char* GetDataPtr(
     const ui64 relOffset = offset - alignedByteRange.Offset;
     const ui32 blockNo = relOffset / blockSize;
     const auto block = buffer.GetBlock(blockNo);
-    return const_cast<char*>(block.Data()) + relOffset - blockNo * blockSize;
+    return const_cast<char*>(block.data()) + relOffset - blockNo * blockSize;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -210,7 +210,7 @@ private:
                 request = std::make_unique<TEvBlobStorage::TEvPut>(
                     blobId,
                     TString(
-                        WriteRequest.GetBuffer().Data() + offset,
+                        WriteRequest.GetBuffer().data() + offset,
                         blobId.BlobSize()),
                     TInstant::Max(),
                     NKikimrBlobStorage::UserData);
@@ -489,7 +489,7 @@ void TStorageServiceActor::HandleWriteData(
 
     const TByteRange range(
         msg->Record.GetOffset(),
-        msg->Record.GetBuffer().Size(),
+        msg->Record.GetBuffer().size(),
         blockSize);
     const bool threeStageWriteEnabled =
         range.Length >= filestore.GetFeatures().GetThreeStageWriteThreshold()
@@ -501,7 +501,7 @@ void TStorageServiceActor::HandleWriteData(
             ctx,
             TFileStoreComponents::SERVICE,
             "Using three-stage write for request, size: %lu",
-            msg->Record.GetBuffer().Size());
+            msg->Record.GetBuffer().size());
 
         auto [cookie, inflight] = CreateInFlightRequest(
             TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1970,7 +1970,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         auto data = TString(100, 'x') + TString(200, 'y') + TString(300, 'z');
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         auto readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
         // fresh blocks - adding multiple adjacent blocks is important here to
@@ -1978,14 +1978,14 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         data = TString(8_KB, 'a');
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
         // blobs
         data = TString(1_MB, 'b');
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
         readDataResult = service.ReadData(
@@ -1994,7 +1994,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId,
             handle,
             DefaultBlockSize,
-            data.Size() - DefaultBlockSize);
+            data.size() - DefaultBlockSize);
         UNIT_ASSERT_VALUES_EQUAL(
             readDataResult->Record.GetBuffer(),
             data.substr(DefaultBlockSize));
@@ -2004,8 +2004,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         const ui32 patchOffset = 20_KB;
         service.WriteData(headers, fs, nodeId, handle, patchOffset, patch);
         readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
-        memcpy(data.begin() + patchOffset, patch.Data(), patch.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
+        memcpy(data.begin() + patchOffset, patch.data(), patch.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
         auto counters = env.GetCounters()
@@ -2102,7 +2102,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TString data(4_KB, 'A');
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         auto readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
         UNIT_ASSERT_VALUES_EQUAL(2, describeDataResponses);
         UNIT_ASSERT_VALUES_EQUAL(4, readDataResponses);
@@ -2186,7 +2186,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TString data(1_MB, 'A');
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         auto readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
         UNIT_ASSERT_VALUES_EQUAL(2, describeDataResponses);
         UNIT_ASSERT_VALUES_EQUAL(8, evGets);
@@ -2344,7 +2344,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             service.WriteData(headers, fs, nodeId, handle, offset, data);
             auto readDataResult =
                 service
-                    .ReadData(headers, fs, nodeId, handle, offset, data.Size());
+                    .ReadData(headers, fs, nodeId, handle, offset, data.size());
             // clang-format off
             UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
             UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsRequest));
@@ -2465,7 +2465,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             service.WriteData(headers, fs, nodeId, handle, offset, data);
             auto readDataResult =
                 service
-                    .ReadData(headers, fs, nodeId, handle, offset, data.Size());
+                    .ReadData(headers, fs, nodeId, handle, offset, data.size());
             // clang-format off
             UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
             UNIT_ASSERT_VALUES_EQUAL(0, runtime.GetCounter(TEvIndexTablet::EvGenerateBlobIdsRequest));
@@ -2534,7 +2534,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId,
             handle,
             offset,
-            data.Size())->Record.GetBuffer();
+            data.size())->Record.GetBuffer();
         UNIT_ASSERT_VALUES_EQUAL(data, readData);
         UNIT_ASSERT_VALUES_EQUAL(2, addData.UnalignedDataRangesSize());
         UNIT_ASSERT_VALUES_EQUAL(
@@ -2549,7 +2549,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             fs,
             RootNodeId,
             "file")->Record.GetNode();
-        UNIT_ASSERT_VALUES_EQUAL(data.Size() + offset, stat.GetSize());
+        UNIT_ASSERT_VALUES_EQUAL(data.size() + offset, stat.GetSize());
     }
 
     Y_UNIT_TEST(ShouldFallbackThreeStageWriteToSimpleWrite)
@@ -2607,7 +2607,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TString data = GenerateValidateData(256_KB);
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         auto readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
         auto& runtime = env.GetRuntime();
         // clang-format off
@@ -2635,7 +2635,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         data = GenerateValidateData(256_KB);
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
         // clang-format off
         UNIT_ASSERT_VALUES_EQUAL(2, runtime.GetCounter(TEvIndexTablet::EvAddDataResponse));
@@ -2680,7 +2680,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         data = GenerateValidateData(256_KB);
         service.WriteData(headers, fs, nodeId, handle, 0, data);
         readDataResult =
-            service.ReadData(headers, fs, nodeId, handle, 0, data.Size());
+            service.ReadData(headers, fs, nodeId, handle, 0, data.size());
         UNIT_ASSERT_VALUES_EQUAL(readDataResult->Record.GetBuffer(), data);
 
         // clang-format off
@@ -3442,7 +3442,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             handle1,
             0,
-            data.Size())->Record;
+            data.size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse.GetBuffer());
 
         auto destroyHandleResponse = service.DestroyHandle(
@@ -3655,7 +3655,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             handle1,
             0,
-            data.Size())->Record;
+            data.size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse.GetBuffer());
 
         data = GenerateValidateData(1_MB);
@@ -3666,7 +3666,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId2,
             handle2,
             0,
-            data.Size())->Record;
+            data.size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse.GetBuffer());
 
         service.DestroyHandle(headers, fsId, nodeId1, handle1);
@@ -3724,7 +3724,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             handle1,
             0,
-            data.Size())->Record;
+            data.size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse.GetBuffer());
     }
 
@@ -4372,7 +4372,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             handle1r,
             0,
-            data1.Size())->Record;
+            data1.size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data1, readDataResponse.GetBuffer());
 
         // checking that node listing shows file3 and file2
@@ -4427,7 +4427,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             nodeId1,
             handle1r,
             0,
-            data1.Size())->Record;
+            data1.size())->Record;
         UNIT_ASSERT_VALUES_EQUAL(data1, readDataResponse.GetBuffer());
 
         // listing should show only file2 now
@@ -4700,7 +4700,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             linkNodeResponse->Record.GetNode().GetId(),
             handle2,
             0,
-            data.Size())->Record.GetBuffer();
+            data.size())->Record.GetBuffer();
         UNIT_ASSERT_VALUES_EQUAL(data, data2);
 
         // Removal of both the file and a hardlink should remove file from both

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -34,7 +34,7 @@ TWriteDataActor::TWriteDataActor(
     , WriteRange(writeRange)
 {
     for (const auto& blob: Blobs) {
-        BlobsSize += blob.BlobContent.Size();
+        BlobsSize += blob.BlobContent.size();
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/model/fresh_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_blocks.cpp
@@ -38,7 +38,7 @@ TStringBuf TFreshBlocks::AllocateBlock(TStringBuf content, ui32 blockSize)
     Y_ABORT_UNLESS(blockSize >= content.size());
 
     auto block = Allocator->Allocate(blockSize);
-    memcpy(block.Data, content.Data(), content.Size());
+    memcpy(block.Data, content.data(), content.size());
 
     if (content.size() < blockSize) {
         memset(static_cast<char*>(block.Data) + content.size(), 0, blockSize - content.size());
@@ -49,7 +49,7 @@ TStringBuf TFreshBlocks::AllocateBlock(TStringBuf content, ui32 blockSize)
 
 void TFreshBlocks::ReleaseBlock(TStringBuf content)
 {
-    IAllocator::TBlock block { const_cast<char*>(content.Data()), content.Size() };
+    IAllocator::TBlock block { const_cast<char*>(content.data()), content.size() };
     Allocator->Release(block);
 }
 

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -67,7 +67,7 @@ void TFreshBytes::DeleteBytes(
             const auto shift = end - hi->second.Offset;
             hi->second.Buf = hi->second.Buf.substr(
                 shift,
-                hi->second.Buf.Size() - shift
+                hi->second.Buf.size() - shift
             );
             hi->second.Offset = end;
         }
@@ -126,7 +126,7 @@ void TFreshBytes::AddBytes(
     TKey key{nodeId, offset + storage.size()};
     TRef ref{TStringBuf(storage.data(), storage.size()), offset, commitId};
 
-    DeleteBytes(c, nodeId, offset, data.Size(), commitId);
+    DeleteBytes(c, nodeId, offset, data.size(), commitId);
 
     c.Refs[key] = ref;
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -171,7 +171,7 @@ void TIndexTabletActor::ReassignDataChannelsIfNeeded(
     {
         TStringBuilder sb;
         for (const auto channel: channels) {
-            if (sb.Size()) {
+            if (sb.size()) {
                 sb << ", ";
             }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -387,7 +387,7 @@ void TIndexTabletActor::HandleAddData(
 
     TVector<TBlockBytesMeta> unalignedDataParts;
     for (auto& part: *msg->Record.MutableUnalignedDataRanges()) {
-        if (part.GetContent().Empty()) {
+        if (part.GetContent().empty()) {
             auto response =
                 std::make_unique<TEvIndexTablet::TEvAddDataResponse>(MakeError(
                     E_ARGUMENT,
@@ -398,14 +398,14 @@ void TIndexTabletActor::HandleAddData(
 
         const ui32 blockIndex = part.GetOffset() / GetBlockSize();
         const ui32 lastBlockIndex =
-            (part.GetOffset() + part.GetContent().Size() - 1) / GetBlockSize();
+            (part.GetOffset() + part.GetContent().size() - 1) / GetBlockSize();
         if (blockIndex != lastBlockIndex) {
             auto response =
                 std::make_unique<TEvIndexTablet::TEvAddDataResponse>(MakeError(
                     E_ARGUMENT,
                     TStringBuilder() << "unaligned part spanning more than one"
                         << " block: " << part.GetOffset() << ":"
-                        << part.GetContent().Size()));
+                        << part.GetContent().size()));
             NCloud::Reply(ctx, *ev, std::move(response));
             return;
         }
@@ -423,13 +423,13 @@ void TIndexTabletActor::HandleAddData(
     auto unalignedMsg = [&] () {
         TStringBuilder sb;
         for (auto& part: unalignedDataParts) {
-            if (sb.Size()) {
+            if (sb.size()) {
                 sb << ", ";
             }
 
             sb << part.BlockIndex
                 << ":" << part.OffsetInBlock
-                << ":" << part.Data.Size();
+                << ":" << part.Data.size();
         }
         return sb;
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -71,7 +71,7 @@ void TIndexTabletActor::HandleCreateHandle(
         if (!GetDupCacheEntry(e, response->Record)) {
             // invalid entry type - it's certainly a request id collision
             session->DropDupEntry(requestId);
-        } else if (msg->Record.GetName().Empty() && msg->Record.GetNodeId()
+        } else if (msg->Record.GetName().empty() && msg->Record.GetNodeId()
                 != response->Record.GetNodeAttr().GetId())
         {
             // this handle relates to a different node id => it's certainly a
@@ -276,7 +276,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
     TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
     if (args.TargetNodeId == InvalidNodeId
-            && (args.ShardId.Empty() || args.IsNewShardNode))
+            && (args.ShardId.empty() || args.IsNewShardNode))
     {
         if (args.TargetNode) {
             auto message = ReportTargetNodeWithoutRef(TStringBuilder()
@@ -292,7 +292,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             return;
         }
 
-        if (args.ShardId.Empty()) {
+        if (args.ShardId.empty()) {
             NProto::TNode attrs =
                 CreateRegularAttrs(args.Mode, args.Uid, args.Gid);
             args.TargetNodeId = CreateNode(
@@ -328,7 +328,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             parent,
             args.ParentNode->Attrs);
 
-    } else if (args.ShardId.Empty()
+    } else if (args.ShardId.empty()
         && HasFlag(args.Flags, NProto::TCreateHandleRequest::E_TRUNCATE))
     {
         auto e = Truncate(
@@ -354,7 +354,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             args.TargetNode->Attrs);
     }
 
-    if (args.ShardId.Empty()) {
+    if (args.ShardId.empty()) {
         auto* handle = CreateHandle(
             db,
             session,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -415,7 +415,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
             return false;   // not ready
         }
 
-        if (args.ShardId.Empty()) {
+        if (args.ShardId.empty()) {
             args.ChildNodeId = args.TargetNodeId;
             if (!args.ChildNode) {
                 // should exist
@@ -468,7 +468,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
     }
 
     if (args.TargetNodeId == InvalidNodeId) {
-        if (args.ShardId.Empty()) {
+        if (args.ShardId.empty()) {
             args.ChildNodeId = CreateNode(
                 db,
                 args.CommitId,
@@ -500,7 +500,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
 
         // If the shard is set, no need to update the child node since it is
         // an external node
-        if (args.ShardId.Empty()) {
+        if (args.ShardId.empty()) {
             auto attrs =
                 CopyAttrs(args.ChildNode->Attrs, E_CM_CMTIME | E_CM_REF);
             UpdateNode(
@@ -534,7 +534,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         args.ShardId,
         args.ShardName);
 
-    if (args.ShardId.Empty()) {
+    if (args.ShardId.empty()) {
         if (args.ChildNodeId == InvalidNodeId) {
             auto message = ReportInvalidNodeIdForLocalNode(TStringBuilder()
                 << "CreateNode: " << args.Request.ShortDebugString());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -213,7 +213,7 @@ TFlushBytesActor::TFlushBytesActor(
     for (const auto& b: DstBlobs) {
         for (const auto& block: b.Blocks) {
             for (const auto& i: block.BlockBytes.Intervals) {
-                OperationSize += i.Data.Size();
+                OperationSize += i.Data.size();
             }
         }
     }
@@ -302,29 +302,29 @@ void TFlushBytesActor::WriteBlob(const TActorContext& ctx)
         for (const auto& block: blob.Blocks) {
             blobContent.append(BlockSize, 0);
             TStringBuf blockContent =
-                TStringBuf(blobContent).substr(blobContent.Size() - BlockSize);
+                TStringBuf(blobContent).substr(blobContent.size() - BlockSize);
             if (auto* ref = std::get_if<TBlockDataRef>(&block.Block)) {
                 TBlockLocationInBlob key{ref->BlobId, ref->BlobOffset};
 
                 auto& buffer = Buffers[ref->BlobId];
                 memcpy(
-                    const_cast<char*>(blockContent.Data()),
-                    buffer->GetBlock(SrcBlobOffset2DstBlobOffset[key]).Data(),
+                    const_cast<char*>(blockContent.data()),
+                    buffer->GetBlock(SrcBlobOffset2DstBlobOffset[key]).data(),
                     BlockSize
                 );
             } else if (auto* fresh = std::get_if<TOwningFreshBlock>(&block.Block)) {
                 memcpy(
-                    const_cast<char*>(blockContent.Data()),
-                    fresh->BlockData.Data(),
+                    const_cast<char*>(blockContent.data()),
+                    fresh->BlockData.data(),
                     BlockSize
                 );
             }
 
             for (const auto& interval: block.BlockBytes.Intervals) {
                 memcpy(
-                    const_cast<char*>(blockContent.Data()) + interval.OffsetInBlock,
-                    interval.Data.Data(),
-                    interval.Data.Size()
+                    const_cast<char*>(blockContent.data()) + interval.OffsetInBlock,
+                    interval.Data.data(),
+                    interval.Data.size()
                 );
             }
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -40,7 +40,7 @@ void ApplyBytes(const TBlockBytes& bytes, TStringBuf blockData)
 {
     for (const auto& interval: bytes.Intervals) {
         memcpy(
-            const_cast<char*>(blockData.Data()) + interval.OffsetInBlock,
+            const_cast<char*>(blockData.data()) + interval.OffsetInBlock,
             interval.Data.data(),
             interval.Data.size());
     }
@@ -273,7 +273,7 @@ public:
             if (prev.MinCommitId < bytes.MinCommitId) {
                 Args.Bytes[blockIndex].Intervals.push_back({
                     IntegerCast<ui32>(offsetInBlock),
-                    TString(data.Data() + i, next - i)
+                    TString(data.data() + i, next - i)
                 });
             }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -121,7 +121,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
         return true;
     }
 
-    if (args.ChildRef->ShardId.Empty()) {
+    if (args.ChildRef->ShardId.empty()) {
         if (!ReadNode(
                 db,
                 args.ChildRef->ChildNodeId,
@@ -175,7 +175,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
             return true;
         }
 
-        if (args.NewChildRef->ShardId.Empty()) {
+        if (args.NewChildRef->ShardId.empty()) {
             // read new child node to unlink it
             if (!ReadNode(
                     db,
@@ -313,7 +313,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.NewChildRef->ChildNodeId,
                 args.NewChildRef->ShardId,
                 args.NewChildRef->ShardName);
-        } else if (args.NewChildRef->ShardId.Empty()) {
+        } else if (args.NewChildRef->ShardId.empty()) {
             if (!args.NewChildNode) {
                 auto message = ReportNewChildNodeIsNull(TStringBuilder()
                     << "RenameNode: " << args.Request.ShortDebugString());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -27,7 +27,7 @@ template <>
 ui64 CalculateByteCount<NProto::TWriteDataRequest>(
     const NProto::TWriteDataRequest& request)
 {
-    return request.GetBuffer().Size();
+    return request.GetBuffer().size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -305,7 +305,7 @@ void TIndexTabletActor::HandleWriteBlob(
                 blob.BlobContent,
                 out.begin());
             Metrics.UncompressedBytesWritten.fetch_add(
-                blob.BlobContent.Size(),
+                blob.BlobContent.size(),
                 std::memory_order_relaxed);
             Metrics.CompressedBytesWritten.fetch_add(
                 sz,

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1019,7 +1019,7 @@ void TIndexTabletDatabase::WriteFreshBytes(
         .Key(commitId, nodeId, offset)
         .Update(
             NIceDb::TUpdate<TTable::Data>(TString(data)),
-            NIceDb::TUpdate<TTable::Len>(data.Size()));
+            NIceDb::TUpdate<TTable::Len>(data.size()));
 }
 
 void TIndexTabletDatabase::WriteFreshBytesDeletionMarker(
@@ -1068,7 +1068,7 @@ bool TIndexTabletDatabase::ReadFreshBytes(TVector<TFreshBytesEntry>& bytes)
         TString data = it.GetValue<TTable::Data>();
         if (data && !len) {
             // backwards-compat
-            len = data.Size();
+            len = data.size();
         }
 
         bytes.emplace_back(TFreshBytesEntry {

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -314,7 +314,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
             UNIT_ASSERT_VALUES_EQUAL(commitId, bytes[0].MinCommitId);
             UNIT_ASSERT_VALUES_EQUAL(offset, bytes[0].Offset);
             UNIT_ASSERT_VALUES_EQUAL(data, bytes[0].Data);
-            UNIT_ASSERT_VALUES_EQUAL(data.Size(), bytes[0].Len);
+            UNIT_ASSERT_VALUES_EQUAL(data.size(), bytes[0].Len);
 
             UNIT_ASSERT_VALUES_EQUAL(nodeId, bytes[1].NodeId);
             UNIT_ASSERT_VALUES_EQUAL(commitId + 10, bytes[1].MinCommitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -382,7 +382,7 @@ void TIndexTabletState::WriteFreshBytes(
         offset,
         data);
 
-    IncrementFreshBytesCount(db, data.Size());
+    IncrementFreshBytesCount(db, data.size());
 
     InvalidateReadAheadCache(nodeId);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5118,17 +5118,17 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         TVector<NProtoPrivate::TFreshDataRange> unalignedParts;
         {
             NProtoPrivate::TFreshDataRange part;
-            part.SetOffset(block - unalignedHead.Size());
+            part.SetOffset(block - unalignedHead.size());
             part.SetContent(unalignedHead);
             unalignedParts.push_back(part);
-            part.SetOffset(block + alignedBody.Size());
+            part.SetOffset(block + alignedBody.size());
             part.ClearContent();
             unalignedParts.push_back(part);
         }
 
-        const ui64 offset = block - unalignedHead.Size();
+        const ui64 offset = block - unalignedHead.size();
         const ui64 len =
-            unalignedHead.Size() + alignedBody.Size() + unalignedTail.Size();
+            unalignedHead.size() + alignedBody.size() + unalignedTail.size();
 
         tablet.SendAddDataRequest(
             id,
@@ -5168,7 +5168,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // AddData should correctly update file size
         auto stat = tablet.GetNodeAttr(id)->Record.GetNode();
         UNIT_ASSERT_VALUES_EQUAL(
-            block + alignedBody.Size() + unalignedTail.Size(),
+            block + alignedBody.size() + unalignedTail.size(),
             stat.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(
             unalignedHead + alignedBody + unalignedTail,

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -237,7 +237,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
             Max<ui32>(),
             &next));
         UNIT_ASSERT(refs.empty());
-        UNIT_ASSERT(next.Empty());
+        UNIT_ASSERT(next.empty());
 
         // Though the node is present in NodeRefs table, it is not visible at
         // commitId1. So read from cache is considered successful, but the node

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_throttling.cpp
@@ -204,7 +204,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Throttling)
             if (i == 0) {
                 UNIT_ASSERT_VALUES_EQUAL(
                     0,
-                    readResponse->Record.GetBuffer().Size());
+                    readResponse->Record.GetBuffer().size());
             } else {
                 UNIT_ASSERT_VALUES_EQUAL(
                     TString(4_KB, static_cast<char>('a' + i - 1)),
@@ -255,7 +255,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Throttling)
             } else {
                 UNIT_ASSERT_VALUES_EQUAL(
                     0,
-                    readResponse->Record.GetBuffer().Size());
+                    readResponse->Record.GetBuffer().size());
             }
         }
 
@@ -557,7 +557,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Throttling)
         const auto response = AssertReadDataResponse(S_OK);
         UNIT_ASSERT_VALUES_EQUAL(
             0,
-            response->Record.GetBuffer().Size());
+            response->Record.GetBuffer().size());
         AssertWriteDataResponse(S_OK);
     }
 

--- a/cloud/filestore/libs/vfs_fuse/file_ring_buffer.cpp
+++ b/cloud/filestore/libs/vfs_fuse/file_ring_buffer.cpp
@@ -38,8 +38,8 @@ struct Y_PACKED TEntryHeader
 void WriteEntry(IOutputStream& os, TStringBuf data)
 {
     TEntryHeader eh;
-    eh.Size = data.Size();
-    eh.Checksum = Crc32c(data.Data(), data.Size());
+    eh.Size = data.size();
+    eh.Checksum = Crc32c(data.data(), data.size());
     os.Write(&eh, sizeof(eh));
     os.Write(data);
 }
@@ -100,7 +100,7 @@ private:
         }
 
         TStringBuf entry(b + sizeof(TEntryHeader), eh->Size);
-        if (entry.Data() + entry.Size() > End) {
+        if (entry.data() + entry.size() > End) {
             visitor(eh->Checksum, INVALID_MARKER);
             return INVALID_POS;
         }
@@ -160,11 +160,11 @@ public:
 public:
     bool Push(TStringBuf data)
     {
-        if (data.Empty() || data.Size() > MaxEntrySize) {
+        if (data.empty() || data.size() > MaxEntrySize) {
             return false;
         }
 
-        const auto sz = data.Size() + sizeof(TEntryHeader);
+        const auto sz = data.size() + sizeof(TEntryHeader);
         auto* ptr = Data + Header()->WritePos;
 
         if (!Empty()) {
@@ -217,7 +217,7 @@ public:
 
         const auto* eh = reinterpret_cast<const TEntryHeader*>(b);
         TStringBuf result{b + sizeof(TEntryHeader), eh->Size};
-        if (result.Data() + result.Size() > End) {
+        if (result.data() + result.size() > End) {
             // corruption
             // TODO: report?
             return {};
@@ -233,7 +233,7 @@ public:
             return;
         }
 
-        Header()->ReadPos += sizeof(TEntryHeader) + data.Size();
+        Header()->ReadPos += sizeof(TEntryHeader) + data.size();
         --Count;
 
         SkipSlackSpace();
@@ -256,7 +256,7 @@ public:
         TVector<TBrokenFileRingBufferEntry> entries;
 
         Visit([&] (ui32 checksum, TStringBuf entry) {
-            const ui32 actualChecksum = Crc32c(entry.Data(), entry.Size());
+            const ui32 actualChecksum = Crc32c(entry.data(), entry.size());
             if (actualChecksum != checksum) {
                 entries.push_back({
                     TString(entry),

--- a/cloud/storage/core/libs/auth/authorizer.cpp
+++ b/cloud/storage/core/libs/auth/authorizer.cpp
@@ -349,7 +349,7 @@ private:
         const bool requireAuthorization =
             AuthMode == NProto::AUTHORIZATION_REQUIRE;
 
-        if (msg->Token.Empty()) {
+        if (msg->Token.empty()) {
             if (requireAuthorization) {
                 LOG_ERROR_S(ctx, Component,
                     "Request for authorization with empty token: "

--- a/cloud/storage/core/libs/common/block_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/block_buffer_ut.cpp
@@ -29,7 +29,7 @@ Y_UNIT_TEST_SUITE(TBlockBufferTest)
         for (auto c : content) {
             if (c.fill) {
                 TString tmp(c.size, *c.fill);
-                b.AddBlock({tmp.Data(), tmp.Size()});
+                b.AddBlock({tmp.data(), tmp.size()});
             } else {
                 b.AddZeroBlock(c.size);
             }

--- a/cloud/storage/core/libs/common/block_data_ref_ut.cpp
+++ b/cloud/storage/core/libs/common/block_data_ref_ut.cpp
@@ -12,15 +12,15 @@ Y_UNIT_TEST_SUITE(TBlockDataRefTest)
     Y_UNIT_TEST(ConstructFromString)
     {
         TString expected = "test";
-        TBlockDataRef actual(expected.Data(), expected.Size());
+        TBlockDataRef actual(expected.data(), expected.size());
         UNIT_ASSERT_VALUES_EQUAL(expected, actual.AsStringBuf());
     }
 
     Y_UNIT_TEST(EqualityOperator)
     {
         TString expected = "test";
-        TBlockDataRef lhs(expected.Data(), expected.Size());
-        TBlockDataRef rhs(expected.Data(), expected.Size());
+        TBlockDataRef lhs(expected.data(), expected.size());
+        TBlockDataRef rhs(expected.data(), expected.size());
         UNIT_ASSERT_VALUES_EQUAL(lhs == rhs, true);
     }
 

--- a/cloud/storage/core/libs/common/compressed_bitmap.cpp
+++ b/cloud/storage/core/libs/common/compressed_bitmap.cpp
@@ -805,10 +805,10 @@ public:
     {
         // TODO: endianness
         chunk->UnsetAll(compressedChunkCount);
-        Y_DEBUG_ABORT_UNLESS(data.Size() > 0);
+        Y_DEBUG_ABORT_UNLESS(data.size() > 0);
         switch (chunk->Type() = data[0]) {
             case PLAIN: {
-                Y_DEBUG_ABORT_UNLESS(data.Size() >= sizeof(TPlainChunkData) + 1);
+                Y_DEBUG_ABORT_UNLESS(data.size() >= sizeof(TPlainChunkData) + 1);
                 auto& plain = chunk->Data.Plain;
                 plain.Data = new TPlainChunkData;
                 memcpy(
@@ -823,11 +823,11 @@ public:
             }
 
             case RLE: {
-                Y_DEBUG_ABORT_UNLESS(data.Size() >= sizeof(TCompressedChunkData) + 1);
+                Y_DEBUG_ABORT_UNLESS(data.size() >= sizeof(TCompressedChunkData) + 1);
                 auto& compressed = chunk->Data.Compressed;
                 memcpy(
                     compressed.Data.Runs,
-                    data.Data() + 1,
+                    data.data() + 1,
                     sizeof(TCompressedChunkData)
                 );
                 chunk->Count() = compressed.Data.Count();

--- a/cloud/storage/core/libs/common/guarded_sglist_inl.h
+++ b/cloud/storage/core/libs/common/guarded_sglist_inl.h
@@ -53,7 +53,7 @@ public:
 
 inline TSgList CreateSgList(const TString& s)
 {
-    if (s.Empty()) {
+    if (s.empty()) {
         return {{}};
     }
     return {{ s.data(), s.length() }};

--- a/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
+++ b/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
@@ -203,7 +203,7 @@ TString BuildCpuWaitStatsFilename(const TString& serviceName)
 {
     static constexpr auto CpuWaitStatsFilenameTemplate =
         "/sys/fs/cgroup/cpu/system.slice/%s.service/cpuacct.wait";
-    if (!serviceName.Empty()) {
+    if (!serviceName.empty()) {
         return Sprintf(CpuWaitStatsFilenameTemplate, serviceName.c_str());
     }
     return {};

--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon.cpp
@@ -283,10 +283,10 @@ public:
             monitoring->RegisterIndexPage("tracelogs", "Traces Logs");
         auto& index = static_cast<TIndexMonPage&>(*rootPage);
         index.Register(
-            new TMonPageHtml(*this, randomName.Data(), "Random samples"));
+            new TMonPageHtml(*this, randomName.data(), "Random samples"));
         index.Register(
-            new TMonPageHtml(*this, slowName.Data(), "Slow samples"));
-        index.Register(new TMonPageJson(*this, jsonName.Data()));
+            new TMonPageHtml(*this, slowName.data(), "Slow samples"));
+        index.Register(new TMonPageJson(*this, jsonName.data()));
     }
 
     void Start() override

--- a/cloud/storage/core/libs/features/features_config_ut.cpp
+++ b/cloud/storage/core/libs/features/features_config_ut.cpp
@@ -17,7 +17,7 @@ TVector<TString> RandomStrings(ui32 n)
     TVector<TString> r;
     for (ui32 i = 0; i < n; ++i) {
         TString s(20, 0);
-        for (ui32 j = 0; j < s.Size(); ++j) {
+        for (ui32 j = 0; j < s.size(); ++j) {
             s[j] = RandomNumber<ui8>();
         }
         r.push_back(s);

--- a/cloud/storage/core/libs/vhost-client/vhost-client.cpp
+++ b/cloud/storage/core/libs/vhost-client/vhost-client.cpp
@@ -87,7 +87,7 @@ bool TClient::Connect()
     if (int errorCode = connect(
         sock,
         reinterpret_cast<sockaddr*>(&un),
-        sizeof(un.sun_family) + SockPath.Size()) == -1)
+        sizeof(un.sun_family) + SockPath.size()) == -1)
     {
         Logger.AddLog(
             ELogPriority::TLOG_ERR,


### PR DESCRIPTION
Arcadia removes some of string related functions. now we should use equivalent std like functions. I have to bring this to github because otherwise syncing to aracadia would be painful, sorry