### PR TITLE
Introduce GetDeviceForRange method and companion for it

### DIFF
--- a/cloud/blockstore/libs/storage/core/forward_helpers.h
+++ b/cloud/blockstore/libs/storage/core/forward_helpers.h
@@ -114,4 +114,23 @@ inline TGuardedSgList GetSglist(const NProto::TWriteBlocksLocalRequest& request)
     return request.Sglist;
 }
 
+template <typename TEvent>
+void ForwardMessageToActor(
+    TEvent& ev,
+    const NActors::TActorContext& ctx,
+    NActors::TActorId destActor)
+{
+    NActors::TActorId nondeliveryActor = ev->GetForwardOnNondeliveryRecipient();
+    auto message = std::make_unique<NActors::IEventHandle>(
+        destActor,
+        ev->Sender,
+        ev->ReleaseBase().Release(),
+        ev->Flags,
+        ev->Cookie,
+        ev->Flags & NActors::IEventHandle::FlagForwardOnNondelivery
+            ? &nondeliveryActor
+            : nullptr);
+    ctx.Send(std::move(message));
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/forward_helpers.h
+++ b/cloud/blockstore/libs/storage/core/forward_helpers.h
@@ -7,8 +7,6 @@
 #include <cloud/blockstore/libs/storage/partition_common/model/blob_markers.h>
 #include <cloud/storage/core/libs/common/compressed_bitmap.h>
 
-#include <util/generic/hash_set.h>
-
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -114,15 +112,17 @@ inline TGuardedSgList GetSglist(const NProto::TWriteBlocksLocalRequest& request)
     return request.Sglist;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 template <typename TEvent>
 void ForwardMessageToActor(
     TEvent& ev,
     const NActors::TActorContext& ctx,
-    NActors::TActorId destActor)
+    NActors::TActorId dstActor)
 {
     NActors::TActorId nondeliveryActor = ev->GetForwardOnNondeliveryRecipient();
     auto message = std::make_unique<NActors::IEventHandle>(
-        destActor,
+        dstActor,
         ev->Sender,
         ev->ReleaseBase().Release(),
         ev->Flags,
@@ -132,5 +132,7 @@ void ForwardMessageToActor(
             : nullptr);
     ctx.Send(std::move(message));
 }
+
+////////////////////////////////////////////////////////////////////////////////
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.cpp
@@ -1,0 +1,89 @@
+#include "get_device_for_range_companion.h"
+
+#include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/blockstore/libs/storage/core/forward_helpers.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/config.h>
+#include <cloud/storage/core/libs/actors/helpers.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TGetDeviceForRangeCompanion::TGetDeviceForRangeCompanion() = default;
+
+TGetDeviceForRangeCompanion::TGetDeviceForRangeCompanion(
+        TNonreplicatedPartitionConfigPtr partConfig)
+    : PartConfig(std::move(partConfig))
+{}
+
+void TGetDeviceForRangeCompanion::SetDelegate(NActors::TActorId delegate)
+{
+    Delegate = delegate;
+}
+
+void TGetDeviceForRangeCompanion::HandleGetDeviceForRange(
+    const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx) const
+{
+    const auto* msg = ev->Get();
+
+    if (Delegate) {
+        ForwardMessageToActor(ev, ctx, Delegate);
+        return;
+    }
+
+    if (!PartConfig) {
+        auto response = std::make_unique<
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>(MakeError(
+            E_INVALID_STATE,
+            "GetDeviceForRange companion not initialized"));
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return;
+    }
+
+    auto requests = PartConfig->ToDeviceRequests(msg->BlockRange);
+    if (requests.size() != 1) {
+        ReplyCanNotUseDirectCopy(ev, ctx);
+        return;
+    }
+
+    auto response = std::make_unique<
+        TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+
+    response->Device = requests[0].Device;
+    response->DeviceBlockRange = requests[0].DeviceBlockRange;
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+void TGetDeviceForRangeCompanion::RejectGetDeviceForRange(
+    const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx) const
+{
+    auto response = std::make_unique<
+        TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>(
+        MakeError(E_REJECTED, "GetDeviceForRange request rejected"));
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+void TGetDeviceForRangeCompanion::ReplyCanNotUseDirectCopy(
+    const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx) const
+{
+    const auto* msg = ev->Get();
+
+    NCloud::Reply(
+        ctx,
+        *ev,
+        std::make_unique<
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>(MakeError(
+            E_ABORTED,
+            TStringBuilder() << "Can't use direct range copying for "
+                             << DescribeRange(msg->BlockRange))));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
@@ -18,14 +18,23 @@ namespace NCloud::NBlockStore::NStorage {
 // responds to requests with an error.
 class TGetDeviceForRangeCompanion
 {
+public:
+    enum class EAllowedOperation
+    {
+        Read,       // Reply with an error to requests intended for writing
+        ReadWrite   // Requests with any purpose are allowed
+    };
+
 private:
+    EAllowedOperation AllowedOperation = EAllowedOperation::Read;
     const TNonreplicatedPartitionConfigPtr PartConfig;
     NActors::TActorId Delegate;
 
 public:
-    TGetDeviceForRangeCompanion();
+    explicit TGetDeviceForRangeCompanion(EAllowedOperation allowedOperation);
 
-    explicit TGetDeviceForRangeCompanion(
+    TGetDeviceForRangeCompanion(
+        EAllowedOperation allowedOperation,
         TNonreplicatedPartitionConfigPtr partConfig);
 
     void SetDelegate(NActors::TActorId delegate);

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cloud/blockstore/libs/storage/core/public.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A companion for processing EvGetDeviceForRangeRequest requests. Finds how
+// many requests needs for processing the range. If only one request is
+// needed, then everything is fine, request can be executed in direct
+// DiskAgent-to-DiskAgent mode.
+// Performs the work himself, if the PartConfig is set, or delegates it to
+// another actor if it set via SetDelegate method. If neither is done, it
+// responds to requests with an error.
+class TGetDeviceForRangeCompanion
+{
+private:
+    const TNonreplicatedPartitionConfigPtr PartConfig;
+    NActors::TActorId Delegate;
+
+public:
+    TGetDeviceForRangeCompanion();
+
+    explicit TGetDeviceForRangeCompanion(
+        TNonreplicatedPartitionConfigPtr partConfig);
+
+    void SetDelegate(NActors::TActorId delegate);
+
+    void HandleGetDeviceForRange(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+    void RejectGetDeviceForRange(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+    void ReplyCanNotUseDirectCopy(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/ya.make
+++ b/cloud/blockstore/libs/storage/partition_common/ya.make
@@ -8,7 +8,7 @@ SRCS(
     actor_loadfreshblobs.cpp
     actor_trimfreshlog.cpp
     drain_actor_companion.cpp
-    get_changed_blocks_companion.cpp
+    get_device_for_range_companion.cpp
     long_running_operation_companion.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition_common/ya.make
+++ b/cloud/blockstore/libs/storage/partition_common/ya.make
@@ -8,6 +8,7 @@ SRCS(
     actor_loadfreshblobs.cpp
     actor_trimfreshlog.cpp
     drain_actor_companion.cpp
+    get_changed_blocks_companion.cpp
     long_running_operation_companion.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -547,6 +547,9 @@ STFUNC(TMirrorPartitionActor::StateWork)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            HandleGetDeviceForRange);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, HandleGetCompactionStatus);
@@ -597,6 +600,9 @@ STFUNC(TMirrorPartitionActor::StateZombie)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.RejectGetDeviceForRange);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, RejectDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, RejectGetCompactionStatus);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -17,6 +17,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -64,6 +65,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         DiskId};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion;
 
     TRequestInfoPtr Poisoner;
     size_t AliveReplicas = 0;
@@ -148,6 +150,10 @@ private:
 
     void HandleRangeResynced(
         const TEvNonreplPartitionPrivate::TEvRangeResynced::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleGetDeviceForRange(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandlePoisonPill(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -65,7 +65,8 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         DiskId};
-    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion;
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
+        TGetDeviceForRangeCompanion::EAllowedOperation::Read};
 
     TRequestInfoPtr Poisoner;
     size_t AliveReplicas = 0;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_get_device_for_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_get_device_for_range.cpp
@@ -40,7 +40,8 @@ void TMirrorPartitionActor::HandleGetDeviceForRange(
         return;
     }
 
-    ForwardMessageToActor(ev, ctx, replicaActorId);
+    GetDeviceForRangeCompanion.SetDelegate(replicaActorId);
+    GetDeviceForRangeCompanion.HandleGetDeviceForRange(ev, ctx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_get_device_for_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_get_device_for_range.cpp
@@ -1,0 +1,46 @@
+#include "part_mirror_actor.h"
+
+#include <cloud/blockstore/libs/storage/core/forward_helpers.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TMirrorPartitionActor::HandleGetDeviceForRange(
+    const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto replyError = [&](NProto::TError error)
+    {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>(
+                std::move(error)));
+    };
+
+    if (ResyncRangeStarted && GetScrubbingRange().Overlaps(msg->BlockRange)) {
+        replyError(MakeError(
+            E_REJECTED,
+            TStringBuilder() << "Request GetDeviceForRange intersects with "
+                                "currently resyncing range"));
+        return;
+    }
+
+    TActorId replicaActorId;
+    auto error = State.NextReadReplica(msg->BlockRange, &replicaActorId);
+
+    if (HasError(error)) {
+        replyError(std::move(error));
+        return;
+    }
+
+    ForwardMessageToActor(ev, ctx, replicaActorId);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
@@ -110,6 +110,8 @@ void TMirrorPartitionResyncActor::SetupPartitions(const TActorContext& ctx)
             SelfId(),
             SelfId()));
 
+    GetDeviceForRangeCompanion.SetDelegate(MirrorActorId);
+
     const auto& replicaInfos = State.GetReplicaInfos();
     for (ui32 i = 0; i < replicaInfos.size(); i++) {
         IActorPtr actor = CreateNonreplicatedPartition(
@@ -254,6 +256,9 @@ STFUNC(TMirrorPartitionResyncActor::StateWork)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            HandleGetDeviceForRange);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, HandleGetCompactionStatus);
@@ -305,6 +310,9 @@ STFUNC(TMirrorPartitionResyncActor::StateZombie)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.RejectGetDeviceForRange);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, RejectDescribeBlocks);
         HFunc(TEvVolume::TEvGetCompactionStatusRequest, RejectGetCompactionStatus);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
@@ -63,7 +63,8 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         PartConfig->GetName()};
-    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion;
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
+        TGetDeviceForRangeCompanion::EAllowedOperation::Read};
 
     TRequestInfoPtr Poisoner;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
@@ -17,6 +17,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -62,6 +63,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         PartConfig->GetName()};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion;
 
     TRequestInfoPtr Poisoner;
 
@@ -201,6 +203,10 @@ private:
     void SendReadBlocksResponse(
         const NProto::TError& error,
         const TFastPathRecord& record,
+        const NActors::TActorContext& ctx);
+
+    void HandleGetDeviceForRange(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_readblocks.cpp
@@ -299,4 +299,17 @@ void TMirrorPartitionResyncActor::HandleReadResyncFastPathResponse(
     FastPathRecords.erase(ev->Cookie);
 }
 
+void TMirrorPartitionResyncActor::HandleGetDeviceForRange(
+    const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    bool canUseDirectCopy = ResyncFinished || State.IsResynced(msg->BlockRange);
+    if (canUseDirectCopy) {
+        GetDeviceForRangeCompanion.HandleGetDeviceForRange(ev, ctx);
+    } else {
+        GetDeviceForRangeCompanion.ReplyCanNotUseDirectCopy(ev, ctx);
+    }
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
@@ -94,9 +94,12 @@ struct TResyncController
 
     void WaitForResyncedRangeCount(ui32 count)
     {
-        while (ResyncedRanges.size() < count) {
-            Runtime.DispatchEvents({}, ResyncNextRangeInterval);
-        }
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return ResyncedRanges.size() >= count;
+        };
+        Runtime.DispatchEvents(options, ResyncNextRangeInterval);
     }
 
     void WaitForResyncFinished()
@@ -1299,6 +1302,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionResyncTest)
 
         if (afterResync) {
             env.ResyncController.WaitForResyncedRangeCount(5);
+            env.ResyncController.WaitForResyncFinished();
             UNIT_ASSERT(env.ResyncController.ResyncFinished);
         }
 
@@ -1344,6 +1348,95 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionResyncTest)
     Y_UNIT_TEST(ShouldTreatFreshDevicesProperlyDuringResync)
     {
         DoTestShouldTreatFreshDevicesProperly(false);
+    }
+
+    Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        // Resync first range [0..1023]
+        env.CatchEvents(TEvNonreplPartitionPrivate::EvResyncNextRange);
+        env.StartResync();
+        env.ReleaseEvents();
+        env.ResyncController.WaitForResyncedRangeCount(1);
+
+        {   // Request to first device over an already resynchronized range
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(0, 10)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response->Device.GetDeviceUUID(),
+                "vasya");
+        }
+        {   // Request over not synced range
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(1024, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
+        }
+
+        // Resync second range [1024..2047].
+        env.ResyncController.WaitForResyncedRangeCount(2);
+
+        {
+            // Request to first device over an already resynchronized range
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(1024, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response->Device.GetDeviceUUID(),
+                "vasya");
+        }
+
+        // Resync range [2048..3095].
+        env.ResyncController.WaitForResyncedRangeCount(3);
+
+        {   // Request to second device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2048, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response->Device.GetDeviceUUID(),
+                "petya");
+        }
+        {   // Request on the border of two devices
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 16)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -1,6 +1,5 @@
 #include "part_mirror.h"
 #include "part_mirror_actor.h"
