### PR TITLE
issue-2137: support for GarbageBlocksCount in CompactionMap

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.h
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.h
@@ -21,6 +21,7 @@ struct TCompactionStats
 {
     ui32 BlobsCount = 0;
     ui32 DeletionsCount = 0;
+    ui32 GarbageBlocksCount = 0;
 };
 
 struct TCompactionRangeInfo
@@ -35,9 +36,11 @@ struct TCompactionMapStats
     ui64 AllocatedRangesCount = 0;
     ui64 TotalBlobsCount = 0;
     ui64 TotalDeletionsCount = 0;
+    ui64 TotalGarbageBlocksCount = 0;
 
-    TVector<TCompactionRangeInfo> TopRangesByCleanupScore;
     TVector<TCompactionRangeInfo> TopRangesByCompactionScore;
+    TVector<TCompactionRangeInfo> TopRangesByCleanupScore;
+    TVector<TCompactionRangeInfo> TopRangesByGarbageScore;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -55,16 +58,25 @@ public:
     TCompactionMap(IAllocator* alloc);
     ~TCompactionMap();
 
-    void Update(ui32 rangeId, ui32 blobsCount, ui32 deletionsCount);
+    void Update(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount);
     void Update(const TVector<TCompactionRangeInfo>& ranges);
 
     TCompactionStats Get(ui32 rangeId) const;
 
     TCompactionCounter GetTopCompactionScore() const;
     TCompactionCounter GetTopCleanupScore() const;
+    TCompactionCounter GetTopGarbageScore() const;
 
-    TVector<TCompactionRangeInfo> GetTopRangesByCompactionScore(ui32 topSize) const;
-    TVector<TCompactionRangeInfo> GetTopRangesByCleanupScore(ui32 topSize) const;
+    TVector<TCompactionRangeInfo> GetTopRangesByCompactionScore(
+        ui32 topSize) const;
+    TVector<TCompactionRangeInfo> GetTopRangesByCleanupScore(
+        ui32 topSize) const;
+    TVector<TCompactionRangeInfo> GetTopRangesByGarbageScore(
+        ui32 topSize) const;
 
     TVector<ui32> GetNonEmptyCompactionRanges() const;
     TVector<ui32> GetAllCompactionRanges() const;

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
@@ -12,64 +12,69 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100);
-        compactionMap.Update(1, 11, 101);
-        compactionMap.Update(10000, 20, 200);
-        compactionMap.Update(20000, 5, 50);
+        compactionMap.Update(0, 10, 100, 1000);
+        compactionMap.Update(1, 11, 101, 2000);
+        compactionMap.Update(10000, 20, 200, 100);
+        compactionMap.Update(20000, 5, 50, 300);
 
         auto stats = compactionMap.Get(0);
         UNIT_ASSERT_VALUES_EQUAL(10, stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(100, stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(1000, stats.GarbageBlocksCount);
 
         stats = compactionMap.Get(1);
         UNIT_ASSERT_VALUES_EQUAL(11, stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(101, stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, stats.GarbageBlocksCount);
 
         stats = compactionMap.Get(10000);
         UNIT_ASSERT_VALUES_EQUAL(20, stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(200, stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(100, stats.GarbageBlocksCount);
 
         stats = compactionMap.Get(20000);
         UNIT_ASSERT_VALUES_EQUAL(5, stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(50, stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(300, stats.GarbageBlocksCount);
 
         stats = compactionMap.Get(30000);
         UNIT_ASSERT_VALUES_EQUAL(0, stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(0, stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GarbageBlocksCount);
     }
 
     Y_UNIT_TEST(ShouldSelectTopRangesByCompactionScore)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100);
-        compactionMap.Update(1, 11, 101);
-        compactionMap.Update(10000, 20, 200);
-        compactionMap.Update(20000, 5, 50);
+        compactionMap.Update(0, 10, 100, 1000);
+        compactionMap.Update(1, 11, 101, 2000);
+        compactionMap.Update(10000, 20, 200, 100);
+        compactionMap.Update(20000, 5, 50, 300);
 
         auto counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 20);
 
-        compactionMap.Update(10000, 1, 200);
+        compactionMap.Update(10000, 1, 200, 100);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 11);
 
-        compactionMap.Update(1, 1, 101);
+        compactionMap.Update(1, 1, 101, 2000);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 0);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 10);
 
-        compactionMap.Update(0, 1, 100);
+        compactionMap.Update(0, 1, 100, 1000);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 20000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 5);
 
-        compactionMap.Update(20000, 1, 50);
+        compactionMap.Update(20000, 1, 50, 300);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 1);
@@ -79,36 +84,79 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100);
-        compactionMap.Update(1, 11, 101);
-        compactionMap.Update(10000, 20, 200);
-        compactionMap.Update(20000, 5, 50);
+        compactionMap.Update(0, 10, 100, 1000);
+        compactionMap.Update(1, 11, 101, 2000);
+        compactionMap.Update(10000, 20, 200, 100);
+        compactionMap.Update(20000, 5, 50, 300);
 
         auto counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 200);
 
