### PR TITLE
[Disk Manager] TasksToListLimit parameter added to avoid situation when all tasks from front of `ready_to_run` table can not be executed due to inflightTasksByType limit

### DIFF
--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -65,8 +65,9 @@ message TasksConfig {
     // will not be cleared from the database.
     optional bool RegularSystemTasksEnabled = 33 [default = true];
 
-    // Number of tasks from database that will be listed. We use this parameter
-    // to avoid situation when all tasks from front of `ready_to_run` table can
-    // not be executed due to inflightTasksByType limit.
+    // Lister retrieves tasks from the front of the tasks table and sends them
+    // to workers if possible.
+    // This parameter limits the number of tasks that will be retrieved from the
+    // database.
     optional uint64 TasksToListLimit = 34 [default = 10000];
 }

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -65,5 +65,8 @@ message TasksConfig {
     // will not be cleared from the database.
     optional bool RegularSystemTasksEnabled = 33 [default = true];
 
+    // Number of tasks from database that will be listed. We use this parameter
+    // to avoid situation when all tasks from front of `ready_to_run` table can
+    // not be executed due to inflightTasksByType limit.
     optional uint64 TasksToListLimit = 34 [default = 10000];
 }

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -64,4 +64,6 @@ message TasksConfig {
     // Warning: if this flag is false, then information about ended tasks
     // will not be cleared from the database.
     optional bool RegularSystemTasksEnabled = 33 [default = true];
+
+    optional uint64 TasksToListLimit = 34 [default = 10000];
 }

