### PR TITLE
issue-1751: add WRITEBACK_CACHE flag to fuse contrib

### DIFF
--- a/contrib/libs/fuse/include/fuse_common.h
+++ b/contrib/libs/fuse/include/fuse_common.h
@@ -100,6 +100,7 @@ struct fuse_file_info {
  * FUSE_CAP_SPLICE_MOVE: ability to move data to the fuse device with splice()
  * FUSE_CAP_SPLICE_READ: ability to use splice() to read from the fuse device
  * FUSE_CAP_IOCTL_DIR: ioctl support on directories
+ * FUSE_CAP_WRITEBACK_CACHE: writeback caching should be enabled
  */
 #define FUSE_CAP_ASYNC_READ	(1 << 0)
 #define FUSE_CAP_POSIX_LOCKS	(1 << 1)
@@ -112,6 +113,7 @@ struct fuse_file_info {
 #define FUSE_CAP_SPLICE_READ	(1 << 9)
 #define FUSE_CAP_FLOCK_LOCKS	(1 << 10)
 #define FUSE_CAP_IOCTL_DIR	(1 << 11)
+#define FUSE_CAP_WRITEBACK_CACHE	(1 << 16)
 
 /**
  * Ioctl flags

--- a/contrib/libs/fuse/include/fuse_kernel.h
+++ b/contrib/libs/fuse/include/fuse_kernel.h
@@ -211,6 +211,7 @@ struct fuse_file_lock {
 #define FUSE_BIG_WRITES		(1 << 5)
 #define FUSE_DONT_MASK		(1 << 6)
 #define FUSE_FLOCK_LOCKS	(1 << 10)
+#define FUSE_WRITEBACK_CACHE	(1 << 16)
 
 /**
  * CUSE INIT request/reply flags

--- a/contrib/libs/fuse/lib/fuse_lowlevel.c
+++ b/contrib/libs/fuse/lib/fuse_lowlevel.c
@@ -1856,6 +1856,9 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outarg.flags |= FUSE_DONT_MASK;
 	if (f->conn.want & FUSE_CAP_FLOCK_LOCKS)
 		outarg.flags |= FUSE_FLOCK_LOCKS;
+	if (f->conn.want & FUSE_CAP_WRITEBACK_CACHE)
+		outarg.flags |= FUSE_WRITEBACK_CACHE;
+
 	outarg.max_readahead = f->conn.max_readahead;
 	outarg.max_write = f->conn.max_write;
 	if (f->conn.proto_minor >= 13) {


### PR DESCRIPTION
original flag was added in upstream libfuse [here](https://github.com/libfuse/libfuse/commit/8bb62a632caa4269bb6436cae67307404882b936)