### PR TITLE
Enable duplicating logs to stderr

### DIFF
--- a/contrib/ydb/core/log_backend/log_backend_build.cpp
+++ b/contrib/ydb/core/log_backend/log_backend_build.cpp
@@ -12,6 +12,13 @@ TAutoPtr<TLogBackend> TLogBackendBuildHelper::CreateLogBackendFromLogConfig(cons
     } else if (logConfig.HasBackendFileName()) {
         logBackend = NActors::CreateFileBackend(logConfig.GetBackendFileName());
     }
+
+    if (logBackend && logConfig.GetSysLogToStdErr()) {
+        logBackend = NActors::CreateCompositeLogBackend(
+            {logBackend, NActors::CreateStderrBackend()}
+        );
+    }
+
     return logBackend;
 }
 

--- a/contrib/ydb/core/protos/config.proto
+++ b/contrib/ydb/core/protos/config.proto
@@ -330,7 +330,7 @@ message TLogConfig {
     optional bool UseLocalTimestamps = 9 [default = false];
     optional string BackendFileName = 10;
     optional string SysLogService = 11;
-    optional bool SysLogToStdErr = 12; // writes logs to stderr as well as in syslog
+    optional bool SysLogToStdErr = 12; // writes logs to stderr as well as in syslog/file
     optional TUAClientConfig UAClientConfig = 13;
     optional uint64 TimeThresholdMs = 14 [default = 1000];
     optional bool IgnoreUnknownComponents = 15 [default = true];
@@ -1261,7 +1261,7 @@ message TImmediateControlsConfig {
                 optional uint64 MaxBurst = 2 [(ControlOptions) = {
                     Description: "Maximum burst of traced events",
                     MinValue: 0,
-                    MaxValue: 300, 
+                    MaxValue: 300,
                     DefaultValue: 0,
                 }];
             }


### PR DESCRIPTION
### Changelog
Now with the `SysLogToStdErr` option from `TLogConfig` enabled, logs are duplicated in stderr. 

### Additional information
This option `SysLogToStdErr` existed but was not used in any way before. This functionality is necessary to write logs both to a local file and to stderr (in order to support cloud logging in kubernetes)
