### PR TITLE
issue-2074: disable IO of broken devices

### DIFF
--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -266,6 +266,15 @@ message TDiskAgentConfig
 
     // Disable devices that have been recognized as broken by the DR
     optional bool DisableBrokenDevices = 36;
+
+    // Path to serial number mapping. For testing purposes only.
+    message TPathToSerialNumber
+    {
+        required string Path = 1;
+        required string SerialNumber = 2;
+    }
+
+    repeated TPathToSerialNumber PathToSerialNumberMapping = 37;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -258,6 +258,10 @@ message TDiskAgentConfig
     // 2 means that one IO service will be created for every two file paths.
     // etc.
     optional uint32 PathsPerFileIOService = 34;
+
+    // List of device UUIDs with suspended I/O.
+    // I/O operations for such a device will result in errors.
+    repeated string DevicesWithSuspendedIO = 35;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -261,7 +261,11 @@ message TDiskAgentConfig
 
     // List of device UUIDs with suspended I/O.
     // I/O operations for such a device will result in errors.
+    // Is used for the config cache file only.
     repeated string DevicesWithSuspendedIO = 35;
+
+    // Disable devices that have been recognized as broken by the DR
+    optional bool DisableBrokenDevices = 36;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -107,8 +107,10 @@ bool AgentHasDevices(
     const TString storagePath = storageConfig->GetCachedDiskAgentConfigPath();
     const TString diskAgentPath = agentConfig->GetCachedConfigPath();
     const TString& path = diskAgentPath.empty() ? storagePath : diskAgentPath;
-    auto cachedDevices = NStorage::LoadCachedConfig(path);
-    if (!cachedDevices.empty()) {
+
+    if (auto [config, _] = NStorage::LoadDiskAgentConfig(path);
+        config.FileDevicesSize() != 0)
+    {
         return true;
     }
 

--- a/cloud/blockstore/libs/rdma_test/rdma_test_environment.cpp
+++ b/cloud/blockstore/libs/rdma_test/rdma_test_environment.cpp
@@ -22,15 +22,18 @@ TRdmaTestEnvironment::TRdmaTestEnvironment(size_t deviceSize, ui32 poolSize)
         TDuration::Zero(),   // maxRequestDuration
         TDuration::Zero()    // shutdownTimeout
     );
+
     TVector<TString> uuids;
     for (const auto& [key, value]: devices) {
         uuids.push_back(key);
     }
-    auto deviceClient = std::make_shared<TDeviceClient>(
+
+    DeviceClient = std::make_shared<TDeviceClient>(
         TDuration::MilliSeconds(100),
         uuids,
         Logging->CreateLog("BLOCKSTORE_DISK_AGENT"));
-    deviceClient->AcquireDevices(
+
+    DeviceClient->AcquireDevices(
         uuids,
         ClientId,
         TInstant::Now(),
@@ -60,7 +63,7 @@ TRdmaTestEnvironment::TRdmaTestEnvironment(size_t deviceSize, ui32 poolSize)
         std::move(oldRequestCounters),
         Logging,
         Server,
-        std::move(deviceClient),
+        DeviceClient,
         std::move(devices));
 
     RdmaTarget->Start();

--- a/cloud/blockstore/libs/rdma_test/rdma_test_environment.h
+++ b/cloud/blockstore/libs/rdma_test/rdma_test_environment.h
@@ -36,6 +36,8 @@ struct TRdmaTestEnvironment
         "console",
         TLogSettings{TLOG_RESOURCES});
 
+    std::shared_ptr<TDeviceClient> DeviceClient;
+
     TRdmaTestEnvironment(size_t deviceSize = 4_MB, ui32 poolSize = 1);
 
     virtual ~TRdmaTestEnvironment();

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -157,6 +157,10 @@ private:
 
     bool ShouldOffloadRequest(ui32 eventType) const;
 
+    void ProcessDevicesToDisableIO(
+        const NActors::TActorContext& ctx,
+        TVector<TString> devicesToDisableIO);
+
 private:
     STFUNC(StateInit);
     STFUNC(StateWork);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_disable.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_disable.cpp
@@ -26,6 +26,7 @@ void TDiskAgentActor::HandleDisableConcreteAgent(
     if (record.DeviceUUIDsSize()) {
         for (const auto& d: record.GetDeviceUUIDs()) {
             State->DisableDevice(d);
+            State->ReportDisabledDeviceError(d);
         }
     } else {
         HandlePoisonPill(nullptr, ctx);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -62,7 +62,7 @@ void TDiskAgentActor::InitAgent(const TActorContext& ctx)
                 std::move(r.Configs),
                 std::move(r.Errors),
                 std::move(r.ConfigMismatchErrors),
-                std::move(r.DevicesWithNewSerialNumber));
+                std::move(r.DevicesWithSuspendedIO));
 
             actorSystem->Send(
                 new IEventHandle(

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -178,17 +178,6 @@ void TDiskAgentActor::PerformIO(
             started);
     };
 
-    if (State->IsDeviceDisabled(deviceUUID)) {
-        LOG_INFO(ctx, TBlockStoreComponents::DISK_AGENT,
-            "Dropped %s request to device %s, session %s",
-            TMethod::Name,
-            deviceUUID.c_str(),
-            clientId.c_str());
-        State->ReportDisabledDeviceError(deviceUUID);
-        replyError(E_IO, "Device disabled");
-        return;
-    }
-
     LOG_TRACE(ctx, TBlockStoreComponents::DISK_AGENT,
         "%s [%s / %s]",
         TMethod::Name,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
@@ -98,7 +98,9 @@ void TDiskAgentActor::RenderDevices(IOutputStream& out) const
                             config.GetState(),
                             State->IsDeviceDisabled(uuid)
                                 ? EDeviceStateFlags::DISABLED
-                                : EDeviceStateFlags::NONE);
+                                : (State->IsDeviceSuspended(uuid)
+                                       ? EDeviceStateFlags::SUSPENDED
+                                       : EDeviceStateFlags::NONE));
                     }
                     TABLED() {
                         if (config.GetStateTs()) {

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
@@ -3,6 +3,8 @@
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
+#include <contrib/ydb/core/base/appdata.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -87,6 +89,9 @@ void TRegisterActor::HandleRegisterAgentResponse(
 
     auto response = std::make_unique<TEvDiskAgentPrivate::TEvRegisterAgentResponse>(
         msg->GetError());
+    response->DevicesToDisableIO.assign(
+        msg->Record.GetDevicesToDisableIO().cbegin(),
+        msg->Record.GetDevicesToDisableIO().cend());
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 }
 
@@ -100,6 +105,47 @@ STFUNC(TRegisterActor::StateWork)
             break;
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TUpdateDevicesWithSuspendedIOActor
+    : public TActorBootstrapped<TUpdateDevicesWithSuspendedIOActor>
+{
+private:
+    const TString CachePath;
+    const TVector<TString> DevicesToDisableIO;
+
+public:
+    TUpdateDevicesWithSuspendedIOActor(
+            TString cachePath,
+            TVector<TString> devicesToSuspendIO)
+        : CachePath{std::move(cachePath)}
+        , DevicesToDisableIO{std::move(devicesToSuspendIO)}
+    {}
+
+    void Bootstrap(const TActorContext& ctx)
+    {
+        auto error = NStorage::UpdateDevicesWithSuspendedIO(
+            CachePath,
+            DevicesToDisableIO);
+
+        if (HasError(error)) {
+            LOG_ERROR_S(
+                ctx,
+                TBlockStoreComponents::DISK_AGENT,
+                "Can't update DevicesWithSuspendedIO in the config cache "
+                "file: "
+                    << FormatError(error));
+        } else {
+            LOG_INFO(
+                ctx,
+                TBlockStoreComponents::DISK_AGENT,
+                "DevicesWithSuspendedIO has been successfully updated");
+        }
+
+        Die(ctx);
+    }
+};
 
 }   // namespace
 
@@ -135,15 +181,60 @@ void TDiskAgentActor::HandleRegisterAgent(
         std::move(config));
 }
 
