### PR TITLE
issue-1146: make ut_cache stress test use less iterations while being executed under tsan/ubsan/asan alike other ut tests

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache_stress.cpp
@@ -67,7 +67,13 @@ public:
     TVector<TString> RunRandomIndexLoad()
     {
         TVector<TString> responses;
-        const size_t numRequests = 5000;
+
+        const auto sanitizerType = GetEnv("SANITIZER_TYPE");
+        STORAGE_INFO("Sanitizer: %s", sanitizerType.c_str());
+        const THashSet<TString> slowSanitizers({"thread", "undefined", "address"});
+        const ui32 d = slowSanitizers.contains(sanitizerType) ? 20 : 1;
+
+        const size_t numRequests = 5000 / d;
 
         while (responses.size() < numRequests) {
             auto operation = GetRandomOperation();

--- a/cloud/filestore/libs/storage/tablet/ut_cache_stress/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ut_cache_stress/ya.make
@@ -10,6 +10,8 @@ PEERDIR(
     cloud/filestore/libs/storage/testlib
 )
 
+ENV(SANITIZER_TYPE=${SANITIZER_TYPE})
+
 YQL_LAST_ABI_VERSION()
 
 END()


### PR DESCRIPTION
References #1146

Fixes after #2303