### PR TITLE
Use direct copy in TNonreplicatedPartitionMigrationCommonActor

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1071,4 +1071,7 @@ message TStorageServiceConfig
 
     // Enables the encryption at rest for Disk Registry based disks.
     optional bool EncryptionAtRestForDiskRegistryBasedDisksEnabled = 393;
+
+    // Enabling direct copying of data between disk agents.
+    optional bool UseDirectCopyRange = 394;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -490,6 +490,7 @@ TDuration MSeconds(ui32 value)
                                                                                \
     xxx(VolumeProxyCacheRetryDuration,             TDuration, Seconds(15)     )\
                                                                                \
+    xxx(UseDirectCopyRange,                             bool,      false         )\
     xxx(MaxShadowDiskFillBandwidth,                     ui32,      512           )\
     xxx(MaxShadowDiskFillIoDepth,                       ui32,      1             )\
     xxx(BackgroundOperationsTotalBandwidth,             ui32,      1024          )\
@@ -517,7 +518,7 @@ TDuration MSeconds(ui32 value)
     xxx(BlobStorageAsyncGetTimeoutHDD,                  TDuration, Seconds(0)    )\
     xxx(BlobStorageAsyncGetTimeoutSSD,                  TDuration, Seconds(0)    )\
                                                                                \
-    xxx(EncryptionAtRestForDiskRegistryBasedDisksEnabled, bool,    false     ) \
+    xxx(EncryptionAtRestForDiskRegistryBasedDisksEnabled, bool,    false      )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -571,6 +571,7 @@ public:
     TString GetCachedDiskAgentConfigPath() const;
     TString GetCachedDiskAgentSessionsPath() const;
 
+    bool GetUseDirectCopyRange() const;
     ui32 GetMaxShadowDiskFillBandwidth() const;
     ui32 GetMaxShadowDiskFillIoDepth() const;
     ui32 GetBackgroundOperationsTotalBandwidth() const;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_direct_copy.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_direct_copy.cpp
@@ -1,12 +1,9 @@
 #include "disk_agent_actor.h"
 
 #include <cloud/blockstore/libs/storage/disk_agent/actors/direct_copy_actor.h>
-#include <cloud/storage/core/libs/kikimr/helpers.h>
-
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
-using namespace NKikimr;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
@@ -26,7 +26,8 @@ public:
     };
 
 private:
-    EAllowedOperation AllowedOperation = EAllowedOperation::Read;
+    const EAllowedOperation AllowedOperation;
+    const TStorageConfigPtr Config;
     const TNonreplicatedPartitionConfigPtr PartConfig;
     NActors::TActorId Delegate;
 
@@ -35,6 +36,7 @@ public:
 
     TGetDeviceForRangeCompanion(
         EAllowedOperation allowedOperation,
+        TStorageConfigPtr config,
         TNonreplicatedPartitionConfigPtr partConfig);
 
     void SetDelegate(NActors::TActorId delegate);
@@ -48,6 +50,9 @@ public:
     void ReplyCanNotUseDirectCopy(
         const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
         const NActors::TActorContext& ctx) const;
