### PR TITLE
Always retry request after DA timeout

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -732,7 +732,7 @@ message TStorageServiceConfig
 
     // Expected client backoff timeout increment in milliseconds - used to
     // calculate some internal timeouts.
-    optional uint32 ExpectedClientBackoffIncrement = 280;
+    // optional uint32 ExpectedClientBackoffIncrement = 280; // obsolete
 
     // Maximum number of pending deallocation requests per one disk.
     optional uint32 MaxNonReplicatedDiskDeallocationRequests = 281;

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -396,7 +396,6 @@ TDuration MSeconds(ui32 value)
     xxx(NonReplicatedMaxRequestTimeoutSSD,         TDuration, Seconds(30)     )\
     xxx(NonReplicatedMinRequestTimeoutHDD,         TDuration, Seconds(5)      )\
     xxx(NonReplicatedMaxRequestTimeoutHDD,         TDuration, Seconds(30)     )\
-    xxx(ExpectedClientBackoffIncrement,            TDuration, MSeconds(500)   )\
     xxx(NonReplicatedMigrationStartAllowed,        bool,      false           )\
     xxx(NonReplicatedVolumeMigrationDisabled,      bool,      false           )\
     xxx(MigrationIndexCachingInterval,             ui32,      65536           )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -418,7 +418,6 @@ public:
     TDuration GetNonReplicatedMaxRequestTimeoutSSD() const;
     TDuration GetNonReplicatedMinRequestTimeoutHDD() const;
     TDuration GetNonReplicatedMaxRequestTimeoutHDD() const;
-    TDuration GetExpectedClientBackoffIncrement() const;
 
     TDuration GetDeletedCheckpointHistoryLifetime() const;
     bool GetNonReplicatedMigrationStartAllowed() const;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -238,6 +238,9 @@ public:
         if (MuteIOErrors) {
             SetErrorProtoFlag(error, NCloud::NProto::EF_HW_PROBLEMS_DETECTED);
         }
+        if (error.GetCode() == E_IO_SILENT) {
+            SetErrorProtoFlag(error, NCloud::NProto::EF_SILENT);
+        }
     }
 
     NCloud::NProto::TError MakeError(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -313,8 +313,6 @@ bool TNonreplicatedPartitionActor::InitRequests(
         ctx.Now(),
         msg.Record.GetHeaders().GetIsBackgroundRequest());
 
-    Cout << "!!! set timeout " << timeoutPolicy->Timeout.ToString() << " " << timeoutPolicy->ErrorCode << Endl;
-
     return true;
 }
 
@@ -382,8 +380,6 @@ void TNonreplicatedPartitionActor::OnRequestCompleted(
             break;
         }
         case EStatus::Timeout: {
-            Cout << "!!! timeout" << operation.ExecutionTime.ToString() << Endl;
-
             for (ui32 deviceIndex: operation.DeviceIndices) {
                 OnRequestTimeout(deviceIndex, operation.ExecutionTime, now);
             }
@@ -443,10 +439,6 @@ void TNonreplicatedPartitionActor::OnRequestTimeout(
             break;
         }
     }
-
-    Cout << "!!! #" << deviceIndex << "  cumulative "
-         << stat.TimedOutStateDuration.ToString()
-         << " status=" << int(stat.DeviceStatus) << Endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -99,7 +99,7 @@ TNonreplicatedPartitionActor::GetMaxTimedOutDeviceStateDuration() const
     return maxTimedOutDeviceStateDuration;
 }
 
