### PR TITLE
Enable SuppressVersionCheck by default for every YDB-based program; add EnableVersionCheck flag instead

### DIFF
--- a/cloud/blockstore/libs/disk_agent/config_initializer.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.cpp
@@ -96,7 +96,10 @@ void TConfigInitializer::InitKikimrConfig()
         );
     }
 
-    if (Options->SuppressVersionCheck) {
+    if (Options->EnableVersionCheck) {
+        nameServiceConfig.SetSuppressVersionCheck(false);
+    } else {
+        // We would like to have SuppressVersionCheck enabled by default.
         nameServiceConfig.SetSuppressVersionCheck(true);
     }
 

--- a/cloud/blockstore/tests/python/lib/nbs_runner.py
+++ b/cloud/blockstore/tests/python/lib/nbs_runner.py
@@ -54,7 +54,6 @@ class LocalNbs(Daemon):
             kms_config=None,
             ping_path='/blockstore',
             rack="the_rack",
-            use_ic_version_check=False,
             use_secure_registration=False,
             grpc_ssl_port=None,
             access_service_type=AccessService,
@@ -156,7 +155,6 @@ class LocalNbs(Daemon):
             self.__proto_configs["auth.txt"] = self.__generate_auth_txt(port)
 
         self.__load_configs_from_cms = load_configs_from_cms
-        self.__use_ic_version_check = use_ic_version_check
         self.__restart_interval = restart_interval
         self.__ping_path = ping_path
         self.__use_secure_registration = use_secure_registration
@@ -566,9 +564,6 @@ ModifyScheme {
                 "--node-broker", "localhost:" + str(self.__grpc_ssl_port),
                 "--use-secure-registration",
             ]
-
-        if not self.__use_ic_version_check:
-            command.append("--suppress-version-check")
 
         if self.ydbstats_config is not None:
             command += [

--- a/cloud/blockstore/tests/recipes/local-kikimr/__main__.py
+++ b/cloud/blockstore/tests/recipes/local-kikimr/__main__.py
@@ -91,8 +91,7 @@ def start(argv):
         nbs_secure_port=nbs_secure_port,
         nbs_port=nbs_port,
         kikimr_binary_path=kikimr_binary_path,
-        nbs_binary_path=nbs_binary_path,
-        use_ic_version_check=args.use_ic_version_check)
+        nbs_binary_path=nbs_binary_path)
 
     nbs.setup_cms(kikimr_cluster.client)
 

--- a/cloud/filestore/tests/python/lib/daemon_config.py
+++ b/cloud/filestore/tests/python/lib/daemon_config.py
@@ -340,7 +340,6 @@ class FilestoreDaemonConfigGenerator:
                 self.__storage_config_file_path,
                 "--dynamic-naming-file",
                 self.__config_file_path("dyn_ns.txt"),
-                "--suppress-version-check",
                 "--load-configs-from-cms",
                 "--node-broker",
                 "localhost:{}".format(self.__kikimr_port),

--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -81,7 +81,10 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
         );
     }
 
-    if (Options->SuppressVersionCheck) {
+    if (Options->EnableVersionCheck) {
+        nameServiceConfig.SetSuppressVersionCheck(false);
+    } else {
+        // We would like to have SuppressVersionCheck enabled by default.
         nameServiceConfig.SetSuppressVersionCheck(true);
     }
 

--- a/cloud/storage/core/libs/kikimr/options.cpp
+++ b/cloud/storage/core/libs/kikimr/options.cpp
@@ -18,9 +18,9 @@ TOptionsYdbBase::TOptionsYdbBase()
         .RequiredArgument("PATH")
         .StoreResult(&RestartsCountFile);
 
-    Opts.AddLongOption("suppress-version-check", "Suppress version compatibility checking via IC")
+    Opts.AddLongOption("enable-version-check", "Enables version compatibility checking via IC")
         .NoArgument()
-        .StoreTrue(&SuppressVersionCheck);
+        .StoreTrue(&EnableVersionCheck);
 
     Opts.AddLongOption("log-file")
         .RequiredArgument("FILE")

--- a/cloud/storage/core/libs/kikimr/options.h
+++ b/cloud/storage/core/libs/kikimr/options.h
@@ -35,7 +35,7 @@ struct TOptionsYdbBase
     TString LocationFile;
 
     TString RestartsCountFile;
-    bool SuppressVersionCheck = false;
+    bool EnableVersionCheck = false;
 
     bool LoadCmsConfigs = false;
 


### PR DESCRIPTION
Traditional YDB-based programs have `SuppressVersionCheck` disabled by default, but it is very uncomfortable flag to work with, because:
* To roll out major release of YDB-based program one need either include current version to the list of compatible [versions](https://github.com/ydb-platform/nbs/blob/a51bb305809c4ab28581bdba577bbb43eeec1247/contrib/ydb/core/driver_lib/version/version.cpp#L80)  or enable `SuppressVersionCheck` flag in all installations. First is not always possible, because we would like to maintain our `contrib/ydb` in sync with https://github.com/ydb-platform/ydb. Second increases probability of incident because it is easy to forget `SuppressVersionCheck` for some of the clusters and roll out release with major version that is incompatible with previous version
* We do not remember any case when version check saved us from incident