### PR TITLE
Output 'ss -tpna' when stopping filestore recipes

### DIFF
--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -136,6 +136,8 @@ def start(argv):
 
 
 def stop(argv):
+    logging.info(os.system("ss -tpna"))
+
     if not os.path.exists(PID_FILE_NAME):
         return
 

--- a/cloud/filestore/tests/recipes/service-local/__main__.py
+++ b/cloud/filestore/tests/recipes/service-local/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 
 import yatest.common as common
@@ -56,6 +57,8 @@ def start(argv):
 
 
 def stop(argv):
+    logging.info(os.system("ss -tpna"))
+
     if not os.path.exists(PID_FILE_NAME):
         return
 

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import pathlib
 import tempfile
@@ -155,6 +156,8 @@ def start(argv):
 
 
 def stop(argv):
+    logging.info(os.system("ss -tpna"))
+
     if not os.path.exists(PID_FILE_NAME):
         return
 


### PR DESCRIPTION
In order to better diagnose "address already in use" problem