### PR TITLE
[NBS, Filestore]: Add unix socket path to blockstore and filestore clients

### DIFF
--- a/cloud/blockstore/apps/client/README.md
+++ b/cloud/blockstore/apps/client/README.md
@@ -14,6 +14,7 @@
  * ```--input``` - path to a file from which request data should be read: buffers for ```WriteBlocks``` request or whole request protobuf if ```--proto``` option is specified
  * ```--output``` - path to a file where response data should be written: buffers for ```ReadBlocks``` request or whole response protobuf if ```--proto``` option is specified
  * free argument: the name of request to execute; can be written either in camel case (i.e. ```WriteBlocks```) or as a single lowercase or uppercase word (i.e. ```writeblocks```) or with words separated by hyphens or underscores (i.e. ```write-blocks```).
+ * ```--server-unix-socket-path``` - path to a socket on which the NBS server contacted by the client is listening; not mandatory
 
 ## Options for particular commands
 

--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -144,7 +144,6 @@ TCommand::TCommand(IBlockStorePtr client)
         .RequiredArgument("NUM")
         .StoreResult(&SecurePort);
 
-    // server-unix-socket-path to avoid collision with endpoint-proxy parameter
     Opts.AddLongOption("server-unix-socket-path")
         .RequiredArgument("STR")
         .StoreResult(&ServerUnixSocketPath);

--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -144,6 +144,11 @@ TCommand::TCommand(IBlockStorePtr client)
         .RequiredArgument("NUM")
         .StoreResult(&SecurePort);
 
+    // server-unix-socket-path to avoid collision with endpoint-proxy parameter
+    Opts.AddLongOption("server-unix-socket-path")
+        .RequiredArgument("STR")
+        .StoreResult(&ServerUnixSocketPath);
+
     Opts.AddLongOption("endpoint-proxy-host", "endpoint proxy host")
         .RequiredArgument("STR")
         .StoreResult(&EndpointProxyHost);
@@ -626,6 +631,9 @@ void TCommand::InitClientConfig()
     }
     if (SecurePort) {
         clientConfig.SetSecurePort(SecurePort);
+    }
+    if (ServerUnixSocketPath){
+        clientConfig.SetUnixSocketPath(ServerUnixSocketPath);
     }
     if (clientConfig.GetHost() == "localhost" &&
         clientConfig.GetSecurePort() != 0)

--- a/cloud/blockstore/apps/client/lib/command.h
+++ b/cloud/blockstore/apps/client/lib/command.h
@@ -45,6 +45,7 @@ protected:
     TString Host;
     ui32 InsecurePort = 0;
     ui32 SecurePort = 0;
+    TString ServerUnixSocketPath;
     bool SkipCertVerification = false;
 
     TString EndpointProxyHost;

--- a/cloud/blockstore/tests/loadtest/local-auth/test.py
+++ b/cloud/blockstore/tests/loadtest/local-auth/test.py
@@ -32,6 +32,7 @@ def create_server_app_config():
     server.KikimrServiceConfig.CopyFrom(TKikimrServiceConfig())
     return server
 
+
 def create_storage_service_config(folder_id="test_folder_id"):
     storage = TStorageServiceConfig()
     storage.AuthorizationMode = EAuthorizationMode.Value("AUTHORIZATION_REQUIRE")
@@ -235,6 +236,7 @@ def test_new_auth_unknown_subject():
         result = env.create_volume()
         assert result.returncode != 0
         assert json.loads(result.stdout)["Error"]["CodeString"] == "E_UNAUTHORIZED"
+
 
 def test_unix_socket_does_not_require_auth():
     with TemporaryDirectory(dir="/tmp") as temp_dir:

--- a/cloud/blockstore/tests/loadtest/local-auth/test.py
+++ b/cloud/blockstore/tests/loadtest/local-auth/test.py
@@ -95,13 +95,13 @@ class TestFixture:
         self,
         access_service_type=AccessService,
         folder_id="test_folder_id",
