### PR TITLE
[Filestore, merge-to-stable] issue-2216: reject destroy filestore requests for filestore in a denylist, issue-1146: populate in-memory cache upon RO transactions, issue-1285: fix missing StartedTs initialization for requestInfo in Compaction

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -427,6 +427,10 @@ message TStorageConfig
     // Enables persistent backup for tablet path descriptions.
     optional string PathDescriptionBackupFilePath = 395;
 
+    // Server will reject all requests to destroy filestores in the provided
+    // list
+    repeated string DestroyFilestoreDenyList = 396;
+
     // In fallback mode, all requests to SchemeShard are served from backup.
     optional bool SSProxyFallbackMode = 397;
 }

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -272,6 +272,8 @@ public:
 
     TString GetPathDescriptionBackupFilePath() const;
 
+    TVector<TString> GetDestroyFilestoreDenyList() const;
+
     bool GetSSProxyFallbackMode() const;
 };
 

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -195,6 +195,25 @@ void TStorageServiceActor::HandleDestroyFileStore(
         cookie,
         msg->CallContext);
 
+    if (Count(
+            StorageConfig->GetDestroyFilestoreDenyList(),
+            msg->Record.GetFileSystemId()))
+    {
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "FileStore %s is in deny list",
+            msg->Record.GetFileSystemId().c_str());
+        auto response =
+            std::make_unique<TEvService::TEvDestroyFileStoreResponse>(MakeError(
+                E_ARGUMENT,
+                Sprintf(
+                    "FileStore %s is in deny list",
+                    msg->Record.GetFileSystemId().c_str())));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
     bool forceDestroy = msg->Record.GetForceDestroy() &&
                         StorageConfig->GetAllowFileStoreForceDestroy();
     auto actor = std::make_unique<TDestroyFileStoreActor>(

--- a/cloud/filestore/libs/storage/tablet/model/node_index_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/node_index_cache.cpp
@@ -46,7 +46,10 @@ void TNodeIndexCache::RegisterGetNodeAttrResult(
     const TString& name,
     const NProto::TNodeAttr& response)
 {
-    if (AttrByParentNodeId.size() >= MaxNodes) {
+    if (MaxNodes == 0) {
+        return;
+    }
+    if (AttrByParentNodeId.size() == MaxNodes) {
         KeyByNodeId.clear();
         AttrByParentNodeId.clear();
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -623,7 +623,7 @@ private:
     FILESTORE_TABLET_INDEX_RO_TRANSACTIONS(
         FILESTORE_IMPLEMENT_RO_TRANSACTION,
         TTxIndexTablet,
-        TIndexTabletDatabase,
+        TIndexTabletDatabaseProxy,
         IIndexTabletDatabase);
 
     STFUNC(StateBoot);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -479,6 +479,7 @@ void TIndexTabletActor::HandleCompaction(
         ev->Sender,
         ev->Cookie,
         msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
 
     ExecuteTx<TCompaction>(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1900,6 +1900,22 @@ TIndexTabletDatabaseProxy::TIndexTabletDatabaseProxy(
     , NodeUpdates(nodeUpdates)
 {}
 
+bool TIndexTabletDatabaseProxy::ReadNode(
+    ui64 nodeId,
+    ui64 commitId,
+    TMaybe<IIndexTabletDatabase::TNode>& node)
+{
+    auto result = TIndexTabletDatabase::ReadNode(nodeId, commitId, node);
+    if (result && node) {
+        // If ReadNode was successful, it is reasonable to update the cache with
+        // the value that has just been read.
+        NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
+            .NodeId = nodeId,
+            .Row = {.CommitId = node->MinCommitId, .Node = node->Attrs}});
+    }
+    return result;
+}
+
 void TIndexTabletDatabaseProxy::WriteNode(
     ui64 nodeId,
     ui64 commitId,
@@ -1932,6 +1948,27 @@ void TIndexTabletDatabaseProxy::DeleteNodeVer(ui64 nodeId, ui64 commitId)
 {
     TIndexTabletDatabase::DeleteNodeVer(nodeId, commitId);
     // TODO(#1146): _Ver tables not yet supported
+}
+
+bool TIndexTabletDatabaseProxy::ReadNodeAttr(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeAttr>& attr)
+{
+    auto result =
+        TIndexTabletDatabase::ReadNodeAttr(nodeId, commitId, name, attr);
+    if (result && attr) {
+        // If ReadNodeAttr  was successful, it is reasonable to update the cache
+        // with the value that has just been read.
+        NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
+            .NodeAttrsKey = {nodeId, name},
+            .NodeAttrsRow = {
+                .CommitId = attr->MinCommitId,
+                .Value = attr->Value,
+                .Version = attr->Version}});
+    }
+    return result;
 }
 
 void TIndexTabletDatabaseProxy::WriteNodeAttr(
@@ -1980,6 +2017,54 @@ void TIndexTabletDatabaseProxy::DeleteNodeAttrVer(
 {
     TIndexTabletDatabase::DeleteNodeAttrVer(nodeId, commitId, name);
     // TODO(#1146): _Ver tables not yet supported
+}
+
+bool TIndexTabletDatabaseProxy::ReadNodeRef(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<IIndexTabletDatabase::TNodeRef>& ref)
+{
+    auto result =
+        TIndexTabletDatabase::ReadNodeRef(nodeId, commitId, name, ref);
+    if (result && ref) {
+        // If ReadNodeRef was successful, it is reasonable to update the cache
+        // with the value that has just been read.
+        NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
+            .NodeRefsKey = {nodeId, name},
+            .NodeRefsRow = {
+                .CommitId = ref->MinCommitId,
+                .ChildId = ref->ChildNodeId,
+                .FollowerId = ref->FollowerId,
+                .FollowerName = ref->FollowerName}});
+    }
+    return result;
+}
+
+bool TIndexTabletDatabaseProxy::ReadNodeRefs(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& cookie,
+    TVector<IIndexTabletDatabase::TNodeRef>& refs,
+    ui32 maxBytes,
+    TString* next)
+{
+    auto result = TIndexTabletDatabase::ReadNodeRefs(
+        nodeId, commitId, cookie, refs, maxBytes, next);
+    if (result) {
+        // If ReadNodeRefs was successful, it is reasonable to update the cache
+        // with the values that have just been read.
+        for (const auto& ref: refs) {
+            NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
+                .NodeRefsKey = {nodeId, ref.Name},
+                .NodeRefsRow = {
+                    .CommitId = ref.MinCommitId,
+                    .ChildId = ref.ChildNodeId,
+                    .FollowerId = ref.FollowerId,
+                    .FollowerName = ref.FollowerName}});
+        }
+    }
+    return result;
 }
 
 void TIndexTabletDatabaseProxy::WriteNodeRef(

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -2035,8 +2035,8 @@ bool TIndexTabletDatabaseProxy::ReadNodeRef(
             .NodeRefsRow = {
                 .CommitId = ref->MinCommitId,
                 .ChildId = ref->ChildNodeId,
-                .FollowerId = ref->FollowerId,
-                .FollowerName = ref->FollowerName}});
+                .ShardId = ref->ShardId,
+                .ShardName = ref->ShardName}});
     }
     return result;
 }
