### PR TITLE
NOTICKET: Add check=True option to exec_command 

### DIFF
--- a/cloud/blockstore/pylibs/common/ssh_client.py
+++ b/cloud/blockstore/pylibs/common/ssh_client.py
@@ -163,7 +163,7 @@ class SshClient:
         self,
         command: str | list[str],
     ) -> tuple[None, '_StdoutStub', '_StdoutStub']:
-        result = self._exec_command(command)
+        result = self._exec_command(command, check=True)
         return (
             None,
             self._StdoutStub(self, result.stdout, result.returncode),


### PR DESCRIPTION
Add `check=True` option to `exec_command` so that we throw an exception on exit code 1