### PR TITLE
issue-2216: DestroyFileStoreRequest for filestores from DenyList should result in S_FALSE, not E_ARGUMENT

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -327,11 +327,11 @@ void TStorageServiceActor::HandleDestroyFileStore(
         LOG_INFO(
             ctx,
             TFileStoreComponents::SERVICE,
-            "FileStore %s is in deny list",
+            "FileStore %s is in deny list, responding with S_FALSE",
             msg->Record.GetFileSystemId().c_str());
         auto response =
             std::make_unique<TEvService::TEvDestroyFileStoreResponse>(MakeError(
-                E_ARGUMENT,
+                S_FALSE,
                 Sprintf(
                     "FileStore %s is in deny list",
                     msg->Record.GetFileSystemId().c_str())));

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4151,9 +4151,14 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         auto destroyFileStoreResponse = service.AssertDestroyFileStoreFailed(fsId);
         UNIT_ASSERT_VALUES_EQUAL_C(
-            E_ARGUMENT,
+            S_FALSE,
             destroyFileStoreResponse->GetStatus(),
             destroyFileStoreResponse->GetErrorReason());
+
+        auto listing = service.ListFileStores();
+        const auto& fsIds = listing->Record.GetFileStores();
+        UNIT_ASSERT_VALUES_EQUAL(1, fsIds.size());
+        UNIT_ASSERT_VALUES_EQUAL(fsId, fsIds[0]);
     }
 
     Y_UNIT_TEST(ShouldValidateRequestsWithShardId)

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4149,7 +4149,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TServiceClient service(env.GetRuntime(), nodeIdx);
         service.CreateFileStore(fsId, initialBlockCount);
 
-        auto destroyFileStoreResponse = service.AssertDestroyFileStoreFailed(fsId);
+        service.SendDestroyFileStoreRequest(fsId);
+        auto destroyFileStoreResponse = service.RecvDestroyFileStoreResponse();
         UNIT_ASSERT_VALUES_EQUAL_C(
             S_FALSE,
             destroyFileStoreResponse->GetStatus(),


### PR DESCRIPTION
The actual intention is to just ignore this destruction request since for the systems above filestore filesystems listed in DenyList exist elsewhere (e.g. in a different cloud cluster under a different id).

#2216 