### PR TITLE
issue-2137: marking compacted ranges with a special non-persistent flag to: 1. actually guarantee the absence of compaction loops 2. use it later to be able to mark some ranges which are almost perfectly compacted and skip them during later compactions

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.cpp
@@ -5,6 +5,7 @@
 #include <library/cpp/containers/intrusive_rb_tree/rb_tree.h>
 
 #include <util/generic/algorithm.h>
+#include <util/generic/bitmap.h>
 #include <util/generic/intrlist.h>
 #include <util/system/align.h>
 
@@ -130,6 +131,8 @@ using TTreeByGarbageScore = TRbTree<
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TRangeBitMap = TBitMap<TCompactionMap::GroupSize>;
+
 struct TGroup
     : TIntrusiveListItem<TGroup>
     , TTreeItemByGroupIndex
@@ -144,8 +147,9 @@ struct TGroup
     TCompactionCounter TopGarbageScore;
 
     std::array<TCompactionStats, TCompactionMap::GroupSize> Stats = {};
+    TRangeBitMap CompactedRanges;
 
-    TGroup(ui32 groupIndex)
+    explicit TGroup(ui32 groupIndex)
         : GroupIndex(groupIndex)
     {}
 
@@ -158,9 +162,16 @@ struct TGroup
         ui32 rangeId,
         ui32 blobsCount,
         ui32 deletionsCount,
-        ui32 garbageBlocksCount)
+        ui32 garbageBlocksCount,
+        bool compacted)
     {
-        auto& stats = Stats[rangeId - GroupIndex];
+        const auto rangeIndex = rangeId - GroupIndex;
+        if (compacted) {
+            CompactedRanges.Set(rangeIndex);
+        } else {
+            CompactedRanges.Reset(rangeIndex);
+        }
+        auto& stats = Stats[rangeIndex];
 
         bool wasEmpty = stats.BlobsCount == 0
             && stats.DeletionsCount == 0
@@ -181,27 +192,30 @@ struct TGroup
         stats.DeletionsCount = deletionsCount;
         stats.GarbageBlocksCount = garbageBlocksCount;
 
-        ui32 compactionScore = GetCompactionScore(stats);
+        ui32 compactionScore = compacted ? 0 : GetCompactionScore(stats);
         if (TopCompactionScore.Score < compactionScore) {
             TopCompactionScore = { rangeId, compactionScore };
         } else if (TopCompactionScore.RangeId == rangeId) {
-            ui32 i = GetTop<TCompareByCompactionScore>();
-            TopCompactionScore = { GroupIndex + i, GetCompactionScore(Stats[i]) };
+            ui32 i = GetTop<TCompareByCompactionScore>(CompactedRanges);
+            TopCompactionScore = {
+                GroupIndex + i,
+                GetCompactionScore(Stats[i])};
         }
 
+        // 'compacted' flag is deliberately ignored for cleanup score
         ui32 cleanupScore = GetCleanupScore(stats);
         if (TopCleanupScore.Score < cleanupScore) {
             TopCleanupScore = { rangeId, cleanupScore };
         } else if (TopCleanupScore.RangeId == rangeId) {
-            ui32 i = GetTop<TCompareByCleanupScore>();
+            ui32 i = GetTop<TCompareByCleanupScore>({});
             TopCleanupScore = { GroupIndex + i, GetCleanupScore(Stats[i]) };
         }
 
-        ui32 garbageScore = GetGarbageScore(stats);
+        ui32 garbageScore = compacted ? 0 : GetGarbageScore(stats);
         if (TopGarbageScore.Score < garbageScore) {
             TopGarbageScore = { rangeId, garbageScore};
         } else if (TopGarbageScore.RangeId == rangeId) {
-            ui32 i = GetTop<TCompareByGarbageScore>();
+            ui32 i = GetTop<TCompareByGarbageScore>(CompactedRanges);
             TopGarbageScore = { GroupIndex + i, GetGarbageScore(Stats[i]) };
         }
 
@@ -209,17 +223,22 @@ struct TGroup
     }
 
     template <typename TCompare>
-    ui32 GetTop() const
+    ui32 GetTop(const TRangeBitMap& toSkip) const
     {
-        auto top = std::max_element(
-            Stats.begin(),
-            Stats.end(),
-            [] (const auto& top, const auto& next) {
-                // true if lhs < rhs
-                return TCompare::Compare(next, top);
-            });
+        TCompactionStats best;
+        ui32 bestI = 0;
+        for (ui32 i = 0; i < Stats.size(); ++i) {
+            if (toSkip.Get(i)) {
+                continue;
+            }
 
-        return top - Stats.begin();
+            // Compare(a, b) == true <=> a > b
+            if (TCompare::Compare(Stats[i], best)) {
+                best = Stats[i];
+                bestI = i;
+            }
+        }
+        return bestI;
     }
 
     bool Empty() const
@@ -300,7 +319,8 @@ struct TCompactionMap::TImpl
         ui32 rangeId,
         ui32 blobsCount,
         ui32 deletionsCount,
