### PR TITLE
issue-2639: 1. renamed ShardName/shardName to ShardNodeName/shardNodeName where it was still called ShardName/shardName 2. not generating ShardNodeName upon node creation if this node isn't actually going to be created in one of the shards - in order not to waste space in NodeRefs table

### DIFF
--- a/cloud/filestore/apps/client/lib/find_garbage.cpp
+++ b/cloud/filestore/apps/client/lib/find_garbage.cpp
@@ -156,13 +156,13 @@ public:
         FetchAll(session, FileSystemId, RootNodeId, &leaderNodes);
         STORAGE_INFO("Fetched " << leaderNodes.size() << " nodes");
 
-        THashSet<TString> shardNames;
+        THashSet<TString> shardNodeNames;
         for (const auto& node: leaderNodes) {
             if (!node.ShardFileSystemId) {
                 continue;
             }
 
-            shardNames.insert(node.ShardNodeName);
+            shardNodeNames.insert(node.ShardNodeName);
         }
 
         struct TResult
@@ -187,7 +187,7 @@ public:
                 CreateCustomSession(shard, shard + "::" + ClientId);
             auto& shardSession = shardSessionGuard.AccessSession();
             for (const auto& node: nodes) {
-                if (!shardNames.contains(node.Name)) {
+                if (!shardNodeNames.contains(node.Name)) {
                     STORAGE_INFO("Node " << node.Name << " not found in shard"
                         ", calling stat");
                     auto stat =

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -206,7 +206,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
 
             if (args.RequestShardId) {
                 args.ShardId = args.RequestShardId;
-                args.ShardName = CreateGuidAsString();
+                args.ShardNodeName = CreateGuidAsString();
                 args.IsNewShardNode = true;
             }
         } else {
@@ -218,7 +218,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
 
             args.TargetNodeId = ref->ChildNodeId;
             args.ShardId = ref->ShardId;
-            args.ShardName = ref->ShardName;
+            args.ShardNodeName = ref->ShardNodeName;
         }
     } else {
         args.TargetNodeId = args.NodeId;
@@ -317,7 +317,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             args.Name,
             args.TargetNodeId,
             args.ShardId,
-            args.ShardName);
+            args.ShardNodeName);
 
         // update parent cmtime as we created a new entry
         auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
@@ -375,7 +375,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         ConvertNodeFromAttrs(*node, args.TargetNodeId, args.TargetNode->Attrs);
     } else {
         args.Response.SetShardFileSystemId(args.ShardId);
-        args.Response.SetShardNodeName(args.ShardName);
+        args.Response.SetShardNodeName(args.ShardNodeName);
     }
 
     if (args.IsNewShardNode) {
@@ -389,7 +389,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         shardRequest->SetGid(args.Gid);
         shardRequest->SetFileSystemId(args.ShardId);
         shardRequest->SetNodeId(RootNodeId);
-        shardRequest->SetName(args.ShardName);
+        shardRequest->SetName(args.ShardNodeName);
         shardRequest->ClearShardFileSystemId();
 
         db.WriteOpLogEntry(args.OpLogEntry);
@@ -424,7 +424,7 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
             "%s Creating node in shard upon CreateHandle: %s, %s",
             LogTag.c_str(),
             args.ShardId.c_str(),
-            args.ShardName.c_str());
+            args.ShardNodeName.c_str());
 
         RegisterCreateNodeInShardActor(
             ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -491,7 +491,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             shardRequest->CopyFrom(args.Request);
             shardRequest->SetFileSystemId(args.ShardId);
             shardRequest->SetNodeId(RootNodeId);
-            shardRequest->SetName(args.ShardName);
+            shardRequest->SetName(args.ShardNodeName);
             shardRequest->ClearShardFileSystemId();
 
             db.WriteOpLogEntry(args.OpLogEntry);
@@ -533,7 +533,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         args.Name,
         args.ChildNodeId,
         args.ShardId,
-        args.ShardName);
+        args.ShardNodeName);
 
     if (args.ShardId.empty()) {
         if (args.ChildNodeId == InvalidNodeId) {
@@ -572,7 +572,7 @@ void TIndexTabletActor::CompleteTx_CreateNode(
             "%s Creating node in shard upon CreateNode: %s, %s",
             LogTag.c_str(),
             args.ShardId.c_str(),
-            args.ShardName.c_str());
+            args.ShardNodeName.c_str());
 
         RegisterCreateNodeInShardActor(
             ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -205,7 +205,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
                     ref.Name,
                     ref.ChildNodeId,
                     ref.ShardId,
-                    ref.ShardName);
+                    ref.ShardNodeName);
             }
 
             RemoveCheckpointNodes(db, checkpoint, args.NodeIds);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -167,7 +167,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttr(
 
         args.TargetNodeId = ref->ChildNodeId;
         args.ShardId = ref->ShardId;
-        args.ShardName = ref->ShardName;
+        args.ShardNodeName = ref->ShardNodeName;
     } else {
         args.TargetNodeId = args.NodeId;
     }