@@ -2060,8 +2060,8 @@ bool TIndexTabletDatabaseProxy::ReadNodeRefs(
                 .NodeRefsRow = {
                     .CommitId = ref.MinCommitId,
                     .ChildId = ref.ChildNodeId,
-                    .FollowerId = ref.FollowerId,
-                    .FollowerName = ref.FollowerName}});
+                    .ShardId = ref.ShardId,
+                    .ShardName = ref.ShardName}});
         }
     }
     return result;

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -533,6 +533,11 @@ public:
     // Nodes
     //
 
+    bool ReadNode(
+        ui64 nodeId,
+        ui64 commitId,
+        TMaybe<IIndexTabletDatabase::TNode>& node) final;
+
     void WriteNode(
         ui64 nodeId,
         ui64 commitId,
@@ -555,6 +560,12 @@ public:
     //
     // NodeAttrs
     //
+
+    bool ReadNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) override;
 
     void WriteNodeAttr(
         ui64 nodeId,
@@ -585,6 +596,20 @@ public:
     //
     // NodeRefs
     //
+
+    bool ReadNodeRef(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<IIndexTabletDatabase::TNodeRef>& ref) override;
+
+    bool ReadNodeRefs(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& cookie,
+        TVector<IIndexTabletDatabase::TNodeRef>& refs,
+        ui32 maxBytes,
+        TString* next = nullptr) override;
 
     void WriteNodeRef(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -173,6 +173,11 @@ struct TSessionAware
 struct TIndexStateNodeUpdates
 {
     TVector<TInMemoryIndexState::TIndexStateRequest> NodeUpdates;
+
+    void Clear()
+    {
+        NodeUpdates.clear();
+    }
 };
 
 struct TProfileAware
@@ -523,6 +528,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             Nodes.clear();
         }
     };