-        compactionMap.Update(10000, 20, 0);
+        compactionMap.Update(10000, 20, 0, 100);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 101);
 
-        compactionMap.Update(1, 11, 0);
+        compactionMap.Update(1, 11, 0, 2000);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 0);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 100);
 
-        compactionMap.Update(0, 10, 0);
+        compactionMap.Update(0, 10, 0, 1000);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 20000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 50);
 
-        compactionMap.Update(20000, 5, 0);
+        compactionMap.Update(20000, 5, 0, 300);
 
         counter = compactionMap.GetTopCleanupScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 0);
+    }
+
+    Y_UNIT_TEST(ShouldSelectTopRangesByGarbageScore)
+    {
+        TCompactionMap compactionMap(TDefaultAllocator::Instance());
+
+        compactionMap.Update(0, 10, 100, 1000);
+        compactionMap.Update(1, 11, 101, 2000);
+        compactionMap.Update(10000, 20, 200, 100);
+        compactionMap.Update(20000, 5, 50, 300);
+
+        auto counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 2000);
+
+        compactionMap.Update(1, 11, 101, 500);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 0);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 1000);
+
+        compactionMap.Update(0, 10, 100, 0);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 500);
+
+        compactionMap.Update(1, 11, 101, 0);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 20000);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 300);
+
+        compactionMap.Update(20000, 5, 50, 0);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 100);
+
+        compactionMap.Update(10000, 20, 200, 0);
+
+        counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 0);
     }
 
