### PR TITLE
Support per-VM volumes

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -176,7 +176,7 @@ func (s *nodeService) NodeStageVolume(
 			nfsBackend := (req.VolumeContext[backendVolumeContextKey] == "nfs")
 
 			var err error
-			if instanceID := req.VolumeContext[instanceIDKey]; instanceID != "" {
+			if instanceId := req.VolumeContext[instanceIDKey]; instanceId != "" {
 				nbsId := req.VolumeId
 				stageRecordPath := filepath.Join(req.StagingTargetPath, nbsId+".json")
 				// Backend can be empty for old disks, in this case we use NBS
@@ -186,17 +186,17 @@ func (s *nodeService) NodeStageVolume(
 				}
 				if err = s.writeStageData(stageRecordPath, &StageData{
 					Backend:       backend,
-					InstanceId:    instanceID,
-					RealStagePath: s.getEndpointDir(instanceID, nbsId),
+					InstanceId:    instanceId,
+					RealStagePath: s.getEndpointDir(instanceId, nbsId),
 				}); err != nil {
 					return nil, s.statusErrorf(codes.Internal,
 						"Failed to write stage record: %v", err)
 				}
 
 				if nfsBackend {
-					err = s.nodeStageFileStoreAsVhostSocket(ctx, instanceID, nbsId)
+					err = s.nodeStageFileStoreAsVhostSocket(ctx, instanceId, nbsId)
 				} else {
-					err = s.nodeStageDiskAsVhostSocket(ctx, instanceID, nbsId, req.VolumeContext)
+					err = s.nodeStageDiskAsVhostSocket(ctx, instanceId, nbsId, req.VolumeContext)
 				}
 
 				if err != nil {
@@ -328,8 +328,8 @@ func (s *nodeService) NodePublishVolume(
 	switch req.VolumeCapability.GetAccessType().(type) {
 	case *csi.VolumeCapability_Mount:
 		if s.vmMode {
-			if instanceID := req.VolumeContext[instanceIDKey]; instanceID != "" {
-				err = s.nodePublishStagedVhostSocket(req, instanceID)
+			if instanceId := req.VolumeContext[instanceIDKey]; instanceId != "" {
+				err = s.nodePublishStagedVhostSocket(req, instanceId)
 			} else {
 				if nfsBackend {
 					err = s.nodePublishFileStoreAsVhostSocket(ctx, req)
@@ -925,12 +925,12 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 
 func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 	ctx context.Context,
-	instanceID string,
+	instanceId string,
 	filesystemId string) error {
 
-	log.Printf("csi.nodeStageFileStoreAsVhostSocket: %s %s", instanceID, filesystemId)
+	log.Printf("csi.nodeStageFileStoreAsVhostSocket: %s %s", instanceId, filesystemId)
 
-	endpointDir := s.getEndpointDir(instanceID, filesystemId)
+	endpointDir := s.getEndpointDir(instanceId, filesystemId)
 	if err := os.MkdirAll(endpointDir, os.FileMode(0755)); err != nil {
 		return err
 	}
@@ -943,7 +943,7 @@ func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 		Endpoint: &nfsapi.TEndpointConfig{
 			SocketPath:       filepath.Join(endpointDir, nfsSocketName),
 			FileSystemId:     filesystemId,
-			ClientId:         fmt.Sprintf("%s-%s", s.clientID, instanceID),
+			ClientId:         fmt.Sprintf("%s-%s", s.clientID, instanceId),
 			VhostQueuesCount: 8,
 			Persistent:       true,
 		},

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -199,6 +199,7 @@ func (s *nodeService) NodeStageVolume(
 				}
 
 				if err != nil {
+					ignoreError(os.Remove(stageRecordPath))
 					return nil, s.statusErrorf(codes.Internal,
 						"Failed to stage volume: %v", err)
 				}

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -1,5 +1,7 @@
 package driver
 
+//lint:file-ignore ST1003 protobuf generates names that break golang naming convention
+
 import (
 	"context"
 	"encoding/json"

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -955,7 +955,7 @@ func (s *nodeService) nodeUnstageVolume(
 	req *csi.NodeUnstageVolumeRequest) error {
 
 	// Check mount points for StagingTargetPath and StagingTargetPath/VolumeId
-	// as it's not possible to distingiush mount and blok mode from request
+	// as it's not possible to distinguish mount and block mode from request
 	// parameters
 	mountPoint := req.StagingTargetPath
 	mounted, _ := s.mounter.IsMountPoint(mountPoint)

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -422,23 +422,23 @@ func (s *nodeService) nodePublishDiskAsVhostSocket(
 	req *csi.NodePublishVolumeRequest) error {
 
 	podId := s.getPodId(req)
-	volumeId := req.VolumeId
+	diskId := req.VolumeId
 	volumeContext := req.VolumeContext
 
-	endpointDir := s.getEndpointDir(podId, volumeId)
+	endpointDir := s.getEndpointDir(podId, diskId)
 	if err := os.MkdirAll(endpointDir, os.FileMode(0755)); err != nil {
 		return err
 	}
 
 	deviceName, found := volumeContext[deviceNameVolumeContextKey]
 	if !found {
-		deviceName = volumeId
+		deviceName = diskId
 	}
 
 	hostType := nbsapi.EHostType_HOST_TYPE_DEFAULT
 	_, err := s.nbsClient.StartEndpoint(ctx, &nbsapi.TStartEndpointRequest{
 		UnixSocketPath:   filepath.Join(endpointDir, nbsSocketName),
-		DiskId:           volumeId,
+		DiskId:           diskId,
 		InstanceId:       podId,
 		ClientId:         fmt.Sprintf("%s-%s", s.clientID, podId),
 		DeviceName:       deviceName,

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -510,25 +510,25 @@ func (s *nodeService) readStageData(path string) (*StageData, error) {
 func (s *nodeService) nodeStageDiskAsVhostSocket(
 	ctx context.Context,
 	instanceId string,
-	volumeId string,
+	diskId string,
 	volumeContext map[string]string) error {
 
-	log.Printf("csi.nodeStageDiskAsVhostSocket: %s %s %+v", instanceId, volumeId, volumeContext)
+	log.Printf("csi.nodeStageDiskAsVhostSocket: %s %s %+v", instanceId, diskId, volumeContext)
 
-	endpointDir := s.getEndpointDir(instanceId, volumeId)
+	endpointDir := s.getEndpointDir(instanceId, diskId)
 	if err := os.MkdirAll(endpointDir, os.FileMode(0755)); err != nil {
 		return err
 	}
 
 	deviceName, found := volumeContext[deviceNameVolumeContextKey]
 	if !found {
-		deviceName = volumeId
+		deviceName = diskId
 	}
 
 	hostType := nbsapi.EHostType_HOST_TYPE_DEFAULT
 	_, err := s.nbsClient.StartEndpoint(ctx, &nbsapi.TStartEndpointRequest{
 		UnixSocketPath:   filepath.Join(endpointDir, nbsSocketName),
-		DiskId:           volumeId,
+		DiskId:           diskId,
 		InstanceId:       instanceId,
 		ClientId:         fmt.Sprintf("%s-%s", s.clientID, instanceId),
 		DeviceName:       deviceName,
@@ -917,11 +917,11 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 	ctx context.Context,
 	instanceID string,
-	volumeID string) error {
+	filesystemId string) error {
 
-	log.Printf("csi.nodeStageFileStoreAsVhostSocket: %s %s", instanceID, volumeID)
+	log.Printf("csi.nodeStageFileStoreAsVhostSocket: %s %s", instanceID, filesystemId)
 
-	endpointDir := s.getEndpointDir(instanceID, volumeID)
+	endpointDir := s.getEndpointDir(instanceID, filesystemId)
 	if err := os.MkdirAll(endpointDir, os.FileMode(0755)); err != nil {
 		return err
 	}
@@ -933,7 +933,7 @@ func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 	_, err := s.nfsClient.StartEndpoint(ctx, &nfsapi.TStartEndpointRequest{
 		Endpoint: &nfsapi.TEndpointConfig{
 			SocketPath:       filepath.Join(endpointDir, nfsSocketName),
-			FileSystemId:     volumeID,
+			FileSystemId:     filesystemId,
 			ClientId:         fmt.Sprintf("%s-%s", s.clientID, instanceID),
 			VhostQueuesCount: 8,
 			Persistent:       true,

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -31,26 +31,26 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 	mounter := csimounter.NewMock()
 
 	ctx := context.Background()
-	nodeID := "testNodeId"
-	clientID := "testClientId"
-	podID := "test-pod-id-13"
+	nodeId := "testNodeId"
+	clientId := "testClientId"
+	podId := "test-pod-id-13"
 	actualClientId := "testClientId-test-pod-id-13"
-	diskID := "test-disk-id-42"
-	deviceName := diskID
+	diskId := "test-disk-id-42"
+	deviceName := diskId
 	if deviceNameOpt != nil {
 		deviceName = *deviceNameOpt
 	}
 	stagingTargetPath := "testStagingTargetPath"
 	socketsDir := filepath.Join(tempDir, "sockets")
-	sourcePath := filepath.Join(socketsDir, podID, diskID)
-	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
+	sourcePath := filepath.Join(socketsDir, podId, diskId)
+	targetPath := filepath.Join(tempDir, "pods", podId, "volumes", diskId, "mount")
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	nbsSocketPath := filepath.Join(sourcePath, "nbs.sock")
 	nfsSocketPath := filepath.Join(sourcePath, "nfs.sock")
 
 	nodeService := newNodeService(
-		nodeID,
-		clientID,
+		nodeId,
+		clientId,
 		true, // vmMode
 		socketsDir,
 		targetFsPathPattern,
@@ -82,7 +82,7 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 	}
 
 	_, err := nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 		VolumeCapability:  &volumeCapability,
 		VolumeContext:     volumeContext,
@@ -94,8 +94,8 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 	if backend == "nbs" {
 		nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 			UnixSocketPath:   nbsSocketPath,
-			DiskId:           diskID,
-			InstanceId:       podID,
+			DiskId:           diskId,
+			InstanceId:       podId,
 			ClientId:         actualClientId,
 			DeviceName:       deviceName,
 			IpcType:          nbs.EClientIpcType_IPC_VHOST,
@@ -116,7 +116,7 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 		nfsClient.On("StartEndpoint", ctx, &nfs.TStartEndpointRequest{
 			Endpoint: &nfs.TEndpointConfig{
 				SocketPath:       nfsSocketPath,
-				FileSystemId:     diskID,
+				FileSystemId:     diskId,
 				ClientId:         actualClientId,
 				VhostQueuesCount: 8,
 				Persistent:       true,
@@ -128,7 +128,7 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 	mounter.On("Mount", sourcePath, targetPath, "", []string{"bind"}).Return(nil)
 
 	_, err = nodeService.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 		TargetPath:        targetPath,
 		VolumeCapability:  &volumeCapability,
@@ -162,16 +162,16 @@ func doTestPublishUnpublishVolumeForKubevirt(t *testing.T, backend string, devic
 	}).Return(&nfs.TStopEndpointResponse{}, nil)
 
 	_, err = nodeService.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{
-		VolumeId:   diskID,
+		VolumeId:   diskId,
 		TargetPath: targetPath,
 	})
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(socketsDir, podID))
+	_, err = os.Stat(filepath.Join(socketsDir, podId))
 	assert.True(t, os.IsNotExist(err))
 
 	_, err = nodeService.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 	})
 	require.NoError(t, err)
@@ -198,31 +198,31 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 	mounter := csimounter.NewMock()
 
 	ctx := context.Background()
-	nodeID := "testNodeId"
-	clientID := "testClientId"
-	podID := "test-pod-id-13"
-	instanceID := "testInstanceId"
-	actualClientId := "testClientId-" + instanceID
-	diskID := "test-disk-id-42"
-	deviceName := diskID
+	nodeId := "testNodeId"
+	clientId := "testClientId"
+	podId := "test-pod-id-13"
+	instanceId := "testInstanceId"
+	actualClientId := "testClientId-" + instanceId
+	diskId := "test-disk-id-42"
+	deviceName := diskId
 	if deviceNameOpt != nil {
 		deviceName = *deviceNameOpt
 	}
-	volumeId := diskID
+	volumeId := diskId
 	if perInstanceVolumes {
-		volumeId = diskID + "#" + instanceID
+		volumeId = diskId + "#" + instanceId
 	}
 	stagingTargetPath := filepath.Join(tempDir, "testStagingTargetPath")
 	socketsDir := filepath.Join(tempDir, "sockets")
-	sourcePath := filepath.Join(socketsDir, instanceID, diskID)
-	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
+	sourcePath := filepath.Join(socketsDir, instanceId, diskId)
+	targetPath := filepath.Join(tempDir, "pods", podId, "volumes", diskId, "mount")
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	nbsSocketPath := filepath.Join(sourcePath, "nbs.sock")
 	nfsSocketPath := filepath.Join(sourcePath, "nfs.sock")
 
 	nodeService := newNodeService(
-		nodeID,
-		clientID,
+		nodeId,
+		clientId,
 		true, // vmMode
 		socketsDir,
 		targetFsPathPattern,
@@ -248,7 +248,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 
 	volumeContext := map[string]string{
 		backendVolumeContextKey: backend,
-		instanceIdKey:           instanceID,
+		instanceIdKey:           instanceId,
 	}
 	if deviceNameOpt != nil {
 		volumeContext[deviceNameVolumeContextKey] = *deviceNameOpt
@@ -258,8 +258,8 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 	if backend == "nbs" {
 		nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 			UnixSocketPath:   nbsSocketPath,
-			DiskId:           diskID,
-			InstanceId:       instanceID,
+			DiskId:           diskId,
+			InstanceId:       instanceId,
 			ClientId:         actualClientId,
 			DeviceName:       deviceName,
 			IpcType:          nbs.EClientIpcType_IPC_VHOST,
@@ -280,7 +280,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 		nfsClient.On("StartEndpoint", ctx, &nfs.TStartEndpointRequest{
 			Endpoint: &nfs.TEndpointConfig{
 				SocketPath:       nfsSocketPath,
-				FileSystemId:     diskID,
+				FileSystemId:     diskId,
 				ClientId:         actualClientId,
 				VhostQueuesCount: 8,
 				Persistent:       true,
@@ -328,11 +328,11 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 	if !perInstanceVolumes {
 		// Driver attempts to stop legacy endpoints only for legacy volumes.
 		nbsClient.On("StopEndpoint", ctx, &nbs.TStopEndpointRequest{
-			UnixSocketPath: filepath.Join(socketsDir, podID, diskID, nbsSocketName),
+			UnixSocketPath: filepath.Join(socketsDir, podId, diskId, nbsSocketName),
 		}).Return(&nbs.TStopEndpointResponse{}, nil)
 
 		nfsClient.On("StopEndpoint", ctx, &nfs.TStopEndpointRequest{
-			SocketPath: filepath.Join(socketsDir, podID, diskID, nfsSocketName),
+			SocketPath: filepath.Join(socketsDir, podId, diskId, nfsSocketName),
 		}).Return(&nfs.TStopEndpointResponse{}, nil)
 	}
 
@@ -360,7 +360,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 	})
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(socketsDir, instanceID))
+	_, err = os.Stat(filepath.Join(socketsDir, instanceId))
 	assert.True(t, os.IsNotExist(err))
 }
 
@@ -414,22 +414,22 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	nodeID := "testNodeId"
-	clientID := "testClientId"
-	podID := "test-pod-id-13"
-	diskID := "test-disk-id-42"
+	nodeId := "testNodeId"
+	clientId := "testClientId"
+	podId := "test-pod-id-13"
+	diskId := "test-disk-id-42"
 	actualClientId := "testClientId-testNodeId"
-	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
+	targetPath := filepath.Join(tempDir, "pods", podId, "volumes", diskId, "mount")
 	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 	stagingTargetPath := "testStagingTargetPath"
 	socketsDir := filepath.Join(tempDir, "sockets")
-	sourcePath := filepath.Join(socketsDir, diskID)
-	socketPath := filepath.Join(socketsDir, diskID, "nbs.sock")
-	deprecatedSocketPath := filepath.Join(socketsDir, podID, diskID, "nbs.sock")
+	sourcePath := filepath.Join(socketsDir, diskId)
+	socketPath := filepath.Join(socketsDir, diskId, "nbs.sock")
+	deprecatedSocketPath := filepath.Join(socketsDir, podId, diskId, "nbs.sock")
 
 	nodeService := newNodeService(
-		nodeID,
-		clientID,
+		nodeId,
+		clientId,
 		false, // vmMode
 		socketsDir,
 		targetFsPathPattern,
@@ -455,10 +455,10 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
 	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 		UnixSocketPath:   socketPath,
-		DiskId:           diskID,
-		InstanceId:       nodeID,
+		DiskId:           diskId,
+		InstanceId:       nodeId,
 		ClientId:         actualClientId,
-		DeviceName:       diskID,
+		DeviceName:       diskId,
 		IpcType:          ipcType,
 		VhostQueuesCount: 8,
 		VolumeAccessMode: nbs.EVolumeAccessMode_VOLUME_ACCESS_READ_WRITE,
@@ -483,7 +483,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	mounter.On("Mount", nbdDeviceFile, stagingTargetPath, "ext4", []string{}).Return(nil)
 
 	_, err = nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 		VolumeCapability:  &volumeCapability,
 		VolumeContext:     volumeContext,
@@ -498,7 +498,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	mounter.On("Mount", stagingTargetPath, targetPath, "", []string{"bind"}).Return(nil)
 
 	_, err = nodeService.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 		TargetPath:        targetPath,
 		VolumeCapability:  &volumeCapability,
@@ -529,7 +529,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	}).Return(&nbs.TStopEndpointResponse{}, nil)
 
 	_, err = nodeService.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{
-		VolumeId:   diskID,
+		VolumeId:   diskId,
 		TargetPath: targetPath,
 	})
 	require.NoError(t, err)
@@ -537,7 +537,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	mockCallStopEndpoint.Unset()
 	mockCallCleanupMountPoint.Unset()
 
-	_, err = os.Stat(filepath.Join(socketsDir, podID))
+	_, err = os.Stat(filepath.Join(socketsDir, podId))
 	assert.True(t, os.IsNotExist(err))
 
 	mounter.On("CleanupMountPoint", stagingTargetPath).Return(nil)
@@ -547,7 +547,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	}).Return(&nbs.TStopEndpointResponse{}, nil)
 
 	_, err = nodeService.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 	})
 	require.NoError(t, err)
@@ -565,23 +565,23 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	nodeID := "testNodeId"
-	clientID := "testClientId"
-	podID := "test-pod-id-13"
-	diskID := "test-disk-id-42"
+	nodeId := "testNodeId"
+	clientId := "testClientId"
+	podId := "test-pod-id-13"
+	diskId := "test-disk-id-42"
 	actualClientId := "testClientId-testNodeId"
-	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskID, podID)
+	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskId, podId)
 	targetBlkPathPattern := filepath.Join(tempDir, "volumeDevices/publish/([a-z0-9-]+)/([a-z0-9-]+)")
 	stagingTargetPath := "testStagingTargetPath"
-	stagingDevicePath := filepath.Join(stagingTargetPath, diskID)
+	stagingDevicePath := filepath.Join(stagingTargetPath, diskId)
 	socketsDir := filepath.Join(tempDir, "sockets")
-	sourcePath := filepath.Join(socketsDir, diskID)
-	socketPath := filepath.Join(socketsDir, diskID, "nbs.sock")
-	deprecatedSocketPath := filepath.Join(socketsDir, podID, diskID, "nbs.sock")
+	sourcePath := filepath.Join(socketsDir, diskId)
+	socketPath := filepath.Join(socketsDir, diskId, "nbs.sock")
+	deprecatedSocketPath := filepath.Join(socketsDir, podId, diskId, "nbs.sock")
 
 	nodeService := newNodeService(
-		nodeID,
-		clientID,
+		nodeId,
+		clientId,
 		false, // vmMode
 		socketsDir,
 		"", // targetFsPathPattern
@@ -605,10 +605,10 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
 	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 		UnixSocketPath:   socketPath,
-		DiskId:           diskID,
-		InstanceId:       nodeID,
+		DiskId:           diskId,
+		InstanceId:       nodeId,
 		ClientId:         actualClientId,
-		DeviceName:       diskID,
+		DeviceName:       diskId,
 		IpcType:          ipcType,
 		VhostQueuesCount: 8,
 		VolumeAccessMode: nbs.EVolumeAccessMode_VOLUME_ACCESS_READ_WRITE,
@@ -628,7 +628,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	mockCallMount := mounter.On("Mount", nbdDeviceFile, stagingDevicePath, "", []string{"bind"}).Return(nil)
 
 	_, err = nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 		VolumeCapability:  &volumeCapability,
 		VolumeContext:     volumeContext,
@@ -640,7 +640,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	mounter.On("Mount", stagingDevicePath, targetPath, "", []string{"bind"}).Return(nil)
 
 	_, err = nodeService.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 		TargetPath:        targetPath,
 		VolumeCapability:  &volumeCapability,
@@ -673,12 +673,12 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	}).Return(&nbs.TStopEndpointResponse{}, nil)
 
 	_, err = nodeService.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{
-		VolumeId:   diskID,
+		VolumeId:   diskId,
 		TargetPath: targetPath,
 	})
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(socketsDir, podID))
+	_, err = os.Stat(filepath.Join(socketsDir, podId))
 	assert.True(t, os.IsNotExist(err))
 
 	mounter.On("IsMountPoint", stagingTargetPath).Return(false, nil)
@@ -690,7 +690,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	}).Return(&nbs.TStopEndpointResponse{}, nil)
 
 	_, err = nodeService.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: stagingTargetPath,
 	})
 	require.NoError(t, err)
@@ -702,10 +702,10 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	nbsClient := mocks.NewNbsClientMock()
 	mounter := csimounter.NewMock()
 
-	podID := "test-pod-id-13"
-	diskID := "test-disk-id-42"
+	podId := "test-pod-id-13"
+	diskId := "test-disk-id-42"
 	socketsDir := filepath.Join(tempDir, "sockets")
-	targetPath := filepath.Join(tempDir, "pods", podID, "volumes", diskID, "mount")
+	targetPath := filepath.Join(tempDir, "pods", podId, "volumes", diskId, "mount")
 	targetFsPathPattern := filepath.Join(tempDir,
 		"pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
 
@@ -742,11 +742,11 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 		})
 	assert.NotEqual(t, -1, capabilityIndex)
 
-	nbsClient.On("DescribeVolume", ctx, &nbs.TDescribeVolumeRequest{DiskId: diskID}).Return(&nbs.TDescribeVolumeResponse{}, nil)
+	nbsClient.On("DescribeVolume", ctx, &nbs.TDescribeVolumeRequest{DiskId: diskId}).Return(&nbs.TDescribeVolumeResponse{}, nil)
 	mounter.On("IsMountPoint", targetPath).Return(true, nil)
 
 	stat, err := nodeService.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
-		VolumeId:   diskID,
+		VolumeId:   diskId,
 		VolumePath: targetPath,
 	})
 	require.NoError(t, err)
@@ -769,17 +769,17 @@ func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 	nbsClient := mocks.NewNbsClientMock()
 	mounter := csimounter.NewMock()
 
-	clientID := "testClientId"
-	podID := "test-pod-id-13"
-	diskID := "test-disk-id-42"
-	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskID, podID)
+	clientId := "testClientId"
+	podId := "test-pod-id-13"
+	diskId := "test-disk-id-42"
+	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskId, podId)
 	targetBlkPathPattern := filepath.Join(tempDir,
 		"volumeDevices/publish/([a-z0-9-]+)/([a-z0-9-]+)")
 	socketsDir := filepath.Join(tempDir, "sockets")
 
 	nodeService := newNodeService(
 		"testNodeId",
-		clientID,
+		clientId,
 		true,
 		socketsDir,
 		"",
@@ -807,7 +807,7 @@ func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 	assert.Equal(t, -1, capabilityIndex)
 
 	_, err = nodeService.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
-		VolumeId:   diskID,
+		VolumeId:   diskId,
 		VolumePath: targetPath,
 	})
 	require.Error(t, err)
@@ -820,10 +820,10 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 	mounter := csimounter.NewMock()
 
 	ctx := context.Background()
-	clientID := "testClientId"
-	podID := "test-pod-id-13"
-	diskID := "test-disk-id-42"
-	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskID, podID)
+	clientId := "testClientId"
+	podId := "test-pod-id-13"
+	diskId := "test-disk-id-42"
+	targetPath := filepath.Join(tempDir, "volumeDevices", "publish", diskId, podId)
 	targetBlkPathPattern := filepath.Join(tempDir, "volumeDevices/publish/([a-z0-9-]+)/([a-z0-9-]+)")
 	socketsDir := filepath.Join(tempDir, "sockets")
 	volumeContext := map[string]string{
@@ -832,7 +832,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 
 	nodeService := newNodeService(
 		"testNodeId",
-		clientID,
+		clientId,
 		false,
 		socketsDir,
 		"",
@@ -843,7 +843,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 	)
 
 	_, err := nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: "testStagingTargetPath",
 		VolumeCapability: &csi.VolumeCapability{
 			AccessType: &csi.VolumeCapability_Block{
@@ -855,7 +855,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 
 	// NodePublishVolume without access mode should fail
 	_, err = nodeService.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: "testStagingTargetPath",
 		TargetPath:        targetPath,
 		VolumeCapability: &csi.VolumeCapability{
@@ -868,7 +868,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = nodeService.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
-		VolumeId:          diskID,
+		VolumeId:          diskId,
 		StagingTargetPath: "testStagingTargetPath",
 		TargetPath:        targetPath,
 		VolumeCapability: &csi.VolumeCapability{

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -1,5 +1,7 @@
 package driver
 
+//lint:file-ignore ST1003 protobuf generates names that break golang naming convention
+
 import (
 	"context"
 	"io/fs"

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -244,7 +244,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirt(t *testing.T, backend string,
 
 	volumeContext := map[string]string{
 		backendVolumeContextKey: backend,
-		instanceIDKey:           instanceID,
+		instanceIdKey:           instanceID,
 	}
 	if deviceNameOpt != nil {
 		volumeContext[deviceNameVolumeContextKey] = *deviceNameOpt

--- a/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
+++ b/cloud/blockstore/tools/csi_driver/stage-publish-unpublish-unstage-flow.md
@@ -22,8 +22,8 @@ New format of UnixSocketPath: socketsDir/volumeId
 Current format of InstanceId: podId
 New format of InstanceId: nodeId
 
-Current format of ClientId: clientID-podId
-New format of ClientId: clientID-nodeId
+Current format of ClientId: clientId-podId
+New format of ClientId: clientId-nodeId
 
 Possible scenarios:
 


### PR DESCRIPTION
After merge of  #1982 using single FS share by multiple VMs on the same host was broken. Also testing showed that quickly unplugging disk from a VM and hotplugging to other VM on the same host doesn't work as expected.

These problems have same root cause: Kubernetes treats different PVs that have same `volumeHandle` as referring to the same volume. And we used NBS disk/filesystem ID as a `volumeHandle`, so when we the volume has been already staged on the host scheduling a VM with different PV/PVC but same `volumeHandle` on this host resulted only in `NodePublish` call (mount to pod) but not `NodeStage` call (start endpoint).
This breaks VM scenarios because only one qemu process can work with vhost-socket simultaneously, so each VM requires its own endpoint to be started.

This PR resolves the problem by introducing support for new `volumeHandle` format: `nbsId#instanceId` instead of just `nbsId`.
With such handles volumes belonging to the same VM are reused across different pods (in case of hotplug) and volumes referring to the same FS/disk for different VMs have independent endpoints.

Support for old format is kept to avoid breaking existing volumes, but it should be deprecated and removed after the migration is complete.