### PR TITLE
[Disk Manager] Add parent span for regular tasks, add parent span rotation for long-running regular tasks

### DIFF
--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -56,4 +56,7 @@ message TasksConfig {
     // Needed for tracing.
     // Spans of tasks with greater generation id will not be sampled.
     optional uint64 MaxSampledTaskGeneration = 32 [default = 100];
+    // Needed for tracing.
+    // After this timeout regular task's snaps will be created in another trace.
+    optional string RegularTaskTraceExpirationTimeout = 33 [default = "72h"];
 }

--- a/cloud/tasks/headers/headers.go
+++ b/cloud/tasks/headers/headers.go
@@ -8,6 +8,13 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const (
+	TraceparentHeaderKey = "traceparent"
+	TracestateHeaderKey  = "tracestate"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
 func appendToIncomingContext(
 	ctx context.Context,
 	metadata grpc_metadata.MD,
@@ -130,8 +137,8 @@ func GetTracingHeaders(ctx context.Context) map[string]string {
 		"x-operation-id",
 		"x-request-id",
 		"x-request-uid",
-		"traceparent",
-		"tracestate",
+		TraceparentHeaderKey,
+		TracestateHeaderKey,
 	}
 	return GetFromIncomingContext(ctx, allowedKeys)
 }

--- a/cloud/tasks/storage/compound_storage.go
+++ b/cloud/tasks/storage/compound_storage.go
@@ -460,6 +460,13 @@ func NewStorage(
 		return nil, err
 	}
 
+	regularTaskTraceExpirationTimeout, err := time.ParseDuration(
+		config.GetRegularTaskTraceExpirationTimeout(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	newStorage := func(storageFolder string, metrics storageMetrics) *storageYDB {
 		return &storageYDB{
 			db:                  db,
@@ -474,6 +481,7 @@ func NewStorage(
 			exceptHangingTaskTypes:            config.GetExceptHangingTaskTypes(),
 			hangingTaskTimeout:                hangingTaskTimeout,
 			missedEstimatesUntilTaskIsHanging: config.GetMissedEstimatesUntilTaskIsHanging(),
+			regularTaskTraceExpirationTimeout: regularTaskTraceExpirationTimeout,
 		}
 	}
 

--- a/cloud/tasks/storage/storage_ydb.go
+++ b/cloud/tasks/storage/storage_ydb.go
@@ -22,6 +22,7 @@ type storageYDB struct {
 	exceptHangingTaskTypes            []string
 	hangingTaskTimeout                time.Duration
 	missedEstimatesUntilTaskIsHanging uint64
+	regularTaskTraceExpirationTimeout time.Duration
 }
 
 func (s *storageYDB) CreateTask(

--- a/cloud/tasks/tracing/tracing_context.go
+++ b/cloud/tasks/tracing/tracing_context.go
@@ -10,21 +10,14 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const (
-	traceparentHeaderKey = "traceparent"
-	tracestateHeaderKey  = "tracestate"
-)
-
-////////////////////////////////////////////////////////////////////////////////
-
 // Gets traceparent and tracestate headers from incoming grpc metadata.
 func GetTracingContext(ctx context.Context) context.Context {
 	tracingContext := headers.GetFromIncomingContext(ctx, []string{
-		traceparentHeaderKey,
-		tracestateHeaderKey,
+		headers.TraceparentHeaderKey,
+		headers.TracestateHeaderKey,
 	})
 
-	traceparent, ok := tracingContext[traceparentHeaderKey]
+	traceparent, ok := tracingContext[headers.TraceparentHeaderKey]
 	if !ok || len(traceparent) == 0 {
 		return ctx
 	}
@@ -43,15 +36,15 @@ func SetTracingContext(ctx context.Context) context.Context {
 
 	tracingContextHeaders := make(map[string]string)
 
-	traceparent, ok := mapCarrier[traceparentHeaderKey]
+	traceparent, ok := mapCarrier[headers.TraceparentHeaderKey]
 	if !ok {
 		return ctx
 	}
-	tracingContextHeaders[traceparentHeaderKey] = traceparent
+	tracingContextHeaders[headers.TraceparentHeaderKey] = traceparent
 
-	tracestate, ok := mapCarrier[tracestateHeaderKey]
+	tracestate, ok := mapCarrier[headers.TracestateHeaderKey]
 	if ok {
-		tracingContextHeaders[tracestateHeaderKey] = tracestate
+		tracingContextHeaders[headers.TracestateHeaderKey] = tracestate
 	}
 	return headers.Replace(ctx, tracingContextHeaders)
 }


### PR DESCRIPTION
#1199

Now spans for regular are inconvenient. Tasks have no common parent. For example, if a regular tasks had several generations, each generation will create spans in separate trace.

In this pr we create common parent span for spans created by a regular task. Also, we rotate the parent span if the task runs for long. This prevents from obtaining too large trace and from losing all spans due to trace expiration.

For example, assume that some task ran for 7 days, trace ttl is 5 days and parent rotation period is 3 days. And assume that we want to look at the traced of this task just after it's completion. Then the task will have three traces, the oldest one will be already expired, but we will be able to see the remaining two traces. Without rotation, we wouldn't be able to see anything.

Note: parent span rotation will not happen if a task is runned for long with one and the same generation. 