### PR TITLE
Fix shadow disk notification

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -258,6 +258,8 @@ class TDiskRegistryState
 
         ui32 ReplicaCount = 0;
         TString MasterDiskId;
+
+        // Filled if the disk is a shadow disk for the checkpoint.
         NProto::TCheckpointReplica CheckpointReplica;
 
         TVector<TDeviceId> DeviceReplacementIds;


### PR DESCRIPTION
Исправляется недоделки:
1. DiskRegistry больше не пытается делать миграции устройств теневых дисков.
2. DiskRegistry при нотификации об изменении конфига теневого диска теперь идет в диск источника. Это нужно если например NodeId дискагента под теневым диском поменялся. https://github.com/ydb-platform/nbs/issues/2609
