### PR TITLE
Fix missing hw problems flag in the nonrepl partition response

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
@@ -54,6 +54,7 @@ bool TDiskAgentBaseRequestActor::HandleError(
     bool timedOut)
 {
     if (FAILED(error.GetCode())) {
+        PartConfig->AugmentErrorFlags(error);
         ProcessError(*TActorContext::ActorSystem(), *PartConfig, error);
 
         Done(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -1409,6 +1409,11 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         UNIT_ASSERT_C(
             HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT),
             FormatError(response->GetError()));
+        UNIT_ASSERT_C(
+            HasProtoFlag(
+                response->GetError().GetFlags(),
+                NProto::EF_HW_PROBLEMS_DETECTED),
+            FormatError(response->GetError()));
     }
 
     Y_UNIT_TEST(ShouldSendStatsToVolume)


### PR DESCRIPTION
После https://github.com/ydb-platform/nbs/pull/2359 запросы к диску всегда пытаются отправляться в DA. Раньше же ошибка создавалась внутри партишиона и флаг выставлялся при вызове `PartConfig->MakeError()`
