### PR TITLE
[Disk Manager] better test with replacing url source diring image creation

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/image_service_test/image_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/image_service_test/image_service_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -556,8 +557,15 @@ func TestImageServiceCreateQCOW2ImageFromURL(t *testing.T) {
 	testCreateQCOW2ImageFromURL(t)
 }
 
-func TestImageServiceCreateQCOW2ImageFromURLWhichIsOverwrittenInProcess(
+func testImageServiceCreateImageFromURLWhichIsOverwrittenInProcess(
 	t *testing.T,
+	imageID string,
+	imageURL string,
+	defaultImageSize uint64,
+	defaultImageCrc32 uint32,
+	otherImageSize uint64,
+	otherImageCrc32 uint32,
+	overwriteImage func(t *testing.T),
 ) {
 
 	ctx := testcommon.NewContext()
@@ -566,13 +574,11 @@ func TestImageServiceCreateQCOW2ImageFromURLWhichIsOverwrittenInProcess(
 	require.NoError(t, err)
 	defer client.Close()
 
-	imageID := t.Name()
-
 	reqCtx := testcommon.GetRequestContext(t, ctx)
 	operation, err := client.CreateImage(reqCtx, &disk_manager.CreateImageRequest{
 		Src: &disk_manager.CreateImageRequest_SrcUrl{
 			SrcUrl: &disk_manager.ImageUrl{
-				Url: testcommon.GetQCOW2ImageFileURL(),
+				Url: imageURL,
 			},
 		},
 		DstImageId: imageID,
@@ -585,29 +591,38 @@ func TestImageServiceCreateQCOW2ImageFromURLWhichIsOverwrittenInProcess(
 	// Need to add some variance for better testing.
 	common.WaitForRandomDuration(1000*time.Millisecond, 2*time.Second)
 	// Overwrites image URL contents.
-	testcommon.UseOtherQCOW2ImageFile(t)
+	overwriteImage(t)
 
 	imageResponse := disk_manager.CreateImageResponse{}
 	err = internal_client.WaitResponse(ctx, client, operation.Id, &imageResponse)
+
 	if err != nil {
-		// TODO: remove this branch after NBS-4002.
-		require.Contains(t, err.Error(), "wrong ETag")
-		return
+		if strings.Contains(err.Error(), "wrong ETag") {
+			testcommon.CheckErrorDetails(t, err, codes.Aborted, "", true /*internal*/)
+			return
+		}
+
+		// http code 416 might be returned if other image size is less then
+		// default image size.
+		if strings.Contains(err.Error(), "http code 416") {
+			testcommon.CheckErrorDetails(t, err, codes.BadSource, "", true /*internal*/)
+			return
+		}
 	}
 
-	imageSize := testcommon.GetOtherQCOW2ImageSize(t)
-	imageCrc32 := testcommon.GetOtherQCOW2ImageCrc32(t)
+	imageSize := otherImageSize
+	imageCrc32 := otherImageCrc32
 
 	if int64(imageSize) != imageResponse.Size {
 		// Default image file is also allowed, image could have already been
 		// created before we started using 'other image'.
-		imageSize = testcommon.GetQCOW2ImageSize(t)
-		imageCrc32 = testcommon.GetQCOW2ImageCrc32(t)
+		imageSize = defaultImageSize
+		imageCrc32 = defaultImageCrc32
 
 		require.Equal(t, int64(imageSize), imageResponse.Size)
 	}
 
-	diskID := t.Name()
+	diskID := imageID
 
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
@@ -639,6 +654,59 @@ func TestImageServiceCreateQCOW2ImageFromURLWhichIsOverwrittenInProcess(
 	require.NoError(t, err)
 
 	testcommon.CheckConsistency(t, ctx)
+}
+
+func TestImageServiceCreateImageFromURLWhichIsOverwrittenInProcess(
+	t *testing.T,
+) {
+
+	testcommon.UseDefaultQCOW2ImageFile(t)
+	testImageServiceCreateImageFromURLWhichIsOverwrittenInProcess(
+		t,
+		t.Name()+"_qcow_1",
+		testcommon.GetQCOW2ImageFileURL(),
+		testcommon.GetQCOW2ImageSize(t),
+		testcommon.GetQCOW2ImageCrc32(t),
+		testcommon.GetOtherQCOW2ImageSize(t),
+		testcommon.GetOtherQCOW2ImageCrc32(t),
+		testcommon.UseOtherQCOW2ImageFile,
+	)
+
+	testcommon.UseOtherQCOW2ImageFile(t)
+	testImageServiceCreateImageFromURLWhichIsOverwrittenInProcess(
+		t,
+		t.Name()+"_qcow_2",
+		testcommon.GetQCOW2ImageFileURL(),
+		testcommon.GetOtherQCOW2ImageSize(t),
+		testcommon.GetOtherQCOW2ImageCrc32(t),
+		testcommon.GetQCOW2ImageSize(t),
+		testcommon.GetQCOW2ImageCrc32(t),
+		testcommon.UseDefaultQCOW2ImageFile,
+	)
+
+	testcommon.UseDefaultBigRawImageFile(t)
+	testImageServiceCreateImageFromURLWhichIsOverwrittenInProcess(
+		t,
+		t.Name()+"_raw_1",
+		testcommon.GetBigRawImageURL(),
+		testcommon.GetBigRawImageSize(t),
+		testcommon.GetBigRawImageCrc32(t),
+		testcommon.GetOtherBigRawImageSize(t),
+		testcommon.GetOtherBigRawImageCrc32(t),
+		testcommon.UseOtherBigRawImageFile,
+	)
+
+	testcommon.UseOtherBigRawImageFile(t)
+	testImageServiceCreateImageFromURLWhichIsOverwrittenInProcess(
+		t,
+		t.Name()+"_raw_2",
+		testcommon.GetBigRawImageURL(),
+		testcommon.GetOtherBigRawImageSize(t),
+		testcommon.GetOtherBigRawImageCrc32(t),
+		testcommon.GetBigRawImageSize(t),
+		testcommon.GetBigRawImageCrc32(t),
+		testcommon.UseDefaultBigRawImageFile,
+	)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -116,6 +116,11 @@ func UseOtherQCOW2ImageFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func UseDefaultQCOW2ImageFile(t *testing.T) {
+	_, err := http.Get(GetQCOW2ImageFileURL() + "/use_default_image")
+	require.NoError(t, err)
+}
+
 func GetOtherQCOW2ImageSize(t *testing.T) uint64 {
 	value, err := strconv.ParseUint(os.Getenv("DISK_MANAGER_RECIPE_OTHER_QCOW2_IMAGE_SIZE"), 10, 64)
 	require.NoError(t, err)
@@ -151,6 +156,45 @@ func GetGeneratedVMDKImageSize(t *testing.T) uint64 {
 
 func GetGeneratedVMDKImageCrc32(t *testing.T) uint32 {
 	value, err := strconv.ParseUint(os.Getenv("DISK_MANAGER_RECIPE_GENERATED_VMDK_IMAGE_CRC32"), 10, 32)
+	require.NoError(t, err)
+	return uint32(value)
+}
+
+func GetBigRawImageURL() string {
+	port := os.Getenv("DISK_MANAGER_RECIPE_BIG_RAW_IMAGE_FILE_SERVER_PORT")
+	return fmt.Sprintf("http://localhost:%v", port)
+}
+
+func GetBigRawImageSize(t *testing.T) uint64 {
+	value, err := strconv.ParseUint(os.Getenv("DISK_MANAGER_RECIPE_BIG_RAW_IMAGE_SIZE"), 10, 64)
+	require.NoError(t, err)
+	return uint64(value)
+}
+
+func GetBigRawImageCrc32(t *testing.T) uint32 {
+	value, err := strconv.ParseUint(os.Getenv("DISK_MANAGER_RECIPE_BIG_RAW_IMAGE_CRC32"), 10, 32)
+	require.NoError(t, err)
+	return uint32(value)
+}
+
+func UseOtherBigRawImageFile(t *testing.T) {
+	_, err := http.Get(GetBigRawImageURL() + "/use_other_image")
+	require.NoError(t, err)
+}
+
+func UseDefaultBigRawImageFile(t *testing.T) {
+	_, err := http.Get(GetBigRawImageURL() + "/use_default_image")
+	require.NoError(t, err)
+}
+
+func GetOtherBigRawImageSize(t *testing.T) uint64 {
+	value, err := strconv.ParseUint(os.Getenv("DISK_MANAGER_RECIPE_OTHER_BIG_RAW_IMAGE_SIZE"), 10, 64)
+	require.NoError(t, err)
+	return uint64(value)
+}
+
+func GetOtherBigRawImageCrc32(t *testing.T) uint32 {
+	value, err := strconv.ParseUint(os.Getenv("DISK_MANAGER_RECIPE_OTHER_BIG_RAW_IMAGE_CRC32"), 10, 32)
 	require.NoError(t, err)
 	return uint32(value)
 }

--- a/cloud/disk_manager/test/images/recipe/__main__.py
+++ b/cloud/disk_manager/test/images/recipe/__main__.py
@@ -8,6 +8,7 @@ from library.python.testing.recipe import declare_recipe, set_env
 
 from cloud.disk_manager.test.images.recipe.image_file_server_launcher import ImageFileServerLauncher
 from cloud.disk_manager.test.images.recipe.vmdk_image_generator import VMDKImageGenerator
+from cloud.disk_manager.test.images.recipe.raw_image_generator import RawImageGenerator
 
 
 def start(argv):
@@ -173,6 +174,27 @@ def start(argv):
     )
     ensure_path_exists(working_dir)
 
+    big_raw_image_file_path = os.path.join(working_dir, "generated_big_raw_image")
+    other_big_raw_image_file_path = os.path.join(working_dir, "generated_other_big_raw_image")
+    big_raw_image_file_size = 536870912 # 512 MB
+    other_big_raw_image_file_size = 1073741824 # 1GB
+    raw_image_generator = RawImageGenerator(big_raw_image_file_path, big_raw_image_file_size)
+    raw_image_generator.generate()
+    other_raw_image_generator = RawImageGenerator(other_big_raw_image_file_path, other_big_raw_image_file_size)
+    other_raw_image_generator.generate()
+    big_raw_image_file_server = ImageFileServerLauncher(
+        big_raw_image_file_path,
+        big_raw_image_file_size,
+        other_big_raw_image_file_path,
+        other_big_raw_image_file_size,
+    )
+    big_raw_image_file_server.start()
+    set_env("DISK_MANAGER_RECIPE_BIG_RAW_IMAGE_FILE_SERVER_PORT", str(big_raw_image_file_server.port))
+    set_env("DISK_MANAGER_RECIPE_BIG_RAW_IMAGE_SIZE", str(big_raw_image_file_size))
+    set_env("DISK_MANAGER_RECIPE_BIG_RAW_IMAGE_CRC32", str(raw_image_generator.image_crc32))
+    set_env("DISK_MANAGER_RECIPE_OTHER_BIG_RAW_IMAGE_SIZE", str(other_big_raw_image_file_size))
+    set_env("DISK_MANAGER_RECIPE_OTHER_BIG_RAW_IMAGE_CRC32", str(other_raw_image_generator.image_crc32))
+
     invalid_qcow2_image_file_path = os.path.join(
         working_dir,
         "invalid_qcow2_image"
@@ -226,6 +248,8 @@ def start(argv):
         set_env("DISK_MANAGER_RECIPE_GENERATED_VMDK_IMAGE_SIZE", str(vmdk_image_generator.raw_image_size))
         set_env("DISK_MANAGER_RECIPE_GENERATED_VMDK_IMAGE_CRC32", str(vmdk_image_generator.raw_image_crc32))
 
+    if '--generate-big-raw-images' in argv:
+        pass
 
 def stop(argv):
     ImageFileServerLauncher.stop()

--- a/cloud/disk_manager/test/images/recipe/raw_image_generator.py
+++ b/cloud/disk_manager/test/images/recipe/raw_image_generator.py
@@ -1,0 +1,44 @@
+import binascii
+
+from yatest.common import process
+
+class RawImageGenerator():
+
+    def __init__(self, image_file_path, image_size):
+        self.__image_size = image_size  # _ or __ ?
+        self.__image_file_path = image_file_path
+
+        self.__batch_size = 1024 * 1024
+        if image_size % self.__batch_size != 0:
+            raise Exception("image size should be divisible by {}, image size = {}".format(self.__batch_size, image_size))
+
+    def generate(self):
+        # Write some zero bytes in the beginning of the file
+        # to ensure that image format will be treated as raw
+        process.execute([
+            "dd",
+            "if=/dev/zero",
+            "of={}".format(self.__image_file_path),
+            "bs={}".format(self.__batch_size),
+            "count={}".format(1),
+        ])
+
+        # Fill image with random bytes
+        batch_count = self.__image_size // self.__batch_size - 1
+        process.execute([
+            "dd",
+            "if=/dev/urandom",
+            "of={}".format(self.__image_file_path),
+            "bs={}".format(self.__batch_size),
+            "count={}".format(batch_count),
+            "seek={}".format(1),
+        ])
+
+    @property
+    def image_crc32(self):
+        crc32 = 0
+        with open(self.__image_file_path, "rb") as f:
+            for _ in range(0, self.__image_size, self.__batch_size):
+                batch = f.read(self.__batch_size)
+                crc32 = binascii.crc32(batch, crc32)
+        return crc32

--- a/cloud/disk_manager/test/images/recipe/ya.make
+++ b/cloud/disk_manager/test/images/recipe/ya.make
@@ -3,6 +3,7 @@ PY3_PROGRAM()
 PY_SRCS(
     __main__.py
     image_file_server_launcher.py
+    raw_image_generator.py
     vmdk_image_generator.py
 )
 

--- a/cloud/disk_manager/test/images/server/main.go
+++ b/cloud/disk_manager/test/images/server/main.go
@@ -51,6 +51,13 @@ func main() {
 				},
 			)
 
+			http.HandleFunc("/use_default_image",
+				func(w http.ResponseWriter, r *http.Request) {
+					log.Printf("Using default image file %v", imageFilePath)
+					useOtherImage.Store(false)
+				},
+			)
+
 			endpoint := fmt.Sprintf(":%v", port)
 			log.Printf(
 				"Listening on %v, serving files %v %v\n",


### PR DESCRIPTION
The existing test had two disadvantages:
- Wrong etag error occured very rarely. (2 times out of 100 runs). This is because the image is quite small, so its creation was very fast and the probability that the url data would be replaced in time was very small. 
- Size of the other image was always greater than the size of the default image. This missed an interesting scenario: when the size of the other image is smaller, http code 416 (i.e. bad content range) error might return instead of wrong etag error.

To fix these disadvantages, we run image creation 4 times:
- 16 MB qcow image -> 32 MB qcow image (the same as in the old test).
- 32 MB qcow image -> 16 MB qcow image 
- 512 MB raw image -> 1GB raw image
- 1GB raw image -> 512 MB  raw image

Previous pr (use aborted error on wrong etag): https://github.com/ydb-platform/nbs/pull/2248