-bool TNonreplicatedPartitionActor::HasBrokenDevice(
+bool TNonreplicatedPartitionActor::CalculateHasBrokenDeviceCounterValue(
     const NActors::TActorContext& ctx,
     bool silent) const
 {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -153,8 +153,7 @@ TRequestTimeoutPolicy TNonreplicatedPartitionActor::MakeTimeoutPolicyForRequest(
 
     policy.Timeout =
         Min(GetMaxRequestTimeout(),
-            longestTimedOutStateDuration +
-                Config->GetExpectedClientBackoffIncrement());
+            longestTimedOutStateDuration + TDuration::MilliSeconds(500));
 
     if (isBackground) {
         return policy;
@@ -293,7 +292,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
 
     for (const auto& dr: *deviceRequests) {
         if (dr.Device.GetNodeId() == 0) {
-            // Accessing to a non-allocated device causes the disk to break.
+            // Accessing a non-allocated device causes the disk to break.
             DeviceStats[dr.DeviceIdx].BrokenTransitionTs = ctx.Now();
             DeviceStats[dr.DeviceIdx].DeviceStatus = EDeviceStatus::Broken;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -60,11 +60,8 @@ private:
 
     struct TDeviceStat
     {
-        // When the last timeout was detected.
-        TInstant LastTimeoutTs;
-
-        // How long has it been since no response was received from the server.
-        TDuration TimedOutStateDuration;
+        // The start time of the first timed out request.
+        TInstant FirstTimeoutTs;
 
         // Execution times of the last 10 requests.
         TSimpleRingBuffer<TDuration> ResponseTimes{10};
@@ -77,6 +74,8 @@ private:
 
         // Returns the maximum request execution time among the latest.
         [[nodiscard]] TDuration WorstRequestTime() const;
+
+        [[nodiscard]] TDuration GetTimedOutStateDuration(TInstant now) const;
 
         [[nodiscard]] bool CooldownPassed(
             TInstant now,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -27,17 +27,17 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Adjusts the behavior when a response is not received from the server during
+// Adjusts the behavior when a response is not received from the server within
 // the timeout.
 struct TRequestTimeoutPolicy
 {
     // How long to wait for a response from the server.
     TDuration Timeout;
 
-    // An error that needs to be generated when a timeout occurs.
+    // The error that needs to be generated when a timeout occurs.
     EWellKnownResultCodes ErrorCode;
 
-    // Message for response.
+    // Message for the response.
     TString OverrideMessage;
 };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -136,7 +136,7 @@ private:
     bool InitRequests(
         const typename TMethod::TRequest& msg,
         const NActors::TActorContext& ctx,
-        TRequestInfo& requestInfo,
+        const TRequestInfo& requestInfo,
         const TBlockRange64& blockRange,
         TVector<TDeviceRequest>* deviceRequests,
         TRequestTimeoutPolicy* timeoutPolicy);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -124,7 +124,9 @@ private:
     TDuration GetMinRequestTimeout() const;
     TDuration GetMaxRequestTimeout() const;
     TDuration GetMaxTimedOutDeviceStateDuration() const;
-    bool HasBrokenDevice(const NActors::TActorContext& ctx, bool silent) const;
+    bool CalculateHasBrokenDeviceCounterValue(
+        const NActors::TActorContext& ctx,
+        bool silent) const;
 
     TRequestTimeoutPolicy MakeTimeoutPolicyForRequest(
         const TVector<TDeviceRequest>& deviceRequests,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -69,7 +69,7 @@ private:
     bool HandleError(
         const TActorContext& ctx,
         NProto::TError error,
-        bool timedout);
+        bool timedOut);
 
     void Done(const TActorContext& ctx, IEventBasePtr response, EStatus status);
 
@@ -154,7 +154,7 @@ void TDiskAgentChecksumActor::ChecksumBlocks(const TActorContext& ctx)
 bool TDiskAgentChecksumActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error,
-    bool timedout)
+    bool timedOut)
 {
     if (FAILED(error.GetCode())) {
         ProcessError(ctx, *PartConfig, error);
@@ -165,7 +165,7 @@ bool TDiskAgentChecksumActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timeout : EStatus::Fail);
+            timedOut ? EStatus::Timeout : EStatus::Fail);
         return true;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -165,7 +165,7 @@ bool TDiskAgentChecksumActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timedout : EStatus::Failed);
+            timedout ? EStatus::Timeout : EStatus::Fail);
         return true;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -223,12 +223,7 @@ void TDiskAgentChecksumActor::HandleChecksumDeviceBlocksUndelivery(
             << GetRequestId(Request) << " undelivered. Disk id: "
             << PartConfig->GetName() << " Device: " << LogDevice(device));
 
-    HandleError(
-        ctx,
-        MakeError(
-            TimeoutPolicy.ErrorCode,
-            "ChecksumBlocks request undelivered"),
-        true);
+    // Ignore undelivered event. Wait for TEvWakeup.
 }
 
 void TDiskAgentChecksumActor::HandleTimeout(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -190,7 +190,9 @@ void TDiskAgentChecksumActor::Done(
     auto& counters = *completion->Stats.MutableSysChecksumCounters();
     completion->TotalCycles = RequestInfo->GetTotalCycles();
     completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = ctx.Now() - StartTime;
+    completion->ExecutionTime = status == EStatus::Timeout
+                                    ? TimeoutPolicy.Timeout
+                                    : ctx.Now() - StartTime;
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -66,7 +66,7 @@ private:
     bool HandleError(
         const TActorContext& ctx,
         NProto::TError error,
-        bool timedout);
+        bool timedOut);
 
     void Done(const TActorContext& ctx, IEventBasePtr response, EStatus status);
 
@@ -165,7 +165,7 @@ void TDiskAgentReadActor::ReadBlocks(const TActorContext& ctx)
 bool TDiskAgentReadActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error,
-    bool timedout)
+    bool timedOut)
 {
     if (FAILED(error.GetCode())) {
         ProcessError(ctx, *PartConfig, error);
@@ -176,7 +176,7 @@ bool TDiskAgentReadActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timeout : EStatus::Fail);
+            timedOut ? EStatus::Timeout : EStatus::Fail);
         return true;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -197,29 +197,24 @@ void TDiskAgentReadActor::Done(
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 
     auto completion =
-        std::make_unique<TEvNonreplPartitionPrivate::TEvReadBlocksCompleted>();
-    auto& counters = *completion->Stats.MutableUserReadCounters();
-    completion->TotalCycles = RequestInfo->GetTotalCycles();
-    completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = status == EStatus::Timeout
-                                    ? TimeoutPolicy.Timeout
-                                    : ctx.Now() - StartTime;
+        std::make_unique<TEvNonreplPartitionPrivate::TEvReadBlocksCompleted>(
+            status,
+            RequestInfo->GetTotalCycles(),
+            RequestInfo->GetExecCycles(),
+            status == EStatus::Timeout ? TimeoutPolicy.Timeout
+                                       : ctx.Now() - StartTime);
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {
         blocks += dr.BlockRange.Size();
         completion->DeviceIndices.push_back(dr.DeviceIdx);
     }
-    counters.SetBlocksCount(blocks);
-    completion->Status = status;
+    completion->Stats.MutableUserReadCounters()->SetBlocksCount(blocks);
 
     completion->NonVoidBlockCount = NonVoidBlockCount;
     completion->VoidBlockCount = VoidBlockCount;
 
-    NCloud::Send(
-        ctx,
-        Part,
-        std::move(completion));
+    NCloud::Send(ctx, Part, std::move(completion));
 
     Die(ctx);
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -238,12 +238,7 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksUndelivery(
             << GetRequestId(Request) << " undelivered. Disk id: "
             << PartConfig->GetName() << " Device: " << LogDevice(device));
 
-    HandleError(
-        ctx,
-        PartConfig->MakeError(
-            TimeoutPolicy.ErrorCode,
-            "ReadBlocks request undelivered"),
-        true);
+    // Ignore undelivered event. Wait for TEvWakeup.
 }
 
 void TDiskAgentReadActor::HandleTimeout(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -176,7 +176,7 @@ bool TDiskAgentReadActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timedout : EStatus::Failed);
+            timedout ? EStatus::Timeout : EStatus::Fail);
         return true;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -201,7 +201,9 @@ void TDiskAgentReadActor::Done(
     auto& counters = *completion->Stats.MutableUserReadCounters();
     completion->TotalCycles = RequestInfo->GetTotalCycles();
     completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = ctx.Now() - StartTime;
+    completion->ExecutionTime = status == EStatus::Timeout
+                                    ? TimeoutPolicy.Timeout
+                                    : ctx.Now() - StartTime;
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -63,7 +63,7 @@ private:
     bool HandleError(
         const TActorContext& ctx,
         NProto::TError error,
-        bool timedout);
+        bool timedOut);
 
     void Done(const TActorContext& ctx, IEventBasePtr response, EStatus status);
 