@@ -116,47 +164,68 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 444);
-        compactionMap.Update(1, 11, 222);
-        compactionMap.Update(10000, 20, 111);
-        compactionMap.Update(20000, 5, 333);
+        compactionMap.Update(0, 10, 444, 1000);
+        compactionMap.Update(1, 11, 222, 2000);
+        compactionMap.Update(10000, 20, 111, 200);
+        compactionMap.Update(20000, 5, 333, 300);
 
         auto topRanges = compactionMap.GetTopRangesByCompactionScore(3);
         UNIT_ASSERT_VALUES_EQUAL(3, topRanges.size());
         UNIT_ASSERT_VALUES_EQUAL(10000, topRanges[0].RangeId);
         UNIT_ASSERT_VALUES_EQUAL(20, topRanges[0].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(111, topRanges[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(200, topRanges[0].Stats.GarbageBlocksCount);
         UNIT_ASSERT_VALUES_EQUAL(1, topRanges[1].RangeId);
         UNIT_ASSERT_VALUES_EQUAL(11, topRanges[1].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(222, topRanges[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, topRanges[1].Stats.GarbageBlocksCount);
         UNIT_ASSERT_VALUES_EQUAL(0, topRanges[2].RangeId);
         UNIT_ASSERT_VALUES_EQUAL(10, topRanges[2].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(444, topRanges[2].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(1000, topRanges[2].Stats.GarbageBlocksCount);
 
         topRanges = compactionMap.GetTopRangesByCleanupScore(3);
         UNIT_ASSERT_VALUES_EQUAL(3, topRanges.size());
         UNIT_ASSERT_VALUES_EQUAL(0, topRanges[0].RangeId);
         UNIT_ASSERT_VALUES_EQUAL(10, topRanges[0].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(444, topRanges[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(1000, topRanges[0].Stats.GarbageBlocksCount);
         UNIT_ASSERT_VALUES_EQUAL(20000, topRanges[1].RangeId);
         UNIT_ASSERT_VALUES_EQUAL(5, topRanges[1].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(333, topRanges[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(300, topRanges[1].Stats.GarbageBlocksCount);
         UNIT_ASSERT_VALUES_EQUAL(1, topRanges[2].RangeId);
         UNIT_ASSERT_VALUES_EQUAL(11, topRanges[2].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(222, topRanges[2].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, topRanges[2].Stats.GarbageBlocksCount);
+
+        topRanges = compactionMap.GetTopRangesByGarbageScore(3);
+        UNIT_ASSERT_VALUES_EQUAL(3, topRanges.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, topRanges[0].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(11, topRanges[0].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(222, topRanges[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, topRanges[0].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, topRanges[1].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(10, topRanges[1].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(444, topRanges[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(1000, topRanges[1].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(20000, topRanges[2].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(5, topRanges[2].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(333, topRanges[2].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(300, topRanges[2].Stats.GarbageBlocksCount);
     }
 
     Y_UNIT_TEST(ShouldReturnNonEmptyRanges)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 15, 100);
-        compactionMap.Update(1, 14, 101);
-        compactionMap.Update(3, 13, 101);
-        compactionMap.Update(256, 40, 101);
-        compactionMap.Update(10000, 45, 200);
-        compactionMap.Update(20000, 50, 50);
-        compactionMap.Update(Max<ui32>(), 100, 50);
+        compactionMap.Update(0, 15, 100, 1000);
+        compactionMap.Update(1, 14, 101, 2000);
+        compactionMap.Update(3, 13, 101, 300);
+        compactionMap.Update(256, 40, 101, 200);
+        compactionMap.Update(10000, 45, 200, 3000);
+        compactionMap.Update(20000, 50, 50, 500);
+        compactionMap.Update(Max<ui32>(), 100, 50, 400);
 
         auto ranges = compactionMap.GetNonEmptyCompactionRanges();
 
@@ -175,84 +244,139 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         const auto group = TCompactionMap::GroupSize;
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(100, 0, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 0);
+        compactionMap.Update(100, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 100, 100);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
+        compactionMap.Update(100, 100, 100, 100);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 0, 100);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
+        compactionMap.Update(100, 0, 100, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 100, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
+        compactionMap.Update(100, 100, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(101, 0, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
+        compactionMap.Update(101, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 10, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 2 * group);
+        compactionMap.Update(1000, 10, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 0, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
+        compactionMap.Update(100, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 0, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 0);
+        compactionMap.Update(1000, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 0, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 0);
+        compactionMap.Update(1000, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            compactionMap.GetStats(1).AllocatedRangesCount);
+
+        compactionMap.Update(1000, 0, 0, 100);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
     }
 
-    Y_UNIT_TEST(ShouldKeepTrackNonEmptyRanges)
+    Y_UNIT_TEST(ShouldKeepTrackOfNonEmptyRanges)
     {
         const auto group = TCompactionMap::GroupSize;
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            compactionMap.GetStats(1).AllocatedRangesCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, compactionMap.GetStats(1).UsedRangesCount);
 
         for (ui32 i = 1; i <= TCompactionMap::GroupSize; ++i) {
-            compactionMap.Update(i - 1, 0, 0);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i - 1);
+            compactionMap.Update(i - 1, 0, 0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i - 1,
+                compactionMap.GetStats(1).UsedRangesCount);
 
-            compactionMap.Update(i - 1, 100, 0);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i);
+            compactionMap.Update(i - 1, 100, 0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1 * group,
+                compactionMap.GetStats(1).AllocatedRangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i,
+                compactionMap.GetStats(1).UsedRangesCount);
 
-            compactionMap.Update(i - 1, 0, 100);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i);
+            compactionMap.Update(i - 1, 0, 100, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1 * group,
+                compactionMap.GetStats(1).AllocatedRangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i,
+                compactionMap.GetStats(1).UsedRangesCount);
 
-            compactionMap.Update(i - 1, 100, 100);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 1 * group);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i);
+            compactionMap.Update(i - 1, 100, 100, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1 * group,
+                compactionMap.GetStats(1).AllocatedRangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i,
+                compactionMap.GetStats(1).UsedRangesCount);
         }
 
-        compactionMap.Update(1000000, 100, 100);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 2 * group);
+        compactionMap.Update(1000000, 100, 100, 100);
         UNIT_ASSERT_VALUES_EQUAL(
-            compactionMap.GetStats(1).UsedRangesCount,
-            TCompactionMap::GroupSize + 1);
+            2 * group,
+            compactionMap.GetStats(1).AllocatedRangesCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TCompactionMap::GroupSize + 1,
+            compactionMap.GetStats(1).UsedRangesCount);
 
         for (ui32 i = TCompactionMap::GroupSize; i > 0; --i) {
-            compactionMap.Update(i - 1, 100, 0);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i + 1);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 2 * group);
+            compactionMap.Update(i - 1, 100, 0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i + 1,
+                compactionMap.GetStats(1).UsedRangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                2 * group,
+                compactionMap.GetStats(1).AllocatedRangesCount);
 
-            compactionMap.Update(i - 1, 0, 100);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i + 1);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 2 * group);
+            compactionMap.Update(i - 1, 0, 100, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i + 1,
+                compactionMap.GetStats(1).UsedRangesCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                2 * group,
+                compactionMap.GetStats(1).AllocatedRangesCount);
 
-            compactionMap.Update(i - 1, 0, 0);
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, i);
+            compactionMap.Update(i - 1, 0, 0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                i,
+                compactionMap.GetStats(1).UsedRangesCount);
 
             ui32 groups = i - 1 > 0 ? 2 : 1;
-            UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, groups * group);
+            UNIT_ASSERT_VALUES_EQUAL(
+                groups * group,
+                compactionMap.GetStats(1).AllocatedRangesCount);
         }
 
-        compactionMap.Update(1000000, 0, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).AllocatedRangesCount, 0);
-        UNIT_ASSERT_VALUES_EQUAL(compactionMap.GetStats(1).UsedRangesCount, 0);
+        compactionMap.Update(1000000, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            compactionMap.GetStats(1).AllocatedRangesCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, compactionMap.GetStats(1).UsedRangesCount);
     }
 
     Y_UNIT_TEST(ShouldReturnTopRanges)
@@ -265,65 +389,136 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore.size(), 0);
         }
 
-        compactionMap.Update(1, 10, 20);
+        compactionMap.Update(1, 10, 20, 30);
 
         {
             auto stats = compactionMap.GetStats(2);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[0].RangeId, 1);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[0].Stats.BlobsCount, 10);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[0].Stats.DeletionsCount, 20);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.TopRangesByCleanupScore.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.TopRangesByCleanupScore[0].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                10,
+                stats.TopRangesByCleanupScore[0].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                20,
+                stats.TopRangesByCleanupScore[0].Stats.DeletionsCount);
 
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[0].RangeId, 1);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[0].Stats.BlobsCount, 10);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[0].Stats.DeletionsCount, 20);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.TopRangesByCompactionScore.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.TopRangesByCompactionScore[0].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                10,
+                stats.TopRangesByCompactionScore[0].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                20,
+                stats.TopRangesByCompactionScore[0].Stats.DeletionsCount);
         }
 