+
+private:
+    [[nodiscard]] TDuration GetMinRequestTimeout() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
@@ -1,0 +1,277 @@
+#include "direct_copy_range.h"
+
+#include "part_nonrepl_events_private.h"
+
+#include <cloud/blockstore/libs/diagnostics/block_digest.h>
+#include <cloud/blockstore/libs/kikimr/components.h>
+#include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/storage/core/forward_helpers.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h>
+#include <cloud/storage/core/libs/common/sglist.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui64 SourcePartitionTag = 1;
+constexpr ui64 TargetPartitionTag = 2;
+
+}   // namespace
+
+TDirectCopyRangeActor::TDirectCopyRangeActor(
+        TRequestInfoPtr requestInfo,
+        ui32 blockSize,
+        TBlockRange64 range,
+        TActorId source,
+        TActorId target,
+        TString writerClientId,
+        IBlockDigestGeneratorPtr blockDigestGenerator)
+    : RequestInfo(std::move(requestInfo))
+    , BlockSize(blockSize)
+    , Range(range)
+    , SourceActor(source)
+    , TargetActor(target)
+    , WriterClientId(std::move(writerClientId))
+    , BlockDigestGenerator(std::move(blockDigestGenerator))
+{}
+
+void TDirectCopyRangeActor::Bootstrap(const TActorContext& ctx)
+{
+    TRequestScope timer(*RequestInfo);
+
+    Become(&TThis::StateWork);
+
+    LWTRACK(
+        RequestReceived_PartitionWorker,
+        RequestInfo->CallContext->LWOrbit,
+        "DirectCopyRange",
+        RequestInfo->CallContext->RequestId);
+
+    GetDevicesInfo(ctx);
+}
+
+void TDirectCopyRangeActor::GetDevicesInfo(const TActorContext& ctx)
+{
+    using EPurpose =
+        TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::EPurpose;
+
+    ctx.Send(
+        SourceActor,
+        std::make_unique<
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+            EPurpose::ForReading,
+            Range),
+        0,
+        SourcePartitionTag);
+    ctx.Send(
+        TargetActor,
+        std::make_unique<
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest>(
+            EPurpose::ForWriting,
+            Range),
+        0,
+        TargetPartitionTag);
+}
+
+void TDirectCopyRangeActor::DirectCopy(const NActors::TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvDiskAgent::TEvDirectCopyBlocksRequest>();
+    auto& rec = request->Record;
+
+    rec.MutableHeaders()->SetIsBackgroundRequest(true);
+    rec.MutableHeaders()->SetClientId(TString(BackgroundOpsClientId));
+    rec.SetSourceDeviceUUID(SourceInfo->Device.GetDeviceUUID());
+    rec.SetSourceStartIndex(SourceInfo->DeviceBlockRange.Start);
+    rec.SetBlockSize(BlockSize);
+    rec.SetBlockCount(SourceInfo->DeviceBlockRange.Size());
+    rec.SetTargetNodeId(TargetInfo->Device.GetNodeId());
+    rec.SetTargetClientId(
+        WriterClientId ? WriterClientId : TString(BackgroundOpsClientId));
+    rec.SetTargetDeviceUUID(TargetInfo->Device.GetDeviceUUID());
+    rec.SetTargetStartIndex(TargetInfo->DeviceBlockRange.Start);
+
+    auto event = std::make_unique<IEventHandle>(
+        MakeDiskAgentServiceId(SourceInfo->Device.GetNodeId()),
+        ctx.SelfID,
+        request.release(),
+        IEventHandle::FlagForwardOnNondelivery,
+        0,
+        &ctx.SelfID   // forwardOnNondelivery
+    );
+
+    StartTs = ctx.Now();
+    ctx.Send(std::move(event));
+    ctx.Schedule(
+        SourceInfo->RequestTimeout + TargetInfo->RequestTimeout,
+        new TEvents::TEvWakeup());
+}
+
+void TDirectCopyRangeActor::Fallback(const TActorContext& ctx)
+{
+    if (FallbackActorId) {
+        return;
+    }
+
+    FallbackActorId = NCloud::Register<TCopyRangeActor>(
+        ctx,
+        CreateRequestInfo(
+            SelfId(),
+            RequestInfo->Cookie,
+            RequestInfo->CallContext),
+        BlockSize,
+        Range,
+        SourceActor,
+        TargetActor,
+        WriterClientId,
+        BlockDigestGenerator);
+}
+
+void TDirectCopyRangeActor::Done(const TActorContext& ctx, NProto::TError error)
+{
+    ProcessError(
+        *NActors::TActorContext::ActorSystem(),
+        *TargetInfo->PartConfig,
+        error);
+
+    const auto writeTs = StartTs + ReadDuration;
+    auto response =
+        std::make_unique<TEvNonreplPartitionPrivate::TEvRangeMigrated>(
+            std::move(error),
+            Range,
+            StartTs,
+            ReadDuration,
+            writeTs,
+            WriteDuration,
+            TVector<IProfileLog::TBlockInfo>(),
+            AllZeroes,
+            RequestInfo->GetExecCycles());
+
+    LWTRACK(
+        ResponseSent_PartitionWorker,
+        RequestInfo->CallContext->LWOrbit,
+        "DirectCopyRange",
+        RequestInfo->CallContext->RequestId);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+
+    Die(ctx);
+}
+
+void TDirectCopyRangeActor::HandleGetDeviceForRange(
+    const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (ev->Cookie == SourcePartitionTag) {
+        SourceInfo.reset(ev->Release().Release());
+    } else if (ev->Cookie == TargetPartitionTag) {
+        TargetInfo.reset(ev->Release().Release());
+    }
+
+    if (!SourceInfo || !TargetInfo) {
+        return;
+    }
+
+    if (FAILED(SourceInfo->Error.GetCode()) ||
+        FAILED(TargetInfo->Error.GetCode()))
+    {
+        Fallback(ctx);
+        return;
+    }
+
+    DirectCopy(ctx);
+}
+
+void TDirectCopyRangeActor::HandleDirectCopyUndelivered(
+    const TEvDiskAgent::TEvDirectCopyBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    Done(
+        ctx,
+        MakeError(E_REJECTED, "DirectCopyBlocksRequest request undelivered"));
+}
+
+void TDirectCopyRangeActor::HandleDirectCopyBlocksResponse(
+    const TEvDiskAgent::TEvDirectCopyBlocksResponse::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (SUCCEEDED(msg->GetError().GetCode())) {
+        ReadDuration = TDuration::MicroSeconds(msg->Record.GetReadDuration());
+        WriteDuration = TDuration::MicroSeconds(msg->Record.GetReadDuration());
+        AllZeroes = msg->Record.GetAllZeroes();
+    }
+
+    Done(ctx, msg->GetError());
+}
+
+void TDirectCopyRangeActor::HandleRangeMigratedByFallbackActor(
+    const TEvNonreplPartitionPrivate::TEvRangeMigrated::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ForwardMessageToActor(ev, ctx, RequestInfo->Sender);
+    Die(ctx);
+}
+
+void TDirectCopyRangeActor::HandleRangeMigrationTimeout(
+    const NActors::TEvents::TEvWakeup::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    auto error = MakeError(
+        E_TIMEOUT,
+        TStringBuilder() << "Range " << DescribeRange(Range)
+                         << " migration timeout");
+    Done(ctx, std::move(error));
+}
+
+void TDirectCopyRangeActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    Done(ctx, MakeError(E_REJECTED, "Dead"));
+}
+
+STFUNC(TDirectCopyRangeActor::StateWork)
+{
+    TRequestScope timer(*RequestInfo);
+
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse,
+            HandleGetDeviceForRange);
+        HFunc(
+            TEvDiskAgent::TEvDirectCopyBlocksResponse,
+            HandleDirectCopyBlocksResponse);
+        HFunc(
+            TEvDiskAgent::TEvDirectCopyBlocksRequest,
+            HandleDirectCopyUndelivered);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvRangeMigrated,
+            HandleRangeMigratedByFallbackActor);
+
+        HFunc(TEvents::TEvWakeup, HandleRangeMigrationTimeout);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            break;
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.h
@@ -38,8 +38,6 @@ private:
     TDuration WriteDuration;
     bool AllZeroes = false;
 