@@ -151,7 +151,7 @@ void TDiskAgentReadActor::ReadBlocks(const TActorContext& ctx)
 bool TDiskAgentReadActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error,
-    bool timedout)
+    bool timedOut)
 {
     if (FAILED(error.GetCode())) {
         ProcessError(ctx, *PartConfig, error);
@@ -162,7 +162,7 @@ bool TDiskAgentReadActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timeout : EStatus::Fail);
+            timedOut ? EStatus::Timeout : EStatus::Fail);
         return true;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -224,12 +224,7 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksUndelivery(
             << GetRequestId(Request) << " undelivered. Disk id: "
             << PartConfig->GetName() << " Device: " << LogDevice(device));
 
-    HandleError(
-        ctx,
-        PartConfig->MakeError(
-            TimeoutPolicy.ErrorCode,
-            "ReadBlocksLocal request undelivered"),
-        true);
+    // Ignore undelivered event. Wait for TEvWakeup.
 }
 
 void TDiskAgentReadActor::HandleTimeout(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -162,7 +162,7 @@ bool TDiskAgentReadActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timedout : EStatus::Failed);
+            timedout ? EStatus::Timeout : EStatus::Fail);
         return true;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -187,7 +187,9 @@ void TDiskAgentReadActor::Done(
     auto& counters = *completion->Stats.MutableUserReadCounters();
     completion->TotalCycles = RequestInfo->GetTotalCycles();
     completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = ctx.Now() - StartTime;
+    completion->ExecutionTime = status == EStatus::Timeout
+                                    ? TimeoutPolicy.Timeout
+                                    : ctx.Now() - StartTime;
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_stats.cpp
@@ -34,8 +34,10 @@ void TNonreplicatedPartitionActor::SendStats(const TActorContext& ctx)
         PartConfig->GetBlockCount() * PartConfig->GetBlockSize()
     );
 