-        ui32 garbageBlocksCount)
+        ui32 garbageBlocksCount,
+        bool compacted)
     {
         ui32 groupIndex = GetGroupIndex(rangeId);
 
@@ -321,7 +341,8 @@ struct TCompactionMap::TImpl
             rangeId,
             blobsCount,
             deletionsCount,
-            garbageBlocksCount);
+            garbageBlocksCount,
+            compacted);
 
         if (group->Empty()) {
             UnLinkGroup(group);
@@ -358,7 +379,8 @@ struct TCompactionMap::TImpl
                 ranges[i].RangeId,
                 ranges[i].Stats.BlobsCount,
                 ranges[i].Stats.DeletionsCount,
-                ranges[i].Stats.GarbageBlocksCount);
+                ranges[i].Stats.GarbageBlocksCount,
+                false /* compacted */);
         }
 
         if (group->Empty()) {
@@ -398,7 +420,8 @@ struct TCompactionMap::TImpl
 
     TVector<TCompactionRangeInfo> GetTopRanges(
         ui32 c,
-        const TGetScore& getScore) const
+        const TGetScore& getScore,
+        bool skipCompactedRanges) const
     {
         if (!c) {
             return {};
@@ -408,6 +431,10 @@ struct TCompactionMap::TImpl
 
         for (const auto& g: Groups) {
             for (ui32 i = 0; i < GroupSize; ++i) {
+                if (skipCompactedRanges && g.CompactedRanges.Get(i)) {
+                    continue;
+                }
+
                 if (g.Stats[i].BlobsCount
                         || g.Stats[i].DeletionsCount
                         || g.Stats[i].GarbageBlocksCount)
@@ -423,85 +450,72 @@ struct TCompactionMap::TImpl
         return ranges;
     }
 
-    TVector<TCompactionRangeInfo> GetTopRangesByCompactionScore(ui32 c) const
+    TCompactionRangeInfo GetTopRange(
+        const TGetScore& getScore,
+        bool skipCompactedRanges) const
     {
-        // TODO efficient implementation for any c
-        if (c == 1) {
-            const auto* group = GetTopCompactionScore();
-            if (group) {
-                ui32 index = 0;
-                TCompactionStats best = group->Stats[0];
-                for (ui32 i = 1; i < GroupSize; ++i) {
-                    auto stats = group->Stats[i];
-                    if (stats.BlobsCount > best.BlobsCount) {
-                        index = i;
-                        best = stats;
-                    }
+        const auto* group = GetTopCompactionScore();
+        if (group) {
+            TCompactionRangeInfo best;
+            for (ui32 i = 0; i < GroupSize; ++i) {
+                if (skipCompactedRanges && group->CompactedRanges.Get(i)) {
+                    continue;
                 }
 
-                return {{group->GroupIndex + index, best}};
+                TCompactionRangeInfo info{
+                    group->GroupIndex + i,
+                    group->Stats[i]};
+                if (getScore(info) > getScore(best)) {
+                    best = info;
+                }
             }
 
-            return {};
+            return best;
         }
 
-        return GetTopRanges(c, [] (const TCompactionRangeInfo& r) {
+        return {};
+    }
+
+    TVector<TCompactionRangeInfo> GetTopRangesByCompactionScore(ui32 c) const
+    {
+        const auto getScore = [] (const TCompactionRangeInfo& r) {
             return -static_cast<double>(r.Stats.BlobsCount);
-        });
+        };
+
+        // TODO efficient implementation for any c
+        if (c == 1) {
+            return {GetTopRange(getScore, true)};
+        }
+
+        return GetTopRanges(c, getScore, true);
     }
 
     TVector<TCompactionRangeInfo> GetTopRangesByCleanupScore(ui32 c) const
     {
+        const auto getScore = [] (const TCompactionRangeInfo& r) {
+            return -static_cast<double>(r.Stats.DeletionsCount);
+        };
+
         // TODO efficient implementation for any c
         if (c == 1) {
-            const auto* group = GetTopCleanupScore();
-            if (group) {
-                ui32 index = 0;
-                TCompactionStats best = group->Stats[0];
-                for (ui32 i = 1; i < GroupSize; ++i) {
-                    auto stats = group->Stats[i];
-                    if (stats.DeletionsCount > best.DeletionsCount) {
-                        index = i;
-                        best = stats;
-                    }
-                }
-
-                return {{group->GroupIndex + index, best}};
-            }
-
-            return {};
+            return {GetTopRange(getScore, false)};
         }
 
-        return GetTopRanges(c, [] (const TCompactionRangeInfo& r) {
-            return -static_cast<double>(r.Stats.DeletionsCount);
-        });
+        return GetTopRanges(c, getScore, false);
     }
 
     TVector<TCompactionRangeInfo> GetTopRangesByGarbageScore(ui32 c) const
     {
+        const auto getScore = [] (const TCompactionRangeInfo& r) {
+            return -static_cast<double>(r.Stats.GarbageBlocksCount);
+        };
+
         // TODO efficient implementation for any c
         if (c == 1) {
-            const auto* group = GetTopGarbageScore();
-            if (group) {
-                ui32 index = 0;
-                TCompactionStats best = group->Stats[0];
-                for (ui32 i = 1; i < GroupSize; ++i) {
-                    auto stats = group->Stats[i];
-                    if (stats.GarbageBlocksCount > best.GarbageBlocksCount) {
-                        index = i;
-                        best = stats;
-                    }
-                }
-
-                return {{group->GroupIndex + index, best}};
-            }
-
-            return {};
+            return {GetTopRange(getScore, true)};
         }
 
-        return GetTopRanges(c, [] (const TCompactionRangeInfo& r) {
-            return -static_cast<double>(r.Stats.GarbageBlocksCount);
-        });
+        return GetTopRanges(c, getScore, true);
     }
 
 private:
@@ -543,9 +557,15 @@ void TCompactionMap::Update(
     ui32 rangeId,
     ui32 blobsCount,
     ui32 deletionsCount,
-    ui32 garbageBlocksCount)
+    ui32 garbageBlocksCount,
+    bool compacted)
 {
-    Impl->UpdateGroup(rangeId, blobsCount, deletionsCount, garbageBlocksCount);
+    Impl->UpdateGroup(
+        rangeId,
+        blobsCount,
+        deletionsCount,
+        garbageBlocksCount,
+        compacted);
 }
 
 void TCompactionMap::Update(

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.cpp
@@ -451,10 +451,10 @@ struct TCompactionMap::TImpl
     }
 
     TCompactionRangeInfo GetTopRange(
+        const TGroup* group,
         const TGetScore& getScore,
         bool skipCompactedRanges) const
     {
-        const auto* group = GetTopCompactionScore();
         if (group) {
             TCompactionRangeInfo best;
             for (ui32 i = 0; i < GroupSize; ++i) {
@@ -465,7 +465,7 @@ struct TCompactionMap::TImpl
                 TCompactionRangeInfo info{
                     group->GroupIndex + i,
                     group->Stats[i]};
-                if (getScore(info) > getScore(best)) {
+                if (getScore(info) < getScore(best)) {
                     best = info;
                 }
             }
@@ -484,7 +484,8 @@ struct TCompactionMap::TImpl
 
         // TODO efficient implementation for any c
         if (c == 1) {
-            return {GetTopRange(getScore, true)};
+            const auto* group = GetTopCompactionScore();
+            return {GetTopRange(group, getScore, true)};
         }
 
         return GetTopRanges(c, getScore, true);
@@ -498,7 +499,8 @@ struct TCompactionMap::TImpl
 
         // TODO efficient implementation for any c
         if (c == 1) {
-            return {GetTopRange(getScore, false)};
+            const auto* group = GetTopCleanupScore();
+            return {GetTopRange(group, getScore, false)};
         }
 
         return GetTopRanges(c, getScore, false);
@@ -512,7 +514,8 @@ struct TCompactionMap::TImpl
 
         // TODO efficient implementation for any c
         if (c == 1) {
-            return {GetTopRange(getScore, true)};
+            const auto* group = GetTopGarbageScore();
+            return {GetTopRange(group, getScore, true)};
         }
 
         return GetTopRanges(c, getScore, true);

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.h
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.h
@@ -62,7 +62,8 @@ public:
         ui32 rangeId,
         ui32 blobsCount,
         ui32 deletionsCount,
-        ui32 garbageBlocksCount);
+        ui32 garbageBlocksCount,
+        bool compacted);
     void Update(const TVector<TCompactionRangeInfo>& ranges);
 
     TCompactionStats Get(ui32 rangeId) const;

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
@@ -12,10 +12,10 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100, 1000);
-        compactionMap.Update(1, 11, 101, 2000);
-        compactionMap.Update(10000, 20, 200, 100);
-        compactionMap.Update(20000, 5, 50, 300);
+        compactionMap.Update(0, 10, 100, 1000, false);
+        compactionMap.Update(1, 11, 101, 2000, false);
+        compactionMap.Update(10000, 20, 200, 100, false);
+        compactionMap.Update(20000, 5, 50, 300, false);
 
         auto stats = compactionMap.Get(0);
         UNIT_ASSERT_VALUES_EQUAL(10, stats.BlobsCount);
@@ -47,34 +47,34 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100, 1000);
-        compactionMap.Update(1, 11, 101, 2000);
-        compactionMap.Update(10000, 20, 200, 100);
-        compactionMap.Update(20000, 5, 50, 300);
+        compactionMap.Update(0, 10, 100, 1000, false);
+        compactionMap.Update(1, 11, 101, 2000, false);
+        compactionMap.Update(10000, 20, 200, 100, false);
+        compactionMap.Update(20000, 5, 50, 300, false);
 
         auto counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 20);
 
-        compactionMap.Update(10000, 1, 200, 100);
+        compactionMap.Update(10000, 1, 200, 100, false);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 11);
 
-        compactionMap.Update(1, 1, 101, 2000);
+        compactionMap.Update(1, 1, 101, 2000, false);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 0);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 10);
 