@@ -202,7 +202,7 @@ void TIndexTabletActor::CompleteTx_GetNodeAttr(
         auto* node = response->Record.MutableNode();
         if (args.ShardId) {
             node->SetShardFileSystemId(args.ShardId);
-            node->SetShardNodeName(args.ShardName);
+            node->SetShardNodeName(args.ShardNodeName);
         } else {
             TABLET_VERIFY(args.TargetNode);
             ConvertNodeFromAttrs(
@@ -389,7 +389,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
         auto* nodeAttr = nodeResult->MutableNode();
         if (refs[i]->ShardId) {
             nodeAttr->SetShardFileSystemId(refs[i]->ShardId);
-            nodeAttr->SetShardNodeName(refs[i]->ShardName);
+            nodeAttr->SetShardNodeName(refs[i]->ShardNodeName);
             continue;
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -27,12 +27,12 @@ void AddExternalNode(
     NProto::TListNodesResponse& record,
     TString name,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     record.AddNames(std::move(name));
     auto* node = record.AddNodes();
     node->SetShardFileSystemId(shardId);
-    node->SetShardNodeName(shardName);
+    node->SetShardNodeName(shardNodeName);
 }
 
 NProto::TError ValidateRequest(const NProto::TListNodesRequest& request)
@@ -199,7 +199,7 @@ void TIndexTabletActor::CompleteTx_ListNodes(
                     record,
                     ref.Name,
                     ref.ShardId,
-                    ref.ShardName);
+                    ref.ShardNodeName);
 
                 continue;
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -204,7 +204,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
         const bool isSameExternalNode = args.ChildRef->ShardId
             && args.NewChildRef->ShardId
             && args.ChildRef->ShardId == args.NewChildRef->ShardId
-            && args.ChildRef->ShardName == args.NewChildRef->ShardName;
+            && args.ChildRef->ShardNodeName == args.NewChildRef->ShardNodeName;
         if (isSameNode || isSameExternalNode) {
             args.Error = MakeError(S_ALREADY, "is the same file");
             return true;
@@ -290,7 +290,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
         args.Name,
         args.ChildRef->ChildNodeId,
         args.ChildRef->ShardId,
-        args.ChildRef->ShardName);
+        args.ChildRef->ShardNodeName);
 
     if (args.NewChildRef) {
         if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
@@ -303,7 +303,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.NewName,
                 args.NewChildRef->NodeId,
                 args.NewChildRef->ShardId,
-                args.NewChildRef->ShardName);
+                args.NewChildRef->ShardNodeName);
 
             // create source ref to target node
             CreateNodeRef(
@@ -313,7 +313,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.Name,
                 args.NewChildRef->ChildNodeId,
                 args.NewChildRef->ShardId,
-                args.NewChildRef->ShardName);
+                args.NewChildRef->ShardNodeName);
         } else if (args.NewChildRef->ShardId.empty()) {
             if (!args.NewChildNode) {
                 auto message = ReportNewChildNodeIsNull(TStringBuilder()
@@ -346,7 +346,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.NewParentNode->NodeId,
                 args.NewName,
                 args.NewChildRef->ShardId,
-                args.NewChildRef->ShardName,
+                args.NewChildRef->ShardNodeName,
                 args.NewChildRef->MinCommitId,
                 args.CommitId);
 
@@ -359,7 +359,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 args.Request.GetHeaders());
             shardRequest->SetFileSystemId(args.NewChildRef->ShardId);
             shardRequest->SetNodeId(RootNodeId);
-            shardRequest->SetName(args.NewChildRef->ShardName);
+            shardRequest->SetName(args.NewChildRef->ShardNodeName);
 
             db.WriteOpLogEntry(args.OpLogEntry);
         }
