### PR TITLE
issue-1932: automatic filesystem shard configuration upon filesystem creation

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -456,4 +456,15 @@ message TStorageConfig
 
     // Disables TwoStageRead for HDD filesystems.
     optional bool TwoStageReadDisabledForHDD = 404;
+
+    // Enables automatic shard creation for new filesystems upon create/resize
+    // operations. Shard count is calculated based on FS size. If this flag is
+    // enabled, new filesystems will have this feature enabled and will create
+    // extra shards upon resize if needed. Existing filesystems are not
+    // affected. Filesystems created with this flag enabled will maintain the
+    // autosharding feature even if this flag is disabled in the global storage
+    // config.
+    optional bool AutomaticShardCreationEnabled = 405;
+    // Affects shard count calculation if AutomaticShardCreationEnabled is on.
+    optional uint64 MaxShardSize = 406;
 }

--- a/cloud/filestore/libs/service/filestore.h
+++ b/cloud/filestore/libs/service/filestore.h
@@ -37,6 +37,7 @@ constexpr ui32 MaxSymlink = NProto::E_FS_LIMITS_SYMLINK;
 constexpr ui64 MaxNodes = static_cast<ui32>(NProto::E_FS_LIMITS_INODES);
 constexpr ui64 MaxXAttrName = NProto::E_FS_LIMITS_XATTR_NAME;
 constexpr ui64 MaxXAttrValue = NProto::E_FS_LIMITS_XATTR_VALUE;
+constexpr ui32 MaxShardCount = NProto::E_FS_LIMITS_MAX_SHARDS;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -52,6 +52,9 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(MaxBlocksPerTruncateTx,             ui32,   0 /*TODO: 32GiB/4KiB*/    )\
     xxx(MaxTruncateTxInflight,              ui32,   10                        )\
                                                                                \
+    xxx(AutomaticShardCreationEnabled,                  bool,   false         )\
+    xxx(MaxShardSize,                                   ui64,   4_TB          )\
+                                                                               \
     xxx(MaxFileBlocks,                                  ui32,   300_GB / 4_KB )\
     xxx(LargeDeletionMarkersEnabled,                    bool,   false         )\
     xxx(LargeDeletionMarkerBlocks,                      ui64,   1_GB / 4_KB   )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -286,6 +286,9 @@ public:
 
     bool GetTwoStageReadDisabledForHDD() const;
     bool GetThreeStageWriteDisabledForHDD() const;
+
+    bool GetAutomaticShardCreationEnabled() const;
+    ui64 GetMaxShardSize() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -4,7 +4,7 @@
 
 #include <cloud/storage/core/protos/media.pb.h>
 
-#include <contrib/ydb/core/protos/filestore_config.pb.h>
+#include <util/string/printf.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -277,6 +277,23 @@ TPoolKinds GetPoolKinds(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ui32 ComputeShardCount(
+    const TStorageConfig& config,
+    const NKikimrFileStore::TConfig& fileStore)
+{
+    const double fileStoreSize =
+        fileStore.GetBlocksCount() * fileStore.GetBlockSize();
+
+    ui32 shardCount = std::ceil(fileStoreSize / config.GetMaxShardSize());
+    Y_DEBUG_ABORT_UNLESS(
+        shardCount >= 1,
+        "size %f shard %lu",
+        fileStoreSize,
+        config.GetMaxShardSize());
+
+    return shardCount;
+}
+
 ui32 ComputeAllocationUnitCount(
     const TStorageConfig& config,
     const NKikimrFileStore::TConfig& fileStore)
@@ -285,7 +302,7 @@ ui32 ComputeAllocationUnitCount(
         return 1;
     }
 
-    double fileStoreSize =
+    const double fileStoreSize =
         fileStore.GetBlocksCount() * fileStore.GetBlockSize() / double(1_GB);
 
     const auto unit = GetAllocationUnit(
@@ -437,10 +454,6 @@ ui32 NodesLimit(
     return Max(limit, static_cast<ui64>(config.GetDefaultNodesLimit()));
 }
 
-}   // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
 #define PERFORMANCE_PROFILE_PARAMETERS_SIMPLE(xxx, ...)                        \
     xxx(ThrottlingEnabled,                      __VA_ARGS__)                   \
     xxx(BoostTime,                              __VA_ARGS__)                   \
