### PR TITLE
issue-2137: calculating GarbageBlocksCount stats in CompactionMap

### DIFF
--- a/cloud/filestore/libs/diagnostics/events/profile_events.ev
+++ b/cloud/filestore/libs/diagnostics/events/profile_events.ev
@@ -69,6 +69,7 @@ message TProfileLogCompactionRangeInfo {
     optional uint64 RangeId = 2;
     optional uint64 BlobsCount = 3;
     optional uint64 DeletionsCount = 4;
+    optional uint64 GarbageBlocksCount = 5;
 };
 
 message TProfileLogRequestInfo {

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -71,6 +71,8 @@ public:
     TVector<TMixedBlobMeta> GetBlobsForCompaction(ui32 rangeId) const;
 
     TMixedBlobMeta FindBlob(ui32 rangeId, TPartialBlobId blobId) const;
+
+    ui32 CalculateGarbageBlockCount(ui32 rangeId) const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/profile_log_events.cpp
+++ b/cloud/filestore/libs/storage/tablet/profile_log_events.cpp
@@ -177,6 +177,7 @@ void AddCompactionRange(
     ui32 rangeId,
     ui32 blobsCount,
     ui32 deletionsCount,
+    ui32 garbageBlocksCount,
     NProto::TProfileLogRequestInfo& profileLogRequest)
 {
     auto* range = profileLogRequest.AddCompactionRanges();
@@ -184,6 +185,7 @@ void AddCompactionRange(
     range->SetRangeId(rangeId);
     range->SetBlobsCount(blobsCount);
     range->SetDeletionsCount(deletionsCount);
+    range->SetGarbageBlocksCount(garbageBlocksCount);
 }
 
 template <typename T>

--- a/cloud/filestore/libs/storage/tablet/profile_log_events.h
+++ b/cloud/filestore/libs/storage/tablet/profile_log_events.h
@@ -87,6 +87,7 @@ void AddCompactionRange(
     ui32 rangeId,
     ui32 blobsCount,
     ui32 deletionsCount,
+    ui32 garbageBlocksCount,
     NProto::TProfileLogRequestInfo& profileLogRequest);
 
 template <typename T>

--- a/cloud/filestore/libs/storage/tablet/profile_log_events_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/profile_log_events_ut.cpp
@@ -409,7 +409,7 @@ Y_UNIT_TEST_SUITE(TProfileLogEvent)
     Y_UNIT_TEST(ShouldAddCompactionRange)
     {
         NProto::TProfileLogRequestInfo profileLogRequest;
-        AddCompactionRange(100500, 500100, 100, 500, profileLogRequest);
+        AddCompactionRange(100500, 500100, 100, 500, 1000, profileLogRequest);
 
         UNIT_ASSERT(!profileLogRequest.HasTimestampMcs());
         UNIT_ASSERT(!profileLogRequest.HasDurationMcs());
@@ -429,6 +429,9 @@ Y_UNIT_TEST_SUITE(TProfileLogEvent)
         UNIT_ASSERT_VALUES_EQUAL(
             500,
             profileLogRequest.GetCompactionRanges().at(0).GetDeletionsCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1000,
+            profileLogRequest.GetCompactionRanges().at(0).GetGarbageBlocksCount());
 
         UNIT_ASSERT(!profileLogRequest.HasNodeInfo());
         UNIT_ASSERT(!profileLogRequest.HasLockInfo());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -315,8 +315,6 @@ private:
         TABLET_VERIFY(!args.MergedBlobs);
         TABLET_VERIFY(!args.UnalignedDataParts);
 
-        THashSet<ui32> rangeIds;
-
         for (const auto& blob: args.SrcBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
             auto& stats = AccessCompactionStats(rangeId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -147,6 +147,9 @@ private:
                 block.BlockIndex,
                 blob.BlocksCount);
             AccessCompactionStats(rangeId).BlobsCount += 1;
+            // conservative estimate
+            AccessCompactionStats(rangeId).GarbageBlocksCount +=
+                blob.BlocksCount;
         }
 
         for (const auto& part: args.UnalignedDataParts) {
@@ -221,6 +224,9 @@ private:
             if (written) {
                 ui32 rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
                 AccessCompactionStats(rangeId).BlobsCount += 1;
+                // conservative estimate
+                AccessCompactionStats(rangeId).GarbageBlocksCount +=
+                    blob.Blocks.size();
             }
         }
 
@@ -257,6 +263,8 @@ private:
             auto& stats = AccessCompactionStats(rangeId);
             if (Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks)) {
                 stats.BlobsCount += 1;
+                // conservative estimate
+                stats.GarbageBlocksCount += blob.Blocks.size();
             }
         }
     }