-    NActors::TActorId FallbackActorId;
-
     TDeviceInfoResponse SourceInfo;
     TDeviceInfoResponse TargetInfo;
 
@@ -76,10 +74,6 @@ private:
 
     void HandleDirectCopyBlocksResponse(
         const TEvDiskAgent::TEvDirectCopyBlocksResponse::TPtr& ev,
-        const NActors::TActorContext& ctx);
-
-    void HandleRangeMigratedByFallbackActor(
-        const TEvNonreplPartitionPrivate::TEvRangeMigrated::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleRangeMigrationTimeout(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cloud/blockstore/libs/diagnostics/profile_log.h>
+#include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/actorid.h>
+#include <contrib/ydb/library/actors/core/events.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// TDirectCopyRangeActor copies the range using TEvDirectCopyBlocksRequest. If
+// copying is not possible, it performcopying via TCopyRangeActor.
+class TDirectCopyRangeActor final
+    : public NActors::TActorBootstrapped<TDirectCopyRangeActor>
+{
+private:
+    using TDeviceInfoResponse = std::unique_ptr<
+        TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse>;
+
+    const TRequestInfoPtr RequestInfo;
+    const ui32 BlockSize;
+    const TBlockRange64 Range;
+    const NActors::TActorId SourceActor;
+    const NActors::TActorId TargetActor;
+    const TString WriterClientId;
+    const IBlockDigestGeneratorPtr BlockDigestGenerator;
+
+    TInstant StartTs;
+    TDuration ReadDuration;
+    TDuration WriteDuration;
+    bool AllZeroes = false;
+
+    NActors::TActorId FallbackActorId;
+
+    TDeviceInfoResponse SourceInfo;
+    TDeviceInfoResponse TargetInfo;
+
+public:
+    TDirectCopyRangeActor(
+        TRequestInfoPtr requestInfo,
+        ui32 blockSize,
+        TBlockRange64 range,
+        NActors::TActorId source,
+        NActors::TActorId target,
+        TString writerClientId,
+        IBlockDigestGeneratorPtr blockDigestGenerator);
+
+    void Bootstrap(const NActors::TActorContext& ctx);
+
+private:
+    void GetDevicesInfo(const NActors::TActorContext& ctx);
+    void DirectCopy(const NActors::TActorContext& ctx);
+    void Fallback(const NActors::TActorContext& ctx);
+
+    void Done(const NActors::TActorContext& ctx, NProto::TError error);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleGetDeviceForRange(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse::TPtr&
+            ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleDirectCopyUndelivered(
+        const TEvDiskAgent::TEvDirectCopyBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleDirectCopyBlocksResponse(
+        const TEvDiskAgent::TEvDirectCopyBlocksResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleRangeMigratedByFallbackActor(
+        const TEvNonreplPartitionPrivate::TEvRangeMigrated::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleRangeMigrationTimeout(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -90,6 +90,7 @@ private:
         PartConfig->GetName()};
     TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
         TGetDeviceForRangeCompanion::EAllowedOperation::ReadWrite,
+        Config,
         PartConfig};
 
     bool UpdateCountersScheduled = false;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -224,6 +224,8 @@ struct TEvNonreplPartitionPrivate
     {
         NProto::TDeviceConfig Device;
         TBlockRange64 DeviceBlockRange;
+        TDuration RequestTimeout;
+        TNonreplicatedPartitionConfigPtr PartConfig;
     };
 
     //

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -91,18 +92,33 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
                              << range << ", diskId: " << DiskId);
     }
 
-    NCloud::Register<TCopyRangeActor>(
-        ctx,
-        CreateRequestInfo(
-            SelfId(),
-            0,   // cookie
-            MakeIntrusive<TCallContext>()),
-        BlockSize,
-        range,
-        SrcActorId,
-        DstActorId,
-        RWClientId,
-        BlockDigestGenerator);
+    if (Config->GetUseDirectCopyRange()) {
+        NCloud::Register<TDirectCopyRangeActor>(
+            ctx,
+            CreateRequestInfo(
+                SelfId(),
+                0,   // cookie
+                MakeIntrusive<TCallContext>()),
+            BlockSize,
+            range,
+            SrcActorId,
+            DstActorId,
+            RWClientId,
+            BlockDigestGenerator);
+    } else {
+        NCloud::Register<TCopyRangeActor>(
+            ctx,
+            CreateRequestInfo(
+                SelfId(),
+                0,   // cookie
+                MakeIntrusive<TCallContext>()),
+            BlockSize,
+            range,
+            SrcActorId,
+            DstActorId,
+            RWClientId,
+            BlockDigestGenerator);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -1,15 +1,15 @@
 #include "part_nonrepl_migration_actor.h"
 #include "ut_env.h"
 
-#include <cloud/blockstore/libs/rdma_test/client_test.h>
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
+#include <cloud/blockstore/libs/rdma_test/client_test.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/disk_agent/actors/direct_copy_actor.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 #include <cloud/blockstore/libs/storage/testlib/disk_agent_mock.h>
-
 #include <cloud/storage/core/libs/common/sglist_test.h>
 
 #include <contrib/ydb/core/testlib/basics/runtime.h>
@@ -28,6 +28,45 @@ using namespace NKikimr;
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+auto MakeLeaderFollowerFilter(
+    TActorId* leaderPartition,
+    TActorId* followerPartition)
+{
+    using TEvGetDeviceForRangeRequest =
+        TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest;
+    using EPurpose =
+        TEvNonreplPartitionPrivate::TGetDeviceForRangeRequest::EPurpose;
+
+    auto findLeaderAndFollower = [leaderPartition, followerPartition](
+                                     TTestActorRuntimeBase& runtime,
+                                     TAutoPtr<IEventHandle>& event) -> bool
+    {
+        Y_UNUSED(runtime);
+        if (event->GetTypeRewrite() == TEvService::EvReadBlocksRequest) {
+            *leaderPartition = event->Recipient;
+        }
+        if (event->GetTypeRewrite() == TEvService::EvWriteBlocksRequest) {
+            *followerPartition = event->Recipient;
+        }
+        if (event->GetTypeRewrite() ==
+            TEvNonreplPartitionPrivate::EvGetDeviceForRangeRequest)
+        {
+            auto& msg = *event->Get<TEvGetDeviceForRangeRequest>();
+            switch (msg.Purpose) {
+                case EPurpose::ForReading:
+                    *leaderPartition = event->Recipient;
+                    break;
+                case EPurpose::ForWriting:
+                    *followerPartition = event->Recipient;
+                    break;
+            }
+        }
+
+        return false;
+    };
+    return findLeaderAndFollower;
+}
 
 struct TTestEnv
 {
@@ -79,7 +118,8 @@ struct TTestEnv
             TMigrations migrations,
             NProto::EVolumeIOMode ioMode,
             bool useRdma,
-            TMigrationStatePtr migrationState)
+            TMigrationStatePtr migrationState,
+            bool useDirectCopy)
         : Runtime(runtime)
         , ActorId(0, "YYY")
         , VolumeActorId(0, "VVV")
@@ -92,11 +132,26 @@ struct TTestEnv
 
         SetupLogging();
 
+        DiskAgentState->CreateDirectCopyActorFunc =
+            [](const TEvDiskAgent::TEvDirectCopyBlocksRequest::TPtr& ev,
+               const NActors::TActorContext& ctx,
+               NActors::TActorId owner)
+        {
+            auto* msg = ev->Get();
+            auto& record = msg->Record;
+            NCloud::Register<TDirectCopyActor>(
+                ctx,
+                owner,
+                CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+                std::move(record));
+        };
+
         NProto::TStorageServiceConfig storageConfig;
         storageConfig.SetMaxTimedOutDeviceStateDuration(20'000);
         storageConfig.SetNonReplicatedMinRequestTimeoutSSD(1'000);
         storageConfig.SetNonReplicatedMaxRequestTimeoutSSD(5'000);
         storageConfig.SetMaxMigrationBandwidth(500);
+        storageConfig.SetUseDirectCopyRange(useDirectCopy);
 
         auto config = std::make_shared<TStorageConfig>(
             std::move(storageConfig),
@@ -223,7 +278,7 @@ struct TTestEnv
 
 Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
 {
-    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigrated)
+    void DoShouldMirrorRequestsAfterAllDataIsMigrated(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -233,8 +288,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            nullptr   // no migration state
-        );
+            nullptr,   // no migration state
+            useDirectCopy);
 
         TPartitionClient client(runtime, env.ActorId);
 
@@ -249,15 +304,24 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         runtime.AdvanceCurrentTime(UpdateCountersInterval);
         runtime.DispatchEvents({}, TDuration::Seconds(1));
 
+        const size_t migrationWrites = useDirectCopy ? 0 : 3;
         auto& counters = env.StorageStatsServiceState->Counters.RequestCounters;
-        UNIT_ASSERT_VALUES_EQUAL(5, counters.WriteBlocks.Count);
+        UNIT_ASSERT_VALUES_EQUAL(2 + migrationWrites, counters.WriteBlocks.Count);
         UNIT_ASSERT_VALUES_EQUAL(
-            (2 + 3072) * DefaultBlockSize,
+            (2 + migrationWrites * 1024) * DefaultBlockSize,
             counters.WriteBlocks.RequestBytes
         );
     }
 
-    Y_UNIT_TEST(ShouldDoMigrationViaRdma)
+    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigrated) {
+        DoShouldMirrorRequestsAfterAllDataIsMigrated(false);
+    }
+
+    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigratedDirectCopy) {
+        DoShouldMirrorRequestsAfterAllDataIsMigrated(true);
+    }
+
+    void DoShouldDoMigrationViaRdma(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -267,8 +331,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             true,
-            nullptr   // no migration state
-        );
+            nullptr,   // no migration state,
+            useDirectCopy);
 
         env.Rdma().InitAllEndpoints();
 
@@ -276,7 +340,15 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         WaitForMigrations(runtime, 3);
     }
 
-    Y_UNIT_TEST(ShouldDoMigrationEvenInReadOnlyMode)
+    Y_UNIT_TEST(DoShouldDoMigrationViaRdma) {
+        DoShouldDoMigrationViaRdma(false);
+    }
+
+    Y_UNIT_TEST(DoShouldDoMigrationViaRdmaDirectCopy) {
+        DoShouldDoMigrationViaRdma(true);
+    }
+
+    void DoShouldDoMigrationEvenInReadOnlyMode(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -286,14 +358,24 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_ERROR_READ_ONLY,
             false,
-            nullptr   // no migration state
-        );
+            nullptr,   // no migration state
+            useDirectCopy);
 
         // petya should be migrated => 3 ranges
         WaitForMigrations(runtime, 3);
     }
 