@@ -463,13 +476,11 @@ ui32 NodesLimit(
 
 void SetupFileStorePerformanceAndChannels(
     bool allocateMixed0Channel,
+    const ui32 allocationUnitCount,
     const TStorageConfig& config,
     NKikimrFileStore::TConfig& fileStore,
     const NProto::TFileStorePerformanceProfile& clientProfile)
 {
-    const auto allocationUnitCount =
-        ComputeAllocationUnitCount(config, fileStore);
-
     OverrideStorageMediaKind(config, fileStore);
 
 #define SETUP_PARAMETER_SIMPLE(name, ...)                                      \
@@ -499,6 +510,56 @@ void SetupFileStorePerformanceAndChannels(
         allocateMixed0Channel,
         config,
         fileStore);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void SetupFileStorePerformanceAndChannels(
+    bool allocateMixed0Channel,
+    const TStorageConfig& config,
+    NKikimrFileStore::TConfig& fileStore,
+    const NProto::TFileStorePerformanceProfile& clientProfile)
+{
+    SetupFileStorePerformanceAndChannels(
+        allocateMixed0Channel,
+        ComputeAllocationUnitCount(config, fileStore),
+        config,
+        fileStore,
+        clientProfile);
+}
+
+TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
+    const TStorageConfig& config,
+    const NKikimrFileStore::TConfig& fileStore,
+    const NProto::TFileStorePerformanceProfile& clientProfile)
+{
+    TMultiShardFileStoreConfig result;
+    result.MainFileSystemConfig = fileStore;
+    SetupFileStorePerformanceAndChannels(
+        false, // allocateMixed0Channel
+        1, // allocationUnitCount
+        config,
+        result.MainFileSystemConfig,
+        clientProfile);
+
+    const auto shardCount = ComputeShardCount(config, fileStore);
+    result.ShardConfigs.resize(shardCount);
+    for (ui32 i = 0; i < shardCount; ++i) {
+        result.ShardConfigs[i] = fileStore;
+        result.ShardConfigs[i].SetBlocksCount(
+            config.GetMaxShardSize() / fileStore.GetBlockSize());
+        result.ShardConfigs[i].SetFileSystemId(
+            Sprintf("%s_s%u", fileStore.GetFileSystemId().c_str(), i + 1));
+        SetupFileStorePerformanceAndChannels(
+            false, // allocateMixed0Channel
+            config,
+            result.ShardConfigs[i],
+            clientProfile);
+    }
+
+    return result;
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -1,5 +1,6 @@
 #include "model.h"
 
+#include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/model/channel_data_kind.h>
 
 #include <cloud/storage/core/protos/media.pb.h>
@@ -291,7 +292,7 @@ ui32 ComputeShardCount(
         fileStoreSize,
         config.GetMaxShardSize());
 
-    return shardCount;
+    return Min(shardCount, MaxShardCount);
 }
 
 ui32 ComputeAllocationUnitCount(

--- a/cloud/filestore/libs/storage/core/model.h
+++ b/cloud/filestore/libs/storage/core/model.h
@@ -2,18 +2,29 @@
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
-namespace NKikimrFileStore {
-    class TConfig;
-}
+#include <contrib/ydb/core/protos/filestore_config.pb.h>
+
+#include <util/generic/vector.h>
 
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TMultiShardFileStoreConfig
+{
+    NKikimrFileStore::TConfig MainFileSystemConfig;
+    TVector<NKikimrFileStore::TConfig> ShardConfigs;
+};
+
+TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
+    const TStorageConfig& config,
+    const NKikimrFileStore::TConfig& fileStore,
+    const NProto::TFileStorePerformanceProfile& clientProfile);
+
 void SetupFileStorePerformanceAndChannels(
     bool allocateMixed0Channel,
     const TStorageConfig& config,
     NKikimrFileStore::TConfig& fileStore,
-    const NProto::TFileStorePerformanceProfile& clientPerformanceProfile);
+    const NProto::TFileStorePerformanceProfile& clientProfile);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -423,7 +423,7 @@ Y_UNIT_TEST_SUITE(TModel)
     }                                                                          \
 // CHECK_CHANNEL
 
