### PR TITLE
issue-2559: actual ShardBalancer implementation

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -493,4 +493,12 @@ message TStorageConfig
     // requests. ShardIds selected in Leader have priority over ShardIds
     // selected at the StorageServiceActor level.
     optional bool ShardIdSelectionInLeaderEnabled = 411;
+
+    // Shard balancer will prefer shards which have at least this amount of
+    // free space in bytes.
+    optional uint64 ShardBalancerDesiredFreeSpaceReserve = 412;
+
+    // Shard balancer will not select shards which have less than this amount of
+    // free space in bytes.
+    optional uint64 ShardBalancerMinFreeSpaceReserve = 413;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -58,6 +58,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(AutomaticallyCreatedShardSize,                          ui64,   5_TB  )\
     xxx(EnforceCorrectFileSystemShardCountUponSessionCreation,  bool,   false )\
     xxx(ShardIdSelectionInLeaderEnabled,                        bool,   false )\
+    xxx(ShardBalancerDesiredFreeSpaceReserve,                   ui64,   1_TB  )\
+    xxx(ShardBalancerMinFreeSpaceReserve,                       ui64,   1_MB  )\
                                                                                \
     xxx(MaxFileBlocks,                                  ui32,   300_GB / 4_KB )\
     xxx(LargeDeletionMarkersEnabled,                    bool,   false         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -296,6 +296,8 @@ public:
     ui64 GetAutomaticallyCreatedShardSize() const;
     bool GetEnforceCorrectFileSystemShardCountUponSessionCreation() const;
     bool GetShardIdSelectionInLeaderEnabled() const;
+    ui64 GetShardBalancerDesiredFreeSpaceReserve() const;
+    ui64 GetShardBalancerMinFreeSpaceReserve() const;
 
     bool GetGuestWritebackCacheEnabled() const;
 };

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -1,1 +1,93 @@
 #include "shard_balancer.h"