-        unix_socket_path: str | None = None,
+        server_unix_socket_path: str | None = None,
     ):
         server_app_config = create_server_app_config()
-        if unix_socket_path is not None:
-            server_app_config.ServerConfig.UnixSocketPath = unix_socket_path
+        if server_unix_socket_path is not None:
+            server_app_config.ServerConfig.UnixSocketPath = server_unix_socket_path
             server_app_config.ServerConfig.AllowAllRequestsViaUDS = True
-        self.unix_socket_path = unix_socket_path
+        self.server_unix_socket_path = server_unix_socket_path
         storage = create_storage_service_config(folder_id)
         self.__local_load_test = LocalLoadTest(
             "",
@@ -132,8 +132,8 @@ class TestFixture:
             "--config",
             str(self.__client_config_path),
         ]
-        if self.unix_socket_path is not None:
-            args += ["--server-unix-socket-path", self.unix_socket_path]
+        if self.server_unix_socket_path is not None:
+            args += ["--server-unix-socket-path", self.server_unix_socket_path]
         env = {}
         if self.__auth_token is not None:
             env['IAM_TOKEN'] = self.__auth_token

--- a/cloud/blockstore/tests/loadtest/local-auth/test.py
+++ b/cloud/blockstore/tests/loadtest/local-auth/test.py
@@ -240,8 +240,8 @@ def test_new_auth_unknown_subject():
 
 def test_unix_socket_does_not_require_auth():
     with TemporaryDirectory(dir="/tmp") as temp_dir:
-        unix_socket_path = str(Path(temp_dir) / "nbs.sock")
-        with TestFixture(NewAccessService, unix_socket_path=unix_socket_path) as env:
+        server_unix_socket_path = str(Path(temp_dir) / "nbs.sock")
+        with TestFixture(NewAccessService, server_unix_socket_path=server_unix_socket_path) as env:
             token = "some_token"
             env.access_service.create_account(
                 "test_user",

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -98,6 +98,10 @@ TCommand::TCommand()
         .RequiredArgument("NUM")
         .StoreResult(&SecurePort);
 
+    Opts.AddLongOption("server-unix-socket-path")
+        .RequiredArgument("STR")
+        .StoreResult(&ServerUnixSocketPath);
+
     Opts.AddLongOption("skip-cert-verification", "skip server certificate verification")
         .StoreTrue(&SkipCertVerification);
 
@@ -196,6 +200,9 @@ void TCommand::Init()
     }
     if (SecurePort) {
         config.SetSecurePort(SecurePort);
+    }
+    if (ServerUnixSocketPath){
+        config.SetUnixSocketPath(ServerUnixSocketPath);
     }
     if (config.GetHost() == "localhost" &&
         config.GetSecurePort() != 0)

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -52,6 +52,7 @@ protected:
     TString ServerAddress;
     ui32 ServerPort = 0;
     ui32 SecurePort = 0;
+    TString ServerUnixSocketPath;
     bool SkipCertVerification = false;
     TString IamTokenFile;
     TString ConfigFile;

--- a/cloud/filestore/tests/auth/lib/__init__.py
+++ b/cloud/filestore/tests/auth/lib/__init__.py
@@ -40,9 +40,8 @@ class TestFixture:
         self.__client_config_path.write_text(MessageToString(client_config))
 
     def get_client(self, auth_token, use_unix_socket=False):
-        # auth_token should be string, otherwise, iam config will not be created
-        # and for secure connection, filestore client expects iam token config
-        # at the default path, which obviously will not be present.
+        # auth_token MUST be a non-empty string; otherwise, the client will look
+        # for the IAM token config at the default path, which does not exist.
         client = FilestoreCliClient(
             self.__binary_path,
             self.__port,

--- a/cloud/filestore/tests/auth/lib/__init__.py
+++ b/cloud/filestore/tests/auth/lib/__init__.py
@@ -52,5 +52,6 @@ class TestFixture:
             check_exit_code=False,
             return_json=True,
             use_unix_socket=use_unix_socket,
+            verbose=True,
         )
         return client

