### PR TITLE
[Blockstore] handle disk allocation errors when updating the volume config

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -306,6 +306,21 @@ void TVolumeActor::HandleAllocateDiskResponse(
             FormatError(error).c_str(),
             GetNewestConfig().GetDiskId().Quote().c_str());
 
+        if (UpdateVolumeConfigInProgress && State) {
+            UnfinishedUpdateVolumeConfig.Devices = State->GetMeta().GetDevices();
+            UnfinishedUpdateVolumeConfig.Migrations =
+                State->GetMeta().GetMigrations();
+
+            UnfinishedUpdateVolumeConfig.Replicas.clear();
+            for (auto& r: State->GetMeta().GetReplicas()) {
+                UnfinishedUpdateVolumeConfig.Replicas.push_back(r.GetDevices());
+            }
+
+            UnfinishedUpdateVolumeConfig.FreshDeviceIds.assign(
+                State->GetMeta().GetFreshDeviceIds().begin(),
+                State->GetMeta().GetFreshDeviceIds().end());
+        }
+
         if (GetErrorKind(error) == EErrorKind::ErrorRetriable) {
             ScheduleAllocateDiskIfNeeded(ctx);
         } else {


### PR DESCRIPTION
If an allocation error occurs during a volume configuration update, the volume stores inconsistent data in Meta (non-empty replicas containing empty device lists).