### PR TITLE
[Filestore] Enable unix socket support in NFS server

### DIFF
--- a/cloud/filestore/tests/auth/lib/__init__.py
+++ b/cloud/filestore/tests/auth/lib/__init__.py
@@ -46,7 +46,8 @@ class TestFixture:
         client_config.ClientConfig.CopyFrom(TClientConfig())
         client_config.ClientConfig.RootCertsFile = common.source_path(
             "cloud/filestore/tests/certs/server.crt")
-        client_config.ClientConfig.SecurePort = int(self.__port)
+        if self.__port:
+            client_config.ClientConfig.SecurePort = int(self.__port)
         self.__client_config_path.write_text(MessageToString(client_config))
 
     def get_client(self, auth_token, unix_socket=None):

--- a/cloud/filestore/tests/auth/new/server/test.py
+++ b/cloud/filestore/tests/auth/new/server/test.py
@@ -24,18 +24,18 @@ def test_new_auth_authorization_ok():
     log_result("test_new_auth_authorization_ok", result)
     assert result.returncode == 0
 
-# TODO: enable when unix sockets without auth are supported
-# def test_unix_socket_does_not_require_auth():
-#     fixture = TestFixture()
-#     client = fixture.get_client("some-token", use_unix_socket=True)
-#     result = client.create(
-#         "test_unix_socket_does_not_require_auth",
-#         "some_cloud",
-#         fixture.folder_id,
-#         return_stdout=False,
-#     )
-#     log_result("test_unix_socket_does_not_require_auth", result)
-#     assert result.returncode != 0
+
+def test_unix_socket_does_not_require_auth():
+    fixture = TestFixture()
+    client = fixture.get_client("some-token", use_unix_socket=True)
+    result = client.create(
+        "test_unix_socket_does_not_require_auth",
+        "some_cloud",
+        fixture.folder_id,
+        return_stdout=False,
+    )
+    log_result("test_unix_socket_does_not_require_auth", result)
+    assert result.returncode == 0
 
 
 def test_new_auth_unauthorized():

--- a/cloud/filestore/tests/auth/new/server/test.py
+++ b/cloud/filestore/tests/auth/new/server/test.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from cloud.filestore.tests.auth.lib import TestFixture, log_result
 
@@ -27,7 +28,8 @@ def test_new_auth_authorization_ok():
 
 def test_unix_socket_does_not_require_auth():
     fixture = TestFixture()
-    client = fixture.get_client("some-token", use_unix_socket=True)
+    uds_path = os.getenv("NFS_SERVER_UNIX_SOCKET_PATH")
+    client = fixture.get_client("some-token", unix_socket=uds_path)
     result = client.create(
         "test_unix_socket_does_not_require_auth",
         "some_cloud",


### PR DESCRIPTION
issue: #2570

At this moment only nfs-vhost server handles UDS request(https://github.com/ydb-platform/nbs/issues/380). Using the same ValidateRequest implementation as for vhost to handle requests from uds