--- a/cloud/filestore/tests/auth/lib/__init__.py
+++ b/cloud/filestore/tests/auth/lib/__init__.py
@@ -39,7 +39,10 @@ class TestFixture:
         client_config.ClientConfig.SecurePort = int(self.__port)
         self.__client_config_path.write_text(MessageToString(client_config))
 
-    def get_client(self, auth_token):
+    def get_client(self, auth_token, use_unix_socket=False):
+        # auth_token should be string, otherwise, iam config will not be created
+        # and for secure connection, filestore client expects iam token config
+        # at the default path, which obviously will not be present.
         client = FilestoreCliClient(
             self.__binary_path,
             self.__port,
@@ -48,5 +51,6 @@ class TestFixture:
             config_path=str(self.__client_config_path),
             check_exit_code=False,
             return_json=True,
+            use_unix_socket=use_unix_socket,
         )
         return client

--- a/cloud/filestore/tests/auth/new/test.py
+++ b/cloud/filestore/tests/auth/new/test.py
@@ -37,7 +37,7 @@ def test_new_auth_authorization_ok():
 
 def test_unix_socket_does_not_require_auth():
     fixture = TestFixture()
-    client = fixture.get_client("", use_unix_socket=True)
+    client = fixture.get_client("some-token", use_unix_socket=True)
     result = client.create(
         "test_new_auth_unauthorized",
         "some_cloud",

--- a/cloud/filestore/tests/auth/new/test.py
+++ b/cloud/filestore/tests/auth/new/test.py
@@ -35,6 +35,19 @@ def test_new_auth_authorization_ok():
     assert result.returncode == 0
 
 
+def test_unix_socket_does_not_require_auth():
+    fixture = TestFixture()
+    client = fixture.get_client("", use_unix_socket=True)
+    result = client.create(
+        "test_new_auth_unauthorized",
+        "some_cloud",
+        fixture.folder_id,
+        return_stdout=False,
+    )
+    log_result("test_new_auth_unauthorized", result)
+    assert result.returncode == 0
+
+
 def test_new_auth_unauthorized():
     fixture = TestFixture()
     token = "test_auth_token"

--- a/cloud/filestore/tests/auth/new/test.py
+++ b/cloud/filestore/tests/auth/new/test.py
@@ -34,17 +34,17 @@ def test_new_auth_authorization_ok():
     log_result("test_new_auth_authorization_ok", result)
     assert result.returncode == 0
 
-# TODO: enable when unix sockets are enabled
+# TODO: enable when unix sockets without auth are supported
 # def test_unix_socket_does_not_require_auth():
 #     fixture = TestFixture()
 #     client = fixture.get_client("some-token", use_unix_socket=True)
 #     result = client.create(
-#         "test_new_auth_unauthorized",
+#         "test_unix_socket_does_not_require_auth",
 #         "some_cloud",
 #         fixture.folder_id,
 #         return_stdout=False,
 #     )
-#     log_result("test_new_auth_unauthorized", result)
+#     log_result("test_unix_socket_does_not_require_auth", result)
 #     assert result.returncode != 0
 
 

--- a/cloud/filestore/tests/auth/new/test.py
+++ b/cloud/filestore/tests/auth/new/test.py
@@ -34,18 +34,18 @@ def test_new_auth_authorization_ok():
     log_result("test_new_auth_authorization_ok", result)
     assert result.returncode == 0
 
-
-def test_unix_socket_does_not_require_auth():
-    fixture = TestFixture()
-    client = fixture.get_client("some-token", use_unix_socket=True)
-    result = client.create(
-        "test_new_auth_unauthorized",
-        "some_cloud",
-        fixture.folder_id,
-        return_stdout=False,
-    )
-    log_result("test_new_auth_unauthorized", result)
-    assert result.returncode == 0
+# TODO: enable when unix sockets are enabled
+# def test_unix_socket_does_not_require_auth():
+#     fixture = TestFixture()
+#     client = fixture.get_client("some-token", use_unix_socket=True)
+#     result = client.create(
+#         "test_new_auth_unauthorized",
+#         "some_cloud",
+#         fixture.folder_id,
+#         return_stdout=False,
+#     )
+#     log_result("test_new_auth_unauthorized", result)
+#     assert result.returncode != 0
 
 
 def test_new_auth_unauthorized():

--- a/cloud/filestore/tests/auth/new/ya.make
+++ b/cloud/filestore/tests/auth/new/ya.make
@@ -23,6 +23,7 @@ PEERDIR(
     cloud/filestore/tests/python/lib
 )
 
+SET(USE_UNIX_SOCKET, 1)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/access-service-new.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 

--- a/cloud/filestore/tests/auth/new/ya.make
+++ b/cloud/filestore/tests/auth/new/ya.make
@@ -23,7 +23,7 @@ PEERDIR(
     cloud/filestore/tests/python/lib
 )
 
-SET(USE_UNIX_SOCKET, 1)
+SET(USE_UNIX_SOCKET 1)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/access-service-new.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -43,9 +43,9 @@ class FilestoreCliClient:
         self.__check_exit_code = check_exit_code
         self.__return_json = return_json
         if use_unix_socket:
-            self.__unix_socket_path = os.getenv("FILESTORE_RECIPE_UNIX_SOCKET_PATH")
+            self.__server_unix_socket_path = os.getenv("NFS_SERVER_UNIX_SOCKET_PATH")
         else:
-            self.__unix_socket_path = None
+            self.__server_unix_socket_path = None
         if auth_token is not None:
             self.__env = {"IAM_TOKEN": auth_token}
 
@@ -278,8 +278,8 @@ class FilestoreCliClient:
             opts += ["--verbose", "trace"]
         if self.__return_json:
             opts += ["--json"]
-        if self.__unix_socket_path is not None:
-            opts += ["--server-unix-socket-path", self.__unix_socket_path]
+        if self.__server_unix_socket_path is not None:
+            opts += ["--server-unix-socket-path", self.__server_unix_socket_path]
         return opts
 
     def standard_command(input_arg):

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -30,6 +30,7 @@ class FilestoreCliClient:
         auth_token=None,
         check_exit_code=True,
         return_json=False,
+        use_unix_socket=False,
     ):
         self.__binary_path = binary_path
         self.__port = port
