### PR TITLE
issue-2137: if all ranges in CompactionMap have the 'compacted' flag then GetTop{Compaction,Garbage}Score should return zero (in order not to trigger dud Compaction iterations all the time)

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.cpp
@@ -199,7 +199,7 @@ struct TGroup
             ui32 i = GetTop<TCompareByCompactionScore>(CompactedRanges);
             TopCompactionScore = {
                 GroupIndex + i,
-                GetCompactionScore(Stats[i])};
+                CompactedRanges.Get(i) ? 0 : GetCompactionScore(Stats[i])};
         }
 
         // 'compacted' flag is deliberately ignored for cleanup score
@@ -216,7 +216,9 @@ struct TGroup
             TopGarbageScore = { rangeId, garbageScore};
         } else if (TopGarbageScore.RangeId == rangeId) {
             ui32 i = GetTop<TCompareByGarbageScore>(CompactedRanges);
-            TopGarbageScore = { GroupIndex + i, GetGarbageScore(Stats[i]) };
+            TopGarbageScore = {
+                GroupIndex + i,
+                CompactedRanges.Get(i) ? 0 : GetGarbageScore(Stats[i])};
         }
 
         return diff;

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map_ut.cpp
@@ -304,6 +304,22 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         UNIT_ASSERT_VALUES_EQUAL(10, topRanges[1].Stats.BlobsCount);
         UNIT_ASSERT_VALUES_EQUAL(100, topRanges[1].Stats.DeletionsCount);
         UNIT_ASSERT_VALUES_EQUAL(1000, topRanges[1].Stats.GarbageBlocksCount);
+
+        compactionMap.Update(1, 20, 200, 2000, true);
+        compactionMap.Update(0, 10, 100, 1000, true);
+
+        topRanges = compactionMap.GetTopRangesByCompactionScore(3);
+        UNIT_ASSERT_VALUES_EQUAL(0, topRanges.size());
+
+        counter = compactionMap.GetTopCompactionScore();
+        UNIT_ASSERT_VALUES_EQUAL(0, counter.Score);
+
+        counter = compactionMap.GetTopCleanupScore();
+        UNIT_ASSERT_VALUES_EQUAL(10001, counter.RangeId);
+        UNIT_ASSERT_VALUES_EQUAL(400, counter.Score);
+
+        counter = compactionMap.GetTopGarbageScore();
+        UNIT_ASSERT_VALUES_EQUAL(0, counter.Score);
     }
 
     Y_UNIT_TEST(ShouldReturnNonEmptyRanges)


### PR DESCRIPTION
This check was implemented in the GetTopRangesXXX funcs which are used by monpages and stat requests but was forgotten in the funcs that are used by the tablet itself. Now if all ranges have the 'compacted' flag Compaction starts to re-check one of the ranges all the time - it sees that e.g. BlobsCount for that range is greater than threshold, ignores the 'compacted' flag, scans mixed blocks index for that range, finds out that there's no point in compacting it, then does the same thing all over again. 

#2137 