### PR TITLE
[merge-to-stable-23-3] [Filestore]  issue-2461: local filestore cache cleanup on umount, issue-1861: show client hostname and recovery timestamp in list of active sessions

### DIFF
--- a/cloud/filestore/libs/service_local/fs.cpp
+++ b/cloud/filestore/libs/service_local/fs.cpp
@@ -29,12 +29,6 @@ TLocalFileSystem::TLocalFileSystem(
         ", DirectIoEnabled=" << Config->GetDirectIoEnabled() <<
         ", DirectIoAlign=" << Config->GetDirectIoAlign());
 
-    Index = std::make_shared<TLocalIndex>(
-        Root,
-        StatePath,
-        Config->GetMaxNodeCount(),
-        Log);
-
     ScheduleCleanupSessions();
 }
 

--- a/cloud/filestore/libs/service_local/fs.h
+++ b/cloud/filestore/libs/service_local/fs.h
@@ -98,8 +98,6 @@ private:
     NProto::TFileStore Store;
     TLog Log;
 
-    TLocalIndexPtr Index;
-
     TSessionList SessionsList;
     THashMap<TString, TSessionList::iterator> SessionsById;
     THashMap<TString, TSessionList::iterator> SessionsByClient;

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -54,12 +54,11 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         Root,
         clientSessionStatePath,
         clientId,
-        Index,
+        Config->GetMaxNodeCount(),
+        Config->GetMaxHandlePerSessionCount(),
         Logging);
 
-    session->Init(
-        request.GetRestoreClientSession(),
-        Config->GetMaxHandlePerSessionCount());
+    session->Init(request.GetRestoreClientSession());
     session->AddSubSession(sessionSeqNo, readOnly);
 
     SessionsList.push_front(session);

--- a/cloud/filestore/libs/service_local/index.cpp
+++ b/cloud/filestore/libs/service_local/index.cpp
@@ -2,8 +2,6 @@
 
 #include "lowlevel.h"
 
-#include <cloud/filestore/libs/service/filestore.h>
-
 namespace NCloud::NFileStore {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/service_local/index.h
+++ b/cloud/filestore/libs/service_local/index.h
@@ -215,6 +215,15 @@ public:
         return node;
     }
 
+    void Clear()
+    {
+        TWriteGuard guard(NodesLock);
+
+        NodeTable->Clear();
+        Nodes.clear();
+        Nodes.insert(TIndexNode::CreateRoot(Root));
+    }
+
 private:
     void Init()
     {

--- a/cloud/filestore/libs/service_local/index.h
+++ b/cloud/filestore/libs/service_local/index.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <cloud/filestore/libs/service/filestore.h>
+
 #include <cloud/storage/core/libs/common/persistent_table.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -33,7 +35,7 @@ public:
         , NodeFd(std::move(node))
     {}
 
-    ui64 GetRecordIndex() const
+    [[nodiscard]] ui64 GetRecordIndex() const
     {
         return RecordIndex;
     }
@@ -46,7 +48,7 @@ public:
     static TIndexNodePtr CreateRoot(const TFsPath& path);
     static TIndexNodePtr Create(const TIndexNode& parent, const TString& name);
 
-    ui64 GetNodeId() const
+    [[nodiscard]] ui64 GetNodeId() const
     {
         return NodeId;
     }
@@ -66,7 +68,7 @@ public:
         unsigned int flags);
     void Unlink(const TString& name, bool directory);
 
-    TString ReadLink() const;
+    [[nodiscard]] TString ReadLink() const;
 
     TFileStat Stat();
     TFileStat Stat(const TString& name);
@@ -128,10 +130,12 @@ private:
         char Name[NAME_MAX + 1] = {};
     };
 
-private:
     using TNodeMap = THashSet<TIndexNodePtr, THash, TEqual>;
     using TNodeTable = TPersistentTable<TNodeTableHeader, TNodeTableRecord>;
 
+    const TFsPath Root;
+    const TFsPath StatePath;
+    ui32 MaxNodeCount;
     TNodeMap Nodes;
     std::unique_ptr<TNodeTable> NodeTable;
     TRWMutex NodesLock;
@@ -139,13 +143,16 @@ private:
 
 public:
     TLocalIndex(
-            const TFsPath& root,
-            const TFsPath& statePath,
+            TFsPath root,
+            TFsPath statePath,
             ui32 maxNodeCount,
             TLog log)
-        : Log(std::move(log))
+        : Root(std::move(root))
+        , StatePath(std::move(statePath))
+        , MaxNodeCount(maxNodeCount)
+        , Log(std::move(log))
     {
-        Init(root, statePath, maxNodeCount);
+        Init();
     }
 
     TIndexNodePtr LookupNode(ui64 nodeId)