-#include "part_mirror_resync_util.h"
 #include "part_nonrepl_actor.h"
 #include "ut_env.h"
 
@@ -27,11 +26,24 @@
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
-using namespace NKikimr;
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+class TTestRuntime: public TTestBasicRuntime
+{
+public:
+    TTestRuntime()
+    {
+        SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+    }
+};
 
 struct TTestEnv
 {
@@ -245,7 +257,7 @@ struct TTestEnv
             )
         );
 
-        SetupTabletServices(Runtime);
+        NKikimr::SetupTabletServices(Runtime);
     }
 
     void AddReplica(
@@ -324,14 +336,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     Y_UNIT_TEST(ShouldReadWriteZero)
     {
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -486,14 +491,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     Y_UNIT_TEST(ShouldLocalReadWrite)
     {
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -587,14 +585,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     Y_UNIT_TEST(ShouldMirrorWriteAndZeroRequests)
     {
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         THashMap<TString, TBlockRange64> device2WriteRange;
         THashMap<TString, TBlockRange64> device2ZeroRange;
@@ -706,14 +697,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     Y_UNIT_TEST(ShouldNotReadFromFreshDevices)
     {
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         const THashSet<TString> freshDeviceIds{"vasya", "vasya#1", "petya#2"};
         TTestEnv env(
@@ -799,7 +783,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     struct TMigrationTestRuntime
     {
-        TTestBasicRuntime Runtime;
+        TTestRuntime Runtime;
 
         TString DiskId;
         TString SourceDeviceId;
@@ -988,14 +972,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     void DoShouldTransformAnyErrorToRetriable(NProto::TError error)
     {
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -1133,14 +1110,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     Y_UNIT_TEST(ShouldReportSimpleCounters)
     {
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -1180,13 +1150,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
     {
         using namespace NMonitoring;
 
-        TTestBasicRuntime runtime;
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -1207,14 +1171,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
     {
         using namespace NMonitoring;
 
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TDynamicCountersPtr critEventsCounters = new TDynamicCounters();
         InitCriticalEventsCounter(critEventsCounters);
@@ -1270,13 +1227,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         TDynamicCountersPtr counters = new TDynamicCounters();
         InitCriticalEventsCounter(counters);
 
-        TTestBasicRuntime runtime;
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -1341,13 +1292,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         TDynamicCountersPtr counters = new TDynamicCounters();
         InitCriticalEventsCounter(counters);
 
-        TTestBasicRuntime runtime;
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -1451,13 +1396,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         TDynamicCountersPtr critEventsCounters = new TDynamicCounters();
         InitCriticalEventsCounter(critEventsCounters);
 
-        TTestBasicRuntime runtime;
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-            {
-                Y_UNUSED(parentId);
-                runtime.EnableScheduleForActor(actorId);
-            });
+        TTestRuntime runtime;
 
         TTestEnv env(runtime);
 
@@ -1532,14 +1471,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
     {
         using namespace NMonitoring;
 
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         TAutoPtr<IEventHandle> delayedRangeResynced;
         runtime.SetEventFilter([&] (auto& runtime, auto& event) {
@@ -1639,14 +1571,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
     {
         using namespace NMonitoring;
 
-        TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
+        TTestRuntime runtime;
 
         ui32 rangeResynced = 0;
         runtime.SetEventFilter([&] (auto& runtime, auto& event) {
@@ -1802,6 +1727,161 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
             2,
             mirroredDiskChecksumMismatchUponRead->Val());
     }
+
+    Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
+    {
+        TTestRuntime runtime;
+        TTestEnv env(runtime);
+        TPartitionClient client(runtime, env.ActorId);
+
+        {   // Request to first device #1
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 8)));
+            auto response1 = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response1->GetStatus()),
+                response1->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response1->Device.GetDeviceUUID(),
+                "vasya");
+
+            // Request to first device #2
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 8)));
+            auto response2 = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response2->GetStatus()),
+                response2->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response2->Device.GetDeviceUUID(),
+                "vasya");
+
+            // Replicas are rotated and requests should return different
+            // devices.
+            UNIT_ASSERT_STRINGS_UNEQUAL(
+                response1->Device.GetDeviceUUID(),
+                response2->Device.GetDeviceUUID());
+        }
+        {
+            // Request to second device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2048, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response->Device.GetDeviceUUID(),
+                "petya");
+        }
+
+        {   // Request on the border of two devices
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 16)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequestWhenResync)
+    {
+        TTestRuntime runtime;
+
+        // Block range resync finish.
+        bool rangeResyncedCatched = false;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() ==
+                    TEvNonreplPartitionPrivate::EvRangeResynced)
+                {
+                    rangeResyncedCatched = true;
+                    return true;
+                }
+                return false;
+            });
+
+        TTestEnv env(runtime);
+        TPartitionClient client(runtime, env.ActorId);
+
+        const auto range = TBlockRange64::WithLength(0, 1024);
+
+        env.WriteReplica(0, range, 'A');
+        env.WriteReplica(1, range, 'B');
+        env.WriteReplica(2, range, 'B');
+
+        // Start resync of range [0..1023]
+        runtime.AdvanceCurrentTime(
+            env.Config->GetScrubbingChecksumMismatchTimeout());
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return rangeResyncedCatched;
+        };
+        runtime.DispatchEvents(options, TDuration::Seconds(1));
+        UNIT_ASSERT(rangeResyncedCatched);
+
+        {   // Request to resyncing range
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(0, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetError().GetCode(),
+                response->GetErrorReason());
+        }
+        {   // Request overlaps with resyncing range
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(1020, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetError().GetCode(),
+                response->GetErrorReason());
+        }
+        {
+            // Request to not resyncing range
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(1024, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_STRING_CONTAINS(
+                response->Device.GetDeviceUUID(),
+                "vasya");
+        }
+    }
+
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -538,6 +538,9 @@ STFUNC(TNonreplicatedPartitionActor::StateWork)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.HandleGetDeviceForRange);
 
         HFunc(TEvNonreplPartitionPrivate::TEvReadBlocksCompleted, HandleReadBlocksCompleted);
         HFunc(TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted, HandleWriteBlocksCompleted);