-    Y_UNIT_TEST(ShouldReportSimpleCounters)
+    Y_UNIT_TEST(ShouldDoMigrationEvenInReadOnlyMode)
+    {
+        DoShouldDoMigrationEvenInReadOnlyMode(false);
+    }
+
+    Y_UNIT_TEST(ShouldDoMigrationEvenInReadOnlyModeDirectCopy)
+    {
+        DoShouldDoMigrationEvenInReadOnlyMode(true);
+    }
+
+    void DoShouldReportSimpleCounters(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -303,8 +385,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            nullptr   // no migration state
-        );
+            nullptr,   // no migration state
+            useDirectCopy);
 
         TPartitionClient client(runtime, env.ActorId);
 
@@ -319,7 +401,17 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             counters.BytesCount.Value);
     }
 
-    Y_UNIT_TEST(ShouldDelayMigration)
+    Y_UNIT_TEST(ShouldReportSimpleCounters)
+    {
+        DoShouldReportSimpleCounters(false);
+    }
+
+    Y_UNIT_TEST(ShouldReportSimpleCountersDirectCopy)
+    {
+        DoShouldReportSimpleCounters(true);
+    }
+
+    void DoShouldDelayMigration(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -332,7 +424,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            migrationState);
+            migrationState,
+            useDirectCopy);
 
         WaitForNoMigrations(runtime, TDuration::Seconds(5));
 
