### PR TITLE
[Blockstore] PopCount => std::popcount

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -4,6 +4,8 @@
 #include <cloud/blockstore/libs/storage/stats_service/stats_service_events_private.h>
 #include <cloud/storage/core/libs/common/media.h>
 
+#include <bit>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NTestVolume;
@@ -49,7 +51,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         auto popCountStr = [](const TString& s) {
             ui64 count = 0;
             for (char c : s) {
-                count += PopCount(c);
+                count += std::popcount(static_cast<unsigned char>(c));
             }
             return count;
         };
@@ -2237,7 +2239,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         auto popCountStr = [](const TString& s) {
             ui64 count = 0;
             for (char c : s) {
-                count += PopCount(c);
+                count += std::popcount(static_cast<unsigned char>(c));
             }
             return count;
         };


### PR DESCRIPTION
use std::popcount() from C++20 standard
___
В С++20 появилась стандартная реализация [popcount](https://en.cppreference.com/w/cpp/numeric/popcount)
Бонусом - она является constexpr
Нужно перейти на неё
___
сравнение перфа:
TLTR:

    хуже для 8-ми битных (но их использование я не нашёл)
    лучше для 16-ти битных 17.9G -> 19.7G (у нас используется)
    одинаково для 32 и 64 битных