-        compactionMap.Update(0, 1, 100, 1000);
+        compactionMap.Update(0, 1, 100, 1000, false);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 20000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 5);
 
-        compactionMap.Update(20000, 1, 50, 300);
+        compactionMap.Update(20000, 1, 50, 300, false);
 
         counter = compactionMap.GetTopCompactionScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 1);
@@ -84,34 +84,34 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100, 1000);
-        compactionMap.Update(1, 11, 101, 2000);
-        compactionMap.Update(10000, 20, 200, 100);
-        compactionMap.Update(20000, 5, 50, 300);
+        compactionMap.Update(0, 10, 100, 1000, false);
+        compactionMap.Update(1, 11, 101, 2000, false);
+        compactionMap.Update(10000, 20, 200, 100, false);
+        compactionMap.Update(20000, 5, 50, 300, false);
 
         auto counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 200);
 
-        compactionMap.Update(10000, 20, 0, 100);
+        compactionMap.Update(10000, 20, 0, 100, false);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 101);
 
-        compactionMap.Update(1, 11, 0, 2000);
+        compactionMap.Update(1, 11, 0, 2000, false);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 0);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 100);
 
-        compactionMap.Update(0, 10, 0, 1000);
+        compactionMap.Update(0, 10, 0, 1000, false);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 20000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 50);
 