@@ -41,6 +42,10 @@ class FilestoreCliClient:
         self.__env = {}
         self.__check_exit_code = check_exit_code
         self.__return_json = return_json
+        if use_unix_socket:
+            self.__unix_socket_path = os.getenv("FILESTORE_RECIPE_UNIX_SOCKET_PATH")
+        else:
+            self.__unix_socket_path = None
         if auth_token is not None:
             self.__env = {"IAM_TOKEN": auth_token}
 
@@ -273,6 +278,8 @@ class FilestoreCliClient:
             opts += ["--verbose", "trace"]
         if self.__return_json:
             opts += ["--json"]
+        if self.__unix_socket_path is not None:
+            opts += ["--server-unix-socket-path", self.__unix_socket_path]
         return opts
 
     def standard_command(input_arg):

--- a/cloud/filestore/tests/recipes/service-kikimr.inc
+++ b/cloud/filestore/tests/recipes/service-kikimr.inc
@@ -33,3 +33,7 @@ USE_RECIPE(
     cloud/filestore/tests/recipes/service-kikimr/service-kikimr-recipe
     ${RECIPE_ARGS}
 )
+
+IF (USE_UNIX_SOCKET)
+    SET_APPEND(RECIPE_ARGS --use-unix-socket)
+ENDIF()

--- a/cloud/filestore/tests/recipes/service-kikimr.inc
+++ b/cloud/filestore/tests/recipes/service-kikimr.inc
@@ -29,11 +29,11 @@ IF (NOT OPENSOURCE OR NFS_FORCE_VERBOSE)
     SET_APPEND(RECIPE_ARGS --verbose)
 ENDIF()
 
