### PR TITLE
issue-2388: counting all MixedBlobs generated by a single Compaction run as a single logical blob in CompactionMap range stats

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -5,6 +5,8 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/storage/tablet/model/group_by.h>
 
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/set.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -23,7 +25,6 @@ class TAddBlobsExecutor
 private:
     const TString LogTag;
     TIndexTabletActor& Tablet;
-    const ui32 CompactionThreshold;
 
     struct TCompactionRangeInfo
     {
@@ -33,15 +34,10 @@ private:
     THashMap<ui32, TCompactionRangeInfo> RangeId2CompactionStats;
 
 public:
-    TAddBlobsExecutor(
-            TString logTag,
-            TIndexTabletActor& tablet,
-            ui32 compactionThreshold)
+    TAddBlobsExecutor(TString logTag, TIndexTabletActor& tablet)
         : LogTag(std::move(logTag))
         , Tablet(tablet)
-        , CompactionThreshold(compactionThreshold)
-    {
-    }
+    {}
 
 public:
     void Execute(
@@ -343,29 +339,24 @@ private:
             rangeIds.insert(rangeId);
         }
 
-        THashMap<ui32, ui32> rangeId2AddedBlobsCount;
+        THashSet<ui32> writtenRangeIds;
         for (auto& blob: args.MixedBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            // Incrementing blobs count as there could be multiple blobs
-            // per compacted range see NBS-4424
             if (Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks)) {
-                ++rangeId2AddedBlobsCount[rangeId];
+                writtenRangeIds.insert(rangeId);
             }
 
             rangeIds.insert(rangeId);
         }
 
-        for (const auto& [rangeId, addedBlobsCount]: rangeId2AddedBlobsCount) {
-            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
-
-            // If addedBlobsCount >= compactionThreshold, then Compaction will
-            // enter an infinite loop
-            // A simple solution is to limit addedBlobsCount by threshold - 1
-            auto increment = addedBlobsCount;
-            if (increment >= CompactionThreshold && CompactionThreshold > 1) {
-                increment = CompactionThreshold - 1;
-            }
-            stats.BlobsCount += increment;
+        for (const auto& rangeId: writtenRangeIds) {
+            // Deliberately incrementing BlobsCount only once per range. The
+            // data belonging to a range might need to be stored in more than
+            // one blob due to hash collisions in the calculation of
+            // <nodeId, blockIndex> -> rangeId mapping. We don't want such
+            // situations to cause extra compactions and we thus treat such
+            // a group of blobs as a single "logical" blob in CompactionMap.
+            ++AccessCompactionRangeInfo(rangeId).Stats.BlobsCount;
         }
 
         // recalculating GarbageBlocksCount for each of the affected ranges
@@ -514,9 +505,7 @@ void TIndexTabletActor::ExecuteTx_AddBlob(
     TTransactionContext& tx,
     TTxIndexTablet::TAddBlob& args)
 {
-    const auto compactionThreshold =
-        ScaleCompactionThreshold(Config->GetCompactionThreshold());
-    TAddBlobsExecutor executor(LogTag, *this, compactionThreshold);
+    TAddBlobsExecutor executor(LogTag, *this);
     executor.Execute(ctx, tx, args);
 }
 


### PR DESCRIPTION
This PR addresses the following line from #2388 : 
> if some range contains a lot of data logically (due to hash collisions) we should permanently increase Compaction/Cleanup thresholds for that range

Suppose CompactionThreshold is 10 and due to hash collisions the data in that range needs to be stored in >= 10 blobs (due to the MaxBlobSize limit). Then every 
new write will cause a new Compaction iteration because BlobsCount for that range will get >= CompactionThreshold upon every new write which is not the desired behaviour. We store the data in multiple blobs only because of BlobStorage limitations. Logically we want to treat that data as a single blob - we want to perform a Compaction iteration triggered by the "BlobsCount >= CompactionThreshold" condition only when we have a chance to make BlobsCount much smaller than CompactionThreshold.