@@ -383,7 +383,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
         args.NewName,
         args.ChildRef->ChildNodeId,
         args.ChildRef->ShardId,
-        args.ChildRef->ShardName);
+        args.ChildRef->ShardNodeName);
 
     auto newParent = CopyAttrs(args.NewParentNode->Attrs, E_CM_CMTIME);
     UpdateNode(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -381,7 +381,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
             args.ParentNodeId,
             args.Name,
             args.ChildRef->ShardId,
-            args.ChildRef->ShardName,
+            args.ChildRef->ShardNodeName,
             args.ChildRef->MinCommitId,
             args.CommitId);
 
@@ -392,7 +392,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
         shardRequest->CopyFrom(args.Request);
         shardRequest->SetFileSystemId(args.ChildRef->ShardId);
         shardRequest->SetNodeId(RootNodeId);
-        shardRequest->SetName(args.ChildRef->ShardName);
+        shardRequest->SetName(args.ChildRef->ShardNodeName);
 
         db.WriteOpLogEntry(args.OpLogEntry);
     } else {
@@ -452,7 +452,7 @@ void TIndexTabletActor::CompleteTx_UnlinkNode(
                 "%s Unlinking node in shard upon UnlinkNode: %s, %s",
                 LogTag.c_str(),
                 args.ChildRef->ShardId.c_str(),
-                args.ChildRef->ShardName.c_str());
+                args.ChildRef->ShardNodeName.c_str());
 
             RegisterUnlinkNodeInShardActor(
                 ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -484,7 +484,7 @@ void TIndexTabletDatabase::WriteNodeRef(
     const TString& name,
     ui64 childNodeId,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     using TTable = TIndexTabletSchema::NodeRefs;
 
@@ -494,7 +494,7 @@ void TIndexTabletDatabase::WriteNodeRef(
             NIceDb::TUpdate<TTable::CommitId>(commitId),
             NIceDb::TUpdate<TTable::ChildId>(childNodeId),
             NIceDb::TUpdate<TTable::ShardId>(shardId),
-            NIceDb::TUpdate<TTable::ShardName>(shardName)
+            NIceDb::TUpdate<TTable::ShardNodeName>(shardNodeName)
         );
 }
 
@@ -533,7 +533,7 @@ bool TIndexTabletDatabase::ReadNodeRef(
                 name,
                 it.GetValue<TTable::ChildId>(),
                 it.GetValue<TTable::ShardId>(),
-                it.GetValue<TTable::ShardName>(),
+                it.GetValue<TTable::ShardNodeName>(),
                 minCommitId,
                 maxCommitId
             };
@@ -573,7 +573,7 @@ bool TIndexTabletDatabase::ReadNodeRefs(
                 it.GetValue<TTable::Name>(),
                 it.GetValue<TTable::ChildId>(),
                 it.GetValue<TTable::ShardId>(),
-                it.GetValue<TTable::ShardName>(),
+                it.GetValue<TTable::ShardNodeName>(),
                 minCommitId,
                 maxCommitId
             });
@@ -624,7 +624,7 @@ bool TIndexTabletDatabase::ReadNodeRefs(
             it.GetValue<TTable::Name>(),
             it.GetValue<TTable::ChildId>(),
             it.GetValue<TTable::ShardId>(),
-            it.GetValue<TTable::ShardName>(),
+            it.GetValue<TTable::ShardNodeName>(),
             it.GetValue<TTable::CommitId>(),
             InvalidCommitId});
         --maxCount;
@@ -666,7 +666,7 @@ void TIndexTabletDatabase::WriteNodeRefVer(
     const TString& name,
     ui64 childNodeId,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     using TTable = TIndexTabletSchema::NodeRefs_Ver;
 
@@ -676,7 +676,7 @@ void TIndexTabletDatabase::WriteNodeRefVer(
             NIceDb::TUpdate<TTable::MaxCommitId>(maxCommitId),
             NIceDb::TUpdate<TTable::ChildId>(childNodeId),
             NIceDb::TUpdate<TTable::ShardId>(shardId),
-            NIceDb::TUpdate<TTable::ShardName>(shardName)
+            NIceDb::TUpdate<TTable::ShardNodeName>(shardNodeName)
         );
 }
 