-        compactionMap.Update(0, 1000, 444);
-        compactionMap.Update(300, 40, 522);
-        compactionMap.Update(400, 50, 22);
-        compactionMap.Update(10000, 20, 211);
-        compactionMap.Update(20000, 100500, 4);
-        compactionMap.Update(70000, 500, 100);
-        compactionMap.Update(200000, 100, 400);
+        compactionMap.Update(0, 1000, 444, 1000);
+        compactionMap.Update(300, 40, 522, 300);
+        compactionMap.Update(400, 50, 22, 2000);
+        compactionMap.Update(10000, 20, 211, 5000);
+        compactionMap.Update(20000, 100500, 4, 7000);
+        compactionMap.Update(70000, 500, 100, 0);
+        compactionMap.Update(200000, 100, 400, 30);
 
         {
             auto stats = compactionMap.GetStats(2);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.TopRangesByCleanupScore.size());
 
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[0].RangeId, 300);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[0].Stats.BlobsCount, 40);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[0].Stats.DeletionsCount, 522);
+            UNIT_ASSERT_VALUES_EQUAL(
+                300,
+                stats.TopRangesByCleanupScore[0].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                40,
+                stats.TopRangesByCleanupScore[0].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                522,
+                stats.TopRangesByCleanupScore[0].Stats.DeletionsCount);
 
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[1].RangeId, 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[1].Stats.BlobsCount, 1000);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCleanupScore[1].Stats.DeletionsCount, 444);
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.TopRangesByCleanupScore[1].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1000,
+                stats.TopRangesByCleanupScore[1].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                444,
+                stats.TopRangesByCleanupScore[1].Stats.DeletionsCount);
 
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                stats.TopRangesByCompactionScore.size());
 
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[0].RangeId, 20000);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[0].Stats.BlobsCount, 100500);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[0].Stats.DeletionsCount, 4);
+            UNIT_ASSERT_VALUES_EQUAL(
+                20000,
+                stats.TopRangesByCompactionScore[0].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                100500,
+                stats.TopRangesByCompactionScore[0].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                4,
+                stats.TopRangesByCompactionScore[0].Stats.DeletionsCount);
 
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[1].RangeId, 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[1].Stats.BlobsCount, 1000);
-            UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore[1].Stats.DeletionsCount, 444);
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.TopRangesByCompactionScore[1].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                1000,
+                stats.TopRangesByCompactionScore[1].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                444,
+                stats.TopRangesByCompactionScore[1].Stats.DeletionsCount);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.TopRangesByGarbageScore.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                20000,
+                stats.TopRangesByGarbageScore[0].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                100500,
+                stats.TopRangesByGarbageScore[0].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                4,
+                stats.TopRangesByGarbageScore[0].Stats.DeletionsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                7000,
+                stats.TopRangesByGarbageScore[0].Stats.GarbageBlocksCount);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                10000,
+                stats.TopRangesByGarbageScore[1].RangeId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                20,
+                stats.TopRangesByGarbageScore[1].Stats.BlobsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                211,
+                stats.TopRangesByGarbageScore[1].Stats.DeletionsCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                5000,
+                stats.TopRangesByGarbageScore[1].Stats.GarbageBlocksCount);
         }
     }
 