-        compactionMap.Update(20000, 5, 0, 300);
+        compactionMap.Update(20000, 5, 0, 300, false);
 
         counter = compactionMap.GetTopCleanupScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 0);
@@ -121,40 +121,40 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 100, 1000);
-        compactionMap.Update(1, 11, 101, 2000);
-        compactionMap.Update(10000, 20, 200, 100);
-        compactionMap.Update(20000, 5, 50, 300);
+        compactionMap.Update(0, 10, 100, 1000, false);
+        compactionMap.Update(1, 11, 101, 2000, false);
+        compactionMap.Update(10000, 20, 200, 100, false);
+        compactionMap.Update(20000, 5, 50, 300, false);
 
         auto counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 2000);
 
-        compactionMap.Update(1, 11, 101, 500);
+        compactionMap.Update(1, 11, 101, 500, false);
 
         counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 0);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 1000);
 
-        compactionMap.Update(0, 10, 100, 0);
+        compactionMap.Update(0, 10, 100, 0, false);
 
         counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 500);
 
-        compactionMap.Update(1, 11, 101, 0);
+        compactionMap.Update(1, 11, 101, 0, false);
 
         counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 20000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 300);
 
-        compactionMap.Update(20000, 5, 50, 0);
+        compactionMap.Update(20000, 5, 50, 0, false);
 
         counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 100);
 
-        compactionMap.Update(10000, 20, 200, 0);
+        compactionMap.Update(10000, 20, 200, 0, false);
 
         counter = compactionMap.GetTopGarbageScore();
         UNIT_ASSERT_VALUES_EQUAL(counter.Score, 0);
@@ -164,10 +164,10 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 10, 444, 1000);
-        compactionMap.Update(1, 11, 222, 2000);
-        compactionMap.Update(10000, 20, 111, 200);
-        compactionMap.Update(20000, 5, 333, 300);
+        compactionMap.Update(0, 10, 444, 1000, false);
+        compactionMap.Update(1, 11, 222, 2000, false);
+        compactionMap.Update(10000, 20, 111, 200, false);
+        compactionMap.Update(20000, 5, 333, 300, false);
 
         auto topRanges = compactionMap.GetTopRangesByCompactionScore(3);
         UNIT_ASSERT_VALUES_EQUAL(3, topRanges.size());
@@ -215,17 +215,108 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         UNIT_ASSERT_VALUES_EQUAL(300, topRanges[2].Stats.GarbageBlocksCount);
     }
 