@@ -725,7 +725,7 @@ bool TIndexTabletDatabase::ReadNodeRefVer(
                 name,
                 it.GetValue<TTable::ChildId>(),
                 it.GetValue<TTable::ShardId>(),
-                it.GetValue<TTable::ShardName>(),
+                it.GetValue<TTable::ShardNodeName>(),
                 minCommitId,
                 maxCommitId
             };
@@ -765,7 +765,7 @@ bool TIndexTabletDatabase::ReadNodeRefVers(
                 it.GetValue<TTable::Name>(),
                 it.GetValue<TTable::ChildId>(),
                 it.GetValue<TTable::ShardId>(),
-                it.GetValue<TTable::ShardName>(),
+                it.GetValue<TTable::ShardNodeName>(),
                 minCommitId,
                 maxCommitId
             });
@@ -2138,7 +2138,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
     const TString& name,
     ui64 childNode,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     TIndexTabletDatabase::WriteNodeRef(
         nodeId,
@@ -2146,14 +2146,14 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
         name,
         childNode,
         shardId,
-        shardName);
+        shardNodeName);
     NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
         .NodeRefsKey = {nodeId, name},
         .NodeRefsRow = {
             .CommitId = commitId,
             .ChildId = childNode,
             .ShardId = shardId,
-            .ShardName = shardName}});
+            .ShardNodeName = shardNodeName}});
 }
 
 void TIndexTabletDatabaseProxy::DeleteNodeRef(ui64 nodeId, const TString& name)
@@ -2170,7 +2170,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRefVer(
     const TString& name,
     ui64 childNode,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     TIndexTabletDatabase::WriteNodeRefVer(
         nodeId,
@@ -2179,7 +2179,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRefVer(
         name,
         childNode,
         shardId,
-        shardName);
+        shardNodeName);
     // TODO(#1146): _Ver tables not yet supported
 }
 
@@ -2201,7 +2201,7 @@ TIndexTabletDatabaseProxy::ExtractWriteNodeRefsFromNodeRef(const TNodeRef& ref)
             .CommitId = ref.MinCommitId,
             .ChildId = ref.ChildNodeId,
             .ShardId = ref.ShardId,
-            .ShardName = ref.ShardName}};
+            .ShardNodeName = ref.ShardNodeName}};
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -189,7 +189,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& name,
         ui64 childNode,
         const TString& shardId,
-        const TString& shardName);
+        const TString& shardNodeName);
 
     virtual void DeleteNodeRef(ui64 nodeId, const TString& name);
 
@@ -231,7 +231,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& name,
         ui64 childNode,
         const TString& shardId,
-        const TString& shardName);
+        const TString& shardNodeName);
 
     virtual void DeleteNodeRefVer(
         ui64 nodeId,
@@ -641,7 +641,7 @@ public:
         const TString& name,
         ui64 childNode,
         const TString& shardId,
-        const TString& shardName) override;
+        const TString& shardNodeName) override;
 
     void DeleteNodeRef(ui64 nodeId, const TString& name) override;
 
@@ -656,7 +656,7 @@ public:
         const TString& name,
         ui64 childNode,
         const TString& shardId,
