### PR TITLE
Add PURGE_HOST cms action

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1049,5 +1049,8 @@ message TStorageServiceConfig
 
     // Whether the disk registry is allowed to allocate local disks while agent
     // is in warning state.
+    // When enabled, the Disk Registry REMOVE_HOST CMS action will not "forget"
+    // agents devices and will not suspend local devices. Instead, PURGE_HOST
+    // should be used for these purposes.
     optional bool DiskRegistryAlwaysAllocatesLocalDisks = 388;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1013,7 +1013,7 @@ message TStorageServiceConfig
 
     // CMS actions such as "REMOVE_HOST" and "REMOVE_DEVICE" will attempt to
     // remove devices and the host from DR memory (including persistent storage).
-    optional bool CleanupDRConfigOnCMSActions = 375;
+    // optional bool CleanupDRConfigOnCMSActions = 375;  // obsolete
 
     // Resync range, if scrubbing found a mismatch.
     optional bool ResyncRangeAfterScrubbing = 376;
@@ -1046,4 +1046,8 @@ message TStorageServiceConfig
 
     // Timeout between disks reallocations.
     optional uint32 DiskRegistryDisksNotificationTimeout = 387;
+
+    // Whether the disk registry is allowed to allocate local disks while agent
+    // is in warning state.
+    optional bool DiskRegistryAlwaysAllocatesLocalDisks = 388;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -60,6 +60,8 @@ namespace NCloud::NBlockStore {
     xxx(BlockDigestMismatchInBlob)                                             \
     xxx(DiskRegistryResumeDeviceFailed)                                        \
     xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
+    xxx(DiskRegistryPurgeHostError)                                            \
+    xxx(DiskRegistryCleanupAgentConfigError)                                   \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -431,7 +431,7 @@ TDuration MSeconds(ui32 value)
     xxx(MaxLocalVolumes,                           ui32,      100             )\
                                                                                \
     xxx(DiskRegistryVolumeConfigUpdatePeriod,      TDuration, Minutes(5)      )\
-    xxx(CleanupDRConfigOnCMSActions,               bool,      false           )\
+    xxx(DiskRegistryAlwaysAllocatesLocalDisks,     bool,      false           )\
                                                                                \
     xxx(ReassignRequestRetryTimeout,               TDuration, Seconds(5)      )\
     xxx(ReassignChannelsPercentageThreshold,       ui32,      10              )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -461,7 +461,7 @@ public:
     ui32 GetMaxLocalVolumes() const;
 
     TDuration GetDiskRegistryVolumeConfigUpdatePeriod() const;
-    bool GetCleanupDRConfigOnCMSActions() const;
+    bool GetDiskRegistryAlwaysAllocatesLocalDisks() const;
     TDuration GetReassignRequestRetryTimeout() const;
     ui32 GetReassignChannelsPercentageThreshold() const;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_purge_host_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_purge_host_cms.cpp
@@ -1,0 +1,104 @@
+#include "disk_registry_actor.h"
+#include "disk_registry_database.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::HandlePurgeHostCms(
+    const TEvDiskRegistryPrivate::TEvPurgeHostCmsRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    BLOCKSTORE_DISK_REGISTRY_COUNTER(PurgeHostCms);
+
+    auto* msg = ev->Get();
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "[%lu] Received PurgeHostCms request: Host=%s",
+        TabletID(),
+        msg->Host.c_str());
+
+    ExecuteTx<TPurgeHostCms>(
+        ctx,
+        std::move(requestInfo),
+        std::move(msg->Host),
+        msg->DryRun);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TDiskRegistryActor::PreparePurgeHostCms(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxDiskRegistry::TPurgeHostCms& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TDiskRegistryActor::ExecutePurgeHostCms(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxDiskRegistry::TPurgeHostCms& args)
+{
+    TDiskRegistryDatabase db(tx.DB);
+    args.Error = State->PurgeHost(
+        db,
+        args.Host,
+        ctx.Now(),
+        args.DryRun,
+        args.AffectedDisks);
+}
+
+void TDiskRegistryActor::CompletePurgeHostCms(
+    const TActorContext& ctx,
+    TTxDiskRegistry::TPurgeHostCms& args)
+{
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "PurgeHostCms result: Host=%s Error=%s AffectedDisks=%s",
+        args.Host.c_str(),
+        FormatError(args.Error).c_str(),
+        [&]
+        {
+            TStringStream out;
+            out << "[";
+            for (const auto& diskId: args.AffectedDisks) {
+                out << " " << diskId << ":"
+                    << NProto::EDiskState_Name(State->GetDiskState(diskId));
+            }
+            out << " ]";
+            return out.Str();
+        }().c_str());
+
+    ReallocateDisks(ctx);
+    NotifyUsers(ctx);
+    PublishDiskStates(ctx);
+
+    SecureErase(ctx);
+    StartMigration(ctx);
+
+    auto response =
+        std::make_unique<TEvDiskRegistryPrivate::TEvPurgeHostCmsResponse>(
+            std::move(args.Error));
+    response->Timeout = TDuration();
+    response->DependentDiskIds = std::move(args.AffectedDisks);
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_purge_host_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_purge_host_cms.cpp
@@ -95,9 +95,10 @@ void TDiskRegistryActor::CompletePurgeHostCms(
 
     auto response =
         std::make_unique<TEvDiskRegistryPrivate::TEvPurgeHostCmsResponse>(
-            std::move(args.Error));
-    response->Timeout = TDuration();
-    response->DependentDiskIds = std::move(args.AffectedDisks);
+            std::move(args.Error),
+            TDuration(),   // Timeout
+            std::move(args.AffectedDisks));
+
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -300,54 +300,14 @@ void TDiskRegistryActor::CompleteCleanupDevices(
 void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
 {
     auto dirtyDevices = State->GetDirtyDevices();
-    EraseIf(dirtyDevices, [&] (auto& d) {
-        if (d.GetState() == NProto::DEVICE_STATE_ERROR) {
-            LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-                "[%lu] Skip SecureErase for device '%s'. Device in error state",
-                TabletID(),
-                d.GetDeviceUUID().c_str());
-
-            return true;
-        }
-
-        if (State->IsAutomaticallyReplaced(d.GetDeviceUUID())) {
-            LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-                "[%lu] Skip SecureErase for device '%s'."
-                " Device was automatically replaced recently.",
-                TabletID(),
-                d.GetDeviceUUID().c_str(),
-                d.GetNodeId());
-
-            return true;
-        }
-
-        auto* agent = State->FindAgent(d.GetNodeId());
-        if (!agent) {
-            LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-                "[%lu] Skip SecureErase for device '%s'."
-                " Agent for node id %d not found",
-                TabletID(),
-                d.GetDeviceUUID().c_str(),
-                d.GetNodeId());
-
-            return true;
-        }
-
-        if (agent->GetState() == NProto::AGENT_STATE_UNAVAILABLE) {
-            LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-                "[%lu] Skip SecureErase for device '%s'."
-                " Agent is unavailable",
-                TabletID(),
-                d.GetDeviceUUID().c_str());
-
-            return true;
-        }
-
-        return false;
-    });
+    EraseIf(
+        dirtyDevices,
+        [this](auto& device) { return !State->CanSecureErase(device); });
 
     if (!dirtyDevices) {
-        LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
             "[%lu] Nothing to erase",
             TabletID());
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
@@ -13,7 +13,7 @@ void TDiskRegistryActor::HandleUpdateCmsHostState(
     const TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    BLOCKSTORE_DISK_REGISTRY_COUNTER(UpdateCmsHostDeviceState);
+    BLOCKSTORE_DISK_REGISTRY_COUNTER(UpdateCmsHostState);
 
     auto* msg = ev->Get();
 
@@ -55,9 +55,6 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostState(
     TTransactionContext& tx,
     TTxDiskRegistry::TUpdateCmsHostState& args)
 {
-    Y_UNUSED(ctx);
-    Y_UNUSED(args);
-
     TDiskRegistryDatabase db(tx.DB);
 
     args.TxTs = ctx.Now();
@@ -94,7 +91,7 @@ void TDiskRegistryActor::CompleteUpdateCmsHostState(
                 out << " " << diskId
                     << ":" << NProto::EDiskState_Name(State->GetDiskState(diskId));
             }
-            out << "]";
+            out << " ]";
             return out.Str();
         }().c_str());
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -197,6 +197,7 @@ using TVolumeConfig = NKikimrBlockStore::TVolumeConfig;
     xxx(FinishVolumeConfigUpdate,                   __VA_ARGS__)               \
     xxx(RestoreDiskRegistryPart,                    __VA_ARGS__)               \
     xxx(SwitchAgentDisksToReadOnly,                 __VA_ARGS__)               \
