### PR TITLE
issue-1928: filestore-client: using ISession instead of IClient for the Session-aware methods to properly process E_FS_INVALID_SESSION errors; existing tests are more or less sufficient to ensure that this code is correct

### DIFF
--- a/cloud/filestore/apps/client/lib/mkdir.cpp
+++ b/cloud/filestore/apps/client/lib/mkdir.cpp
@@ -34,6 +34,7 @@ public:
     bool Execute() override
     {
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
         auto makeDir = [&] (ui64 nodeId, TStringBuf name) {
             auto request = CreateRequest<NProto::TCreateNodeRequest>();
@@ -41,7 +42,7 @@ public:
             request->SetName(ToString(name));
             request->MutableDirectory()->SetMode(MODE0777);
 
-            auto response = WaitFor(Client->CreateNode(
+            auto response = WaitFor(session.CreateNode(
                 PrepareCallContext(),
                 std::move(request)));
 
@@ -50,7 +51,7 @@ public:
             return response.GetNode();
         };
 
-        auto resolved = ResolvePath(Path, true);
+        auto resolved = ResolvePath(session, Path, true);
 
         if (resolved.size() == 1) {
             return true;

--- a/cloud/filestore/apps/client/lib/read.cpp
+++ b/cloud/filestore/apps/client/lib/read.cpp
@@ -39,8 +39,9 @@ public:
     bool Execute() override
     {
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
-        const auto resolved = ResolvePath(Path, false);
+        const auto resolved = ResolvePath(session, Path, false);
 
         Y_ENSURE(
             resolved.back().Node.GetType() != NProto::E_DIRECTORY_NODE,
@@ -58,7 +59,7 @@ public:
         createRequest->SetName(ToString(resolved.back().Name));
         createRequest->SetFlags(flags);
 
-        auto createResponse = WaitFor(Client->CreateHandle(
+        auto createResponse = WaitFor(session.CreateHandle(
             PrepareCallContext(),
             std::move(createRequest)));
 
@@ -76,7 +77,7 @@ public:
         readRequest->SetOffset(Offset);
         readRequest->SetLength(Length);
 
-        auto readResponse = WaitFor(Client->ReadData(
+        auto readResponse = WaitFor(session.ReadData(
             PrepareCallContext(),
             std::move(readRequest)
         ));

--- a/cloud/filestore/apps/client/lib/reset_session.cpp
+++ b/cloud/filestore/apps/client/lib/reset_session.cpp
@@ -42,11 +42,11 @@ public:
 
     bool Execute() override
     {
-        Headers.SetSessionId(SessionId);
-        Headers.SetClientId(ClientId);
-        Headers.SetSessionSeqNo(SeqNo);
-
         auto request = CreateRequest<NProto::TResetSessionRequest>();
+        auto& headers = *request->MutableHeaders();
+        headers.SetSessionId(SessionId);
+        headers.SetClientId(ClientId);
+        headers.SetSessionSeqNo(SeqNo);
         if (SessionState) {
             request->SetSessionState(Base64Decode(SessionState));
         }

--- a/cloud/filestore/apps/client/lib/rm.cpp
+++ b/cloud/filestore/apps/client/lib/rm.cpp
@@ -33,8 +33,9 @@ public:
     bool Execute() override
     {
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
-        const auto resolved = ResolvePath(Path, false);
+        const auto resolved = ResolvePath(session, Path, false);
 
         Y_ENSURE(resolved.size() >= 2, "can't rm root node");
 
@@ -44,7 +45,7 @@ public:
         request->SetName(ToString(resolved.back().Name));
         request->SetUnlinkDirectory(RemoveDir);
 
-        auto response = WaitFor(Client->UnlinkNode(
+        auto response = WaitFor(session.UnlinkNode(
             PrepareCallContext(),
             std::move(request)));
 

--- a/cloud/filestore/apps/client/lib/set_node_attr.cpp
+++ b/cloud/filestore/apps/client/lib/set_node_attr.cpp
@@ -65,6 +65,7 @@ public:
     bool Execute() override
     {
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
         auto request = CreateRequest<NProto::TSetNodeAttrRequest>();
         request->SetNodeId(NodeId);
@@ -112,7 +113,7 @@ public:
         }
 
         auto response = WaitFor(
-            Client->SetNodeAttr(PrepareCallContext(), std::move(request)));
+            session.SetNodeAttr(PrepareCallContext(), std::move(request)));
 
         CheckResponse(response);
         return true;

--- a/cloud/filestore/apps/client/lib/stat.cpp
+++ b/cloud/filestore/apps/client/lib/stat.cpp
@@ -40,15 +40,16 @@ public:
     bool Execute() override
     {
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
-        const auto resolved = ResolvePath(Path, false);
+        const auto resolved = ResolvePath(session, Path, false);
         Y_ABORT_UNLESS(resolved.size() >= 2);
 
         auto request = CreateRequest<NProto::TGetNodeAttrRequest>();
         request->SetNodeId(resolved[resolved.size() - 2].Node.GetId());
         request->SetName(ToString(resolved.back().Name));
         auto response = WaitFor(
-            Client->GetNodeAttr(PrepareCallContext(), std::move(request)));
+            session.GetNodeAttr(PrepareCallContext(), std::move(request)));
 
         CheckResponse(response);
         Print(response.GetNode(), JsonOutput);

--- a/cloud/filestore/apps/client/lib/touch.cpp
+++ b/cloud/filestore/apps/client/lib/touch.cpp
@@ -29,8 +29,9 @@ public:
     bool Execute() override
     {
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
-        auto resolved = ResolvePath(Path, true);
+        auto resolved = ResolvePath(session, Path, true);
 
         if (resolved.size() == 1) {
             return true;
@@ -47,9 +48,9 @@ public:
             update->SetMTime(now);
             request->SetNodeId(node.GetId());
 
-            auto response = WaitFor(Client->SetNodeAttr(
-                    PrepareCallContext(),
-                    std::move(request)));
+            auto response = WaitFor(session.SetNodeAttr(
+                PrepareCallContext(),
+                std::move(request)));
 
             CheckResponse(response);
             return true;
@@ -66,7 +67,7 @@ public:
             request->SetName(ToString(resolved.back().Name));
             request->MutableFile()->SetMode(0644);
 
-            auto response = WaitFor(Client->CreateNode(
+            auto response = WaitFor(session.CreateNode(
                 PrepareCallContext(),
                 std::move(request)));
 

--- a/cloud/filestore/apps/client/lib/write.cpp
+++ b/cloud/filestore/apps/client/lib/write.cpp
@@ -41,8 +41,9 @@ public:
         TString data = TIFStream(DataPath).ReadAll();
 
         auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
 
-        const auto resolved = ResolvePath(Path, true);
+        const auto resolved = ResolvePath(session, Path, true);
 
         Y_ENSURE(
             resolved.back().Node.GetType() != NProto::E_DIRECTORY_NODE,
@@ -67,7 +68,7 @@ public:
         createRequest->SetName(ToString(resolved.back().Name));
         createRequest->SetFlags(flags);
 
-        auto createResponse = WaitFor(Client->CreateHandle(
+        auto createResponse = WaitFor(session.CreateHandle(
             PrepareCallContext(),
             std::move(createRequest)));
 
@@ -80,7 +81,7 @@ public:
         writeRequest->SetOffset(Offset);
         *writeRequest->MutableBuffer() = data;
 
-        auto writeResponse = WaitFor(Client->WriteData(
+        auto writeResponse = WaitFor(session.WriteData(
             PrepareCallContext(),
             std::move(writeRequest)
         ));


### PR DESCRIPTION
#1928 