-        const TString& shardName) override;
+        const TString& shardNodeName) override;
 
     void DeleteNodeRefVer(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -150,13 +150,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child1", ref1));
             UNIT_ASSERT_EQUAL(ref1->ChildNodeId, childNodeId1);
             UNIT_ASSERT_EQUAL(ref1->ShardId, "");
-            UNIT_ASSERT_EQUAL(ref1->ShardName, "");
+            UNIT_ASSERT_EQUAL(ref1->ShardNodeName, "");
 
             TMaybe<IIndexTabletDatabase::TNodeRef> ref2;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child2", ref2));
             UNIT_ASSERT_EQUAL(ref2->ChildNodeId, childNodeId2);
             UNIT_ASSERT_EQUAL(ref2->ShardId, "shard");
-            UNIT_ASSERT_EQUAL(ref2->ShardName, "name");
+            UNIT_ASSERT_EQUAL(ref2->ShardNodeName, "name");
 
             TMaybe<IIndexTabletDatabase::TNodeRef> ref3;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child3", ref3));

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -219,7 +219,7 @@ struct TIndexTabletSchema
         struct Name         : Column<3, NKikimr::NScheme::NTypeIds::String> {};
         struct ChildId      : Column<4, NKikimr::NScheme::NTypeIds::Uint64> {};
         struct ShardId      : Column<5, NKikimr::NScheme::NTypeIds::String> {};
-        struct ShardName    : Column<6, NKikimr::NScheme::NTypeIds::String> {};
+        struct ShardNodeName: Column<6, NKikimr::NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<NodeId, Name>;
 
@@ -229,7 +229,7 @@ struct TIndexTabletSchema
             Name,
             ChildId,
             ShardId,
-            ShardName
+            ShardNodeName
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
@@ -244,7 +244,7 @@ struct TIndexTabletSchema
         struct Name         : Column<4, NKikimr::NScheme::NTypeIds::String> {};
         struct ChildId      : Column<5, NKikimr::NScheme::NTypeIds::Uint64> {};
         struct ShardId      : Column<6, NKikimr::NScheme::NTypeIds::String> {};
-        struct ShardName    : Column<7, NKikimr::NScheme::NTypeIds::String> {};
+        struct ShardNodeName: Column<7, NKikimr::NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<NodeId, Name, MinCommitId>;
 
@@ -255,7 +255,7 @@ struct TIndexTabletSchema
             Name,
             ChildId,
             ShardId,
-            ShardName
+            ShardNodeName
         >;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -410,7 +410,7 @@ public:
         ui64 parentNodeId,
         const TString& name,
         const TString& shardId,
-        const TString& shardName,
+        const TString& shardNodeName,
         ui64 minCommitId,
         ui64 maxCommitId);
 
@@ -504,7 +504,7 @@ public:
         const TString& childName,
         ui64 childNodeId,
         const TString& shardId,
-        const TString& shardName);
+        const TString& shardNodeName);
 
     void RemoveNodeRef(
         TIndexTabletDatabase& db,
@@ -514,7 +514,7 @@ public:
         const TString& childName,
         ui64 prevChildNodeId,
         const TString& shardId,
-        const TString& shardName);
+        const TString& shardNodeName);
 
     bool ReadNodeRef(
         IIndexTabletDatabase& db,
@@ -555,7 +555,7 @@ public:
         const TString& childName,
         ui64 childNodeId,
         const TString& shardId,
-        const TString& shardName);
+        const TString& shardNodeName);
 
     //
     // Sessions

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -31,7 +31,7 @@ void TInMemoryIndexState::LoadNodeRefs(const TVector<TNodeRef>& nodeRefs)
             nodeRef.Name,
             nodeRef.ChildNodeId,
             nodeRef.ShardId,
-            nodeRef.ShardName);
+            nodeRef.ShardNodeName);
     }
 }
 
@@ -225,7 +225,7 @@ bool TInMemoryIndexState::ReadNodeRef(
             name,
             it->second.ChildId,
             it->second.ShardId,
-            it->second.ShardName,
+            it->second.ShardNodeName,
             minCommitId,
             maxCommitId};
     }
@@ -263,7 +263,7 @@ bool TInMemoryIndexState::ReadNodeRefs(
                 it->first.Name,
                 it->second.ChildId,
                 it->second.ShardId,
-                it->second.ShardName,
+                it->second.ShardNodeName,
                 minCommitId,
                 maxCommitId});
 
@@ -316,7 +316,7 @@ void TInMemoryIndexState::WriteNodeRef(
     const TString& name,
     ui64 childNode,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     const auto key = TNodeRefsKey(nodeId, name);
     if (NodeRefs.size() == NodeRefsCapacity && !NodeRefs.contains(key)) {
@@ -329,7 +329,7 @@ void TInMemoryIndexState::WriteNodeRef(
         .CommitId = commitId,
         .ChildId = childNode,
         .ShardId = shardId,
-        .ShardName = shardName};
+        .ShardNodeName = shardNodeName};
 }
 
 void TInMemoryIndexState::DeleteNodeRef(ui64 nodeId, const TString& name)
@@ -415,7 +415,7 @@ void TInMemoryIndexState::UpdateState(
                 request->NodeRefsKey.Name,
                 request->NodeRefsRow.ChildId,
                 request->NodeRefsRow.ShardId,
-                request->NodeRefsRow.ShardName);
+                request->NodeRefsRow.ShardNodeName);
         } else if (
             const auto* request = std::get_if<TDeleteNodeRefsRequest>(&update))
         {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -149,7 +149,7 @@ private:
         const TString& name,
         ui64 childNode,
         const TString& shardId,
-        const TString& shardName);
+        const TString& shardNodeName);
 
     void DeleteNodeRef(ui64 nodeId, const TString& name);
 
