### PR TITLE
[Disk Agent] handle disable concrete agent event in disk agent actor

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -340,6 +340,10 @@ STFUNC(TDiskAgentActor::StateWork)
             TEvDiskAgentPrivate::TEvCancelSuspensionRequest,
             HandleCancelSuspension);
 
+        HFunc(
+            TEvDiskAgent::TEvDisableConcreteAgentRequest,
+            HandleDisableConcreteAgent);
+
         case TEvDiskAgentPrivate::EvParsedWriteDeviceBlocksRequest:
             HandleWriteDeviceBlocks(
                 *reinterpret_cast<


### PR DESCRIPTION
#1950

Need DisableConcreteAgent event in integration test for Disk Manager in order to enforce shadow disk failure.