### PR TITLE
Fix typo

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(ValidateTest)
             100,  // writeRage
             1,    // requestBlockCount
             1,    // writeParts
-            0,    // alternatingPhase
+            "0",    // alternatingPhase
             maxWriteRequestCount);
 
         auto executor = CreateTestExecutor(


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp:37:13: error: conversion from 'int' to 'TString' (aka 'TBasicString<char>') is ambiguous
   37 |             0,    // alternatingPhase
      |             ^
$(SOURCE_ROOT)/util/generic/string.h:462:5: note: candidate constructor
  462 |     TBasicString(const TCharType* pc)
      |     ^
$(SOURCE_ROOT)/util/generic/string.h:466:5: note: candidate constructor has been explicitly deleted
  466 |     TBasicString(std::nullptr_t) = delete;
      |     ^
$(SOURCE_ROOT)/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h:34:13: note: passing argument to parameter 'alternatingPhase' here
   34 |     TString alternatingPhase = "",
      |             ^
1 error generated.

```