@@ -340,7 +433,17 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         WaitForMigrations(runtime, 3);
     }
 
-    Y_UNIT_TEST(ShouldRegisterTrafficSource)
+    Y_UNIT_TEST(ShouldDelayMigration)
+    {
+        DoShouldDelayMigration(false);
+    }
+
+    Y_UNIT_TEST(ShouldDelayMigrationDirectCopy)
+    {
+        DoShouldDelayMigration(true);
+    }
+
+    void DoShouldRegisterTrafficSource(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -353,7 +456,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            migrationState);
+            migrationState,
+            useDirectCopy);
 
         WaitForNoMigrations(runtime, TDuration::Seconds(5));
 
@@ -391,7 +495,17 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         UNIT_ASSERT_VALUES_EQUAL(2, registerSourceCounter);
     }
 
-    Y_UNIT_TEST(ShouldNotFailRequestOnFollowerNonRetriableError)
+    Y_UNIT_TEST(ShouldRegisterTrafficSource)
+    {
+        DoShouldRegisterTrafficSource(false);
+    }
+
+    Y_UNIT_TEST(ShouldRegisterTrafficSourceDirectCopy)
+    {
+        DoShouldRegisterTrafficSource(true);
+    }
+
+    void DoShouldNotFailRequestOnFollowerNonRetriableError(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -404,23 +518,14 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            migrationState);
+            migrationState,
+            useDirectCopy);
 
         // Find the ActorIDs of the leader and follower partitions.
         TActorId leaderPartition;
         TActorId followerPartition;
