### PR TITLE
deleting explicit ActivityType setting - 1. it's broken 2. the default value is better anyway

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.cpp
@@ -26,9 +26,7 @@ public:
     explicit TIORequestParserActor(const TActorId& owner)
         : TActor(&TIORequestParserActor::StateWork)
         , Owner(owner)
-    {
-        ActivityType = TBlockStoreComponents::DISK_AGENT_WORKER;
-    }
+    {}
 
 private:
     STFUNC(StateWork)

--- a/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.cpp
@@ -71,9 +71,7 @@ public:
         TDuration releaseInactiveSessionsTimeout)
         : CachePath{std::move(cachePath)}
         , ReleaseInactiveSessionsTimeout{releaseInactiveSessionsTimeout}
-    {
-        ActivityType = TBlockStoreComponents::DISK_AGENT_WORKER;
-    }
+    {}
 
     void Bootstrap(const TActorContext& ctx)
     {


### PR DESCRIPTION
Otherwise we get activity=='-' for these actors in monitoring whereas the default value for activity is the name of the actor (which is good)