### PR TITLE
issue-2137: filestore-client forcedcompaction can now distinguish between completed operations and tablet restarts and retries operations aborted due to tablet restarts from the last processed range id; tweaked CompactRange check - it doesn't skip ranges with 0 used blocks now

### DIFF
--- a/cloud/filestore/apps/client/lib/forced_compaction.cpp
+++ b/cloud/filestore/apps/client/lib/forced_compaction.cpp
@@ -60,6 +60,18 @@ private:
         }
     }
 
+    auto RunCompaction()
+    {
+        NProtoPrivate::TForcedOperationRequest request;
+        request.SetFileSystemId(FileSystemId);
+        request.SetOpType(NProtoPrivate::TForcedOperationRequest::E_COMPACTION);
+        request.SetMinRangeId(MinRangeId);
+        NProtoPrivate::TForcedOperationResponse response;
+        ExecuteAction("forcedoperation", request, &response);
+        CheckResponse(response);
+        return response;
+    }
+
 public:
     TForcedCompactionCommand()
     {
@@ -73,13 +85,7 @@ public:
     {
         auto callContext = PrepareCallContext();
 
-        NProtoPrivate::TForcedOperationRequest request;
-        request.SetFileSystemId(FileSystemId);
-        request.SetOpType(NProtoPrivate::TForcedOperationRequest::E_COMPACTION);
-        request.SetMinRangeId(MinRangeId);
-        NProtoPrivate::TForcedOperationResponse response;
-        ExecuteAction("forcedoperation", request, &response);
-        CheckResponse(response);
+        auto response = RunCompaction();
 
         while (true) {
             NProtoPrivate::TForcedOperationStatusRequest statusRequest;
@@ -92,9 +98,16 @@ public:
                 &statusResponse);
 
             if (statusResponse.GetError().GetCode() == E_NOT_FOUND) {
-                // TODO: distinguish between finished operations and tablet
-                // restarts
+                // tablet rebooted
+                response = RunCompaction();
+                continue;
+            }
+
+            const auto processed = statusResponse.GetProcessedRangeCount();
+            const auto total = statusResponse.GetRangeCount();
+            if (processed >= total) {
                 Cout << "finished" << Endl;
+                // operation completed
                 break;
             }
 
@@ -103,6 +116,8 @@ public:
             Cout << "progress: " << statusResponse.GetProcessedRangeCount()
                 << "/" << statusResponse.GetRangeCount() << ", last="
                 << statusResponse.GetLastProcessedRangeId() << Endl;
+
+            MinRangeId = statusResponse.GetLastProcessedRangeId();
 
             Sleep(TDuration::Seconds(1));
         }

--- a/cloud/filestore/apps/client/lib/forced_compaction.cpp
+++ b/cloud/filestore/apps/client/lib/forced_compaction.cpp
@@ -106,8 +106,8 @@ public:
             const auto processed = statusResponse.GetProcessedRangeCount();
             const auto total = statusResponse.GetRangeCount();
             if (processed >= total) {
-                Cout << "finished" << Endl;
                 // operation completed
+                Cout << "finished" << Endl;
                 break;
             }
 

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -460,11 +460,16 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
             TString buf;
             google::protobuf::util::MessageToJsonString(request, &buf);
             service.SendExecuteActionRequest("forcedoperationstatus", buf);
-            auto response = service.RecvExecuteActionResponse();
+            auto jsonResponse = service.RecvExecuteActionResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_NOT_FOUND,
-                response->GetStatus(),
-                response->GetErrorReason());
+                S_OK,
+                jsonResponse->GetStatus(),
+                jsonResponse->GetErrorReason());
+            NProtoPrivate::TForcedOperationStatusResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+            UNIT_ASSERT_VALUES_EQUAL(4, response.GetRangeCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, response.GetProcessedRangeCount());
         }
 
         env.GetRegistry()->Update(env.GetRuntime().GetCurrentTime());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -765,19 +765,16 @@ void TIndexTabletActor::HandleForcedOperationStatus(
     const TActorContext& ctx)
 {
     const auto& request = ev->Get()->Record;
-    const auto* state = GetForcedRangeOperationState();
 
     using TResponse = TEvIndexTablet::TEvForcedOperationStatusResponse;
     auto response = std::make_unique<TResponse>();
 
+    const auto* state = FindForcedRangeOperation(request.GetOperationId());
     if (!state) {
-        response->Record.MutableError()->CopyFrom(
-            MakeError(E_NOT_FOUND, "forced operation not running"));
-    } else if (state->OperationId != request.GetOperationId()) {
         response->Record.MutableError()->CopyFrom(MakeError(
             E_NOT_FOUND,
-            TStringBuilder() << "forced operation id mismatch: "
-                << state->OperationId << " != " << request.GetOperationId()));
+            TStringBuilder() << "forced operation with id "
+                << request.GetOperationId() << "not found"));
     } else {
         response->Record.SetRangeCount(state->RangesToCompact.size());
         response->Record.SetProcessedRangeCount(state->Current);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -770,15 +770,15 @@ void TIndexTabletActor::HandleForcedOperationStatus(
     auto response = std::make_unique<TResponse>();
 
     const auto* state = FindForcedRangeOperation(request.GetOperationId());
-    if (!state) {
+    if (state) {
+        response->Record.SetRangeCount(state->RangesToCompact.size());
+        response->Record.SetProcessedRangeCount(state->Current);
+        response->Record.SetLastProcessedRangeId(state->GetCurrentRange());
+    } else {
         response->Record.MutableError()->CopyFrom(MakeError(
             E_NOT_FOUND,
             TStringBuilder() << "forced operation with id "
                 << request.GetOperationId() << "not found"));
-    } else {
-        response->Record.SetRangeCount(state->RangesToCompact.size());
-        response->Record.SetProcessedRangeCount(state->Current);
-        response->Record.SetLastProcessedRangeId(state->GetCurrentRange());
     }
 
     NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -572,7 +572,7 @@ void TIndexTabletActor::ExecuteTx_Compaction(
 
         const ui32 usedBlocks = storedBlocks - garbageBlocks;
         const ui32 garbagePercentage =
-            usedBlocks ? 100 * garbageBlocks / usedBlocks : 0;
+            usedBlocks ? 100 * garbageBlocks / usedBlocks : Max<ui32>();
         const ui32 averageBlobSize = static_cast<ui64>(GetBlockSize())
             * storedBlocks / args.CompactionBlobs.size();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1178,7 +1178,8 @@ public:
 
         ui32 GetCurrentRange() const
         {
-            return RangesToCompact[Current];
+            return Current < RangesToCompact.size()
+                ? RangesToCompact[Current] : 0;
         }
     };
 
@@ -1192,6 +1193,7 @@ private:
 
     TVector<TPendingForcedRangeOperation> PendingForcedRangeOperations;
     TMaybe<TForcedRangeOperationState> ForcedRangeOperationState;
+    TVector<TForcedRangeOperationState> CompletedForcedRangeOperations;
 
 public:
     TString EnqueueForcedRangeOperation(
@@ -1210,6 +1212,9 @@ public:
     {
         return ForcedRangeOperationState.Get();
     }
+
+    const TForcedRangeOperationState* FindForcedRangeOperation(
+        const TString& operationId) const;
 
     void UpdateForcedRangeOperationProgress(ui32 current)
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1364,7 +1364,31 @@ void TIndexTabletState::StartForcedRangeOperation(
 
 void TIndexTabletState::CompleteForcedRangeOperation()
 {
+    Y_DEBUG_ABORT_UNLESS(ForcedRangeOperationState);
+    if (ForcedRangeOperationState && ForcedRangeOperationState->OperationId) {
+        ForcedRangeOperationState->Current =
+            ForcedRangeOperationState->RangesToCompact.size();
+        CompletedForcedRangeOperations.push_back(*ForcedRangeOperationState);
+    }
     ForcedRangeOperationState.Clear();
+}
+
+auto TIndexTabletState::FindForcedRangeOperation(
+    const TString& operationId) const -> const TForcedRangeOperationState*
+{
+    if (ForcedRangeOperationState
+            && ForcedRangeOperationState->OperationId == operationId)
+    {
+        return ForcedRangeOperationState.Get();
+    }
+
+    for (const auto& op: CompletedForcedRangeOperations) {
+        if (op.OperationId == operationId) {
+            return &op;
+        }
+    }
+
+    return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#2137 