-        auto findLeaderAndFollower = [&](TTestActorRuntimeBase& runtime,
-                                         TAutoPtr<IEventHandle>& event) -> bool
-        {
-            Y_UNUSED(runtime);
-            if (event->GetTypeRewrite() == TEvService::EvReadBlocksRequest) {
-                leaderPartition = event->Recipient;
-            }
-            if (event->GetTypeRewrite() == TEvService::EvWriteBlocksRequest) {
-                followerPartition = event->Recipient;
-            }
-            return false;
-        };
+        auto findLeaderAndFollower =
+            MakeLeaderFollowerFilter(&leaderPartition, &followerPartition);
         runtime.SetEventFilter(findLeaderAndFollower);
 
         migrationState->IsMigrationAllowed = true;
@@ -556,7 +661,17 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldFailRequestOnFollowerRetriableError)
+    Y_UNIT_TEST(ShouldNotFailRequestOnFollowerNonRetriableError)
+    {
+        DoShouldNotFailRequestOnFollowerNonRetriableError(false);
+    }
+
+    Y_UNIT_TEST(ShouldNotFailRequestOnFollowerNonRetriableErrorDirectCopy)
+    {
+        DoShouldNotFailRequestOnFollowerNonRetriableError(true);
+    }
+
+    void DoShouldFailRequestOnFollowerRetriableError(bool useDirectCopy)
     {
         TTestBasicRuntime runtime;
 
@@ -569,23 +684,14 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            migrationState);
+            migrationState,
+            useDirectCopy);
 
         // Find the ActorIDs of the leader and follower partitions.
         TActorId leaderPartition;
         TActorId followerPartition;
