### PR TITLE
issue-2077: read N/M for mirrored disks (1 ReadBlocks + N-1 ChecksumBlocks)

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1056,4 +1056,11 @@ message TStorageServiceConfig
 
     optional uint32 BlobStorageAsyncGetTimeoutHDD = 389;
     optional uint32 BlobStorageAsyncGetTimeoutSSD = 390;
+
+    // Specifies the minimum number of replicas to read from in a mirrored disk
+    // for every read request.
+    // Values 0 and 1 mean the same thing - read from 1 replica.
+    // Values greater than disk replica count also mean the same thing - read
+    // from all replicas.
+    optional uint32 MirrorReadReplicaCount = 391;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -63,6 +63,7 @@ namespace NCloud::NBlockStore {
     xxx(DiskRegistryPurgeHostError)                                            \
     xxx(DiskRegistryCleanupAgentConfigError)                                   \
     xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
+    xxx(MirroredDiskChecksumMismatchUponRead)                                  \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -461,6 +461,7 @@ TDuration MSeconds(ui32 value)
     xxx(ForceMirrorResync,                         bool,      false           )\
     xxx(ResyncIndexCachingInterval,                ui32,      65536           )\
     xxx(ResyncAfterClientInactivityInterval,       TDuration, Minutes(1)      )\
+    xxx(MirrorReadReplicaCount,                    ui32,      0               )\
                                                                                \
     xxx(PingMetricsHalfDecayInterval,              TDuration, Seconds(15)     )\
     xxx(DisableManuallyPreemptedVolumesTracking,   bool,      false           )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -524,6 +524,7 @@ public:
     bool GetForceMirrorResync() const;
     ui32 GetResyncIndexCachingInterval() const;
     TDuration GetResyncAfterClientInactivityInterval() const;
+    ui32 GetMirrorReadReplicaCount() const;
 
     TString GetManuallyPreemptedVolumesFile() const;
     TDuration GetManuallyPreemptedVolumeLivenessCheckPeriod() const;

--- a/cloud/blockstore/libs/storage/model/requests_in_progress.h
+++ b/cloud/blockstore/libs/storage/model/requests_in_progress.h
@@ -124,7 +124,7 @@ public:
         if (it->second.Write) {
             --WriteRequestCount;
         }
-        *value = it->second.Value;
+        *value = std::move(it->second.Value);
         RequestsInProgress.erase(it);
         return true;
     }

