### PR TITLE
issue-9: [Filestore] CompressedBytesWritten metric should take into account that blob should be divided into chunks of a certain size and each chunk should be compressed separately

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -332,6 +332,9 @@ message TStorageConfig
     // Blob compression experiment params.
     optional uint32 BlobCompressionRate = 364;
     optional string BlobCompressionCodec = 365;
+    // Blob is divided into chunks of a certain size (in bytes) and each chunk
+    // is compressed separately.
+    optional uint32 BlobCompressionChunkSize = 400;
 
     // Enables ThreeStageWrite for unaligned requests.
     optional bool UnalignedThreeStageWriteEnabled = 366;

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -190,6 +190,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(NodeType,                        TString,               {}            )\
     xxx(BlobCompressionRate,             ui32,                  0             )\
     xxx(BlobCompressionCodec,            TString,               "lz4"         )\
+    xxx(BlobCompressionChunkSize,        ui32,                  40_KB         )\
                                                                                \
     xxx(MaxZeroCompactionRangesToDeletePerTx,           ui32,      10000      )\
     xxx(ChannelFreeSpaceThreshold,                      ui32,      25         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -253,6 +253,7 @@ public:
 
     ui32 GetBlobCompressionRate() const;
     TString GetBlobCompressionCodec() const;
+    ui32 GetBlobCompressionChunkSize() const;
 
     ui32 GetNonNetworkMetricsBalancingFactor() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -705,7 +705,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         const auto handle = CreateHandle(tablet, nodeId);
 
-        tablet.WriteData(handle, 0, 4_KB, 'a');
+        tablet.WriteData(handle, 0, 100_KB, 'a');
 
         TTestRegistryVisitor visitor;
         registry->Visit(TInstant::Zero(), visitor);
@@ -715,14 +715,14 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                     {"sensor", "UncompressedBytesWritten"},
                     {"filesystem", "test"}
                 },
-                4_KB // expected
+                100_KB // expected
             },
             {
                 {
                     {"sensor", "CompressedBytesWritten"},
                     {"filesystem", "test"}
                 },
-                34 // expected
+                457 // expected
             },
         });
     }


### PR DESCRIPTION
#9 