+    Y_UNIT_TEST(ShouldPessimizeCompactedRanges)
+    {
+        TCompactionMap compactionMap(TDefaultAllocator::Instance());
+
+        compactionMap.Update(0, 10, 100, 1000, false);
+        compactionMap.Update(1, 20, 200, 2000, false);
+        compactionMap.Update(10000, 30, 300, 3000, false);
+        compactionMap.Update(10001, 40, 400, 4000, false);
+
+        auto counter = compactionMap.GetTopCompactionScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10001);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 40);
+
+        counter = compactionMap.GetTopCleanupScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10001);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 400);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10001);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 4000);
+
+        auto topRanges = compactionMap.GetTopRangesByCompactionScore(3);
+        UNIT_ASSERT_VALUES_EQUAL(3, topRanges.size());
+        UNIT_ASSERT_VALUES_EQUAL(10001, topRanges[0].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(40, topRanges[0].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(400, topRanges[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(4000, topRanges[0].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(10000, topRanges[1].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(30, topRanges[1].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(300, topRanges[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(3000, topRanges[1].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, topRanges[2].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(20, topRanges[2].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(200, topRanges[2].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, topRanges[2].Stats.GarbageBlocksCount);
+
+        compactionMap.Update(10001, 40, 400, 4000, true);
+
+        counter = compactionMap.GetTopCompactionScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 30);
+
+        counter = compactionMap.GetTopCleanupScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10001);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 400);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10000);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 3000);
+
+        topRanges = compactionMap.GetTopRangesByCompactionScore(3);
+        UNIT_ASSERT_VALUES_EQUAL(3, topRanges.size());
+        UNIT_ASSERT_VALUES_EQUAL(10000, topRanges[0].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(30, topRanges[0].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(300, topRanges[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(3000, topRanges[0].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, topRanges[1].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(20, topRanges[1].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(200, topRanges[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, topRanges[1].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, topRanges[2].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(10, topRanges[2].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(100, topRanges[2].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(1000, topRanges[2].Stats.GarbageBlocksCount);
+
+        compactionMap.Update(10000, 30, 300, 3000, true);
+
+        counter = compactionMap.GetTopCompactionScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 20);
+
+        counter = compactionMap.GetTopCleanupScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 10001);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 400);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(counter.RangeId, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counter.Score, 2000);
+
+        topRanges = compactionMap.GetTopRangesByCompactionScore(3);
+        UNIT_ASSERT_VALUES_EQUAL(2, topRanges.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, topRanges[0].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(20, topRanges[0].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(200, topRanges[0].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(2000, topRanges[0].Stats.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, topRanges[1].RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(10, topRanges[1].Stats.BlobsCount);
+        UNIT_ASSERT_VALUES_EQUAL(100, topRanges[1].Stats.DeletionsCount);
+        UNIT_ASSERT_VALUES_EQUAL(1000, topRanges[1].Stats.GarbageBlocksCount);
+    }
+
     Y_UNIT_TEST(ShouldReturnNonEmptyRanges)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(0, 15, 100, 1000);
-        compactionMap.Update(1, 14, 101, 2000);
-        compactionMap.Update(3, 13, 101, 300);
-        compactionMap.Update(256, 40, 101, 200);
-        compactionMap.Update(10000, 45, 200, 3000);
-        compactionMap.Update(20000, 50, 50, 500);
-        compactionMap.Update(Max<ui32>(), 100, 50, 400);
+        compactionMap.Update(0, 15, 100, 1000, false);
+        compactionMap.Update(1, 14, 101, 2000, false);
+        compactionMap.Update(3, 13, 101, 300, false);
+        compactionMap.Update(256, 40, 101, 200, false);
+        compactionMap.Update(10000, 45, 200, 3000, false);
+        compactionMap.Update(20000, 50, 50, 500, false);
+        compactionMap.Update(Max<ui32>(), 100, 50, 400, false);
 
         auto ranges = compactionMap.GetNonEmptyCompactionRanges();
 
@@ -244,52 +335,52 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         const auto group = TCompactionMap::GroupSize;
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(100, 0, 0, 0);
+        compactionMap.Update(100, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 100, 100, 100);
+        compactionMap.Update(100, 100, 100, 100, false);
         UNIT_ASSERT_VALUES_EQUAL(
             1 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 0, 100, 0);
+        compactionMap.Update(100, 0, 100, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             1 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 100, 0, 0);
+        compactionMap.Update(100, 100, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             1 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(101, 0, 0, 0);
+        compactionMap.Update(101, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             1 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 10, 0, 0);
+        compactionMap.Update(1000, 10, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             2 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(100, 0, 0, 0);
+        compactionMap.Update(100, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             1 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 0, 0, 0);
+        compactionMap.Update(1000, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 0, 0, 0);
+        compactionMap.Update(1000, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             compactionMap.GetStats(1).AllocatedRangesCount);
 
-        compactionMap.Update(1000, 0, 0, 100);
+        compactionMap.Update(1000, 0, 0, 100, false);
         UNIT_ASSERT_VALUES_EQUAL(
             1 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
@@ -306,12 +397,12 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         UNIT_ASSERT_VALUES_EQUAL(0, compactionMap.GetStats(1).UsedRangesCount);
 
         for (ui32 i = 1; i <= TCompactionMap::GroupSize; ++i) {
-            compactionMap.Update(i - 1, 0, 0, 0);
+            compactionMap.Update(i - 1, 0, 0, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 i - 1,
                 compactionMap.GetStats(1).UsedRangesCount);
 
-            compactionMap.Update(i - 1, 100, 0, 0);
+            compactionMap.Update(i - 1, 100, 0, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 1 * group,
                 compactionMap.GetStats(1).AllocatedRangesCount);
@@ -319,7 +410,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 i,
                 compactionMap.GetStats(1).UsedRangesCount);
 
-            compactionMap.Update(i - 1, 0, 100, 0);
+            compactionMap.Update(i - 1, 0, 100, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 1 * group,
                 compactionMap.GetStats(1).AllocatedRangesCount);
@@ -327,7 +418,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 i,
                 compactionMap.GetStats(1).UsedRangesCount);
 
-            compactionMap.Update(i - 1, 100, 100, 0);
+            compactionMap.Update(i - 1, 100, 100, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 1 * group,
                 compactionMap.GetStats(1).AllocatedRangesCount);
@@ -336,7 +427,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 compactionMap.GetStats(1).UsedRangesCount);
         }
 
-        compactionMap.Update(1000000, 100, 100, 100);
+        compactionMap.Update(1000000, 100, 100, 100, false);
         UNIT_ASSERT_VALUES_EQUAL(
             2 * group,
             compactionMap.GetStats(1).AllocatedRangesCount);
@@ -345,7 +436,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             compactionMap.GetStats(1).UsedRangesCount);
 
         for (ui32 i = TCompactionMap::GroupSize; i > 0; --i) {
-            compactionMap.Update(i - 1, 100, 0, 0);
+            compactionMap.Update(i - 1, 100, 0, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 i + 1,
                 compactionMap.GetStats(1).UsedRangesCount);
@@ -353,7 +444,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 2 * group,
                 compactionMap.GetStats(1).AllocatedRangesCount);
 
-            compactionMap.Update(i - 1, 0, 100, 0);
+            compactionMap.Update(i - 1, 0, 100, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 i + 1,
                 compactionMap.GetStats(1).UsedRangesCount);
@@ -361,7 +452,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 2 * group,
                 compactionMap.GetStats(1).AllocatedRangesCount);
 
-            compactionMap.Update(i - 1, 0, 0, 0);
+            compactionMap.Update(i - 1, 0, 0, 0, false);
             UNIT_ASSERT_VALUES_EQUAL(
                 i,
                 compactionMap.GetStats(1).UsedRangesCount);
@@ -372,7 +463,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 compactionMap.GetStats(1).AllocatedRangesCount);
         }
 
-        compactionMap.Update(1000000, 0, 0, 0);
+        compactionMap.Update(1000000, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             compactionMap.GetStats(1).AllocatedRangesCount);
@@ -389,7 +480,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             UNIT_ASSERT_VALUES_EQUAL(stats.TopRangesByCompactionScore.size(), 0);
         }
 
-        compactionMap.Update(1, 10, 20, 30);
+        compactionMap.Update(1, 10, 20, 30, false);
 
         {
             auto stats = compactionMap.GetStats(2);
@@ -420,13 +511,13 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
                 stats.TopRangesByCompactionScore[0].Stats.DeletionsCount);
         }
 
-        compactionMap.Update(0, 1000, 444, 1000);
-        compactionMap.Update(300, 40, 522, 300);
-        compactionMap.Update(400, 50, 22, 2000);
-        compactionMap.Update(10000, 20, 211, 5000);
-        compactionMap.Update(20000, 100500, 4, 7000);
-        compactionMap.Update(70000, 500, 100, 0);
-        compactionMap.Update(200000, 100, 400, 30);
+        compactionMap.Update(0, 1000, 444, 1000, false);
+        compactionMap.Update(300, 40, 522, 300, false);
+        compactionMap.Update(400, 50, 22, 2000, false);
+        compactionMap.Update(10000, 20, 211, 5000, false);
+        compactionMap.Update(20000, 100500, 4, 7000, false);
+        compactionMap.Update(70000, 500, 100, 0, false);
+        compactionMap.Update(200000, 100, 400, 30, false);
 
         {
             auto stats = compactionMap.GetStats(2);
@@ -510,10 +601,10 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap compactionMap(TDefaultAllocator::Instance());
 
-        compactionMap.Update(1, 10, 20, 100);
-        compactionMap.Update(2, 5, 40, 200);
-        compactionMap.Update(2, 15, 50, 90);
-        compactionMap.Update(100, 7, 100, 3000);
+        compactionMap.Update(1, 10, 20, 100, false);
+        compactionMap.Update(2, 5, 40, 200, false);
+        compactionMap.Update(2, 15, 50, 90, false);
+        compactionMap.Update(100, 7, 100, 3000, false);
 
         auto stats = compactionMap.GetStats(1);
         UNIT_ASSERT_VALUES_EQUAL(32, stats.TotalBlobsCount);
@@ -556,7 +647,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             }
         }
 
-        compactionMap.Update(1, 10000, 20000, 30000);
+        compactionMap.Update(1, 10000, 20000, 30000, false);
         auto stats = compactionMap.GetStats(2);
         UNIT_ASSERT_VALUES_EQUAL(
             totalBlobsCount + 10000,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -24,7 +24,13 @@ private:
     const TString LogTag;
     TIndexTabletActor& Tablet;
     const ui32 CompactionThreshold;
-    THashMap<ui32, TCompactionStats> RangeId2CompactionStats;
+
+    struct TCompactionRangeInfo
+    {
+        TCompactionStats Stats;
+        bool Compacted = false;
+    };
+    THashMap<ui32, TCompactionRangeInfo> RangeId2CompactionStats;
 
 public:
     TAddBlobsExecutor(
@@ -146,9 +152,9 @@ private:
                 block.NodeId,
                 block.BlockIndex,
                 blob.BlocksCount);
-            AccessCompactionStats(rangeId).BlobsCount += 1;
+            AccessCompactionRangeInfo(rangeId).Stats.BlobsCount += 1;
             // conservative estimate
-            AccessCompactionStats(rangeId).GarbageBlocksCount +=
+            AccessCompactionRangeInfo(rangeId).Stats.GarbageBlocksCount +=
                 blob.BlocksCount;
         }
 
@@ -223,9 +229,9 @@ private:
             bool written = Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks);
             if (written) {
                 ui32 rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-                AccessCompactionStats(rangeId).BlobsCount += 1;
+                AccessCompactionRangeInfo(rangeId).Stats.BlobsCount += 1;
                 // conservative estimate
-                AccessCompactionStats(rangeId).GarbageBlocksCount +=
+                AccessCompactionRangeInfo(rangeId).Stats.GarbageBlocksCount +=
                     blob.Blocks.size();
             }
         }
@@ -260,7 +266,7 @@ private:
             Tablet.DeleteFreshBlocks(db, blob.Blocks);
 
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionStats(rangeId);
+            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
             if (Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks)) {
                 stats.BlobsCount += 1;
                 // conservative estimate
@@ -278,7 +284,7 @@ private:
 
         for (auto& blob: args.SrcBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionStats(rangeId);
+            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
             if (!Tablet.UpdateBlockLists(db, blob)) {
                 stats.BlobsCount = Max(stats.BlobsCount, 1U) - 1;
                 // no proper way to reliably decrement stats.GarbageBlocksCount
@@ -299,7 +305,7 @@ private:
 
         for (auto& blob: args.MixedBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionStats(rangeId);
+            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
             if (Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks)) {
                 stats.BlobsCount += 1;
                 // conservative estimate
@@ -319,12 +325,19 @@ private:
 
         for (const auto& blob: args.SrcBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionStats(rangeId);
+            auto& rangeInfo = AccessCompactionRangeInfo(rangeId);
             // Decrementing compaction counter for the overwritten blobs.
             // The counter is not guaranteed to be perfectly in sync with the
             // actual blob count in range so a check for moving below zero is
             // needed.
-            stats.BlobsCount = Max(1U, stats.BlobsCount) - 1;
+            rangeInfo.Stats.BlobsCount =
+                Max(1U, rangeInfo.Stats.BlobsCount) - 1;
+            if (rangeInfo.Stats.BlobsCount == 0) {
+                // this range will be fully compacted after this Compaction
+                // iteration
+                rangeInfo.Compacted = true;
+            }
+
             Tablet.DeleteMixedBlocks(db, blob.BlobId, blob.Blocks);
 
             rangeIds.insert(rangeId);
@@ -343,7 +356,7 @@ private:
         }
 
         for (const auto& [rangeId, addedBlobsCount]: rangeId2AddedBlobsCount) {
-            auto& stats = AccessCompactionStats(rangeId);
+            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
 
             // If addedBlobsCount >= compactionThreshold, then Compaction will
             // enter an infinite loop
@@ -357,7 +370,7 @@ private:
 
         // recalculating GarbageBlocksCount for each of the affected ranges
         for (const auto rangeId: rangeIds) {
-            AccessCompactionStats(rangeId).GarbageBlocksCount =
+            AccessCompactionRangeInfo(rangeId).Stats.GarbageBlocksCount =
                 Tablet.CalculateMixedIndexRangeGarbageBlockCount(rangeId);
         }
     }
@@ -369,21 +382,22 @@ private:
         for (const auto& x: RangeId2CompactionStats) {
             db.WriteCompactionMap(
                 x.first,
-                x.second.BlobsCount,
-                x.second.DeletionsCount,
-                x.second.GarbageBlocksCount);
+                x.second.Stats.BlobsCount,
+                x.second.Stats.DeletionsCount,
+                x.second.Stats.GarbageBlocksCount);
             Tablet.UpdateCompactionMap(
                 x.first,
-                x.second.BlobsCount,
-                x.second.DeletionsCount,
-                x.second.GarbageBlocksCount);
+                x.second.Stats.BlobsCount,
+                x.second.Stats.DeletionsCount,
+                x.second.Stats.GarbageBlocksCount,
+                x.second.Compacted);
 
             AddCompactionRange(
                 args.CommitId,
                 x.first,
-                x.second.BlobsCount,
-                x.second.DeletionsCount,
-                x.second.GarbageBlocksCount,
+                x.second.Stats.BlobsCount,
+                x.second.Stats.DeletionsCount,
+                x.second.Stats.GarbageBlocksCount,
                 args.ProfileLogRequest);
         }
     }
@@ -411,22 +425,24 @@ private:
         }
     }
 
-    TCompactionStats& AccessCompactionStats(ui32 rangeId)
+    TCompactionRangeInfo& AccessCompactionRangeInfo(ui32 rangeId)
     {
-        THashMap<ui32, TCompactionStats>::insert_ctx ctx;
+        THashMap<ui32, TCompactionRangeInfo>::insert_ctx ctx;
         auto it = RangeId2CompactionStats.find(rangeId, ctx);
         if (it == RangeId2CompactionStats.end()) {
             it = RangeId2CompactionStats.emplace_direct(
                 ctx,
                 rangeId,
-                Tablet.GetCompactionStats(rangeId));
+                TCompactionRangeInfo{
+                    Tablet.GetCompactionStats(rangeId),
+                    false});
         }
 
         return it->second;
     }
 };
 
-}
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -548,7 +548,7 @@ void TIndexTabletActor::ExecuteTx_Compaction(
 
     if (!args.CompactionBlobs) {
         TIndexTabletDatabase db(tx.DB);
-        UpdateCompactionMap(args.RangeId, 0, 0, 0);
+        UpdateCompactionMap(args.RangeId, 0, 0, 0, true);
         db.WriteCompactionMap(args.RangeId, 0, 0, 0);
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1123,7 +1123,8 @@ public:
         ui32 rangeId,
         ui32 blobsCount,
         ui32 deletionsCount,
-        ui32 garbageBlocksCount);
+        ui32 garbageBlocksCount,
+        bool compacted);
 
     TCompactionStats GetCompactionStats(ui32 rangeId) const;
     TCompactionCounter GetRangeToCompact() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -853,7 +853,8 @@ void TIndexTabletState::MarkMixedBlocksDeleted(
         rangeId,
         stats.BlobsCount,
         stats.DeletionsCount + blocksCount,
-        stats.GarbageBlocksCount);
+        stats.GarbageBlocksCount,
+        false /* compacted */);
 
     InvalidateReadAheadCache(nodeId);
 }