@@ -273,6 +281,7 @@ private:
             auto& stats = AccessCompactionStats(rangeId);
             if (!Tablet.UpdateBlockLists(db, blob)) {
                 stats.BlobsCount = Max(stats.BlobsCount, 1U) - 1;
+                // no proper way to reliably decrement stats.GarbageBlocksCount
             }
         }
 
@@ -293,6 +302,8 @@ private:
             auto& stats = AccessCompactionStats(rangeId);
             if (Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks)) {
                 stats.BlobsCount += 1;
+                // conservative estimate
+                stats.GarbageBlocksCount += blob.Blocks.size();
             }
         }
     }
@@ -303,6 +314,8 @@ private:
     {
         TABLET_VERIFY(!args.MergedBlobs);
         TABLET_VERIFY(!args.UnalignedDataParts);
+
+        THashSet<ui32> rangeIds;
 
         for (const auto& blob: args.SrcBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
@@ -337,8 +350,15 @@ private:
             }
             stats.BlobsCount += increment;
         }
-    }
 
+        // recalculating GarbageBlocksCount for each of the affected ranges
+        for (const auto& blob: args.SrcBlobs) {
+            const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
+
+            AccessCompactionStats(rangeId).GarbageBlocksCount =
+                Tablet.CalculateMixedIndexRangeGarbageBlockCount(rangeId);
+        }
+    }
 
     void UpdateCompactionMap(
         TIndexTabletDatabase& db,
@@ -361,6 +381,7 @@ private:
                 x.first,
                 x.second.BlobsCount,
                 x.second.DeletionsCount,
+                x.second.GarbageBlocksCount,
                 args.ProfileLogRequest);
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -908,6 +908,8 @@ public:
     ui32 GetMixedRangeIndex(const TVector<TBlock>& blocks) const;
     const IBlockLocation2RangeIndex& GetRangeIdHasher() const;
 