+
+#include <util/generic/algorithm.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+ui64 FreeSpace(const TShardStats& s)
+{
+    return s.TotalBlocksCount - Min(s.UsedBlocksCount, s.TotalBlocksCount);
+}
+
+}   // namespace
+
+bool operator<(
+    const TShardBalancer::TShardMeta& lhs,
+    const TShardBalancer::TShardMeta& rhs)
+{
+    return FreeSpace(lhs.Stats) == FreeSpace(rhs.Stats)
+        ? lhs.ShardIdx < rhs.ShardIdx
+        : FreeSpace(lhs.Stats) > FreeSpace(rhs.Stats);
+}
+
+bool operator<(ui64 lhs, const TShardBalancer::TShardMeta& rhs)
+{
+    return lhs > FreeSpace(rhs.Stats);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TShardBalancer::SetParameters(
+    ui64 desiredFreeSpaceReserve,
+    ui64 minFreeSpaceReserve)
+{
+    DesiredFreeSpaceReserve = desiredFreeSpaceReserve;
+    MinFreeSpaceReserve = minFreeSpaceReserve;
+}
+
+void TShardBalancer::UpdateShards(TVector<TString> shardIds)
+{
+    Ids = std::move(shardIds);
+    Metas.clear();
+    for (ui32 i = 0; i < Ids.size(); ++i) {
+        Metas.emplace_back(i, TShardStats{DesiredFreeSpaceReserve, 0, 0, 0});
+    }
+    ShardSelector = 0;
+}
+
+void TShardBalancer::UpdateShardStats(const TVector<TShardStats>& stats)
+{
+    Y_DEBUG_ABORT_UNLESS(stats.size() == Metas.size());
+    ui32 cnt = Min(stats.size(), Metas.size());
+    for (ui32 i = 0; i < cnt; ++i) {
+        Metas[i].Stats = {};
+    }
+    Sort(Metas.begin(), Metas.end());
+    for (ui32 i = 0; i < cnt; ++i) {
+        Metas[i].Stats = stats[i];
+    }
+    Sort(Metas.begin(), Metas.end());
+    ShardSelector = 0;
+}
+
+NProto::TError TShardBalancer::SelectShard(ui64 fileSize, TString* shardId)
+{
+    auto* e = UpperBound(
+        Metas.begin(),
+        Metas.end(),
+        fileSize + DesiredFreeSpaceReserve);
+    if (e == Metas.begin()) {
+        e = UpperBound(
+            Metas.begin(),
+            Metas.end(),
+            fileSize + MinFreeSpaceReserve);
+    }
+
+    if (e == Metas.begin()) {
+        return MakeError(E_FS_NOSPC, "all shards are full");
+    }
+
+    const auto endIdx = std::distance(Metas.begin(), e);
+    if (ShardSelector >= endIdx) {
+        ShardSelector = 0;
+    }
+
+    *shardId = Ids[Metas[ShardSelector++].ShardIdx];
+    return {};
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
@@ -1,0 +1,223 @@
+#include "shard_balancer.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TShardBalancerTest)
+{
+#define ASSERT_NO_SB_ERROR(fileSize, expectedShardId) {                        \
+    TString shardId;                                                           \
+    const auto error = balancer.SelectShard(fileSize, &shardId);               \
+    UNIT_ASSERT_VALUES_EQUAL_C(                                                \
+        S_OK,                                                                  \
+        error.GetCode(),                                                       \
+        error.GetMessage());                                                   \
+    UNIT_ASSERT_VALUES_EQUAL(expectedShardId, shardId);                        \
+}                                                                              \
+// ASSERT_NO_ERROR
+
+#define ASSERT_SB_ERROR(fileSize, expectedCode) {                              \
+    TString shardId;                                                           \
+    const auto error = balancer.SelectShard(fileSize, &shardId);               \
+    UNIT_ASSERT_VALUES_EQUAL_C(                                                \
+        expectedCode,                                                          \
+        error.GetCode(),                                                       \
+        error.GetMessage());                                                   \
+}                                                                              \
+// ASSERT_ERROR
+
+    Y_UNIT_TEST(ShouldBalanceShards)
+    {
+        TShardBalancer balancer;
+        balancer.SetParameters(1_TB, 1_MB);
+        balancer.UpdateShards({"s1", "s2", "s3", "s4", "s5"});
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s5");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s5");
+
+        balancer.UpdateShardStats({
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 3_TB, 0, 0},
+        });
+
+        // order changed: s1, s3, s4, s2, s5
+
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s5");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s5");
+
+        // order changed: s1, s2, s3, s4, s5
+
+        balancer.UpdateShardStats({
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 4_TB, 0, 0},
+        });
+
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s5");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s5");
+
+        // one of the shard has less than desired free space
+        // order changed: s1, s2, s3, s4
+
+        balancer.UpdateShardStats({
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 4_TB + 500_GB, 0, 0},
+        });
+
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s2");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s4");
+
+        // more full / close to full shards
+        // order changed: s1, s4
+        // tier 2: s3, s5
+
+        balancer.UpdateShardStats({
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 5_TB, 0, 0},
+            {5_TB, 4_TB + 300_GB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 4_TB + 500_GB, 0, 0},
+        });
+
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s4");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s4");
+
+        // 3 close to full shards, 2 full shards
+        // order changed: s3, s1, s5
+
+        balancer.UpdateShardStats({
+            {5_TB, 4_TB + 400_GB, 0, 0},
+            {5_TB, 5_TB + 100_GB, 0, 0},
+            {5_TB, 4_TB + 300_GB, 0, 0},
+            {5_TB, 5_TB, 0, 0},
+            {5_TB, 4_TB + 500_GB, 0, 0},
+        });
+
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s5");
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s1");
+        ASSERT_NO_SB_ERROR(0, "s5");
+
+        // 1 close to full shard left: s3
+
+        balancer.UpdateShardStats({
+            {5_TB, 5_TB - 512_KB, 0, 0},
+            {5_TB, 5_TB + 100_GB, 0, 0},
+            {5_TB, 4_TB + 300_GB, 0, 0},
+            {5_TB, 5_TB, 0, 0},
+            {5_TB, 5_TB, 0, 0},
+        });
+
+        ASSERT_NO_SB_ERROR(0, "s3");
+        ASSERT_NO_SB_ERROR(0, "s3");
+
+        // out of space
+
+        balancer.UpdateShardStats({
+            {5_TB, 5_TB - 512_KB, 0, 0},
+            {5_TB, 5_TB + 100_GB, 0, 0},
+            {5_TB, 5_TB + 300_GB, 0, 0},
+            {5_TB, 5_TB, 0, 0},
+            {5_TB, 5_TB, 0, 0},
+        });
+
+        ASSERT_SB_ERROR(0, E_FS_NOSPC);
+        ASSERT_SB_ERROR(0, E_FS_NOSPC);
+        ASSERT_SB_ERROR(0, E_FS_NOSPC);
+    }
+
+    Y_UNIT_TEST(ShouldBalanceShardsWithFileSize)
+    {
+        TShardBalancer balancer;
+        balancer.SetParameters(1_TB, 1_MB);
+        balancer.UpdateShards({"s1", "s2", "s3", "s4", "s5"});
+
+        balancer.UpdateShardStats({
+            {5_TB, 512_GB, 0, 0},
+            {5_TB, 2_TB, 0, 0},
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 1_TB, 0, 0},
+            {5_TB, 3_TB, 0, 0},
+        });
+
+        // 1_TB can fit in any shard
+
+        ASSERT_NO_SB_ERROR(1_TB, "s1");
+        ASSERT_NO_SB_ERROR(1_TB, "s3");
+        ASSERT_NO_SB_ERROR(1_TB, "s4");
+        ASSERT_NO_SB_ERROR(1_TB, "s2");
+        ASSERT_NO_SB_ERROR(1_TB, "s5");
+        ASSERT_NO_SB_ERROR(1_TB, "s1");
+        ASSERT_NO_SB_ERROR(1_TB, "s3");
+        ASSERT_NO_SB_ERROR(1_TB, "s4");
+        ASSERT_NO_SB_ERROR(1_TB, "s2");
+        ASSERT_NO_SB_ERROR(1_TB, "s5");
+
+        // 3_TB can fit in s1, s3, s4
+        // but s1 is selected because it has >= 1_TB reserve
+
+        ASSERT_NO_SB_ERROR(3_TB, "s1");
+
+        // 3_TB + 600_GB can't fit with a 1_TB reserve but can physically
+        // fit in s1, s3, s4
+
+        ASSERT_NO_SB_ERROR(3_TB + 600_GB, "s3");
+        ASSERT_NO_SB_ERROR(3_TB + 600_GB, "s4");
+        ASSERT_NO_SB_ERROR(3_TB + 600_GB, "s1");
+
+        // 4_TB + 512_GB can't fit at all
+
+        ASSERT_SB_ERROR(4_TB + 512_GB, E_FS_NOSPC);
+        ASSERT_SB_ERROR(4_TB + 512_GB, E_FS_NOSPC);
+        ASSERT_SB_ERROR(4_TB + 512_GB, E_FS_NOSPC);
+    }
+}
+
+#undef ASSERT_NO_SB_ERROR
+#undef ASSERT_SB_ERROR
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ut/ya.make
@@ -18,6 +18,7 @@ SRCS(
     profile_log_events_ut.cpp
     range_locks_ut.cpp
     read_ahead_ut.cpp
+    shard_balancer_ut.cpp
     sparse_segment_ut.cpp
     split_range_ut.cpp
     throttling_policy_ut.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -331,7 +331,7 @@ private:
     } Metrics;
 
     NProtoPrivate::TStorageStats CachedAggregateStats;
