### PR TITLE
issue-1932: introducing ShardAllocationUnit and AutomaticallyCreatedShardSize parameters instead of MaxShardSize; creating 5TiB shards by default, calculating shard count as floor(fsSize/ShardAllocationUnit) instead of ceil(fsSize/ShardAllocationUnit)

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -470,7 +470,7 @@ message TStorageConfig
     // config.
     optional bool AutomaticShardCreationEnabled = 405;
     // Affects shard count calculation if AutomaticShardCreationEnabled is on.
-    optional uint64 MaxShardSize = 406;
+    optional uint64 ShardAllocationUnit = 406;
 
     // Enable Writeback cache on guest (fuse client)
     optional bool GuestWritebackCacheEnabled = 407;
@@ -478,4 +478,7 @@ message TStorageConfig
     // Ignore orphan sessions upon filestore sessions check during destruction
     // attempts.
     optional bool AllowFileStoreDestroyWithOrphanSessions = 408;
+
+    // Automatically created shards will be of this size.
+    optional uint64 AutomaticallyCreatedShardSize = 409;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -54,7 +54,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(MaxTruncateTxInflight,              ui32,   10                        )\
                                                                                \
     xxx(AutomaticShardCreationEnabled,                  bool,   false         )\
-    xxx(MaxShardSize,                                   ui64,   4_TB          )\
+    xxx(ShardAllocationUnit,                            ui64,   4_TB          )\
+    xxx(AutomaticallyCreatedShardSize,                  ui64,   5_TB          )\
                                                                                \
     xxx(MaxFileBlocks,                                  ui32,   300_GB / 4_KB )\
     xxx(LargeDeletionMarkersEnabled,                    bool,   false         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -292,7 +292,8 @@ public:
     bool GetThreeStageWriteDisabledForHDD() const;
 
     bool GetAutomaticShardCreationEnabled() const;
-    ui64 GetMaxShardSize() const;
+    ui64 GetShardAllocationUnit() const;
+    ui64 GetAutomaticallyCreatedShardSize() const;
 
     bool GetGuestWritebackCacheEnabled() const;
 };

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -278,23 +278,6 @@ TPoolKinds GetPoolKinds(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ui32 ComputeShardCount(
-    const TStorageConfig& config,
-    const NKikimrFileStore::TConfig& fileStore)
-{
-    const double fileStoreSize =
-        fileStore.GetBlocksCount() * fileStore.GetBlockSize();
-
-    ui32 shardCount = std::ceil(fileStoreSize / config.GetMaxShardSize());
-    Y_DEBUG_ABORT_UNLESS(
-        shardCount >= 1,
-        "size %f shard %lu",
-        fileStoreSize,
-        config.GetMaxShardSize());
-
-    return Min(shardCount, MaxShardCount);
-}
-
 ui32 ComputeAllocationUnitCount(
     const TStorageConfig& config,
     const NKikimrFileStore::TConfig& fileStore)
@@ -517,6 +500,23 @@ void SetupFileStorePerformanceAndChannels(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ui32 ComputeShardCount(
+    const ui64 blocksCount,
+    const ui32 blockSize,
+    const ui64 shardAllocationUnit)
+{
+    const double fileStoreSize = blocksCount * blockSize;
+
+    const ui32 shardCount = std::floor(fileStoreSize / shardAllocationUnit);
+    Y_DEBUG_ABORT_UNLESS(
+        shardCount >= 1,
+        "size %f shard %lu",
+        fileStoreSize,
+        shardAllocationUnit);
+
+    return Min(shardCount, MaxShardCount);
+}
+
 void SetupFileStorePerformanceAndChannels(
     bool allocateMixed0Channel,
     const TStorageConfig& config,
@@ -545,13 +545,17 @@ TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
         result.MainFileSystemConfig,
         clientProfile);
 
-    const auto shardCount = ComputeShardCount(config, fileStore);
+    const auto shardCount = ComputeShardCount(
+        fileStore.GetBlocksCount(),
+        fileStore.GetBlockSize(),
+        config.GetShardAllocationUnit());
     result.ShardConfigs.resize(shardCount);
     for (ui32 i = 0; i < shardCount; ++i) {
         result.ShardConfigs[i] = fileStore;
         result.ShardConfigs[i].ClearVersion();
         result.ShardConfigs[i].SetBlocksCount(
-            config.GetMaxShardSize() / fileStore.GetBlockSize());
+            config.GetAutomaticallyCreatedShardSize()
+            / fileStore.GetBlockSize());
         result.ShardConfigs[i].SetFileSystemId(
             Sprintf("%s_s%u", fileStore.GetFileSystemId().c_str(), i + 1));
         SetupFileStorePerformanceAndChannels(

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -508,12 +508,6 @@ ui32 ComputeShardCount(
     const double fileStoreSize = blocksCount * blockSize;
 
     const ui32 shardCount = std::floor(fileStoreSize / shardAllocationUnit);
-    Y_DEBUG_ABORT_UNLESS(
-        shardCount >= 1,
-        "size %f shard %lu",
-        fileStoreSize,
-        shardAllocationUnit);
-
     return Min(shardCount, MaxShardCount);
 }
 

--- a/cloud/filestore/libs/storage/core/model.h
+++ b/cloud/filestore/libs/storage/core/model.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "config.h"
 
 #include <cloud/filestore/public/api/protos/fs.pb.h>
@@ -15,6 +17,11 @@ struct TMultiShardFileStoreConfig
     NKikimrFileStore::TConfig MainFileSystemConfig;
     TVector<NKikimrFileStore::TConfig> ShardConfigs;
 };
+
+ui32 ComputeShardCount(
+    const ui64 blocksCount,
+    const ui32 blockSize,
+    const ui64 shardAllocationUnit);
 
 TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
     const TStorageConfig& config,

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -2297,7 +2297,8 @@ Y_UNIT_TEST_SUITE(TModel)
 
         // Disable media type override.
         StorageConfig.SetAutomaticShardCreationEnabled(true);
-        StorageConfig.SetMaxShardSize(4_TB);
+        StorageConfig.SetShardAllocationUnit(4_TB);
+        StorageConfig.SetAutomaticallyCreatedShardSize(5_TB);
 
         auto fs = SetupMultiShardFileStorePerformanceAndChannels(
             StorageConfig,
@@ -2325,6 +2326,10 @@ Y_UNIT_TEST_SUITE(TModel)
             KikimrConfig,
             ClientPerformanceProfile);
         UNIT_ASSERT_VALUES_EQUAL(254, fs.ShardConfigs.size());
+
+        for (const auto& sc: fs.ShardConfigs) {
+            UNIT_ASSERT_VALUES_EQUAL(5_TB / 4_KB, sc.GetBlocksCount());
+        }
     }
 }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -6206,6 +6206,25 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             {fsId, fsId + "_s1", fsId + "_s2"});
     }
 