--- a/cloud/tasks/lister.go
+++ b/cloud/tasks/lister.go
@@ -20,6 +20,7 @@ type listTasksFunc = func(
 ) ([]storage.TaskInfo, error)
 
 type lister struct {
+	tasksToListLimit      uint64
 	listTasks             listTasksFunc
 	channels              []*channel
 	pollForTasksPeriodMin time.Duration
@@ -64,9 +65,7 @@ func (l *lister) loop(ctx context.Context) {
 			continue
 		}
 
-		limit := channelsLen - inflightTaskCount
-
-		tasks, err := l.listTasks(ctx, uint64(limit))
+		tasks, err := l.listTasks(ctx, l.tasksToListLimit)
 		if err == nil {
 			logging.Debug(ctx, "lister listed %v tasks", len(tasks))
 
@@ -170,6 +169,7 @@ func (l *lister) getInflightTaskCount() uint32 {
 
 func newLister(
 	ctx context.Context,
+	tasksToListLimit uint64,
 	listTasks listTasksFunc,
 	channelsCount uint64,
 	pollForTasksPeriodMin time.Duration,
@@ -178,6 +178,7 @@ func newLister(
 ) *lister {
 
 	lister := &lister{
+		tasksToListLimit:      tasksToListLimit,
 		listTasks:             listTasks,
 		channels:              make([]*channel, channelsCount),
 		pollForTasksPeriodMin: pollForTasksPeriodMin,

--- a/cloud/tasks/lister.go
+++ b/cloud/tasks/lister.go
@@ -20,9 +20,9 @@ type listTasksFunc = func(
 ) ([]storage.TaskInfo, error)
 
 type lister struct {
-	tasksToListLimit      uint64
 	listTasks             listTasksFunc
 	channels              []*channel
+	tasksToListLimit      uint64
 	pollForTasksPeriodMin time.Duration
 	pollForTasksPeriodMax time.Duration
 	inflightTasks         sync.Map
@@ -169,18 +169,18 @@ func (l *lister) getInflightTaskCount() uint32 {
 
 func newLister(
 	ctx context.Context,
-	tasksToListLimit uint64,
 	listTasks listTasksFunc,
 	channelsCount uint64,
+	tasksToListLimit uint64,
 	pollForTasksPeriodMin time.Duration,
 	pollForTasksPeriodMax time.Duration,
 	inflightTaskLimits map[string]int64,
 ) *lister {
 
 	lister := &lister{
-		tasksToListLimit:      tasksToListLimit,
 		listTasks:             listTasks,
 		channels:              make([]*channel, channelsCount),
+		tasksToListLimit:      tasksToListLimit,
 		pollForTasksPeriodMin: pollForTasksPeriodMin,
 		pollForTasksPeriodMax: pollForTasksPeriodMax,
 		inflightTaskLimits:    inflightTaskLimits,

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -900,6 +900,7 @@ func StartRunners(
 
 	listerReadyToRun := newLister(
 		ctx,
+		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksReadyToRun(
 				ctx,
@@ -914,6 +915,7 @@ func StartRunners(
 	)
 	listerReadyToCancel := newLister(
 		ctx,
+		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksReadyToCancel(
 				ctx,
@@ -951,6 +953,7 @@ func StartRunners(
 
 	listerStallingWhileRunning := newLister(
 		ctx,
+		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksStallingWhileRunning(
 				ctx,
@@ -966,6 +969,7 @@ func StartRunners(
 	)
 	listerStallingWhileCancelling := newLister(
 		ctx,
+		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksStallingWhileCancelling(
 				ctx,

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -900,7 +900,6 @@ func StartRunners(
 
 	listerReadyToRun := newLister(
 		ctx,
-		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksReadyToRun(
 				ctx,
@@ -909,13 +908,13 @@ func StartRunners(
 			)
 		},
 		config.GetRunnersCount(),
+		config.GetTasksToListLimit(),
 		pollForTasksPeriodMin,
 		pollForTasksPeriodMax,
 		inflightTaskLimits,
 	)
 	listerReadyToCancel := newLister(
 		ctx,
-		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksReadyToCancel(
 				ctx,
@@ -924,6 +923,7 @@ func StartRunners(
 			)
 		},
 		config.GetRunnersCount(),
+		config.GetTasksToListLimit(),
 		pollForTasksPeriodMin,
 		pollForTasksPeriodMax,
 		inflightTaskLimits,
@@ -953,7 +953,6 @@ func StartRunners(
 
 	listerStallingWhileRunning := newLister(
 		ctx,
-		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksStallingWhileRunning(
 				ctx,
@@ -963,13 +962,13 @@ func StartRunners(
 			)
 		},
 		config.GetStalkingRunnersCount(),
+		config.GetTasksToListLimit(),
 		pollForStallingTasksPeriodMin,
 		pollForStallingTasksPeriodMax,
 		inflightTaskLimits,
 	)
 	listerStallingWhileCancelling := newLister(
 		ctx,
-		config.GetTasksToListLimit(),
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return taskStorage.ListTasksStallingWhileCancelling(
 				ctx,
@@ -979,6 +978,7 @@ func StartRunners(
 			)
 		},
 		config.GetStalkingRunnersCount(),
+		config.GetTasksToListLimit(),
 		pollForStallingTasksPeriodMin,
 		pollForStallingTasksPeriodMax,
 		inflightTaskLimits,

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1421,13 +1421,14 @@ func testListerLoop(
 	}
 	lister := newLister(
 		ctx,
+		100, // tasksToListLimit
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return tasks, nil
 		},
-		uint64(channelCount),
-		50*time.Millisecond,
-		100*time.Millisecond,
-		make(map[string]int64),
+		uint64(channelCount),   // channelsCount
+		50*time.Millisecond,    // pollForTasksPeriodMin
+		100*time.Millisecond,   // pollForTasksPeriodMax
+		make(map[string]int64), // inflightTaskLimits
 	)
 
 	receivedTasks := make([]storage.TaskInfo, 0)
@@ -1497,13 +1498,14 @@ func TestListerLoopCancellingWhileReceiving(t *testing.T) {
 	}
 	lister := newLister(
 		ctx,
+		100, // tasksToListLimit
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return tasks, nil
 		},
-		uint64(channelCount),
-		50*time.Millisecond,
-		100*time.Millisecond,
-		make(map[string]int64),
+		uint64(channelCount),   // channelsCount
+		50*time.Millisecond,    // pollForTasksPeriodMin
+		100*time.Millisecond,   // pollForTasksPeriodMax
+		make(map[string]int64), // inflightTaskLimits
 	)
 
 	receivedTasks := make([]storage.TaskInfo, 0)

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1421,11 +1421,11 @@ func testListerLoop(
 	}
 	lister := newLister(
 		ctx,
-		100, // tasksToListLimit
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return tasks, nil
 		},
 		uint64(channelCount),   // channelsCount
+		100,                    // tasksToListLimit
 		50*time.Millisecond,    // pollForTasksPeriodMin
 		100*time.Millisecond,   // pollForTasksPeriodMax
 		make(map[string]int64), // inflightTaskLimits
@@ -1498,11 +1498,11 @@ func TestListerLoopCancellingWhileReceiving(t *testing.T) {
 	}
 	lister := newLister(
 		ctx,
-		100, // tasksToListLimit
 		func(ctx context.Context, limit uint64) ([]storage.TaskInfo, error) {
 			return tasks, nil
 		},
 		uint64(channelCount),   // channelsCount
+		100,                    // tasksToListLimit
 		50*time.Millisecond,    // pollForTasksPeriodMin
 		100*time.Millisecond,   // pollForTasksPeriodMax
 		make(map[string]int64), // inflightTaskLimits

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -722,38 +722,38 @@ func TestTasksRunningLimit(t *testing.T) {
 	err = s.startRunners(ctx)
 	require.NoError(t, err)
 
-	longTasksIds := []string{}
+	longTaskIDs := []string{}
 	scheduledLongTaskCount := 6 * inflightLongTaskPerNodeLimit
 	for i := 0; i < scheduledLongTaskCount; i++ {
 		reqCtx := getRequestContext(t, ctx)
 		id, err := scheduleLongTask(reqCtx, s.scheduler)
 		require.NoError(t, err)
 
-		longTasksIds = append(longTasksIds, id)
+		longTaskIDs = append(longTaskIDs, id)
 	}
 
 	endedLongTaskCount := 0
-	longTasksErrs := make(chan error)
-	for _, id := range longTasksIds {
+	longTaskErrs := make(chan error)
+	for _, id := range longTaskIDs {
 		go func(id string) {
 			_, err := waitTask(ctx, s.scheduler, id)
-			longTasksErrs <- err
+			longTaskErrs <- err
 		}(id)
 	}
 
-	doublerTasksIds := []string{}
+	doublerTaskIDs := []string{}
 	scheduledDoublerTaskCount := 2 * inflightLongTaskPerNodeLimit
 	for i := 0; i < scheduledDoublerTaskCount; i++ {
 		reqCtx := getRequestContext(t, ctx)
 		id, err := scheduleDoublerTask(reqCtx, s.scheduler, 1)
 		require.NoError(t, err)
 
-		doublerTasksIds = append(doublerTasksIds, id)
+		doublerTaskIDs = append(doublerTaskIDs, id)
 	}
 
 	endedDoublerTaskCount := 0
 	doublerTaskErrs := make(chan error)
-	for _, id := range doublerTasksIds {
+	for _, id := range doublerTaskIDs {
 		go func(id string) {
 			_, err := waitTaskWithTimeout(
 				ctx,
@@ -792,7 +792,7 @@ func TestTasksRunningLimit(t *testing.T) {
 		case err := <-doublerTaskErrs:
 			require.NoError(t, err)
 			endedDoublerTaskCount++
-		case err := <-longTasksErrs:
+		case err := <-longTaskErrs:
 			require.NoError(t, err)
 			endedLongTaskCount++
 


### PR DESCRIPTION
During the operation of transferring data from legacy storage to current storage, an issue with scheduling arose, where the dataplane was unable to execute user tasks.

This is related to the fact that we read from the tasks database at most as many rows as there are workers on the host.

https://github.com/ydb-platform/nbs/blob/3f335a8812dd778e1f1fa907bd1e9e05e6f6a5ee/cloud/tasks/lister.go#L69

This completely blocks the queue if the tasks that were read are subject to the inflightTasksByType limit per SVM.

___

Let's imagine that we scheduled 2000 tasks of type XXX.

The limit on the number of their executions = 1.

Assume they are at the very beginning in the tables of the database.

There are 8 workers in the dataplane.

Therefore, we will fetch the first 8 tasks, all of which are of type XXX. 
https://github.com/ydb-platform/nbs/blob/1cd8d7460d559a9f144ae8a3d78796bc6b5fc835/cloud/tasks/lister.go#L68

We cannot execute them (except for the one already being executed) because there is a limit on the number of XXX per SVM.

And this shuffle won't help either.
https://github.com/ydb-platform/nbs/blob/1cd8d7460d559a9f144ae8a3d78796bc6b5fc835/cloud/tasks/lister.go#L75
