### PR TITLE
test: set split factor to 1 for keyring tests

### DIFF
--- a/cloud/storage/core/libs/endpoints/keyring/ut/ya.make
+++ b/cloud/storage/core/libs/endpoints/keyring/ut/ya.make
@@ -2,6 +2,8 @@ PY3TEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
+SPLIT_FACTOR(1)
+
 DEPENDS(
     cloud/storage/core/libs/endpoints/keyring/ut/bin
 )


### PR DESCRIPTION
Run all keyring unit tests in the one vm to speedup tests execution. Time execution is approximately 40s vs 170s on my developer VM.