### PR TITLE
Users/yegorskii/fix location during legacy registration

### DIFF
--- a/cloud/blockstore/tests/registration/test.py
+++ b/cloud/blockstore/tests/registration/test.py
@@ -71,7 +71,6 @@ def setup_cms_configs(ydb_client):
     update_cms_config(ydb_client, 'StorageServiceConfig', storage, '')
 
 
-<<<<<<< HEAD
 def prepare(
         ydb,
         kikimr_ssl,
@@ -80,9 +79,6 @@ def prepare(
         ic_port=None,
         use_location=True,
         location=None):
-=======
-def prepare(ydb, kikimr_ssl, blockstore_ssl, node_type, ic_port=None, use_location=True, location=None):
->>>>>>> registration tests should use proper nbs-location.txt
     nbs_configurator = NbsConfigurator(
         ydb,
         ssl_registration=blockstore_ssl,
@@ -219,11 +215,11 @@ def test_da_registration(kikimr_ssl, blockstore_ssl, result):
 
 
 def test_server_registration_migration():
-    setup_and_run_registration_migration_server(False)
+    setup_and_run_registration_migration_server(True)
 
 
 def test_hw_server_registration_migration():
-    setup_and_run_registration_migration_server(True)
+    setup_and_run_registration_migration_server(False)
 
 
 def test_da_registration_migration():

--- a/cloud/blockstore/tests/registration/test.py
+++ b/cloud/blockstore/tests/registration/test.py
@@ -5,7 +5,7 @@ from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
 
 from cloud.blockstore.tests.python.lib.config import NbsConfigurator, generate_disk_agent_txt
 from cloud.blockstore.tests.python.lib.client import NbsClient
-from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, start_disk_agent
+from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, start_disk_agent, restart_ydb
 
 from contrib.ydb.core.protos import msgbus_pb2 as msgbus
 from contrib.ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
@@ -130,7 +130,7 @@ def setup_and_run_test_for_da(kikimr_ssl, blockstore_ssl):
     return True
 
 
-def setup_and_run_registration_migration_server(use_location=False):
+def setup_and_run_registration_migration_server(use_location=True):
     ydb = start_ydb(grpc_ssl_enable=True)
     setup_cms_configs(ydb.client)
 
@@ -152,6 +152,7 @@ def setup_and_run_registration_migration_server(use_location=False):
             use_location=use_location,
             location=location)
         nbs = start_nbs(configurator)
+
         if ic_port is not None:
             assert configurator.ic_port == ic_port
         else:
@@ -215,11 +216,11 @@ def test_da_registration(kikimr_ssl, blockstore_ssl, result):
 
 
 def test_server_registration_migration():
-    setup_and_run_registration_migration_server(True)
+    setup_and_run_registration_migration_server(False)
 
 
 def test_hw_server_registration_migration():
-    setup_and_run_registration_migration_server(False)
+    setup_and_run_registration_migration_server(True)
 
 
 def test_da_registration_migration():

--- a/cloud/blockstore/tests/registration/test.py
+++ b/cloud/blockstore/tests/registration/test.py
@@ -71,6 +71,7 @@ def setup_cms_configs(ydb_client):
     update_cms_config(ydb_client, 'StorageServiceConfig', storage, '')
 
 
+<<<<<<< HEAD
 def prepare(
         ydb,
         kikimr_ssl,
@@ -79,6 +80,9 @@ def prepare(
         ic_port=None,
         use_location=True,
         location=None):
+=======
+def prepare(ydb, kikimr_ssl, blockstore_ssl, node_type, ic_port=None, use_location=True, location=None):
+>>>>>>> registration tests should use proper nbs-location.txt
     nbs_configurator = NbsConfigurator(
         ydb,
         ssl_registration=blockstore_ssl,
@@ -215,11 +219,11 @@ def test_da_registration(kikimr_ssl, blockstore_ssl, result):
 
 
 def test_server_registration_migration():
-    setup_and_run_registration_migration_server(True)
+    setup_and_run_registration_migration_server(False)
 
 
 def test_hw_server_registration_migration():
-    setup_and_run_registration_migration_server(False)
+    setup_and_run_registration_migration_server(True)
 
 
 def test_da_registration_migration():

--- a/cloud/blockstore/tests/registration/test.py
+++ b/cloud/blockstore/tests/registration/test.py
@@ -5,7 +5,7 @@ from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
 
 from cloud.blockstore.tests.python.lib.config import NbsConfigurator, generate_disk_agent_txt
 from cloud.blockstore.tests.python.lib.client import NbsClient
-from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, start_disk_agent, restart_ydb
+from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, start_disk_agent
 
 from contrib.ydb.core.protos import msgbus_pb2 as msgbus
 from contrib.ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds


### PR DESCRIPTION
#1445
Кажется проблема в том что код регистрации был переделан на
```
Location(Options.DataCenter, {}, Options.Rack, ToString(Options.Body))
```
Это отличается от того что было раньше 
```
        NActorsInterconnect::TNodeLocation proto;
        proto.SetDataCenter(options.DataCenter);
        proto.SetRack(options.Rack);
        proto.SetUnit(ToString(options.Body));
        Location = TNodeLocation(proto);
```
В первом случае в location попадают только не пустые поля, во втором все поля, даже если они пустые.