### PR TITLE
NOTICKET: Add a "proxy" for ydb.tests.library.harness

### DIFF
--- a/cloud/blockstore/pylibs/ya.make
+++ b/cloud/blockstore/pylibs/ya.make
@@ -3,4 +3,5 @@ RECURSE(
     common
     sdk
     ycp
+    ydb
 )

--- a/cloud/blockstore/pylibs/ydb/tests/library/harness/daemon.py
+++ b/cloud/blockstore/pylibs/ydb/tests/library/harness/daemon.py
@@ -1,0 +1,1 @@
+from contrib.ydb.tests.library.harness.daemon import *  # noqa

--- a/cloud/blockstore/pylibs/ydb/tests/library/harness/kikimr_cluster.py
+++ b/cloud/blockstore/pylibs/ydb/tests/library/harness/kikimr_cluster.py
@@ -1,0 +1,1 @@
+from contrib.ydb.tests.library.harness.kikimr_cluster import *  # noqa

--- a/cloud/blockstore/pylibs/ydb/tests/library/harness/kikimr_config.py
+++ b/cloud/blockstore/pylibs/ydb/tests/library/harness/kikimr_config.py
@@ -1,0 +1,1 @@
+from contrib.ydb.tests.library.harness.kikimr_config import *  # noqa

--- a/cloud/blockstore/pylibs/ydb/tests/library/harness/kikimr_runner.py
+++ b/cloud/blockstore/pylibs/ydb/tests/library/harness/kikimr_runner.py
@@ -1,0 +1,1 @@
+from contrib.ydb.tests.library.harness.kikimr_runner import *  # noqa

--- a/cloud/blockstore/pylibs/ydb/tests/library/harness/util.py
+++ b/cloud/blockstore/pylibs/ydb/tests/library/harness/util.py
@@ -1,0 +1,1 @@
+from contrib.ydb.tests.library.harness.util import *  # noqa

--- a/cloud/blockstore/pylibs/ydb/tests/library/ya.make
+++ b/cloud/blockstore/pylibs/ydb/tests/library/ya.make
@@ -1,0 +1,16 @@
+PY23_LIBRARY()
+
+PY_SRCS(
+    harness/__init__.py
+    harness/daemon.py
+    harness/kikimr_cluster.py
+    harness/kikimr_config.py
+    harness/kikimr_runner.py
+    harness/util.py
+)
+
+PEERDIR(
+    contrib/ydb/tests/library
+)
+
+END()

--- a/cloud/blockstore/pylibs/ydb/tests/ya.make
+++ b/cloud/blockstore/pylibs/ydb/tests/ya.make
@@ -1,0 +1,3 @@
+RECURSE(
+    library
+)

--- a/cloud/blockstore/pylibs/ydb/ya.make
+++ b/cloud/blockstore/pylibs/ydb/ya.make
@@ -1,0 +1,3 @@
+RECURSE(
+    tests
+)

--- a/cloud/blockstore/tests/client/test_with_multiple_agents.py
+++ b/cloud/blockstore/tests/client/test_with_multiple_agents.py
@@ -31,11 +31,11 @@ from cloud.blockstore.tests.python.lib.nonreplicated_setup import (
     DeviceInfo
 )
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import \
     kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import \
     KikimrConfigGenerator
-from contrib.ydb.tests.library.harness.kikimr_runner import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import \
     get_unique_path_for_current_test, ensure_path_exists
 
 import yatest.common as yatest_common

--- a/cloud/blockstore/tests/client/ya.make
+++ b/cloud/blockstore/tests/client/ya.make
@@ -27,6 +27,7 @@ PEERDIR(
     cloud/storage/core/protos
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/blockstore/tests/config_dispatcher/test.py
+++ b/cloud/blockstore/tests/config_dispatcher/test.py
@@ -12,8 +12,8 @@ from cloud.blockstore.tests.python.lib.test_base import thread_count, wait_for_n
 
 from contrib.ydb.core.protos import config_pb2
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 from contrib.ydb.core.protos.config_pb2 import TLogConfig
 

--- a/cloud/blockstore/tests/config_dispatcher/ya.make
+++ b/cloud/blockstore/tests/config_dispatcher/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     contrib/python/requests/py3
 )