-    Y_UNIT_TEST(ShouldTrackTotalBlobsCountAndDeletionsCount)
+    Y_UNIT_TEST(ShouldTrackTotals)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(1, 10, 20);
-        compactionMap.Update(2, 5, 40);
-        compactionMap.Update(2, 15, 50);
-        compactionMap.Update(100, 7, 100);
+        compactionMap.Update(1, 10, 20, 100);
+        compactionMap.Update(2, 5, 40, 200);
+        compactionMap.Update(2, 15, 50, 90);
+        compactionMap.Update(100, 7, 100, 3000);
 
         auto stats = compactionMap.GetStats(1);
         UNIT_ASSERT_VALUES_EQUAL(32, stats.TotalBlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(170, stats.TotalDeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(3190, stats.TotalGarbageBlocksCount);
     }
 
     Y_UNIT_TEST(ShouldUpdateCompactionMapByGroups)
@@ -335,10 +530,15 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         ui32 rangeId = 0;
         ui32 totalBlobsCount = 0;
         ui32 totalDeletionsCount = 0;
+        ui32 totalGarbageBlocksCount = 0;
         while (rangeId < 3 * groupSize) {
-            rangeInfos.emplace_back(rangeId, TCompactionStats{rangeId * 2, rangeId + 1});
-            totalBlobsCount += rangeId * 2;
-            totalDeletionsCount += rangeId + 1;
+            rangeInfos.emplace_back(
+                rangeId,
+                TCompactionStats{rangeId * 2, rangeId + 1, rangeId * 10});
+            const auto& last = rangeInfos.back();
+            totalBlobsCount += last.Stats.BlobsCount;
+            totalDeletionsCount += last.Stats.DeletionsCount;
+            totalGarbageBlocksCount += last.Stats.GarbageBlocksCount;
             rangeId += 2;
         }
         compactionMap.Update(rangeInfos);
@@ -348,16 +548,25 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             if (i % 2) {
                 UNIT_ASSERT_VALUES_EQUAL(0, stats.BlobsCount);
                 UNIT_ASSERT_VALUES_EQUAL(0, stats.DeletionsCount);
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GarbageBlocksCount);
             } else {
                 UNIT_ASSERT_VALUES_EQUAL(i * 2, stats.BlobsCount);
                 UNIT_ASSERT_VALUES_EQUAL(i + 1, stats.DeletionsCount);
+                UNIT_ASSERT_VALUES_EQUAL(i * 10, stats.GarbageBlocksCount);
             }
         }
 
