### PR TITLE
catch TSystemError in SafeExecute

### DIFF
--- a/cloud/blockstore/libs/nbd/server_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_ut.cpp
@@ -690,7 +690,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         bootstrap1->Stop();
     }
 
-    Y_UNIT_TEST(ShouldGetFatalErrorIfEndpointHasInvalidSocketPath)
+    Y_UNIT_TEST(ShouldGetSystemErrorIfEndpointHasInvalidSocketPath)
     {
         TUnixSocketPath socketPath("./invalid/path/to/socket");
         TNetworkAddress connectAddress(socketPath);
@@ -700,12 +700,16 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto error = bootstrap->Start();
         UNIT_ASSERT_VALUES_EQUAL_C(
-            EDiagnosticsErrorKind::ErrorFatal,
+            EDiagnosticsErrorKind::ErrorRetriable,
             GetDiagnosticsErrorKind(error),
             error);
         UNIT_ASSERT_VALUES_EQUAL_C(
-            EErrorKind::ErrorFatal,
+            EErrorKind::ErrorRetriable,
             GetErrorKind(error),
+            error);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            FACILITY_SYSTEM,
+            FACILITY_FROM_CODE(error.GetCode()),
             error);
 
         bootstrap->Stop();

--- a/cloud/storage/core/libs/common/error.h
+++ b/cloud/storage/core/libs/common/error.h
@@ -435,7 +435,7 @@ TResponse SafeExecute(T&& block)
         return block();
     } catch (const TServiceError& e) {
         return TErrorResponse(e);
-    } catch (const TIoSystemError& e) {
+    } catch (const TSystemError& e) {
         return TErrorResponse(MAKE_SYSTEM_ERROR(e.Status()), e.what());
     } catch (...) {
         return TErrorResponse(E_FAIL, CurrentExceptionMessage());


### PR DESCRIPTION
Problem:
Start endpoint returns E_FAIL if bind socket fails with "Directory not found" error

Expected behavior:
Meaningful error code. e.g. we can return system error code

Solution:
bind throws TSystemError: [nbs/library/cpp/coroutine/listener/listen.cpp at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/library/cpp/coroutine/listener/listen.cpp#L83) 
nbd server calls bind  inside of SafeExecute: [nbs/cloud/blockstore/libs/nbd/server.cpp at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/nbd/server.cpp#L315) 
SafeExecute converts system error to E_FAIL: [nbs/cloud/storage/core/libs/common/error.h at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/cloud/storage/core/libs/common/error.h#L441) 

We can throw TIoSystemError in bind or handle TSystemError in SafeExecute but in both cases the error type would be Retriable  instead of Fatal