### PR TITLE
issue-9: increase default BlobCompressionChunkSize to 80 KiB

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -192,7 +192,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(NodeType,                        TString,               {}            )\
     xxx(BlobCompressionRate,             ui32,                  0             )\
     xxx(BlobCompressionCodec,            TString,               "lz4"         )\
-    xxx(BlobCompressionChunkSize,        ui32,                  40_KB         )\
+    xxx(BlobCompressionChunkSize,        ui32,                  80_KB         )\
                                                                                \
     xxx(MaxZeroCompactionRangesToDeletePerTx,           ui32,      10000      )\
     xxx(ChannelFreeSpaceThreshold,                      ui32,      25         )\

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -726,7 +726,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                     {"sensor", "CompressedBytesWritten"},
                     {"filesystem", "test"}
                 },
-                457 // expected
+                439 // expected
             },
         });
     }


### PR DESCRIPTION
Previous (40 KiB) value did not show good compression ratio on real data, so increase a little bit

#9 