### PR TITLE
issue-1444: create CpuWaitFailure counter in filestore/blockstore actors

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -499,19 +499,12 @@ void TBootstrapYdb::InitKikimrService()
 
     STORAGE_INFO("ProfileLog initialized");
 
-    auto cgroupStatsFetcherMonitoringSettings =
-        TCgroupStatsFetcherMonitoringSettings{
-            .CountersGroupName = "blockstore",
-            .ComponentGroupName = "server",
-            .CounterName = "CpuWaitFailure",
-        };
-
-    CgroupStatsFetcher = CreateCgroupStatsFetcher(
-        "BLOCKSTORE_CGROUPS",
-        logging,
-        monitoring,
+    CgroupStatsFetcher = BuildCgroupStatsFetcher(
+        "",
         Configs->DiagnosticsConfig->GetCpuWaitFilename(),
-        std::move(cgroupStatsFetcherMonitoringSettings));
+        Log,
+        logging,
+        "BLOCKSTORE_CGROUPS");
 
     if (Configs->StorageConfig->GetBlockDigestsEnabled()) {
         if (Configs->StorageConfig->GetUseTestBlockDigestGenerator()) {

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -500,7 +500,6 @@ void TBootstrapYdb::InitKikimrService()
     STORAGE_INFO("ProfileLog initialized");
 
     CgroupStatsFetcher = BuildCgroupStatsFetcher(
-        "",
         Configs->DiagnosticsConfig->GetCpuWaitFilename(),
         Log,
         logging,

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -184,6 +184,7 @@ void TVolumeBalancerActor::RegisterCounters(const TActorContext& ctx)
     InitiallyPreempted = serviceCounters->GetCounter("InitiallyPreempted", false);
 
     CpuWait = serverCounters->GetCounter("CpuWait", false);
+    CpuWaitFailure = serverCounters->GetCounter("CpuWaitFailure", false);
 
     ctx.Schedule(Timeout, new TEvents::TEvWakeup);
 }
@@ -247,10 +248,14 @@ void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
         auto interval = (now - LastCpuWaitQuery).MicroSeconds();
         auto [cpuWait, error] = CgroupStatsFetcher->GetCpuWait();
         if (HasError(error)) {
-            LOG_ERROR_S(
-                ctx,
-                TBlockStoreComponents::VOLUME_BALANCER,
-                "Failed to get CpuWait stats: " << error);
+            if (CpuWaitFailure) {
+                *CpuWaitFailure = 1;
+            } else {
+                LOG_ERROR_S(
+                    ctx,
+                    TBlockStoreComponents::VOLUME_BALANCER,
+                    "Failed to get CpuWait stats: " << error);
+            }
         }
         auto cpuLack =
             CpuLackPercentsMultiplier * cpuWait.MicroSeconds();

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -240,7 +240,7 @@ void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
     const TEvService::TEvGetVolumeStatsResponse::TPtr& ev,
     const TActorContext& ctx)
 {
-    if (State && CgroupStatsFetcher && CpuWait && CpuWaitFailure) {
+    if (State) {
         const auto *msg = ev->Get();
 
         auto now = ctx.Now();
@@ -249,7 +249,7 @@ void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
         auto [cpuWait, error] = CgroupStatsFetcher->GetCpuWait();
         if (HasError(error)) {
             *CpuWaitFailure = 1;
-            LOG_ERROR_S(
+            LOG_TRACE_S(
                 ctx,
                 TBlockStoreComponents::VOLUME_BALANCER,
                 "Failed to get CpuWait stats: " << error);

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -256,7 +256,6 @@ void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
         } else {
             *CpuWaitFailure = 0;
         }
-
         auto cpuLack =
             CpuLackPercentsMultiplier * cpuWait.MicroSeconds();
         cpuLack /= interval;

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
@@ -40,6 +40,7 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr InitiallyPreempted;
 
     NMonitoring::TDynamicCounters::TCounterPtr CpuWait;
+    NMonitoring::TDynamicCounters::TCounterPtr CpuWaitFailure;
 
     std::unique_ptr<TVolumeBalancerState> State;
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -753,8 +753,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
         auto counters = testEnv.GetRuntime().GetAppData(0).Counters
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "server");
-        auto cpuWaitCounter = counters->GetCounter("CpuWait", false);
 
+        auto cpuWaitCounter = counters->GetCounter("CpuWait", false);
         UNIT_ASSERT_VALUES_UNEQUAL(0, cpuWaitCounter->Val());
         UNIT_ASSERT(cpuWaitCounter->Val() <= 90);
 
@@ -878,8 +878,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
         auto counters = testEnv.GetRuntime().GetAppData(0).Counters
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "server");
-        auto cpuWaitCounter = counters->GetCounter("CpuWait", false);
 
+        auto cpuWaitCounter = counters->GetCounter("CpuWait", false);
         UNIT_ASSERT_VALUES_EQUAL(0, cpuWaitCounter->Val());
 
         auto cpuWaitFailureCounter =

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -196,7 +196,7 @@ struct TVolumeStatsTestMock final
 
 struct TCgroupStatsFetcherMock: public NCloud::NStorage::ICgroupStatsFetcher
 {
-    TResultOrError<TDuration> Value;
+    TResultOrError<TDuration> Value = TDuration::Zero();
 
     void SetCpuWaitValue(TResultOrError<TDuration> value)
     {
@@ -435,8 +435,8 @@ TString RunState(
     TActorId actorId,
     TVector<TVolumeState> volumes,
     TVolumePerfStatuses perfStats,
-    double cpuWait,
-    EChangeBindingOp expected,
+    TResultOrError<double> cpuWait,
+    TMaybe<EChangeBindingOp> expected,
     TDuration runFor)
 {
     auto now = testEnv.GetRuntime().GetCurrentTime();
@@ -461,7 +461,11 @@ TString RunState(
         }
 
         testEnv.VolumeStats->SetPerfStats(std::move(perfStats));
-        testEnv.Fetcher->SetCpuWaitValue(cpuWait * TDuration::Seconds(15));
+        testEnv.Fetcher->SetCpuWaitValue(
+            HasError(cpuWait)
+                ? TResultOrError<TDuration>(cpuWait.GetError())
+                : TResultOrError<TDuration>(
+                      cpuWait.GetResult() * TDuration::Seconds(15)));
 
         testEnv.SendVolumesStatsResponse(actorId, stats);
 
@@ -469,50 +473,14 @@ TString RunState(
     }
 
     auto ev = testEnv.GrabBindingRequest();
-    UNIT_ASSERT(ev);
-    UNIT_ASSERT(ev->Action == expected);
-    return ev->DiskId;
-}
-
-void RunStateNoAction(
-    TVolumeBalancerTestEnv& testEnv,
-    TActorId actorId,
-    TVector<TVolumeState> volumes,
-    TVolumePerfStatuses perfStats,
-    double cpuWait,
-    TDuration runFor)
-{
-    auto now = testEnv.GetRuntime().GetCurrentTime();
-    while (testEnv.GetRuntime().GetCurrentTime() - now < runFor) {
-        testEnv.AdjustTime();
-
-        auto ev = testEnv.GrabBindingRequest();
-        UNIT_ASSERT(!ev);
-
-        testEnv.GrabVolumesStatsRequest();
-
-        TVector<NProto::TVolumeBalancerDiskStats> stats;
-        for (const auto& v: volumes) {
-            auto stat = CreateVolumeStats(
-                v.DiskId,
-                "",
-                "",
-                v.IsLocal,
-                v.Source);
-
-            stats.push_back(stat);
-        }
-
-        testEnv.VolumeStats->SetPerfStats(std::move(perfStats));
-        testEnv.Fetcher->SetCpuWaitValue(cpuWait * TDuration::Seconds(15));
-
-        testEnv.SendVolumesStatsResponse(actorId, stats);
-
-        testEnv.DispatchEvents(TDuration::Seconds(1));
+    if (expected) {
+        UNIT_ASSERT(ev);
+        UNIT_ASSERT(ev->Action == expected);
+        return ev->DiskId;
     }
 
-    auto ev = testEnv.GrabBindingRequest();
     UNIT_ASSERT(!ev);
+    return {};
 }
 
 } // namespace
@@ -669,7 +637,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
 
         UNIT_ASSERT_VALUES_EQUAL("vol0", diskId);
 
-        RunStateNoAction(
+        RunState(
             testEnv,
             volumeBindingActorID,
             {
@@ -681,6 +649,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
                 {"vol1", 1}
             },
             0.1,
+            {},
             TDuration::Seconds(15) + TDuration::Seconds(20));
 
         UNIT_ASSERT_VALUES_EQUAL("vol0", diskId);
@@ -699,7 +668,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
 
         testEnv.DispatchEvents();
 
-        RunStateNoAction(
+        RunState(
             testEnv,
             volumeBindingActorID,
             {
@@ -711,6 +680,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
                 {"vol1", 1}
             },
             1,
+            {},
             TDuration::Seconds(15));
     }
 
@@ -734,7 +704,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
 
         UNIT_ASSERT_VALUES_EQUAL(EBalancerStatus::ENABLE, response->Record.GetOpStatus());
 
-        RunStateNoAction(
+        RunState(
             testEnv,
             volumeBindingActorID,
             {
@@ -746,6 +716,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
                 {"vol1", 1}
             },
             1,
+            {},
             TDuration::Seconds(15));
     }
 
@@ -809,7 +780,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
 
         testEnv.DispatchEvents();
 
-        RunStateNoAction(
+        RunState(
             testEnv,
             volumeBindingActorID,
             {
@@ -821,6 +792,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
                 {"vol1", 1}
             },
             1,
+            {},
             TDuration::Seconds(15));
     }
 
@@ -873,6 +845,46 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
         UNIT_ASSERT_VALUES_EQUAL(2, manuallyPreempted->Val());
         UNIT_ASSERT_VALUES_EQUAL(3, balancerPreempted->Val());
         UNIT_ASSERT_VALUES_EQUAL(4, initiallyPreempted->Val());
+    }
+
+    Y_UNIT_TEST(ShouldSetCpuWaitFailure)
+    {
+        TVolumeBalancerTestEnv testEnv;
+        TVolumeBalancerConfigBuilder config;
+
+        auto volumeBindingActorID = testEnv.Register(CreateVolumeBalancerActor(
+            config.WithType(NProto::PREEMPTION_MOVE_MOST_HEAVY),
+            testEnv.VolumeStats,
+            testEnv.Fetcher,
+            testEnv.GetEdgeActor()));
+
+        testEnv.DispatchEvents();
+
+        auto diskId = RunState(
+            testEnv,
+            volumeBindingActorID,
+            {
+                {"vol0", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol1", true, NProto::EPreemptionSource::SOURCE_NONE},
+            },
+            {
+                {"vol0", 10},
+                {"vol1", 1}
+            },
+            MakeError(E_INVALID_STATE),
+            {},
+            TDuration::Seconds(15));
+
+        auto counters = testEnv.GetRuntime().GetAppData(0).Counters
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server");
+        auto cpuWaitCounter = counters->GetCounter("CpuWait", false);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, cpuWaitCounter->Val());
+
+        auto cpuWaitFailureCounter =
+            counters->GetCounter("CpuWaitFailure", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, cpuWaitFailureCounter->Val());
     }
 }
 

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -55,42 +55,6 @@ namespace {
 const TString TraceLoggerId = "st_trace_logger";
 const TString SlowRequestsFilterId = "st_slow_requests_filter";
 
-// One can use either a service name and have the stats file inferred from it,
-// or provide the stats file explicitly.
-NCloud::NStorage::ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
-    const TString& cpuWaitServiceName,
-    const TString& cpuWaitFilename,
-    const TLog& log,
-    ILoggingServicePtr logging,
-    IMonitoringServicePtr monitoring,
-    const TString& metricsComponent)
-{
-    if (cpuWaitServiceName.empty() && cpuWaitFilename.empty()) {
-        const auto& Log = log;
-        STORAGE_INFO(
-            "CpuWaitServiceName and CpuWaitFilename are empty, can't build "
-            "CgroupStatsFetcher");
-        return CreateCgroupStatsFetcherStub();
-    }
-    auto cgroupStatsFetcherMonitoringSettings =
-        TCgroupStatsFetcherMonitoringSettings{
-            .CountersGroupName = "filestore",
-            .ComponentGroupName = metricsComponent,
-            .CounterName = "CpuWaitFailure",
-        };
-    TString statsFile =
-        cpuWaitFilename.empty()
-            ? NCloud::NStorage::BuildCpuWaitStatsFilename(cpuWaitServiceName)
-            : cpuWaitFilename;
-
-    return CreateCgroupStatsFetcher(
-        "FILESTORE_CGROUPS",
-        std::move(logging),
-        std::move(monitoring),
-        statsFile,
-        std::move(cgroupStatsFetcherMonitoringSettings));
-};
-
 } // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -311,8 +275,7 @@ void TBootstrapCommon::InitActorSystem()
         Configs->DiagnosticsConfig->GetCpuWaitFilename(),
         Log,
         logging,
-        monitoring,
-        MetricsComponent);
+        "FILESTORE_CGROUPS");
 
     STORAGE_INFO("CgroupStatsFetcher initialized");
 

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -270,9 +270,12 @@ void TBootstrapCommon::InitActorSystem()
 
     STORAGE_INFO("TraceSerializer initialized");
 
+    auto cpuWaitFilename = Configs->DiagnosticsConfig->GetCpuWaitFilename();
     CgroupStatsFetcher = BuildCgroupStatsFetcher(
-        Configs->DiagnosticsConfig->GetCpuWaitServiceName(),
-        Configs->DiagnosticsConfig->GetCpuWaitFilename(),
+        cpuWaitFilename.empty()
+            ? NCloud::NStorage::BuildCpuWaitStatsFilename(
+                  Configs->DiagnosticsConfig->GetCpuWaitServiceName())
+            : std::move(cpuWaitFilename),
         Log,
         logging,
         "FILESTORE_CGROUPS");

--- a/cloud/filestore/libs/storage/service/service_actor.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor.cpp
@@ -63,6 +63,8 @@ void TStorageServiceActor::RegisterCounters(const NActors::TActorContext& ctx)
     auto serverCounters = rootGroup->GetSubgroup("component", "server");
 
     CpuWait = serverCounters->GetCounter("CpuWait", false);
+    CpuWaitFailure = serverCounters->GetCounter("CpuWaitFailure", false);
+
 }
 
 void TStorageServiceActor::ScheduleUpdateStats(const NActors::TActorContext& ctx)

