### PR TITLE
issue-1541: fixed TFileRingBuffer validation for the case when slack space is smaller than TEntryHeader

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/file_ring_buffer.cpp
+++ b/cloud/filestore/libs/vfs_fuse/file_ring_buffer.cpp
@@ -89,8 +89,8 @@ private:
     {
         const auto* b = Data + pos;
         if (b + sizeof(TEntryHeader) > End) {
-            visitor(0, INVALID_MARKER);
-            return INVALID_POS;
+            // slack space smaller than TEntryHeader
+            return 0;
         }
 
         const auto* eh = reinterpret_cast<const TEntryHeader*>(b);


### PR DESCRIPTION
#1541 