+IF (USE_UNIX_SOCKET)
+    SET_APPEND(RECIPE_ARGS --use-unix-socket)
+ENDIF()
+
 USE_RECIPE(
     cloud/filestore/tests/recipes/service-kikimr/service-kikimr-recipe
     ${RECIPE_ARGS}
 )
-
-IF (USE_UNIX_SOCKET)
-    SET_APPEND(RECIPE_ARGS --use-unix-socket)
-ENDIF()

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -78,9 +78,10 @@ def start(argv):
                 TStorageConfig())
     if args.use_unix_socket:
         # Create in temp directory because we would like a shorter path
-        unix_socket_path = str(pathlib.Path(tempfile.mkdtemp(dir="/tmp")) / "filestore.sock")
-        set_env("FILESTORE_RECIPE_UNIX_SOCKET_PATH", unix_socket_path)
-        server_config.ServerConfig.UnixSocketPath = unix_socket_path
+        server_unix_socket_path = str(
+            pathlib.Path(tempfile.mkdtemp(dir="/tmp")) / "filestore.sock")
+        set_env("NFS_SERVER_UNIX_SOCKET_PATH", server_unix_socket_path)
+        server_config.ServerConfig.UnixSocketPath = server_unix_socket_path
 
     secure = False
     if access_service_port:

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -1,6 +1,8 @@
 import argparse
 import logging
 import os
+import pathlib
+import tempfile
 
 import yatest.common as common
 import google.protobuf.text_format as text_format
@@ -35,6 +37,7 @@ def start(argv):
     parser.add_argument("--restart-interval", action="store", default=None)
     parser.add_argument("--storage-config-patch", action="store", default=None)
     parser.add_argument("--bs-cache-file-path", action="store", default=None)
+    parser.add_argument("--use-unix-socket", action="store_true", default=None)
     args = parser.parse_args(argv)
 
     kikimr_binary_path = common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
@@ -73,6 +76,11 @@ def start(argv):
             storage_config = text_format.Parse(
                 p.read(),
                 TStorageConfig())
+    if args.use_unix_socket:
+        # Create in temp directory because we would like a shorted path
+        unix_socket_path = pathlib.Path(tempfile.mkdtemp(dir="/tmp"))
+        set_env("FILESTORE_RECIPE_UNIX_SOCKET_PATH", unix_socket_path)
+        server_config.ServerConfig.UnixSocketPath = unix_socket_path
 
     secure = False
     if access_service_port:

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -37,7 +37,7 @@ def start(argv):
     parser.add_argument("--restart-interval", action="store", default=None)
     parser.add_argument("--storage-config-patch", action="store", default=None)
     parser.add_argument("--bs-cache-file-path", action="store", default=None)
-    parser.add_argument("--use-unix-socket", action="store_true", default=None)
+    parser.add_argument("--use-unix-socket", action="store_true", default=False)
     args = parser.parse_args(argv)
 
     kikimr_binary_path = common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
@@ -77,8 +77,8 @@ def start(argv):
                 p.read(),
                 TStorageConfig())
     if args.use_unix_socket:
-        # Create in temp directory because we would like a shorted path
-        unix_socket_path = pathlib.Path(tempfile.mkdtemp(dir="/tmp"))
+        # Create in temp directory because we would like a shorter path
+        unix_socket_path = str(pathlib.Path(tempfile.mkdtemp(dir="/tmp")) / "filestore.sock")
         set_env("FILESTORE_RECIPE_UNIX_SOCKET_PATH", unix_socket_path)
         server_config.ServerConfig.UnixSocketPath = unix_socket_path
 


### PR DESCRIPTION
* Add a server-unix-socket-path argument for blockstore and filestore clients.
* Add option to listen on the unix socket in the filestore recipe.
* Add tests which check that the unix socket server does not require authorization.
