### PR TITLE
issue-2137: changing default value for GarbageCompactionThresholdAverage 20 -> 10

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -40,7 +40,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(CompactionThreshold,                ui32,   20                        )\
     xxx(GarbageCompactionThreshold,         ui32,   100                       )\
     xxx(CompactionThresholdAverage,         ui32,   4                         )\
-    xxx(GarbageCompactionThresholdAverage,  ui32,   20                        )\
+    xxx(GarbageCompactionThresholdAverage,  ui32,   10                        )\
     xxx(CompactRangeGarbagePercentageThreshold, ui32,    0                    )\
     xxx(CompactRangeAverageBlobSizeThreshold,   ui32,    0                    )\
     xxx(GuestWritebackCacheEnabled,         bool,   false                     )\


### PR DESCRIPTION
10% garbage threshold seems completely reasonable. Right now after all the recent improvements in Compaction the rate of Compactions in real clusters with 20% threshold is really small. We can afford increasing that rate a bit in exchange for storing less garbage. 

#2137 