@@ -209,18 +216,18 @@ public:
     }
 
 private:
-    void Init(const TFsPath& root, const TFsPath& statePath, ui32 maxNodeCount)
+    void Init()
     {
         STORAGE_INFO(
-            "Init index, Root=" << root <<
-            ", StatePath=" << statePath
-            << ", MaxNodeCount=" << maxNodeCount);
+            "Init index, Root=" << Root <<
+            ", StatePath=" << StatePath
+            << ", MaxNodeCount=" << MaxNodeCount);
 
-        Nodes.insert(TIndexNode::CreateRoot(root));
+        Nodes.insert(TIndexNode::CreateRoot(Root));
 
         NodeTable = std::make_unique<TNodeTable>(
-            (statePath / "nodes").GetPath(),
-            maxNodeCount);
+            (StatePath / "nodes").GetPath(),
+            MaxNodeCount);
 
         RecoverNodesFromPersistentTable();
     }
@@ -297,7 +304,7 @@ private:
                     TIndexNode::Create(**parentNodeIt, pathElemRecord->Name);
                 node->SetRecordIndex(pathElemIndex);
 
-                Nodes.insert(std::move(node));
+                Nodes.insert(node);
 
                 unresolvedPath.pop();
                 unresolvedRecords.erase(pathElemRecord->NodeId);

--- a/cloud/filestore/libs/service_local/public.h
+++ b/cloud/filestore/libs/service_local/public.h
@@ -15,9 +15,6 @@ using TLocalFileStoreConfigPtr = std::shared_ptr<TLocalFileStoreConfig>;
 class TLocalFileSystem;
 using TLocalFileSystemPtr = std::shared_ptr<TLocalFileSystem>;
 
-class TLocalIndex;
-using TLocalIndexPtr = std::shared_ptr<TLocalIndex>;
-
 class TSession;
 using TSessionPtr = std::shared_ptr<TSession>;
 

