### PR TITLE
NBSDUTY-146: add optional retry timeout parameter

### DIFF
--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
@@ -8,7 +8,7 @@ import cloud.blockstore.tests.csi_driver.lib.csi_runner as csi
 
 
 def test_nbs_csi_driver_mounted_disk_protected_from_deletion():
-    env, run = csi.init()
+    env, run = csi.init(retry_timeout_ms=5000)
     try:
         volume_name = "example-disk"
         volume_size = 10 * 1024 ** 3

--- a/cloud/blockstore/tests/csi_driver/lib/csi_runner.py
+++ b/cloud/blockstore/tests/csi_driver/lib/csi_runner.py
@@ -253,7 +253,7 @@ def cleanup_after_test(
     env.tear_down()
 
 
-def init(vm_mode: bool = False):
+def init(vm_mode: bool = False, retry_timeout_ms: int | None = None):
     server_config_patch = TServerConfig()
     server_config_patch.NbdEnabled = True
     endpoints_dir = Path(common.output_path()) / f"endpoints-{hash(common.context.test_name)}"
@@ -291,6 +291,8 @@ def init(vm_mode: bool = False):
     client_config_path = Path(yatest_common.output_path()) / "client-config.txt"
     client_config = TClientAppConfig()
     client_config.ClientConfig.CopyFrom(TClientConfig())
+    if retry_timeout_ms:
+        client_config.ClientConfig.RetryTimeout = retry_timeout_ms
     client_config.ClientConfig.Host = "localhost"
     client_config.ClientConfig.InsecurePort = env.nbs_port
     client_config_path.write_text(MessageToString(client_config))


### PR DESCRIPTION
Problem:

hardcoded 1ms retry timeout was removed here: https://github.com/ydb-platform/nbs/pull/2428

As a result `test_nbs_csi_driver_mounted_disk_protected_from_deletion` hangs for 5 minutes trying to destroy mounted volume.

Solution:
Add optional `retry_timeout` parameter and set it only for specific tests.

