### PR TITLE
[Blockstore] do not change Config if it is equal to the global config

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_change_storage_config.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_change_storage_config.cpp
@@ -57,6 +57,9 @@ void TVolumeActor::CompleteChangeStorageConfig(
     Config = std::make_shared<TStorageConfig>(*GlobalStorageConfig);
     Config->Merge(std::move(args.ResultStorageConfig));
     HasStorageConfigPatch = !Config->Equals(*GlobalStorageConfig);
+    if (!HasStorageConfigPatch) {
+        Config = GlobalStorageConfig;
+    }
 
     if (State->GetPartitionsState() == TPartitionInfo::READY ||
         State->GetPartitionsState() == TPartitionInfo::STARTED)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -103,6 +103,9 @@ void TVolumeActor::CompleteLoadState(
         Config = std::make_shared<TStorageConfig>(*Config);
         Config->Merge(*args.StorageConfig.Get());
         HasStorageConfigPatch = !Config->Equals(*GlobalStorageConfig);
+        if (!HasStorageConfigPatch) {
+            Config = GlobalStorageConfig;
+        }
     }
 
     if (args.Meta.Defined()) {
@@ -122,7 +125,7 @@ void TVolumeActor::CompleteLoadState(
             Config->GetVolumeHistoryCacheSize(),
             std::move(args.MountHistory)};
 
-        State.reset(new TVolumeState(
+        State = std::make_unique<TVolumeState>(
             Config,
             std::move(*args.Meta),
             std::move(args.MetaHistory),
@@ -131,7 +134,7 @@ void TVolumeActor::CompleteLoadState(
             std::move(args.Clients),
             std::move(volumeHistory),
             std::move(args.CheckpointRequests),
-            startPartitionsNeeded));
+            startPartitionsNeeded);
 
         ResetThrottlingPolicy();
 

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -119,7 +119,7 @@ bool TVolumeDatabase::ReadStorageConfig(
         return false;   // not ready
     }
 
-    if (it.IsValid()) {
+    if (it.IsValid() && it.HaveValue<TTable::StorageConfig>()) {
         storageConfig = it.GetValue<TTable::StorageConfig>();
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
@@ -1253,6 +1253,10 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
         TTestExecutor executor;
         executor.WriteTx([&] (TVolumeDatabase db) {
             db.InitSchema();
+
+            NProto::TVolumeMeta meta;
+            meta.MutableVolumeConfig()->SetDiskId("vol0");
+            db.WriteMeta(meta);
         });
 
         TMaybe<NProto::TStorageServiceConfig> serviceConfig;


### PR DESCRIPTION
`TVolumeDatabase::ReadStorageConfig` always sets `storageConfig` to Defined, because it only checks the iterator for validity (it should also check for `HaveValue`). It results that the Volume always creates a copy of the Config when loading a state. Because of this, it is not possible to change the configuration of the Volume via ICB.