@@ -580,6 +583,9 @@ STFUNC(TNonreplicatedPartitionActor::StateZombie)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.RejectGetDeviceForRange);
 
         HFunc(TEvNonreplPartitionPrivate::TEvReadBlocksCompleted, HandleReadBlocksCompleted);
         HFunc(TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted, HandleWriteBlocksCompleted);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -88,7 +88,9 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
-    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{PartConfig};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
+        TGetDeviceForRangeCompanion::EAllowedOperation::ReadWrite,
+        PartConfig};
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -12,6 +12,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -87,6 +88,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{PartConfig};
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -205,7 +205,19 @@ struct TEvNonreplPartitionPrivate
 
     struct TGetDeviceForRangeRequest
     {
+        enum class EPurpose
+        {
+            ForReading,
+            ForWriting
+        };
+
+        EPurpose Purpose;
         TBlockRange64 BlockRange;
+
+        TGetDeviceForRangeRequest(EPurpose purpose, TBlockRange64 blockRange)
+            : Purpose(purpose)
+            , BlockRange(blockRange)
+        {}
     };
 
     struct TGetDeviceForRangeResponse

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/config.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 #include <cloud/blockstore/libs/storage/protos/part.pb.h>
 
@@ -199,6 +200,21 @@ struct TEvNonreplPartitionPrivate
     };
 
     //
