### PR TITLE
[Filestore] dump `ss -tpn` upon completion for debugging `service-kikimr-localdb-compaction-test` failure

### DIFF
--- a/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test.py
+++ b/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test.py
@@ -132,3 +132,5 @@ def test_load(test_case, ops):
     # On the test completion, revert the changes back
     if new_compaction_policy_enabled:
         set_new_compaction_policy(False)
+
+    logging.info(os.system("ss -tpn"))


### PR DESCRIPTION
Test failed here: https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(asan)/11285116769/1/nebius-x86-64-asan/summary/ya-test.html#FAIL

```
2024-10-11T03:31:59.748139Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:317: CgroupStatsFetcher initialized
Failed to set up IC listener on port 22170 errno# 98 (Address already in use)
```

This commit will hep debug failure to start filestore in case of