### PR TITLE
issue-1932: disabling tablet-side shard count check by default, can be reenabled via EnforceCorrectFileSystemShardCountUponSessionCreation StorageServiceConfig flag

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -481,4 +481,11 @@ message TStorageConfig
 
     // Automatically created shards will be of this size.
     optional uint64 AutomaticallyCreatedShardSize = 409;
+
+    // Forbids session creation (forces E_REJECTED) if filesystem shard count
+    // calculated based on the filesystem's size is too small.
+    // We can't enable this logic by default yet since we need to maintain
+    // backward compatibility during the update which enables automatic
+    // sharding.
+    optional bool EnforceCorrectFileSystemShardCountUponSessionCreation = 410;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -53,9 +53,10 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(MaxBlocksPerTruncateTx,             ui32,   0 /*TODO: 32GiB/4KiB*/    )\
     xxx(MaxTruncateTxInflight,              ui32,   10                        )\
                                                                                \
-    xxx(AutomaticShardCreationEnabled,                  bool,   false         )\
-    xxx(ShardAllocationUnit,                            ui64,   4_TB          )\
-    xxx(AutomaticallyCreatedShardSize,                  ui64,   5_TB          )\
+    xxx(AutomaticShardCreationEnabled,                          bool,   false )\
+    xxx(ShardAllocationUnit,                                    ui64,   4_TB  )\
+    xxx(AutomaticallyCreatedShardSize,                          ui64,   5_TB  )\
+    xxx(EnforceCorrectFileSystemShardCountUponSessionCreation,  bool,   false )\
                                                                                \
     xxx(MaxFileBlocks,                                  ui32,   300_GB / 4_KB )\
     xxx(LargeDeletionMarkersEnabled,                    bool,   false         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -294,6 +294,7 @@ public:
     bool GetAutomaticShardCreationEnabled() const;
     ui64 GetShardAllocationUnit() const;
     ui64 GetAutomaticallyCreatedShardSize() const;
+    bool GetEnforceCorrectFileSystemShardCountUponSessionCreation() const;
 
     bool GetGuestWritebackCacheEnabled() const;
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -147,16 +147,25 @@ void TIndexTabletActor::HandleCreateSession(
     if (actualShardCount < expectedShardCount) {
         auto message = TStringBuilder() << "Shard count smaller than expected: "
             << actualShardCount << " < " << expectedShardCount;
+        const bool shouldReject =
+            Config->GetEnforceCorrectFileSystemShardCountUponSessionCreation();
+        if (shouldReject) {
+            LOG_INFO(ctx, TFileStoreComponents::TABLET,
+                "%s CreateSession rejected: %s",
+                LogTag.c_str(),
+                message.c_str());
+
+            using TResponse = TEvIndexTablet::TEvCreateSessionResponse;
+            auto response = std::make_unique<TResponse>(
+                MakeError(E_REJECTED, std::move(message)));
+            NCloud::Reply(ctx, *requestInfo, std::move(response));
+            return;
+        }
+
         LOG_INFO(ctx, TFileStoreComponents::TABLET,
-            "%s CreateSession rejected: %s",
+            "%s CreateSession: %s",
             LogTag.c_str(),
             message.c_str());
-
-        using TResponse = TEvIndexTablet::TEvCreateSessionResponse;
-        auto response = std::make_unique<TResponse>(
-            MakeError(E_REJECTED, std::move(message)));
-        NCloud::Reply(ctx, *requestInfo, std::move(response));
-        return;
     }
 
     AddTransaction<TEvIndexTablet::TCreateSessionMethod>(*requestInfo);


### PR DESCRIPTION
Otherwise we have backward-compat issues for filesystems created during the deployment of autosharding

#1932 