-    PartCounters->Simple.HasBrokenDevice.Set(HasBrokenDevice(ctx, false));
-    PartCounters->Simple.HasBrokenDeviceSilent.Set(HasBrokenDevice(ctx, true));
+    PartCounters->Simple.HasBrokenDevice.Set(
+        CalculateHasBrokenDeviceCounterValue(ctx, false));
+    PartCounters->Simple.HasBrokenDeviceSilent.Set(
+        CalculateHasBrokenDeviceCounterValue(ctx, true));
 
     auto request =
         std::make_unique<TEvVolume::TEvDiskRegistryBasedPartitionCounters>(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_stats.cpp
@@ -34,11 +34,8 @@ void TNonreplicatedPartitionActor::SendStats(const TActorContext& ctx)
         PartConfig->GetBlockCount() * PartConfig->GetBlockSize()
     );
 
-    PartCounters->Simple.HasBrokenDevice.Set(
-        HasBrokenDevice
-        && !PartConfig->GetMuteIOErrors()
-        && IOErrorCooldownPassed(ctx.Now()));
-    PartCounters->Simple.HasBrokenDeviceSilent.Set(HasBrokenDevice);
+    PartCounters->Simple.HasBrokenDevice.Set(HasBrokenDevice(ctx, false));
+    PartCounters->Simple.HasBrokenDeviceSilent.Set(HasBrokenDevice(ctx, true));
 
     auto request =
         std::make_unique<TEvVolume::TEvDiskRegistryBasedPartitionCounters>(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -207,7 +207,9 @@ void TDiskAgentWriteActor::Done(
     auto& counters = *completion->Stats.MutableUserWriteCounters();
     completion->TotalCycles = RequestInfo->GetTotalCycles();
     completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = ctx.Now() - StartTime;
+    completion->ExecutionTime = status == EStatus::Timeout
+                                    ? TimeoutPolicy.Timeout
+                                    : ctx.Now() - StartTime;
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -203,26 +203,21 @@ void TDiskAgentWriteActor::Done(
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 
     auto completion =
-        std::make_unique<TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted>();
-    auto& counters = *completion->Stats.MutableUserWriteCounters();
-    completion->TotalCycles = RequestInfo->GetTotalCycles();
-    completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = status == EStatus::Timeout
-                                    ? TimeoutPolicy.Timeout
-                                    : ctx.Now() - StartTime;
+        std::make_unique<TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted>(
+            status,
+            RequestInfo->GetTotalCycles(),
+            RequestInfo->GetExecCycles(),
+            status == EStatus::Timeout ? TimeoutPolicy.Timeout
+                                       : ctx.Now() - StartTime);
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {
         blocks += dr.BlockRange.Size();
         completion->DeviceIndices.push_back(dr.DeviceIdx);
     }
-    counters.SetBlocksCount(blocks);
-    completion->Status = status;
+    completion->Stats.MutableUserWriteCounters()->SetBlocksCount(blocks);
 
-    NCloud::Send(
-        ctx,
-        Part,
-        std::move(completion));
+    NCloud::Send(ctx, Part, std::move(completion));
 
     Die(ctx);
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -241,12 +241,7 @@ void TDiskAgentWriteActor::HandleWriteDeviceBlocksUndelivery(
             << GetRequestId(Request) << " undelivered. Disk id: "
             << PartConfig->GetName() << " Device: " << LogDevice(device));
 
-    HandleError(
-        ctx,
-        PartConfig->MakeError(
-            TimeoutPolicy.ErrorCode,
-            "WriteBlocks request undelivered"),
-        true);
+    // Ignore undelivered event. Wait for TEvWakeup.
 }
 
 void TDiskAgentWriteActor::HandleTimeout(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -63,7 +63,7 @@ private:
     bool HandleError(
         const TActorContext& ctx,
         NProto::TError error,
-        bool timedout);
+        bool timedOut);
 
     void Done(const TActorContext& ctx, IEventBasePtr response, EStatus status);
 
@@ -162,7 +162,7 @@ void TDiskAgentWriteActor::WriteBlocks(const TActorContext& ctx)
 bool TDiskAgentWriteActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error,
-    bool timedout)
+    bool timedOut)
 {
     if (FAILED(error.GetCode())) {
         ProcessError(ctx, *PartConfig, error);
@@ -170,7 +170,7 @@ bool TDiskAgentWriteActor::HandleError(
         Done(
             ctx,
             CreateResponse(std::move(error)),
-            timedout ? EStatus::Timeout : EStatus::Fail);
+            timedOut ? EStatus::Timeout : EStatus::Fail);
 
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -170,7 +170,7 @@ bool TDiskAgentWriteActor::HandleError(
         Done(
             ctx,
             CreateResponse(std::move(error)),
-            timedout ? EStatus::Timedout : EStatus::Failed);
+            timedout ? EStatus::Timeout : EStatus::Fail);
 
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -63,7 +63,7 @@ private:
     bool HandleError(
         const TActorContext& ctx,
         NProto::TError error,
-        bool timedout);
+        bool timedOut);
 
     void Done(const TActorContext& ctx, IEventBasePtr response, EStatus status);
 
@@ -154,7 +154,7 @@ void TDiskAgentZeroActor::ZeroBlocks(const TActorContext& ctx)
 bool TDiskAgentZeroActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error,
-    bool timedout)
+    bool timedOut)
 {
     if (FAILED(error.GetCode())) {
         ProcessError(ctx, *PartConfig, error);
@@ -165,7 +165,7 @@ bool TDiskAgentZeroActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timeout : EStatus::Fail);
+            timedOut ? EStatus::Timeout : EStatus::Fail);
 
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -225,12 +225,7 @@ void TDiskAgentZeroActor::HandleZeroDeviceBlocksUndelivery(
             << GetRequestId(Request) << " undelivered. Disk id: "
             << PartConfig->GetName() << " Device: " << LogDevice(device));
 
