### PR TITLE
[Fielstore] issue-2461: simplify the local file store index by making it per session.

### DIFF
--- a/cloud/filestore/libs/service_local/fs.cpp
+++ b/cloud/filestore/libs/service_local/fs.cpp
@@ -29,12 +29,6 @@ TLocalFileSystem::TLocalFileSystem(
         ", DirectIoEnabled=" << Config->GetDirectIoEnabled() <<
         ", DirectIoAlign=" << Config->GetDirectIoAlign());
 
-    Index = std::make_shared<TLocalIndex>(
-        Root,
-        StatePath,
-        Config->GetMaxNodeCount(),
-        Log);
-
     ScheduleCleanupSessions();
 }
 

--- a/cloud/filestore/libs/service_local/fs.h
+++ b/cloud/filestore/libs/service_local/fs.h
@@ -98,8 +98,6 @@ private:
     NProto::TFileStore Store;
     TLog Log;
 
-    TLocalIndexPtr Index;
-
     TSessionList SessionsList;
     THashMap<TString, TSessionList::iterator> SessionsById;
     THashMap<TString, TSessionList::iterator> SessionsByClient;

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -54,12 +54,11 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         Root,
         clientSessionStatePath,
         clientId,
-        Index,
+        Config->GetMaxNodeCount(),
+        Config->GetMaxHandlePerSessionCount(),
         Logging);
 
-    session->Init(
-        request.GetRestoreClientSession(),
-        Config->GetMaxHandlePerSessionCount());
+    session->Init(request.GetRestoreClientSession());
     session->AddSubSession(sessionSeqNo, readOnly);
 
     SessionsList.push_front(session);

--- a/cloud/filestore/libs/service_local/index.cpp
+++ b/cloud/filestore/libs/service_local/index.cpp
@@ -2,8 +2,6 @@
 
 #include "lowlevel.h"
 
-#include <cloud/filestore/libs/service/filestore.h>
-
 namespace NCloud::NFileStore {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/service_local/index.h
+++ b/cloud/filestore/libs/service_local/index.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <cloud/filestore/libs/service/filestore.h>
+
 #include <cloud/storage/core/libs/common/persistent_table.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -33,7 +35,7 @@ public:
         , NodeFd(std::move(node))
     {}
 
-    ui64 GetRecordIndex() const
+    [[nodiscard]] ui64 GetRecordIndex() const
     {
         return RecordIndex;
     }
@@ -46,7 +48,7 @@ public:
     static TIndexNodePtr CreateRoot(const TFsPath& path);
     static TIndexNodePtr Create(const TIndexNode& parent, const TString& name);
 
-    ui64 GetNodeId() const
+    [[nodiscard]] ui64 GetNodeId() const
     {
         return NodeId;
     }
@@ -66,7 +68,7 @@ public:
         unsigned int flags);
     void Unlink(const TString& name, bool directory);
 
-    TString ReadLink() const;
+    [[nodiscard]] TString ReadLink() const;
 
     TFileStat Stat();
     TFileStat Stat(const TString& name);
@@ -128,10 +130,12 @@ private:
         char Name[NAME_MAX + 1] = {};
     };
 
-private:
     using TNodeMap = THashSet<TIndexNodePtr, THash, TEqual>;
     using TNodeTable = TPersistentTable<TNodeTableHeader, TNodeTableRecord>;
 
+    const TFsPath Root;
+    const TFsPath StatePath;
+    ui32 MaxNodeCount;
     TNodeMap Nodes;
     std::unique_ptr<TNodeTable> NodeTable;
     TRWMutex NodesLock;
@@ -139,13 +143,16 @@ private:
 
 public:
     TLocalIndex(
-            const TFsPath& root,
-            const TFsPath& statePath,
+            TFsPath root,
+            TFsPath statePath,
             ui32 maxNodeCount,
             TLog log)