-    TVector<TEvIndexTabletPrivate::TShardStats> CachedShardStats;
+    TVector<TShardStats> CachedShardStats;
     bool CachedStatsFetchingInProgress = false;
 
     const IProfileLogPtr ProfileLog;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -27,7 +27,7 @@ private:
     const NProtoPrivate::TGetStorageStatsRequest Request;
     const google::protobuf::RepeatedPtrField<TString> ShardIds;
     std::unique_ptr<TEvIndexTablet::TEvGetStorageStatsResponse> Response;
-    TVector<TEvIndexTabletPrivate::TShardStats> ShardStats;
+    TVector<TShardStats> ShardStats;
     int Responses = 0;
 
 public:
@@ -924,6 +924,7 @@ void TIndexTabletActor::HandleGetShardStatsCompleted(
         }
         CachedAggregateStats = std::move(msg->AggregateStats);
         CachedShardStats = std::move(msg->ShardStats);
+        UpdateShardStats(CachedShardStats);
 
         Store(
             Metrics.AggregateUsedBytesCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -206,7 +206,10 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
 
             auto shardId = args.RequestShardId;
             if (!IsShard() && Config->GetShardIdSelectionInLeaderEnabled()) {
-                shardId = SelectShard(0 /*fileSize*/);
+                args.Error = SelectShard(0 /*fileSize*/, &shardId);
+                if (HasError(args.Error)) {
+                    return true;
+                }
             }
 
             if (shardId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -361,7 +361,10 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
             && Config->GetShardIdSelectionInLeaderEnabled()
             && args.Attrs.GetType() == NProto::E_REGULAR_NODE)
     {
-        args.ShardId = SelectShard(args.Attrs.GetSize());
+        args.Error = SelectShard(args.Attrs.GetSize(), &args.ShardId);
+        if (HasError(args.Error)) {
+            return true;
+        }
     }
 
     // For multishard filestore, selection of the shard node name for

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1054,7 +1054,7 @@ void TIndexTabletActor::HandleHttpInfo_Default(
 
                 ui32 shardNo = 0;
                 for (const auto& shardId: shardIds) {
-                    TEvIndexTabletPrivate::TShardStats ss;
+                    TShardStats ss;
                     if (shardNo < CachedShardStats.size()) {
                         ss = CachedShardStats[shardNo];
                     }

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -11,6 +11,7 @@
 #include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/blob.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
+#include <cloud/filestore/libs/storage/tablet/model/shard_balancer.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
@@ -817,14 +818,6 @@ struct TEvIndexTabletPrivate
     //
     // GetShardStats
     //
-
-    struct TShardStats
-    {
-        ui64 TotalBlocksCount{0};
-        ui64 UsedBlocksCount{0};
-        ui64 CurrentLoad{0};
-        ui64 Suffer{0};
-    };
 
     struct TGetShardStatsCompleted
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -157,6 +157,9 @@ void TIndexTabletState::LoadState(
 
     Impl->OrphanNodeIds.insert(orphanNodeIds.begin(), orphanNodeIds.end());
 
+    Impl->ShardBalancer.SetParameters(
+        config.GetShardBalancerDesiredFreeSpaceReserve(),
+        config.GetShardBalancerMinFreeSpaceReserve());
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
     Impl->ShardBalancer.UpdateShards({shardIds.begin(), shardIds.end()});
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -298,7 +298,9 @@ public:
 
     bool CalculateExpectedShardCount() const;
 
-    TString SelectShard(ui64 fileSize);
+    NProto::TError SelectShard(ui64 fileSize, TString* shardId);
+
+    void UpdateShardStats(const TVector<TShardStats>& stats);
 
     //
     // FileSystem Stats

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1432,9 +1432,14 @@ TReadAheadCacheStats TIndexTabletState::CalculateReadAheadCacheStats() const
 ////////////////////////////////////////////////////////////////////////////////
 // Balancing
 
-TString TIndexTabletState::SelectShard(ui64 fileSize)
+NProto::TError TIndexTabletState::SelectShard(ui64 fileSize, TString* shardId)
 {
-    return Impl->ShardBalancer.SelectShard(fileSize);
+    return Impl->ShardBalancer.SelectShard(fileSize, shardId);
+}
+
+void TIndexTabletState::UpdateShardStats(const TVector<TShardStats>& stats)
+{
+    Impl->ShardBalancer.UpdateShardStats(stats);
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
If we have shards with FreeSpace >= ShardBalancerDesiredFreeSpaceReserve, we choose among them in a round robin manner
If not - we choose among shards with FreeSpace >= ShardBalancerMinFreeSpaceReserve in a round robin manner
If all shards have less than ShardBalancerMinFreeSpaceReserve free space, we return ENOSPC

#2559 