### PR TITLE
[Disk Manager] write task request to error in base64 encoding

### DIFF
--- a/cloud/tasks/storage/storage_ydb_impl.go
+++ b/cloud/tasks/storage/storage_ydb_impl.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -557,9 +558,9 @@ func (s *storageYDB) prepareCreateTask(
 			return []stateTransition{}, errors.NewNonRetriableErrorf(
 				`cannot create task with request=%s, because task with same id=%v,
 				 but different request=%s already exists`,
-				state.Request,
+				base64.StdEncoding.EncodeToString(state.Request),
 				state.ID,
-				existingState.Request,
+				base64.StdEncoding.EncodeToString(existingState.Request),
 			)
 		}
 


### PR DESCRIPTION
#2438

Can not write `request` to error as uninterpreted bytes, because this error will be send to ydb (in `error_message` field of task state) as utf8 field https://github.com/ydb-platform/nbs/blob/main/cloud/tasks/storage/common.go#L154, but `request` is not utf8-encoded. So ydb can not parse this error message.

So we write `request` in base64 endocing.

Now this error message looks like this:
```
error:{code:2  message:"Non retriable error, Silent=false: cannot create task with request=CitUZXN0SW1hZ2VTZXJ2aWNlQ3JlYXRlSW1hZ2VGcm9tSW1hZ2VfaW1hZ2UxEgZ6b25lLWEYAQ==, because task with same id=28f44fe0-aea1-4b82-9a4d-5f87131a16f7,\n\t\t\t\t but different request=CitUZXN0SW1hZ2VTZXJ2aWNlQ3JlYXRlSW1hZ2VGcm9tSW1hZ2VfaW1hZ2UxEgZ6b25lLWEYASCAgIAU already exists
```