-        : Log(std::move(log))
+        : Root(std::move(root))
+        , StatePath(std::move(statePath))
+        , MaxNodeCount(maxNodeCount)
+        , Log(std::move(log))
     {
-        Init(root, statePath, maxNodeCount);
+        Init();
     }
 
     TIndexNodePtr LookupNode(ui64 nodeId)
@@ -209,18 +216,18 @@ public:
     }
 
 private:
-    void Init(const TFsPath& root, const TFsPath& statePath, ui32 maxNodeCount)
+    void Init()
     {
         STORAGE_INFO(
-            "Init index, Root=" << root <<
-            ", StatePath=" << statePath
-            << ", MaxNodeCount=" << maxNodeCount);
+            "Init index, Root=" << Root <<
+            ", StatePath=" << StatePath
+            << ", MaxNodeCount=" << MaxNodeCount);
 
-        Nodes.insert(TIndexNode::CreateRoot(root));
+        Nodes.insert(TIndexNode::CreateRoot(Root));
 
         NodeTable = std::make_unique<TNodeTable>(
-            (statePath / "nodes").GetPath(),
-            maxNodeCount);
+            (StatePath / "nodes").GetPath(),
+            MaxNodeCount);
 
         RecoverNodesFromPersistentTable();
     }
@@ -297,7 +304,7 @@ private:
                     TIndexNode::Create(**parentNodeIt, pathElemRecord->Name);
                 node->SetRecordIndex(pathElemIndex);
 
-                Nodes.insert(std::move(node));
+                Nodes.insert(node);
 
                 unresolvedPath.pop();
                 unresolvedRecords.erase(pathElemRecord->NodeId);

--- a/cloud/filestore/libs/service_local/public.h
+++ b/cloud/filestore/libs/service_local/public.h
@@ -15,9 +15,6 @@ using TLocalFileStoreConfigPtr = std::shared_ptr<TLocalFileStoreConfig>;
 class TLocalFileSystem;
 using TLocalFileSystemPtr = std::shared_ptr<TLocalFileSystem>;
 
-class TLocalIndex;
-using TLocalIndexPtr = std::shared_ptr<TLocalIndex>;
-
 class TSession;
 using TSessionPtr = std::shared_ptr<TSession>;
 

--- a/cloud/filestore/libs/service_local/session.h
+++ b/cloud/filestore/libs/service_local/session.h
@@ -89,12 +89,12 @@ public:
 
     void Init(bool restoreClientSession)
     {
-        bool isSessionRestored = false;
         auto handlesPath = StatePath / "handles";
 
-        if (!restoreClientSession || !HasStateFile("session") ||
-            !HasStateFile("fuse_state"))
-        {
+        bool isNewSession = !restoreClientSession || !HasStateFile("session") ||
+                            !HasStateFile("fuse_state");
+
+        if (isNewSession) {
             DeleteStateFile("session");
             DeleteStateFile("fuse_state");
             handlesPath.DeleteIfExists();
@@ -104,13 +104,12 @@ public:
             WriteStateFile("session", SessionId);
             WriteStateFile("fuse_state", "");
         } else {
-            isSessionRestored = true;
             SessionId = ReadStateFile("session");
             FuseState = ReadStateFile("fuse_state");
         }
 
         STORAGE_INFO(
-            (isSessionRestored ? "Restore" : "Create") << " session" <<
+            (isNewSession ? "Create" : "Restore") << " session" <<
             ", StatePath=" << StatePath <<
             ", SessionId=" << SessionId <<
             ", MaxNodeCount=" << MaxNodeCount <<


### PR DESCRIPTION
#2461 

Previously, the node index was shared between all sessions belonging to the same
local filesystem. A shared index can reduce memory consumption and require fewer
open file descriptors. However, synchronizing the shared index makes the code
more complex and error-prone.

We already implemented per-session node state, which needs to be restored during
reconnect. This change aligns better with the per-session state design.