-        compactionMap.Update(1, 10000, 20000);
+        compactionMap.Update(1, 10000, 20000, 30000);
         auto stats = compactionMap.GetStats(2);
-        UNIT_ASSERT_VALUES_EQUAL(totalBlobsCount + 10000, stats.TotalBlobsCount);
-        UNIT_ASSERT_VALUES_EQUAL(totalDeletionsCount + 20000, stats.TotalDeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            totalBlobsCount + 10000,
+            stats.TotalBlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            totalDeletionsCount + 20000,
+            stats.TotalDeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            totalGarbageBlocksCount + 30000,
+            stats.TotalGarbageBlocksCount);
 
         UNIT_ASSERT_VALUES_EQUAL(
             1,
@@ -368,6 +577,9 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         UNIT_ASSERT_VALUES_EQUAL(
             20000,
             stats.TopRangesByCompactionScore[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            30000,
+            stats.TopRangesByCompactionScore[0].Stats.GarbageBlocksCount);
 
         UNIT_ASSERT_VALUES_EQUAL(
             3 * groupSize - 2,
@@ -378,6 +590,9 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         UNIT_ASSERT_VALUES_EQUAL(
             3 * groupSize - 1,
             stats.TopRangesByCompactionScore[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            (3 * groupSize - 2) * 10,
+            stats.TopRangesByCompactionScore[1].Stats.GarbageBlocksCount);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -348,13 +348,13 @@ private:
             db.WriteCompactionMap(
                 x.first,
                 x.second.BlobsCount,
-                x.second.DeletionsCount
-            );
+                x.second.DeletionsCount,
+                x.second.GarbageBlocksCount);
             Tablet.UpdateCompactionMap(
                 x.first,
                 x.second.BlobsCount,
-                x.second.DeletionsCount
-            );
+                x.second.DeletionsCount,
+                x.second.GarbageBlocksCount);
 
             AddCompactionRange(
                 args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -548,8 +548,8 @@ void TIndexTabletActor::ExecuteTx_Compaction(
 
     if (!args.CompactionBlobs) {
         TIndexTabletDatabase db(tx.DB);
-        UpdateCompactionMap(args.RangeId, 0, 0);
-        db.WriteCompactionMap(args.RangeId, 0, 0);
+        UpdateCompactionMap(args.RangeId, 0, 0, 0);
+        db.WriteCompactionMap(args.RangeId, 0, 0, 0);
     }
 
     for (const ui64 nodeId: args.Nodes) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_delete_zero_compaction_ranges.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_delete_zero_compaction_ranges.cpp
@@ -60,7 +60,8 @@ void TIndexTabletActor::ExecuteTx_DeleteZeroCompactionRanges(
         db.WriteCompactionMap(
             range,
             GetCompactionStats(range).BlobsCount,
-            GetCompactionStats(range).DeletionsCount);
+            GetCompactionStats(range).DeletionsCount,
+            GetCompactionStats(range).GarbageBlocksCount);
     }
 
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_write_compactionmap.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_write_compactionmap.cpp
@@ -58,7 +58,8 @@ void TIndexTabletActor::ExecuteTx_WriteCompactionMap(
         db.ForceWriteCompactionMap(
             range.GetRangeId(),
             range.GetBlobCount(),
-            range.GetDeletionCount());
+            range.GetDeletionCount(),
+            range.GetGarbageBlockCount());
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1743,25 +1743,32 @@ bool TIndexTabletDatabase::ReadCheckpointBlobs(
 void TIndexTabletDatabase::ForceWriteCompactionMap(
     ui32 rangeId,
     ui32 blobsCount,
-    ui32 deletionsCount)
+    ui32 deletionsCount,
+    ui32 garbageBlocksCount)
 {
     using TTable = TIndexTabletSchema::CompactionMap;
 
     Table<TTable>()
         .Key(rangeId)
         .Update(NIceDb::TUpdate<TTable::BlobsCount>(blobsCount))
-        .Update(NIceDb::TUpdate<TTable::DeletionsCount>(deletionsCount));
+        .Update(NIceDb::TUpdate<TTable::DeletionsCount>(deletionsCount))
+        .Update(NIceDb::TUpdate<TTable::GarbageBlocksCount>(garbageBlocksCount));
 }
 
 void TIndexTabletDatabase::WriteCompactionMap(
     ui32 rangeId,
     ui32 blobsCount,
-    ui32 deletionsCount)
+    ui32 deletionsCount,
+    ui32 garbageBlocksCount)
 {
     using TTable = TIndexTabletSchema::CompactionMap;
 
-    if (blobsCount || deletionsCount) {
-        ForceWriteCompactionMap(rangeId, blobsCount, deletionsCount);
+    if (blobsCount || deletionsCount || garbageBlocksCount) {
+        ForceWriteCompactionMap(
+            rangeId,
+            blobsCount,
+            deletionsCount,
+            garbageBlocksCount);
     } else {
         Table<TTable>().Key(rangeId).Delete();
     }
@@ -1799,6 +1806,7 @@ bool TIndexTabletDatabase::ReadCompactionMap(
             {
                 it.GetValue<TTable::BlobsCount>(),
                 it.GetValue<TTable::DeletionsCount>(),
+                it.GetValue<TTable::GarbageBlocksCount>(),
             }
         });
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -508,8 +508,16 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // CompactionMap
     //
 
-    void ForceWriteCompactionMap(ui32 rangeId, ui32 blobsCount, ui32 deletionsCount);
-    void WriteCompactionMap(ui32 rangeId, ui32 blobsCount, ui32 deletionsCount);
+    void ForceWriteCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount);
+    void WriteCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount);
     bool ReadCompactionMap(TVector<TCompactionRangeInfo>& compactionMap);
     bool ReadCompactionMap(
         TVector<TCompactionRangeInfo>& compactionMap,

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -364,19 +364,19 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
 
         using TEntries = TVector<TCompactionRangeInfo>;
         TEntries entries = {
-            {1, {50, 100}},
-            {4, {42, 10}},
-            {32, {50, 200}},
-            {65, {1, 400}},
-            {110, {2, 333}},
-            {113, {7, 444}},
-            {4233, {150, 555}},
-            {5632, {1000, 3}},
-            {6000, {30, 11}},
-            {6001, {12, 15}},
-            {6002, {2, 20}},
-            {6005, {99, 7}},
-            {7000, {1000, 5000}},
+            {1, {50, 100, 200}},
+            {4, {42, 10, 300}},
+            {32, {50, 200, 100}},
+            {65, {1, 400, 50}},
+            {110, {2, 333, 10}},
+            {113, {7, 444, 0}},
+            {4233, {150, 555, 0}},
+            {5632, {1000, 3, 500}},
+            {6000, {30, 11, 600}},
+            {6001, {12, 15, 30}},
+            {6002, {2, 20, 10}},
+            {6005, {99, 7, 55}},
+            {7000, {1000, 5000, 7000}},
         };
 
         executor.WriteTx([&] (TIndexTabletDatabase db) {
@@ -384,7 +384,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
                 db.WriteCompactionMap(
                     entry.RangeId,
                     entry.Stats.BlobsCount,
-                    entry.Stats.DeletionsCount);
+                    entry.Stats.DeletionsCount,
+                    entry.Stats.GarbageBlocksCount);
             }
         });
 
