### PR TITLE
fix memory leak in partition2 tests

### DIFF
--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -59,7 +59,9 @@ TPartitionActor::TPartitionActor(
 {}
 
 TPartitionActor::~TPartitionActor()
-{}
+{
+    ReleaseTransactions();
+}
 
 TString TPartitionActor::GetStateName(ui32 state)
 {
@@ -372,6 +374,18 @@ void TPartitionActor::RemoveTransaction(TRequestInfo& requestInfo)
         TabletID());
 
     requestInfo.UnRef();
+}
+
+void TPartitionActor::ReleaseTransactions()
+{
+    while (ActiveTransactions) {
+        TRequestInfo* requestInfo = ActiveTransactions.PopFront();
+        STORAGE_VERIFY(
+            requestInfo->RefCount() >= 1,
+            TWellKnownEntityTypes::TABLET,
+            TabletID());
+        requestInfo->UnRef();
+    }
 }
 
 void TPartitionActor::TerminateTransactions(const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.h
@@ -148,7 +148,7 @@ public:
         EStorageAccessMode storageAccessMode,
         ui32 siblingCount,
         const NActors::TActorId& VolumeActorId);
-    ~TPartitionActor();
+    ~TPartitionActor() override;
 
     static constexpr ui32 LogComponent = TBlockStoreComponents::PARTITION;
     using TCounters = TPartitionCounters;


### PR DESCRIPTION
Тест падал потому что на момент его окончания была "висящая" операция compaction и поскольку не вызывался обычный код убивания таблетки (а просто деструктор, который ничего не делал)