+    xxx(PurgeHostCms,                               __VA_ARGS__)               \
 // BLOCKSTORE_DISK_REGISTRY_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -563,8 +564,26 @@ struct TEvDiskRegistryPrivate
         {}
     };
 
+    //
+    // PurgeHostCms
+    //
+
+    struct TPurgeHostCmsRequest
+    {
+        TString Host;
+        bool DryRun;
+
+        TPurgeHostCmsRequest(
+                TString host,
+                bool dryRun)
+            : Host(std::move(host))
+            , DryRun(dryRun)
+        {}
+    };
+
     using TUpdateCmsHostDeviceStateResponse = TCmsActionResponse;
     using TUpdateCmsHostStateResponse = TCmsActionResponse;
+    using TPurgeHostCmsResponse = TCmsActionResponse;
 
     //
     // StartMigration

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -604,6 +604,13 @@ public:
         TVector<TDiskId>& affectedDisks,
         TDuration& timeout);
 
+    NProto::TError PurgeHost(
+        TDiskRegistryDatabase& db,
+        const TString& agentId,
+        TInstant now,
+        bool dryRun,
+        TVector<TDiskId>& affectedDisks);
+
     TMaybe<NProto::EAgentState> GetAgentState(const TString& agentId) const;
     TMaybe<TInstant> GetAgentCmsTs(const TString& agentId) const;
 
