### PR TITLE
Replace TString methods Data() -> data(), Size() -> size(), Empty() -> empty()

### DIFF
--- a/cloud/blockstore/apps/client/lib/backup_volume.cpp
+++ b/cloud/blockstore/apps/client/lib/backup_volume.cpp
@@ -224,7 +224,7 @@ protected:
             return TRange{0, 0};
         }
 
-        return NextRange(changedBlocks.GetMask().Data(), i, n);
+        return NextRange(changedBlocks.GetMask().data(), i, n);
     }
 
     void ReadBlocks(ui32 bucket)

--- a/cloud/blockstore/apps/client/lib/read_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/read_blocks.cpp
@@ -464,14 +464,14 @@ private:
                 auto buffer = holder.Extract();
 
                 auto brokenDataMarker = NStorage::GetBrokenDataMarker();
-                if (brokenDataMarker.Size() > Volume.GetBlockSize()) {
+                if (brokenDataMarker.size() > Volume.GetBlockSize()) {
                     brokenDataMarker = brokenDataMarker.SubString(
                         0,
                         Volume.GetBlockSize());
                 }
-                for (ui32 i = 0; i < buffer.Size(); i += Volume.GetBlockSize()) {
+                for (ui32 i = 0; i < buffer.size(); i += Volume.GetBlockSize()) {
                     TStringBuf view(buffer);
-                    if (view.SubString(i, brokenDataMarker.Size()) == brokenDataMarker) {
+                    if (view.SubString(i, brokenDataMarker.size()) == brokenDataMarker) {
                         with_lock (OutputError) {
                             GetErrorStream()
                                 << "NODATA@"

--- a/cloud/blockstore/libs/common/iovector.cpp
+++ b/cloud/blockstore/libs/common/iovector.cpp
@@ -164,7 +164,7 @@ ui32 CountVoidBuffers(const NProto::TIOVector& iov)
 {
     ui32 result = 0;
     for (const auto& buffer: iov.GetBuffers()) {
-        if (buffer.Empty()) {
+        if (buffer.empty()) {
             ++result;
         }
     }

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -124,7 +124,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                         GetDeviceBlocks(request->GetDeviceUUID(), minSize);
 
                     for (ui32 i = request->GetStartIndex(); i < minSize; ++i) {
-                        sglist.emplace_back(blocks[i].Data(), blocks[i].Size());
+                        sglist.emplace_back(blocks[i].data(), blocks[i].size());
                     }
                 }
 
@@ -150,7 +150,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                     using TProto = NProto::TWriteDeviceBlocksRequest;
                     auto* request = static_cast<TProto*>(result.Proto.get());
                     const auto blockCount =
-                        result.Data.Size() / request->GetBlockSize();
+                        result.Data.size() / request->GetBlockSize();
                     const size_t minSize = request->GetStartIndex() + blockCount;
 
                     auto& blocks =
@@ -222,7 +222,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
 
                     TBlockChecksum checksum;
                     for (ui32 i = request->GetStartIndex(); i < minSize; ++i) {
-                        checksum.Extend(blocks[i].Data(), blocks[i].Size());
+                        checksum.Extend(blocks[i].data(), blocks[i].size());
                     }
                     response.SetChecksum(checksum.GetValue());
                 }

--- a/cloud/blockstore/libs/rdma_test/rdma_test_environment.cpp
+++ b/cloud/blockstore/libs/rdma_test/rdma_test_environment.cpp
@@ -76,7 +76,7 @@ ui64 TRdmaTestEnvironment::CalcChecksum(ui32 size, char fill)
 {
     TString data(size, fill);
     TBlockChecksum checksum;
-    checksum.Extend(data.Data(), data.Size());
+    checksum.Extend(data.data(), data.size());
     return checksum.GetValue();
 }
 

--- a/cloud/blockstore/libs/storage/core/block_handler_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/block_handler_ut.cpp
@@ -23,13 +23,13 @@ IWriteBlocksHandlerPtr CreateTestWriteBlocksHandler(
     TBlockRange64 range,
     const TString& content)
 {
-    TSgList sglist(range.Size(), {content.Data(), content.Size()});
+    TSgList sglist(range.Size(), {content.data(), content.size()});
 
     auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
     request->Record.Sglist = TGuardedSgList(std::move(sglist));
     request->Record.SetStartIndex(range.Start);
     request->Record.BlocksCount = range.Size();
-    request->Record.BlockSize = content.Size() / range.Size();
+    request->Record.BlockSize = content.size() / range.Size();
 
     return CreateWriteBlocksHandler(range, std::move(request));
 }
@@ -129,7 +129,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
             auto blockContent = GetBlockContent(blockIndex);
             handler->SetBlock(
                 blockIndex,
-                TBlockDataRef(blockContent.Data(), blockContent.Size()),
+                TBlockDataRef(blockContent.data(), blockContent.size()),
                 false);
         }
 
@@ -181,7 +181,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
         TString blockContent1(DefaultBlockSize, 'b');
         handler->SetBlock(
             1,
-            TBlockDataRef(blockContent1.Data(), blockContent1.Size()),
+            TBlockDataRef(blockContent1.data(), blockContent1.size()),
             false);
 
         auto guardedSgList1 = handler->GetGuardedSgList({4, 5}, false);
@@ -198,7 +198,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
         TString blockContent2(DefaultBlockSize, 'c');
         handler->SetBlock(
             2,
-            TBlockDataRef(blockContent2.Data(), blockContent2.Size()),
+            TBlockDataRef(blockContent2.data(), blockContent2.size()),
             false);
 
         auto guardedSgList2 = handler->GetGuardedSgList({6, 7}, false);
@@ -238,7 +238,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
         TString blockContent1(DefaultBlockSize, 'b');
         handler->SetBlock(
             1,
-            TBlockDataRef(blockContent1.Data(), blockContent1.Size()),
+            TBlockDataRef(blockContent1.data(), blockContent1.size()),
             false);
 
         auto guardedSgList1 = handler->GetGuardedSgList({4, 5}, false);
@@ -255,7 +255,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
         TString blockContent2(DefaultBlockSize, 'c');
         handler->SetBlock(
             2,
-            TBlockDataRef(blockContent2.Data(), blockContent2.Size()),
+            TBlockDataRef(blockContent2.data(), blockContent2.size()),
             false);
 
         auto guardedSgList2 = handler->GetGuardedSgList({6, 7}, false);
@@ -370,7 +370,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
     Y_UNIT_TEST(ShouldFillUnencryptedBlockMaskInReadBlocksHandler)
     {
         auto blockContent = GetBlockContent();
-        TBlockDataRef blockContentRef(blockContent.Data(), blockContent.Size());
+        TBlockDataRef blockContentRef(blockContent.data(), blockContent.size());
 
         ui64 startIndex = 10;
         auto handler = CreateReadBlocksHandler(
@@ -407,7 +407,7 @@ Y_UNIT_TEST_SUITE(TBlockHandlerTest)
     Y_UNIT_TEST(ShouldFillUnencryptedBlockMaskInLocalReadBlocksHandler)
     {
         auto blockContent = GetBlockContent();
-        TBlockDataRef blockContentRef(blockContent.Data(), blockContent.Size());
+        TBlockDataRef blockContentRef(blockContent.data(), blockContent.size());
 
         ui64 startIndex = 10;
         TVector<TString> blocks;

--- a/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
@@ -109,7 +109,7 @@ TString TManuallyPreemptedVolumes::Serialize() const
 NProto::TError TManuallyPreemptedVolumes::Deserialize(const TString& input)
 {
     try {
-        if (input.Empty()) {
+        if (input.empty()) {
             return {};
         }
 

--- a/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
@@ -1029,7 +1029,7 @@ void DumpDataHash(IOutputStream& out, const TString& data)
     }
 
     if (haveNonZeroes) {
-        auto digest = NOpenSsl::NSha1::Calc(data.Data(), data.Size());
+        auto digest = NOpenSsl::NSha1::Calc(data.data(), data.size());
         for (ui32 i = 0; i < NOpenSsl::NSha1::DIGEST_LENGTH; ++i) {
             out << Hex(digest[i]);
             if (i < NOpenSsl::NSha1::DIGEST_LENGTH - 1) {

--- a/cloud/blockstore/libs/storage/core/volume_model.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model.cpp
@@ -166,7 +166,7 @@ void AddOrModifyChannel(
     const auto found = data.find(channelId);
     if (found != data.end()) {
         profile->SetPoolKind(found->second);
-    } else if (profile->GetPoolKind().Empty()) {
+    } else if (profile->GetPoolKind().empty()) {
         profile->SetPoolKind(poolKind);
     }
 
@@ -190,7 +190,7 @@ void SetupVolumeChannel(
     }
     auto* profile = volumeConfig.MutableVolumeExplicitChannelProfiles(channelId);
 
-    if (profile->GetPoolKind().Empty()) {
+    if (profile->GetPoolKind().empty()) {
         profile->SetPoolKind(poolKind);
     }
     profile->SetDataKind(static_cast<ui32>(dataKind));
@@ -234,25 +234,25 @@ TPoolKinds GetPoolKinds(
             auto systemChannelPoolKind =
                 config.GetSSDSystemChannelPoolKindFeatureValue(
                     cloudId, folderId, diskId);
-            if (systemChannelPoolKind.Empty()) {
+            if (systemChannelPoolKind.empty()) {
                 systemChannelPoolKind = config.GetSSDSystemChannelPoolKind();
             }
             auto logChannelPoolKind =
                 config.GetSSDLogChannelPoolKindFeatureValue(
                     cloudId, folderId, diskId);
-            if (logChannelPoolKind.Empty()) {
+            if (logChannelPoolKind.empty()) {
                 logChannelPoolKind = config.GetSSDLogChannelPoolKind();
             }
             auto indexChannelPoolKind =
                 config.GetSSDIndexChannelPoolKindFeatureValue(
                     cloudId, folderId, diskId);
-            if (indexChannelPoolKind.Empty()) {
+            if (indexChannelPoolKind.empty()) {
                 indexChannelPoolKind = config.GetSSDIndexChannelPoolKind();
             }
             auto freshChannelPoolKind =
                 config.GetSSDFreshChannelPoolKindFeatureValue(
                     cloudId, folderId, diskId);
-            if (freshChannelPoolKind.Empty()) {
+            if (freshChannelPoolKind.empty()) {
                 freshChannelPoolKind = config.GetSSDFreshChannelPoolKind();
             }
             return {

--- a/cloud/blockstore/libs/storage/core/write_buffer_request_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/write_buffer_request_ut.cpp
@@ -29,7 +29,7 @@ TString ToString(
 {
     TStringBuilder sb;
     for (const auto& group: g.Groups) {
-        if (sb.Size()) {
+        if (sb.size()) {
             sb << "|";
         }
         sb << "GROUP:W=" << group.Weight;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -64,7 +64,7 @@ void TDiskRegistryActor::ScheduleMakeBackup(
 {
     const auto backupDirPath = Config->GetDiskRegistryBackupDirPath();
 
-    if (backupDirPath.Empty()) {
+    if (backupDirPath.empty()) {
         LOG_WARN(ctx, TBlockStoreComponents::DISK_REGISTRY,
             "Path for backups was not specified");
         return;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -557,7 +557,7 @@ void TDiskRegistryState::ProcessCheckpoints()
     for (const auto& [diskId, diskState]: Disks) {
         const auto& checkpointReplica = diskState.CheckpointReplica;
 
-        if (!checkpointReplica.GetCheckpointId().Empty()) {
+        if (!checkpointReplica.GetCheckpointId().empty()) {
             auto* sourceDisk = Disks.FindPtr(checkpointReplica.GetSourceDiskId());
             if (!sourceDisk) {
                 ReportDiskRegistrySourceDiskNotFound(
@@ -2593,7 +2593,7 @@ NProto::TError TDiskRegistryState::AllocateSimpleDisk(
         params.DiskId);
 
     const bool isShadowDiskAllocation =
-        !checkpointParams.GetCheckpointId().Empty();
+        !checkpointParams.GetCheckpointId().empty();
 
     auto onError = [&] {
         const bool isNewDisk = disk.Devices.empty();

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -3998,7 +3998,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         // uuid-5 : online -> warning
@@ -4014,7 +4014,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         // uuid-7 : online -> warning
@@ -4030,7 +4030,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -4044,7 +4044,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         // uuid-2 : online -> warning
@@ -4084,7 +4084,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         // uuid-4 : warning -> error
@@ -4207,7 +4207,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -4260,7 +4260,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -5433,7 +5433,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         // uuid-1.1 : error
@@ -6210,7 +6210,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 affectedDisk);
 
             UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, error.GetCode());
-            UNIT_ASSERT(affectedDisk.Empty());
+            UNIT_ASSERT(affectedDisk.empty());
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -136,7 +136,7 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
         executor.WriteTx([&] (TPartitionDatabase db) {
             ui64 commitId = executor.CommitId();
             auto one = GetBlockContent(1);
-            db.WriteFreshBlock(1, commitId, {one.Data(), one.Size()});
+            db.WriteFreshBlock(1, commitId, {one.data(), one.size()});
         });
 
         executor.ReadTx([&] (TPartitionDatabase db) {

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
@@ -192,8 +192,8 @@ void TReadBlobActor::HandleGetResult(
                     Y_ABORT_UNLESS(block.Data());
                     memcpy(
                         const_cast<char*>(block.Data()),
-                        marker.Data(),
-                        Min(block.Size(), marker.Size())
+                        marker.data(),
+                        Min(block.Size(), marker.size())
                     );
                     ++sglistIndex;
 
@@ -208,8 +208,8 @@ void TReadBlobActor::HandleGetResult(
                         Y_ABORT_UNLESS(block.Data());
                         memcpy(
                             const_cast<char*>(block.Data()),
-                            marker.Data(),
-                            Min(block.Size(), marker.Size())
+                            marker.data(),
+                            Min(block.Size(), marker.size())
                         );
 
                         ++sglistIndex;
@@ -242,9 +242,9 @@ void TReadBlobActor::HandleGetResult(
                     auto block = TString::Uninitialized(BlockSize);
                     iter.ExtractPlainDataAndAdvance(block.begin(), BlockSize);
                     blockChecksums.push_back(
-                        ComputeDefaultDigest({block.Data(), BlockSize}));
+                        ComputeDefaultDigest({block.data(), BlockSize}));
 
-                    memcpy(to, block.Data(), BlockSize);
+                    memcpy(to, block.data(), BlockSize);
                 } else {
                     iter.ExtractPlainDataAndAdvance(to, BlockSize);
                 }

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -336,7 +336,7 @@ TVolumeClient::CreateWriteBlocksLocalRequest(
     const TString& blockContent)
 {
     TSgList sglist;
-    sglist.resize(writeRange.Size(), {blockContent.Data(), blockContent.Size()});
+    sglist.resize(writeRange.Size(), {blockContent.data(), blockContent.size()});
 
     auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
     request->Record.SetStartIndex(writeRange.Start);

--- a/cloud/blockstore/tools/analytics/compaction-sim/main.cpp
+++ b/cloud/blockstore/tools/analytics/compaction-sim/main.cpp
@@ -164,11 +164,11 @@ struct TOptions
         TStringBuf sit(EvlogDumperParamsStr);
         TStringBuf arg;
         while (sit.NextTok(' ', arg)) {
-            if (sit.Size()) {
-                const auto idx = EvlogDumperParamsStr.Size() - sit.Size() - 1;
+            if (sit.size()) {
+                const auto idx = EvlogDumperParamsStr.size() - sit.size() - 1;
                 EvlogDumperParamsStr[idx] = 0;
             }
-            EvlogDumperArgv.push_back(arg.Data());
+            EvlogDumperArgv.push_back(arg.data());
         }
     }
 };
@@ -273,7 +273,7 @@ void PrintStat(const TString& label, const TString& sublabel, const TStat& stat)
 
     Cout << CONSOLE_YELLOW << label << CONSOLE_ENDC
         << CONSOLE_GREEN << sublabel << CONSOLE_ENDC
-        << " " << Indented(stat.Count, 30 - label.Size() - sublabel.Size())
+        << " " << Indented(stat.Count, 30 - label.size() - sublabel.size())
         << " " << Indented(Bytes2String(stat.Bytes), 20)
         << " " << Indented(Bytes2String(bpr), 20)
         << WIPE << Endl;

--- a/cloud/blockstore/tools/analytics/event-log-disk-usage/main.cpp
+++ b/cloud/blockstore/tools/analytics/event-log-disk-usage/main.cpp
@@ -144,11 +144,11 @@ struct TOptions
             TStringBuf sit(EvlogDumperParamsStr);
             TStringBuf arg;
             while (sit.NextTok(' ', arg)) {
-                if (sit.Size()) {
-                    const auto idx = EvlogDumperParamsStr.Size() - sit.Size() - 1;
+                if (sit.size()) {
+                    const auto idx = EvlogDumperParamsStr.size() - sit.size() - 1;
                     EvlogDumperParamsStr[idx] = 0;
                 }
-                EvlogDumperArgv.push_back(arg.Data());
+                EvlogDumperArgv.push_back(arg.data());
             }
         }
     }

--- a/cloud/blockstore/tools/analytics/event-log-stats/main.cpp
+++ b/cloud/blockstore/tools/analytics/event-log-stats/main.cpp
@@ -86,11 +86,11 @@ struct TOptions
         TStringBuf sit(EvlogDumperParamsStr);
         TStringBuf arg;
         while (sit.NextTok(' ', arg)) {
-            if (sit.Size()) {
-                const auto idx = EvlogDumperParamsStr.Size() - sit.Size() - 1;
+            if (sit.size()) {
+                const auto idx = EvlogDumperParamsStr.size() - sit.size() - 1;
                 EvlogDumperParamsStr[idx] = 0;
             }
-            EvlogDumperArgv.push_back(arg.Data());
+            EvlogDumperArgv.push_back(arg.data());
         }
     }
 };

--- a/cloud/blockstore/tools/analytics/event-log-suffer/main.cpp
+++ b/cloud/blockstore/tools/analytics/event-log-suffer/main.cpp
@@ -107,11 +107,11 @@ struct TOptions
         TStringBuf sit(EvlogDumperParamsStr);
         TStringBuf arg;
         while (sit.NextTok(' ', arg)) {
-            if (sit.Size()) {
-                const auto idx = EvlogDumperParamsStr.Size() - sit.Size() - 1;
+            if (sit.size()) {
+                const auto idx = EvlogDumperParamsStr.size() - sit.size() - 1;
                 EvlogDumperParamsStr[idx] = 0;
             }
-            EvlogDumperArgv.push_back(arg.Data());
+            EvlogDumperArgv.push_back(arg.data());
         }
     }
 };

--- a/cloud/blockstore/tools/analytics/find-block-accesses/main.cpp
+++ b/cloud/blockstore/tools/analytics/find-block-accesses/main.cpp
@@ -61,11 +61,11 @@ struct TOptions
         TStringBuf sit(EvlogDumperParamsStr);
         TStringBuf arg;
         while (sit.NextTok(' ', arg)) {
-            if (sit.Size()) {
-                const auto idx = EvlogDumperParamsStr.Size() - sit.Size() - 1;
+            if (sit.size()) {
+                const auto idx = EvlogDumperParamsStr.size() - sit.size() - 1;
                 EvlogDumperParamsStr[idx] = 0;
             }
-            EvlogDumperArgv.push_back(arg.Data());
+            EvlogDumperArgv.push_back(arg.data());
         }
 
         for (const auto block: Blocks) {

--- a/cloud/blockstore/tools/analytics/visualize-event-log/main.cpp
+++ b/cloud/blockstore/tools/analytics/visualize-event-log/main.cpp
@@ -118,11 +118,11 @@ struct TOptions
         TStringBuf sit(EvlogDumperParamsStr);
         TStringBuf arg;
         while (sit.NextTok(' ', arg)) {
-            if (sit.Size()) {
-                const auto idx = EvlogDumperParamsStr.Size() - sit.Size() - 1;
+            if (sit.size()) {
+                const auto idx = EvlogDumperParamsStr.size() - sit.size() - 1;
                 EvlogDumperParamsStr[idx] = 0;
             }
-            EvlogDumperArgv.push_back(arg.Data());
+            EvlogDumperArgv.push_back(arg.data());
         }
 
         TimeInterval = TDuration::Parse(TimeIntervalStr);

--- a/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
@@ -100,8 +100,8 @@ struct TDigestCalculatorImpl final
         }
 
         ui64 result;
-        Y_ABORT_UNLESS(block.Size() >= sizeof(result));
-        memcpy(&result, block.Data(), sizeof(result));
+        Y_ABORT_UNLESS(block.size() >= sizeof(result));
+        memcpy(&result, block.data(), sizeof(result));
         return result;
     }
 };

--- a/cloud/blockstore/tools/testing/loadtest/lib/compare_data_action_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/compare_data_action_runner.cpp
@@ -235,7 +235,7 @@ void TCompareDataActionRunner::ReadBlocks(
             {}
         );
 
-        for (ui32 i = 0; i < response.GetMask().Size(); ++i) {
+        for (ui32 i = 0; i < response.GetMask().size(); ++i) {
             for (ui32 j = 0; j < 8; ++j) {
                 if (response.GetMask()[i] & (1 << j)) {
                     const auto idx = (i * 8 + j) * TestContext.Volume.GetBlockSize();

--- a/cloud/filestore/apps/client/lib/execute_action.cpp
+++ b/cloud/filestore/apps/client/lib/execute_action.cpp
@@ -44,12 +44,12 @@ public:
     {
         auto callContext = PrepareCallContext();
 
-        if (!InputFilePath.Empty()) {
+        if (!InputFilePath.empty()) {
             Input = ReadFile(InputFilePath);
         }
         TStringInput inputBytes(Input);
 
-        auto& input = Input.Empty() ? Cin : inputBytes;
+        auto& input = Input.empty() ? Cin : inputBytes;
         auto inputJsonStr = input.ReadAll();
 
         STORAGE_DEBUG("Reading ExecuteAction request");

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -65,7 +65,7 @@ NCloud::NStorage::ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
     IMonitoringServicePtr monitoring,
     const TString& metricsComponent)
 {
-    if (cpuWaitServiceName.Empty() && cpuWaitFilename.Empty()) {
+    if (cpuWaitServiceName.empty() && cpuWaitFilename.empty()) {
         const auto& Log = log;
         STORAGE_INFO(
             "CpuWaitServiceName and CpuWaitFilename are empty, can't build "
@@ -79,7 +79,7 @@ NCloud::NStorage::ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
             .CounterName = "CpuWaitFailure",
         };
     TString statsFile =
-        cpuWaitFilename.Empty()
+        cpuWaitFilename.empty()
             ? NCloud::NStorage::BuildCpuWaitStatsFilename(cpuWaitServiceName)
             : cpuWaitFilename;
 

--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -224,7 +224,7 @@ void InitProfileLogRequestInfo(
     rangeInfo->SetNodeId(request.GetNodeId());
     rangeInfo->SetHandle(request.GetHandle());
     rangeInfo->SetOffset(request.GetOffset());
-    rangeInfo->SetBytes(request.GetBuffer().Size());
+    rangeInfo->SetBytes(request.GetBuffer().size());
 }
 
 template <>

--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -80,7 +80,7 @@ TFuture<NProto::TReadDataResponse> TLocalFileSystem::ReadDataAsync(
     }
 
     auto b = TString::Uninitialized(request.GetLength());
-    NSan::Unpoison(b.Data(), b.Size());
+    NSan::Unpoison(b.data(), b.size());
 
     TArrayRef<char> data(b.begin(), b.vend());
     auto promise = NewPromise<NProto::TReadDataResponse>();

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -333,7 +333,7 @@ void AddOrModifyChannel(
     }
 
     auto* profile = config.MutableExplicitChannelProfiles(channelId);
-    if (profile->GetPoolKind().Empty()) {
+    if (profile->GetPoolKind().empty()) {
         profile->SetPoolKind(poolKind);
     }
 

--- a/cloud/filestore/libs/storage/model/block_buffer.cpp
+++ b/cloud/filestore/libs/storage/model/block_buffer.cpp
@@ -165,12 +165,12 @@ void CopyFileData(
     if (origin.Offset > aligned.Offset) {
         const auto block = buffer.GetBlock(i);
         const auto shift = origin.Offset - aligned.Offset;
-        const auto sz = Min(block.Size() - shift, out->Size());
+        const auto sz = Min(block.size() - shift, out->size());
         STORAGE_VERIFY(
             outPtr + sz <= out->end(),
             TWellKnownEntityTypes::FILESYSTEM,
             logTag);
-        memcpy(outPtr, block.Data() + shift, sz);
+        memcpy(outPtr, block.data() + shift, sz);
         outPtr += sz;
 
         ++i;
@@ -179,12 +179,12 @@ void CopyFileData(
     while (i < aligned.BlockCount()) {
         const auto block = buffer.GetBlock(i);
         // Min needed to properly process unaligned tail
-        const auto len = Min<ui64>(out->end() - outPtr, block.Size());
+        const auto len = Min<ui64>(out->end() - outPtr, block.size());
         if (!len) {
             // origin.End() is greater than fileSize
             break;
         }
-        memcpy(outPtr, block.Data(), len);
+        memcpy(outPtr, block.data(), len);
         outPtr += len;
 
         ++i;

--- a/cloud/filestore/tools/analytics/profile_tool/lib/command.cpp
+++ b/cloud/filestore/tools/analytics/profile_tool/lib/command.cpp
@@ -18,7 +18,7 @@ constexpr TStringBuf ProfileLogLabel = "profile-log";
 TCommand::TCommand()
 {
     Opts.AddLongOption(
-            ProfileLogLabel.Data(),
+            ProfileLogLabel.data(),
             "Path to profile log")
         .Required()
         .RequiredArgument("STR")

--- a/cloud/filestore/tools/analytics/profile_tool/lib/common_filter_params.cpp
+++ b/cloud/filestore/tools/analytics/profile_tool/lib/common_filter_params.cpp
@@ -21,11 +21,11 @@ TMaybe<T> Parse(
     TStringBuf label,
     const NLastGetopt::TOptsParseResultException& parseResult)
 {
-    if (!parseResult.Has(label.Data())) {
+    if (!parseResult.Has(label.data())) {
         return {};
     }
 
-    return parseResult.Get<T>(label.Data());
+    return parseResult.Get<T>(label.data());
 }
 
 template <>
@@ -33,11 +33,11 @@ TMaybe<TInstant> Parse(
     TStringBuf label,
     const NLastGetopt::TOptsParseResultException& parseResult)
 {
-    if (!parseResult.Has(label.Data())) {
+    if (!parseResult.Has(label.data())) {
         return {};
     }
 
-    const auto res = parseResult.Get<TString>(label.Data());
+    const auto res = parseResult.Get<TString>(label.data());
     TInstant ts;
     if (!TInstant::TryParseIso8601(res, ts)) {
         Cerr << "Failed to parse time format: " << res << Endl;
@@ -55,28 +55,28 @@ TMaybe<TInstant> Parse(
 TCommonFilterParams::TCommonFilterParams(NLastGetopt::TOpts& opts)
 {
     opts.AddLongOption(
-            FileSystemIdLabel.Data(),
+            FileSystemIdLabel.data(),
             "FileSystemId, used for filtering")
         .RequiredArgument("STR");
 
     opts.AddLongOption(
-            NodeIdLabel.Data(),
+            NodeIdLabel.data(),
             "NodeId, used for filtering")
         .RequiredArgument("NUM");
 
     opts.AddLongOption(
-            HandleLabel.Data(),
+            HandleLabel.data(),
             "Handle, used for filtering")
         .RequiredArgument("NUM");
 
     opts.AddLongOption(
-            SinceLabel.Data(),
+            SinceLabel.data(),
             "Since timestamp, used for filtering. "
             "Format: YYYY-MM-DDThh:mm:ss (https://www.iso.org/standard/40874.html)")
         .RequiredArgument("STR");
 
     opts.AddLongOption(
-            UntilLabel.Data(),
+            UntilLabel.data(),
             "Until timestamp, used for filtering. "
             "Format: YYYY-MM-DDThh:mm:ss (https://www.iso.org/standard/40874.html)")
         .RequiredArgument("STR");

--- a/cloud/filestore/tools/analytics/profile_tool/lib/find_bytes_access.cpp
+++ b/cloud/filestore/tools/analytics/profile_tool/lib/find_bytes_access.cpp
@@ -78,21 +78,21 @@ public:
         : CommonFilterParams(Opts)
     {
         Opts.AddLongOption(
-                StartLabel.Data(),
+                StartLabel.data(),
                 "Start of the semi-interval (index of the first block)")
             .Required()
             .RequiredArgument("NUM")
             .StoreResult(&Start);
 
         Opts.AddLongOption(
-                CountLabel.Data(),
+                CountLabel.data(),
                 "Size of the semi-interval (number of blocks)")
             .Required()
             .RequiredArgument("NUM")
             .StoreResult(&Count);
 
         Opts.AddLongOption(
-                BlockSizeLabel.Data(),
+                BlockSizeLabel.data(),
                 "Block size (in bytes)")
             .RequiredArgument("NUM")
             .StoreResult(&BlockSize)

--- a/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
@@ -49,7 +49,7 @@ bool Compare(
     }
 
     if (expected.LastWriteRequestId != actual.LastWriteRequestId) {
-        if (sb.Size()) {
+        if (sb.size()) {
             sb << ", ";
         }
 
@@ -60,7 +60,7 @@ bool Compare(
 
     *message = sb;
 
-    return sb.Empty();
+    return sb.empty();
 }
 
 struct TSegments: TVector<TSegment>, TAtomicRefCount<TSegments>

--- a/cloud/storage/core/libs/common/compressed_bitmap.cpp
+++ b/cloud/storage/core/libs/common/compressed_bitmap.cpp
@@ -813,7 +813,7 @@ public:
                 plain.Data = new TPlainChunkData;
                 memcpy(
                     plain.Data->Data,
-                    data.Data() + 1,
+                    data.data() + 1,
                     sizeof(TPlainChunkData)
                 );
                 chunk->Count() = plain.Data->Count();


### PR DESCRIPTION
В аркадии начали делать чтобы TString стал совместим с std::string по этому нужно перестать использовать аркадийные расширения.