+    // GetDeviceForRange
+    //
+
+    struct TGetDeviceForRangeRequest
+    {
+        TBlockRange64 BlockRange;
+    };
+
+    struct TGetDeviceForRangeResponse
+    {
+        NProto::TDeviceConfig Device;
+        TBlockRange64 DeviceBlockRange;
+    };
+
+    //
     // Events declaration
     //
 
@@ -219,6 +235,8 @@ struct TEvNonreplPartitionPrivate
         EvResyncNextRange,
         EvRangeResynced,
         EvReadResyncFastPathResponse,
+        EvGetDeviceForRangeRequest,
+        EvGetDeviceForRangeResponse,
 
         BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(BLOCKSTORE_DECLARE_EVENT_IDS)
 
@@ -268,6 +286,15 @@ struct TEvNonreplPartitionPrivate
     using TEvReadResyncFastPathResponse = TResponseEvent<
         TReadResyncFastPathResponse,
         EvReadResyncFastPathResponse
+    >;
+
+    using TEvGetDeviceForRangeRequest = TResponseEvent<
+        TGetDeviceForRangeRequest,
+        EvGetDeviceForRangeRequest
+    >;
+    using TEvGetDeviceForRangeResponse = TResponseEvent<
+        TGetDeviceForRangeResponse,
+        EvGetDeviceForRangeResponse
     >;
 
     BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(BLOCKSTORE_DECLARE_PROTO_EVENTS)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -167,6 +167,9 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateWork)
             NPartition::TEvPartition::TEvDrainRequest,
             DrainActorCompanion.HandleDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.HandleGetDeviceForRange);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocks);
         HFunc(
@@ -227,6 +230,10 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateZombie)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
+        HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.RejectGetDeviceForRange);
 
         HFunc(TEvVolume::TEvDescribeBlocksRequest, RejectDescribeBlocks);
         HFunc(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -118,7 +118,8 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         DiskId};