+void TDiskAgentActor::ProcessDevicesToDisableIO(
+    const NActors::TActorContext& ctx,
+    TVector<TString> devicesToDisableIO)
+{
+    if (!AgentConfig->GetDisableBrokenDevices()) {
+        return;
+    }
+
+    const THashSet<TString> uuids(
+        devicesToDisableIO.cbegin(),
+        devicesToDisableIO.cend());
+
+    for (const auto& uuid: State->GetDeviceIds()) {
+        if (uuids.contains(uuid)) {
+            LOG_INFO_S(
+                ctx,
+                TBlockStoreComponents::DISK_AGENT,
+                "Disable device " << uuid);
+            State->DisableDevice(uuid);
+        } else {
+            State->EnableDevice(uuid);
+        }
+    }
+
+    TString cachePath = Config->GetCachedDiskAgentConfigPath().empty()
+                            ? AgentConfig->GetCachedConfigPath()
+                            : Config->GetCachedDiskAgentConfigPath();
+
+    if (cachePath.empty()) {
+        return;
+    }
+
+    auto actor = std::make_unique<TUpdateDevicesWithSuspendedIOActor>(
+        std::move(cachePath),
+        std::move(devicesToDisableIO));
+
+    // Starting an actor on the IO pool to avoid file operations in the User
+    // pool
+    ctx.Register(
+        actor.release(),
+        TMailboxType::HTSwap,
+        NKikimr::AppData()->IOPoolId);
+}
+
 void TDiskAgentActor::HandleRegisterAgentResponse(
     const TEvDiskAgentPrivate::TEvRegisterAgentResponse::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto* msg = ev->Get();
+    auto* msg = ev->Get();
 
     if (!HasError(msg->GetError())) {
         RegistrationState = ERegistrationState::Registered;
         LOG_INFO(ctx, TBlockStoreComponents::DISK_AGENT, "Register completed");
+        ProcessDevicesToDisableIO(ctx, std::move(msg->DevicesToDisableIO));
     } else {
         LOG_WARN(ctx, TBlockStoreComponents::DISK_AGENT,
             "Register failed: %s. Try later", FormatError(msg->GetError()).c_str());

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/common/block_checksum.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/nvme/nvme.h>
 #include <cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h>
 #include <cloud/blockstore/libs/storage/model/composite_id.h>
 #include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
@@ -57,6 +58,60 @@ TFsPath TryGetRamDrivePath()
         ? GetSystemTempDir()
         : p;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestNvmeManager
+    : NNvme::INvmeManager
+{
+    THashMap<TString, TString> PathToSerial;
+
+    explicit TTestNvmeManager(
+            const TVector<std::pair<TString, TString>>& pathToSerial)
+        : PathToSerial{pathToSerial.cbegin(), pathToSerial.cend()}
+    {
+    }
+
+    TFuture<NProto::TError> Format(
+        const TString& path,
+        NNvme::nvme_secure_erase_setting ses) override
+    {
+        Y_UNUSED(path);
+        Y_UNUSED(ses);
+
+        return MakeFuture<NProto::TError>();
+    }
+
+    TFuture<NProto::TError> Deallocate(
+        const TString& path,
+        ui64 offsetBytes,
+        ui64 sizeBytes) override
+    {
+        Y_UNUSED(path);
+        Y_UNUSED(offsetBytes);
+        Y_UNUSED(sizeBytes);
+
+        return MakeFuture<NProto::TError>();
+    }
+
+    TResultOrError<TString> GetSerialNumber(const TString& path) override
+    {
+        const auto filename = TFsPath{path}.Basename();
+        auto it = PathToSerial.find(filename);
+        if (it == PathToSerial.end()) {
+            return MakeError(MAKE_SYSTEM_ERROR(42), filename);
+        }
+
+        return it->second;
+    }
+
+    TResultOrError<bool> IsSsd(const TString& path) override
+    {
+        Y_UNUSED(path);
+
+        return true;
+    }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -114,10 +169,12 @@ struct TFixture
     const TTempDir TempDir;
     const TString CachedSessionsPath =
         TempDir.Path() / "nbs-disk-agent-sessions.txt";
+    const TString CachedConfigPath = TempDir.Path() / "nbs-disk-agent.txt";
     const TDuration ReleaseInactiveSessionsTimeout = 10s;
 
     TTestBasicRuntime Runtime;
-    NMonitoring::TDynamicCountersPtr Counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    NMonitoring::TDynamicCountersPtr Counters =
+        MakeIntrusive<NMonitoring::TDynamicCounters>();
 
     TVector<TFsPath> Files;
 
@@ -142,10 +199,12 @@ struct TFixture
         pool.SetMaxSize(DefaultFileSize);
 
         config.SetCachedSessionsPath(CachedSessionsPath);
+        config.SetCachedConfigPath(CachedConfigPath);
         config.SetBackend(NProto::DISK_AGENT_BACKEND_AIO);
         config.SetAcquireRequired(true);
         config.SetReleaseInactiveSessionsTimeout(
             ReleaseInactiveSessionsTimeout.MilliSeconds());
+        config.SetDisableBrokenDevices(true);
 
         return config;
     }
@@ -1054,7 +1113,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
 
         // Return all stolen request - write/zero request will be completed
         // after this
-        for (auto& request : stolenWriteCompletedRequests) {
+        for (auto& request: stolenWriteCompletedRequests) {
             runtime.Send(request.release());
         }
 
@@ -1257,7 +1316,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
 
         // Return all stolen request - write/zero request will be completed
         // after this
-        for (auto& request : stolenWriteCompletedRequests) {
+        for (auto& request: stolenWriteCompletedRequests) {
             runtime.Send(request.release());
         }
         {
@@ -4559,6 +4618,176 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         UNIT_ASSERT_VALUES_EQUAL(1, parsedZeroes);
         UNIT_ASSERT_VALUES_EQUAL(1, parsedZeroes);
         UNIT_ASSERT_VALUES_EQUAL(5, actors.size());
+    }
+
+    Y_UNIT_TEST_F(ShouldDisableDevicesAfterRegistration, TFixture)
+    {
+        const TString uuids[] {
+            "79955ae90189fe8a89ab832a8b0cb57d", // NVMENBS01
+            "657dabaf3d224c9177b00c437716dfb1", // NVMENBS02
+            "e85cd1d217c3239507fc0cd180a075fd", // NVMENBS03
+            "5ea2fcdce0a180a63db2b5f6a5b34221"  // NVMENBS04
+        };
+
+        TVector<std::pair<TString, TString>> pathToSerial{
+            {"NVMENBS01", "W"},
+            {"NVMENBS02", "X"},
+            {"NVMENBS03", "Y"},
+            {"NVMENBS04", "Z"},
+        };
+
+        // build the config cache
+        {
+            NProto::TDiskAgentConfig config;
+
+            size_t i = 0;
+            for (const auto& [filename, sn]: pathToSerial) {
+                auto& file = *config.AddFileDevices();
+                file.SetPath(TempDir.Path() / filename);
+                file.SetSerialNumber(sn);
+                file.SetDeviceId(uuids[i]);
+                file.SetBlockSize(4_KB);
+
+                ++i;
+            }
+
+            auto error = SaveDiskAgentConfig(CachedConfigPath, config);
+            UNIT_ASSERT_C(!HasError(error), FormatError(error));
+        }
+
+        // change serial numbers of NVMENBS02 & NVMENBS04
+        pathToSerial[1].second = "new-X";   // NVMENBS02
+        pathToSerial[3].second = "new-Z";   // NVMENBS04
+
+        auto diskregistryState = MakeIntrusive<TDiskRegistryState>();
+
+        // Disable only NVMENBS02
+        diskregistryState->DisabledDevices = {uuids[1]};
+
+        // Postpone the registration in DR
+        auto oldEventFilterFn = Runtime.SetEventFilter(
+            [](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistry::EvRegisterAgentRequest)
+                {
+                    auto response = std::make_unique<
+                        TEvDiskRegistry::TEvRegisterAgentResponse>(
+                        MakeError(E_REJECTED));
+
+                    runtime.Send(new NActors::IEventHandle(
+                        event->Sender,
+                        event->GetRecipientRewrite(),
+                        response.release()));
+
+                    return true;
+                }
+
+                return false;
+            });
+
+        auto env = TTestEnvBuilder(Runtime)
+            .With(CreateDiskAgentConfig())
+            .With(std::make_shared<TTestNvmeManager>(pathToSerial))
+            .With(diskregistryState)
+            .Build();
+
+        Runtime.UpdateCurrentTime(Now());
+
+        TDiskAgentClient diskAgent(Runtime);
+        diskAgent.WaitReady();
+
+        diskAgent.AcquireDevices(
+            TVector{
+                uuids[0],   // NVMENBS01
+                uuids[1],   // NVMENBS02
+                uuids[3],   // NVMENBS04
+            },
+            "reader-1",
+            NProto::VOLUME_ACCESS_READ_ONLY,
+            -1,   // MountSeqNumber
+            "vol0",
+            1000);   // VolumeGeneration
+
+        // NVMENBS01 is OK
+        {
+            auto error = Read(diskAgent, "reader-1", uuids[0]);
+            UNIT_ASSERT_EQUAL_C(S_OK, error.GetCode(), error);
+        }
+
+        // Before the registration in DR NVMENBS02 & NVMENBS04 should be
+        // suspended
+        {
+            auto error = Read(diskAgent, "reader-1", uuids[1]);
+            UNIT_ASSERT_EQUAL_C(E_REJECTED, error.GetCode(), error);
+            UNIT_ASSERT_C(
+                error.GetMessage().Contains("Device disabled"),
+                error);
+        }
+
+        {
+            auto error = Read(diskAgent, "reader-1", uuids[3]);
+            UNIT_ASSERT_EQUAL_C(E_REJECTED, error.GetCode(), error);
+            UNIT_ASSERT_C(
+                error.GetMessage().Contains("Device disabled"),
+                error);
+        }
+
+        // check the config cache
+        {
+            auto [config, error] = LoadDiskAgentConfig(CachedConfigPath);
+            UNIT_ASSERT_EQUAL_C(S_OK, error.GetCode(), error);
+            UNIT_ASSERT_VALUES_EQUAL(4, config.FileDevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(2, config.DevicesWithSuspendedIOSize());
+
+            Sort(*config.MutableDevicesWithSuspendedIO());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                uuids[3],   // NVMENBS04
+                config.GetDevicesWithSuspendedIO(0));
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                uuids[1],   // NVMENBS02
+                config.GetDevicesWithSuspendedIO(1));
+        }
+
+        Runtime.SetEventFilter(oldEventFilterFn);
+        Runtime.AdvanceCurrentTime(5s);
+        Runtime.DispatchEvents(TDispatchOptions{
+            .FinalEvents = {TDispatchOptions::TFinalEventCondition(
+                TEvDiskRegistry::EvRegisterAgentResponse)}});
+
+        // NVMENBS01 is OK
+        {
+            auto error = Read(diskAgent, "reader-1", uuids[0]);
+            UNIT_ASSERT_EQUAL_C(S_OK, error.GetCode(), error);
+        }
+
+        // After the registartion in DR NVMENBS02 should be disabled
+        {
+            auto error = Read(diskAgent, "reader-1", uuids[1]);
+            UNIT_ASSERT_EQUAL_C(E_IO, error.GetCode(), error);
+            UNIT_ASSERT_C(
+                error.GetMessage().Contains("Device disabled"),
+                error);
+        }
+
+        // NVMENBS04 should be OK
+        {
+            auto error = Read(diskAgent, "reader-1", uuids[3]);
+            UNIT_ASSERT_EQUAL_C(S_OK, error.GetCode(), error);
+        }
+
+        // check the config cache
+        {
+            auto [config, error] = LoadDiskAgentConfig(CachedConfigPath);
+            UNIT_ASSERT_EQUAL_C(S_OK, error.GetCode(), error);
+            UNIT_ASSERT_VALUES_EQUAL(4, config.FileDevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, config.DevicesWithSuspendedIOSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                uuids[1],   // NVMENBS02
+                config.GetDevicesWithSuspendedIO(0));
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
@@ -61,7 +61,9 @@ struct TEvDiskAgentPrivate
     {};
 
     struct TRegisterAgentResponse
-    {};
+    {
+        TVector<TString> DevicesToDisableIO;
+    };
 
     //
     // CollectStats

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
@@ -37,7 +37,7 @@ struct TEvDiskAgentPrivate
         TVector<NProto::TDeviceConfig> Configs;
         TVector<TString> Errors;
         TVector<TString> ConfigMismatchErrors;
-        TVector<TString> DevicesWithNewSerialNumber;
+        TVector<TString> DevicesWithSuspendedIO;
 
         TInitAgentCompleted() = default;
 
@@ -45,11 +45,11 @@ struct TEvDiskAgentPrivate
                 TVector<NProto::TDeviceConfig> configs,
                 TVector<TString> errors,
                 TVector<TString> configMismatchErrors,
-                TVector<TString> devicesWithNewSerialNumber)
+                TVector<TString> devicesWithSuspendedIO)
             : Configs(std::move(configs))
             , Errors(std::move(errors))
             , ConfigMismatchErrors(std::move(configMismatchErrors))
-            , DevicesWithNewSerialNumber(std::move(devicesWithNewSerialNumber))
+            , DevicesWithSuspendedIO(std::move(devicesWithSuspendedIO))
         {}
     };
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -894,6 +894,11 @@ bool TDiskAgentState::IsDeviceDisabled(const TString& uuid) const
     return DeviceClient->IsDeviceDisabled(uuid);
 }
 