--- a/cloud/blockstore/tests/csi_driver/csi_sanity_tests/ya.make
+++ b/cloud/blockstore/tests/csi_driver/csi_sanity_tests/ya.make
@@ -26,6 +26,7 @@ PEERDIR(
     cloud/storage/core/protos
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 SET_APPEND(QEMU_INVOKE_TEST YES)
 SET_APPEND(QEMU_VIRTIO none)

--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part1/ya.make
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part1/ya.make
@@ -31,6 +31,7 @@ PEERDIR(
     cloud/storage/core/protos
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 SET_APPEND(QEMU_INVOKE_TEST YES)
 SET_APPEND(QEMU_VIRTIO none)

--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part2/ya.make
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part2/ya.make
@@ -31,6 +31,7 @@ PEERDIR(
     cloud/storage/core/protos
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 SET_APPEND(QEMU_INVOKE_TEST YES)
 SET_APPEND(QEMU_VIRTIO none)

--- a/cloud/blockstore/tests/csi_driver/lib/csi_runner.py
+++ b/cloud/blockstore/tests/csi_driver/lib/csi_runner.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import yatest.common as common
 
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
 from cloud.blockstore.config.client_pb2 import TClientConfig, TClientAppConfig
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest

--- a/cloud/blockstore/tests/csi_driver/lib/ya.make
+++ b/cloud/blockstore/tests/csi_driver/lib/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     cloud/storage/core/protos
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 PY_SRCS(

--- a/cloud/blockstore/tests/disk_agent_config/test.py
+++ b/cloud/blockstore/tests/disk_agent_config/test.py
@@ -16,7 +16,7 @@ from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
 
 import yatest.common as yatest_common
 
-from contrib.ydb.tests.library.harness.kikimr_runner import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import \
     get_unique_path_for_current_test, ensure_path_exists
 
 

--- a/cloud/blockstore/tests/e2e-tests/ya.make
+++ b/cloud/blockstore/tests/e2e-tests/ya.make
@@ -26,6 +26,7 @@ PEERDIR(
     cloud/storage/core/protos
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 SET_APPEND(QEMU_INVOKE_TEST YES)
 SET_APPEND(QEMU_VIRTIO none)

--- a/cloud/blockstore/tests/external_endpoint/multiple_endpoints.py
+++ b/cloud/blockstore/tests/external_endpoint/multiple_endpoints.py
@@ -18,7 +18,7 @@ from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
 
 import yatest.common as yatest_common
 
-from contrib.ydb.tests.library.harness.kikimr_runner import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import \
     get_unique_path_for_current_test, \
     ensure_path_exists
 

--- a/cloud/blockstore/tests/external_endpoint/test.py
+++ b/cloud/blockstore/tests/external_endpoint/test.py
@@ -22,7 +22,7 @@ from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
 import yatest.common as yatest_common
 
 from contrib.ydb.tests.library.common.yatest_common import PortManager
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
     ensure_path_exists
 
 from library.python.retry import retry

--- a/cloud/blockstore/tests/infra-cms/test.py
+++ b/cloud/blockstore/tests/infra-cms/test.py
@@ -20,8 +20,8 @@ from cloud.blockstore.tests.python.lib.test_base import thread_count, wait_for_n
 from cloud.blockstore.tests.python.lib.nonreplicated_setup import setup_nonreplicated, \
     create_file_devices, setup_disk_registry_config_simple, enable_writable_state
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 import yatest.common as yatest_common
 

--- a/cloud/blockstore/tests/infra-cms/ya.make
+++ b/cloud/blockstore/tests/infra-cms/ya.make
@@ -24,6 +24,7 @@ PEERDIR(
     cloud/blockstore/tests/python/lib
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/blockstore/tests/loadtest/local-change-device/test.py
+++ b/cloud/blockstore/tests/loadtest/local-change-device/test.py
@@ -13,9 +13,9 @@ from cloud.blockstore.tests.python.lib.test_base import \
 
 from cloud.blockstore.tests.python.lib.disk_agent_runner import LocalDiskAgent
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import \
     kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import \
     KikimrConfigGenerator
 
 from cloud.blockstore.tests.python.lib.nonreplicated_setup import \

--- a/cloud/blockstore/tests/loadtest/local-emergency/test.py
+++ b/cloud/blockstore/tests/loadtest/local-emergency/test.py
@@ -8,7 +8,7 @@ from cloud.blockstore.tests.python.lib.config import storage_config_with_default
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import run_test
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 
 def default_storage_config(backups_folder):

--- a/cloud/blockstore/tests/loadtest/local-encryption/test.py
+++ b/cloud/blockstore/tests/loadtest/local-encryption/test.py
@@ -7,7 +7,7 @@ from cloud.blockstore.config.client_pb2 import TClientConfig
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TServerConfig, TKikimrServiceConfig
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 
 class TestCase(object):

--- a/cloud/blockstore/tests/loadtest/local-metrics/test.py
+++ b/cloud/blockstore/tests/loadtest/local-metrics/test.py
@@ -15,9 +15,9 @@ from cloud.blockstore.tests.python.lib.nbs_runner import \
 from cloud.blockstore.tests.python.lib.test_base import \
     thread_count, wait_for_nbs_server
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import \
     kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import \
     KikimrConfigGenerator
 
 from subprocess import call, check_output

--- a/cloud/blockstore/tests/loadtest/local-mirror/test.py
+++ b/cloud/blockstore/tests/loadtest/local-mirror/test.py
@@ -15,9 +15,9 @@ from cloud.blockstore.tests.python.lib.nonreplicated_setup import setup_nonrepli
     create_devices, setup_disk_registry_config, \
     enable_writable_state, make_agent_node_type, make_agent_id, AgentInfo, DeviceInfo
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 import yatest.common as yatest_common
 

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -19,9 +19,9 @@ from cloud.blockstore.tests.python.lib.nonreplicated_setup import setup_nonrepli
     create_devices, setup_disk_registry_config, \
     update_cms_config, enable_writable_state, make_agent_id, AgentInfo, DeviceInfo
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from contrib.ydb.tests.library.harness.kikimr_runner import ensure_path_exists, \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import ensure_path_exists, \
     get_unique_path_for_current_test
 
 import yatest.common as yatest_common

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make.inc
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make.inc
@@ -33,6 +33,7 @@ PEERDIR(
 
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 REQUIREMENTS(

--- a/cloud/blockstore/tests/loadtest/local-user-metrics/test.py
+++ b/cloud/blockstore/tests/loadtest/local-user-metrics/test.py
@@ -13,9 +13,9 @@ from cloud.blockstore.tests.python.lib.nbs_runner import \
 from cloud.blockstore.tests.python.lib.test_base import \
     thread_count, wait_for_nbs_server
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import \
     kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import \
     KikimrConfigGenerator
 
 from subprocess import call

--- a/cloud/blockstore/tests/loadtest/local/test.py
+++ b/cloud/blockstore/tests/loadtest/local/test.py
@@ -7,7 +7,7 @@ from cloud.blockstore.tests.python.lib.config import storage_config_with_default
 from cloud.blockstore.tests.python.lib.loadtest_env import LocalLoadTest
 from cloud.blockstore.tests.python.lib.test_base import thread_count, run_test
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 
 def default_storage_config(tablet_version, backups_folder):

--- a/cloud/blockstore/tests/loadtest/ya.make.inc
+++ b/cloud/blockstore/tests/loadtest/ya.make.inc
@@ -19,4 +19,5 @@ PEERDIR(
 
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )

--- a/cloud/blockstore/tests/local_ssd/test.py
+++ b/cloud/blockstore/tests/local_ssd/test.py
@@ -15,7 +15,7 @@ from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
 
 import yatest.common as yatest_common
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
     ensure_path_exists
 
 

--- a/cloud/blockstore/tests/monitoring/test.py
+++ b/cloud/blockstore/tests/monitoring/test.py
@@ -20,8 +20,8 @@ from cloud.blockstore.tests.python.lib.test_base import \
     thread_count, wait_for_nbs_server, wait_for_secure_erase
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 DEFAULT_BLOCK_SIZE = 4096
 DEFAULT_DEVICE_COUNT = 4

--- a/cloud/blockstore/tests/monitoring/ya.make
+++ b/cloud/blockstore/tests/monitoring/ya.make
@@ -21,6 +21,7 @@ PEERDIR(
     cloud/blockstore/tests/python/lib
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/blockstore/tests/mount/test.py
+++ b/cloud/blockstore/tests/mount/test.py
@@ -18,8 +18,8 @@ from cloud.blockstore.tests.python.lib.test_base import \
     thread_count, wait_for_nbs_server
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 
 class MountContext:

--- a/cloud/blockstore/tests/mount/ya.make
+++ b/cloud/blockstore/tests/mount/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     cloud/blockstore/tests/python/lib
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/blockstore/tests/notify/test.py
+++ b/cloud/blockstore/tests/notify/test.py
@@ -20,8 +20,8 @@ from cloud.blockstore.tests.python.lib.test_base import thread_count, wait_for_n
 from cloud.blockstore.tests.python.lib.nonreplicated_setup import setup_nonreplicated, \
     create_file_devices, setup_disk_registry_config_simple, enable_writable_state
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 from contrib.ydb.core.protos import console_config_pb2 as console
 from contrib.ydb.core.protos import msgbus_pb2 as msgbus

--- a/cloud/blockstore/tests/notify/ya.make
+++ b/cloud/blockstore/tests/notify/ya.make
@@ -24,6 +24,7 @@ PEERDIR(
     contrib/python/requests/py3
     contrib/ydb/core/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/blockstore/tests/python/lib/daemon.py
+++ b/cloud/blockstore/tests/python/lib/daemon.py
@@ -16,9 +16,9 @@ from contrib.ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 from contrib.ydb.core.protos import console_config_pb2 as console
 from contrib.ydb.core.protos import msgbus_pb2 as msgbus
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
     ensure_path_exists
 
 

--- a/cloud/blockstore/tests/python/lib/disk_agent_runner.py
+++ b/cloud/blockstore/tests/python/lib/disk_agent_runner.py
@@ -4,8 +4,8 @@ import logging
 import subprocess
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 from cloud.blockstore.config.diagnostics_pb2 import TDiagnosticsConfig
 from cloud.blockstore.config.disk_pb2 import TDiskRegistryProxyConfig
 from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig

--- a/cloud/blockstore/tests/python/lib/loadtest_env.py
+++ b/cloud/blockstore/tests/python/lib/loadtest_env.py
@@ -1,7 +1,7 @@
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test
-from contrib.ydb.tests.library.harness.util import LogLevels
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test
+from cloud.blockstore.pylibs.ydb.tests.library.harness.util import LogLevels
 
 from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
 

--- a/cloud/blockstore/tests/python/lib/nbs_http_proxy.py
+++ b/cloud/blockstore/tests/python/lib/nbs_http_proxy.py
@@ -1,7 +1,7 @@
 import os
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 

--- a/cloud/blockstore/tests/python/lib/nbs_runner.py
+++ b/cloud/blockstore/tests/python/lib/nbs_runner.py
@@ -21,7 +21,7 @@ from contrib.ydb.core.protos.config_pb2 import TLogConfig
 from contrib.ydb.core.protos import console_config_pb2 as console
 from contrib.ydb.core.protos import msgbus_pb2 as msgbus
 from contrib.ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 logger = logging.getLogger(__name__)
 

--- a/cloud/blockstore/tests/python/lib/test_base.py
+++ b/cloud/blockstore/tests/python/lib/test_base.py
@@ -14,7 +14,7 @@ import uuid
 
 import yatest.common as common
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
 
 import cloud.blockstore.public.sdk.python.protos as protos
 

--- a/cloud/blockstore/tests/python/lib/ya.make
+++ b/cloud/blockstore/tests/python/lib/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     contrib/ydb/core/protos
     contrib/ydb/public/api/protos
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     contrib/python/requests/py3
     contrib/python/retrying

--- a/cloud/blockstore/tests/recipes/local-kikimr/__main__.py
+++ b/cloud/blockstore/tests/recipes/local-kikimr/__main__.py
@@ -10,8 +10,8 @@ from cloud.blockstore.config.discovery_pb2 import TDiscoveryServiceConfig
 from cloud.blockstore.tests.python.lib.nbs_runner import LocalNbs
 from cloud.blockstore.tests.python.lib.test_base import thread_count, wait_for_nbs_server
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 import yatest.common as yatest_common
 

--- a/cloud/blockstore/tests/recipes/local-kikimr/ya.make
+++ b/cloud/blockstore/tests/recipes/local-kikimr/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 DATA(

--- a/cloud/blockstore/tests/recipes/local-null/ya.make
+++ b/cloud/blockstore/tests/recipes/local-null/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 DATA(

--- a/cloud/blockstore/tests/recipes/service-local/ya.make
+++ b/cloud/blockstore/tests/recipes/service-local/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 DATA(

--- a/cloud/blockstore/tests/registration/ya.make
+++ b/cloud/blockstore/tests/registration/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     contrib/python/requests/py3
 )

--- a/cloud/blockstore/tests/session_cache/test.py
+++ b/cloud/blockstore/tests/session_cache/test.py
@@ -14,7 +14,7 @@ from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
 
 import yatest.common as yatest_common
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
     ensure_path_exists
 
 from library.python.retry import retry

--- a/cloud/blockstore/tests/storage_discovery/test.py
+++ b/cloud/blockstore/tests/storage_discovery/test.py
@@ -18,7 +18,7 @@ from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
 
 import yatest.common as yatest_common
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, \
     ensure_path_exists
 
 

--- a/cloud/blockstore/tools/http_proxy/tests/ya.make
+++ b/cloud/blockstore/tools/http_proxy/tests/ya.make
@@ -17,6 +17,7 @@ DATA(
 
 PEERDIR(
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     cloud/blockstore/tests/python/lib
 )

--- a/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
+++ b/cloud/disk_manager/test/acceptance/test_runner/base_acceptance_test_runner.py
@@ -15,7 +15,7 @@ from typing import List, Type
 from cloud.blockstore.pylibs import common
 from cloud.blockstore.pylibs.clusters.test_config import get_cluster_test_config
 from cloud.blockstore.pylibs.ycp import Ycp, YcpWrapper
-from contrib.ydb.tests.library.harness.kikimr_runner import (
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import (
     get_unique_path_for_current_test,
     ensure_path_exists
 )

--- a/cloud/disk_manager/test/acceptance/test_runner/ya.make
+++ b/cloud/disk_manager/test/acceptance/test_runner/ya.make
@@ -13,6 +13,7 @@ PY_SRCS(
 PEERDIR(
     cloud/disk_manager/test/acceptance/test_runner/lib
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/disk_manager/test/images/recipe/__main__.py
+++ b/cloud/disk_manager/test/images/recipe/__main__.py
@@ -2,7 +2,7 @@ import os
 
 from yatest.common import process
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 from library.python.testing.recipe import declare_recipe, set_env
 

--- a/cloud/disk_manager/test/images/recipe/image_file_server_launcher.py
+++ b/cloud/disk_manager/test/images/recipe/image_file_server_launcher.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from cloud.storage.core.tools.common.python.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 from cloud.tasks.test.common.processes import register_process, kill_processes

--- a/cloud/disk_manager/test/images/recipe/ya.make
+++ b/cloud/disk_manager/test/images/recipe/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     cloud/storage/core/tools/common/python
     cloud/tasks/test/common
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
     library/python/testing/recipe
 )
 

--- a/cloud/disk_manager/test/recipe/__main__.py
+++ b/cloud/disk_manager/test/recipe/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import os
 
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 from library.python.testing.recipe import declare_recipe, set_env
 
 from cloud.disk_manager.test.recipe.compute_launcher import ComputeLauncher

--- a/cloud/disk_manager/test/recipe/compute_launcher.py
+++ b/cloud/disk_manager/test/recipe/compute_launcher.py
@@ -1,6 +1,6 @@
 from cloud.storage.core.tools.common.python.daemon import Daemon
 from cloud.tasks.test.common.processes import register_process, kill_processes
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 SERVICE_NAME = "compute"

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -6,7 +6,7 @@ from yatest.common import process
 
 from cloud.storage.core.tools.common.python.daemon import Daemon
 from cloud.tasks.test.common.processes import register_process, kill_processes
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 

--- a/cloud/disk_manager/test/recipe/kms_launcher.py
+++ b/cloud/disk_manager/test/recipe/kms_launcher.py
@@ -1,6 +1,6 @@
 from cloud.storage.core.tools.common.python.daemon import Daemon
 from cloud.tasks.test.common.processes import register_process, kill_processes
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 SERVICE_NAME = "kms"

--- a/cloud/disk_manager/test/recipe/metadata_service_launcher.py
+++ b/cloud/disk_manager/test/recipe/metadata_service_launcher.py
@@ -2,7 +2,7 @@ import os
 
 from cloud.storage.core.tools.common.python.daemon import Daemon
 from cloud.tasks.test.common.processes import register_process, kill_processes
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 DEFAULT_CONFIG_TEMPLATE = """

--- a/cloud/disk_manager/test/recipe/s3_launcher.py
+++ b/cloud/disk_manager/test/recipe/s3_launcher.py
@@ -2,7 +2,7 @@ import logging
 
 from cloud.storage.core.tools.common.python.daemon import Daemon
 from cloud.tasks.test.common.processes import register_process, kill_processes
-from contrib.ydb.tests.library.harness.kikimr_runner import \
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import \
     get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 

--- a/cloud/disk_manager/test/recipe/ya.make
+++ b/cloud/disk_manager/test/recipe/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     cloud/filestore/tests/python/lib
     cloud/tasks/test/common
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
     library/python/testing/recipe
 )
 

--- a/cloud/disk_manager/test/recipe/ydb_launcher.py
+++ b/cloud/disk_manager/test/recipe/ydb_launcher.py
@@ -1,6 +1,6 @@
 from cloud.tasks.test.common.processes import register_process, kill_processes
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 SERVICE_NAME = "ydb"
 

--- a/cloud/filestore/tests/config_dispatcher/test.py
+++ b/cloud/filestore/tests/config_dispatcher/test.py
@@ -11,8 +11,8 @@ from cloud.filestore.tests.python.lib.daemon_config import NfsVhostConfigGenerat
 from contrib.ydb.core.protos import config_pb2
 from contrib.ydb.core.protos.config_pb2 import TLogConfig
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 import yatest.common as yatest_common
 

--- a/cloud/filestore/tests/config_dispatcher/ya.make
+++ b/cloud/filestore/tests/config_dispatcher/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     contrib/python/requests/py3
 )

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -10,7 +10,7 @@ import yatest.common as common
 
 from cloud.filestore.tests.python.lib.common import daemon_log_files, wait_for
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
 
 logger = logging.getLogger(__name__)
 

--- a/cloud/filestore/tests/python/lib/daemon_config.py
+++ b/cloud/filestore/tests/python/lib/daemon_config.py
@@ -4,7 +4,7 @@ import yatest.common as common
 
 from google.protobuf.text_format import MessageToString
 
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 from contrib.ydb.core.protos.config_pb2 import (
     TDomainsConfig,
     TStaticNameserviceConfig,

--- a/cloud/filestore/tests/python/lib/http_proxy.py
+++ b/cloud/filestore/tests/python/lib/http_proxy.py
@@ -4,8 +4,8 @@ import time
 import requests
 import urllib3
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 

--- a/cloud/filestore/tests/python/lib/server.py
+++ b/cloud/filestore/tests/python/lib/server.py
@@ -4,7 +4,7 @@ import cloud.filestore.public.sdk.python.client as client
 import cloud.filestore.public.sdk.python.protos as protos
 
 from cloud.filestore.tests.python.lib.common import daemon_log_files, is_grpc_error
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
 
 
 class NfsServer(Daemon):

--- a/cloud/filestore/tests/python/lib/vhost.py
+++ b/cloud/filestore/tests/python/lib/vhost.py
@@ -4,7 +4,7 @@ import cloud.filestore.public.sdk.python.protos as protos
 
 from cloud.filestore.public.sdk.python.client.grpc_client import CreateGrpcEndpointClient
 from cloud.filestore.tests.python.lib.common import daemon_log_files, is_grpc_error
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
 
 
 class NfsVhost(Daemon):

--- a/cloud/filestore/tests/python/lib/ya.make
+++ b/cloud/filestore/tests/python/lib/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     contrib/python/retrying
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 PY_SRCS(

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -7,8 +7,8 @@ import google.protobuf.text_format as text_format
 
 from library.python.testing.recipe import declare_recipe, set_env
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 from cloud.filestore.config.server_pb2 import TServerAppConfig, TKikimrServiceConfig
 from cloud.filestore.config.storage_pb2 import TStorageConfig

--- a/cloud/filestore/tests/registration/test.py
+++ b/cloud/filestore/tests/registration/test.py
@@ -17,8 +17,8 @@ from contrib.ydb.core.protos import msgbus_pb2 as msgbus
 
 from google.protobuf.text_format import MessageToString
 
-from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
-from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 import yatest.common as yatest_common
 

--- a/cloud/filestore/tests/registration/ya.make
+++ b/cloud/filestore/tests/registration/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     library/python/testing/yatest_common
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     contrib/python/requests/py3
 )

--- a/cloud/storage/core/tests/recipes/access-service-new/__main__.py
+++ b/cloud/storage/core/tests/recipes/access-service-new/__main__.py
@@ -7,7 +7,7 @@ from library.python.testing.recipe import declare_recipe, set_env
 
 from cloud.storage.core.tools.testing.access_service_new.lib import NewAccessService
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 logger = logging.getLogger(__name__)
 

--- a/cloud/storage/core/tests/recipes/access-service-new/ya.make
+++ b/cloud/storage/core/tests/recipes/access-service-new/ya.make
@@ -14,6 +14,7 @@ DATA(
 PEERDIR(
     cloud/storage/core/tools/testing/access_service_new/lib
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
     library/python/testing/recipe
 )
 

--- a/cloud/storage/core/tests/recipes/access-service/ya.make
+++ b/cloud/storage/core/tests/recipes/access-service/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     cloud/storage/core/tools/testing/access_service/lib
 
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 
     library/python/testing/recipe
 )

--- a/cloud/storage/core/tools/testing/access_service/lib/__init__.py
+++ b/cloud/storage/core/tools/testing/access_service/lib/__init__.py
@@ -5,7 +5,7 @@ import time
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 from cloud.storage.core.tools.common.python.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 logger = logging.getLogger(__name__)
 

--- a/cloud/storage/core/tools/testing/access_service/lib/ya.make
+++ b/cloud/storage/core/tools/testing/access_service/lib/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     cloud/storage/core/tools/common/python
     contrib/python/requests/py3
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/storage/core/tools/testing/access_service_new/lib/__init__.py
+++ b/cloud/storage/core/tools/testing/access_service_new/lib/__init__.py
@@ -6,7 +6,7 @@ import requests
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 from cloud.storage.core.tools.common.python.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
 
 SERVICE_NAME = "access_service_new"

--- a/cloud/storage/core/tools/testing/access_service_new/lib/ya.make
+++ b/cloud/storage/core/tools/testing/access_service_new/lib/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     cloud/storage/core/tools/common/python
     contrib/python/requests/py3
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -7,7 +7,7 @@ import uuid
 import yatest.common
 import yatest.common.network
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
 from .qmp import QmpClient
 
 logger = logging.getLogger(__name__)

--- a/cloud/storage/core/tools/testing/qemu/lib/ya.make
+++ b/cloud/storage/core/tools/testing/qemu/lib/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     library/python/retry
     library/python/testing/recipe
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/storage/core/tools/testing/virtiofs_server/lib/__init__.py
+++ b/cloud/storage/core/tools/testing/virtiofs_server/lib/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
 
 
 def daemon_log_files(prefix, cwd):

--- a/cloud/storage/core/tools/testing/virtiofs_server/lib/ya.make
+++ b/cloud/storage/core/tools/testing/virtiofs_server/lib/ya.make
@@ -4,6 +4,7 @@ PY_SRCS(__init__.py)
 
 PEERDIR(
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
 )
 
 END()

--- a/cloud/tasks/acceptance_tests/recipe/node_launcher.py
+++ b/cloud/tasks/acceptance_tests/recipe/node_launcher.py
@@ -4,8 +4,8 @@ import time
 
 from yatest.common import process
 
-from contrib.ydb.tests.library.harness.daemon import Daemon
-from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
+from cloud.blockstore.pylibs.ydb.tests.library.harness.daemon import Daemon
+from cloud.blockstore.pylibs.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 from cloud.tasks.test.common.processes import register_process, kill_processes

--- a/cloud/tasks/acceptance_tests/recipe/ya.make
+++ b/cloud/tasks/acceptance_tests/recipe/ya.make
@@ -8,6 +8,7 @@ PY_SRCS(
 PEERDIR(
     cloud/tasks/test/common
     contrib/ydb/tests/library
+    cloud/blockstore/pylibs/ydb/tests/library
     library/python/testing/recipe
 )
 


### PR DESCRIPTION
We use internal ydb test library `ydb.tests.library.harness` in our tests. YDB Team wants to improve this lib, which will cause changes in its interfaces

"Proxy" module created to accomodate for future changes