-    struct ChannelState final
+    struct TChannelState final
     {
         ui32 DataType;
         TString PoolType;
@@ -441,7 +441,7 @@ Y_UNIT_TEST_SUITE(TModel)
         ui32 minChannelsCount,
         bool allocateMixed0,
         ui32 channelsCount,
-        TVector<ChannelState> channels,
+        TVector<TChannelState> channels,
         NKikimrFileStore::TConfig& kikimrConfig,
         NProto::TStorageConfig& storageConfig)
     {
@@ -482,8 +482,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHDDMinGreater, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -492,7 +492,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "rot",
                 .Size = 16_MB,
@@ -501,7 +501,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -513,7 +513,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 7; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -538,8 +538,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHDDMinLower, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -548,7 +548,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "rot",
                 .Size = 16_MB,
@@ -557,7 +557,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -569,7 +569,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 6; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -594,8 +594,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHDDEnormousSize, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -604,7 +604,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "rot",
                 .Size = 16_MB,
@@ -613,7 +613,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -625,7 +625,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 19; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -653,8 +653,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsSSDMinGreater, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -663,7 +663,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -672,7 +672,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -684,7 +684,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 7; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "ssd",
                     .Size = 2_GB,
@@ -709,8 +709,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsSSDMinLower, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -719,7 +719,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -728,7 +728,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -740,7 +740,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 6; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "ssd",
                     .Size = 2_GB,
@@ -765,8 +765,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsSSDEnormousSize, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -775,7 +775,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 31'000,
                 .WriteBandwidth = 471'859'200,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -784,7 +784,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 31'000,
                 .WriteBandwidth = 471'859'200,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -796,7 +796,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 34; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "ssd",
                     .Size = 2_GB,
@@ -824,8 +824,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHybridMinGreater, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -834,7 +834,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -843,7 +843,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -855,7 +855,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 7; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -880,8 +880,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHybridMinLower, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -890,7 +890,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -899,7 +899,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -911,7 +911,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 6; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -936,8 +936,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHybridEnormousSize, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -946,7 +946,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -955,7 +955,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -967,7 +967,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 19; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -995,8 +995,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHDDMinGreaterDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -1005,7 +1005,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "rot",
                 .Size = 16_MB,
@@ -1014,7 +1014,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -1023,7 +1023,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "rot",
                 .Size = 4_GB,
@@ -1035,7 +1035,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 8; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -1060,8 +1060,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHDDMinLowerDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -1070,7 +1070,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "rot",
                 .Size = 16_MB,
@@ -1079,7 +1079,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -1088,7 +1088,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "rot",
                 .Size = 4_GB,
@@ -1100,7 +1100,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 7; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -1125,8 +1125,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHDDEnormousSizeDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -1135,7 +1135,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "rot",
                 .Size = 16_MB,
@@ -1144,7 +1144,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "rot",
                 .Size = 128_MB,
@@ -1153,7 +1153,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "rot",
                 .Size = 4_GB,
@@ -1165,7 +1165,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 20; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -1193,8 +1193,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsSSDMinGreaterDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1203,7 +1203,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -1212,7 +1212,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1221,7 +1221,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "ssd",
                 .Size = 2_GB,
@@ -1233,7 +1233,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 8; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "ssd",
                     .Size = 2_GB,
@@ -1258,8 +1258,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsSSDMinLowerDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1268,7 +1268,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -1277,7 +1277,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1286,7 +1286,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 1'000,
                 .WriteBandwidth = 15'728'640,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "ssd",
                 .Size = 2_GB,
@@ -1298,7 +1298,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 6; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "ssd",
                     .Size = 2_GB,
@@ -1323,8 +1323,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsSSDEnormousSizeDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1333,7 +1333,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 31'000,
                 .WriteBandwidth = 471'859'200,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -1342,7 +1342,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 31'000,
                 .WriteBandwidth = 471'859'200,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1351,7 +1351,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 31'000,
                 .WriteBandwidth = 471'859'200,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "ssd",
                 .Size = 2_GB,
@@ -1363,7 +1363,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 3; i < 34; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "ssd",
                     .Size = 2_GB,
@@ -1391,8 +1391,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHybridMinGreaterDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1401,7 +1401,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -1410,7 +1410,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1419,7 +1419,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "rot",
                 .Size = 4_GB,
@@ -1431,7 +1431,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 8; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -1456,8 +1456,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHybridMinLowerDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1466,7 +1466,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -1475,7 +1475,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1484,7 +1484,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 300,
                 .WriteBandwidth = 31'457'280,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "rot",
                 .Size = 4_GB,
@@ -1496,7 +1496,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 7; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -1521,8 +1521,8 @@ Y_UNIT_TEST_SUITE(TModel)
     Y_UNIT_TEST_F(ShouldCorrectlySetupChannelsHybridEnormousSizeDefault, TConfigs)
     {
         using namespace ::NCloud::NProto;
-        TVector<ChannelState> channels = {
-            ChannelState{
+        TVector<TChannelState> channels = {
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::System),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1531,7 +1531,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Index),
                 .PoolType = "ssd",
                 .Size = 16_MB,
@@ -1540,7 +1540,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Fresh),
                 .PoolType = "ssd",
                 .Size = 128_MB,
@@ -1549,7 +1549,7 @@ Y_UNIT_TEST_SUITE(TModel)
                 .WriteIops = 4'800,
                 .WriteBandwidth = 251'658'240,
             },
-            ChannelState{
+            TChannelState{
                 .DataType = static_cast<ui32>(EChannelDataKind::Mixed0),
                 .PoolType = "rot",
                 .Size = 4_GB,
@@ -1561,7 +1561,7 @@ Y_UNIT_TEST_SUITE(TModel)
         };
         for (size_t i = 4; i < 20; ++i) {
             channels.push_back(
-                ChannelState{
+                TChannelState{
                     .DataType = static_cast<ui32>(EChannelDataKind::Mixed),
                     .PoolType = "rot",
                     .Size = 4_GB,
@@ -2288,6 +2288,44 @@ Y_UNIT_TEST_SUITE(TModel)
     }
 
 #undef DO_TEST
+
+    Y_UNIT_TEST_F(ShouldCreateProperNumberOfShards, TConfigs)
+    {
+        using namespace ::NCloud::NProto;
+        KikimrConfig.SetBlockSize(4_KB);
+        KikimrConfig.SetBlocksCount(4_TB / 4_KB);
+
+        // Disable media type override.
+        StorageConfig.SetAutomaticShardCreationEnabled(true);
+        StorageConfig.SetMaxShardSize(4_TB);
+
+        auto fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile);
+        UNIT_ASSERT_VALUES_EQUAL(1, fs.ShardConfigs.size());
+
+        KikimrConfig.SetBlocksCount(16_TB / 4_KB);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile);
+        UNIT_ASSERT_VALUES_EQUAL(4, fs.ShardConfigs.size());
+
+        KikimrConfig.SetBlocksCount(512_TB / 4_KB);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile);
+        UNIT_ASSERT_VALUES_EQUAL(128, fs.ShardConfigs.size());
+
+        KikimrConfig.SetBlocksCount(1_PB / 4_KB);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile);
+        UNIT_ASSERT_VALUES_EQUAL(254, fs.ShardConfigs.size());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -5977,6 +5977,253 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         CheckThreeStageWrites(NProto::STORAGE_MEDIA_SSD, true);
         CheckTwoStageReads(NProto::STORAGE_MEDIA_SSD, true);
     }
+
+    void DoTestShardedFileSystemConfigured(
+        const TString& fsId,
+        TServiceClient& service)
+    {
+        TVector<TString> expected = {fsId, fsId + "_s1", fsId + "_s2"};
+
+        auto response = service.ListFileStores();
+        const auto& fsIds = response->Record.GetFileStores();
+        TVector<TString> ids(fsIds.begin(), fsIds.end());
+        Sort(ids);
+
+        UNIT_ASSERT_VALUES_EQUAL(expected, ids);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        for (const auto& id: ids) {
+            NProtoPrivate::TDescribeSessionsRequest request;
+            request.SetFileSystemId(id);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("describesessions", buf);
+            NProtoPrivate::TDescribeSessionsResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+
+            const auto& sessions = response.GetSessions();
+            UNIT_ASSERT_VALUES_EQUAL(1, sessions.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                headers.SessionId,
+                sessions[0].GetSessionId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                headers.ClientId,
+                sessions[0].GetClientId());
+            UNIT_ASSERT_VALUES_EQUAL("", sessions[0].GetSessionState());
+        }
+
+        const TString sessionState = "some_state";
+        service.ResetSession(headers, sessionState);
+
+        for (const auto& id: ids) {
+            NProtoPrivate::TDescribeSessionsRequest request;
+            request.SetFileSystemId(id);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("describesessions", buf);
+            NProtoPrivate::TDescribeSessionsResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+
+            const auto& sessions = response.GetSessions();
+            UNIT_ASSERT_VALUES_EQUAL(1, sessions.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                headers.SessionId,
+                sessions[0].GetSessionId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                headers.ClientId,
+                sessions[0].GetClientId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                sessionState,
+                sessions[0].GetSessionState());
+        }
+
+        service.DestroySession(headers);
+
+        for (const auto& id: ids) {
+            NProtoPrivate::TDescribeSessionsRequest request;
+            request.SetFileSystemId(id);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("describesessions", buf);
+            NProtoPrivate::TDescribeSessionsResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+
+            const auto& sessions = response.GetSessions();
+            UNIT_ASSERT_VALUES_EQUAL(0, sessions.size());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldConfigureShardsAutomatically)
+    {
+        NProto::TStorageConfig config;
+        config.SetAutomaticShardCreationEnabled(true);
+        config.SetMaxShardSize(1_GB);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, 2_GB / 4_KB);
+
+        DoTestShardedFileSystemConfigured(fsId, service);
+    }
+
+    Y_UNIT_TEST(ShouldHandleErrorsDuringShardedFileSystemCreation)
+    {
+        NProto::TStorageConfig config;
+        config.SetAutomaticShardCreationEnabled(true);
+        config.SetMaxShardSize(1_GB);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+        const auto blockCount = 2_GB / 4_KB;
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        TVector<TString> expected = {fsId, fsId + "_s1", fsId + "_s2"};
+
+        NProto::TError createShardError;
+        NProto::TError configureShardError;
+        NProto::TError configureShardsError;
+
+        env.GetRuntime().SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvCreateFileStoreRequest: {
+                        using TRequest = TEvSSProxy::TEvCreateFileStoreRequest;
+                        using TResponse =
+                            TEvSSProxy::TEvCreateFileStoreResponse;
+                        const auto* msg = event->Get<TRequest>();
+                        if (msg->Config.GetFileSystemId() != expected[1]) {
+                            break;
+                        }
+
+                        if (!HasError(createShardError)) {
+                            break;
+                        }
+
+                        auto response = std::make_unique<TResponse>(
+                            createShardError);
+
+                        env.GetRuntime().Send(new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie), nodeIdx);
+
+                        return true;
+                    }
+
+                    case TEvIndexTablet::EvConfigureAsShardRequest: {
+                        using TRequest =
+                            TEvIndexTablet::TEvConfigureAsShardRequest;
+                        using TResponse =
+                            TEvIndexTablet::TEvConfigureAsShardResponse;
+                        const auto* msg = event->Get<TRequest>();
+                        if (msg->Record.GetFileSystemId() != expected[1]) {
+                            break;
+                        }
+
+                        if (!HasError(configureShardError)) {
+                            break;
+                        }
+
+                        auto response = std::make_unique<TResponse>(
+                            configureShardError);
+
+                        env.GetRuntime().Send(new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie), nodeIdx);
+
+                        return true;
+                    }
+
+                    case TEvIndexTablet::EvConfigureShardsRequest: {
+                        using TResponse =
+                            TEvIndexTablet::TEvConfigureShardsResponse;
+
+                        if (!HasError(configureShardsError)) {
+                            break;
+                        }
+
+                        auto response = std::make_unique<TResponse>(
+                            configureShardsError);
+
+                        env.GetRuntime().Send(new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie), nodeIdx);
+
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+
+        createShardError = MakeError(E_REJECTED, "failed to create shard");
+        service.SendCreateFileStoreRequest(fsId, blockCount);
+        {
+            auto response = service.RecvCreateFileStoreResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                FormatError(createShardError),
+                FormatError(response->GetError()));
+        }
+
+        createShardError = {};
+        configureShardError =
+            MakeError(E_REJECTED, "failed to configure shard");
+        service.SendCreateFileStoreRequest(fsId, blockCount);
+        {
+            auto response = service.RecvCreateFileStoreResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                FormatError(configureShardError),
+                FormatError(response->GetError()));
+        }
+
+        configureShardError = {};
+        configureShardsError =
+            MakeError(E_REJECTED, "failed to configure shards");
+        service.SendCreateFileStoreRequest(fsId, blockCount);
+        {
+            auto response = service.RecvCreateFileStoreResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                FormatError(configureShardsError),
+                FormatError(response->GetError()));
+        }
+
+        configureShardsError = {};
+        service.SendCreateFileStoreRequest(fsId, blockCount);
+        {
+            auto response = service.RecvCreateFileStoreResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                FormatError(MakeError(S_OK)),
+                FormatError(response->GetError()));
+        }
+
+        DoTestShardedFileSystemConfigured(fsId, service);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -44,6 +44,8 @@ message TFileSystem
 
     repeated string ShardFileSystemIds = 13;
     uint32 ShardNo = 14;
