### PR TITLE
issue-2605: remove blocks count validation for remote requests

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -426,7 +426,6 @@ NActors::IActorPtr CreateReadBlocksRemoteActor(
 NActors::IActorPtr CreateWriteBlocksRemoteActor(
     TEvService::TEvWriteBlocksLocalRequest::TPtr request,
     ui64 blockSize,
-    ui64 maxBlocksCount,
     NActors::TActorId volumeClient);
 
 NActors::IActorPtr CreateVolumeSessionActor(

--- a/cloud/blockstore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_forward.cpp
@@ -53,7 +53,6 @@ bool ConvertToRemoteRequestAndForward<TEvService::TWriteBlocksLocalMethod>(
     NCloud::Register(ctx, CreateWriteBlocksRemoteActor(
         ev,
         volume.VolumeInfo->GetBlockSize(),
-        volume.VolumeInfo->GetBlocksCount(),
         volume.VolumeClientActor));
     return true;
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_writeblocks.cpp
@@ -28,18 +28,15 @@ class TWriteBlocksRemoteRequestActor final
 private:
     const TEvService::TEvWriteBlocksLocalRequest::TPtr Request;
     const ui64 BlockSize;
-    const ui64 MaxBlocksCount;
     const TActorId VolumeClient;
 
 public:
     TWriteBlocksRemoteRequestActor(
             TEvService::TEvWriteBlocksLocalRequest::TPtr request,
             ui64 blockSize,
-            ui64 maxBlocksCount,
             TActorId volumeClient)
         : Request(request)
         , BlockSize(blockSize)
-        , MaxBlocksCount(maxBlocksCount)
         , VolumeClient(volumeClient)
     {}
 
@@ -59,9 +56,7 @@ private:
         const ui64 startIndex = msg->Record.GetStartIndex();
         ui32 blocksCount = msg->Record.BlocksCount;
 
-        if (!blocksCount ||
-            MaxBlocksCount <= startIndex ||
-            MaxBlocksCount - startIndex < blocksCount)
+        if (!blocksCount)
         {
             auto error = MakeError(E_ARGUMENT, TStringBuilder()
                 << "invalid block range [index" << startIndex
@@ -168,13 +163,11 @@ private:
 IActorPtr CreateWriteBlocksRemoteActor(
     TEvService::TEvWriteBlocksLocalRequest::TPtr request,
     ui64 blockSize,
-    ui64 maxBlocksCount,
     TActorId volumeClient)
 {
     return std::make_unique<TWriteBlocksRemoteRequestActor>(
         std::move(request),
         blockSize,
-        maxBlocksCount,
         volumeClient);
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_writeblocks.cpp
@@ -53,18 +53,6 @@ private:
         const auto& clientId = GetClientId(*msg);
         const auto& diskId = GetDiskId(*msg);
 
-        const ui64 startIndex = msg->Record.GetStartIndex();
-        ui32 blocksCount = msg->Record.BlocksCount;
-
-        if (!blocksCount)
-        {
-            auto error = MakeError(E_ARGUMENT, TStringBuilder()
-                << "invalid block range [index" << startIndex
-                << ", count: " << blocksCount << "]");
-            ReplyAndDie(ctx, error);
-            return;
-        }
-
         auto request = CreateRemoteRequest();
         if (!request) {
             ReplyAndDie(ctx, MakeError(E_REJECTED, "failed to create remote request"));


### PR DESCRIPTION
issue: #2605

remove redundant validation of blocks count for remote requests