@@ -399,7 +400,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
             while (i < v.size() && processed < c) {
                 if (skipZeroes
                         && !v[i].Stats.BlobsCount
-                        && !v[i].Stats.DeletionsCount)
+                        && !v[i].Stats.DeletionsCount
+                        && !v[i].Stats.GarbageBlocksCount)
                 {
                     ++i;
                     continue;
@@ -410,7 +412,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
                 }
                 sb << v[i].RangeId
                     << "," << v[i].Stats.BlobsCount
-                    << "," << v[i].Stats.DeletionsCount;
+                    << "," << v[i].Stats.DeletionsCount
+                    << "," << v[i].Stats.GarbageBlocksCount;
                 ++processed;
                 ++i;
             }
@@ -439,7 +442,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
 
         executor.WriteTx([&] (TIndexTabletDatabase db) {
             for (const auto i: toDelete) {
-                db.WriteCompactionMap(entries[i].RangeId, 0, 0);
+                db.WriteCompactionMap(entries[i].RangeId, 0, 0, 0);
                 entries[i].Stats = {};
             }
         });

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -420,16 +420,20 @@ struct TIndexTabletSchema
 
     struct CompactionMap: TTableSchema<20>
     {
-        struct RangeId          : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
-        struct BlobsCount       : Column<2, NKikimr::NScheme::NTypeIds::Uint32> {};
-        struct DeletionsCount   : Column<3, NKikimr::NScheme::NTypeIds::Uint32> {};
+        // TODO: migrate to a new table with Uint16 fields - 16 bits are enough
+        // for BlobsCount, DeletionsCount and GarbageBlocksCount
+        struct RangeId              : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct BlobsCount           : Column<2, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct DeletionsCount       : Column<3, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct GarbageBlocksCount   : Column<4, NKikimr::NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<RangeId>;
 
         using TColumns = TableColumns<
             RangeId,
             BlobsCount,
-            DeletionsCount
+            DeletionsCount,
+            GarbageBlocksCount
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1117,7 +1117,11 @@ private:
     //
 
 public:
-    void UpdateCompactionMap(ui32 rangeId, ui32 blobsCount, ui32 deletionsCount);
+    void UpdateCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount);
 
     TCompactionStats GetCompactionStats(ui32 rangeId) const;
     TCompactionCounter GetRangeToCompact() const;