@@ -967,7 +968,8 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
         rangeId,
         stats.BlobsCount,
         stats.DeletionsCount,
-        stats.GarbageBlocksCount);
+        stats.GarbageBlocksCount,
+        false /* compacted */);
 
     AddCompactionRange(
         GetCurrentCommitId(),
@@ -1216,13 +1218,15 @@ void TIndexTabletState::UpdateCompactionMap(
     ui32 rangeId,
     ui32 blobsCount,
     ui32 deletionsCount,
-    ui32 garbageBlocksCount)
+    ui32 garbageBlocksCount,
+    bool compacted)
 {
     Impl->CompactionMap.Update(
         rangeId,
         blobsCount,
         deletionsCount,
-        garbageBlocksCount);
+        garbageBlocksCount,
+        compacted);
 }
 
 TCompactionStats TIndexTabletState::GetCompactionStats(ui32 rangeId) const

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1682,16 +1682,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(
                 256,
                 stats.GetAllocatedCompactionRanges());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.CompactionRangeStatsSize());
+            // only 1 range is returned since other 2 are marked with the
+            // 'compacted' flag and thus skipped during top ranges gathering
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.CompactionRangeStatsSize());
             UNIT_ASSERT_VALUES_EQUAL(
                 "r=1177944065 b=53 d=180 g=52",
                 CompactionRangeToString(stats.GetCompactionRangeStats(0)));
