### PR TITLE
should not pass --bs-cache-file-path if NFS_BS_CACHE_FILE_PATH is not set

### DIFF
--- a/cloud/filestore/tests/recipes/service-kikimr.inc
+++ b/cloud/filestore/tests/recipes/service-kikimr.inc
@@ -15,11 +15,14 @@ SET(RECIPE_ARGS
     --use-log-files
     --in-memory-pdisks
     --restart-interval $NFS_RESTART_INTERVAL
-    --bs-cache-file-path $NFS_BS_CACHE_FILE_PATH
 )
 
 IF (NFS_STORAGE_CONFIG_PATCH)
     SET_APPEND(RECIPE_ARGS --storage-config-patch $NFS_STORAGE_CONFIG_PATCH)
+ENDIF()
+
+IF (NFS_BS_CACHE_FILE_PATH)
+    SET_APPEND(RECIPE_ARGS --bs-cache-file-path $NFS_BS_CACHE_FILE_PATH)
 ENDIF()
 
 IF (NOT OPENSOURCE OR NFS_FORCE_VERBOSE)


### PR DESCRIPTION
Arcadia trunk tests crash if --bs-cache-file-path is passed to kikimr but NFS_BS_CACHE_FILE_PATH is not set in the environment