### PR TITLE
[Blockstore] fix storage config overriding

### DIFF
--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -35,15 +35,13 @@ public:
         NFeatures::TFeaturesConfigPtr featuresConfig);
     ~TStorageConfig();
 
-    TStorageConfig(const TStorageConfig& config);
-
     void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig);
 
     void Register(NKikimr::TControlBoard& controlBoard);
 
-    void Merge(const NProto::TStorageServiceConfig& storageServiceConfig);
-
-    bool Equals(const TStorageConfig& other) const;
+    static TStorageConfigPtr Merge(
+        TStorageConfigPtr config,
+        const NProto::TStorageServiceConfig& patch);
 
     struct TValueByName
     {

--- a/cloud/blockstore/libs/storage/core/config_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/config_ut.cpp
@@ -1,0 +1,60 @@
+#include "config.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TConfigTest)
+{
+    Y_UNIT_TEST(ShouldOverrideConfigFields)
+    {
+        NProto::TStorageServiceConfig globalConfigProto;
+        globalConfigProto.SetMaxMigrationBandwidth(100);
+        globalConfigProto.SetMaxMigrationIoDepth(4);
+
+        NProto::TStorageServiceConfig patch;
+        patch.SetMaxMigrationBandwidth(400);
+
+        auto globalConfig = std::make_shared<TStorageConfig>(
+            globalConfigProto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        auto config = TStorageConfig::Merge(globalConfig, patch);
+        UNIT_ASSERT_UNEQUAL(config, globalConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            patch.GetMaxMigrationBandwidth(),
+            config->GetMaxMigrationBandwidth());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            globalConfigProto.GetMaxMigrationIoDepth(),
+            config->GetMaxMigrationIoDepth());
+
+        UNIT_ASSERT_VALUES_EQUAL("/Root", config->GetSchemeShardDir());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreEmptyPath)
+    {
+        NProto::TStorageServiceConfig globalConfigProto;
+        globalConfigProto.SetMaxMigrationBandwidth(100);
+
+        NProto::TStorageServiceConfig patch;
+
+        auto globalConfig = std::make_shared<TStorageConfig>(
+            globalConfigProto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        auto config = TStorageConfig::Merge(globalConfig, patch);
+        UNIT_ASSERT_EQUAL(globalConfig, config);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            globalConfigProto.GetMaxMigrationBandwidth(),
+            config->GetMaxMigrationBandwidth());
+
+        UNIT_ASSERT_VALUES_EQUAL("/Root", config->GetSchemeShardDir());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/ut/ya.make
+++ b/cloud/blockstore/libs/storage/core/ut/ya.make
@@ -6,6 +6,7 @@ SRCS(
     block_handler_ut.cpp
     compaction_map_ut.cpp
     compaction_policy_ut.cpp
+    config_ut.cpp
     disk_counters_ut.cpp
     manually_preempted_volumes_ut.cpp
     metrics_ut.cpp

--- a/cloud/blockstore/libs/storage/volume/volume_actor_change_storage_config.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_change_storage_config.cpp
@@ -54,12 +54,9 @@ void TVolumeActor::CompleteChangeStorageConfig(
         "ChangeStorageConfig",
         args.RequestInfo->CallContext->RequestId);
 
-    Config = std::make_shared<TStorageConfig>(*GlobalStorageConfig);
-    Config->Merge(std::move(args.ResultStorageConfig));
-    HasStorageConfigPatch = !Config->Equals(*GlobalStorageConfig);
-    if (!HasStorageConfigPatch) {
-        Config = GlobalStorageConfig;
-    }
+    Config =
+        TStorageConfig::Merge(GlobalStorageConfig, args.ResultStorageConfig);
+    HasStorageConfigPatch = Config != GlobalStorageConfig;
 
     if (State->GetPartitionsState() == TPartitionInfo::READY ||
         State->GetPartitionsState() == TPartitionInfo::STARTED)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -100,12 +100,9 @@ void TVolumeActor::CompleteLoadState(
     TTxVolume::TLoadState& args)
 {
     if (args.StorageConfig.Defined()) {
-        Config = std::make_shared<TStorageConfig>(*Config);
-        Config->Merge(*args.StorageConfig.Get());
-        HasStorageConfigPatch = !Config->Equals(*GlobalStorageConfig);
-        if (!HasStorageConfigPatch) {
-            Config = GlobalStorageConfig;
-        }
+        Config =
+            TStorageConfig::Merge(GlobalStorageConfig, *args.StorageConfig);
+        HasStorageConfigPatch = Config != GlobalStorageConfig;
     }
 
     if (args.Meta.Defined()) {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -883,21 +883,21 @@ void TVolumeActor::RenderStorageConfig(IOutputStream& out) const
                 }
                 const auto& protoValues = Config->GetStorageConfigProto();
                 constexpr i32 expectedNonRepeatedFieldIndex = -1;
-                const auto* descriptor = protoValues.GetDescriptor();
-                if (descriptor == nullptr) {
+                const auto* descriptor =
+                    NProto::TStorageServiceConfig::GetDescriptor();
+                if (!descriptor) {
                     return;
                 }
 
                 const auto* reflection =
                     NProto::TStorageServiceConfig::GetReflection();
 
-                for (int i = 0; i < descriptor->field_count(); ++i)
-                {
+                for (int i = 0; i < descriptor->field_count(); ++i) {
                     TStringBuilder value;
-                    const auto field_descriptor = descriptor->field(i);
-                    if (field_descriptor->is_repeated()) {
+                    const auto* fieldDescriptor = descriptor->field(i);
+                    if (fieldDescriptor->is_repeated()) {
                         const auto repeatedSize =
-                            reflection->FieldSize(protoValues, field_descriptor);
+                            reflection->FieldSize(protoValues, fieldDescriptor);
                         if (!repeatedSize) {
                             continue;
                         }
@@ -906,18 +906,18 @@ void TVolumeActor::RenderStorageConfig(IOutputStream& out) const
                             TString curValue;
                             google::protobuf::TextFormat::PrintFieldValueToString(
                                 protoValues,
-                                field_descriptor,
+                                fieldDescriptor,
                                 j,
                                 &curValue);
                             value.append(curValue);
                             value.append("; ");
                         }
                     } else if (
-                        reflection->HasField(protoValues, field_descriptor))
+                        reflection->HasField(protoValues, fieldDescriptor))
                     {
                         google::protobuf::TextFormat::PrintFieldValueToString(
                             protoValues,
-                            field_descriptor,
+                            fieldDescriptor,
                             expectedNonRepeatedFieldIndex,
                             &value);
                     } else {
@@ -926,7 +926,7 @@ void TVolumeActor::RenderStorageConfig(IOutputStream& out) const
 
                     TABLER() {
                         TABLED() {
-                            out << field_descriptor->name();;
+                            out << fieldDescriptor->name();;
                         }
                         TABLED() {
                             out << value;


### PR DESCRIPTION
Fixed overriding of configs via ChangeStorageConfig action: the configuration patch had no effect because it was applied only to the internal protobuf, not to all fields of TStorageConfig.