### PR TITLE
[Filestore] issue-1751: support guest writeback cache

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -48,4 +48,7 @@ message TFileSystemConfig
 
     // Aligment needed for buffers when using direct io
     optional uint32 DirectIoAlign = 14;
+
+    // Enable Writeback cache on guest (fuse client)
+    optional bool GuestWritebackCacheEnabled = 15;
 }

--- a/cloud/filestore/config/server.proto
+++ b/cloud/filestore/config/server.proto
@@ -89,6 +89,10 @@ message TLocalServiceConfig
 
     // Aligment needed for buffers when using direct io
     optional uint32 DirectIoAlign = 10;
+
+    // Enable Writeback cache on guest (fuse client)
+    optional bool GuestWritebackCacheEnabled = 11;
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -467,4 +467,7 @@ message TStorageConfig
     optional bool AutomaticShardCreationEnabled = 405;
     // Affects shard count calculation if AutomaticShardCreationEnabled is on.
     optional uint64 MaxShardSize = 406;
+
+    // Enable Writeback cache on guest (fuse client)
+    optional bool GuestWritebackCacheEnabled = 407;
 }

--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -21,6 +21,7 @@ namespace {
     xxx(MaxHandlePerSessionCount,    ui32,          10000                     )\
     xxx(DirectIoEnabled,             bool,          false                     )\
     xxx(DirectIoAlign,               ui32,          4_KB                      )\
+    xxx(GuestWritebackCacheEnabled,  bool,          false                     )\
 // FILESTORE_SERVICE_CONFIG
 
 #define FILESTORE_SERVICE_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/filestore/libs/service_local/config.h
+++ b/cloud/filestore/libs/service_local/config.h
@@ -31,6 +31,7 @@ public:
     ui32 GetMaxHandlePerSessionCount() const;
     bool GetDirectIoEnabled() const;
     ui32 GetDirectIoAlign() const;
+    bool GetGuestWritebackCacheEnabled() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -78,6 +78,8 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
     auto* features = response.MutableFileStore()->MutableFeatures();
     features->SetDirectIoEnabled(Config->GetDirectIoEnabled());
     features->SetDirectIoAlign(Config->GetDirectIoAlign());
+    features->SetGuestWritebackCacheEnabled(
+        Config->GetGuestWritebackCacheEnabled());
 
     return response;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -43,6 +43,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(GarbageCompactionThresholdAverage,  ui32,   20                        )\
     xxx(CompactRangeGarbagePercentageThreshold, ui32,    0                    )\
     xxx(CompactRangeAverageBlobSizeThreshold,   ui32,    0                    )\
+    xxx(GuestWritebackCacheEnabled,         bool,   false                     )\
     xxx(NewCompactionEnabled,               bool,   false                     )\
     xxx(UseMixedBlocksInsteadOfAliveBlocksInCompaction, bool,   false         )\
     xxx(CollectGarbageThreshold,            ui32,   4_MB                      )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -289,6 +289,8 @@ public:
 
     bool GetAutomaticShardCreationEnabled() const;
     ui64 GetMaxShardSize() const;
+
+    bool GetGuestWritebackCacheEnabled() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -43,6 +43,9 @@ void FillFeatures(const TStorageConfig& config, NProto::TFileStore& fileStore)
         config.GetAsyncDestroyHandleEnabled());
     features->SetAsyncHandleOperationPeriod(
         config.GetAsyncHandleOperationPeriod().MilliSeconds());
+
+    features->SetGuestWritebackCacheEnabled(
+        config.GetGuestWritebackCacheEnabled());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -32,6 +32,8 @@ namespace {
                                                                                \
     xxx(DirectIoEnabled,            bool,       false                         )\
     xxx(DirectIoAlign,              ui32,       4_KB                          )\
+                                                                               \
+    xxx(GuestWritebackCacheEnabled, bool,       false                         )\
 // FILESTORE_FUSE_CONFIG
 
 #define FILESTORE_FILESYSTEM_DECLARE_CONFIG(name, type, value)                 \

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -42,6 +42,8 @@ public:
     bool GetDirectIoEnabled() const;
     ui32 GetDirectIoAlign() const;
 
+    bool GetGuestWritebackCacheEnabled() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -936,7 +936,7 @@ private:
         ResetSessionState(SessionThread->GetSession().Dump());
 
         if (FileSystemConfig->GetGuestWritebackCacheEnabled()) {
-            conn->want |=  FUSE_CAP_WRITEBACK_CACHE;
+            conn->want |= FUSE_CAP_WRITEBACK_CACHE;
         }
 
         FileSystem->Init();

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -26,6 +26,7 @@ message TFileStoreFeatures
     uint32 DirectIoAlign = 11;
     bool TwoStageReadDisabledForHDD = 12;
     bool ThreeStageWriteDisabledForHDD = 13;
+    bool GuestWritebackCacheEnabled = 14;
 }
 
 message TFileStore


### PR DESCRIPTION
Pass FUSE_CAP_WRITEBACK_CACHE to fuse client when GuestWritebackCacheEnabled
flag is set. This flag ensures that individual write request may be buffered and
merged in the kernel of the filesystem client