@@ -250,7 +250,7 @@ private:
         ui64 CommitId = 0;
         ui64 ChildId = 0;
         TString ShardId;
-        TString ShardName;
+        TString ShardNodeName;
     };
 
     TMap<TNodeRefsKey, TNodeRefsRow> NodeRefs;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -35,7 +35,7 @@ public:
         TString Name;
         ui64 ChildNodeId;
         TString ShardId;
-        TString ShardName;
+        TString ShardNodeName;
         ui64 MinCommitId;
         ui64 MaxCommitId;
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -173,7 +173,7 @@ NProto::TError TIndexTabletState::UnlinkNode(
         name,
         node.NodeId,
         "", // shardId
-        "" // shardName
+        "" // shardNodeName
     );
 
     return {};
@@ -184,7 +184,7 @@ void TIndexTabletState::UnlinkExternalNode(
     ui64 parentNodeId,
     const TString& name,
     const TString& shardId,
-    const TString& shardName,
+    const TString& shardNodeName,
     ui64 minCommitId,
     ui64 maxCommitId)
 {
@@ -196,7 +196,7 @@ void TIndexTabletState::UnlinkExternalNode(
         name,
         InvalidNodeId, // prevChildNodeId
         shardId,
-        shardName);
+        shardNodeName);
 }
 
 bool TIndexTabletState::ReadNode(
@@ -417,7 +417,7 @@ void TIndexTabletState::CreateNodeRef(
     const TString& childName,
     ui64 childNodeId,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     db.WriteNodeRef(
         nodeId,
@@ -425,7 +425,7 @@ void TIndexTabletState::CreateNodeRef(
         childName,
         childNodeId,
         shardId,
-        shardName);
+        shardNodeName);
 }
 
 void TIndexTabletState::RemoveNodeRef(
@@ -436,7 +436,7 @@ void TIndexTabletState::RemoveNodeRef(
     const TString& childName,
     ui64 prevChildNodeId,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     db.DeleteNodeRef(nodeId, childName);
 
@@ -450,7 +450,7 @@ void TIndexTabletState::RemoveNodeRef(
             childName,
             prevChildNodeId,
             shardId,
-            shardName);
+            shardNodeName);
 
         AddCheckpointNode(db, checkpointId, nodeId);
     }
@@ -540,7 +540,7 @@ void TIndexTabletState::RewriteNodeRef(
     const TString& childName,
     ui64 childNodeId,
     const TString& shardId,
-    const TString& shardName)
+    const TString& shardNodeName)
 {
     ui64 checkpointId = Impl->Checkpoints.FindCheckpoint(nodeId, minCommitId);
     if (checkpointId != InvalidCommitId) {
@@ -552,7 +552,7 @@ void TIndexTabletState::RewriteNodeRef(
             childName,
             childNodeId,
             shardId,
-            shardName);
+            shardNodeName);
 
         AddCheckpointNode(db, checkpointId, nodeId);
     } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -660,7 +660,7 @@ struct TTxIndexTablet
         const TString Name;
         const NProto::TNode Attrs;
         const TString ShardId;
-        const TString ShardName;
+        const TString ShardNodeName;
         NProto::TCreateNodeRequest Request;
 
         ui64 CommitId = InvalidCommitId;
@@ -688,10 +688,10 @@ struct TTxIndexTablet
             // For multishard filestore, selection of the shard node name for
             // hard links is done by the client, not the leader. Thus, the
             // client is able to provide the shard node name explicitly:
-            , ShardName(
+            , ShardNodeName(
                   request.HasLink() && request.GetLink().GetShardNodeName()
                       ? request.GetLink().GetShardNodeName()
-                      : CreateGuidAsString())
+                      : ShardId ? CreateGuidAsString() : TString())
             , Request(std::move(request))
         {
         }
@@ -784,7 +784,7 @@ struct TTxIndexTablet
         NProto::TRenameNodeResponse Response;
 
         TString ShardIdForUnlink;
