### PR TITLE
[Filestore merge-to-stable] issue-1146: add monitoring for in-memory state cache sizes and exhaustiveness, get rid of multi-line log lines

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -327,7 +327,7 @@ void TReadDataActor::ReadBlobIfNeeded(const TActorContext& ctx)
             ctx,
             TFileStoreComponents::SERVICE,
             "Processing blob piece: %s, size: %lu",
-            blobPiece.DebugString().c_str(),
+            blobPiece.DebugString().Quote().c_str(),
             blobId.BlobSize());
         NKikimr::TActorId proxy =
             MakeBlobStorageProxyID(blobPiece.GetBSGroupId());
@@ -451,7 +451,7 @@ void TReadDataActor::HandleReadBlobResponse(
             TFileStoreComponents::SERVICE,
             "ReadBlobResponse: blobId: %s, offset: %lu, length: %lu, size: "
             "%lu, target: %s",
-            blobPiece.GetBlobId().DebugString().c_str(),
+            blobPiece.GetBlobId().DebugString().Quote().c_str(),
             blobRange.GetBlobOffset(),
             blobRange.GetLength(),
             response.Buffer.size(),
@@ -460,7 +460,7 @@ void TReadDataActor::HandleReadBlobResponse(
             blobRange.GetLength() == response.Buffer.size(),
             "Blob range length mismatch: all requested ranges: %s, response: "
             "#%lu, size is %lu",
-            DescribeResponse.DebugString().c_str(),
+            DescribeResponse.DebugString().Quote().c_str(),
             i,
             response.Buffer.size());
         TABLET_VERIFY(blobRange.GetOffset() >= AlignedByteRange.Offset);
@@ -669,7 +669,7 @@ void TStorageServiceActor::HandleReadData(
         ctx,
         TFileStoreComponents::SERVICE,
         "read data %s",
-        msg->Record.DebugString().c_str());
+        msg->Record.DebugString().Quote().c_str());
 
     auto [cookie, inflight] = CreateInFlightRequest(
         TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -114,6 +114,11 @@ private:
         // Read-write transactions
         std::atomic<i64> InMemoryIndexStateRWCount{0};
 
+        std::atomic<i64> InMemoryIndexStateNodesCount;
+        std::atomic<i64> InMemoryIndexStateNodeRefsCount;
+        std::atomic<i64> InMemoryIndexStateNodeAttrsCount;
+        std::atomic<i64> InMemoryIndexStateIsExhaustive;
+
         // Data stats
         std::atomic<i64> FreshBytesCount{0};
         std::atomic<i64> DeletedFreshBytesCount{0};
@@ -221,7 +226,8 @@ private:
             const TReadAheadCacheStats& readAheadStats,
             const TNodeIndexCacheStats& nodeIndexCacheStats,
             const TNodeToSessionCounters& nodeToSessionCounters,
-            const TMiscNodeStats& miscNodeStats);
+            const TMiscNodeStats& miscNodeStats,
+            const TInMemoryIndexStateStats& inMemoryIndexStateStats);
     } Metrics;
 
     const IProfileLogPtr ProfileLog;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -288,6 +288,18 @@ void TIndexTabletActor::TMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(
         InMemoryIndexStateRWCount,
         EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateNodesCount,
+        EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateNodeRefsCount,
+        EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateNodeAttrsCount,
+        EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateIsExhaustive,
+        EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(FreshBytesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(DeletedFreshBytesCount, EMetricType::MT_ABSOLUTE);
@@ -405,7 +417,8 @@ void TIndexTabletActor::TMetrics::Update(
     const TReadAheadCacheStats& readAheadStats,
     const TNodeIndexCacheStats& nodeIndexCacheStats,
     const TNodeToSessionCounters& nodeToSessionCounters,
-    const TMiscNodeStats& miscNodeStats)
+    const TMiscNodeStats& miscNodeStats,
+    const TInMemoryIndexStateStats& inMemoryIndexStateStats)
 {
     const ui32 blockSize = fileSystem.GetBlockSize();
 
@@ -473,6 +486,11 @@ void TIndexTabletActor::TMetrics::Update(
     Store(ReadAheadCacheNodeCount, readAheadStats.NodeCount);
     Store(NodeIndexCacheNodeCount, nodeIndexCacheStats.NodeCount);
 
+    Store(InMemoryIndexStateNodesCount, inMemoryIndexStateStats.NodesCount);
+    Store(InMemoryIndexStateNodeRefsCount, inMemoryIndexStateStats.NodeRefsCount);
+    Store(InMemoryIndexStateNodeAttrsCount, inMemoryIndexStateStats.NodeAttrsCount);
+    Store(InMemoryIndexStateIsExhaustive, inMemoryIndexStateStats.IsNodeRefsExhaustive);
+
     Store(
         NodesOpenForWritingBySingleSession,
         nodeToSessionCounters.NodesOpenForWritingBySingleSession);
@@ -537,7 +555,8 @@ void TIndexTabletActor::RegisterStatCounters()
         CalculateReadAheadCacheStats(),
         CalculateNodeIndexCacheStats(),
         GetNodeToSessionCounters(),
-        GetMiscNodeStats());
+        GetMiscNodeStats(),
+        GetInMemoryIndexStateStats());
 
     Metrics.Register(fsId, storageMediaKind);
 }
