### PR TITLE
fix slow requests sampling rate

### DIFF
--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -376,12 +376,12 @@ void TBootstrapCommon::InitLWTrace(
         traceReaders.push_back(CreateTraceLogger(TraceLoggerId, traceLog, "NFS_TRACE"));
     }
 
-    if (auto samplingRate = Configs->DiagnosticsConfig->GetSlowRequestSamplingRate() &&
-        !probesToTrace.empty())
-    {
+    auto slowRequestSamplingRate =
+        Configs->DiagnosticsConfig->GetSlowRequestSamplingRate();
+    if (slowRequestSamplingRate && !probesToTrace.empty()) {
         NLWTrace::TQuery query = ProbabilisticQuery(
             probesToTrace,
-            samplingRate,
+            slowRequestSamplingRate,
             Configs->DiagnosticsConfig->GetLWTraceShuttleCount());
 
         lwManager.New(SlowRequestsFilterId, query);


### PR DESCRIPTION
samplingRate was bool, and we were always getting a probability of tracing requests as 1