### PR TITLE
[Filestore] issue-1861: show client hostname and recovery timestamp in list of active sessions

### DIFF
--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -123,6 +123,7 @@ message TSession
     uint64 MaxSeqNo = 6;
     uint64 MaxRwSeqNo = 7;
     string OriginFqdn = 8;
+    uint64 RecoveryTimestampUs = 9;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -720,6 +720,7 @@ void DumpSessions(IOutputStream& out, const TVector<TMonSessionInfo>& sessions)
             TABLEHEAD() {
                 TABLER() {
                     TABLEH() { out << "ClientId";}
+                    TABLEH() { out << "FQDN";}
                     TABLEH() { out << "SessionId"; }
                     TABLEH() { out << "SeqNo"; }
                     TABLEH() { out << "ReadOnly"; }
@@ -730,6 +731,7 @@ void DumpSessions(IOutputStream& out, const TVector<TMonSessionInfo>& sessions)
                 for (const auto& ss: session.SubSessions) {
                     TABLER() {
                         TABLED() { out << session.ProtoInfo.GetClientId(); }
+                        TABLED() { out << session.ProtoInfo.GetOriginFqdn(); }
                         TABLED() { out << session.ProtoInfo.GetSessionId(); }
                         TABLED() { out << ss.SeqNo; }
                         TABLED() { out << (ss.ReadOnly ? "True" : "False"); }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -722,17 +722,25 @@ void DumpSessions(IOutputStream& out, const TVector<TMonSessionInfo>& sessions)
                     TABLEH() { out << "ClientId";}
                     TABLEH() { out << "FQDN";}
                     TABLEH() { out << "SessionId"; }
+                    TABLEH() { out << "Recovery"; }
                     TABLEH() { out << "SeqNo"; }
                     TABLEH() { out << "ReadOnly"; }
                     TABLEH() { out << "Owner"; }
                 }
             }
             for (const auto& session: sessions) {
+                const auto recoveryTimestamp = TInstant::MicroSeconds(
+                    session.ProtoInfo.GetRecoveryTimestampUs());
                 for (const auto& ss: session.SubSessions) {
                     TABLER() {
                         TABLED() { out << session.ProtoInfo.GetClientId(); }
                         TABLED() { out << session.ProtoInfo.GetOriginFqdn(); }
                         TABLED() { out << session.ProtoInfo.GetSessionId(); }
+                        if (recoveryTimestamp) {
+                            TABLED() { out << recoveryTimestamp; }
+                        } else {
+                            TABLED() { out << ""; }
+                        }
                         TABLED() { out << ss.SeqNo; }
                         TABLED() { out << (ss.ReadOnly ? "True" : "False"); }
                         TABLED() { out << ToString(ss.Owner); }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -214,6 +214,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         Impl->SessionByOwner.emplace(owner, session);
     }
 
+    session->SetRecoveryTimestampUs(Now().MicroSeconds());
+
     return oldOwner;
 }
 


### PR DESCRIPTION
#1861 
- **[Filestore] issue-1861: show client hostname in list of active sessions**
- **[Filestore] issue-1861: show recovery timestamp in list of active session**
