### PR TITLE
tracking ShardRequestActors to kill them upon tablet shutdown

### DIFF
--- a/cloud/filestore/libs/storage/tablet/shard_request_actor.h
+++ b/cloud/filestore/libs/storage/tablet/shard_request_actor.h
@@ -179,6 +179,10 @@ void TShardRequestActor<TRequest, TResponse>::ReplyAndDie(
         }
     }
 
+    using TCompletion = TEvIndexTabletPrivate::TEvShardRequestCompleted;
+    auto completion = std::make_unique<TCompletion>(error);
+    NCloud::Send(ctx, Tablet, std::move(completion));
+
     TBase::Die(ctx);
 }
 

--- a/cloud/filestore/libs/storage/tablet/shard_request_actor.h
+++ b/cloud/filestore/libs/storage/tablet/shard_request_actor.h
@@ -15,6 +15,7 @@ class TShardRequestActor final
 {
 private:
     const TString LogTag;
+    const NActors::TActorId Tablet;
     const TRequestInfoPtr RequestInfo;
     const TRequest::ProtoRecordType Request;
     const TVector<TString> ShardIds;
@@ -29,6 +30,7 @@ private:
 public:
     TShardRequestActor(
         TString logTag,
+        NActors::TActorId tablet,
         TRequestInfoPtr requestInfo,
         TRequest::ProtoRecordType request,
         TVector<TString> shardIds,
@@ -70,11 +72,13 @@ private:
 template <typename TRequest, typename TResponse>
 TShardRequestActor<TRequest, TResponse>::TShardRequestActor(
         TString logTag,
+        NActors::TActorId tablet,
         TRequestInfoPtr requestInfo,
         TRequest::ProtoRecordType request,
         TVector<TString> shardIds,
         std::unique_ptr<TResponse> response)
     : LogTag(std::move(logTag))
+    , Tablet(tablet)
     , RequestInfo(std::move(requestInfo))
     , Request(std::move(request))
     , ShardIds(std::move(shardIds))

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -806,6 +806,16 @@ void TIndexTabletActor::HandleForcedOperationStatus(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TIndexTabletActor::HandleShardRequestCompleted(
+    const TEvIndexTabletPrivate::TEvShardRequestCompleted::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ctx);
+    WorkerActors.erase(ev->Sender);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 bool TIndexTabletActor::HandleRequests(STFUNC_SIG)
 {
     switch (ev->GetTypeRewrite()) {
@@ -926,6 +936,9 @@ STFUNC(TIndexTabletActor::StateInit)
         HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
+        HFunc(
+            TEvIndexTabletPrivate::TEvShardRequestCompleted,
+            HandleShardRequestCompleted);
 
         FILESTORE_HANDLE_REQUEST(WaitReady, TEvIndexTablet)
 
@@ -970,6 +983,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
+        HFunc(
+            TEvIndexTabletPrivate::TEvShardRequestCompleted,
+            HandleShardRequestCompleted);
 
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
@@ -1031,6 +1047,9 @@ STFUNC(TIndexTabletActor::StateZombie)
         HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
+        HFunc(
+            TEvIndexTabletPrivate::TEvShardRequestCompleted,
+            HandleShardRequestCompleted);
 
         default:
             HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);
@@ -1074,6 +1093,9 @@ STFUNC(TIndexTabletActor::StateBroken)
         HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
+        HFunc(
+            TEvIndexTabletPrivate::TEvShardRequestCompleted,
+            HandleShardRequestCompleted);
 
         default:
             HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -731,6 +731,10 @@ private:
         const TEvIndexTabletPrivate::TEvGetShardStatsCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleShardRequestCompleted(
+        const TEvIndexTabletPrivate::TEvShardRequestCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleLoadCompactionMapChunkResponse(
         const TEvIndexTabletPrivate::TEvLoadCompactionMapChunkResponse::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -418,15 +418,14 @@ void TIndexTabletActor::CreateSessionsInShards(
 
     auto actor = std::make_unique<TCreateShardSessionsActor>(
         std::move(logTag),
+        SelfId(),
         std::move(requestInfo),
         std::move(request),
         std::move(shardIds),
         std::move(response));
 
     auto actorId = NCloud::Register(ctx, std::move(actor));
-
-    Y_UNUSED(actorId);
-    // TODO(#1350): register actorId in WorkerActors, erase upon completion
+    WorkerActors.insert(actorId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -208,12 +208,14 @@ void TIndexTabletActor::CompleteTx_DestroySession(
 
     auto actor = std::make_unique<TDestroyShardSessionsActor>(
         LogTag,
+        SelfId(),
         std::move(args.RequestInfo),
         std::move(args.Request),
         TVector<TString>(shardIds.begin(), shardIds.end()),
         std::move(response));
 
-    NCloud::Register(ctx, std::move(actor));
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -202,12 +202,14 @@ void TIndexTabletActor::CompleteTx_ResetSession(
 
     auto actor = std::make_unique<TResetShardSessionsActor>(
         LogTag,
+        SelfId(),
         std::move(args.RequestInfo),
         std::move(args.Request),
         TVector<TString>(shardIds.begin(), shardIds.end()),
         std::move(response));
 
-    NCloud::Register(ctx, std::move(actor));
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -851,6 +851,8 @@ struct TEvIndexTabletPrivate
 
         EvGetShardStatsCompleted,
 
+        EvShardRequestCompleted,
+
         EvEnd
     };
 
@@ -861,17 +863,22 @@ struct TEvIndexTabletPrivate
     FILESTORE_TABLET_REQUESTS_PRIVATE_SYNC(FILESTORE_DECLARE_EVENTS)
 
     using TEvUpdateCounters = TRequestEvent<TEmpty, EvUpdateCounters>;
-    using TEvUpdateLeakyBucketCounters = TRequestEvent<TEmpty, EvUpdateLeakyBucketCounters>;
+    using TEvUpdateLeakyBucketCounters =
+        TRequestEvent<TEmpty, EvUpdateLeakyBucketCounters>;
 
     using TEvReleaseCollectBarrier =
         TRequestEvent<TReleaseCollectBarrier, EvReleaseCollectBarrier>;
 
-    using TEvReadDataCompleted = TResponseEvent<TReadWriteCompleted, EvReadDataCompleted>;
-    using TEvWriteDataCompleted = TResponseEvent<TReadWriteCompleted, EvWriteDataCompleted>;
-    using TEvAddDataCompleted = TResponseEvent<TAddDataCompleted, EvAddDataCompleted>;
+    using TEvReadDataCompleted =
+        TResponseEvent<TReadWriteCompleted, EvReadDataCompleted>;
+    using TEvWriteDataCompleted =
+        TResponseEvent<TReadWriteCompleted, EvWriteDataCompleted>;
+    using TEvAddDataCompleted =
+        TResponseEvent<TAddDataCompleted, EvAddDataCompleted>;
 
-    using TEvForcedRangeOperationProgress =
-        TRequestEvent<TForcedRangeOperationProgress, EvForcedRangeOperationProgress>;
+    using TEvForcedRangeOperationProgress = TRequestEvent<
+        TForcedRangeOperationProgress,
+        EvForcedRangeOperationProgress>;
 
     using TEvNodeCreatedInShard =
         TRequestEvent<TNodeCreatedInShard, EvNodeCreatedInShard>;
@@ -881,6 +888,9 @@ struct TEvIndexTabletPrivate
 
     using TEvGetShardStatsCompleted =
         TResponseEvent<TGetShardStatsCompleted, EvGetShardStatsCompleted>;
+
+    using TEvShardRequestCompleted =
+        TResponseEvent<TEmpty, EvShardRequestCompleted>;
 };
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
Will presumably fix hangups like this: https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/12151536344/1/nebius-x86-64-tsan/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/test-results/py3test/chunk2/testing_out_stuff/filestore-server.err

And making this code consistent with the other code that spawns one-shot actors