### PR TITLE
issue-2559: aggregating shard stats in background

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
@@ -101,6 +101,8 @@ void TStatFileStoreActor::HandleDescribeFileStoreResponse(
     Convert(config, FileStore);
 
     auto request = std::make_unique<TEvIndexTablet::TEvGetStorageStatsRequest>();
+    // explicitly stating the intent
+    request->Record.SetAllowCache(false);
     request->Record.SetFileSystemId(FileSystemId);
 
     // forward request through tablet proxy
@@ -121,7 +123,7 @@ void TStatFileStoreActor::HandleStorageStats(
     auto response = std::make_unique<TEvService::TEvStatFileStoreResponse>();
     response->Record.MutableFileStore()->CopyFrom(FileStore);
 
-    auto stats = response->Record.MutableStats();
+    auto* stats = response->Record.MutableStats();
     stats->SetUsedNodesCount(msg->Record.GetStats().GetUsedNodesCount());
     stats->SetUsedBlocksCount(msg->Record.GetStats().GetUsedBlocksCount());
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4976,7 +4976,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.WriteData(headers, fsId, nodeId2, handle2, 0, data2);
 
         // waiting for async stats aggregation from shards
-        // doing it before triggering another event to avoid DispatchEvent call
+        // doing it before triggering another event to avoid DispatchEvents call
         // which does a long busy-wait loop
         env.GetRuntime().AdvanceCurrentTime(TDuration::Seconds(15));
 
@@ -5015,7 +5015,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.WriteData(headers, fsId, nodeId2, handle2, 0, data2);
 
         // waiting for async stats aggregation from shards
-        // doing it before triggering another event to avoid DispatchEvent call
+        // doing it before triggering another event to avoid DispatchEvents call
         // which does a long busy-wait loop
         env.GetRuntime().AdvanceCurrentTime(TDuration::Seconds(15));
         // just triggering another event chain - doesn't matter which one

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4975,6 +4975,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         auto data2 = GenerateValidateData(512_KB);
         service.WriteData(headers, fsId, nodeId2, handle2, 0, data2);
 
+        // waiting for async stats aggregation from shards
+        // doing it before triggering another event to avoid DispatchEvent call
+        // which does a long busy-wait loop
+        env.GetRuntime().AdvanceCurrentTime(TDuration::Seconds(15));
+
         const auto fsStat = service.StatFileStore(headers, fsId)->Record;
         const auto& fileStore = fsStat.GetFileStore();
         UNIT_ASSERT_VALUES_EQUAL(fsId, fileStore.GetFileSystemId());
@@ -4986,6 +4991,55 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(
             768_KB / 4_KB,
             fileStoreStats.GetUsedBlocksCount());
+
+        {
+            NProtoPrivate::TGetStorageStatsRequest request;
+            request.SetFileSystemId(fsId);
+            request.SetAllowCache(true);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            const auto response = service.ExecuteAction("GetStorageStats", buf);
+            NProtoPrivate::TGetStorageStatsResponse record;
+            auto status = google::protobuf::util::JsonStringToMessage(
+                response->Record.GetOutput(),
+                &record);
+            const auto& stats = record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                (data1.size() + data2.size()) / 4_KB,
+                stats.GetUsedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                (data1.size() + data2.size()) / 4_KB,
+                stats.GetMixedBlocksCount());
+        }
+
+        service.WriteData(headers, fsId, nodeId2, handle2, 0, data2);
+
+        // waiting for async stats aggregation from shards
+        // doing it before triggering another event to avoid DispatchEvent call
+        // which does a long busy-wait loop
+        env.GetRuntime().AdvanceCurrentTime(TDuration::Seconds(15));
+        // just triggering another event chain - doesn't matter which one
+        service.StatFileStore(headers, fsId);
+
+        {
+            NProtoPrivate::TGetStorageStatsRequest request;
+            request.SetFileSystemId(fsId);
+            request.SetAllowCache(true);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            const auto response = service.ExecuteAction("GetStorageStats", buf);
+            NProtoPrivate::TGetStorageStatsResponse record;
+            auto status = google::protobuf::util::JsonStringToMessage(
+                response->Record.GetOutput(),
+                &record);
+            const auto& stats = record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                (data1.size() + data2.size()) / 4_KB,
+                stats.GetUsedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                (data1.size() + 2 * data2.size()) / 4_KB,
+                stats.GetMixedBlocksCount());
+        }
     }
 
     Y_UNIT_TEST(ShouldRetryUnlinkingInShard)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -329,6 +329,9 @@ private:
             const NProto::TFileSystem& fileSystem);
     } Metrics;
 
+    NProtoPrivate::TStorageStats CachedAggregateStats;
+    bool AggregateStatsFetchingInProgress = false;
+
     const IProfileLogPtr ProfileLog;
     const ITraceSerializerPtr TraceSerializer;
 
@@ -612,6 +615,8 @@ private:
         const TVector<NProto::TOpLogEntry>& opLog);
 
     bool IsShard() const;
+
+    void FillSelfStorageStats(NProtoPrivate::TStorageStats* stats);
 
 private:
     template <typename TMethod>

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -820,6 +820,7 @@ struct TEvIndexTabletPrivate
 
     struct TGetShardStatsCompleted
     {
+        NProtoPrivate::TStorageStats AggregateStats;
         TInstant StartedTs;
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -614,7 +614,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                 {"filesystem", "test"}}, 0},
         });
 
-        // hard to guarantee something better than the absense of overflows
+        // hard to guarantee something better than the absence of overflows
         const auto latencySensorPredicate = [] (i64 val) {
             return val < 1e9;
         };

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -153,6 +153,9 @@ message TGetStorageStatsRequest
     uint32 CompactionRangeCountByCleanupScore = 4;
     // The same but for garbage score.
     uint32 CompactionRangeCountByGarbageScore = 5;
+
+    // Use cached data, don't require up-to-date stats.
+    bool AllowCache = 6;
 }
 
 message TGetStorageStatsResponse


### PR DESCRIPTION
will use these aggregated metrics to:
* implement cheap ENOSPC checks taking aggregated space usage into account
* report aggregated space usage in main tablet monitoring metrics

#2559 