--- a/cloud/filestore/libs/service_local/session.h
+++ b/cloud/filestore/libs/service_local/session.h
@@ -256,11 +256,10 @@ public:
     {
         TWriteGuard guard(Lock);
 
-        for (auto& [_, handle]: Handles) {
-            HandleTable->DeleteRecord(handle.RecordIndex);
-        }
-
+        HandleTable->Clear();
         Handles.clear();
+
+        Index.Clear();
 
         FuseState = std::move(state);
         WriteStateFile("fuse_state", FuseState);

--- a/cloud/filestore/libs/service_local/session.h
+++ b/cloud/filestore/libs/service_local/session.h
@@ -14,8 +14,8 @@
 #include <util/generic/guid.h>
 #include <util/generic/hash.h>
 #include <util/generic/map.h>
-#include <util/string/builder.h>
 #include <util/stream/file.h>
+#include <util/string/builder.h>
 #include <util/system/file.h>
 #include <util/system/rwlock.h>
 #include <util/system/tempfile.h>
@@ -31,7 +31,6 @@ public:
     const TFsPath StatePath;
     const TString ClientId;
     TString SessionId;
-    const TLocalIndexPtr Index;
 
 private:
     struct THandle
@@ -64,6 +63,10 @@ private:
     const ILoggingServicePtr Logging;
     TLog Log;
 
+    const ui32 MaxNodeCount;
+    const ui32 MaxHandleCount;
+
+    TLocalIndex Index;
     THashMap<ui64, std::pair<bool, TInstant>> SubSessions;
 public:
     TSession(
@@ -71,50 +74,51 @@ public:
             const TFsPath& root,
             const TFsPath& statePath,
             TString clientId,
-            TLocalIndexPtr index,
+            ui32 maxNodeCount,
+            ui32 maxHandleCount,
             ILoggingServicePtr logging)
         : Root(root.RealPath())
         , StatePath(statePath.RealPath())
         , ClientId(std::move(clientId))
-        , Index(std::move(index))
         , Logging(std::move(logging))
-    {
-        Log = Logging->CreateLog(fileSystemId + "." + ClientId);
-    }
+        , Log(Logging->CreateLog(fileSystemId + "." + ClientId))
+        , MaxNodeCount(maxNodeCount)
+        , MaxHandleCount(maxHandleCount)
+        , Index(Root, StatePath, MaxNodeCount, Log)
+    {}
 
-    void Init(bool restoreClientSession, ui32 maxHandlesPerSessionCount)
+    void Init(bool restoreClientSession)
     {
         auto handlesPath = StatePath / "handles";
 
-        if (!restoreClientSession || !HasStateFile("session") ||
-            !HasStateFile("fuse_state"))
-        {
+        bool isNewSession = !restoreClientSession || !HasStateFile("session") ||
+                            !HasStateFile("fuse_state");
+
+        if (isNewSession) {
             DeleteStateFile("session");
             DeleteStateFile("fuse_state");
             handlesPath.DeleteIfExists();
 
             SessionId = CreateGuidAsString();
 
-            STORAGE_INFO(
-                "Create session, StatePath=" << StatePath <<
-                ", SessionId=" << SessionId <<
-                ", MaxHandlesPerSessionCount=" << maxHandlesPerSessionCount);
-
             WriteStateFile("session", SessionId);
             WriteStateFile("fuse_state", "");
         } else {
             SessionId = ReadStateFile("session");
             FuseState = ReadStateFile("fuse_state");
-
-            STORAGE_INFO(
-                "Restore existing session, StatePath=" << StatePath <<
-                ", SessionId=" << SessionId <<
-                ", MaxHandlesPerSessionCount=" << maxHandlesPerSessionCount);
         }
+
+        STORAGE_INFO(
+            (isNewSession ? "Create" : "Restore") << " session" <<
+            ", StatePath=" << StatePath <<
+            ", SessionId=" << SessionId <<
+            ", MaxNodeCount=" << MaxNodeCount <<
+            ", MaxHandleCount=" << MaxHandleCount);
+
 
         HandleTable = std::make_unique<THandleTable>(
             handlesPath.GetPath(),
-            maxHandlesPerSessionCount);
+            MaxHandleCount);
 
         ui64 maxHandleId = 0;
         for (auto it = HandleTable->begin(); it != HandleTable->end(); it++) {
@@ -211,7 +215,7 @@ public:
 
     TIndexNodePtr LookupNode(ui64 nodeId)
     {
-        return Index->LookupNode(nodeId);
+        return Index.LookupNode(nodeId);
     }
 
     [[nodiscard]] bool TryInsertNode(
@@ -219,12 +223,12 @@ public:
         ui64 parentNodeId,
         const TString& name)
     {
-        return Index->TryInsertNode(std::move(node), parentNodeId, name);
+        return Index.TryInsertNode(std::move(node), parentNodeId, name);
     }
 
     void ForgetNode(ui64 nodeId)
     {
-        Index->ForgetNode(nodeId);
+        Index.ForgetNode(nodeId);
     }
 
     void Ping(ui64 sessionSeqNo)

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -123,6 +123,7 @@ message TSession
     uint64 MaxSeqNo = 6;
     uint64 MaxRwSeqNo = 7;
     string OriginFqdn = 8;
+    uint64 RecoveryTimestampUs = 9;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -718,17 +718,27 @@ void DumpSessions(IOutputStream& out, const TVector<TMonSessionInfo>& sessions)
             TABLEHEAD() {
                 TABLER() {
                     TABLEH() { out << "ClientId";}
+                    TABLEH() { out << "FQDN";}
                     TABLEH() { out << "SessionId"; }
+                    TABLEH() { out << "Recovery"; }
                     TABLEH() { out << "SeqNo"; }
                     TABLEH() { out << "ReadOnly"; }
                     TABLEH() { out << "Owner"; }
                 }
             }
             for (const auto& session: sessions) {
+                const auto recoveryTimestamp = TInstant::MicroSeconds(
+                    session.ProtoInfo.GetRecoveryTimestampUs());
                 for (const auto& ss: session.SubSessions) {
                     TABLER() {
                         TABLED() { out << session.ProtoInfo.GetClientId(); }
+                        TABLED() { out << session.ProtoInfo.GetOriginFqdn(); }
                         TABLED() { out << session.ProtoInfo.GetSessionId(); }
+                        if (recoveryTimestamp) {
+                            TABLED() { out << recoveryTimestamp; }
+                        } else {
+                            TABLED() { out << ""; }
+                        }
                         TABLED() { out << ss.SeqNo; }
                         TABLED() { out << (ss.ReadOnly ? "True" : "False"); }
                         TABLED() { out << ToString(ss.Owner); }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -215,6 +215,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         Impl->SessionByOwner.emplace(owner, session);
     }
 
+    session->SetRecoveryTimestampUs(Now().MicroSeconds());
+
     return oldOwner;
 }
 

--- a/cloud/storage/core/libs/common/persistent_table.h
+++ b/cloud/storage/core/libs/common/persistent_table.h
@@ -145,48 +145,7 @@ public:
         : FileName(fileName)
         , RecordCount(initialRecordCount)
     {
-        // if file doesn't exist create file with zeroed header
-        TFile file(FileName, OpenAlways | WrOnly);
-        if (file.GetLength() == 0) {
-            file.Resize(CalcFileSize(0));
-        }
-        file.Close();
-
-        FileMap = std::make_unique<TFileMap>(FileName, TMemoryMapCommon::oRdWr);
-        FileMap->Map(0, sizeof(THeader));
-
-        auto* header = reinterpret_cast<THeader*>(FileMap->Ptr());
-        if (header->RecordCount == 0) {
-            header->Version = Version;
-            header->RecordCount = RecordCount;
-            header->HeaderSize = sizeof(THeader);
-            header->RecordSize = sizeof(TRecord);
-            header->CompactedRecordSrcIndex = InvalidIndex;
-            header->CompactedRecordDstIndex = InvalidIndex;
-        }
-
-        Y_ABORT_UNLESS(
-            header->Version == Version,
-            "Invalid header version %d",
-            header->Version);
-        Y_ABORT_UNLESS(
-            header->HeaderSize == sizeof(THeader),
-            "Invalid header size %lu != %lu",
-            header->HeaderSize,
-            sizeof(THeader));
-        Y_ABORT_UNLESS(
-            header->RecordSize == sizeof(TRecord),
-            "Invalid record size %lu != %lu",
-            header->RecordSize,
-            sizeof(TRecord));
-
-        RecordCount = header->RecordCount;
-
-        FileMap->ResizeAndRemap(0, CalcFileSize(RecordCount));
-        HeaderPtr = reinterpret_cast<THeader*>(FileMap->Ptr());
-        RecordsPtr = reinterpret_cast<TRecord*>(HeaderPtr + 1);
-
-        CompactRecords();
+        Init();
     }
 
     H* HeaderData()
@@ -240,7 +199,62 @@ public:
         return NextFreeRecord - FreeRecords.size();
     }
 
+    void Clear()
+    {
+        NextFreeRecord = 0;
+        FileMap->ResizeAndRemap(0, 0);
+        FileMap.reset();
+        FreeRecords.clear();
+        Init();
+    }
+
 private:
+    void Init()
+    {
+        // if file doesn't exist create file with zeroed header
+        TFile file(FileName, OpenAlways | WrOnly);
+        if (file.GetLength() == 0) {
+            file.Resize(CalcFileSize(0));
+        }
+        file.Close();
+
+        FileMap = std::make_unique<TFileMap>(FileName, TMemoryMapCommon::oRdWr);
+        FileMap->Map(0, sizeof(THeader));
+
+        auto* header = reinterpret_cast<THeader*>(FileMap->Ptr());
+        if (header->RecordCount == 0) {
+            header->Version = Version;
+            header->RecordCount = RecordCount;
+            header->HeaderSize = sizeof(THeader);
+            header->RecordSize = sizeof(TRecord);
+            header->CompactedRecordSrcIndex = InvalidIndex;
+            header->CompactedRecordDstIndex = InvalidIndex;
+        }
+
+        Y_ABORT_UNLESS(
+            header->Version == Version,
+            "Invalid header version %d",
+            header->Version);
+        Y_ABORT_UNLESS(
+            header->HeaderSize == sizeof(THeader),
+            "Invalid header size %lu != %lu",
+            header->HeaderSize,
+            sizeof(THeader));
+        Y_ABORT_UNLESS(
+            header->RecordSize == sizeof(TRecord),
+            "Invalid record size %lu != %lu",
+            header->RecordSize,
+            sizeof(TRecord));
+
+        RecordCount = header->RecordCount;
+
+        FileMap->ResizeAndRemap(0, CalcFileSize(RecordCount));
+        HeaderPtr = reinterpret_cast<THeader*>(FileMap->Ptr());
+        RecordsPtr = reinterpret_cast<TRecord*>(HeaderPtr + 1);
+
+        CompactRecords();
+    }
+
     size_t CalcFileSize(size_t recordCount)
     {
         return sizeof(THeader) + recordCount * sizeof(TRecord);


### PR DESCRIPTION
- **issue-2461: support clear operation on persistent table (#2465)**
- **[Fielstore] issue-2461: simplify the local file store index by making it per session. (#2476)**
- **[Fielstore] issue-2461: clear local filestore node cache on umount (#2495)**
- **[Filestore] issue-1861: show client hostname and recovery timestamp in list of active sessions (#2514)**