### PR TITLE
issue-2434: DescribeSessions method should return OrphanSessions as well as active sessions to prevent filesystem destruction right after tablet reboot

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -367,7 +367,9 @@ void TIndexTabletActor::HandleSyncShardSessions(
 {
     THashSet<TString> filter;
     for (auto& s: *ev->Get()->Sessions.MutableSessions()) {
-        filter.insert(*s.MutableSessionId());
+        if (!s.GetIsOrphan()) {
+            filter.insert(*s.MutableSessionId());
+        }
     }
     TEvIndexTabletPrivate::TShardSessionsInfo info;
     info.ShardId = std::move(ev->Get()->ShardId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -49,15 +49,17 @@ void TIndexTabletActor::HandleDestroySession(
 
     auto* session = FindSession(sessionId);
     if (!session) {
-        auto response = std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>();
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>();
 
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }
 
     if (session->GetClientId() != clientId) {
-        auto response = std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>(
-            ErrorInvalidSession(clientId, sessionId, sessionSeqNo));
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>(
+                ErrorInvalidSession(clientId, sessionId, sessionSeqNo));
 
         NCloud::Reply(ctx, *ev, std::move(response));
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -392,18 +392,26 @@ TVector<TSession*> TIndexTabletState::GetSessionsToNotify(
     return result;
 }
 
-TVector<NProtoPrivate::TTabletSessionInfo> TIndexTabletState::DescribeSessions() const
+auto TIndexTabletState::DescribeSessions() const
+    -> TVector<NProtoPrivate::TTabletSessionInfo>
 {
     TVector<NProtoPrivate::TTabletSessionInfo> sessionInfos;
-    for (const auto& session: Impl->Sessions) {
-        NProtoPrivate::TTabletSessionInfo sessionInfo;
-        sessionInfo.SetSessionId(session.GetSessionId());
-        sessionInfo.SetClientId(session.GetClientId());
-        sessionInfo.SetSessionState(session.GetSessionState());
-        sessionInfo.SetMaxSeqNo(session.GetMaxSeqNo());
-        sessionInfo.SetMaxRwSeqNo(session.GetMaxRwSeqNo());
-        sessionInfos.push_back(std::move(sessionInfo));
-    }
+    auto addSessionInfos = [&] (const TSessionList& sessions, bool isOrphan) {
+        for (const auto& session: sessions) {
+            NProtoPrivate::TTabletSessionInfo sessionInfo;
+            sessionInfo.SetSessionId(session.GetSessionId());
+            sessionInfo.SetClientId(session.GetClientId());
+            sessionInfo.SetSessionState(session.GetSessionState());
+            sessionInfo.SetMaxSeqNo(session.GetMaxSeqNo());
+            sessionInfo.SetMaxRwSeqNo(session.GetMaxRwSeqNo());
+            sessionInfo.SetIsOrphan(isOrphan);
+            sessionInfos.push_back(std::move(sessionInfo));
+        }
+    };
+
+    addSessionInfos(Impl->Sessions, false);
+    addSessionInfos(Impl->OrphanSessions, true);
+
     return sessionInfos;
 }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -365,6 +365,7 @@ message TTabletSessionInfo
     bytes SessionState = 3;
     uint64 MaxSeqNo = 4;
     uint64 MaxRwSeqNo = 5;
+    bool IsOrphan = 6;
 }
 
 message TDescribeSessionsResponse


### PR DESCRIPTION
#2434 