+    ui32 CalculateMixedIndexRangeGarbageBlockCount(ui32 rangeId) const;
+
 private:
     bool WriteMixedBlocks(
         TIndexTabletDatabase& db,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -954,8 +954,9 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
     stats.BlobsCount = (stats.BlobsCount > removedBlobs)
         ? (stats.BlobsCount - removedBlobs) : 0;
     stats.DeletionsCount = 0;
-    // TODO: calculate GarbageBlocksCount
-    stats.GarbageBlocksCount = 0;
+    if (stats.BlobsCount == 0) {
+        stats.GarbageBlocksCount = 0;
+    }
 
     db.WriteCompactionMap(
         rangeId,
@@ -973,6 +974,7 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
         rangeId,
         stats.BlobsCount,
         stats.DeletionsCount,
+        stats.GarbageBlocksCount,
         profileLogRequest);
 
     return deletionMarkerCount;
@@ -1076,6 +1078,12 @@ const IBlockLocation2RangeIndex& TIndexTabletState::GetRangeIdHasher() const
     TABLET_VERIFY(Impl->RangeIdHasher);
 
     return *Impl->RangeIdHasher;
+}
+
+ui32 TIndexTabletState::CalculateMixedIndexRangeGarbageBlockCount(
+    ui32 rangeId) const
+{
+    return Impl->MixedBlocks.CalculateGarbageBlockCount(rangeId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -3566,28 +3566,28 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 stats.GetAllocatedCompactionRanges());
             UNIT_ASSERT_VALUES_EQUAL(8, stats.CompactionRangeStatsSize());
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=1656356864 b=16 d=1024",
+                "r=1656356864 b=16 d=1024 g=1024",
                 CompactionRangeToString(stats.GetCompactionRangeStats(0)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=1656356865 b=16 d=1024",
+                "r=1656356865 b=16 d=1024 g=1024",
                 CompactionRangeToString(stats.GetCompactionRangeStats(1)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=4283236352 b=16 d=1024",
+                "r=4283236352 b=16 d=1024 g=1024",
                 CompactionRangeToString(stats.GetCompactionRangeStats(2)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=4283236353 b=16 d=1024",
+                "r=4283236353 b=16 d=1024 g=1024",
                 CompactionRangeToString(stats.GetCompactionRangeStats(3)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=1177944064 b=14 d=833",
+                "r=1177944064 b=14 d=833 g=832",
                 CompactionRangeToString(stats.GetCompactionRangeStats(4)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=1177944065 b=13 d=832",
+                "r=1177944065 b=13 d=832 g=832",
                 CompactionRangeToString(stats.GetCompactionRangeStats(5)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=737148928 b=3 d=192",
+                "r=737148928 b=3 d=192 g=192",
                 CompactionRangeToString(stats.GetCompactionRangeStats(6)));
             UNIT_ASSERT_VALUES_EQUAL(
-                "r=737148929 b=3 d=192",
+                "r=737148929 b=3 d=192 g=192",
                 CompactionRangeToString(stats.GetCompactionRangeStats(7)));
         };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -465,7 +465,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
             UNIT_ASSERT_VALUES_EQUAL(1, stats.CompactionRangeStatsSize());
             UNIT_ASSERT_VALUES_EQUAL(
                 Sprintf(
-                    "r=1177944064 b=%u d=%u",
+                    "r=1177944064 b=%u d=%u g=0",
                     (compactionThreshold - 1),
                     deletionMarkers),
                 CompactionRangeToString(stats.GetCompactionRangeStats(0)));

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -49,10 +49,11 @@ inline auto CompactionRangeToString(
     const NProtoPrivate::TCompactionRangeStats& rs)
 {
     return Sprintf(
-        "r=%u b=%u d=%u",
+        "r=%u b=%u d=%u g=%u",
         rs.GetRangeId(),
         rs.GetBlobCount(),
-        rs.GetDeletionCount());
+        rs.GetDeletionCount(),
+        rs.GetGarbageBlockCount());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -151,6 +151,8 @@ message TGetStorageStatsRequest
     uint32 CompactionRangeCountByCompactionScore = 3;
     // The same but for cleanup score.
     uint32 CompactionRangeCountByCleanupScore = 4;
+    // The same but for garbage score.
+    uint32 CompactionRangeCountByGarbageScore = 5;
 }
 
 message TGetStorageStatsResponse

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
@@ -260,7 +260,14 @@ TString PrintCompactionRanges(
             currentRange << PrintValue("blobsCount", range.GetBlobsCount()) << ", ";
         }
         if (range.HasDeletionsCount()) {
-            currentRange << PrintValue("deletionsCount", range.GetDeletionsCount()) << ", ";
+            currentRange << PrintValue(
+                "deletionsCount",
+                range.GetDeletionsCount()) << ", ";
+        }
+        if (range.HasGarbageBlocksCount()) {
+            currentRange << PrintValue(
+                "garbageBlocksCount",
+                range.GetGarbageBlocksCount()) << ", ";
         }
 
         if (currentRange.empty()) {


### PR DESCRIPTION
Follow-up for https://github.com/ydb-platform/nbs/pull/2301
Will use GarbageBlocksCount to order CompactionRanges for Garbage-based Compaction in the 3rd PR.

#2137 