@@ -584,7 +603,8 @@ void TIndexTabletActor::HandleUpdateCounters(
         CalculateReadAheadCacheStats(),
         CalculateNodeIndexCacheStats(),
         GetNodeToSessionCounters(),
-        GetMiscNodeStats());
+        GetMiscNodeStats(),
+        GetInMemoryIndexStateStats());
     SendMetricsToExecutor(ctx);
 
     UpdateCountersScheduled = false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1076,7 +1076,7 @@ void TIndexTabletActor::HandleHttpInfo_Default(
             }
         } else {
             DIV_CLASS("alert") {
-                out << "Write allowed: " << message;
+                out << "Write allowed";
             }
         }
         if (BackpressurePeriodStart || BackpressureErrorCount) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1331,6 +1331,7 @@ public:
     void UpdateInMemoryIndexState(
         TVector<TInMemoryIndexState::TIndexStateRequest> nodeUpdates);
     void MarkNodeRefsLoadComplete();
+    TInMemoryIndexStateStats GetInMemoryIndexStateStats() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -41,6 +41,16 @@ void TInMemoryIndexState::MarkNodeRefsLoadComplete()
     IsNodeRefsExhaustive = !IsNodeRefsEvictionObserved;
 }
 
+TInMemoryIndexStateStats TInMemoryIndexState::GetStats() const
+{
+    return TInMemoryIndexStateStats{
+        .NodesCount = Nodes.size(),
+        .NodeRefsCount = NodeRefs.size(),
+        .NodeAttrsCount = NodeAttrs.size(),
+        .IsNodeRefsExhaustive = IsNodeRefsExhaustive,
+    };
+}
+
 //
 // Nodes
 //

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -10,6 +10,16 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TInMemoryIndexStateStats
+{
+    ui64 NodesCount;
+    ui64 NodeRefsCount;
+    ui64 NodeAttrsCount;
+    bool IsNodeRefsExhaustive;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 /**
  * @brief Stores the state of the index tables in memory. Can be used to perform
  * read-only operations.
@@ -27,6 +37,8 @@ public:
     void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs);
 
     void MarkNodeRefsLoadComplete();
+
+    [[nodiscard]] TInMemoryIndexStateStats GetStats() const;
 
     //
     // Nodes

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -619,4 +619,9 @@ void TIndexTabletState::MarkNodeRefsLoadComplete()
     Impl->InMemoryIndexState.MarkNodeRefsLoadComplete();
 }
 
+TInMemoryIndexStateStats TIndexTabletState::GetInMemoryIndexStateStats() const
+{
+    return Impl->InMemoryIndexState.GetStats();
+}
+
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
f0e639feb85aa40ebe4d4f8f8f822872a9c901c3
9a583b72e8df557f98a8f609df0f094df9c58351