--- a/cloud/filestore/libs/storage/service/service_actor.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor.cpp
@@ -64,7 +64,6 @@ void TStorageServiceActor::RegisterCounters(const NActors::TActorContext& ctx)
 
     CpuWait = serverCounters->GetCounter("CpuWait", false);
     CpuWaitFailure = serverCounters->GetCounter("CpuWaitFailure", false);
-
 }
 
 void TStorageServiceActor::ScheduleUpdateStats(const NActors::TActorContext& ctx)

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -45,6 +45,7 @@ private:
     THashMap<ui64, TInFlightRequest> InFlightRequests;
 
     NMonitoring::TDynamicCounters::TCounterPtr CpuWait;
+    NMonitoring::TDynamicCounters::TCounterPtr CpuWaitFailure;
     TInstant LastCpuWaitQuery;
 
 public:

--- a/cloud/filestore/libs/storage/service/service_actor_update_stats.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_update_stats.cpp
@@ -32,7 +32,7 @@ void TStorageServiceActor::HandleUpdateStats(
             InFlightRequests.erase(it++);
         }
     }
-    if (CgroupStatsFetcher && CpuWait && CpuWaitFailure) {
+    if (CgroupStatsFetcher) {
         auto now = ctx.Now();
 
         auto interval = (now - LastCpuWaitQuery).MicroSeconds();
@@ -61,7 +61,7 @@ void TStorageServiceActor::HandleUpdateStats(
             }
         } else {
             *CpuWaitFailure = 1;
-            LOG_ERROR_S(
+            LOG_TRACE_S(
                 ctx,
                 TFileStoreComponents::SERVICE,
                 "Failed to get CpuWait stats: " << error);

--- a/cloud/filestore/libs/storage/service/service_actor_update_stats.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_update_stats.cpp
@@ -59,10 +59,15 @@ void TStorageServiceActor::HandleUpdateStats(
                     "Cpu wait is " << cpuLack);
             }
         } else {
+            if (CpuWaitFailure) {
+                *CpuWaitFailure = 1;
+            }
+            else {
             LOG_ERROR_S(
                 ctx,
                 TFileStoreComponents::SERVICE,
                 "Failed to get CpuWait stats: " << error);
+            }
         }
     }
 