-    HandleError(
-        ctx,
-        PartConfig->MakeError(
-            TimeoutPolicy.ErrorCode,
-            "ZeroBlocks request undelivered"),
-        true);
+    // Ignore undelivered event. Wait for TEvWakeup.
 }
 
 void TDiskAgentZeroActor::HandleTimeout(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -165,7 +165,7 @@ bool TDiskAgentZeroActor::HandleError(
         Done(
             ctx,
             std::move(response),
-            timedout ? EStatus::Timedout : EStatus::Failed);
+            timedout ? EStatus::Timeout : EStatus::Fail);
 
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -191,7 +191,9 @@ void TDiskAgentZeroActor::Done(
     auto& counters = *completion->Stats.MutableUserWriteCounters();
     completion->TotalCycles = RequestInfo->GetTotalCycles();
     completion->ExecCycles = RequestInfo->GetExecCycles();
-    completion->ExecutionTime = ctx.Now() - StartTime;
+    completion->ExecutionTime = status == EStatus::Timeout
+                                    ? TimeoutPolicy.Timeout
+                                    : ctx.Now() - StartTime;
 
     ui32 blocks = 0;
     for (const auto& dr: DeviceRequests) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -157,10 +157,10 @@ struct TEvNonreplPartitionPrivate
     {
         enum class EStatus
         {
-            Success,    // The request was completed successfully
-            Failed,     // The request was executed with an error
-            Timedout,   // The response from the server was not received during
-                        // the timeout.
+            Success,   // The request was completed successfully
+            Fail,      // The request was executed with an error
+            Timeout,   // The response from the server was not received during
+                       // the timeout.
         };
 
         NProto::TPartitionStats Stats;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -163,6 +163,9 @@ struct TEvNonreplPartitionPrivate
                        // the timeout.
         };
 
+        // Request completion status
+        EStatus Status = EStatus::Fail;
+
         NProto::TPartitionStats Stats;
 
         ui64 TotalCycles = 0;
@@ -173,11 +176,23 @@ struct TEvNonreplPartitionPrivate
         // Indexes of devices that participated in the request.
         TStackVec<ui32, 2> DeviceIndices;
 
-        // Request completion status
-        EStatus Status = EStatus::Success;
-
         ui32 NonVoidBlockCount = 0;
         ui32 VoidBlockCount = 0;
+
+        // TODO(drbasic) remove and use non-default constructor in
+        // TNonreplicatedPartitionRdmaActor
+        TOperationCompleted() = default;
+
+        TOperationCompleted(
+                EStatus status,
+                ui64 totalCycles,
+                ui64 execCycles,
+                TDuration executionTime)
+            : Status(status)
+            , TotalCycles(totalCycles)
+            , ExecCycles(execCycles)
+            , ExecutionTime(executionTime)
+        {}
     };
 
     //

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -155,15 +155,26 @@ struct TEvNonreplPartitionPrivate
 
     struct TOperationCompleted
     {
+        enum class EStatus
+        {
+            Success,    // The request was completed successfully
+            Failed,     // The request was executed with an error
+            Timedout,   // The response from the server was not received during
+                        // the timeout.
+        };
+
         NProto::TPartitionStats Stats;
 
         ui64 TotalCycles = 0;
         ui64 ExecCycles = 0;
+        // Request execution total time.
+        TDuration ExecutionTime;
 
-        TStackVec<int, 2> DeviceIndices;
-        TDuration ActorSystemTime;
+        // Indexes of devices that participated in the request.
+        TStackVec<ui32, 2> DeviceIndices;
 
-        bool Failed = false;
+        // Request completion status
+        EStatus Status = EStatus::Success;
 
         ui32 NonVoidBlockCount = 0;
         ui32 VoidBlockCount = 0;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -646,7 +646,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
 
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
-            UNIT_ASSERT(response->GetErrorReason().Contains("undelivered"));
+            UNIT_ASSERT(response->GetErrorReason().Contains("request timed out"));
         }
 
         {
@@ -657,7 +657,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
             auto response = client.RecvWriteBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
-            UNIT_ASSERT(response->GetErrorReason().Contains("undelivered"));
+            UNIT_ASSERT(response->GetErrorReason().Contains("request timed out"));
         }
 
         {
@@ -667,7 +667,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
             auto response = client.RecvZeroBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
-            UNIT_ASSERT(response->GetErrorReason().Contains("undelivered"));
+            UNIT_ASSERT(response->GetErrorReason().Contains("request timed out"));
         }
     }
 
