### PR TITLE
Temporarily turn off the check in ~TGrpcState()

### DIFF
--- a/cloud/storage/core/libs/grpc/init.cpp
+++ b/cloud/storage/core/libs/grpc/init.cpp
@@ -26,7 +26,8 @@ struct TGrpcState
     ~TGrpcState()
     {
         // ensure that GRPC is shut down
-        Y_ABORT_UNLESS(AtomicGet(Counter) == 0);
+        // NOTE: temporarily turned off
+        // Y_ABORT_UNLESS(AtomicGet(Counter) == 0);
     }
 
     static TGrpcState& Instance()


### PR DESCRIPTION
Will turn it on again once the issue with exit(1) is fixed https://github.com/ydb-platform/nbs/blob/50a2e91348f2dd5264c66432b307928682fc511d/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp#L786

Otherwise the check may fail during initialization