-    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion;
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
+        TGetDeviceForRangeCompanion::EAllowedOperation::ReadWrite};
 
     // Statistics
     const NActors::TActorId StatActorId;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -13,6 +13,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/changed_ranges_map.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set.h>
@@ -117,6 +118,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         DiskId};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion;
 
     // Statistics
     const NActors::TActorId StatActorId;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -34,6 +34,8 @@ void TNonreplicatedPartitionMigrationCommonActor::InitWork(
     PoisonPillHelper.TakeOwnership(ctx, SrcActorId);
     PoisonPillHelper.TakeOwnership(ctx, DstActorId);
 
+    GetDeviceForRangeCompanion.SetDelegate(SrcActorId);
+
     if (DstActorId == NActors::TActorId{}) {
         ProcessingBlocks.AbortProcessing();
     } else {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -676,6 +676,66 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
 
         UNIT_ASSERT_VALUES_EQUAL(2, failedPartitionRequestCount);
     }
+
+    Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
+    {
+        TTestBasicRuntime runtime;
+
+        auto migrationState = std::make_shared<TMigrationState>();
+        migrationState->IsMigrationAllowed = false;
+
+        TTestEnv env(
+            runtime,
+            TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
+            TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
+            NProto::VOLUME_IO_OK,
+            false,
+            migrationState);
+        TPartitionClient client(runtime, env.ActorId);
+
+        migrationState->IsMigrationAllowed = true;
+
+        {   // Request to first device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL("vasya", response->Device.GetDeviceUUID());
+        }
+
+        WaitForMigrations(runtime, 3);
+
+        {
+            // Request to second device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2048, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL("petya", response->Device.GetDeviceUUID());
+        }
+        {   // Request on the border of two devices
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 16)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -679,6 +679,12 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
 
     Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
     {
+        using TEvGetDeviceForRangeRequest =
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest;
+        using TEvGetDeviceForRangeResponse =
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse;
+        using EPurpose = TEvGetDeviceForRangeRequest::EPurpose;
+
         TTestBasicRuntime runtime;
 
         auto migrationState = std::make_shared<TMigrationState>();
@@ -698,15 +704,17 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         {   // Request to first device
             client.SendRequest(
                 env.ActorId,
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                std::make_unique<TEvGetDeviceForRangeRequest>(
+                    EPurpose::ForReading,
                     TBlockRange64::WithLength(2040, 8)));
-            auto response = client.RecvResponse<
-                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_C(
                 SUCCEEDED(response->GetStatus()),
                 response->GetErrorReason());
             UNIT_ASSERT_VALUES_EQUAL("vasya", response->Device.GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(
+                TBlockRange64::WithLength(2040, 8),
+                response->DeviceBlockRange);
         }
 
         WaitForMigrations(runtime, 3);
@@ -715,24 +723,25 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             // Request to second device
             client.SendRequest(
                 env.ActorId,
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                std::make_unique<TEvGetDeviceForRangeRequest>(
+                    EPurpose::ForWriting,
                     TBlockRange64::WithLength(2048, 8)));
-            auto response = client.RecvResponse<
-                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_C(
                 SUCCEEDED(response->GetStatus()),
                 response->GetErrorReason());
             UNIT_ASSERT_VALUES_EQUAL("petya", response->Device.GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(
+                TBlockRange64::WithLength(0, 8),
+                response->DeviceBlockRange);
         }
         {   // Request on the border of two devices
             client.SendRequest(
                 env.ActorId,
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                std::make_unique<TEvGetDeviceForRangeRequest>(
+                    EPurpose::ForReading,
                     TBlockRange64::WithLength(2040, 16)));
-            auto response = client.RecvResponse<
-                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -558,6 +558,9 @@ STFUNC(TNonreplicatedPartitionRdmaActor::StateWork)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.HandleGetDeviceForRange);
 
         HFunc(TEvService::TEvReadBlocksLocalRequest, HandleReadBlocksLocal);
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);
@@ -615,6 +618,9 @@ STFUNC(TNonreplicatedPartitionRdmaActor::StateZombie)
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.RejectGetDeviceForRange);
 
         HFunc(TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest, RejectChecksumBlocks);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -56,7 +56,9 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
-    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{PartConfig};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
+        TGetDeviceForRangeCompanion::EAllowedOperation::ReadWrite,
+        PartConfig};
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -13,6 +13,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -55,6 +56,7 @@ private:
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{PartConfig};
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
@@ -1196,6 +1196,52 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionRdmaTest)
             }
         }
     }