--- a/cloud/blockstore/libs/storage/model/requests_in_progress.h
+++ b/cloud/blockstore/libs/storage/model/requests_in_progress.h
@@ -108,6 +108,12 @@ public:
 
     bool RemoveRequest(const TKey& key)
     {
+        TValue v;
+        return ExtractRequest(key, &v);
+    }
+
+    bool ExtractRequest(const TKey& key, TValue* value)
+    {
         auto it = RequestsInProgress.find(key);
 
         if (it == RequestsInProgress.end()) {
@@ -118,6 +124,7 @@ public:
         if (it->second.Write) {
             --WriteRequestCount;
         }
+        *value = it->second.Value;
         RequestsInProgress.erase(it);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -562,6 +562,10 @@ STFUNC(TMirrorPartitionActor::StateWork)
             HandleWriteOrZeroCompleted);
 
         HFunc(
+            TEvNonreplPartitionPrivate::TEvMirroredReadCompleted,
+            HandleMirroredReadCompleted);
+
+        HFunc(
             TEvVolume::TEvRWClientIdChanged,
             HandleRWClientIdChanged);
         HFunc(
@@ -603,6 +607,7 @@ STFUNC(TMirrorPartitionActor::StateZombie)
         HFunc(TEvVolume::TEvGetScanDiskStatusRequest, RejectGetScanDiskStatus);
 
         IgnoreFunc(TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted);
+        IgnoreFunc(TEvNonreplPartitionPrivate::TEvMirroredReadCompleted);
 
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
         IgnoreFunc(TEvVolume::TEvDiskRegistryBasedPartitionCounters);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -58,6 +58,7 @@ private:
     ui64 NetworkBytes = 0;
     TDuration CpuUsage;
 
+    THashMap<ui64, bool> ReadRequestIdentityKey2DirtyFlag;
     TRequestsInProgress<ui64, TBlockRange64> RequestsInProgress{
         EAllowedRequests::ReadWrite};
     TDrainActorCompanion DrainActorCompanion{
@@ -116,6 +117,10 @@ private:
 
     void HandleWriteOrZeroCompleted(
         const TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleMirroredReadCompleted(
+        const TEvNonreplPartitionPrivate::TEvMirroredReadCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleRWClientIdChanged(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -25,6 +25,7 @@
 #include <contrib/ydb/library/actors/core/mon.h>
 
 #include <util/generic/deque.h>
+#include <util/generic/hash_set.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -58,7 +59,7 @@ private:
     ui64 NetworkBytes = 0;
     TDuration CpuUsage;
 
-    THashMap<ui64, bool> ReadRequestIdentityKey2DirtyFlag;
+    THashSet<ui64> DirtyReadRequestIds;
     TRequestsInProgress<ui64, TBlockRange64> RequestsInProgress{
         EAllowedRequests::ReadWrite};
     TDrainActorCompanion DrainActorCompanion{

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -22,6 +22,7 @@ void TMirrorPartitionActor::HandleWriteOrZeroCompleted(
     const auto requestIdentityKey = ev->Get()->RequestCounter;
     RequestsInProgress.RemoveRequest(requestIdentityKey);
     DrainActorCompanion.ProcessDrainRequests(ctx);
+    // TODO: invalidate read lock
 
     if (ResyncActorId) {
         ForwardRequestWithNondeliveryTracking(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -192,13 +192,13 @@ template <typename TMethod>
 void TRequestActor<TMethod>::CompareChecksums(const TActorContext& ctx)
 {
     ui32 firstChecksum = ResponseChecksums[0];
+    if (!firstChecksum) {
+        // zero is a special value meaning "checksum couldn't be calculated"
+        return;
+    }
+
     for (ui32 i = 1; i < ResponseChecksums.size(); ++i) {
         const auto checksum = ResponseChecksums[i];
-        if (!checksum) {
-            // zero is a special value meaning "checksum couldn't be calculated"
-            continue;
-        }
-
         if (firstChecksum != checksum) {
             LOG_INFO(
                 ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -195,8 +195,7 @@ void TRequestActor<TMethod>::CompareChecksums(const TActorContext& ctx)
             LOG_INFO(
                 ctx,
                 TBlockStoreComponents::PARTITION,
-                "[%s] Read range %s: checksum mismatch, %u (%s) != %u (%s)"
-                ", fast path reading is not available",
+                "[%s] Read range %s: checksum mismatch, %u (%s) != %u (%s)",
                 DiskId.c_str(),
                 DescribeRange(Range).c_str(),
                 firstChecksum,
@@ -329,6 +328,8 @@ void TRequestActor<TMethod>::HandleResponse(
         ResponseCount < ResponseChecksums.size(),
         TWellKnownEntityTypes::DISK,
         DiskId);
+
+    Response = std::move(record);
 
     if (++ResponseCount == ResponseChecksums.size()) {
         CompareChecksums(ctx);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -2,7 +2,12 @@
 
 #include "mirror_request_actor.h"
 
+#include <cloud/blockstore/libs/common/block_checksum.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/storage/api/undelivered.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+
+#include <cloud/storage/core/libs/common/verify.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -12,47 +17,96 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ui32 CalculateChecksum(
+    const TEvService::TEvReadBlocksRequest::ProtoRecordType& request,
+    const TEvService::TEvReadBlocksResponse::ProtoRecordType& response)
+{
+    Y_UNUSED(request);
+
+    TBlockChecksum checksum;
+    for (const auto& buffer: response.GetBlocks().GetBuffers()) {
+        checksum.Extend(buffer.data(), buffer.size());
+    }
+    return checksum.GetValue();
+}
+
+ui32 CalculateChecksum(
+    const TEvService::TEvReadBlocksLocalRequest::ProtoRecordType& request,
+    const TEvService::TEvReadBlocksLocalResponse::ProtoRecordType& response)
+{
+    Y_UNUSED(response);
+
+    auto g = request.Sglist.Acquire();
+    if (!g) {
+        return 0;
+    }
+
+    const auto& sgList = g.Get();
+    TBlockChecksum checksum;
+    for (auto blockData: sgList) {
+        checksum.Extend(blockData.Data(), blockData.Size());
+    }
+    return checksum.GetValue();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 template <typename TMethod>
 class TRequestActor final
-    : public NActors::TActorBootstrapped<TRequestActor<TMethod>>
+    : public TActorBootstrapped<TRequestActor<TMethod>>
 {
 private:
     const TRequestInfoPtr RequestInfo;
-    const NActors::TActorId Partition;
+    const TVector<TActorId> Partitions;
     typename TMethod::TRequest::ProtoRecordType Request;
+    const TBlockRange64 Range;
     const TString DiskId;
 
     using TResponseProto = typename TMethod::TResponse::ProtoRecordType;
-    using TBase = NActors::TActorBootstrapped<TRequestActor<TMethod>>;
+    using TBase = TActorBootstrapped<TRequestActor<TMethod>>;
+
+    TVector<ui32> ResponseChecksums;
+    ui32 ResponseCount = 0;
+    TResponseProto Response;
 
 public:
     TRequestActor(
         TRequestInfoPtr requestInfo,
-        const NActors::TActorId& partition,
+        const TVector<TActorId>& partitions,
         typename TMethod::TRequest::ProtoRecordType request,
+        const TBlockRange64 range,
         TString diskId);
 
-    void Bootstrap(const NActors::TActorContext& ctx);
+    void Bootstrap(const TActorContext& ctx);
 
 private:
-    void SendRequest(const NActors::TActorContext& ctx);
-    bool HandleError(const NActors::TActorContext& ctx, NProto::TError error);
-    void Done(const NActors::TActorContext& ctx, TResponseProto record);
+    void SendRequests(const TActorContext& ctx);
+    bool HandleError(const TActorContext& ctx, NProto::TError error);
+    void CompareChecksums(const TActorContext& ctx);
+    void Done(const TActorContext& ctx);
 
 private:
     STFUNC(StateWork);
 
-    void HandleResponse(
-        const typename TMethod::TResponse::TPtr& ev,
-        const NActors::TActorContext& ctx);
+    void HandleChecksumUndelivery(
+        const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
+        const TActorContext& ctx);
 
-    void HandlePoisonPill(
-        const NActors::TEvents::TEvPoisonPill::TPtr& ev,
-        const NActors::TActorContext& ctx);
+    void HandleChecksumResponse(
+        const TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse::TPtr& ev,
+        const TActorContext& ctx);
 
     void HandleUndelivery(
         const typename TMethod::TRequest::TPtr& ev,
-        const NActors::TActorContext& ctx);
+        const TActorContext& ctx);
+
+    void HandleResponse(
+        const typename TMethod::TResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,37 +114,65 @@ private:
 template <typename TMethod>
 TRequestActor<TMethod>::TRequestActor(
         TRequestInfoPtr requestInfo,
-        const NActors::TActorId& partition,
+        const TVector<TActorId>& partitions,
         typename TMethod::TRequest::ProtoRecordType request,
+        const TBlockRange64 range,
         TString diskId)
     : RequestInfo(std::move(requestInfo))
-    , Partition(partition)
+    , Partitions(partitions)
     , Request(std::move(request))
+    , Range(range)
     , DiskId(std::move(diskId))
+    , ResponseChecksums(Partitions.size(), 0)
 {}
 
 template <typename TMethod>
-void TRequestActor<TMethod>::Bootstrap(const NActors::TActorContext& ctx)
+void TRequestActor<TMethod>::Bootstrap(const TActorContext& ctx)
 {
     TRequestScope timer(*RequestInfo);
 
     TBase::Become(&TBase::TThis::StateWork);
 
-    SendRequest(ctx);
+    SendRequests(ctx);
 }
 
 template <typename TMethod>
-void TRequestActor<TMethod>::SendRequest(const NActors::TActorContext& ctx)
+void TRequestActor<TMethod>::SendRequests(const TActorContext& ctx)
 {
+    using TChecksumRequest =
+        TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest;
+    for (ui32 i = 1; i < Partitions.size(); ++i) {
+        auto request = std::make_unique<TChecksumRequest>();
+        request->Record.SetStartIndex(Request.GetStartIndex());
+        request->Record.SetBlocksCount(GetBlocksCount(Request));
+        *request->Record.MutableHeaders() = Request.GetHeaders();
+
+        auto event = std::make_unique<IEventHandle>(
+            Partitions[i],
+            ctx.SelfID,
+            request.release(),
+            IEventHandle::FlagForwardOnNondelivery,
+            RequestInfo->Cookie + i,
+            &ctx.SelfID   // forwardOnNondelivery
+        );
+
+        ctx.Send(event.release());
+    }
+
     auto request = std::make_unique<typename TMethod::TRequest>();
     request->CallContext = RequestInfo->CallContext;
-    request->Record = std::move(Request);
+    if (Partitions.size() > 1) {
+        // Request will be used during checksum calculation
+        request->Record = Request;
+    } else {
+        request->Record = std::move(Request);
+    }
 
     auto event = std::make_unique<IEventHandle>(
-        Partition,
+        Partitions[0],
         ctx.SelfID,
         request.release(),
-        NActors::IEventHandle::FlagForwardOnNondelivery,
+        IEventHandle::FlagForwardOnNondelivery,
         RequestInfo->Cookie,
         &ctx.SelfID   // forwardOnNondelivery
     );
@@ -99,12 +181,41 @@ void TRequestActor<TMethod>::SendRequest(const NActors::TActorContext& ctx)
 }
 
 template <typename TMethod>
-void TRequestActor<TMethod>::Done(
-    const NActors::TActorContext& ctx,
-    TResponseProto record)
+void TRequestActor<TMethod>::CompareChecksums(const TActorContext& ctx)
+{
+    ui32 firstChecksum = ResponseChecksums[0];
+    for (ui32 i = 1; i < ResponseChecksums.size(); ++i) {
+        const auto checksum = ResponseChecksums[i];
+        if (!checksum) {
+            // zero is a special value meaning "checksum couldn't be calculated"
+            continue;
+        }
+
+        if (firstChecksum != checksum) {
+            LOG_INFO(
+                ctx,
+                TBlockStoreComponents::PARTITION,
+                "[%s] Read range %s: checksum mismatch, %u (%s) != %u (%s)"
+                ", fast path reading is not available",
+                DiskId.c_str(),
+                DescribeRange(Range).c_str(),
+                firstChecksum,
+                Partitions[0].ToString().c_str(),
+                checksum,
+                Partitions[i].ToString().c_str());
+            *Response.MutableError() =
+                MakeError(E_REJECTED, "Checksum mismatch detected");
+            ReportMirroredDiskChecksumMismatchUponRead();
+            break;
+        }
+    }
+}
+
+template <typename TMethod>
+void TRequestActor<TMethod>::Done(const TActorContext& ctx)
 {
     auto response = std::make_unique<typename TMethod::TResponse>();
-    response->Record = std::move(record);
+    response->Record = std::move(Response);
 
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 
@@ -114,9 +225,63 @@ void TRequestActor<TMethod>::Done(
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
+void TRequestActor<TMethod>::HandleChecksumUndelivery(
+    const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    LOG_WARN(ctx, TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] %s (ChecksumBlocks) request undelivered to some nonrepl"
+        " partitions",
+        DiskId.c_str(),
+        TMethod::Name);
+
+    *Response.MutableError() = MakeError(E_REJECTED, TStringBuilder()
+        << TMethod::Name << " (ChecksumBlocks) request undelivered to some"
+        << " nonrepl partitions");
+    Done(ctx);
+}
+
+template <typename TMethod>
+void TRequestActor<TMethod>::HandleChecksumResponse(
+    const TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    auto& record = msg->Record;
+    ProcessMirrorActorError(*record.MutableError());
+
+    if (HasError(record.GetError())) {
+        *Response.MutableError() = *record.MutableError();
+        Done(ctx);
+        return;
+    }
+
+    ui32 responseIdx = ev->Cookie - RequestInfo->Cookie;
+    STORAGE_VERIFY(
+        responseIdx < ResponseChecksums.size(),
+        TWellKnownEntityTypes::DISK,
+        DiskId);
+    ResponseChecksums[responseIdx] = record.GetChecksum();
+
+    STORAGE_VERIFY(
+        ResponseCount < ResponseChecksums.size(),
+        TWellKnownEntityTypes::DISK,
+        DiskId);
+
+    if (++ResponseCount == ResponseChecksums.size()) {
+        CompareChecksums(ctx);
+        Done(ctx);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TMethod>
 void TRequestActor<TMethod>::HandleUndelivery(
     const typename TMethod::TRequest::TPtr& ev,
-    const NActors::TActorContext& ctx)
+    const TActorContext& ctx)
 {
     Y_UNUSED(ev);
 
@@ -125,44 +290,61 @@ void TRequestActor<TMethod>::HandleUndelivery(
         DiskId.c_str(),
         TMethod::Name);
 
-    TResponseProto record;
-    record.MutableError()->CopyFrom(MakeError(E_REJECTED, TStringBuilder()
-        << TMethod::Name << " request undelivered to some nonrepl partitions"));
-
-    Done(ctx, std::move(record));
+    *Response.MutableError() = MakeError(E_REJECTED, TStringBuilder()
+        << TMethod::Name << " request undelivered to some nonrepl partitions");
+    Done(ctx);
 }
 
 template <typename TMethod>
 void TRequestActor<TMethod>::HandleResponse(
     const typename TMethod::TResponse::TPtr& ev,
-    const NActors::TActorContext& ctx)
+    const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-
     auto& record = msg->Record;
+    ProcessMirrorActorError(*record.MutableError());
+
     if (HasError(record)) {
         LOG_ERROR(ctx, TBlockStoreComponents::PARTITION_WORKER,
             "[%s] %s got error from nonreplicated partition: %s",
             DiskId.c_str(),
             TMethod::Name,
             FormatError(record.GetError()).c_str());
+
+        *Response.MutableError() = *record.MutableError();
+        Done(ctx);
+        return;
     }
 
-    ProcessMirrorActorError(*record.MutableError());
+    if (ResponseChecksums.size() > 1) {
+        ui32 responseIdx = ev->Cookie - RequestInfo->Cookie;
+        STORAGE_VERIFY(
+            responseIdx < ResponseChecksums.size(),
+            TWellKnownEntityTypes::DISK,
+            DiskId);
+        ResponseChecksums[responseIdx] = CalculateChecksum(Request, record);
+    }
 
-    Done(ctx, std::move(record));
+    STORAGE_VERIFY(
+        ResponseCount < ResponseChecksums.size(),
+        TWellKnownEntityTypes::DISK,
+        DiskId);
+
+    if (++ResponseCount == ResponseChecksums.size()) {
+        CompareChecksums(ctx);
+        Done(ctx);
+    }
 }
 
 template <typename TMethod>
 void TRequestActor<TMethod>::HandlePoisonPill(
-    const NActors::TEvents::TEvPoisonPill::TPtr& ev,
-    const NActors::TActorContext& ctx)
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
 {
     Y_UNUSED(ev);
 
-    TResponseProto record;
-    record.MutableError()->CopyFrom(MakeError(E_REJECTED, "Dead"));
-    Done(ctx, std::move(record));
+    *Response.MutableError() = MakeError(E_REJECTED, "Dead");
+    Done(ctx);
 }
 
 template <typename TMethod>
@@ -171,10 +353,16 @@ STFUNC(TRequestActor<TMethod>::StateWork)
     TRequestScope timer(*RequestInfo);
 
     switch (ev->GetTypeRewrite()) {
-        HFunc(NActors::TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
-        HFunc(TMethod::TResponse, HandleResponse);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest,
+            HandleChecksumUndelivery);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse,
+            HandleChecksumResponse);
         HFunc(TMethod::TRequest, HandleUndelivery);
+        HFunc(TMethod::TResponse, HandleResponse);
 
         default:
             HandleUnexpectedEvent(
@@ -224,22 +412,50 @@ void TMirrorPartitionActor::ReadBlocks(
         return;
     }
 
-    TActorId replicaActorId;
-    const auto error = State.NextReadReplica(blockRange, &replicaActorId);
-    if (HasError(error)) {
-        Reply(
-            ctx,
-            *requestInfo,
-            std::make_unique<typename TMethod::TResponse>(error));
+    // TODO:
+    // 1. take 2 replicas
+    // 2. acquire optimistic read lock
+    // 3. send response to TMirrorPartitionActor upon read completion - if read lock is still in place and data checksums differ, report critical event, respond with E_REJECTED and do out-of-order range scrubbing for this range
 
-        return;
+    TVector<TActorId> replicaActorIds;
+    const ui32 readReplicaCount = Min<ui32>(
+        Max<ui32>(1, Config->GetMirrorReadReplicaCount()),
+        State.GetReplicaInfos().size());
+    for (ui32 i = 0; i < readReplicaCount; ++i) {
+        TActorId replicaActorId;
+        const auto error = State.NextReadReplica(blockRange, &replicaActorId);
+        if (HasError(error)) {
+            Reply(
+                ctx,
+                *requestInfo,
+                std::make_unique<typename TMethod::TResponse>(error));
+
+            return;
+        }
+
+        const auto* it = Find(
+            replicaActorIds.begin(),
+            replicaActorIds.end(),
+            replicaActorId);
+        if (it != replicaActorIds.end()) {
+            break;
+        }
+
+        replicaActorIds.push_back(replicaActorId);
     }
+
+    LOG_DEBUG(ctx, TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Will read %s from %u replicas",
+        DiskId.c_str(),
+        DescribeRange(blockRange).c_str(),
+        replicaActorIds.size());
 
     NCloud::Register<TRequestActor<TMethod>>(
         ctx,
         std::move(requestInfo),
-        replicaActorId,
+        replicaActorIds,
         std::move(record),
+        blockRange,
         State.GetReplicaInfos()[0].Config->GetName());
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -1686,7 +1686,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(1, rangeResynced);
     }
 
-    Y_UNIT_TEST(ShouldRejectReadAndForceRangeScrubbingUponChecksumMismatchIfRead2IsEnabled)
+    Y_UNIT_TEST(ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled)
     {
         using namespace NMonitoring;
 
@@ -1784,8 +1784,9 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
         interceptReadDeviceBlocks = true;
         client.SendReadBlocksRequest(range);
-        client.WriteBlocks(range, 'C');
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
         UNIT_ASSERT(toSend);
+        client.WriteBlocks(range, 'C');
         runtime.Send(toSend);
         {
             // checksum mismatch => E_REJECTED

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -99,14 +99,19 @@ struct TTestEnv
         return migrations;
     }
 
-    TTestEnv(TTestActorRuntime& runtime)
+    explicit TTestEnv(
+            TTestActorRuntime& runtime,
+            NProto::TStorageServiceConfig configBase = {})
         : TTestEnv(
             runtime,
             DefaultDevices(runtime.GetNodeId(0)),
             TVector<TDevices>{
                 DefaultReplica(runtime.GetNodeId(0), 1),
                 DefaultReplica(runtime.GetNodeId(0), 2),
-            }
+            },
+            {}, // migrations
+            {}, // freshDeviceIds
+            std::move(configBase)
         )
     {
     }
@@ -116,7 +121,8 @@ struct TTestEnv
             TDevices devices,
             TVector<TDevices> replicas,
             TMigrations migrations = {},
-            THashSet<TString> freshDeviceIds = {})
+            THashSet<TString> freshDeviceIds = {},
+            NProto::TStorageServiceConfig configBase = {})
         : Runtime(runtime)
         , ActorId(0, "YYY")
         , VolumeActorId(0, "VVV")
@@ -125,7 +131,7 @@ struct TTestEnv
     {
         SetupLogging();
 
-        NProto::TStorageServiceConfig storageConfig;
+        NProto::TStorageServiceConfig storageConfig = std::move(configBase);
         storageConfig.SetMaxTimedOutDeviceStateDuration(20'000);
         storageConfig.SetNonReplicatedMinRequestTimeoutSSD(1'000);
         storageConfig.SetNonReplicatedMaxRequestTimeoutSSD(5'000);
@@ -1680,6 +1686,75 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(1, rangeResynced);
     }
 
+    Y_UNIT_TEST(ShouldRejectReadAndForceRangeScrubbingUponChecksumMismatchIfRead2IsEnabled)
+    {
+        using namespace NMonitoring;
+
+        TTestBasicRuntime runtime;
+
+        runtime.SetRegistrationObserverFunc(
+            [] (auto& runtime, const auto& parentId, const auto& actorId)
+        {
+            Y_UNUSED(parentId);
+            runtime.EnableScheduleForActor(actorId);
+        });
+
+        ui32 rangeResynced = 0;
+        runtime.SetEventFilter([&] (auto& runtime, auto& event) {
+            Y_UNUSED(runtime);
+            if (event->GetTypeRewrite() ==
+                TEvNonreplPartitionPrivate::EvRangeResynced)
+            {
+                ++rangeResynced;
+            }
+            return false;
+        });
+
+        TDynamicCountersPtr critEventsCounters = new TDynamicCounters();
+        InitCriticalEventsCounter(critEventsCounters);
+
+        auto mirroredDiskChecksumMismatchUponRead =
+            critEventsCounters->GetCounter(
+                "AppCriticalEvents/MirroredDiskChecksumMismatchUponRead",
+                true);
+
+        NProto::TStorageServiceConfig config;
+        config.SetMirrorReadReplicaCount(2);
+        TTestEnv env(runtime, config);
+
+        // Write different data to all replicas.
+        const auto range = TBlockRange64::WithLength(2049, 50);
+        env.WriteReplica(0, range, 'A');
+        env.WriteReplica(1, range, 'B');
+        env.WriteReplica(2, range, 'B');
+
+        // Read request should cause E_REJECTED error since data checksums in
+        // replicas 0 and 1 are different.
+        TPartitionClient client(runtime, env.ActorId);
+        {
+            TVector<TString> blocks;
+            client.SendReadBlocksLocalRequest(
+                range,
+                TGuardedSgList(ResizeBlocks(
+                    blocks,
+                    range.Size(),
+                    TString(DefaultBlockSize, '\0')
+                )));
+            auto response = client.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // TODO: check nonlocal requests as well
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            mirroredDiskChecksumMismatchUponRead->Val());
+
+        // TODO: check that consistency was restored and that ReadBlocks returns S_OK
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -81,9 +81,9 @@ struct TEvNonreplPartitionPrivate
 
     struct TWriteOrZeroCompleted
     {
-        ui64 RequestCounter;
-        ui64 TotalCycles;
-        bool FollowerGotNonRetriableError;
+        const ui64 RequestCounter;
+        const ui64 TotalCycles;
+        const bool FollowerGotNonRetriableError;
 
         TWriteOrZeroCompleted(
                 ui64 requestCounter,
@@ -92,6 +92,24 @@ struct TEvNonreplPartitionPrivate
             : RequestCounter(requestCounter)
             , TotalCycles(totalCycles)
             , FollowerGotNonRetriableError(followerGotNonRetriableError)
+        {
+        }
+    };
+
+    //
+    // MirroredReadCompleted
+    //
+
+    struct TMirroredReadCompleted
+    {
+        const ui64 RequestCounter;
+        const bool ChecksumMismatchObserved;
+
+        TMirroredReadCompleted(
+                ui64 requestCounter,
+                bool checksumMismatchObserved)
+            : RequestCounter(requestCounter)
+            , ChecksumMismatchObserved(checksumMismatchObserved)
         {
         }
     };
@@ -211,6 +229,7 @@ struct TEvNonreplPartitionPrivate
         EvRangeMigrated,
         EvMigrateNextRange,
         EvWriteOrZeroCompleted,
+        EvMirroredReadCompleted,
         EvChecksumBlocksCompleted,
         EvResyncNextRange,
         EvRangeResynced,
@@ -244,6 +263,11 @@ struct TEvNonreplPartitionPrivate
     using TEvWriteOrZeroCompleted = TResponseEvent<
         TWriteOrZeroCompleted,
         EvWriteOrZeroCompleted
+    >;
+
+    using TEvMirroredReadCompleted = TResponseEvent<
+        TMirroredReadCompleted,
+        EvMirroredReadCompleted
     >;
 
     using TEvResyncNextRange = TResponseEvent<

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -242,6 +242,7 @@ private:
     NActors::TActorId ActorId;
     NActors::TActorId Sender;
     const ui32 BlockSize;
+    ui64 RequestId = 0;
 
 public:
     TPartitionClient(
@@ -367,7 +368,7 @@ public:
     void Send##name##Request(Args&&... args)                                   \
     {                                                                          \
         auto request = Create##name##Request(std::forward<Args>(args)...);     \
-        SendRequest(ActorId, std::move(request));                              \
+        SendRequest(ActorId, std::move(request), ++RequestId);                 \
     }                                                                          \
                                                                                \
     std::unique_ptr<ns::TEv##name##Response> Recv##name##Response()            \
@@ -379,7 +380,7 @@ public:
     std::unique_ptr<ns::TEv##name##Response> name(Args&&... args)              \
     {                                                                          \
         auto request = Create##name##Request(std::forward<Args>(args)...);     \
-        SendRequest(ActorId, std::move(request));                              \
+        SendRequest(ActorId, std::move(request), ++RequestId);                 \
                                                                                \
         auto response = RecvResponse<ns::TEv##name##Response>();               \
         UNIT_ASSERT_C(                                                         \


### PR DESCRIPTION
If MirrorReadReplicaCount > 1, we read data from one of the replicas and we request checksums from the remaining replicas. If some of the checksums differ, we return E_REJECTED. For m3 disks and MirrorReadReplicaCount=2 one of the next retries will return S_OK if at least 2 replicas contain the same data. If data is different in all replicas, nothing can be done automatically and read request will hang (will be retried until someone manually fixes the discrepancy). 

If such a discrepancy upon read is detected, MirroredDiskChecksumMismatchUponRead critical event is raised if there were no concurrent writes whose ranges overlap the range of the read request.

In case of a 2/3 read and a discrepancy in checksums we could write some code to read the 3rd replica and, if the data in it matches the data in one of the other 2 replicas, we could return S_OK, but the code would be more complex. So for simplicity we just return E_REJECTED and one of the next retries will hit the 2 replicas which contain the same versions of the data so eventually we will return S_OK. There's no point optimizing this scenario since we hope that this scenario isn't just rare - we hope it never happens.

There is also a small chance of a false positive MirroredDiskChecksumMismatchUponRead critical event in the following scenario:
1. WriteBlocks request is processed, it successfully executes in some replicas, fails in other replicas, E_REJECTED is returned, backoff in DurableClient begins
2. ReadBlocks request comes, sees checksum discrepancy (due to the incomplete write), sees no dirty flag upon completion, reports MirroredDiskChecksumMismatchUponRead
3. WriteBlocks gets retried and restores consistency among the replicas

But it's pretty hard to fix this case at the storage libs level and we think that the probability of such a case is low enough because normally guests don't do concurrent overlapping reads+writes. Let's try to use the current logic and, if such false positives become a problem, let's just do overlapping read/write protection at the client stack level (we already have conceptually similar logic there - e.g. read-modify-write for unaligned writes).  

#2077 