### PR TITLE
[CSI] Support volume resize in vm mode

### DIFF
--- a/cloud/blockstore/tests/csi_driver/csi_sanity_tests/test.py
+++ b/cloud/blockstore/tests/csi_driver/csi_sanity_tests/test.py
@@ -8,11 +8,12 @@ import yatest.common as common
 import cloud.blockstore.tests.csi_driver.lib.csi_runner as csi
 
 
-@pytest.mark.parametrize('mount_path,volume_access_type,vm_mode',
-                         [("/var/lib/kubelet/pods/123/volumes/kubernetes.io~csi/456/mount", "mount", False),
-                          ("/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/123/456", "block", False),
-                          ("/var/lib/kubelet/pods/123/volumes/kubernetes.io~csi/456/mount", "mount", True)])
-def test_csi_sanity_nbs_backend(mount_path, volume_access_type, vm_mode):
+@pytest.mark.parametrize('mount_path,volume_access_type,vm_mode,skip_tests',
+                         [("/var/lib/kubelet/pods/123/volumes/kubernetes.io~csi/456/mount", "mount", False, []),
+                          ("/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/123/456", "block", False, []),
+                          ("/var/lib/kubelet/pods/123/volumes/kubernetes.io~csi/456/mount", "mount", True,
+                           ["should work if node-expand is called after node-publish"])])
+def test_csi_sanity_nbs_backend(mount_path, volume_access_type, vm_mode, skip_tests):
     env, run = csi.init(vm_mode)
     backend = "nbs"
 
@@ -29,7 +30,6 @@ def test_csi_sanity_nbs_backend(mount_path, volume_access_type, vm_mode):
             }
         ))
 
-        skipTests = []
         args = [CSI_SANITY_BINARY_PATH,
                 "-csi.endpoint",
                 env.csi._endpoint,
@@ -40,7 +40,7 @@ def test_csi_sanity_nbs_backend(mount_path, volume_access_type, vm_mode):
                 "-csi.testvolumeaccesstype",
                 volume_access_type,
                 "--ginkgo.skip",
-                '|'.join(skipTests)]
+                '|'.join(skip_tests)]
         subprocess.run(
             args,
             check=True,

--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
@@ -108,8 +108,6 @@ def test_node_volume_expand(fs_type):
         env.csi.create_volume(name=volume_name, size=volume_size)
 
         env.csi.stage_volume(volume_name, access_type)
-        env.csi.publish_volume(pod_id, volume_name, pod_name, fs_type)
-        env.csi.stage_volume(volume_name, access_type)
         env.csi.publish_volume(pod_id, volume_name, pod_name, access_type, fs_type)
 
         new_volume_size = 2 * volume_size

--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part2/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part2/test.py
@@ -127,3 +127,44 @@ def test_mount_volume_group():
         raise
     finally:
         csi.cleanup_after_test(env, volume_name, access_type, [pod_id])
+
+
+def test_node_volume_expand_vm_mode():
+    env, run = csi.init(vm_mode=True)
+    try:
+        volume_name = "example-disk"
+        block_size = 4096
+        blocks_count = 1000
+        volume_size = blocks_count * block_size
+        pod_name = "example-pod"
+        pod_id = "deadbeef"
+        access_type = "mount"
+        env.csi.create_volume(name=volume_name, size=volume_size)
+        env.csi.stage_volume(volume_name, access_type)
+        env.csi.publish_volume(pod_id, volume_name, pod_name, access_type)
+
+        new_volume_size = 2 * volume_size
+        result = run(
+            "resizevolume",
+            "--disk-id",
+            volume_name,
+            "--blocks-count",
+            str(blocks_count * 2)
+        )
+        assert result.returncode == 0
+
+        try:
+            # expand volume to wrong size must fail
+            env.csi.expand_volume(pod_id, volume_name, 2 * new_volume_size, access_type)
+            assert False
+        except subprocess.CalledProcessError:
+            pass
+
+        env.csi.expand_volume(pod_id, volume_name, new_volume_size, access_type)
+        # check that expand_volume is idempotent method
+        env.csi.expand_volume(pod_id, volume_name, new_volume_size, access_type)
+    except subprocess.CalledProcessError as e:
+        csi.log_called_process_error(e)
+        raise
+    finally:
+        csi.cleanup_after_test(env, volume_name, access_type, [pod_id])

--- a/cloud/blockstore/tools/csi_driver/client/main.go
+++ b/cloud/blockstore/tools/csi_driver/client/main.go
@@ -604,7 +604,7 @@ func newNodeGetVolumeStatsCommand(endpoint *string) *cobra.Command {
 ////////////////////////////////////////////////////////////////////////////////
 
 func newNodeExpandVolumeCommand(endpoint *string) *cobra.Command {
-	var volumeId, podId, accessType string
+	var volumeId, podId, accessType, stagingTargetPath string
 	var size int64
 	cmd := cobra.Command{
 		Use:   "expandvolume",
@@ -620,8 +620,9 @@ func newNodeExpandVolumeCommand(endpoint *string) *cobra.Command {
 			_, err = client.NodeExpandVolume(
 				ctx,
 				&csi.NodeExpandVolumeRequest{
-					VolumeId:   volumeId,
-					VolumePath: getTargetPath(podId, volumeId, accessType),
+					VolumeId:          volumeId,
+					VolumePath:        getTargetPath(podId, volumeId, accessType),
+					StagingTargetPath: stagingTargetPath,
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
 					},
@@ -640,6 +641,13 @@ func newNodeExpandVolumeCommand(endpoint *string) *cobra.Command {
 		"volume id",
 	)
 	cmd.Flags().StringVar(&podId, "pod-id", "", "pod id")
+	cmd.Flags().StringVar(
+		&stagingTargetPath,
+		"staging-target-path",
+		"/var/lib/kubelet/plugins/kubernetes.io/csi/nbs.csi.nebius.ai/"+
+			"a/globalmount",
+		"staging target path",
+	)
 	cmd.Flags().Int64Var(
 		&size,
 		"size",


### PR DESCRIPTION
issue: #2654

disk manager resizes volumes in [VM mode](https://github.com/ydb-platform/nbs/blob/main/doc/k8s/kubevirt.svg) however we must refresh nbs endpoint in csi driver.