### PR TITLE
issue-2364: return E_NOT_FOUND when unix socket path doesn't exist

### DIFF
--- a/cloud/blockstore/libs/nbd/server_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_ut.cpp
@@ -690,7 +690,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         bootstrap1->Stop();
     }
 
-    Y_UNIT_TEST(ShouldGetFatalErrorIfEndpointHasInvalidSocketPath)
+    Y_UNIT_TEST(ShouldReturnNotFoundErrorIfEndpointHasInvalidSocketPath)
     {
         TUnixSocketPath socketPath("./invalid/path/to/socket");
         TNetworkAddress connectAddress(socketPath);
@@ -706,6 +706,10 @@ Y_UNIT_TEST_SUITE(TServerTest)
         UNIT_ASSERT_VALUES_EQUAL_C(
             EErrorKind::ErrorFatal,
             GetErrorKind(error),
+            error);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_NOT_FOUND,
+            error.GetCode(),
             error);
 
         bootstrap->Stop();


### PR DESCRIPTION
issue: #2364 

Problem:
Start endpoint returns E_FAIL if bind socket fails with "Directory not found" error

bind throws TSystemError: [nbs/library/cpp/coroutine/listener/listen.cpp at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/library/cpp/coroutine/listener/listen.cpp#L83)
nbd server calls bind inside of SafeExecute: [nbs/cloud/blockstore/libs/nbd/server.cpp at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/nbd/server.cpp#L315)
SafeExecute converts system error to E_FAIL: [nbs/cloud/storage/core/libs/common/error.h at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/cloud/storage/core/libs/common/error.h#L441)

Solution:
Throw exception with E_NOT_FOUND error if directory doesn't exist before calling bind