### PR TITLE
EIO is now non retriable error

### DIFF
--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -72,8 +72,10 @@ EErrorKind GetErrorKind(const NProto::TError& e)
         return EErrorKind::ErrorRetriable;
     }
 
+    // FACILITY_SYSTEM error codes are obtained from "errno". The list of all
+    // possible errors: contrib/libs/linux-headers/asm-generic/errno-base.h
     if (FACILITY_FROM_CODE(code) == FACILITY_SYSTEM) {
-        switch (code) {
+        switch (STATUS_FROM_CODE(code)) {
             case EIO:
                 return EErrorKind::ErrorFatal;
             default:

--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -73,8 +73,13 @@ EErrorKind GetErrorKind(const NProto::TError& e)
     }
 
     if (FACILITY_FROM_CODE(code) == FACILITY_SYSTEM) {
-        // system/network errors should be retriable
-        return EErrorKind::ErrorRetriable;
+        switch (code) {
+            case EIO:
+                return EErrorKind::ErrorFatal;
+            default:
+                // system/network errors should be retriable
+                return EErrorKind::ErrorRetriable;
+        }
     }
 
     if (FACILITY_FROM_CODE(code) == FACILITY_KIKIMR) {


### PR DESCRIPTION
#2274

Повод для изменений: у нас сломался SSD у одной из реплик mirror3 диска. DR не менял состояние девайса на сломанное, т.к. `EIO` ошибка считается ретрабельной. В итоге диск завис в нерабочем состоянии до ручного рестарта диск агента со сломанным SSD.