### PR TITLE
[Disk Manager] do not print stacktrace in error in traces, do not print retriable errors above non-retriable errors in logs and traces

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -462,7 +462,7 @@ func (c *client) updateVolume(
 				"Retry in blockstore client",
 				tracing.WithAttributes(
 					tracing.AttributeInt("failed_attempts", retries),
-					tracing.AttributeString("error", err.Error()),
+					tracing.AttributeError(err),
 				),
 			)
 			continue
@@ -515,7 +515,7 @@ func (c *client) updatePlacementGroup(
 				"Retry in blockstore client",
 				tracing.WithAttributes(
 					tracing.AttributeInt("failed_attempts", retries),
-					tracing.AttributeString("error", err.Error()),
+					tracing.AttributeError(err),
 				),
 			)
 			continue

--- a/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
@@ -209,7 +209,7 @@ func (f *factory) initClients(
 					tracing.SpanFromContext(ctx).AddEvent(
 						"Retriable error in blockstore SDK",
 						tracing.WithAttributes(
-							tracing.AttributeString("error", err.Error()),
+							tracing.AttributeError(&err),
 						),
 					)
 					f.metrics.OnError(err)

--- a/cloud/tasks/errors/errors.go
+++ b/cloud/tasks/errors/errors.go
@@ -11,7 +11,7 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type tasksError interface {
+type errorForTracing interface {
 	error
 	ErrorForTracing() string
 }
@@ -134,10 +134,7 @@ func (e *NonRetriableError) ErrorForTracing() string {
 }
 
 func (e *NonRetriableError) message() string {
-	return fmt.Sprintf(
-		"Non retriable error, Silent=%v",
-		e.Silent,
-	)
+	return fmt.Sprintf("Non retriable error, Silent=%v", e.Silent)
 }
 
 func (e *NonRetriableError) Unwrap() error {
@@ -254,15 +251,11 @@ func NewWrongGenerationError() *WrongGenerationError {
 }
 
 func (e WrongGenerationError) Error() string {
-	return e.message()
+	return "Wrong generation"
 }
 
 func (e WrongGenerationError) ErrorForTracing() string {
-	return e.message()
-}
-
-func (WrongGenerationError) message() string {
-	return "Wrong generation"
+	return e.Error()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -274,15 +267,11 @@ func NewInterruptExecutionError() *InterruptExecutionError {
 }
 
 func (e InterruptExecutionError) Error() string {
-	return e.message()
+	return "Interrupt execution"
 }
 
 func (e InterruptExecutionError) ErrorForTracing() string {
-	return e.message()
-}
-
-func (InterruptExecutionError) message() string {
-	return "Interrupt execution"
+	return e.Error()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -350,19 +339,15 @@ func newNotFoundError(taskID, idempotencyKey string) *NotFoundError {
 }
 
 func (e NotFoundError) Error() string {
-	return e.message()
-}
-
-func (e NotFoundError) ErrorForTracing() string {
-	return e.message()
-}
-
-func (e NotFoundError) message() string {
 	return fmt.Sprintf(
 		"No task with ID=%v, IdempotencyKey=%v",
 		e.TaskID,
 		e.IdempotencyKey,
 	)
+}
+
+func (e NotFoundError) ErrorForTracing() string {
+	return e.Error()
 }
 
 // HACK: Need to avoid default comparator that uses inner fields.
@@ -500,8 +485,8 @@ func IsSilent(err error) bool {
 ////////////////////////////////////////////////////////////////////////////////
 
 func ErrorForTracing(err error) string {
-	if tasksErr, ok := err.(tasksError); ok {
-		return tasksErr.ErrorForTracing()
+	if errForTracing, ok := err.(errorForTracing); ok {
+		return errForTracing.ErrorForTracing()
 	}
 	return err.Error()
 }

--- a/cloud/tasks/errors/errors.go
+++ b/cloud/tasks/errors/errors.go
@@ -493,8 +493,8 @@ func appendStackTrace(errorMessage string, stackTrace []byte) string {
 }
 
 func getFirstNonRetriableError(err error) *NonRetriableError {
-	var nonRetriableErr *NonRetriableError
-	if As(err, nonRetriableErr) {
+	nonRetriableErr := NewEmptyNonRetriableError()
+	if errors.As(err, &nonRetriableErr) {
 		return nonRetriableErr
 	}
 	return nil

--- a/cloud/tasks/errors/errors.go
+++ b/cloud/tasks/errors/errors.go
@@ -485,8 +485,8 @@ func IsSilent(err error) bool {
 ////////////////////////////////////////////////////////////////////////////////
 
 func ErrorForTracing(err error) string {
-	if errForTracing, ok := err.(errorForTracing); ok {
-		return errForTracing.ErrorForTracing()
+	if e, ok := err.(errorForTracing); ok {
+		return e.ErrorForTracing()
 	}
 	return err.Error()
 }

--- a/cloud/tasks/errors/errors_test.go
+++ b/cloud/tasks/errors/errors_test.go
@@ -223,7 +223,7 @@ func TestErrorMessageWhenBothRetriableAndNonRetriableErrors(t *testing.T) {
 }
 
 func TestErrorMessageWithAndWithoutStacktrace(t *testing.T) {
-	checkError := func(err tasksError, hasStacktrace bool) {
+	checkError := func(err errorForTracing, hasStacktrace bool) {
 		require.Equal(t, ErrorForTracing(err), err.ErrorForTracing())
 
 		if hasStacktrace {

--- a/cloud/tasks/errors/errors_test.go
+++ b/cloud/tasks/errors/errors_test.go
@@ -223,17 +223,15 @@ func TestErrorMessageWhenBothRetriableAndNonRetriableErrors(t *testing.T) {
 }
 
 func TestErrorMessageWithAndWithoutStacktrace(t *testing.T) {
-	checkError := func(err diskManagerError, hasStacktrace bool) {
-		require.Equal(t, ErrorMessage(err, true), err.CustomError(true))
-		require.Equal(t, ErrorMessage(err, false), err.CustomError(false))
-		require.Equal(t, err.Error(), err.CustomError(true))
+	checkError := func(err tasksError, hasStacktrace bool) {
+		require.Equal(t, ErrorForTracing(err), err.ErrorForTracing())
 
 		if hasStacktrace {
-			require.Contains(t, err.CustomError(true), err.CustomError(false))
-			require.Contains(t, err.CustomError(true), "runtime/debug.Stack()")
-			require.NotContains(t, err.CustomError(false), "runtime/debug.Stack()")
+			require.Contains(t, err.Error(), err.ErrorForTracing())
+			require.Contains(t, err.Error(), "runtime/debug.Stack()")
+			require.NotContains(t, err.ErrorForTracing(), "runtime/debug.Stack()")
 		} else {
-			require.Equal(t, err.CustomError(true), err.CustomError(false))
+			require.Equal(t, err.Error(), err.ErrorForTracing())
 		}
 	}
 
@@ -262,6 +260,5 @@ func TestErrorMessageWithAndWithoutStacktrace(t *testing.T) {
 	)
 
 	externalErr := fmt.Errorf("externalErr")
-	require.Equal(t, ErrorMessage(externalErr, true), externalErr.Error())
-	require.Equal(t, ErrorMessage(externalErr, false), externalErr.Error())
+	require.Equal(t, ErrorForTracing(externalErr), externalErr.Error())
 }

--- a/cloud/tasks/tracing/attributes.go
+++ b/cloud/tasks/tracing/attributes.go
@@ -36,6 +36,6 @@ func AttributeString(key string, value string) attribute.KeyValue {
 func AttributeError(err error) attribute.KeyValue {
 	return attribute.String(
 		"error",
-		errors.ErrorMessage(err, false /*printStacktraces*/),
+		errors.ErrorForTracing(err),
 	)
 }

--- a/cloud/tasks/tracing/attributes.go
+++ b/cloud/tasks/tracing/attributes.go
@@ -34,5 +34,8 @@ func AttributeString(key string, value string) attribute.KeyValue {
 }
 
 func AttributeError(err error) attribute.KeyValue {
-	return attribute.String("error", errors.ErrorMessage(err, false))
+	return attribute.String(
+		"error",
+		errors.ErrorMessage(err, false /*printStacktraces*/),
+	)
 }

--- a/cloud/tasks/tracing/attributes.go
+++ b/cloud/tasks/tracing/attributes.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -30,4 +31,8 @@ func AttributeInt64(key string, value int64) attribute.KeyValue {
 
 func AttributeString(key string, value string) attribute.KeyValue {
 	return attribute.String(key, value)
+}
+
+func AttributeError(err error) attribute.KeyValue {
+	return attribute.String("error", errors.ErrorMessage(err, false))
 }

--- a/cloud/tasks/tracing/init.go
+++ b/cloud/tasks/tracing/init.go
@@ -53,7 +53,7 @@ func SpanFromContext(ctx context.Context) trace.Span {
 
 func SetError(span trace.Span, err *error) {
 	if *err != nil {
-		span.SetStatus(codes.Error, (*err).Error())
+		span.SetStatus(codes.Error, errors.GetShortError(*err))
 	}
 }
 

--- a/cloud/tasks/tracing/init.go
+++ b/cloud/tasks/tracing/init.go
@@ -53,7 +53,10 @@ func SpanFromContext(ctx context.Context) trace.Span {
 
 func SetError(span trace.Span, err *error) {
 	if *err != nil {
-		span.SetStatus(codes.Error, errors.GetShortError(*err))
+		span.SetStatus(
+			codes.Error,
+			errors.ErrorMessage(*err, false /*printStacktraces*/),
+		)
 	}
 }
 

--- a/cloud/tasks/tracing/init.go
+++ b/cloud/tasks/tracing/init.go
@@ -55,7 +55,7 @@ func SetError(span trace.Span, err *error) {
 	if *err != nil {
 		span.SetStatus(
 			codes.Error,
-			errors.ErrorMessage(*err, false /*printStacktraces*/),
+			errors.ErrorForTracing(*err),
 		)
 	}
 }


### PR DESCRIPTION
- Some errors in disk manager have stacktrace, but it might be too unwieldy write it in span/events in traces. In this pr we don't wrte stacktrace in traces, but still write it in logs.

- Sometimes errors chains have both retriable and non-retriable errors. In this pr we stop printing retriable errors created over non-retriabe errors.

example 1:
[Errors from ydb](https://github.com/ydb-platform/nbs/blob/main/cloud/tasks/persistence/ydb.go#L612). Here retriable error might wrap non-retriable error. In this case error message looks like this:
```
Retriable error <...> Non retriable error <...>
```
This is confusing, because the word 'retriable' goes first, but the error is actually non-retryable.
We get rid of such messages.

example 2:
[Too many retriable errors for task](https://github.com/ydb-platform/nbs/blob/main/cloud/tasks/runner.go#L256). Here non-retriable error wraps retriable error. This looks ok.