-        TString ShardNameForUnlink;
+        TString ShardNodeNameForUnlink;
 
         TRenameNode(
                 TRequestInfoPtr requestInfo,
@@ -816,7 +816,7 @@ struct TTxIndexTablet
             Response.Clear();
 
             ShardIdForUnlink.clear();
-            ShardNameForUnlink.clear();
+            ShardNodeNameForUnlink.clear();
         }
     };
 
@@ -982,7 +982,7 @@ struct TTxIndexTablet
         ui64 TargetNodeId = InvalidNodeId;
         TMaybe<IIndexTabletDatabase::TNode> TargetNode;
         TString ShardId;
-        TString ShardName;
+        TString ShardNodeName;
 
         TGetNodeAttr(
                 TRequestInfoPtr requestInfo,
@@ -1002,7 +1002,7 @@ struct TTxIndexTablet
             TargetNodeId = InvalidNodeId;
             TargetNode.Clear();
             ShardId.clear();
-            ShardName.clear();
+            ShardNodeName.clear();
         }
     };
 
@@ -1208,7 +1208,7 @@ struct TTxIndexTablet
         ui64 WriteCommitId = InvalidCommitId;
         ui64 TargetNodeId = InvalidNodeId;
         TString ShardId;
-        TString ShardName;
+        TString ShardNodeName;
         bool IsNewShardNode = false;
         TMaybe<IIndexTabletDatabase::TNode> TargetNode;
         TMaybe<IIndexTabletDatabase::TNode> ParentNode;
@@ -1240,7 +1240,7 @@ struct TTxIndexTablet
             WriteCommitId = InvalidCommitId;
             TargetNodeId = InvalidNodeId;
             ShardId.clear();
-            ShardName.clear();
+            ShardNodeName.clear();
             IsNewShardNode = false;
             TargetNode.Clear();
             ParentNode.Clear();

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -191,15 +191,15 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     const TString nodeName1 = "node1";
     const TString nodeName2 = "node2";
-    const TString shardName1 = "shard1";
-    const TString shardName2 = "shard2";
+    const TString shardNodeName1 = "shard1";
+    const TString shardNodeName2 = "shard2";
     const TString shardId1 = "shardId1";
     const TString shardId2 = "shardId2";
 
     //
     // NodeRefs
     //
-    Y_UNIT_TEST(ShoulPopulateNodeRefs)
+    Y_UNIT_TEST(ShouldPopulateNodeRefs)
     {
         // For now
         TInMemoryIndexState state(TDefaultAllocator::Instance());
@@ -214,7 +214,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .CommitId = commitId2,
                 .ChildId = nodeId1,
                 .ShardId = shardId1,
-                .ShardName = shardName1}}});
+                .ShardNodeName = shardNodeName1}}});
 
         UNIT_ASSERT(state.ReadNodeRef(RootNodeId, commitId2, nodeName1, ref));
         UNIT_ASSERT_VALUES_EQUAL(RootNodeId, ref->NodeId);
@@ -223,7 +223,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT_VALUES_EQUAL(commitId2, ref->MinCommitId);
         UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, ref->MaxCommitId);
         UNIT_ASSERT_VALUES_EQUAL(shardId1, ref->ShardId);
-        UNIT_ASSERT_VALUES_EQUAL(shardName1, ref->ShardName);
+        UNIT_ASSERT_VALUES_EQUAL(shardNodeName1, ref->ShardNodeName);
 
         // The cache is preemptive, so the listing should not be possible for
         // now
@@ -260,7 +260,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                          .CommitId = commitId1,
                          .ChildId = nodeId1,
                          .ShardId = shardId1,
-                         .ShardName = shardName1,
+                         .ShardNodeName = shardNodeName1,
                      }},
              TInMemoryIndexState::TWriteNodeRefsRequest{
                  .NodeRefsKey = {RootNodeId, nodeName2},
@@ -268,7 +268,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                      .CommitId = commitId1,
                      .ChildId = nodeId2,
                      .ShardId = shardId2,
-                     .ShardName = shardName2,
+                     .ShardNodeName = shardNodeName2,
                  }}});
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
@@ -287,7 +287,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .CommitId = commitId1,
                 .ChildId = nodeId1,
                 .ShardId = shardId1,
-                .ShardName = shardName1,
+                .ShardNodeName = shardNodeName1,
             }}});
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;


### PR DESCRIPTION
#2639 