+bool TDiskAgentState::IsDeviceSuspended(const TString& uuid) const
+{
+    return DeviceClient->IsDeviceSuspended(uuid);
+}
+
 void TDiskAgentState::ReportDisabledDeviceError(const TString& uuid)
 {
     if (auto* d = Devices.FindPtr(uuid)) {

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -416,8 +416,7 @@ TFuture<TInitializeResult> TDiskAgentState::InitAioStorage()
                 .Configs = std::move(r.Configs),
                 .Errors = std::move(r.Errors),
                 .ConfigMismatchErrors = std::move(r.ConfigMismatchErrors),
-                .DevicesWithNewSerialNumber =
-                    std::move(r.DevicesWithNewSerialNumber),
+                .DevicesWithSuspendedIO = std::move(r.DevicesWithSuspendedIO),
                 .Guard = std::move(r.Guard)};
         });
 }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -86,7 +86,7 @@ public:
         TVector<NProto::TDeviceConfig> Configs;
         TVector<TString> Errors;
         TVector<TString> ConfigMismatchErrors;
-        TVector<TString> DevicesWithNewSerialNumber;
+        TVector<TString> DevicesWithSuspendedIO;
 
         TDeviceGuard Guard;
     };

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -118,6 +118,7 @@ public:
     TString GetDeviceName(const TString& uuid) const;
 
     TVector<NProto::TDeviceConfig> GetDevices() const;