@@ -1016,7 +1016,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1030,7 +1030,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             client.SendWriteBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072),
                 1);
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvWriteBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1043,7 +1043,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendZeroBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvZeroBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1056,7 +1056,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1079,7 +1079,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1093,7 +1093,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             client.SendWriteBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072),
                 1);
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvWriteBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1106,7 +1106,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendZeroBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvZeroBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1119,7 +1119,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1131,7 +1131,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -1140,7 +1140,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
+            //runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -103,7 +103,6 @@ struct TTestEnv
             storageConfig.SetNonReplicatedMinRequestTimeoutHDD(60'000);
             storageConfig.SetNonReplicatedMaxRequestTimeoutHDD(60'000);
         }
-        storageConfig.SetExpectedClientBackoffIncrement(500);
         storageConfig.SetNonReplicatedAgentMaxTimeout(300'000);
         storageConfig.SetAssignIdToWriteAndZeroRequestsEnabled(true);
 
@@ -702,9 +701,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             UNIT_ASSERT(response->GetErrorReason().Contains("timed out"));
         }
 
-        // backoff = 0.5s (ExpectedClientBackoffIncrement())
         // cumulative = 1.0s
-        // timeout = 1.5s (cumulative + backoff)
+        // timeout = 1.5s (cumulative + 0.5s)
         {
             client.SendWriteBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072),
@@ -716,9 +714,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             UNIT_ASSERT(response->GetErrorReason().Contains("timed out"));
         }
 
