### PR TITLE
issue-688 Followup: enable new compaction policy for Nodes and NodeRefs table

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -146,6 +146,7 @@ struct TIndexTabletSchema
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
+        using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;
     };
 
     struct Nodes_Ver: TTableSchema<6>
@@ -232,6 +233,7 @@ struct TIndexTabletSchema
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
+        using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;
     };
 
     struct NodeRefs_Ver: TTableSchema<10>


### PR DESCRIPTION
In the light of the growth of number of nodes it is reasonable to enable a three-stage compaction policy for Nodes and NodeRefs tables

References #688