+    TVector<TString> GetDeviceIds() const;
 
     ui32 GetDevicesCount() const;
 
@@ -145,6 +146,7 @@ public:
     TVector<NProto::TDiskAgentDeviceSession> GetSessions() const;
 
     void DisableDevice(const TString& uuid);
+    void SuspendDevice(const TString& uuid);
     void EnableDevice(const TString& uuid);
     bool IsDeviceDisabled(const TString& uuid) const;
     void ReportDisabledDeviceError(const TString& uuid);
@@ -185,6 +187,8 @@ private:
     void InitRdmaTarget();
 
     void RestoreSessions(TDeviceClient& client) const;
+
+    void CheckIfDeviceIsDisabled(const TString& uuid, const TString& clientId);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -149,6 +149,7 @@ public:
     void SuspendDevice(const TString& uuid);
     void EnableDevice(const TString& uuid);
     bool IsDeviceDisabled(const TString& uuid) const;
+    bool IsDeviceSuspended(const TString& uuid) const;
     void ReportDisabledDeviceError(const TString& uuid);
 
     void StopTarget();

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.cpp
@@ -48,6 +48,7 @@ namespace {
     xxx(DisableNodeBrokerRegistrationOnDevicelessAgent, bool,          false  )\
     xxx(MaxAIOContextEvents,                ui32,       1024                  )\
     xxx(PathsPerFileIOService,              ui32,       0                     )\
+    xxx(DisableBrokenDevices,               bool,       0                     )\
 // BLOCKSTORE_AGENT_CONFIG
 
 #define BLOCKSTORE_DECLARE_CONFIG(name, type, value)                           \
@@ -221,6 +222,20 @@ NProto::TError SaveDiskAgentConfig(
     }
 
     return {};
+}
+
+[[nodiscard]] auto UpdateDevicesWithSuspendedIO(
+    const TString& path,
+    const TVector<TString>& uuids) -> NProto::TError
+{
+    auto [config, error] = LoadDiskAgentConfig(path);
+    if (HasError(error)) {
+        return error;
+    }
+
+    config.MutableDevicesWithSuspendedIO()->Assign(uuids.begin(), uuids.end());
+
+    return SaveDiskAgentConfig(path, config);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -115,6 +115,11 @@ public:
         return Config.GetDevicesWithSuspendedIO();
     }
 
+    const auto& GetPathToSerialNumberMapping() const
+    {
+        return Config.GetPathToSerialNumberMapping();
+    }
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -4,6 +4,8 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 
+#include <cloud/storage/core/libs/common/error.h>
+
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
 #include <util/stream/output.h>
@@ -22,9 +24,9 @@ public:
     TDiskAgentConfig() = default;
 
     TDiskAgentConfig(
-            const NProto::TDiskAgentConfig& config,
+            NProto::TDiskAgentConfig config,
             TString rack)
-        : Config(config)
+        : Config(std::move(config))
         , Rack(std::move(rack))
     {}
 
@@ -32,8 +34,6 @@ public:
     TString GetAgentId() const;
     ui64 GetSeqNumber() const;
     bool GetDedicatedDiskAgent() const;