-        auto findLeaderAndFollower = [&](TTestActorRuntimeBase& runtime,
-                                         TAutoPtr<IEventHandle>& event) -> bool
-        {
-            Y_UNUSED(runtime);
-            if (event->GetTypeRewrite() == TEvService::EvReadBlocksRequest) {
-                leaderPartition = event->Recipient;
-            }
-            if (event->GetTypeRewrite() == TEvService::EvWriteBlocksRequest) {
-                followerPartition = event->Recipient;
-            }
-            return false;
-        };
+        auto findLeaderAndFollower =
+            MakeLeaderFollowerFilter(&leaderPartition, &followerPartition);
         runtime.SetEventFilter(findLeaderAndFollower);
 
         migrationState->IsMigrationAllowed = true;
@@ -677,6 +783,16 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         UNIT_ASSERT_VALUES_EQUAL(2, failedPartitionRequestCount);
     }
 
+    Y_UNIT_TEST(ShouldFailRequestOnFollowerRetriableError)
+    {
+        DoShouldFailRequestOnFollowerRetriableError(false);
+    }
+
+    Y_UNIT_TEST(ShouldFailRequestOnFollowerRetriableErrorDirectCopy)
+    {
+        DoShouldFailRequestOnFollowerRetriableError(true);
+    }
+
     Y_UNIT_TEST(ShouldHandleGetDeviceForRangeRequest)
     {
         using TEvGetDeviceForRangeRequest =
@@ -696,7 +812,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
             NProto::VOLUME_IO_OK,
             false,
-            migrationState);
+            migrationState,
+            true);
         TPartitionClient client(runtime, env.ActorId);
 
         migrationState->IsMigrationAllowed = true;