+    bool AutomaticShardCreationEnabled = 15;
+    uint64 MaxShardSize = 16;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -275,7 +275,7 @@ void TIndexTabletActor::HandleConfigureShards(
             " is smaller than prev shard list: "
             << msg->Record.GetShardFileSystemIds().size() << " < "
             << shardIds.size());
-    } else if (msg->Record.GetShardFileSystemIds().size() > MaxShardCount) {
+    } else if (msg->Record.ShardFileSystemIdsSize() > MaxShardCount) {
         error = MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
             " is bigger than limit: "
             << msg->Record.GetShardFileSystemIds().size() << " > "

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -275,6 +275,11 @@ void TIndexTabletActor::HandleConfigureShards(
             " is smaller than prev shard list: "
             << msg->Record.GetShardFileSystemIds().size() << " < "
             << shardIds.size());
+    } else if (msg->Record.GetShardFileSystemIds().size() > MaxShardCount) {
+        error = MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
+            " is bigger than limit: "
+            << msg->Record.GetShardFileSystemIds().size() << " > "
+            << MaxShardCount);
     } else {
         for (int i = 0; i < shardIds.size(); ++i) {
             if (shardIds[i] != msg->Record.GetShardFileSystemIds(i)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -182,4 +182,24 @@ TMiscNodeStats TIndexTabletState::GetMiscNodeStats() const
     };
 }
 
+bool TIndexTabletState::CalculateExpectedShardCount() const
+{
+    if (FileSystem.GetShardNo()) {
+        // sharding is flat
+        return 0;
+    }
+
+    const auto currentShardCount = FileSystem.ShardFileSystemIdsSize();
+    ui64 autoShardCount = 0;
+    if (FileSystem.GetAutomaticShardCreationEnabled()
+            && FileSystem.GetMaxShardSize())
+    {
+        const double fsSize =
+            FileSystem.GetBlockSize() * FileSystem.GetBlocksCount();
+        autoShardCount = ceil(fsSize / FileSystem.GetMaxShardSize());
+    }
+
+    return Max(currentShardCount, autoShardCount);
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -296,6 +296,8 @@ public:
         return AllocatorRegistry.GetAllocator(tag);
     }
 
+    bool CalculateExpectedShardCount() const;
+
     //
     // FileSystem Stats
     //

--- a/cloud/filestore/public/api/protos/const.proto
+++ b/cloud/filestore/public/api/protos/const.proto
@@ -78,4 +78,10 @@ enum EFilestoreLimits
 
     // Maximum number of inodes.
     E_FS_LIMITS_INODES = -2; // 0xFFFFFFFE
+
+    // Shard number is encoded in the highest 8 bits of nodeId and handleId and
+    // 0 is reserved for the main tablet
+    // so 1 <= shardNo <= 255
+    // so shardCount <= 254
+    E_FS_LIMITS_MAX_SHARDS = 254;
 };


### PR DESCRIPTION
Shard creation and configuration is deliberately done NOT in the tablet code. Even though an implementation like this one leaves a possibility to produce incompletely created filesystems if the client doesn't retry errors it's not a real issue for our production clients (and even if it happens the impact will be insignificant). The upside is that such an implementation leaves no way to make a critical bug which would result in uncontrollable recursive tablet creation (fork bomb-style bug). 

Support for automatic shard creation upon filesystem resize and automatic shard deletion upon filesystem destruction will be implemented in the next PRs.

#1932 