-
-    // TODO
 
     const auto& GetMemoryDevices() const
     {
@@ -112,5 +112,14 @@ public:
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+[[nodiscard]] auto LoadDiskAgentConfig(
+    const TString& path) -> TResultOrError<NProto::TDiskAgentConfig>;
+
+[[nodiscard]] auto SaveDiskAgentConfig(
+    const TString& path,
+    const NProto::TDiskAgentConfig& proto) -> NProto::TError;
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -108,6 +108,7 @@ public:
     bool GetDisableNodeBrokerRegistrationOnDevicelessAgent() const;
     ui32 GetMaxAIOContextEvents() const;
     ui32 GetPathsPerFileIOService() const;
+    bool GetDisableBrokenDevices() const;
 
     const auto& GetDevicesWithSuspendedIO() const
     {
@@ -122,6 +123,10 @@ public:
 
 [[nodiscard]] auto LoadDiskAgentConfig(
     const TString& path) -> TResultOrError<NProto::TDiskAgentConfig>;
+
+[[nodiscard]] auto UpdateDevicesWithSuspendedIO(
+    const TString& path,
+    const TVector<TString>& uuids) -> NProto::TError;
 
 [[nodiscard]] auto SaveDiskAgentConfig(
     const TString& path,

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -109,6 +109,11 @@ public:
     ui32 GetMaxAIOContextEvents() const;
     ui32 GetPathsPerFileIOService() const;
 
+    const auto& GetDevicesWithSuspendedIO() const
+    {
+        return Config.GetDevicesWithSuspendedIO();
+    }
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
@@ -385,7 +385,12 @@ std::optional<ui32> TDeviceClient::GetDeviceIOErrorCode(
 
 bool TDeviceClient::IsDeviceDisabled(const TString& uuid) const
 {
-    return GetDeviceIOErrorCode(uuid).has_value();
+    return GetDeviceIOErrorCode(uuid).value_or(S_OK) == E_IO;
+}
+
+bool TDeviceClient::IsDeviceSuspended(const TString& uuid) const
+{
+    return GetDeviceIOErrorCode(uuid).value_or(S_OK) == E_REJECTED;
 }
 
 // static

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.h
@@ -34,7 +34,11 @@ private:
         ui32 VolumeGeneration = 0;
         TSessionInfo WriterSession;
         TVector<TSessionInfo> ReaderSessions;
-        bool Disabled = false;
+
+        // If the value is set, it is returned as the result of IO
+        // operations and the device is considered to be disabled.
+        std::optional<ui32> IOErrorCode;
+
         TRWMutex Lock;
     };
     using TDevicesState = THashMap<TString, std::unique_ptr<TDeviceState>>;
@@ -80,15 +84,26 @@ public:
     TSessionInfo GetWriterSession(const TString& uuid) const;
     TVector<TSessionInfo> GetReaderSessions(const TString& uuid) const;
 
+    // Return E_IO error on I/O operations.
     void DisableDevice(const TString& uuid) const;
+
+    // Same as DisableDevice but return E_REJECTED.
+    void SuspendDevice(const TString& uuid) const;
+
     void EnableDevice(const TString& uuid) const;
+
     bool IsDeviceDisabled(const TString& uuid) const;
+    std::optional<ui32> GetDeviceIOErrorCode(const TString& uuid) const;
 
     TVector<NProto::TDiskAgentDeviceSession> GetSessions() const;
 
 private:
     static TDevicesState MakeDevices(TVector<TString> uuids);
     [[nodiscard]] TDeviceState* GetDeviceState(const TString& uuid) const;
+
+    void SetDeviceIOErrorCode(
+        const TString& uuid,
+        std::optional<ui32> errorCode) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.h
@@ -93,6 +93,7 @@ public:
     void EnableDevice(const TString& uuid) const;
 
     bool IsDeviceDisabled(const TString& uuid) const;
+    bool IsDeviceSuspended(const TString& uuid) const;
     std::optional<ui32> GetDeviceIOErrorCode(const TString& uuid) const;
 
     TVector<NProto::TDiskAgentDeviceSession> GetSessions() const;

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client_ut.cpp
@@ -791,6 +791,31 @@ Y_UNIT_TEST_SUITE(TDeviceClientTest)
             UNIT_ASSERT(updated);   // new read session
         }
     }
+
+    Y_UNIT_TEST_F(TestShouldDisableDevice, TFixture)
+    {
+        auto client = CreateClient({
+            .Devices = {"uuid1", "uuid2"}
+        });
+
+        UNIT_ASSERT(!client.IsDeviceDisabled("uuid1"));
+        UNIT_ASSERT(!client.IsDeviceDisabled("uuid2"));
+
+        client.DisableDevice("uuid1");
+        client.SuspendDevice("uuid2");
+
+        UNIT_ASSERT(client.IsDeviceDisabled("uuid1"));
+        UNIT_ASSERT(!client.IsDeviceSuspended("uuid1"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_IO,
+            client.GetDeviceIOErrorCode("uuid1").value());
+
+        UNIT_ASSERT(!client.IsDeviceDisabled("uuid2"));
+        UNIT_ASSERT(client.IsDeviceSuspended("uuid2"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            client.GetDeviceIOErrorCode("uuid2").value());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_scanner.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_scanner.cpp
@@ -2,7 +2,6 @@
 
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
-#include <cloud/storage/core/libs/common/proto_helpers.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <util/generic/algorithm.h>
@@ -160,26 +159,6 @@ NProto::TError FindDevices(
     }
 
     return {};
-}
-
-TVector<NProto::TFileDeviceArgs> LoadCachedConfig(const TString& path)
-{
-    if (path.empty()) {
-        return {};
-    }
-
-    if (!NFs::Exists(path)) {
-        return {};
-    }
-
-    NProto::TDiskAgentConfig proto;
-    ParseProtoTextFromFileRobust(path, proto);
-
-    auto& devices = *proto.MutableFileDevices();
-
-    return {
-        std::make_move_iterator(devices.begin()),
-        std::make_move_iterator(devices.end())};
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_scanner.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_scanner.h
@@ -26,6 +26,4 @@ NProto::TError FindDevices(
     const NProto::TStorageDiscoveryConfig& config,
     TDeviceCallback callback);
 
-TVector<NProto::TFileDeviceArgs> LoadCachedConfig(const TString& path);
-
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.h
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.h
@@ -65,7 +65,7 @@ using IRdmaTargetPtr = std::shared_ptr<IRdmaTarget>;
 
 IRdmaTargetPtr CreateRdmaTarget(
     TRdmaTargetConfigPtr rdmaTargetConfig,
-    TOldRequestCounters OldRequestCounters,
+    TOldRequestCounters oldRequestCounters,
     ILoggingServicePtr logging,
     NRdma::IServerPtr server,
     TDeviceClientPtr deviceClient,

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -109,7 +109,7 @@ private:
 
     TVector<TString> Errors;
     TVector<TString> ConfigMismatchErrors;
-    TVector<TString> DevicesWithNewSerialNumber;
+    TVector<TString> DevicesWithSuspendedIO;
     TMutex Lock;
 
     THashMap<TString, TString> PathToSerial;
@@ -474,7 +474,7 @@ TFuture<void> TInitializer::Initialize()
                               << TString(currentSerialNumber).Quote()
                               << " (was " << d.GetSerialNumber().Quote()
                               << ")");
-                DevicesWithNewSerialNumber.push_back(d.GetDeviceId());
+                DevicesWithSuspendedIO.push_back(d.GetDeviceId());
             }
         }
 
@@ -625,7 +625,7 @@ TInitializeStorageResult TInitializer::GetResult()
 
     r.Errors = std::move(Errors);
     r.ConfigMismatchErrors = std::move(ConfigMismatchErrors);
-    r.DevicesWithNewSerialNumber = std::move(DevicesWithNewSerialNumber);
+    r.DevicesWithSuspendedIO = std::move(DevicesWithSuspendedIO);
     r.Guard = std::move(Guard);
 
     return r;

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -399,6 +399,9 @@ void TInitializer::SaveCurrentConfig()
     proto.MutableFileDevices()->Assign(
         FileDevices.cbegin(),
         FileDevices.cend());
+    proto.MutableDevicesWithSuspendedIO()->Assign(
+        DevicesWithSuspendedIO.cbegin(),
+        DevicesWithSuspendedIO.cend());
 
     auto error = SaveDiskAgentConfig(path, proto);
     if (HasError(error)) {
@@ -468,6 +471,12 @@ NProto::TError TInitializer::ProcessConfigCache()
         return error;
     }
 
+    DevicesWithSuspendedIO.insert(
+        DevicesWithSuspendedIO.end(),
+        std::make_move_iterator(
+            config.MutableDevicesWithSuspendedIO()->begin()),
+        std::make_move_iterator(config.MutableDevicesWithSuspendedIO()->end()));
+
     TVector<NProto::TFileDeviceArgs> devices{
         std::make_move_iterator(config.MutableFileDevices()->begin()),
         std::make_move_iterator(config.MutableFileDevices()->end())};
@@ -485,6 +494,8 @@ NProto::TError TInitializer::ProcessConfigCache()
             DevicesWithSuspendedIO.push_back(d.GetDeviceId());
         }
     }
