### PR TITLE
Always call AugmentErrorFlags in ProcessError

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
@@ -54,7 +54,6 @@ bool TDiskAgentBaseRequestActor::HandleError(
     bool timedOut)
 {
     if (FAILED(error.GetCode())) {
-        PartConfig->AugmentErrorFlags(error);
         ProcessError(*TActorContext::ActorSystem(), *PartConfig, error);
 
         Done(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
@@ -34,12 +34,13 @@ void ProcessError(
 {
     if (error.GetCode() == E_BS_INVALID_SESSION) {
         SendEvReacquireDisk(system, config.GetParentActorId());
-
         error.SetCode(E_REJECTED);
     }
 
     if (error.GetCode() == E_IO || error.GetCode() == MAKE_SYSTEM_ERROR(EIO)) {
         error = config.MakeIOError(std::move(*error.MutableMessage()));
+    } else {
+        config.AugmentErrorFlags(error);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -22,17 +22,6 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void HandleError(
-    const TNonreplicatedPartitionConfigPtr& partConfig,
-    TStringBuf responseBuffer,
-    NProto::TError& error)
-{
-    error = NRdma::ParseError(responseBuffer);
-    partConfig->AugmentErrorFlags(error);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 TNonreplicatedPartitionRdmaActor::TNonreplicatedPartitionRdmaActor(
         TStorageConfigPtr config,
         TNonreplicatedPartitionConfigPtr partConfig,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -32,13 +32,6 @@ struct TDeviceReadRequestContext: public NRdma::TNullContext
     ui64 BlockCount = 0;
 };
 
-///////////////////////////////////////////////////////////////////////////////
-
-void HandleError(
-    const TNonreplicatedPartitionConfigPtr& partConfig,
-    TStringBuf responseBuffer,
-    NProto::TError& error);
-
 ////////////////////////////////////////////////////////////////////////////////
 
 class TNonreplicatedPartitionRdmaActor final

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -111,9 +111,9 @@ public:
         auto buffer = req->ResponseBuffer.Head(responseBytes);
 
         if (status == NRdma::RDMA_PROTO_OK) {
-            HandleResult(*dc, std::move(buffer));
+            HandleResult(*dc, buffer);
         } else {
-            HandleError(PartConfig, std::move(buffer), Error);
+            Error = NRdma::ParseError(buffer);
         }
 
         if (--ResponseCount != 0) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
@@ -129,7 +129,7 @@ public:
         if (status == NRdma::RDMA_PROTO_OK) {
             HandleResult(*dr, buffer);
         } else {
-            HandleError(PartConfig, buffer, *Response.MutableError());
+            *Response.MutableError() = NRdma::ParseError(buffer);
         }
 
         if (--ResponseCount != 0) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
@@ -127,7 +127,7 @@ public:
         if (status == NRdma::RDMA_PROTO_OK) {
             HandleResult(*dr, buffer);
         } else {
-            HandleError(PartConfig, buffer, Error);
+            Error = NRdma::ParseError(buffer);
         }
 
         if (--ResponseCount != 0) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -106,7 +106,7 @@ public:
         if (status == NRdma::RDMA_PROTO_OK) {
             HandleResult(buffer);
         } else {
-            HandleError(PartConfig, buffer, Error);
+            Error = NRdma::ParseError(buffer);
         }
 
         if (--ResponseCount != 0) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -85,9 +85,9 @@ public:
         auto buffer = req->ResponseBuffer.Head(responseBytes);
 
         if (status == NRdma::RDMA_PROTO_OK) {
-            HandleResult(std::move(buffer));
+            HandleResult(buffer);
         } else {
-            HandleError(PartConfig, std::move(buffer), Error);
+            Error = NRdma::ParseError(buffer);
         }
 
         if (--ResponseCount != 0) {


### PR DESCRIPTION
Немного лучшее исправление https://github.com/ydb-platform/nbs/pull/2596
Все ответы на чтение/запись/зануление от диск-агента должны дополнительно обрабатываться:
1. выставляться флаг EF_SILENT
2. выставляться флаг EF_HW_PROBLEMS_DETECTED
3. ошибка авторизации заменяться на E_REJECT + отсылаться сообщение TEvVolume::TEvReacquireDisk

Сделал чтобы все это происходило не отдельными вызовами ProcessError() + AugmentErrorFlags(), а одним ProcessError().