### PR TITLE
[GO SDK] fix race condition in remounter

### DIFF
--- a/cloud/blockstore/public/sdk/go/client/session.go
+++ b/cloud/blockstore/public/sdk/go/client/session.go
@@ -481,9 +481,7 @@ func (s *Session) startRemounter(ctx context.Context) {
 				select {
 				case <-r.Done:
 				default:
-					if !s.closed {
-						_, _ = s.remountVolume(r.remountCtx)
-					}
+					_, _ = s.remountVolume(r.remountCtx)
 				}
 
 				s.mountLock.Unlock()


### PR DESCRIPTION
Test failed in pr https://github.com/ydb-platform/nbs/pull/2519

The reason of failure is a race condition in blockstore go SDK. Namely, the volume might be remounted after it was unmounted, but before session is closed. This might cause mount conflict on the next mount of the volume.

Bad scenario in more details:
- Start volume unmount.
- While unmounting, tick of the remounter happens. Remounter starts waiting on the mutex https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/public/sdk/go/client/session.go#L480
- Finish unmount.
- Remounter remounts volume.