@@ -1129,8 +1133,12 @@ public:
 
     TVector<ui32> GetNonEmptyCompactionRanges() const;
     TVector<ui32> GetAllCompactionRanges() const;
-    TVector<TCompactionRangeInfo> GetTopRangesByCompactionScore(ui32 topSize) const;
-    TVector<TCompactionRangeInfo> GetTopRangesByCleanupScore(ui32 topSize) const;
+    TVector<TCompactionRangeInfo> GetTopRangesByCompactionScore(
+        ui32 topSize) const;
+    TVector<TCompactionRangeInfo> GetTopRangesByCleanupScore(
+        ui32 topSize) const;
+    TVector<TCompactionRangeInfo> GetTopRangesByGarbageScore(
+        ui32 topSize) const;
 
     void LoadCompactionMap(const TVector<TCompactionRangeInfo>& compactionMap);
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -94,6 +94,7 @@ message TCompactionRangeStats
     uint32 RangeId = 1;
     uint32 BlobCount = 2;
     uint32 DeletionCount = 3;
+    uint32 GarbageBlockCount = 4;
 }
 
 message TStorageStats


### PR DESCRIPTION
Will properly calculate GarbageBlocksCount (upon writes and compactions) in the next (2nd) PR.
Will use GarbageBlocksCount to order CompactionRanges for Garbage-based Compaction in the 3rd PR.

#2137 