### PR TITLE
[Disk Manager] fix delete image idempotency: do not schedule retire base disks if image was not found in database

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/image_service_test/image_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/image_service_test/image_service_test.go
@@ -1060,6 +1060,16 @@ func TestImageServiceDeleteImage(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, operation.Id)
 	require.NoError(t, err)
 
+	// Check idempotency.
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.DeleteImage(reqCtx, &disk_manager.DeleteImageRequest{
+		ImageId: imageID,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
 	testcommon.CheckConsistency(t, ctx)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -437,8 +437,12 @@ func (s *storageYDB) createImage(
 			return state.toImageMeta(), nil
 		}
 
-		logging.Info(ctx, "image with different params already exists, old=%v, new=%v", state, image)
-		return nil, nil
+		return nil, NewImageIDIsNotAcceptedErrorf(
+			image.ID,
+			"image with different params already exists, old=%v, new=%v",
+			state,
+			image,
+		)
 	}
 
 	state := imageState{

--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -393,7 +393,6 @@ func (s *storageYDB) createImage(
 		}
 
 		return nil, errors.NewNonCancellableErrorf(
-			image.ID,
 			"image with different params already exists, old=%v, new=%v",
 			state,
 			image,
@@ -575,7 +574,6 @@ func (s *storageYDB) deleteImage(
 		}
 
 		return nil, errors.NewNonCancellableErrorf(
-			imageID,
 			"image with id %v can't be deleted, because snapshot with id %v already exists",
 			imageID,
 			imageID,

--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -645,13 +645,12 @@ func (s *storageYDB) deleteImage(
 		return nil, err
 	}
 
-	var state imageState
-
 	if len(states) == 0 {
+		// Should be idempotent.
 		return nil, nil
 	}
 
-	state = states[0]
+	state := states[0]
 
 	if state.status >= imageStatusDeleting {
 		// Image already marked as deleting/deleted.
@@ -945,13 +944,7 @@ func (s *storageYDB) DeleteImage(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
 			var err error
-			image, err = s.deleteImage(
-				ctx,
-				session,
-				imageID,
-				taskID,
-				deletingAt,
-			)
+			image, err = s.deleteImage(ctx, session, imageID, taskID, deletingAt)
 			return err
 		},
 	)

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -55,12 +55,12 @@ func TestImagesCreateImage(t *testing.T) {
 
 	created, err := storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 
 	// Check idempotency.
 	created, err = storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 
 	err = storage.ImageCreated(ctx, image.ID, time.Now(), 0, 0)
 	require.NoError(t, err)
@@ -72,15 +72,14 @@ func TestImagesCreateImage(t *testing.T) {
 	// Check idempotency.
 	created, err = storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 
 	require.EqualValues(t, "disk", created.SrcDiskID)
 
 	image.CreateTaskID = "other"
-	created, err = storage.CreateImage(ctx, image)
+	_, err = storage.CreateImage(ctx, image)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
-	require.Nil(t, created)
 }
 
 func TestImagesDeleteImage(t *testing.T) {
@@ -106,7 +105,7 @@ func TestImagesDeleteImage(t *testing.T) {
 
 	created, err := storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 
 	expected := image
 	expected.CreateRequest = nil
@@ -216,7 +215,7 @@ func TestImagesClearDeletedImages(t *testing.T) {
 
 	created, err := storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 
 	_, err = storage.DeleteImage(ctx, image.ID, "delete", deletedAt)
 	require.NoError(t, err)
@@ -237,7 +236,7 @@ func TestImagesClearDeletedImages(t *testing.T) {
 
 	created, err = storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 }
 
 func TestImagesCreateImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
@@ -264,10 +263,9 @@ func TestImagesCreateImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
 	_, err = storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
 
-	created, err := storage.CreateImage(ctx, ImageMeta{ID: snapshot.ID})
+	_, err = storage.CreateImage(ctx, ImageMeta{ID: snapshot.ID})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
-	require.Nil(t, created)
 }
 
 func TestImagesDeleteImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
@@ -331,7 +329,7 @@ func TestImagesGetImage(t *testing.T) {
 
 	created, err := storage.CreateImage(ctx, image)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, image.ID, created.ID)
 
 	image.CreateRequest = nil
 

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -78,7 +78,8 @@ func TestImagesCreateImage(t *testing.T) {
 
 	image.CreateTaskID = "other"
 	created, err = storage.CreateImage(ctx, image)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, NewEmptyImageIDIsNotAcceptedError()))
 	require.Nil(t, created)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -79,7 +79,7 @@ func TestImagesCreateImage(t *testing.T) {
 	image.CreateTaskID = "other"
 	created, err = storage.CreateImage(ctx, image)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, NewEmptyImageIDIsNotAcceptedError()))
+	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
 	require.Nil(t, created)
 }
 
@@ -266,7 +266,7 @@ func TestImagesCreateImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
 
 	created, err := storage.CreateImage(ctx, ImageMeta{ID: snapshot.ID})
 	require.Error(t, err)
-	require.True(t, errors.Is(err, NewEmptyImageIDIsNotAcceptedError()))
+	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
 	require.Nil(t, created)
 }
 
@@ -296,7 +296,7 @@ func TestImagesDeleteImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
 
 	created, err := storage.DeleteImage(ctx, snapshot.ID, "delete", time.Now())
 	require.Error(t, err)
-	require.True(t, errors.Is(err, NewEmptyImageIDIsNotAcceptedError()))
+	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
 	require.Nil(t, created)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -264,7 +264,8 @@ func TestImagesCreateImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 
 	created, err := storage.CreateImage(ctx, ImageMeta{ID: snapshot.ID})
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, NewEmptyImageIDIsNotAcceptedError()))
 	require.Nil(t, created)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -170,13 +170,13 @@ func TestImagesDeleteNonexistentImage(t *testing.T) {
 	deletingAt := time.Now()
 	actual, err := storage.DeleteImage(ctx, image.ID, "delete", deletingAt)
 	require.NoError(t, err)
-	requireImagesAreEqual(t, image, *actual)
+	require.Nil(t, actual)
 
 	// Check idempotency.
 	deletingAt = deletingAt.Add(time.Second)
 	actual, err = storage.DeleteImage(ctx, image.ID, "delete", deletingAt)
 	require.NoError(t, err)
-	requireImagesAreEqual(t, image, *actual)
+	require.Nil(t, actual)
 
 	_, err = storage.CreateImage(ctx, image)
 	require.Error(t, err)

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -293,7 +293,8 @@ func TestImagesDeleteImageShouldFailIfSnapshotAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 
 	created, err := storage.DeleteImage(ctx, snapshot.ID, "delete", time.Now())
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, NewEmptyImageIDIsNotAcceptedError()))
 	require.Nil(t, created)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/resources/mocks/storage_mock.go