+
+    SortUnique(DevicesWithSuspendedIO);
 
     ValidateCurrentConfigs(devices);
 

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -173,6 +173,10 @@ TInitializer::TInitializer(
     , StorageProvider(std::move(storageProvider))
     , NvmeManager(std::move(nvmeManager))
 {
+    for (const auto& m: AgentConfig->GetPathToSerialNumberMapping()) {
+        PathToSerial.emplace(m.GetPath(), m.GetSerialNumber());
+    }
+
     auto fileDevices = AgentConfig->GetFileDevices();
 
     FileDevices.assign(

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.h
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.h
@@ -29,7 +29,7 @@ struct TInitializeStorageResult
     TVector<TStorageIoStatsPtr> Stats;
     TVector<TString> Errors;
     TVector<TString> ConfigMismatchErrors;
-    TVector<TString> DevicesWithNewSerialNumber;
+    TVector<TString> DevicesWithSuspendedIO;
     TDeviceGuard Guard;
 };
 

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -180,7 +180,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(r.Configs.size(), r.Stats.size());
         UNIT_ASSERT_VALUES_EQUAL(0, r.Errors.size());
         UNIT_ASSERT_VALUES_EQUAL(0, r.ConfigMismatchErrors.size());
-        UNIT_ASSERT_VALUES_EQUAL(0, r.DevicesWithNewSerialNumber.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, r.DevicesWithSuspendedIO.size());
 
         auto configs = r.Configs;
         SortBy(configs, [](const auto& d) { return d.GetDeviceName(); });
@@ -212,7 +212,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
 
         const auto& r1 = future1.GetValueSync();
 
-        UNIT_ASSERT_VALUES_EQUAL(0, r1.DevicesWithNewSerialNumber.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, r1.DevicesWithSuspendedIO.size());
 
         const TVector<std::pair<TString, TString>> newPathToSerial{
             {"NVMENBS01", "W"},
@@ -240,7 +240,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(0, r2.ConfigMismatchErrors.size());
         UNIT_ASSERT_VALUES_EQUAL(
             DeviceCountPerPath * 3,
-            r2.DevicesWithNewSerialNumber.size());
+            r2.DevicesWithSuspendedIO.size());
 
         {
             auto configs = r2.Configs;
@@ -265,7 +265,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
         const auto& r3 = future3.GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(0, r3.ConfigMismatchErrors.size());
-        UNIT_ASSERT_VALUES_EQUAL(0, r3.DevicesWithNewSerialNumber.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, r3.DevicesWithSuspendedIO.size());
         UNIT_ASSERT_VALUES_EQUAL(r2.Configs.size(), r3.Configs.size());
         UNIT_ASSERT(std::equal(
             r2.Configs.cbegin(),
@@ -333,7 +333,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(1, r2.ConfigMismatchErrors.size());
         UNIT_ASSERT_VALUES_EQUAL(
             DeviceCountPerPath * 3,
-            r2.DevicesWithNewSerialNumber.size());
+            r2.DevicesWithSuspendedIO.size());
         UNIT_ASSERT_VALUES_EQUAL(r1.Configs.size(), r2.Configs.size());
         UNIT_ASSERT(std::equal(
             r1.Configs.cbegin(),
@@ -405,7 +405,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(1, r2.ConfigMismatchErrors.size());
         UNIT_ASSERT_VALUES_EQUAL(
             DeviceCountPerPath * 3,
-            r2.DevicesWithNewSerialNumber.size());
+            r2.DevicesWithSuspendedIO.size());
         UNIT_ASSERT_VALUES_EQUAL(r1.Configs.size(), r2.Configs.size());
         UNIT_ASSERT(std::equal(
             r1.Configs.cbegin(),

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -265,7 +265,11 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
         const auto& r3 = future3.GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(0, r3.ConfigMismatchErrors.size());
-        UNIT_ASSERT_VALUES_EQUAL(0, r3.DevicesWithSuspendedIO.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            r2.DevicesWithSuspendedIO.size(),
+            r3.DevicesWithSuspendedIO.size());
+
         UNIT_ASSERT_VALUES_EQUAL(r2.Configs.size(), r3.Configs.size());
         UNIT_ASSERT(std::equal(
             r2.Configs.cbegin(),

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
@@ -53,6 +53,8 @@ struct TDiskRegistryState
 
     THashMap<TString, NProto::TDeviceConfig> Devices;
     THashMap<ui32, NProto::TAgentStats> Stats;
+
+    TVector<TString> DisabledDevices;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -454,6 +456,7 @@ struct TTestEnvBuilder
     NNvme::INvmeManagerPtr NvmeManager;
     NSpdk::ISpdkEnvPtr Spdk;
     NProto::TStorageServiceConfig StorageServiceConfig;
+    TDiskRegistryState::TPtr DiskRegistryState;
 
     explicit TTestEnvBuilder(NActors::TTestActorRuntime& runtime);
 
@@ -463,6 +466,7 @@ struct TTestEnvBuilder
     TTestEnvBuilder& With(NNvme::INvmeManagerPtr nvmeManager);
     TTestEnvBuilder& With(NProto::TDiskAgentConfig config);
     TTestEnvBuilder& With(NProto::TStorageServiceConfig storageServiceConfig);
+    TTestEnvBuilder& With(TDiskRegistryState::TPtr diskRegistryState);
 
     TTestEnv Build();
 };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -905,6 +905,7 @@ auto TDiskRegistryState::RegisterAgent(
 
     TVector<TDiskId> affectedDisks;
     TVector<TDiskId> disksToReallocate;
+    TVector<TString> devicesToDisableIO;
 
     try {
         if (auto* buddy = AgentList.FindAgent(config.GetNodeId());
@@ -968,6 +969,11 @@ auto TDiskRegistryState::RegisterAgent(
 
         for (const auto& d: agent.GetDevices()) {
             const auto& uuid = d.GetDeviceUUID();
+
+            if (d.GetState() == NProto::DEVICE_STATE_ERROR) {
+                devicesToDisableIO.push_back(uuid);
+            }
+
             auto diskId = DeviceList.FindDiskId(uuid);
 
             if (diskId.empty()) {
@@ -995,7 +1001,7 @@ auto TDiskRegistryState::RegisterAgent(
             diskIds.emplace(std::move(diskId));
         }
 
-        for (auto& id: diskIds) {
+        for (const auto& id: diskIds) {
             if (TryUpdateDiskState(db, id, timestamp)) {
                 affectedDisks.push_back(id);
             }
@@ -1030,7 +1036,8 @@ auto TDiskRegistryState::RegisterAgent(
 
     return TAgentRegistrationResult{
         .AffectedDisks = std::move(affectedDisks),
-        .DisksToReallocate = std::move(disksToReallocate)};
+        .DisksToReallocate = std::move(disksToReallocate),
+        .DevicesToDisableIO = std::move(devicesToDisableIO)};
 }
 
 NProto::TError TDiskRegistryState::CheckDestructiveConfigurationChange(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -356,6 +356,7 @@ public:
     {
         TVector<TDiskId> AffectedDisks;
         TVector<TDiskId> DisksToReallocate;
+        TVector<TString> DevicesToDisableIO;
     };
 
     auto RegisterAgent(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -215,6 +215,7 @@ struct TTxDiskRegistry
         NProto::TError Error;
         TVector<TString> AffectedDisks;
         TVector<TString> NotifiedDisks;
+        TVector<TString> DevicesToDisableIO;
 
         TAddAgent(
                 TRequestInfoPtr requestInfo,
@@ -232,6 +233,7 @@ struct TTxDiskRegistry
             Error.Clear();
             AffectedDisks.clear();
             NotifiedDisks.clear();
+            DevicesToDisableIO.clear();
         }
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -165,7 +165,7 @@ TTestRuntimeBuilder& TTestRuntimeBuilder::WithAgents(
     const TVector<NProto::TAgentConfig>& configs)
 {
     DiskAgents.clear();
-    for (auto& config: configs) {
+    for (const auto& config: configs) {
         DiskAgents.push_back(CreateTestDiskAgent(config));
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -309,6 +309,34 @@ inline TTestDiskAgent* CreateSuspendedTestDiskAgent(
     return agent;
 }
 
+struct TCreateDeviceConfigParams
+{
+    TString Name;
+    TString Id;
+    TString SerialNum;
+    TString Rack = "the-rack";
+    ui64 TotalSize = 10_GB;
+    ui32 BlockSize = DefaultBlockSize;
+};
+
+inline NProto::TDeviceConfig CreateDeviceConfig(
+    TCreateDeviceConfigParams params)
+{
+    NProto::TDeviceConfig device;
+
+    device.SetDeviceName(std::move(params.Name));
+    device.SetDeviceUUID(params.Id);
+    device.SetSerialNumber(std::move(params.SerialNum));
+    device.SetRack(std::move(params.Rack));
+    device.SetBlocksCount(params.TotalSize / params.BlockSize);
+    device.SetBlockSize(params.BlockSize);
+    device.SetTransportId(params.Id);
+    device.MutableRdmaEndpoint()->SetHost(std::move(params.Id));
+    device.MutableRdmaEndpoint()->SetPort(10020);
+
+    return device;
+}
+
 inline NProto::TDeviceConfig Device(
     TString name,
     TString uuid,
@@ -316,18 +344,13 @@ inline NProto::TDeviceConfig Device(
     ui64 totalSize = 10_GB,
     ui32 blockSize = DefaultBlockSize)
 {
-    NProto::TDeviceConfig device;
-
-    device.SetDeviceName(std::move(name));
-    device.SetDeviceUUID(uuid);
-    device.SetRack(std::move(rack));
-    device.SetBlocksCount(totalSize / blockSize);
-    device.SetBlockSize(blockSize);
-    device.SetTransportId(uuid);
-    device.MutableRdmaEndpoint()->SetHost(std::move(uuid));
-    device.MutableRdmaEndpoint()->SetPort(10020);
-
-    return device;
+    return CreateDeviceConfig({
+        .Name = std::move(name),
+        .Id = std::move(uuid),
+        .Rack = std::move(rack),
+        .TotalSize = totalSize,
+        .BlockSize = blockSize
+    });
 }
 
 inline auto CreateAgentConfig(

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -541,6 +541,9 @@ message TRegisterAgentResponse
 {
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
+
+    // List of device IDs to which Disk Agent should disable IO operations.
+    repeated string DevicesToDisableIO = 2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tests/disk_agent_config/test.py
+++ b/cloud/blockstore/tests/disk_agent_config/test.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 import pytest
 import requests
 import time
 
 from cloud.blockstore.public.sdk.python.client import CreateClient, Session
+from cloud.blockstore.public.sdk.python.client.error import ClientError
+from cloud.blockstore.public.sdk.python.client.error_codes import EResult
 from cloud.blockstore.public.sdk.python.protos import TCmsActionRequest, \
     TAction, STORAGE_MEDIA_SSD_NONREPLICATED
 from cloud.blockstore.config.disk_pb2 import DISK_AGENT_BACKEND_NULL
@@ -21,6 +24,7 @@ from contrib.ydb.tests.library.harness.kikimr_runner import \
 
 
 DEVICE_SIZE = 1024 ** 3  # 1 GiB
+DEVICES_PER_PATH = 6
 
 KNOWN_DEVICE_POOLS = {
     "KnownDevicePools": [
@@ -91,7 +95,7 @@ def create_device_files(data_path, agent_ids):
     for agent_id in agent_ids:
         p = _get_agent_data_path(agent_id, data_path)
         with open(os.path.join(p, 'NVMENBS01'), 'wb') as f:
-            os.truncate(f.fileno(), 6 * (DEVICE_SIZE + 4096))
+            os.truncate(f.fileno(), DEVICES_PER_PATH * (DEVICE_SIZE + 4096))
 
 
 def _create_disk_agent_configurator(ydb, agent_id, data_path):
@@ -115,6 +119,16 @@ def _create_disk_agent_configurator(ydb, agent_id, data_path):
                     }
                 }]}
             ]})
+
+    caches = os.path.join(
+        get_unique_path_for_current_test(
+            output_path=yatest_common.output_path(),
+            sub_folder="caches"),
+        agent_id)
+    ensure_path_exists(caches)
+
+    disk_agent_config.CachedConfigPath = os.path.join(caches, 'config.txt')
+    disk_agent_config.DisableBrokenDevices = True
 
     configurator.files["disk-agent"] = disk_agent_config
     configurator.files["location"].Rack = 'c:RACK'
@@ -170,7 +184,7 @@ def test_change_rack(nbs, agent_ids, disk_agent_configurators):
 
     assert len(bkp['Agents']) == len(agent_ids)
     for agent in bkp['Agents']:
-        assert len(agent['Devices']) == 6
+        assert len(agent['Devices']) == DEVICES_PER_PATH
         assert agent.get('State') is None  # online
         for d in agent['Devices']:
             assert d.get('State') is None  # online
@@ -224,7 +238,7 @@ def test_change_rack(nbs, agent_ids, disk_agent_configurators):
 
     for agent_id, agent in zip(agent_ids, bkp['Agents']):
         assert agent_id == agent['AgentId']
-        assert len(agent['Devices']) == 6
+        assert len(agent['Devices']) == DEVICES_PER_PATH
         assert agent.get('State') is None  # online
 
         for d in agent['Devices']:
@@ -309,3 +323,84 @@ def test_disable_node_broker_registration(nbs, agent_ids, disk_agent_configurato
 
     for agent in agents:
         agent.kill()
+
+
+def test_disable_io_for_broken_devices(
+        nbs,
+        data_path,
+        agent_ids,
+        disk_agent_configurators):
+
+    agent_id = agent_ids[0]
+    configurator = disk_agent_configurators[0]
+
+    # setup a serial number for NVMENBS01
+    m = configurator.files["disk-agent"].PathToSerialNumberMapping.add()
+    m.Path = os.path.join(_get_agent_data_path(agent_id, data_path), 'NVMENBS01')
+    m.SerialNumber = 'SN'
+
+    logger = logging.getLogger("client")
+    logger.setLevel(logging.DEBUG)
+
+    client = CreateClient(f"localhost:{nbs.port}", log=logger)
+
+    # run an agent
+    agent = start_disk_agent(configurator, name=agent_id)
+
+    agent.wait_for_registration()
+    r = _add_host(client, agent_id)
+    assert len(r.ActionResults) == 1
+    assert r.ActionResults[0].Result.Code == 0
+
+    # create a volume
+    client.create_volume(
+        disk_id="vol1",
+        block_size=4096,
+        blocks_count=DEVICE_SIZE//4096,
+        storage_media_kind=STORAGE_MEDIA_SSD_NONREPLICATED,
+        cloud_id="test")
+
+    bkp = _backup(client)
+    assert len(bkp['Disks']) == 1
+    assert len(bkp['Disks'][0]['DeviceUUIDs']) == 1
+    assert len(bkp['Agents']) == 1
+    for d in bkp['Agents'][0]['Devices']:
+        assert d.get('SerialNumber') == 'SN'
+
+    session = Session(client, "vol1", "")
+    session.mount_volume()
+
+    # IO should work
+    session.write_blocks(0, [b'\1' * 4096])
+    blocks = session.read_blocks(0, 1, checkpoint_id="")
+    assert len(blocks) == 1
+
+    # stop the agent
+    agent.kill()
+
+    # start an IO operation
+    future = session.read_blocks_async(0, 1, checkpoint_id="")
+
+    assert not future.done()
+    time.sleep(5)
+    assert not future.done()
+
+    # change NVMENBS01's serial number
+    m.SerialNumber = 'XXX'
+
+    # restart the agent
+    agent = start_disk_agent(configurator, name=agent_id+'.new')
+    agent.wait_for_registration()
+
+    # IO should result in E_IO_SILENT now
+    try:
+        _ = future.result()
+        assert False
+    except ClientError as e:
+        assert e.code == EResult.E_IO_SILENT.value
+
+    session.unmount_volume()
+
+    bkp = _backup(client)
+    for d in bkp['Agents'][0]['Devices']:
+        assert d.get('SerialNumber') == 'XXX'

--- a/cloud/blockstore/tests/python/lib/daemon.py
+++ b/cloud/blockstore/tests/python/lib/daemon.py
@@ -96,9 +96,10 @@ class Nbs(Daemon):
 
 class DiskAgent(Daemon):
 
-    def __init__(self, mon_port, server_port, commands, cwd):
+    def __init__(self, mon_port, server_port, commands, cwd, config_path):
         self.__mon_port = mon_port
         self.__port = server_port
+        self.__config_path = config_path
 
         super(DiskAgent, self).__init__(
             commands=commands,
@@ -115,6 +116,10 @@ class DiskAgent(Daemon):
     @property
     def mon_port(self):
         return self.__mon_port
+
+    @property
+    def config_path(self):
+        return self.__config_path
 
     @property
     def counters(self):
@@ -194,6 +199,7 @@ def start_disk_agent(config: NbsConfigurator, name='disk-agent'):
         server_port=config.server_port,
         commands=[commands],
         cwd=cwd,
+        config_path=config_path,
     )
 
     agent.start()

--- a/cloud/storage/core/libs/common/error.h
+++ b/cloud/storage/core/libs/common/error.h
@@ -274,7 +274,7 @@ bool HasError(const T& response)
 inline void CheckError(const NProto::TError& error)
 {
     if (HasError(error)) {
-        ythrow TServiceError(error);
+        ythrow TServiceError(error.GetCode()) << error.GetMessage();
     }
 }
 
@@ -282,7 +282,8 @@ template <typename T>
 void CheckError(const T& response)
 {
     if (HasError(response)) {
-        ythrow TServiceError(response.GetError());
+        ythrow TServiceError(response.GetError().GetCode())
+            << response.GetError().GetMessage();
     }
 }
 


### PR DESCRIPTION
#2074

At startup, Disk Agent collects a list of devices with changed serial numbers and suspends such devices.
After Disk Agent registers in Disk Registry, broken devices are disabled and the rest of the devices resumed.
Disk Registry sends a list of broken devices with `TEvRegisterAgentResponse` (`DevicesToDisableIO` field).
Suspending devices means that read/write/zero requests will receive an `E_REJECTED` error.
Disabling devices means that read/write/zero requests will receive an `E_IO` error.

The list of suspended devices is stored in the `DevicesWithSuspendedIO` field in the configuration cache.