--- a/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
+++ b/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
@@ -171,16 +171,13 @@ TString BuildCpuWaitStatsFilename(const TString& serviceName)
     return {};
 }
 
-// One can use either a service name and have the stats file inferred from it,
-// or provide the stats file explicitly.
 NCloud::NStorage::ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
-    const TString& cpuWaitServiceName,
-    const TString& cpuWaitFilename,
+    TString cpuWaitFilename,
     const TLog& log,
     ILoggingServicePtr logging,
     TString componentName)
 {
-    if (cpuWaitServiceName.empty() && cpuWaitFilename.empty()) {
+    if (cpuWaitFilename.empty()) {
         const auto& Log = log;
         STORAGE_INFO(
             "CpuWaitServiceName and CpuWaitFilename are empty, can't build "
@@ -188,15 +185,10 @@ NCloud::NStorage::ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
         return CreateCgroupStatsFetcherStub();
     }
 
-    TString statsFile =
-        cpuWaitFilename.empty()
-            ? NCloud::NStorage::BuildCpuWaitStatsFilename(cpuWaitServiceName)
-            : cpuWaitFilename;
-
     return CreateCgroupStatsFetcher(
         std::move(componentName),
         std::move(logging),
-        statsFile);
+        std::move(cpuWaitFilename));
 };
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
+++ b/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
@@ -1,5 +1,6 @@
 #include "cgroup_stats_fetcher.h"
 
+#include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <util/datetime/cputimer.h>

--- a/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
+++ b/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.cpp
@@ -1,10 +1,6 @@
 #include "cgroup_stats_fetcher.h"
 
-#include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
-#include <cloud/storage/core/libs/diagnostics/monitoring.h>
-
-#include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <util/datetime/cputimer.h>
 #include <util/generic/yexception.h>
@@ -14,8 +10,6 @@
 #include <util/system/file.h>
 
 namespace NCloud::NStorage {
-
-using namespace NMonitoring;
 
 namespace {
 
@@ -28,9 +22,7 @@ private:
     const TString ComponentName;
 
     const ILoggingServicePtr Logging;
-    const IMonitoringServicePtr Monitoring;
     const TString StatsFile;
-    const TCgroupStatsFetcherMonitoringSettings MonitoringSettings;
 
     TLog Log;
 
@@ -38,20 +30,14 @@ private:
 
     TDuration Last;
 
-    TIntrusivePtr<NMonitoring::TCounterForPtr> FailCounter;
-
 public:
     TCgroupStatsFetcher(
             TString componentName,
             ILoggingServicePtr logging,
-            IMonitoringServicePtr monitoring,
-            TString statsFile,
-            TCgroupStatsFetcherMonitoringSettings monitoringSettings)
+            TString statsFile)
         : ComponentName(std::move(componentName))
         , Logging(std::move(logging))
-        , Monitoring(std::move(monitoring))
         , StatsFile(std::move(statsFile))
-        , MonitoringSettings(std::move(monitoringSettings))
     {
     }
 
@@ -64,13 +50,11 @@ public:
                 StatsFile,
                 EOpenModeFlag::OpenExisting | EOpenModeFlag::RdOnly);
         } catch (...) {
-            ReportCpuWaitFatalError();
             STORAGE_ERROR(BuildErrorMessageFromException());
             return;
         }
 
         if (!CpuAcctWait.IsOpen()) {
-            ReportCpuWaitFatalError();
             STORAGE_ERROR("Failed to open " << StatsFile);
             return;
         }
