### PR TITLE
[Disk Manager] add ability to disable DiskRegistry-based disks; add ability to enable DiskRegistry-based disks for specific folders

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test/ya.make
@@ -5,6 +5,7 @@ SET_APPEND(RECIPE_ARGS --multiple-nbs)
 SET_APPEND(RECIPE_ARGS --encryption)
 SET_APPEND(RECIPE_ARGS --min-restart-period-sec 30)
 SET_APPEND(RECIPE_ARGS --max-restart-period-sec 60)
+SET_APPEND(RECIPE_ARGS --disable-disk-registry-based-disks)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
 FORK_SUBTESTS()

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
@@ -27,6 +27,7 @@ type migrationTestParams struct {
 	DiskKind  disk_manager.DiskKind
 	DiskSize  int64
 	FillDisk  bool
+	FolderID  string
 }
 
 func setupMigrationTest(
@@ -50,6 +51,7 @@ func setupMigrationTest(
 			DiskId: params.DiskID,
 			ZoneId: params.SrcZoneID,
 		},
+		FolderId: params.FolderID,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, operation)
@@ -550,6 +552,7 @@ func TestDiskServiceMigrateNonreplDisk(t *testing.T) {
 		DiskKind:  disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
 		DiskSize:  1073741824,
 		FillDisk:  false,
+		FolderID:  "folder",
 	}
 
 	ctx, client := setupMigrationTest(t, params)
@@ -568,6 +571,7 @@ func TestDiskServiceMigrateHddNonreplDisk(t *testing.T) {
 		DiskKind:  disk_manager.DiskKind_DISK_KIND_HDD_NONREPLICATED,
 		DiskSize:  1073741824,
 		FillDisk:  false,
+		FolderID:  "folder",
 	}
 
 	ctx, client := setupMigrationTest(t, params)

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -49,6 +49,35 @@ func TestDiskServiceCreateEmptyDisk(t *testing.T) {
 	testcommon.CheckConsistency(t, ctx)
 }
 
