### PR TITLE
Print TBlockRange the same way

### DIFF
--- a/cloud/blockstore/libs/common/block_range.cpp
+++ b/cloud/blockstore/libs/common/block_range.cpp
@@ -33,13 +33,21 @@ bool TBlockRange<TBlockIndex>::TryParse(
 template bool TBlockRange32::TryParse(TStringBuf s, TBlockRange32& range);
 template bool TBlockRange64::TryParse(TStringBuf s, TBlockRange64& range);
 
+template <std::unsigned_integral TBlockIndex>
+TString TBlockRange<TBlockIndex>::Print() const
+{
+    return TStringBuilder() << "[" << Start << ".." << End << "]";
+}
+
+template TString TBlockRange32::Print() const;
+template TString TBlockRange64::Print() const;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <std::unsigned_integral TBlockIndex>
 TString DescribeRange(const TBlockRange<TBlockIndex>& blockRange)
 {
-    return TStringBuilder()
-        << "[" << blockRange.Start << ".." << blockRange.End << "]";
+    return blockRange.Print();
 }
 
 template TString DescribeRange(const TBlockRange32& blockRange);

--- a/cloud/blockstore/libs/common/block_range.h
+++ b/cloud/blockstore/libs/common/block_range.h
@@ -172,6 +172,8 @@ struct TBlockRange
         return lhs.Start == rhs.Start && lhs.End == rhs.End;
     }
 
+    [[nodiscard]] TString Print() const;
+
 private:
     TBlockRange(TBlockIndex start, TBlockIndex end)
         : Start(start)
@@ -247,7 +249,7 @@ inline TBlockRange64 ConvertRangeSafe(const TBlockRange32& range)
 template <typename T>
 IOutputStream& operator<<(IOutputStream& out, const TBlockRange<T>& rhs)
 {
-    out << "{" << rhs.Start << "," << rhs.End << "}";
+    out << rhs.Print();
     return out;
 }
 


### PR DESCRIPTION
TBlockRange теперь печатается одинаково, что через DescribeRange(), что через operator<<