+    Y_UNIT_TEST(ShouldNotConfigureShardsAutomaticallyForSmallFileSystems)
+    {
+        NProto::TStorageConfig config;
+        config.SetAutomaticShardCreationEnabled(true);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        const TString fsId = "test";
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, (1_GB - 4_KB) / 4_KB);
+
+        DoTestShardedFileSystemConfigured(fsId, service, {fsId});
+    }
+
     Y_UNIT_TEST(ShouldHandleErrorsDuringShardedFileSystemCreation)
     {
         NProto::TStorageConfig config;

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -6184,7 +6184,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetAutomaticShardCreationEnabled(true);
-        config.SetMaxShardSize(1_GB);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 
@@ -6209,7 +6210,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetAutomaticShardCreationEnabled(true);
-        config.SetMaxShardSize(1_GB);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 
@@ -6372,7 +6374,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetAutomaticShardCreationEnabled(true);
-        config.SetMaxShardSize(1_GB);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 
@@ -6423,7 +6426,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetAutomaticShardCreationEnabled(true);
-        config.SetMaxShardSize(1_GB);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 
@@ -6563,7 +6567,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetAutomaticShardCreationEnabled(true);
-        config.SetMaxShardSize(1_GB);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 
@@ -6592,11 +6597,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         Sort(ids);
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
 
-        service.ResizeFileStore(fsId, (3_GB + 4_KB) / 4_KB);
+        service.ResizeFileStore(fsId, (4_GB - 4_KB) / 4_KB);
 
-        expected = TVector<TString>{
-            fsId, fsId + "_s1", fsId + "_s2", fsId + "_s3", fsId + "_s4"
-        };
         listing = service.ListFileStores();
         fsIds = listing->Record.GetFileStores();
         ids = TVector<TString>(fsIds.begin(), fsIds.end());
@@ -6605,6 +6607,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         service.ResizeFileStore(fsId, 4_GB / 4_KB);
 
+        expected = TVector<TString>{
+            fsId, fsId + "_s1", fsId + "_s2", fsId + "_s3", fsId + "_s4"
+        };
         listing = service.ListFileStores();
         fsIds = listing->Record.GetFileStores();
         ids = TVector<TString>(fsIds.begin(), fsIds.end());
@@ -6616,7 +6621,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetAutomaticShardCreationEnabled(true);
-        config.SetMaxShardSize(1_GB);
+        config.SetShardAllocationUnit(1_GB);
+        config.SetAutomaticallyCreatedShardSize(2_GB);
         TTestEnv env({}, config);
         env.CreateSubDomain("nfs");
 

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -45,7 +45,7 @@ message TFileSystem
     repeated string ShardFileSystemIds = 13;
     uint32 ShardNo = 14;
     bool AutomaticShardCreationEnabled = 15;
-    uint64 MaxShardSize = 16;
+    uint64 ShardAllocationUnit = 16;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -133,7 +133,7 @@ void TIndexTabletActor::HandleUpdateConfig(
         // autosharding params are deliberately applied upon FS creation
         newConfig.SetAutomaticShardCreationEnabled(
             Config->GetAutomaticShardCreationEnabled());
-        newConfig.SetMaxShardSize(Config->GetMaxShardSize());
+        newConfig.SetShardAllocationUnit(Config->GetShardAllocationUnit());
 
         LOG_INFO(ctx,TFileStoreComponents::TABLET,
             "%s Starting tablet config initialization [txId: %d]"
@@ -141,7 +141,7 @@ void TIndexTabletActor::HandleUpdateConfig(
             LogTag.c_str(),
             txId,
             Config->GetAutomaticShardCreationEnabled(),
-            Config->GetMaxShardSize());
+            Config->GetShardAllocationUnit());
 
         // First config update on tablet creation. No need to validate config.
         ExecuteTx<TUpdateConfig>(
@@ -159,7 +159,7 @@ void TIndexTabletActor::HandleUpdateConfig(
     newConfig.SetShardNo(oldConfig.GetShardNo());
     newConfig.SetAutomaticShardCreationEnabled(
         oldConfig.GetAutomaticShardCreationEnabled());
-    newConfig.SetMaxShardSize(oldConfig.GetMaxShardSize());
+    newConfig.SetShardAllocationUnit(oldConfig.GetShardAllocationUnit());
 
     // Config update occured due to alter/resize.
     if (auto error = ValidateUpdateConfigRequest(oldConfig, newConfig)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -1,6 +1,7 @@
 #include "tablet_state_impl.h"
 
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
+#include <cloud/filestore/libs/storage/core/model.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
 
 #include <library/cpp/protobuf/json/proto2json.h>
@@ -212,11 +213,12 @@ bool TIndexTabletState::CalculateExpectedShardCount() const
     const auto currentShardCount = FileSystem.ShardFileSystemIdsSize();
     ui64 autoShardCount = 0;
     if (FileSystem.GetAutomaticShardCreationEnabled()
-            && FileSystem.GetMaxShardSize())
+            && FileSystem.GetShardAllocationUnit())
     {
-        const double fsSize =
-            FileSystem.GetBlockSize() * FileSystem.GetBlocksCount();
-        autoShardCount = ceil(fsSize / FileSystem.GetMaxShardSize());
+        autoShardCount = ComputeShardCount(
+            FileSystem.GetBlocksCount(),
+            FileSystem.GetBlockSize(),
+            FileSystem.GetShardAllocationUnit());
     }
 
     return Max(currentShardCount, autoShardCount);

--- a/cloud/filestore/tests/client_sharded/nfs-storage.txt
+++ b/cloud/filestore/tests/client_sharded/nfs-storage.txt
@@ -2,4 +2,5 @@ MultiTabletForwardingEnabled: true
 LargeDeletionMarkersEnabled: true
 MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true
-MaxShardSize: 1073741824
+ShardAllocationUnit: 1073741824
+AutomaticallyCreatedShardSize: 1073741824


### PR DESCRIPTION
Adding some extra space (diff between AutomaticallyCreatedShardSize and ShardAllocationUnit is 1TiB by default) to decrease the risk of ENOSPC due to imperfect data balancing among the shards.

Using floor instead of ceil in order not to create shards at all for small filesystems.

#1932 