@@ -701,6 +708,9 @@ public:
     }
 
     bool IsReadyForCleanup(const TDiskId& diskId) const;
+
+    bool CanSecureErase(const TDeviceId& uuid) const;
+    bool CanSecureErase(const NProto::TDeviceConfig& device) const;
 
     NProto::TError SetUserId(
         TDiskRegistryDatabase& db,
@@ -1282,6 +1292,10 @@ private:
         const TString& deviceId,
         TInstant timestamp,
         TString reason);
+
+    void CleanupAgentConfig(
+        TDiskRegistryDatabase& db,
+        const NProto::TAgentConfig& agent);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -11136,6 +11136,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         agent.SetNodeId(42);
         agent.SetAgentId("agent-1");
         agent.SetWorkTs(TInstant::Days(10).Seconds());
+        *agent.AddDevices() = Device("dev-1", "uuid-1.1", "rack-1");
 
         auto monitoring = CreateMonitoringServiceStub();
         auto diskRegistryGroup = monitoring->GetCounters()

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
@@ -278,7 +278,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 Now(),
                 db,
                 TDiskRegistryState::TAllocateDiskParams {
-                    .DiskId = "nrd0",
+                    .DiskId = "local0",
                     .BlockSize = DefaultLogicalBlockSize,
                     .BlocksCount = DefaultDeviceSize / DefaultLogicalBlockSize,
                     .AgentIds = { Agents[1].GetAgentId() },
@@ -302,7 +302,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
 
                 if (d.GetDeviceUUID() == result.Devices[0].GetDeviceUUID()) {
                     UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, r.Error.GetCode());
-                    ASSERT_VECTORS_EQUAL(TVector{"nrd0"}, r.AffectedDisks);
+                    ASSERT_VECTORS_EQUAL(TVector{"local0"}, r.AffectedDisks);
                 } else {
                     UNIT_ASSERT_VALUES_EQUAL(S_OK, r.Error.GetCode());
                 }
@@ -316,7 +316,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 auto r = state.PurgeHost(
                     db,
                     Agents[1].GetAgentId(),
-                    TInstant::FromValue(3),
+                    TInstant::FromValue(2),
                     false,   // dryRun
                     affectedDisks);
                 UNIT_ASSERT_VALUES_EQUAL(S_OK, r.GetCode());
@@ -338,7 +338,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 db,
                 Agents[2].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
-                TInstant::FromValue(4),
+                TInstant::FromValue(3),
                 false,  // dryRun
                 affectedDisks,
                 timeout));

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -60,6 +60,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(AllocateCheckpoint,                 __VA_ARGS__)                       \
     xxx(DeallocateCheckpoint,               __VA_ARGS__)                       \
     xxx(SetCheckpointDataState,             __VA_ARGS__)                       \