-            UNIT_ASSERT_VALUES_EQUAL(
-                "r=1177944064 b=1 d=193 g=0",
-                CompactionRangeToString(stats.GetCompactionRangeStats(1)));
-            UNIT_ASSERT_VALUES_EQUAL(
-                "r=1177944066 b=1 d=64 g=0",
-                CompactionRangeToString(stats.GetCompactionRangeStats(2)));
         }
 
         TString expected(1_MB, 0);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -450,7 +450,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         // Compactions should've happened automatically
 
         {
-            auto response = tablet.GetStorageStats(1);
+            auto response = tablet.GetStorageStats(0, 1);
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 expectedBlockCount,
@@ -462,6 +462,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
             UNIT_ASSERT_VALUES_EQUAL(
                 256,
                 stats.GetAllocatedCompactionRanges());
+            // CompactionRangeStatsSize is 0 since all ranges are marked with
+            // the 'compacted' flag and thus not returned
             UNIT_ASSERT_VALUES_EQUAL(1, stats.CompactionRangeStatsSize());
             UNIT_ASSERT_VALUES_EQUAL(
                 Sprintf(

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -211,10 +211,15 @@ public:
         return std::make_unique<TEvIndexTablet::TEvWaitReadyRequest>();
     }
 
-    auto CreateGetStorageStatsRequest(ui32 compactionRangeCount = 0)
+    auto CreateGetStorageStatsRequest(
+        ui32 compactionRangeCount = 0,
+        ui32 compactionRangeCountByCleanupScore = 0)
     {
         auto request = std::make_unique<TEvIndexTablet::TEvGetStorageStatsRequest>();
-        request->Record.SetCompactionRangeCountByCompactionScore(compactionRangeCount);
+        request->Record.SetCompactionRangeCountByCompactionScore(
+            compactionRangeCount);
+        request->Record.SetCompactionRangeCountByCleanupScore(
+            compactionRangeCountByCleanupScore);
         return request;
     }
 


### PR DESCRIPTION
#2137 