### PR TITLE
issue-2270: return error if nbd device name is missing

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1417,7 +1417,7 @@ TResultOrError<NBD::IDevicePtr> TEndpointManager::StartNbdDevice(
     }
 
     if (!request->HasNbdDeviceFile() || !request->GetNbdDeviceFile()) {
-        return NBD::CreateDeviceStub();
+        return MakeError(E_ARGUMENT, "NBD device file is missing");
     }
 
     if (!restoring) {

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -560,10 +560,6 @@ func (s *nodeService) nodePublishDiskAsFilesystemDeprecated(
 		return fmt.Errorf("failed to start NBS endpoint: %w", err)
 	}
 
-	if resp.NbdDeviceFile == "" {
-		return fmt.Errorf("NbdDeviceFile shouldn't be empty")
-	}
-
 	logVolume(req.VolumeId, "endpoint started with device: %q", resp.NbdDeviceFile)
 
 	mnt := req.VolumeCapability.GetMount()
@@ -726,10 +722,6 @@ func (s *nodeService) nodeStageDiskAsFilesystem(
 		return fmt.Errorf("failed to start NBS endpoint: %w", err)
 	}
 
-	if resp.NbdDeviceFile == "" {
-		return fmt.Errorf("NbdDeviceFile shouldn't be empty")
-	}
-
 	logVolume(req.VolumeId, "endpoint started with device: %q", resp.NbdDeviceFile)
 
 	mnt := req.VolumeCapability.GetMount()
@@ -802,10 +794,6 @@ func (s *nodeService) nodeStageDiskAsBlockDevice(
 		return fmt.Errorf("failed to start NBS endpoint: %w", err)
 	}
 
-	if resp.NbdDeviceFile == "" {
-		return fmt.Errorf("NbdDeviceFile shouldn't be empty")
-	}
-
 	logVolume(req.VolumeId, "endpoint started with device: %q", resp.NbdDeviceFile)
 
 	devicePath := filepath.Join(req.StagingTargetPath, req.VolumeId)
@@ -819,10 +807,6 @@ func (s *nodeService) nodePublishDiskAsBlockDeviceDeprecated(
 	resp, err := s.startNbsEndpointForNBD(ctx, s.getPodId(req), req.VolumeId, req.VolumeContext)
 	if err != nil {
 		return fmt.Errorf("failed to start NBS endpoint: %w", err)
-	}
-
-	if resp.NbdDeviceFile == "" {
-		return fmt.Errorf("NbdDeviceFile shouldn't be empty")
 	}
 
 	logVolume(req.VolumeId, "endpoint started with device: %q", resp.NbdDeviceFile)


### PR DESCRIPTION
issue: #2270

1. return E_ARGUMENT error if nbd device name is missing or empty and UseFreeNbdDeviceFile is missing or False
2. remove nbd device name checks if StartEndpoint succeeded