### PR TITLE
csi-driver: remove endpoint dir after stopping nbs endpoint

### DIFF
--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
@@ -184,12 +184,17 @@ def test_restart_kubelet_with_new_format_endpoint(access_type):
         volume_size = 1024 ** 3
         pod_name1 = "example-pod-1"
         pod_id1 = "deadbeef1"
+        endpoint_dir = Path(env.csi._sockets_dir) / "example-disk"
         env.csi.create_volume(name=volume_name, size=volume_size)
         env.csi.stage_volume(volume_name, access_type)
+        assert endpoint_dir.exists()
         env.csi.publish_volume(pod_id1, volume_name, pod_name1, access_type)
         # run stage/publish again to simulate kubelet restart
         env.csi.stage_volume(volume_name, access_type)
         env.csi.publish_volume(pod_id1, volume_name, pod_name1, access_type)
+        env.csi.unpublish_volume(pod_id1, volume_name, access_type)
+        env.csi.unstage_volume(volume_name)
+        assert not endpoint_dir.exists()
     except subprocess.CalledProcessError as e:
         csi.log_called_process_error(e)
         raise

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -991,6 +991,10 @@ func (s *nodeService) nodeUnstageVolume(
 		}
 	}
 
+	if err := os.RemoveAll(endpointDir); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Remove endpoint directory in NodeUnstageVolume. For old format endpoints directory removing happens in NodeUnpublishVolume https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/tools/csi_driver/internal/driver/node.go#L1049