@@ -88,10 +88,10 @@ func (s *StorageMock) ListDisks(
 func (s *StorageMock) CreateImage(
 	ctx context.Context,
 	image resources.ImageMeta,
-) (*resources.ImageMeta, error) {
+) (resources.ImageMeta, error) {
 
 	args := s.Called(ctx, image)
-	return args.Get(0).(*resources.ImageMeta), args.Error(1)
+	return args.Get(0).(resources.ImageMeta), args.Error(1)
 }
 
 func (s *StorageMock) ImageCreated(
@@ -161,10 +161,10 @@ func (s *StorageMock) ListImages(
 func (s *StorageMock) CreateSnapshot(
 	ctx context.Context,
 	snapshot resources.SnapshotMeta,
-) (*resources.SnapshotMeta, error) {
+) (resources.SnapshotMeta, error) {
 
 	args := s.Called(ctx, snapshot)
-	return args.Get(0).(*resources.SnapshotMeta), args.Error(1)
+	return args.Get(0).(resources.SnapshotMeta), args.Error(1)
 }
 
 func (s *StorageMock) SnapshotCreated(

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -316,13 +316,11 @@ func (s *storageYDB) createSnapshot(
 			return nil, err
 		}
 
-		logging.Info(
-			ctx,
+		return nil, errors.NewNonCancellableErrorf(
 			"snapshot with id %v can't be created, because image with id %v already exists",
 			snapshot.ID,
 			snapshot.ID,
 		)
-		return nil, nil
 	}
 
 	createRequest, err := proto.Marshal(snapshot.CreateRequest)
@@ -379,13 +377,11 @@ func (s *storageYDB) createSnapshot(
 			return state.toSnapshotMeta(), nil
 		}
 
-		logging.Info(
-			ctx,
+		return nil, errors.NewNonCancellableErrorf(
 			"snapshot with different params already exists, old=%v, new=%v",
 			state,
 			snapshot,
 		)
-		return nil, nil
 	}
 
 	state := snapshotState{
@@ -554,13 +550,11 @@ func (s *storageYDB) deleteSnapshot(
 			return nil, err
 		}
 
-		logging.Info(
-			ctx,
+		return nil, errors.NewNonCancellableErrorf(
 			"snapshot with id %v can't be deleted, because image with id %v already exists",
 			snapshotID,
 			snapshotID,
 		)
-		return nil, nil
 	}
 
 	res, err := tx.Execute(ctx, fmt.Sprintf(`

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -578,21 +578,22 @@ func (s *storageYDB) deleteSnapshot(
 		return nil, err
 	}
 
-	var state snapshotState
+	if len(states) == 0 {
+		// Should be idempotent.
+		return nil, nil
+	}
 
-	if len(states) != 0 {
-		state = states[0]
+	state := states[0]
 
-		if state.status >= snapshotStatusDeleting {
-			// Snapshot already marked as deleting/deleted.
+	if state.status >= snapshotStatusDeleting {
+		// Snapshot already marked as deleting/deleted.
 
-			err = tx.Commit(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			return state.toSnapshotMeta(), nil
+		err = tx.Commit(ctx)
+		if err != nil {
+			return nil, err
 		}
+
+		return state.toSnapshotMeta(), nil
 	}
 
 	state.id = snapshotID

--- a/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
@@ -61,12 +61,12 @@ func TestSnapshotsCreateSnapshot(t *testing.T) {
 
 	created, err := storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 
 	// Check idempotency.
 	created, err = storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 
 	err = storage.SnapshotCreated(ctx, snapshot.ID, time.Now(), 0, 0)
 	require.NoError(t, err)
@@ -78,13 +78,12 @@ func TestSnapshotsCreateSnapshot(t *testing.T) {
 	// Check idempotency.
 	created, err = storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 
 	snapshot.CreateTaskID = "other"
-	created, err = storage.CreateSnapshot(ctx, snapshot)
+	_, err = storage.CreateSnapshot(ctx, snapshot)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
-	require.Nil(t, created)
 }
 
 func TestSnapshotsDeleteSnapshot(t *testing.T) {
@@ -115,7 +114,7 @@ func TestSnapshotsDeleteSnapshot(t *testing.T) {
 
 	created, err := storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 
 	expected := snapshot
 	expected.CreateRequest = nil
@@ -231,7 +230,7 @@ func TestSnapshotsClearDeletedSnapshots(t *testing.T) {
 
 	created, err := storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 
 	_, err = storage.DeleteSnapshot(ctx, snapshot.ID, "delete", deletedAt)
 	require.NoError(t, err)
@@ -252,7 +251,7 @@ func TestSnapshotsClearDeletedSnapshots(t *testing.T) {
 
 	created, err = storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 }
 
 func TestSnapshotsCreateSnapshotShouldFailIfImageAlreadyExists(t *testing.T) {
@@ -275,10 +274,9 @@ func TestSnapshotsCreateSnapshotShouldFailIfImageAlreadyExists(t *testing.T) {
 	_, err = storage.CreateImage(ctx, image)
 	require.NoError(t, err)
 
-	created, err := storage.CreateSnapshot(ctx, SnapshotMeta{ID: image.ID})
+	_, err = storage.CreateSnapshot(ctx, SnapshotMeta{ID: image.ID})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
-	require.Nil(t, created)
 }
 
 func TestSnapshotsDeleteSnapshotShouldFailIfImageAlreadyExists(t *testing.T) {
@@ -343,7 +341,7 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 
 	created, err := storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
-	require.NotNil(t, created)
+	require.Equal(t, snapshot.ID, created.ID)
 
 	snapshot.CreateRequest = nil
 

--- a/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
@@ -82,7 +82,8 @@ func TestSnapshotsCreateSnapshot(t *testing.T) {
 
 	snapshot.CreateTaskID = "other"
 	created, err = storage.CreateSnapshot(ctx, snapshot)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
 	require.Nil(t, created)
 }
 
@@ -275,7 +276,8 @@ func TestSnapshotsCreateSnapshotShouldFailIfImageAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 
 	created, err := storage.CreateSnapshot(ctx, SnapshotMeta{ID: image.ID})
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
 	require.Nil(t, created)
 }
 
@@ -300,7 +302,8 @@ func TestSnapshotsDeleteSnapshotShouldFailIfImageAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 
 	created, err := storage.DeleteSnapshot(ctx, image.ID, "delete", time.Now())
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.NewEmptyNonCancellableError()))
 	require.Nil(t, created)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
@@ -181,13 +181,13 @@ func TestSnapshotsDeleteNonexistentSnapshot(t *testing.T) {
 	deletingAt := time.Now()
 	actual, err := storage.DeleteSnapshot(ctx, snapshot.ID, "delete", deletingAt)
 	require.NoError(t, err)
-	requireSnapshotsAreEqual(t, snapshot, *actual)
+	require.Nil(t, actual)
 
 	// Check idempotency.
 	deletingAt = deletingAt.Add(time.Second)
 	actual, err = storage.DeleteSnapshot(ctx, snapshot.ID, "delete", deletingAt)
 	require.NoError(t, err)
-	requireSnapshotsAreEqual(t, snapshot, *actual)
+	require.Nil(t, actual)
 
 	_, err = storage.CreateSnapshot(ctx, snapshot)
 	require.Error(t, err)

--- a/cloud/disk_manager/internal/pkg/resources/storage.go
+++ b/cloud/disk_manager/internal/pkg/resources/storage.go
@@ -130,7 +130,7 @@ type Storage interface {
 	) ([]string, error)
 
 	// Returns image if action has been accepted by storage and nil otherwise.
-	CreateImage(ctx context.Context, image ImageMeta) (*ImageMeta, error)
+	CreateImage(ctx context.Context, image ImageMeta) (ImageMeta, error)
 
 	ImageCreated(
 		ctx context.Context,
@@ -163,7 +163,7 @@ type Storage interface {
 	) ([]string, error)
 
 	// Returns snapshot if action has been accepted by storage and nil otherwise.
-	CreateSnapshot(ctx context.Context, snapshot SnapshotMeta) (*SnapshotMeta, error)
+	CreateSnapshot(ctx context.Context, snapshot SnapshotMeta) (SnapshotMeta, error)
 
 	SnapshotCreated(
 		ctx context.Context,

--- a/cloud/disk_manager/internal/pkg/services/images/common.go
+++ b/cloud/disk_manager/internal/pkg/services/images/common.go
@@ -11,7 +11,6 @@ import (
 	pools_protos "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
 	"github.com/ydb-platform/nbs/cloud/tasks"
-	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/headers"
 )
 
@@ -51,10 +50,6 @@ func deleteImage(
 		time.Now(),
 	)
 	if err != nil {
-		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
-			return errors.NewNonCancellableError(err)
-		}
-
 		return err
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/images/common.go
+++ b/cloud/disk_manager/internal/pkg/services/images/common.go
@@ -63,17 +63,15 @@ func deleteImage(
 		return nil
 	}
 
-	if imageMeta.Size > 0 {
-		err = scheduleRetireBaseDisks(
-			ctx,
-			execCtx,
-			config,
-			scheduler,
-			*imageMeta,
-		)
-		if err != nil {
-			return err
-		}
+	err = scheduleRetireBaseDisks(
+		ctx,
+		execCtx,
+		config,
+		scheduler,
+		*imageMeta,
+	)
+	if err != nil {
+		return err
 	}
 
 	// Hack for NBS-2225.

--- a/cloud/disk_manager/internal/pkg/services/images/common.go
+++ b/cloud/disk_manager/internal/pkg/services/images/common.go
@@ -51,14 +51,16 @@ func deleteImage(
 		time.Now(),
 	)
 	if err != nil {
+		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
+			return errors.NewNonCancellableError(err)
+		}
+
 		return err
 	}
 
 	if imageMeta == nil {
-		return errors.NewNonCancellableErrorf(
-			"id %v is not accepted",
-			imageID,
-		)
+		// Should be idempotent.
+		return nil
 	}
 
 	if imageMeta.Size > 0 {

--- a/cloud/disk_manager/internal/pkg/services/images/common.go
+++ b/cloud/disk_manager/internal/pkg/services/images/common.go
@@ -61,15 +61,17 @@ func deleteImage(
 		)
 	}
 
-	err = scheduleRetireBaseDisks(
-		ctx,
-		execCtx,
-		config,
-		scheduler,
-		*imageMeta,
-	)
-	if err != nil {
-		return err
+	if imageMeta.Size > 0 {
+		err = scheduleRetireBaseDisks(
+			ctx,
+			execCtx,
+			config,
+			scheduler,
+			*imageMeta,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Hack for NBS-2225.

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
@@ -74,10 +74,6 @@ func (t *createImageFromDiskTask) run(
 		Encryption:        diskParams.EncryptionDesc,
 	})
 	if err != nil {
-		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
-			return errors.NewNonCancellableError(err)
-		}
-
 		return err
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
@@ -74,14 +74,11 @@ func (t *createImageFromDiskTask) run(
 		Encryption:        diskParams.EncryptionDesc,
 	})
 	if err != nil {
-		return err
-	}
+		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
+			return errors.NewNonCancellableError(err)
+		}
 
-	if imageMeta == nil {
-		return errors.NewNonCancellableErrorf(
-			"id %v is not accepted",
-			t.request.DstImageId,
-		)
+		return err
 	}
 
 	if imageMeta.Ready {

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_image_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_image_task.go
@@ -75,10 +75,6 @@ func (t *createImageFromImageTask) Run(
 		Encryption:        srcImageEncryption,
 	})
 	if err != nil {
-		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
-			return errors.NewNonCancellableError(err)
-		}
-
 		return err
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_snapshot_task.go
@@ -75,10 +75,6 @@ func (t *createImageFromSnapshotTask) Run(
 		Encryption:        srcSnapshotEncryption,
 	})
 	if err != nil {
-		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
-			return errors.NewNonCancellableError(err)
-		}
-
 		return err
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_url_task.go
@@ -77,10 +77,6 @@ func (t *createImageFromURLTask) Run(
 		UseDataplaneTasks: true, // TODO: remove it.
 	})
 	if err != nil {
-		if errors.Is(err, resources.NewEmptyImageIDIsNotAcceptedError()) {
-			return errors.NewNonCancellableError(err)
-		}
-
 		return err
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -75,13 +75,6 @@ func (t *createSnapshotFromDiskTask) run(
 		return err
 	}
 
-	if snapshotMeta == nil {
-		return errors.NewNonCancellableErrorf(
-			"id %v is not accepted",
-			t.request.DstSnapshotId,
-		)
-	}
-
 	if snapshotMeta.Ready {
 		// Already created.
 		return nil
@@ -219,10 +212,8 @@ func (t *createSnapshotFromDiskTask) Cancel(
 	}
 
 	if snapshotMeta == nil {
-		return errors.NewNonCancellableErrorf(
-			"id %v is not accepted",
-			t.request.DstSnapshotId,
-		)
+		// Nothing to do.
+		return nil
 	}
 
 	// Hack for NBS-2225.

--- a/cloud/disk_manager/internal/pkg/services/snapshots/delete_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/delete_snapshot_task.go
@@ -58,10 +58,8 @@ func (t *deleteSnapshotTask) deleteSnapshot(
 	}
 
 	if snapshotMeta == nil {
-		return errors.NewNonCancellableErrorf(
-			"id %v is not accepted",
-			t.request.SnapshotId,
-		)
+		// Should be idempotent.
+		return nil
 	}
 
 	// Hack for NBS-2225.


### PR DESCRIPTION
#2438

Fix for the issue.

If imageMeta.size == 0, then the image is already deleted, and there is no reason to schedule retire base disks task.