### PR TITLE
Do not raise crit event when agent is not found

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5512,7 +5512,7 @@ void TDiskRegistryState::CleanupAgentConfig(
     const NProto::TAgentConfig& agent)
 {
     auto error = TryToRemoveAgentDevices(db, agent.GetAgentId());
-    if (!HasError(error)) {
+    if (!HasError(error) || error.GetCode() == E_NOT_FOUND) {
         return;
     }
 


### PR DESCRIPTION
Недавно добавленный `DiskRegistryCleanupAgentConfigError` начал загораться. Для этого достаточно позвать два раза `REMOVE_HOST`