@@ -744,6 +861,70 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             auto response = client.RecvResponse<TEvGetDeviceForRangeResponse>();
             UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, response->Error.GetCode());
         }
+    }
+
+    Y_UNIT_TEST(ShouldFailOnDirectCopyRequestTimeout)
+    {
+        TTestBasicRuntime runtime;
+
+        auto migrationState = std::make_shared<TMigrationState>();
+        migrationState->IsMigrationAllowed = false;
+
+        TTestEnv env(
+            runtime,
+            TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
+            TTestEnv::DefaultMigrations(runtime.GetNodeId(0)),
+            NProto::VOLUME_IO_OK,
+            false,
+            migrationState,
+            true);
+
+        // We will steal a EvDirectCopyBlocksResponse this will cause the
+        // TEvDirectCopyBlocksRequest to hang and the range migration timeout.
+        bool gotTimeout = false;
+        bool directCopyBlocksResponseStolen = false;
+
+        auto stoleTargetWriteRequest =
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event) -> bool
+        {
+            Y_UNUSED(runtime);
+
+            if (event->GetTypeRewrite() ==
+                TEvDiskAgent::EvDirectCopyBlocksResponse)
+            {
+                directCopyBlocksResponseStolen = true;
+                return true;
+            }
+
+            if (event->GetTypeRewrite() ==
+                TEvNonreplPartitionPrivate::EvRangeMigrated)
+            {
+                auto* msg =
+                    event->Get<TEvNonreplPartitionPrivate::TEvRangeMigrated>();
+                gotTimeout = msg->GetError().GetCode() == E_TIMEOUT;
+            }
+            return false;
+        };
+        runtime.SetEventFilter(stoleTargetWriteRequest);
+
+        migrationState->IsMigrationAllowed = true;
+
+        NActors::TDispatchOptions options;
+        options.CustomFinalCondition = [&]()
+        {
+            return directCopyBlocksResponseStolen;
+        };
+        runtime.DispatchEvents(options);
+        UNIT_ASSERT_VALUES_EQUAL(true, directCopyBlocksResponseStolen);
+
+        options.CustomFinalCondition = [&]()
+        {
+            return gotTimeout;
+        };
+        runtime.AdvanceCurrentTime(TDuration::Seconds(10));
+        runtime.DispatchEvents(options, TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(true, gotTimeout);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -51,6 +51,7 @@ private:
         PartConfig->GetName()};
     TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
         TGetDeviceForRangeCompanion::EAllowedOperation::ReadWrite,
+        Config,
         PartConfig};
 
     bool UpdateCountersScheduled = false;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
@@ -19,6 +19,7 @@ PEERDIR(
     cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/rdma_test
     cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/disk_agent/actors
 )
 
 END()

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -4,6 +4,7 @@ SRCS(
     checksum_range.cpp
     config.cpp
     copy_range.cpp
+    direct_copy_range.cpp
     migration_timeout_calculator.cpp
     mirror_request_actor.cpp
     replica_info.cpp

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -5,6 +5,7 @@ NonReplicatedDiskRecyclingPeriod: 5000
 NonReplicatedMigrationStartAllowed: true
 AllocationUnitMirror2SSD: 1
 AllocationUnitMirror3SSD: 1
+MirroredMigrationStartAllowed: true
 NonReplicatedDontSuspendDevices: true
 UseShadowDisksForNonreplDiskCheckpoints: true
 MaxShadowDiskFillIoDepth: 4
@@ -13,3 +14,4 @@ MaxShadowDiskFillBandwidth: 1000
 MaxMigrationBandwidth: 1000
 AssignIdToWriteAndZeroRequestsEnabled: true
 RejectLateRequestsAtDiskAgentEnabled: true
+UseDirectCopyRange: true


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2368
Склеиваю все вместе.
1. Новый актор TDirectCopyRangeActor который ходит в партишены c запросом TGetDeviceForRangeRequest, получает девайсы и затем отправляет запрос TEvDirectCopyBlocksRequest с полученной информацией в ДискаАгента
2. TNonreplicatedPartitionMigrationCommonActor учится использовать TDirectCopyRangeActor для копирования данных под флагом