@@ -551,6 +557,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
         }
     };
@@ -593,6 +600,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
 
             NodeIds.clear();
@@ -609,7 +617,9 @@ struct TTxIndexTablet
     // ResolvePath
     //
 
-    struct TResolvePath : TSessionAware
+    struct TResolvePath
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TResolvePathRequest Request;
@@ -628,6 +638,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
         }
     };
@@ -684,6 +695,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNodeId = InvalidNodeId;
@@ -729,6 +741,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -785,6 +798,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             ChildNode.Clear();
@@ -807,7 +821,9 @@ struct TTxIndexTablet
     // AccessNode
     //
 
-    struct TAccessNode : TSessionAware
+    struct TAccessNode
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TAccessNodeRequest Request;
@@ -827,6 +843,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
         }
@@ -836,7 +853,9 @@ struct TTxIndexTablet
     // ReadLink
     //
 
-    struct TReadLink : TSessionAware
+    struct TReadLink
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TReadLinkRequest Request;
@@ -855,6 +874,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
         }
@@ -864,7 +884,9 @@ struct TTxIndexTablet
     // ListNodes
     //
 
-    struct TListNodes : TSessionAware
+    struct TListNodes
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TListNodesRequest Request;
@@ -895,6 +917,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             ChildRefs.clear();
@@ -932,6 +955,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
         }
@@ -941,7 +965,9 @@ struct TTxIndexTablet
     // GetNodeAttr
     //
 
-    struct TGetNodeAttr : TSessionAware
+    struct TGetNodeAttr
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TGetNodeAttrRequest Request;
@@ -967,6 +993,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
             TargetNodeId = InvalidNodeId;
@@ -980,7 +1007,9 @@ struct TTxIndexTablet
     // GetNodeAttrBatch
     //
 
-    struct TGetNodeAttrBatch : TSessionAware
+    struct TGetNodeAttrBatch
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TGetNodeAttrBatchRequest Request;
@@ -1002,6 +1031,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             ParentNode.Clear();
         }
@@ -1039,6 +1069,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             Version = 0;
             CommitId = InvalidCommitId;
             Node.Clear();
@@ -1050,7 +1081,9 @@ struct TTxIndexTablet
     // GetNodeXAttr
     //
 
-    struct TGetNodeXAttr : TSessionAware
+    struct TGetNodeXAttr
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TGetNodeXAttrRequest Request;
@@ -1073,6 +1106,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             Attr.Clear();
@@ -1083,7 +1117,9 @@ struct TTxIndexTablet
     // ListNodeXAttr
     //
 
-    struct TListNodeXAttr : TSessionAware
+    struct TListNodeXAttr
+        : TSessionAware
+        , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProto::TListNodeXAttrRequest Request;
@@ -1104,6 +1140,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             Attrs.clear();
@@ -1139,6 +1176,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             Node.Clear();
             Attr.Clear();
@@ -1194,6 +1232,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             ReadCommitId = InvalidCommitId;
             WriteCommitId = InvalidCommitId;
             TargetNodeId = InvalidNodeId;
@@ -1232,6 +1271,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             Node.Clear();
         }
     };
@@ -1404,6 +1444,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1483,6 +1524,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             WriteRanges.clear();
             Nodes.clear();
@@ -1520,6 +1562,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
             NodeId = InvalidNodeId;
             Node.Clear();
@@ -1569,6 +1612,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             TProfileAware::Clear();
 
             CommitId = InvalidCommitId;
@@ -1800,6 +1844,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             TProfileAware::Clear();
             Error.Clear();
         }
@@ -2007,6 +2052,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             Node.Clear();
             Error.Clear();
         }
@@ -2028,11 +2074,12 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             Node.Clear();
         }
     };
 
-    struct TUnsafeGetNode
+    struct TUnsafeGetNode: public TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeGetNodeRequest Request;
@@ -2048,6 +2095,7 @@ struct TTxIndexTablet
 
         void Clear()
         {
+            TIndexStateNodeUpdates::Clear();
             Node.Clear();
         }
     };


### PR DESCRIPTION
6e35cdf
4555008a0eb5998036454c9633a8affeddd3a56b
1f6a6ac 
cf8c921 