@@ -98,7 +82,6 @@ public:
             constexpr i64 bufSize = 1024;
 
             if (CpuAcctWait.GetLength() >= bufSize - 1) {
-                ReportCpuWaitFatalError();
                 CpuAcctWait.Close();
                 return MakeError(E_INVALID_STATE, StatsFile + " is too large");
             }
@@ -124,7 +107,6 @@ public:
 
             return retval;
         } catch (...) {
-            ReportCpuWaitFatalError();
             auto errorMessage = BuildErrorMessageFromException();
             CpuAcctWait.Close();
             return MakeError(E_FAIL, std::move(errorMessage));
@@ -136,24 +118,6 @@ public:
         auto msg = TStringBuilder() << "IO error for " << StatsFile;
         msg << " with exception " << CurrentExceptionMessage();
         return msg;
-    }
-
-    void ReportCpuWaitFatalError()
-    {
-        if (FailCounter) {
-            return;
-        }
-        if (MonitoringSettings.ComponentGroupName.empty() ||
-            MonitoringSettings.CountersGroupName.empty() ||
-            MonitoringSettings.CounterName.empty())
-        {
-            return;
-        }
-        FailCounter = Monitoring->GetCounters()
-            ->GetSubgroup("counters", MonitoringSettings.CountersGroupName)
-            ->GetSubgroup("component", MonitoringSettings.ComponentGroupName)
-            ->GetCounter(MonitoringSettings.CounterName, false);
-        *FailCounter = 1;
     }
 };
 