+    xxx(PurgeHostCms,                       __VA_ARGS__)                       \
 // BLOCKSTORE_DISK_REGISTRY_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -673,6 +674,35 @@ struct TTxDiskRegistry
             : RequestInfo(std::move(requestInfo))
             , Host(std::move(host))
             , State(state)
+            , DryRun(dryRun)
+        {}
+
+        void Clear()
+        {
+            AffectedDisks.clear();
+            Error.Clear();
+        }
+    };
+
+    //
+    // PurgeHostCms
+    //
+
+    struct TPurgeHostCms
+    {
+        const TRequestInfoPtr RequestInfo;
+        const TString Host;
+        const bool DryRun;
+
+        NProto::TError Error;
+        TVector<TString> AffectedDisks;
+
+        TPurgeHostCms(
+                TRequestInfoPtr requestInfo,
+                TString host,
+                bool dryRun)
+            : RequestInfo(std::move(requestInfo))
+            , Host(std::move(host))
             , DryRun(dryRun)
         {}
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_pools.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_pools.cpp
@@ -470,12 +470,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 3_GB, msg.GetAvailableStorage(0).GetChunkSize());
             UNIT_ASSERT_VALUES_EQUAL(
-                0, msg.GetAvailableStorage(1).GetChunkSize());
+                4_GB, msg.GetAvailableStorage(1).GetChunkSize());
 
             UNIT_ASSERT_VALUES_EQUAL(
                 1, msg.GetAvailableStorage(0).GetChunkCount());
             UNIT_ASSERT_VALUES_EQUAL(
-                0, msg.GetAvailableStorage(1).GetChunkCount());
+                2, msg.GetAvailableStorage(1).GetChunkCount());
         }
 
         {

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
@@ -64,6 +64,7 @@ private:
     THashMap<TDeviceId, NProto::TSuspendedDevice> SuspendedDevices;
     THashMap<NProto::EDevicePoolKind, TVector<TString>> PoolKind2PoolNames;
     THashMap<TString, ui32> PoolName2DeviceCount;
+    const bool AlwaysAllocateLocalDisks;
 
 public:
     struct TAllocationQuery
@@ -84,12 +85,13 @@ public:
         }
     };
 
-    TDeviceList() = default;
+    TDeviceList();
 
     explicit TDeviceList(
         TVector<TDeviceId> dirtyDevices,
         TVector<NProto::TSuspendedDevice> suspendedDevices,
-        TVector<std::pair<TDeviceId, TDiskId>> allocatedDevices);
+        TVector<std::pair<TDeviceId, TDiskId>> allocatedDevices,
+        bool alwaysAllocateLocalDisks);
 
     [[nodiscard]] size_t Size() const
     {
@@ -137,6 +139,10 @@ public:
     void MarkDeviceAllocated(const TDiskId& diskId, const TDeviceId& id);
     bool ReleaseDevice(const TDeviceId& id);
 
+    [[nodiscard]] bool DevicesAllocationAllowed(
+        NProto::EDevicePoolKind poolKind,
+        NProto::EAgentState agentState) const;
+
     TVector<NProto::TDeviceConfig> AllocateDevices(
         const TDiskId& diskId,
         const TAllocationQuery& query);
@@ -153,6 +159,10 @@ public:
     void ResumeDevice(const TDeviceId& id);
     void ResumeAfterErase(const TDeviceId& id);
     [[nodiscard]] bool IsSuspendedDevice(const TDeviceId& id) const;
+    // Similar to the above, but also checks that the device is not resuming
+    // from suspension.
+    [[nodiscard]] bool IsSuspendedAndNotResumingDevice(
+        const TDeviceId& id) const;
     [[nodiscard]] TVector<NProto::TSuspendedDevice> GetSuspendedDevices() const;
 
     [[nodiscard]] ui64 GetDeviceByteCount(const TDeviceId& id) const;

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
@@ -1257,7 +1257,9 @@ Y_UNIT_TEST_SUITE(TDeviceListTest)
             TDeviceList deviceList{
                 {},   // dirtyDevices
                 {},   // suspendedDevices
-                {{device.GetDeviceUUID(), diskId}}};
+                {{device.GetDeviceUUID(), diskId}},
+                false   // alwaysAllocateLocalDisks
+            };
 
             deviceList.UpdateDevices(agent, poolConfigs);
         }