+
+    Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        env.Rdma().InitAllEndpoints();
+        TPartitionClient client(runtime, env.ActorId);
+
+        {   // Request to first device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL("vasya", response->Device.GetDeviceUUID());
+        }
+        {
+            // Request to second device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2048, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL("petya", response->Device.GetDeviceUUID());
+        }
+        {   // Request on the border of two devices
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 16)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
@@ -1199,6 +1199,12 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionRdmaTest)
 
     Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
     {
+        using TEvGetDeviceForRangeRequest =
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest;
+        using TEvGetDeviceForRangeResponse =
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse;
+        using EPurpose = TEvGetDeviceForRangeRequest::EPurpose;
+
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         env.Rdma().InitAllEndpoints();
@@ -1207,38 +1213,41 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionRdmaTest)
         {   // Request to first device
             client.SendRequest(
                 env.ActorId,
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                std::make_unique<TEvGetDeviceForRangeRequest>(
+                    EPurpose::ForReading,
                     TBlockRange64::WithLength(2040, 8)));
-            auto response = client.RecvResponse<
-                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_C(
                 SUCCEEDED(response->GetStatus()),
                 response->GetErrorReason());
             UNIT_ASSERT_VALUES_EQUAL("vasya", response->Device.GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(
+                TBlockRange64::WithLength(2040, 8),
+                response->DeviceBlockRange);
         }
         {
             // Request to second device
             client.SendRequest(
                 env.ActorId,
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                std::make_unique<TEvGetDeviceForRangeRequest>(
+                    EPurpose::ForWriting,
                     TBlockRange64::WithLength(2048, 8)));
-            auto response = client.RecvResponse<
-                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_C(
                 SUCCEEDED(response->GetStatus()),
                 response->GetErrorReason());
             UNIT_ASSERT_VALUES_EQUAL("petya", response->Device.GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(
+                TBlockRange64::WithLength(0, 8),
+                response->DeviceBlockRange);
         }
         {   // Request on the border of two devices
             client.SendRequest(
                 env.ActorId,
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                std::make_unique<TEvGetDeviceForRangeRequest>(
+                    EPurpose::ForReading,
                     TBlockRange64::WithLength(2040, 16)));
-            auto response = client.RecvResponse<
-                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -1916,6 +1916,51 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         // identical.
         UNIT_ASSERT_EQUAL(buffer, buffer2);
     }
+
+    Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        TPartitionClient client(runtime, env.ActorId);
+
+        {   // Request to first device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL("vasya", response->Device.GetDeviceUUID());
+        }
+        {
+            // Request to second device
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2048, 8)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL("petya", response->Device.GetDeviceUUID());
+        }
+        {   // Request on the border of two devices
+            client.SendRequest(
+                env.ActorId,
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+                    TBlockRange64::WithLength(2040, 16)));
+            auto response = client.RecvResponse<
+                TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -11,6 +11,7 @@ SRCS(
 
     part_mirror.cpp
     part_mirror_actor.cpp
+    part_mirror_actor_get_device_for_range.cpp
     part_mirror_actor_mirror.cpp
     part_mirror_actor_readblocks.cpp
     part_mirror_actor_stats.cpp

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/config.h>
@@ -26,25 +27,6 @@ TString MakeShadowDiskClientId(
         return TString(ShadowDiskClientId);
     }
     return sourceDiskClientId;
-}
-
-template <typename TEvent>
-void ForwardMessageToActor(
-    TEvent& ev,
-    const NActors::TActorContext& ctx,
-    TActorId destActor)
-{
-    NActors::TActorId nondeliveryActor = ev->GetForwardOnNondeliveryRecipient();
-    auto message = std::make_unique<IEventHandle>(
-        destActor,
-        ev->Sender,
-        ev->ReleaseBase().Release(),
-        ev->Flags,
-        ev->Cookie,
-        ev->Flags & NActors::IEventHandle::FlagForwardOnNondelivery
-            ? &nondeliveryActor
-            : nullptr);
-    ctx.Send(std::move(message));
 }
 
 TString GetDeviceUUIDs(const TDevices& devices)


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/2368

Первая часть задачи про то чтобы сделать копирование данных между диск-агентами напрямую.
Здесь сделано новое сообщение, которое умеют обрабатывать все типы нереплицированных партишенов, где они отвечают в какой девайс попадает данный диапазон. Если таких девайсов несколько (диапаон на границе двух устройств), или сейчас невозможно читать из конкретного девайса, так как идет синхронизация, то отвечают E_ABORTED.