@@ -183,16 +147,12 @@ struct TCgroupStatsFetcherStub final
 ICgroupStatsFetcherPtr CreateCgroupStatsFetcher(
     TString componentName,
     ILoggingServicePtr logging,
-    IMonitoringServicePtr monitoring,
-    TString statsFile,
-    TCgroupStatsFetcherMonitoringSettings settings)
+    TString statsFile)
 {
     return std::make_shared<TCgroupStatsFetcher>(
         std::move(componentName),
         std::move(logging),
-        std::move(monitoring),
-        std::move(statsFile),
-        std::move(settings));
+        std::move(statsFile));
 }
 
 ICgroupStatsFetcherPtr CreateCgroupStatsFetcherStub()
@@ -209,5 +169,33 @@ TString BuildCpuWaitStatsFilename(const TString& serviceName)
     }
     return {};
 }
+
+// One can use either a service name and have the stats file inferred from it,
+// or provide the stats file explicitly.
+NCloud::NStorage::ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
+    const TString& cpuWaitServiceName,
+    const TString& cpuWaitFilename,
+    const TLog& log,
+    ILoggingServicePtr logging,
+    TString componentName)
+{
+    if (cpuWaitServiceName.empty() && cpuWaitFilename.empty()) {
+        const auto& Log = log;
+        STORAGE_INFO(
+            "CpuWaitServiceName and CpuWaitFilename are empty, can't build "
+            "CgroupStatsFetcher");
+        return CreateCgroupStatsFetcherStub();
+    }
+
+    TString statsFile =
+        cpuWaitFilename.empty()
+            ? NCloud::NStorage::BuildCpuWaitStatsFilename(cpuWaitServiceName)
+            : cpuWaitFilename;
+
+    return CreateCgroupStatsFetcher(
+        std::move(componentName),
+        std::move(logging),
+        statsFile);
+};
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.h
+++ b/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.h
@@ -29,22 +29,20 @@ using ICgroupStatsFetcherPtr = std::shared_ptr<ICgroupStatsFetcher>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TCgroupStatsFetcherMonitoringSettings
-{
-    TString CountersGroupName;
-    TString ComponentGroupName;
-    TString CounterName;
-};
-
 ICgroupStatsFetcherPtr CreateCgroupStatsFetcher(
     TString componentName,
     ILoggingServicePtr logging,
-    IMonitoringServicePtr monitoring,
-    TString statsFile,
-    TCgroupStatsFetcherMonitoringSettings settings);
+    TString statsFile);
 
 ICgroupStatsFetcherPtr CreateCgroupStatsFetcherStub();
 
 TString BuildCpuWaitStatsFilename(const TString& serviceName);
+
+ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
+    const TString& cpuWaitServiceName,
+    const TString& cpuWaitFilename,
+    const TLog& log,
+    ILoggingServicePtr logging,
+    TString componentName);
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.h
+++ b/cloud/storage/core/libs/diagnostics/cgroup_stats_fetcher.h
@@ -39,8 +39,7 @@ ICgroupStatsFetcherPtr CreateCgroupStatsFetcherStub();
 TString BuildCpuWaitStatsFilename(const TString& serviceName);
 
 ICgroupStatsFetcherPtr BuildCgroupStatsFetcher(
-    const TString& cpuWaitServiceName,
-    const TString& cpuWaitFilename,
+    TString cpuWaitFilename,
     const TLog& log,
     ILoggingServicePtr logging,
     TString componentName);


### PR DESCRIPTION
issue: #1444

refactoring. As we plan to add[ new StatsFetcher implementation](https://github.com/ydb-platform/nbs/pull/1630) it is more convenient to set CpuWaitFailure counter in blockstore/filestore actors.