-        // backoff = 0.5s (ExpectedClientBackoffIncrement())
         // cumulative = 2.5s (1.0 + 1.5)
-        // timeout = 3s (cumulative + backoff)
+        // timeout = 3s (cumulative + 0.5s)
         {
             client.SendZeroBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
@@ -729,7 +726,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             UNIT_ASSERT(response->GetErrorReason().Contains("timed out"));
         }
 
-        // backoff = 0.5s (ExpectedClientBackoffIncrement())
         // cumulative = 5.5s (1.0 + 1.5 + 3.0)
         // timeout = 5s (limited by NonReplicatedMaxRequestTimeoutSSD())
         {
@@ -741,7 +737,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
         }
 
-        // backoff = 0.5s (ExpectedClientBackoffIncrement())
         // cumulative = 10.5 (1.0 + 1.5 + 3.0 + 5.0)
         // timeout = 5s (limited by NonReplicatedMaxRequestTimeoutSSD())
         {
@@ -765,7 +760,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(0, counters.HasBrokenDevice.Value);
         UNIT_ASSERT_VALUES_EQUAL(0, counters.HasBrokenDeviceSilent.Value);
 
-        // backoff = 0.5s (ExpectedClientBackoffIncrement())
         // cumulative = 15.5 (1.0 + 1.5 + 3.0 + 5.0 + 5.0)
         // timeout = 5s (limited by NonReplicatedMaxRequestTimeoutSSD())
         {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -694,7 +694,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -707,7 +706,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             client.SendWriteBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072),
                 1);
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvWriteBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -719,7 +717,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendZeroBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvZeroBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -731,7 +728,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -742,7 +738,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
@@ -765,7 +760,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         {
             client.SendReadBlocksRequest(
                 TBlockRange64::WithLength(1024, 3072));
-            runtime.AdvanceCurrentTime(TDuration::Minutes(10));
             runtime.DispatchEvents();
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -93,7 +93,6 @@ struct TTestEnv
         storageConfig.SetMaxTimedOutDeviceStateDuration(20'000);
         storageConfig.SetNonReplicatedMinRequestTimeoutSSD(1'000);
         storageConfig.SetNonReplicatedMaxRequestTimeoutSSD(5'000);
-        storageConfig.SetExpectedClientBackoffIncrement(500);
 
         auto config = std::make_shared<TStorageConfig>(
             std::move(storageConfig),

--- a/cloud/storage/core/libs/actors/helpers.h
+++ b/cloud/storage/core/libs/actors/helpers.h
@@ -107,7 +107,7 @@ inline void Send(
 template <typename T>
 inline void Reply(
     const NActors::TActorContext& ctx,
-    T& request,
+    const T& request,
     NActors::IEventBasePtr response)
 {
     ctx.Send(


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/720

Делаю так, чтобы если связанность между NBS и DA восстановилась - запросы начинали выполняться, даже если диск уже успел уйти в ошибку и отдать клиенту E_IO/E_IO_SILENT. 
1. таймаут теперь отслеживается точно. Внутри каждого запроса взводится свой таймер.
2. немного поменял логику вычисления таймаута, если последний запрос завершился таймаутом. Теперь это максимальное время последних 10 запросов + сколько мы уже наблюдаем таймауты к девайсу  + backoff.  Отличие в том, что backoff не увеличивается, как раньше, а константный - 0.5 сек по дефолту. Т.е. таймауты будут : 1, 1.5, 3, 6, 12, 24,  и т.д. до достижения верхнего лимита, что сейчас 30 сек.
