### PR TITLE
[Disk Manager] register collectListerMetricsTask in control plane only

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/filesystem/tests/filesystem_test.go
+++ b/cloud/disk_manager/internal/pkg/services/filesystem/tests/filesystem_test.go
@@ -181,7 +181,6 @@ func createServices(
 		taskRegistry,
 		taskStorage,
 		tasksConfig,
-		metrics.NewEmptyRegistry(),
 	)
 	require.NoError(t, err)
 

--- a/cloud/disk_manager/pkg/app/controlplane.go
+++ b/cloud/disk_manager/pkg/app/controlplane.go
@@ -355,6 +355,7 @@ func initControlplane(
 	taskRegistry *tasks.Registry,
 	taskScheduler tasks.Scheduler,
 	nbsFactory nbs.Factory,
+	taskMetricsRegistry metrics.Registry,
 ) (serve func() error, err error) {
 
 	logging.Info(ctx, "Initializing pool storage")
@@ -426,6 +427,18 @@ func initControlplane(
 		poolService,
 		filesystemService,
 		resourceStorage,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tasks.RegisterCollectListerMetricsTaskForExecution(
+		ctx,
+		taskRegistry,
+		taskStorage,
+		config.GetTasksConfig(),
+		taskMetricsRegistry,
+		taskScheduler,
 	)
 	if err != nil {
 		return nil, err

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -244,6 +244,7 @@ func run(
 			taskRegistry,
 			taskScheduler,
 			nbsFactory,
+			taskMetricsRegistry,
 		)
 		if err != nil {
 			logging.Error(ctx, "Failed to initialize GRPC services: %v", err)

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -154,7 +154,6 @@ func run(
 		taskRegistry,
 		taskStorage,
 		config.TasksConfig,
-		taskMetricsRegistry,
 	)
 	if err != nil {
 		logging.Error(ctx, "Failed to create task scheduler: %v", err)

--- a/cloud/tasks/acceptance_tests/recipe/node/main.go
+++ b/cloud/tasks/acceptance_tests/recipe/node/main.go
@@ -77,7 +77,6 @@ func run(config *node_config.Config) error {
 		registry,
 		storage,
 		config.GetTasksConfig(),
-		empty.NewRegistry(),
 	)
 	if err != nil {
 		return err

--- a/cloud/tasks/acceptance_tests/tasks_acceptance_test.go
+++ b/cloud/tasks/acceptance_tests/tasks_acceptance_test.go
@@ -86,7 +86,6 @@ func newClient(ctx context.Context) (*client, error) {
 		registry,
 		storage,
 		config.TasksConfig,
-		metrics_empty.NewRegistry(),
 	)
 	if err != nil {
 		return nil, err

--- a/cloud/tasks/register.go
+++ b/cloud/tasks/register.go
@@ -16,7 +16,6 @@ func RegisterForExecution(
 	registry *Registry,
 	storage tasks_storage.Storage,
 	config *tasks_config.TasksConfig,
-	metricsRegistry metrics.Registry,
 	taskScheduler Scheduler,
 ) error {
 
@@ -69,7 +68,7 @@ func RegisterCollectListerMetricsTaskForExecution(
 	registry *Registry,
 	storage tasks_storage.Storage,
 	config *tasks_config.TasksConfig,
-	metricsRegistry metrics.Registry,
+	tasksMetricsRegistry metrics.Registry,
 	taskScheduler Scheduler,
 ) error {
 
@@ -83,10 +82,12 @@ func RegisterCollectListerMetricsTaskForExecution(
 	err = registry.RegisterForExecution(
 		"tasks.CollectListerMetrics", func() Task {
 			return &collectListerMetricsTask{
-				registry:                  metricsRegistry,
+				registry:                  tasksMetricsRegistry,
 				storage:                   storage,
 				metricsCollectionInterval: listerMetricsCollectionInterval,
 
+				// This task is registered in control plane and collects metrics
+				// for all types of tasks.
 				taskTypes:                 registry.TaskTypes(),
 				hangingTaskGaugesByID:     make(map[string]metrics.Gauge),
 				maxHangingTaskIDsToReport: config.GetMaxHangingTaskIDsToReport(),

--- a/cloud/tasks/register.go
+++ b/cloud/tasks/register.go
@@ -1,0 +1,117 @@
+package tasks
+
+import (
+	"context"
+	"time"
+
+	tasks_config "github.com/ydb-platform/nbs/cloud/tasks/config"
+	"github.com/ydb-platform/nbs/cloud/tasks/metrics"
+	tasks_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func RegisterForExecution(
+	ctx context.Context,
+	registry *Registry,
+	storage tasks_storage.Storage,
+	config *tasks_config.TasksConfig,
+	metricsRegistry metrics.Registry,
+	taskScheduler Scheduler,
+) error {
+
+	err := registry.RegisterForExecution("tasks.Blank", func() Task {
+		return &blankTask{}
+	})
+	if err != nil {
+		return err
+	}
+
+	endedTaskExpirationTimeout, err := time.ParseDuration(
+		config.GetEndedTaskExpirationTimeout(),
+	)
+	if err != nil {
+		return err
+	}
+
+	clearEndedTasksTaskScheduleInterval, err := time.ParseDuration(
+		config.GetClearEndedTasksTaskScheduleInterval(),
+	)
+	if err != nil {
+		return err
+	}
+
+	err = registry.RegisterForExecution("tasks.ClearEndedTasks", func() Task {
+		return &clearEndedTasksTask{
+			storage:           storage,
+			expirationTimeout: endedTaskExpirationTimeout,
+			limit:             int(config.GetClearEndedTasksLimit()),
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	taskScheduler.ScheduleRegularTasks(
+		ctx,
+		"tasks.ClearEndedTasks",
+		TaskSchedule{
+			ScheduleInterval: clearEndedTasksTaskScheduleInterval,
+			MaxTasksInflight: 1,
+		},
+	)
+
+	return nil
+}
+
+func RegisterCollectListerMetricsTaskForExecution(
+	ctx context.Context,
+	registry *Registry,
+	storage tasks_storage.Storage,
+	config *tasks_config.TasksConfig,
+	metricsRegistry metrics.Registry,
+	taskScheduler Scheduler,
+) error {
+
+	listerMetricsCollectionInterval, err := time.ParseDuration(
+		config.GetListerMetricsCollectionInterval(),
+	)
+	if err != nil {
+		return err
+	}
+
+	err = registry.RegisterForExecution(
+		"tasks.CollectListerMetrics", func() Task {
+			return &collectListerMetricsTask{
+				registry:                  metricsRegistry,
+				storage:                   storage,
+				metricsCollectionInterval: listerMetricsCollectionInterval,
+
+				taskTypes:                 registry.TaskTypes(),
+				hangingTaskGaugesByID:     make(map[string]metrics.Gauge),
+				maxHangingTaskIDsToReport: config.GetMaxHangingTaskIDsToReport(),
+			}
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	collectListerMetricsTaskScheduleInterval, err := time.ParseDuration(
+		config.GetCollectListerMetricsTaskScheduleInterval(),
+	)
+	if err != nil {
+		return err
+	}
+
+	taskScheduler.ScheduleRegularTasks(
+		ctx,
+		"tasks.CollectListerMetrics",
+		TaskSchedule{
+			ScheduleInterval: collectListerMetricsTaskScheduleInterval,
+			MaxTasksInflight: 1,
+		},
+	)
+
+	return nil
+}

--- a/cloud/tasks/registry.go
+++ b/cloud/tasks/registry.go
@@ -18,18 +18,26 @@ type Registry struct {
 	taskFactoriesMutex sync.RWMutex
 }
 
-func (r *Registry) TaskTypesForExecution() []string {
+func (r *Registry) getTaskTypes(forExecutionOnly bool) []string {
 	r.taskFactoriesMutex.RLock()
 	defer r.taskFactoriesMutex.RUnlock()
 
 	var taskTypes []string
 	for taskType, taskFactory := range r.taskFactories {
-		if taskFactory.canBeExecuted {
+		if !forExecutionOnly || taskFactory.canBeExecuted {
 			taskTypes = append(taskTypes, taskType)
 		}
 	}
 
 	return taskTypes
+}
+
+func (r *Registry) TaskTypes() []string {
+	return r.getTaskTypes(false /* forExecutionOnly */)
+}
+
+func (r *Registry) TaskTypesForExecution() []string {
+	return r.getTaskTypes(true /* forExecutionOnly */)
 }
 
 func (r *Registry) Register(

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -558,18 +558,6 @@ func NewScheduler(
 		return nil, err
 	}
 
-	endedTaskExpirationTimeout, err := time.ParseDuration(config.GetEndedTaskExpirationTimeout())
-	if err != nil {
-		return nil, err
-	}
-
-	clearEndedTasksTaskScheduleInterval, err := time.ParseDuration(
-		config.GetClearEndedTasksTaskScheduleInterval(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	s := &scheduler{
 		registry:                      registry,
 		storage:                       storage,
@@ -579,72 +567,17 @@ func NewScheduler(
 		scheduleRegularTasksPeriodMax: scheduleRegularTasksPeriodMax,
 	}
 
-	err = registry.RegisterForExecution("tasks.Blank", func() Task {
-		return &blankTask{}
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = registry.RegisterForExecution("tasks.ClearEndedTasks", func() Task {
-		return &clearEndedTasksTask{
-			storage:           storage,
-			expirationTimeout: endedTaskExpirationTimeout,
-			limit:             int(config.GetClearEndedTasksLimit()),
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	s.ScheduleRegularTasks(
+	err = RegisterForExecution(
 		ctx,
-		"tasks.ClearEndedTasks",
-		TaskSchedule{
-			ScheduleInterval: clearEndedTasksTaskScheduleInterval,
-			MaxTasksInflight: 1,
-		},
-	)
-
-	listerMetricsCollectionInterval, err := time.ParseDuration(
-		config.GetListerMetricsCollectionInterval(),
+		registry,
+		storage,
+		config,
+		metricsRegistry,
+		s,
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	err = registry.RegisterForExecution(
-		"tasks.CollectListerMetrics", func() Task {
-			return &collectListerMetricsTask{
-				registry:                  metricsRegistry,
-				storage:                   storage,
-				metricsCollectionInterval: listerMetricsCollectionInterval,
-
-				taskTypes:                 registry.TaskTypesForExecution(),
-				hangingTaskGaugesByID:     make(map[string]metrics.Gauge),
-				maxHangingTaskIDsToReport: config.GetMaxHangingTaskIDsToReport(),
-			}
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	collectListerMetricsTaskScheduleInterval, err := time.ParseDuration(
-		config.GetCollectListerMetricsTaskScheduleInterval(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	s.ScheduleRegularTasks(
-		ctx,
-		"tasks.CollectListerMetrics",
-		TaskSchedule{
-			ScheduleInterval: collectListerMetricsTaskScheduleInterval,
-			MaxTasksInflight: 1,
-		},
-	)
 
 	return s, nil
 }

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/headers"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
-	"github.com/ydb-platform/nbs/cloud/tasks/metrics"
 	"github.com/ydb-platform/nbs/cloud/tasks/operation"
 	tasks_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
 	"github.com/ydb-platform/nbs/cloud/tasks/tracing"
@@ -534,7 +533,6 @@ func NewScheduler(
 	registry *Registry,
 	storage tasks_storage.Storage,
 	config *tasks_config.TasksConfig,
-	metricsRegistry metrics.Registry,
 ) (Scheduler, error) {
 
 	pollForTaskUpdatesPeriod, err := time.ParseDuration(
@@ -572,7 +570,6 @@ func NewScheduler(
 		registry,
 		storage,
 		config,
-		metricsRegistry,
 		s,
 	)
 	if err != nil {

--- a/cloud/tasks/scheduler_test.go
+++ b/cloud/tasks/scheduler_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	tasks_config "github.com/ydb-platform/nbs/cloud/tasks/config"
-	metrics_empty "github.com/ydb-platform/nbs/cloud/tasks/metrics/empty"
 	"github.com/ydb-platform/nbs/cloud/tasks/operation"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
 	tasks_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
@@ -128,7 +127,6 @@ func TestSchedulerScheduleTask(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -178,7 +176,6 @@ func TestSchedulerScheduleZonalTask(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -229,7 +226,6 @@ func TestSchedulerScheduleTaskFailOnCreateTask(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -261,7 +257,6 @@ func TestSchedulerCancelTask(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -284,7 +279,6 @@ func TestSchedulerGetTaskMetadata(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -318,7 +312,6 @@ func TestSchedulerGetOperationReadyToRun(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -374,7 +367,6 @@ func TestSchedulerGetOperationRunning(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -430,7 +422,6 @@ func TestSchedulerGetOperationFinished(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -491,7 +482,6 @@ func TestSchedulerGetOperationReadyToCancel(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -553,7 +543,6 @@ func TestSchedulerGetOperationCancelling(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -615,7 +604,6 @@ func TestSchedulerGetOperationCancelled(t *testing.T) {
 		registry,
 		storage,
 		defaultConfig(),
-		metrics_empty.NewRegistry(),
 	)
 	require.NoError(t, err)
 

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -149,7 +149,7 @@ func createServicesWithConfig(
 	ctx context.Context,
 	db *persistence.YDBClient,
 	config *tasks_config.TasksConfig,
-	schedulerRegistry metrics.Registry,
+	listerRegistry metrics.Registry,
 ) services {
 
 	registry := tasks.NewRegistry()
@@ -167,7 +167,16 @@ func createServicesWithConfig(
 		registry,
 		storage,
 		config,
-		schedulerRegistry,
+	)
+	require.NoError(t, err)
+
+	err = tasks.RegisterCollectListerMetricsTaskForExecution(
+		ctx,
+		registry,
+		storage,
+		config,
+		listerRegistry,
+		scheduler,
 	)
 	require.NoError(t, err)
 
@@ -206,6 +215,21 @@ func (s *services) startRunners(ctx context.Context) error {
 		metrics_empty.NewRegistry(),
 		s.config,
 		"localhost",
+	)
+}
+
+func (s *services) registerCollectListerMetricsTaskForExecution(
+	ctx context.Context,
+	tasksMetricsRegistry metrics.Registry,
+) error {
+
+	return tasks.RegisterCollectListerMetricsTaskForExecution(
+		ctx,
+		s.registry,
+		s.storage,
+		s.config,
+		tasksMetricsRegistry,
+		s.scheduler,
 	)
 }
 

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -218,21 +218,6 @@ func (s *services) startRunners(ctx context.Context) error {
 	)
 }
 
-func (s *services) registerCollectListerMetricsTaskForExecution(
-	ctx context.Context,
-	tasksMetricsRegistry metrics.Registry,
-) error {
-
-	return tasks.RegisterCollectListerMetricsTaskForExecution(
-		ctx,
-		s.registry,
-		s.storage,
-		s.config,
-		tasksMetricsRegistry,
-		s.scheduler,
-	)
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 type doublerTask struct {

--- a/cloud/tasks/ya.make
+++ b/cloud/tasks/ya.make
@@ -7,6 +7,7 @@ SRCS(
     controller.go
     execution_context.go
     lister.go
+    register.go
     registry.go
     runner.go
     runner_metrics.go


### PR DESCRIPTION
There is a bug in collectListerMetricsTask. Now it can be runned both by controlplane and dataplane. Here https://github.com/ydb-platform/nbs/blob/main/cloud/tasks/collect_lister_metrics_task.go#L143 we miss controlplane tasks if the collectListerMetricsTask is currently executed in dataplane, and vice versa. At the same time, here https://github.com/ydb-platform/nbs/blob/main/cloud/tasks/collect_lister_metrics_task.go#L152 we consider all types of tasks. Therefore, if a counter for controlplane task becomes nonzero at dataplane machine, it will never go back to zero.

Solution:
1) Run collectListerMetricsTask in controlplane only.
2) Let collectListerMetricsTask know about all types of tasks (not only registered for execution ones).

UPD: opened https://github.com/ydb-platform/nbs/pull/2496 instead of this pr