+func TestDiskServiceFailToCreateSsdNonreplIfNotAllowed(t *testing.T) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskID := t.Name()
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: 4096,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: "zone-a",
+			DiskId: diskID,
+		},
+		FolderId: "unallowed",
+	})
+	require.Error(t, err)
+	require.Empty(t, operation)
+	require.ErrorContains(t, err, "not allowed for the \"unallowed\" folder")
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
 // NBS-3424: TODO: enable this test.
 func TestDiskServiceShouldFailCreateDiskFromNonExistingImage(t *testing.T) {
 	/*
@@ -369,6 +398,7 @@ func testCreateDiskFromIncrementalSnapshot(
 			ZoneId: "zone-a",
 			DiskId: diskID1,
 		},
+		FolderId: "folder",
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, operation)
@@ -427,6 +457,7 @@ func testCreateDiskFromIncrementalSnapshot(
 			ZoneId: "zone-a",
 			DiskId: diskID2,
 		},
+		FolderId: "another-folder",
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, operation)
@@ -588,6 +619,7 @@ func testCreateDiskFromImage(
 			ZoneId: "zone-a",
 			DiskId: diskID,
 		},
+		FolderId: "folder",
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, operation)

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -63,7 +63,7 @@ func TestDiskServiceShouldCreateSsdNonreplIfFolderIsInAllowedList(t *testing.T) 
 		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
 			SrcEmpty: &empty.Empty{},
 		},
-		Size: 4096,
+		Size: 262144 * 4096,
 		Kind: disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
 		DiskId: &disk_manager.DiskId{
 			ZoneId: "zone-a",
@@ -93,7 +93,7 @@ func TestDiskServiceShouldFailToCreateSsdNonreplIfNotAllowed(t *testing.T) {
 		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
 			SrcEmpty: &empty.Empty{},
 		},
-		Size: 4096,
+		Size: 262144 * 4096,
 		Kind: disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
 		DiskId: &disk_manager.DiskId{
 			ZoneId: "zone-a",

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/ya.make
@@ -3,6 +3,7 @@ GO_TEST_FOR(cloud/disk_manager/internal/pkg/facade)
 SET_APPEND(RECIPE_ARGS --multiple-nbs)
 SET_APPEND(RECIPE_ARGS --encryption)
 SET_APPEND(RECIPE_ARGS --creation-and-deletion-allowed-only-for-disks-with-id-prefix "Test")
+SET_APPEND(RECIPE_ARGS --disable-disk-registry-based-disks)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
 GO_XTEST_SRCS(

--- a/cloud/disk_manager/internal/pkg/services/disks/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/disks/config/config.proto
@@ -18,6 +18,6 @@ message DisksConfig {
     optional string EndedMigrationExpirationTimeout = 9 [default="30m"];
     optional bool EnableOverlayDiskRegistryBasedDisks = 10;
     optional string CreationAndDeletionAllowedOnlyForDisksWithIdPrefix = 11;
-    optional bool EnableDiskRegistryBasedDiskCreation = 12;
+    optional bool DisableDiskRegistryBasedDisks = 12;
     repeated string DiskRegistryBasedDisksFolderIdAllowList = 13;
 }

--- a/cloud/disk_manager/internal/pkg/services/disks/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/disks/config/config.proto
@@ -18,4 +18,6 @@ message DisksConfig {
     optional string EndedMigrationExpirationTimeout = 9 [default="30m"];
     optional bool EnableOverlayDiskRegistryBasedDisks = 10;
     optional string CreationAndDeletionAllowedOnlyForDisksWithIdPrefix = 11;
+    optional bool EnableDiskRegistryBasedDiskCreation = 12;
+    repeated string DiskRegistryBasedDisksFolderIdAllowList = 13;
 }

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -234,8 +234,9 @@ func (s *service) prepareCreateDiskParams(
 
 		if !allowed {
 			return nil, errors.NewInvalidArgumentError(
-				"can't create a DisdRegistry based disk with id %q, because " +
+				"can't create a DiskRegistry based disk with id %q, because " +
 				"it is not allowed for the %q folder",
+				req.DiskId.DiskId,
 				req.FolderId,
 			)
 		}

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -234,8 +234,8 @@ func (s *service) prepareCreateDiskParams(
 
 		if !allowed {
 			return nil, errors.NewInvalidArgumentError(
-				"can't create a DiskRegistry based disk with id %q, because " +
-				"it is not allowed for the %q folder",
+				"can't create a DiskRegistry based disk with id %q, because "+
+					"it is not allowed for the %q folder",
 				req.DiskId.DiskId,
 				req.FolderId,
 			)

--- a/cloud/disk_manager/test/recipe/__main__.py
+++ b/cloud/disk_manager/test/recipe/__main__.py
@@ -54,6 +54,7 @@ def parse_args(args):
         type=str,
         default="cloud/disk_manager/cmd/disk-manager/disk-manager")
     parser.add_argument("--creation-and-deletion-allowed-only-for-disks-with-id-prefix", type=str, default="")
+    parser.add_argument("--disable-disk-registry-based-disks", action='store_true', default=False)
 
     args, _ = parser.parse_known_args(args=args)
     return args
@@ -223,6 +224,7 @@ def start(argv):
             max_restart_period_sec=args.max_restart_period_sec,
             base_disk_id_prefix=base_disk_id_prefix,
             creation_and_deletion_allowed_only_for_disks_with_id_prefix=args.creation_and_deletion_allowed_only_for_disks_with_id_prefix,
+            disable_disk_registry_based_disks=args.disable_disk_registry_based_disks,
         )
         disk_managers.append(disk_manager)
         disk_manager.start()

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -114,6 +114,9 @@ DisksConfig: <
     EndedMigrationExpirationTimeout: "30s"
     EnableOverlayDiskRegistryBasedDisks: true
     CreationAndDeletionAllowedOnlyForDisksWithIdPrefix: "{creation_and_deletion_allowed_only_for_disks_with_id_prefix}"
+    DisableDiskRegistryBasedDisks: true
+    DiskRegistryBasedDisksFolderIdAllowList: "folder"
+    DiskRegistryBasedDisksFolderIdAllowList: "another-folder"
 >
 PoolsConfig: <
     MaxActiveSlots: 10

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -114,7 +114,7 @@ DisksConfig: <
     EndedMigrationExpirationTimeout: "30s"
     EnableOverlayDiskRegistryBasedDisks: true
     CreationAndDeletionAllowedOnlyForDisksWithIdPrefix: "{creation_and_deletion_allowed_only_for_disks_with_id_prefix}"
-    DisableDiskRegistryBasedDisks: true
+    DisableDiskRegistryBasedDisks: {disable_disk_registry_based_disks}
     DiskRegistryBasedDisksFolderIdAllowList: "folder"
     DiskRegistryBasedDisksFolderIdAllowList: "another-folder"
 >
@@ -361,7 +361,8 @@ class DiskManagerLauncher:
         max_restart_period_sec: int = 30,
         base_disk_id_prefix="",
         proxy_overlay_disk_id_prefix="",
-        creation_and_deletion_allowed_only_for_disks_with_id_prefix=""
+        creation_and_deletion_allowed_only_for_disks_with_id_prefix="",
+        disable_disk_registry_based_disks=False,
     ):
         self.__idx = idx
 
@@ -424,6 +425,7 @@ class DiskManagerLauncher:
                     ydb_port=ydb_port,
                     base_disk_id_prefix=base_disk_id_prefix,
                     creation_and_deletion_allowed_only_for_disks_with_id_prefix=creation_and_deletion_allowed_only_for_disks_with_id_prefix,
+                    disable_disk_registry_based_disks="true" if disable_disk_registry_based_disks else "false",
                 )
                 f.write(self.__server_config)
 


### PR DESCRIPTION
Added flag `DisableDiskRegistryBasedDisks` to disable DiskRegistry-based disk.
Added parameter `DiskRegistryBasedDisksFolderIdAllowList` to enable DiskRegistry-based disks for specific folders.