### PR TITLE
turn on tenant poool service to make configs dispatcher working

### DIFF
--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -429,10 +429,9 @@ public:
         };
 
         const bool enableLocal = !StorageConfig->GetDisableLocalService();
+        auto localConfig = MakeIntrusive<TLocalConfig>();
 
         if (enableLocal || IsDiskRegistrySpareNode) {
-            auto localConfig = MakeIntrusive<TLocalConfig>();
-
             if (enableLocal) {
                 localConfig->TabletClassInfo[TTabletTypes::BlockStoreVolume] =
                     TLocalConfig::TTabletClassInfo(
@@ -457,7 +456,12 @@ public:
                     priority);
 
             ConfigureTenantSystemTablets(*appData, *localConfig);
+        }
 
+        if (StorageConfig->GetConfigsDispatcherServiceEnabled() ||
+            enableLocal ||
+            IsDiskRegistrySpareNode)
+        {
             auto tenantPoolConfig = MakeIntrusive<TTenantPoolConfig>(localConfig);
             tenantPoolConfig->AddStaticSlot(StorageConfig->GetSchemeShardDir());
 

--- a/cloud/blockstore/tests/config_dispatcher/test.py
+++ b/cloud/blockstore/tests/config_dispatcher/test.py
@@ -56,6 +56,7 @@ def test_config_dispatcher():
     storage = TStorageServiceConfig()
     storage.ConfigsDispatcherServiceEnabled = True
     storage.ConfigDispatcherSettings.AllowList.Names.append('NameserviceConfigItem')
+    storage.DisableLocalService = True
 
     nbs_binary_path = yatest_common.binary_path('cloud/blockstore/apps/server/nbsd')
     nbs = LocalNbs(


### PR DESCRIPTION
#370

It turned out that in order to work config dispatcher requires tenant pool service to be on. This was true only for nbs-controls and nfs