@@ -1266,9 +1268,10 @@ Y_UNIT_TEST_SUITE(TDeviceListTest)
 
         {
             TDeviceList deviceList{
-                {},   // dirtyDevices
-                {},   // suspendedDevices
-                {}    // allocatedDevices
+                {},     // dirtyDevices
+                {},     // suspendedDevices
+                {},     // allocatedDevices
+                false   // alwaysAllocateLocalDisks
             };
 
             deviceList.UpdateDevices(agent, poolConfigs);

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -20,6 +20,7 @@ NProto::TStorageServiceConfig CreateDefaultStorageConfig()
     configProto.SetAllocationUnitNonReplicatedSSD(10);
     configProto.SetDiskRegistryVolumeConfigUpdatePeriod(5000);
     configProto.SetCachedAcquireRequestLifetime(1000 * 60 * 60);
+    configProto.SetDiskRegistryAlwaysAllocatesLocalDisks(true);
 
     return configProto;
 }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
@@ -323,6 +323,7 @@ NProto::TStorageServiceConfig CreateDefaultStorageConfigProto()
     config.SetNonReplicatedMigrationStartAllowed(true);
     config.SetMirroredMigrationStartAllowed(true);
     config.SetAllocationUnitNonReplicatedSSD(10);
+    config.SetDiskRegistryAlwaysAllocatesLocalDisks(true);
 
     return config;
 }

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -28,6 +28,7 @@ SRCS(
     disk_registry_actor_placement.cpp
     disk_registry_actor_publish_disk_state.cpp
     disk_registry_actor_writable_state.cpp
+    disk_registry_actor_purge_host_cms.cpp
     disk_registry_actor_query_agents_info.cpp
     disk_registry_actor_query_available_storage.cpp
     disk_registry_actor_register.cpp

--- a/cloud/blockstore/public/api/protos/cms.proto
+++ b/cloud/blockstore/public/api/protos/cms.proto
@@ -18,6 +18,7 @@ message TAction {
         GET_DEPENDENT_DISKS = 3;
         ADD_DEVICE = 4;
         ADD_HOST = 5;
+        PURGE_HOST = 6;
     }
 
     // Action type.

--- a/cloud/blockstore/public/sdk/go/client/safe_client.go
+++ b/cloud/blockstore/public/sdk/go/client/safe_client.go
@@ -603,6 +603,29 @@ func (client *safeClient) CmsRemoveHost(
 	return resp, nil
 }
 
+func (client *safeClient) CmsPurgeHost(
+	ctx context.Context,
+	host string,
+	dryRun bool,
+) (*protos.TCmsActionResponse, error) {
+
+	t := protos.TAction_PURGE_HOST
+	req := &protos.TCmsActionRequest{
+		Actions: []*protos.TAction{{
+			Type:   &t,
+			Host:   &host,
+			DryRun: &dryRun,
+		}},
+	}
+
+	resp, err := client.Impl.CmsAction(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 func (client *safeClient) CmsAddDevices(
 	ctx context.Context,
 	host string,

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -11,4 +11,3 @@ MaxShadowDiskFillIoDepth: 4
 OptimizeVoidBuffersTransferForReadsEnabled: true
 MaxShadowDiskFillBandwidth: 1000
 MaxMigrationBandwidth: 1000
-CleanupDRConfigOnCMSActions: true


### PR DESCRIPTION
#2261 

1) Удалил из storage конфига `CleanupDRConfigOnCMSActions` с включением по дефолту
2) Добавил новый параметр `DiskRegistryAlwaysAllocatesLocalDisks`. При включении он изменяет поведение ручек RemoveHost, QueryAvailableStorage и аллокации локальных дисков:
  - RemoveHost перестаёт удалять девайсы из конфига агента
  - QueryAvailableStorage отдает локальные девайсы даже когда агент в warning
  - Можно создать локальный диск из девайсов которые находятся на warning агенте
3) Добавил новую ручку PurgeHost. Она дергает RemoveHost + удаляет девайсы из агента (если нет affectedDisks)   и вводит локальные девайсы в suspend. То есть пока `DiskRegistryAlwaysAllocatesLocalDisks` выключен, RemoveHost делает то то же самое что и PurgeHost. После включения удалением будет заниматься только PurgeHost.
