### PR TITLE
Destroy shadow disk actor before shadow disk deallocation

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -184,6 +184,7 @@ public:
     void ShadowActorCreated(const TString& checkpointId);
     void ShadowActorDestroyed(const TString& checkpointId);
     [[nodiscard]] bool HasShadowActor(const TString& checkpointId) const;
+    [[nodiscard]] bool NeedShadowActor(const TString& checkpointId) const;
 
     [[nodiscard]] bool IsRequestInProgress() const;
     [[nodiscard]] bool IsCheckpointBeingCreated() const;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -295,6 +295,11 @@ void TVolumeActor::BeforeDie(const TActorContext& ctx)
     KillActors(ctx);
     CancelRequests(ctx);
 
+    for (auto& [_, handler]: OnPartitionStopped) {
+        std::invoke(handler, ctx);
+    }
+    OnPartitionStopped.clear();
+
     for (auto& [part, handler]: WaitForPartitions) {
         if (handler) {
             std::invoke(handler, ctx, MakeError(E_REJECTED, "tablet is shutting down"));
@@ -583,6 +588,11 @@ void TVolumeActor::HandlePoisonTaken(
         "[%lu] Partition %s stopped",
         TabletID(),
         ev->Sender.ToString().c_str());
+
+    if (auto* callback = OnPartitionStopped.FindPtr(ev->Cookie)) {
+        std::invoke(*callback, ctx);
+        OnPartitionStopped.erase(ev->Cookie);
+    }
 
     if (WaitForPartitions.empty()) {
         return;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -290,7 +290,7 @@ void TVolumeActor::OnTabletDead(
 void TVolumeActor::BeforeDie(const TActorContext& ctx)
 {
     UnregisterVolume(ctx);
-    StopPartitions(ctx);
+    StopPartitions(ctx, {});
     TerminateTransactions(ctx);
     KillActors(ctx);
     CancelRequests(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -354,6 +354,10 @@ private:
 
     TDeque<std::pair<NActors::TActorId, TPoisonCallback>> WaitForPartitions;
 
+    using TDiskRegistryBasedPartitionStoppedCallback =
+        std::function<void(const NActors::TActorContext&)>;
+    THashMap<ui64, TDiskRegistryBasedPartitionStoppedCallback> OnPartitionStopped;
+
     TVector<ui64> GCCompletedPartitions;
 
 public:
@@ -465,6 +469,9 @@ private:
     void StartPartitionsForUse(const NActors::TActorContext& ctx);
     void StartPartitionsForGc(const NActors::TActorContext& ctx);
     void StopPartitions(const NActors::TActorContext& ctx);
+    void StopPartitionsWithCallback(
+        const NActors::TActorContext& ctx,
+        TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped);
 
     void SetupDiskRegistryBasedPartitions(const NActors::TActorContext& ctx);
 
@@ -989,7 +996,9 @@ private:
         NActors::TActorId nonreplicatedActorId,
         std::shared_ptr<TNonreplicatedPartitionConfig> srcConfig);
 
-    void RestartDiskRegistryBasedPartition(const NActors::TActorContext& ctx);
+    void RestartDiskRegistryBasedPartition(
+        const NActors::TActorContext& ctx,
+        TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped);
     void StartPartitionsImpl(const NActors::TActorContext& ctx);
 
     BLOCKSTORE_VOLUME_REQUESTS(BLOCKSTORE_IMPLEMENT_REQUEST, TEvVolume)

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -468,8 +468,7 @@ private:
     void StartPartitionsIfNeeded(const NActors::TActorContext& ctx);
     void StartPartitionsForUse(const NActors::TActorContext& ctx);
     void StartPartitionsForGc(const NActors::TActorContext& ctx);
-    void StopPartitions(const NActors::TActorContext& ctx);
-    void StopPartitionsWithCallback(
+    void StopPartitions(
         const NActors::TActorContext& ctx,
         TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -590,7 +590,7 @@ void TVolumeActor::CompleteUpdateDevices(
         }
     }
 
-    StopPartitions(ctx);
+    StopPartitions(ctx, {});
     SendVolumeConfigUpdated(ctx);
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_change_storage_config.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_change_storage_config.cpp
@@ -61,7 +61,7 @@ void TVolumeActor::CompleteChangeStorageConfig(
     if (State->GetPartitionsState() == TPartitionInfo::READY ||
         State->GetPartitionsState() == TPartitionInfo::STARTED)
     {
-        StopPartitions(ctx);
+        StopPartitions(ctx, {});
         StartPartitionsForUse(ctx);
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_resync.cpp
@@ -167,7 +167,7 @@ void TVolumeActor::CompleteToggleResync(
     Y_UNUSED(args);
 
     if (args.ResyncWasNeeded != State->IsMirrorResyncNeeded()) {
-        RestartDiskRegistryBasedPartition(ctx);
+        RestartDiskRegistryBasedPartition(ctx, {});
     } else {
         State->SetReadWriteError({});
     }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -265,10 +265,8 @@ NActors::TActorId TVolumeActor::WrapNonreplActorIfNeeded(
     for (const auto& [checkpointId, checkpointInfo]:
          State->GetCheckpointStore().GetActiveCheckpoints())
     {
-        if (checkpointInfo.Data == ECheckpointData::DataDeleted ||
-            !checkpointInfo.IsShadowDiskBased() ||
-            checkpointInfo.ShadowDiskState == EShadowDiskState::Error ||
-            checkpointInfo.HasShadowActor)
+        if (checkpointInfo.HasShadowActor ||
+            !State->GetCheckpointStore().NeedShadowActor(checkpointId))
         {
             continue;
         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -302,7 +302,7 @@ void TVolumeActor::RestartDiskRegistryBasedPartition(
         return;
     }
 
-    StopPartitionsWithCallback(ctx, std::move(onPartitionStopped));
+    StopPartitions(ctx, std::move(onPartitionStopped));
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);
 }
@@ -341,12 +341,7 @@ void TVolumeActor::StartPartitionsForGc(const TActorContext& ctx)
     PartitionsStartedReason = EPartitionsStartedReason::STARTED_FOR_GC;
 }
 
-void TVolumeActor::StopPartitions(const TActorContext& ctx)
-{
-    StopPartitionsWithCallback(ctx, {});
-}
-
-void TVolumeActor::StopPartitionsWithCallback(
+void TVolumeActor::StopPartitions(
     const TActorContext& ctx,
     TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped)
 {
@@ -408,7 +403,7 @@ void TVolumeActor::HandleRdmaUnavailable(
         "[%lu] Rdma unavailable, restarting without rdma",
         TabletID());
 
-    StopPartitions(ctx);
+    StopPartitions(ctx, {});
     State->SetRdmaUnavailable();
     StartPartitionsForUse(ctx);
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -321,7 +321,7 @@ void TVolumeActor::CompleteUpdateConfig(
     }
 
     // stop partitions that might have been using old configuration
-    StopPartitions(ctx);
+    StopPartitions(ctx, {});
 
     if (State) {
         State->ResetMeta(args.Meta);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updatestartpartitionsneeded.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updatestartpartitionsneeded.cpp
@@ -49,7 +49,7 @@ void TVolumeActor::ExecuteResetStartPartitionsNeeded(
                 "[%lu] Stopping partitions after gc finished",
                 TabletID());
 
-            StopPartitions(ctx);
+            StopPartitions(ctx, {});
             State->Reset();
             PartitionsStartedReason = EPartitionsStartedReason::NOT_STARTED;
         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updatevolumeparams.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updatevolumeparams.cpp
@@ -127,7 +127,7 @@ void TVolumeActor::CompleteUpdateVolumeParams(
     auto response = std::make_unique<TEvVolume::TEvUpdateVolumeParamsResponse>();
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 
-    StopPartitions(ctx);
+    StopPartitions(ctx, {});
     SendVolumeConfigUpdated(ctx);
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);
@@ -164,7 +164,7 @@ void TVolumeActor::CompleteDeleteVolumeParams(
 {
     Y_UNUSED(args);
 
-    StopPartitions(ctx);
+    StopPartitions(ctx, {});
     SendVolumeConfigUpdated(ctx);
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -303,6 +303,11 @@ struct TEvVolumePrivate
         {}
     };
 
+    struct TExternalDrainDone
+    {
+        TExternalDrainDone() = default;
+    };
+
     //
     // Events declaration
     //
@@ -324,6 +329,7 @@ struct TEvVolumePrivate
         EvUpdateReadWriteClientInfo,
         EvRemoveExpiredVolumeParams,
         EvShadowDiskAcquired,
+        EvExternalDrainDone,
 
         EvEnd
     };
@@ -380,6 +386,11 @@ struct TEvVolumePrivate
     using TEvShadowDiskAcquired = TRequestEvent<
         TShadowDiskAcquired,
         EvShadowDiskAcquired
+    >;
+
+    using TEvExternalDrainDone = TRequestEvent<
+        TExternalDrainDone,
+        EvExternalDrainDone
     >;
 };
 


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/2136
Сделал чтобы сначала останавливался партишен с теневым диском, и только потом запускается процесс деаллокации теневого диска.
Иначе если чекопоинт удаляется в процессе наливки диска, то актор теневого диска мог слать команды на запись блоков в уже освобожденный девайс, который находился в процессе зачистки.  