### PR TITLE
[Disk Manager] retry with new checkpoint id when create snapshot if shadow disk failed during filling

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/disk_registry_state.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/disk_registry_state.go
@@ -29,9 +29,21 @@ type diskRegistryState struct {
 	Backup DiskRegistryBackup `json:"Backup"`
 }
 
-func (b *DiskRegistryBackup) GetDevicesOfShadowDisk(diskID string) []string {
+func (b *DiskRegistryBackup) GetDevicesOfDisk(diskID string) []string {
 	for _, disk := range b.Disks {
-		if disk.CheckpointReplica.SourceDiskID == diskID {
+		if disk.DiskID == diskID {
+			return disk.DeviceUUIDs
+		}
+	}
+	return nil
+}
+
+func (b *DiskRegistryBackup) GetDevicesOfShadowDisk(
+	originalDiskID string,
+) []string {
+
+	for _, disk := range b.Disks {
+		if disk.CheckpointReplica.SourceDiskID == originalDiskID {
 			return disk.DeviceUUIDs
 		}
 	}

--- a/cloud/disk_manager/internal/pkg/clients/nbs/disk_registry_state.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/disk_registry_state.go
@@ -1,0 +1,50 @@
+package nbs
+
+type diskRegistryCheckpointReplica struct {
+	CheckpointID string `json:"CheckpointId"`
+	SourceDiskID string `json:"SourceDiskId"`
+}
+
+type diskRegistryDisk struct {
+	DiskID            string                        `json:"DiskId"`
+	DeviceUUIDs       []string                      `json:"DeviceUUIDs"`
+	CheckpointReplica diskRegistryCheckpointReplica `json:"CheckpointReplica"`
+}
+
+type diskRegistryDevice struct {
+	DeviceUUID string `json:"DeviceUUID"`
+}
+
+type diskRegistryAgent struct {
+	Devices []diskRegistryDevice `json:"Devices"`
+	AgentID string               `json:"AgentId"`
+}
+
+type DiskRegistryBackup struct {
+	Disks  []diskRegistryDisk  `json:"Disks"`
+	Agents []diskRegistryAgent `json:"Agents"`
+}
+
+type diskRegistryState struct {
+	Backup DiskRegistryBackup `json:"Backup"`
+}
+
+func (b *DiskRegistryBackup) GetDevicesOfShadowDisk(diskID string) []string {
+	for _, disk := range b.Disks {
+		if disk.CheckpointReplica.SourceDiskID == diskID {
+			return disk.DeviceUUIDs
+		}
+	}
+	return nil
+}
+
+func (b *DiskRegistryBackup) GetAgentIDByDeviceUUId(deviceUUID string) string {
+	for _, agent := range b.Agents {
+		for _, device := range agent.Devices {
+			if device.DeviceUUID == deviceUUID {
+				return agent.AgentID
+			}
+		}
+	}
+	return ""
+}

--- a/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/interface.go
@@ -364,6 +364,17 @@ type Client interface {
 
 	// Used in tests.
 	List(ctx context.Context) ([]string, error)
+
+	// Used in tests.
+	BackupDiskRegistryState(ctx context.Context) (*DiskRegistryBackup, error)
+
+	// Used in tests.
+	DisableDevices(
+		ctx context.Context,
+		agentID string,
+		deviceUUIDs []string,
+		message string,
+	) error
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/clients/nbs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/mocks/client_mock.go
@@ -486,6 +486,25 @@ func (c *ClientMock) FinishFillDisk(
 	return args.Error(0)
 }
 
+func (c *ClientMock) BackupDiskRegistryState(
+	ctx context.Context,
+) (*nbs.DiskRegistryBackup, error) {
+
+	args := c.Called(ctx)
+	return args.Get(0).(*nbs.DiskRegistryBackup), args.Error(1)
+}
+
+func (c *ClientMock) DisableDevices(
+	ctx context.Context,
+	agentID string,
+	deviceUUIDs []string,
+	message string,
+) error {
+
+	args := c.Called(ctx, agentID, deviceUUIDs, message)
+	return args.Error(0)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewClientMock() *ClientMock {

--- a/cloud/disk_manager/internal/pkg/clients/nbs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/tests/client_test.go
@@ -1530,3 +1530,142 @@ func TestReadFromProxyOverlayDiskWithMultipartitionBaseDisk(t *testing.T) {
 	err = client.ValidateCrc32(ctx, proxyOverlayDiskID, diskContentInfo)
 	require.NoError(t, err)
 }
+
+func TestDiskRegistryState(t *testing.T) {
+	ctx := newContext()
+	client := newClient(t, ctx)
+
+	diskID := t.Name()
+
+	err := client.Create(ctx, nbs.CreateDiskParams{
+		ID:          diskID,
+		BlocksCount: 2 * 262144,
+		BlockSize:   4096,
+		Kind:        types.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+	})
+	require.NoError(t, err)
+
+	backup, err := client.BackupDiskRegistryState(ctx)
+	require.NoError(t, err)
+
+	deviceUUIDs := backup.GetDevicesOfDisk(diskID)
+	require.Equal(t, len(deviceUUIDs), 2)
+
+	agentID := backup.GetAgentIDByDeviceUUId(deviceUUIDs[0])
+	require.NotEmpty(t, agentID)
+	agentID = backup.GetAgentIDByDeviceUUId(deviceUUIDs[1])
+	require.NotEmpty(t, agentID)
+
+	deviceUUIDs = backup.GetDevicesOfDisk("nonExistingDiskID")
+	require.Nil(t, deviceUUIDs)
+	agentID = backup.GetAgentIDByDeviceUUId("nonExistingDeviceID")
+	require.Empty(t, agentID)
+
+	err = client.Delete(ctx, diskID)
+	require.NoError(t, err)
+}
+
+func TestDiskRegistryDisableDevices(t *testing.T) {
+	ctx := newContext()
+	client := newClient(t, ctx)
+
+	diskID := t.Name()
+
+	err := client.Create(ctx, nbs.CreateDiskParams{
+		ID:          diskID,
+		BlocksCount: 262144,
+		BlockSize:   4096,
+		Kind:        types.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+	})
+	require.NoError(t, err)
+
+	writeBlocks(t, ctx, client, diskID, 0 /* startIndex */, 1 /* blockCount */)
+
+	backup, err := client.BackupDiskRegistryState(ctx)
+	require.NoError(t, err)
+	deviceUUIDs := backup.GetDevicesOfDisk(diskID)
+	require.Equal(t, len(deviceUUIDs), 1)
+	agentID := backup.GetAgentIDByDeviceUUId(deviceUUIDs[0])
+	require.NotEmpty(t, agentID)
+
+	err = client.DisableDevices(ctx, agentID, deviceUUIDs, t.Name())
+	require.NoError(t, err)
+
+	session, err := client.MountRW(
+		ctx,
+		diskID,
+		0,   // fillGeneration
+		0,   // fillSeqNumber
+		nil, // encryption
+	)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	defer session.Close(ctx)
+
+	data := make([]byte, 4096)
+	rand.Read(data)
+
+	// Device is disabled, all read and write requests should return error.
+	err = session.Write(ctx, 0, data)
+	require.Error(t, err)
+	zero := false
+	err = session.Read(ctx, 0, 1, "", data, &zero)
+	require.Error(t, err)
+
+	err = client.Delete(ctx, diskID)
+	require.NoError(t, err)
+}
+
+func TestDiskRegistryFindDevicesOfShadowDisk(t *testing.T) {
+	ctx := newContext()
+	client := newClient(t, ctx)
+
+	diskID := t.Name()
+
+	err := client.Create(ctx, nbs.CreateDiskParams{
+		ID:          diskID,
+		BlocksCount: 262144,
+		BlockSize:   4096,
+		Kind:        types.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+	})
+	require.NoError(t, err)
+
+	backup, err := client.BackupDiskRegistryState(ctx)
+	require.NoError(t, err)
+	deviceUUIDs := backup.GetDevicesOfShadowDisk(diskID)
+	// Shadow disk should not exist because checkpoint is not created yet.
+	require.Nil(t, deviceUUIDs)
+
+	checkpointID := "checkpointID"
+	err = client.CreateCheckpoint(ctx, nbs.CheckpointParams{
+		DiskID:         diskID,
+		CheckpointID:   checkpointID,
+		CheckpointType: nbs.CheckpointTypeNormal,
+	})
+	require.NoError(t, err)
+
+	retries := 0
+	for {
+		// Waiting for shadow disk to be created.
+		time.Sleep(time.Second)
+
+		backup, err := client.BackupDiskRegistryState(ctx)
+		require.NoError(t, err)
+		deviceUUIDs := backup.GetDevicesOfShadowDisk(diskID)
+
+		if len(deviceUUIDs) > 0 {
+			require.Equal(t, len(deviceUUIDs), 1)
+			break
+		}
+
+		retries++
+		if retries == 10 {
+			require.Fail(t, "Shadow disk has not appeared in disk registry state")
+		}
+	}
+
+	err = client.DeleteCheckpoint(ctx, diskID, checkpointID)
+	require.NoError(t, err)
+	err = client.Delete(ctx, diskID)
+	require.NoError(t, err)
+}

--- a/cloud/disk_manager/internal/pkg/clients/nbs/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/tests/ya.make
@@ -2,6 +2,7 @@ GO_TEST_FOR(cloud/disk_manager/internal/pkg/clients/nbs)
 
 SET_APPEND(RECIPE_ARGS --nbs-only)
 SET_APPEND(RECIPE_ARGS --multiple-nbs)
+SET_APPEND(RECIPE_ARGS --disk-agent-count 3)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/test/recipe/recipe.inc)
 
 GO_XTEST_SRCS(

--- a/cloud/disk_manager/internal/pkg/clients/nbs/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/ya.make
@@ -2,6 +2,7 @@ GO_LIBRARY()
 
 SRCS(
     client.go
+    disk_registry_state.go
     factory.go
     interface.go
     metrics.go

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -863,7 +863,7 @@ func testCreateSnapshotFromDiskWithFailedShadowDisk(
 	testcommon.CheckConsistency(t, ctx)
 }
 
-func TestCreateSnapshotFromDiskWithFailedShadowDiskShort(t *testing.T) {
+func TestSnapshotServiceCreateSnapshotFromDiskWithFailedShadowDiskShort(t *testing.T) {
 	testCreateSnapshotFromDiskWithFailedShadowDisk(
 		t,
 		disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
@@ -874,7 +874,7 @@ func TestCreateSnapshotFromDiskWithFailedShadowDiskShort(t *testing.T) {
 	)
 }
 
-func TestCreateSnapshotFromDiskWithFailedShadowDiskLong(t *testing.T) {
+func TestSnapshotServiceCreateSnapshotFromDiskWithFailedShadowDiskLong(t *testing.T) {
 	testCreateSnapshotFromDiskWithFailedShadowDisk(
 		t,
 		disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,

--- a/cloud/disk_manager/internal/pkg/resources/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/resources/mocks/storage_mock.go
@@ -170,12 +170,20 @@ func (s *StorageMock) CreateSnapshot(
 func (s *StorageMock) SnapshotCreated(
 	ctx context.Context,
 	snapshotID string,
+	checkpointID string,
 	createdAt time.Time,
 	snapshotSize uint64,
 	snapshotStorageSize uint64,
 ) error {
 
-	args := s.Called(ctx, snapshotID, createdAt, snapshotSize, snapshotStorageSize)
+	args := s.Called(
+		ctx,
+		snapshotID,
+		checkpointID,
+		createdAt,
+		snapshotSize,
+		snapshotStorageSize,
+	)
 	return args.Error(0)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -445,6 +445,7 @@ func (s *storageYDB) snapshotCreated(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
+	checkpointID string,
 	createdAt time.Time,
 	snapshotSize uint64,
 	snapshotStorageSize uint64,
@@ -505,6 +506,7 @@ func (s *storageYDB) snapshotCreated(
 	}
 
 	state.status = snapshotStatusReady
+	state.checkpointID = checkpointID
 	state.createdAt = createdAt
 	state.size = snapshotSize
 	state.storageSize = snapshotStorageSize
@@ -829,6 +831,7 @@ func (s *storageYDB) CreateSnapshot(
 func (s *storageYDB) SnapshotCreated(
 	ctx context.Context,
 	snapshotID string,
+	checkpointID string,
 	createdAt time.Time,
 	snapshotSize uint64,
 	snapshotStorageSize uint64,
@@ -841,6 +844,7 @@ func (s *storageYDB) SnapshotCreated(
 				ctx,
 				session,
 				snapshotID,
+				checkpointID,
 				createdAt,
 				snapshotSize,
 				snapshotStorageSize,

--- a/cloud/disk_manager/internal/pkg/resources/storage.go
+++ b/cloud/disk_manager/internal/pkg/resources/storage.go
@@ -168,6 +168,7 @@ type Storage interface {
 	SnapshotCreated(
 		ctx context.Context,
 		snapshotID string,
+		checkpointID string,
 		createdAt time.Time,
 		snapshotSize uint64,
 		snapshotStorageSize uint64,

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task_test.go
@@ -55,8 +55,8 @@ func TestCreateSnapshotFromDiskUpdatesCheckpointsCorrectly(t *testing.T) {
 		state:             &protos.CreateSnapshotFromDiskTaskState{},
 	}
 
-	require.Equal(t, int32(0), task.state.FailedCheckpointsCount)
-	require.Empty(t, task.state.FinalCheckpointID)
+	require.Equal(t, int32(0), task.state.CheckpointIteration)
+	require.Empty(t, task.state.CheckpointID)
 
 	// Create first checkpoint and get checkpoint status 'Error'.
 	execCtx.On("GetTaskID").Return("create_snapshot_from_disk_task")
@@ -81,8 +81,8 @@ func TestCreateSnapshotFromDiskUpdatesCheckpointsCorrectly(t *testing.T) {
 	err := task.Run(ctx, execCtx)
 	require.Error(t, err)
 	require.True(t, errors.CanRetry(err))
-	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
-	require.Empty(t, task.state.FinalCheckpointID)
+	require.Equal(t, int32(1), task.state.CheckpointIteration)
+	require.Empty(t, task.state.CheckpointID)
 	mock.AssertExpectationsForObjects(t, scheduler, storage, nbsFactory, nbsClient, execCtx)
 
 	// Create second checkpoint and get checkpoint status 'Ready'.
@@ -126,8 +126,8 @@ func TestCreateSnapshotFromDiskUpdatesCheckpointsCorrectly(t *testing.T) {
 	err = task.Run(ctx, execCtx)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewInterruptExecutionError()))
-	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
-	require.Equal(t, task.state.FinalCheckpointID, "snapshotID_1")
+	require.Equal(t, int32(1), task.state.CheckpointIteration)
+	require.Equal(t, task.state.CheckpointID, "snapshotID_1")
 	mock.AssertExpectationsForObjects(t, scheduler, storage, nbsFactory, nbsClient, execCtx)
 
 	// Finish waiting for the dataplane task, finish creating snapshot.
@@ -154,8 +154,8 @@ func TestCreateSnapshotFromDiskUpdatesCheckpointsCorrectly(t *testing.T) {
 
 	err = task.Run(ctx, execCtx)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
-	require.Equal(t, task.state.FinalCheckpointID, "snapshotID_1")
+	require.Equal(t, int32(1), task.state.CheckpointIteration)
+	require.Equal(t, task.state.CheckpointID, "snapshotID_1")
 	mock.AssertExpectationsForObjects(t, scheduler, storage, nbsFactory, nbsClient, execCtx)
 
 	// Cancel the task.
@@ -185,8 +185,8 @@ func TestCreateSnapshotFromDiskUpdatesCheckpointsCorrectly(t *testing.T) {
 
 	err = task.Cancel(ctx, execCtx)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
-	require.Equal(t, task.state.FinalCheckpointID, "snapshotID_1")
+	require.Equal(t, int32(1), task.state.CheckpointIteration)
+	require.Equal(t, task.state.CheckpointID, "snapshotID_1")
 	mock.AssertExpectationsForObjects(
 		t,
 		scheduler,

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task_test.go
@@ -1,0 +1,199 @@
+package snapshots
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
+	nbs_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs/mocks"
+	dataplane_protos "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/protos"
+	performance_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/performance/config"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/resources"
+	resources_storage_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/resources/mocks"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/snapshots/protos"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	"github.com/ydb-platform/nbs/cloud/tasks/errors"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
+	tasks_mocks "github.com/ydb-platform/nbs/cloud/tasks/mocks"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestCreateSnapshotFromDiskUpdatesCheckpointsCorrectly(t *testing.T) {
+	zoneID := "zone-a"
+	diskID := t.Name()
+
+	ctx := logging.SetLogger(
+		context.Background(),
+		logging.NewStderrLogger(logging.DebugLevel),
+	)
+	scheduler := tasks_mocks.NewSchedulerMock()
+	storage := resources_storage_mocks.NewStorageMock()
+	nbsFactory := nbs_mocks.NewFactoryMock()
+	nbsClient := nbs_mocks.NewClientMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	request := &protos.CreateSnapshotFromDiskRequest{
+		SrcDisk: &types.Disk{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		DstSnapshotId:       "snapshotID",
+		FolderId:            "folder",
+		UseS3:               true,
+		UseProxyOverlayDisk: true,
+	}
+
+	task := &createSnapshotFromDiskTask{
+		performanceConfig: &performance_config.PerformanceConfig{},
+		scheduler:         scheduler,
+		storage:           storage,
+		nbsFactory:        nbsFactory,
+		request:           request,
+		state:             &protos.CreateSnapshotFromDiskTaskState{},
+	}
+
+	require.Equal(t, int32(0), task.state.FailedCheckpointsCount)
+	require.Empty(t, task.state.FinalCheckpointID)
+
+	// Create first checkpoint and get checkpoint status 'Error'.
+	execCtx.On("GetTaskID").Return("create_snapshot_from_disk_task")
+	execCtx.On("SaveState", ctx).Return(nil)
+	nbsFactory.On("GetClient", ctx, zoneID).Return(nbsClient, nil)
+	nbsClient.On("Describe", ctx, diskID).Return(nbs.DiskParams{}, nil)
+	storage.On("CreateSnapshot", ctx, mock.Anything).Return(
+		resources.SnapshotMeta{Ready: false}, nil,
+	)
+
+	nbsClient.On("CreateCheckpoint", ctx, nbs.CheckpointParams{
+		DiskID:       request.SrcDisk.DiskId,
+		CheckpointID: "snapshotID",
+	}).Return(nil)
+	nbsClient.On(
+		"GetCheckpointStatus",
+		ctx,
+		diskID,
+		"snapshotID", // checkpointID
+	).Return(nbs.CheckpointStatusError, nil)
+
+	err := task.Run(ctx, execCtx)
+	require.Error(t, err)
+	require.True(t, errors.CanRetry(err))
+	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
+	require.Empty(t, task.state.FinalCheckpointID)
+	mock.AssertExpectationsForObjects(t, scheduler, storage, nbsFactory, nbsClient, execCtx)
+
+	// Create second checkpoint and get checkpoint status 'Ready'.
+	// Schedule dataplane task and start waiting for it.
+	nbsClient.On("CreateCheckpoint", ctx, nbs.CheckpointParams{
+		DiskID:       request.SrcDisk.DiskId,
+		CheckpointID: "snapshotID",
+	}).Unset()
+	nbsClient.On(
+		"DeleteCheckpoint", ctx, diskID, "snapshotID",
+	).Return(nil).Once() // Should not update checkpoints after checkpoint got ready.
+	nbsClient.On("CreateCheckpoint", ctx, nbs.CheckpointParams{
+		DiskID:       request.SrcDisk.DiskId,
+		CheckpointID: "snapshotID_1",
+	}).Return(nil).Once()
+	nbsClient.On(
+		"GetCheckpointStatus",
+		ctx,
+		diskID,
+		"snapshotID_1", // checkpointID
+	).Return(nbs.CheckpointStatusReady, nil).Once()
+
+	scheduler.On(
+		"ScheduleZonalTask",
+		mock.Anything, // ctx
+		"dataplane.CreateSnapshotFromDisk",
+		mock.Anything, // description
+		zoneID,
+		&dataplane_protos.CreateSnapshotFromDiskRequest{
+			SrcDisk:             request.SrcDisk,
+			SrcDiskCheckpointId: "snapshotID_1",
+			DstSnapshotId:       request.DstSnapshotId,
+			UseS3:               request.UseS3,
+			UseProxyOverlayDisk: request.UseProxyOverlayDisk,
+		},
+	).Return("dataplane_task_id", nil)
+	scheduler.On("WaitTask", ctx, execCtx, "dataplane_task_id").Return(
+		mock.Anything, errors.NewInterruptExecutionError(),
+	)
+
+	err = task.Run(ctx, execCtx)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errors.NewInterruptExecutionError()))
+	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
+	require.Equal(t, task.state.FinalCheckpointID, "snapshotID_1")
+	mock.AssertExpectationsForObjects(t, scheduler, storage, nbsFactory, nbsClient, execCtx)
+
+	// Finish waiting for the dataplane task, finish creating snapshot.
+	scheduler.On(
+		"WaitTask", ctx, execCtx, "dataplane_task_id",
+	).Unset().On(
+		"WaitTask", ctx, execCtx, "dataplane_task_id",
+	).Return(
+		&dataplane_protos.CreateSnapshotFromDiskResponse{}, nil,
+	)
+	execCtx.On("SetEstimate", mock.Anything)
+	storage.On(
+		"SnapshotCreated",
+		ctx,
+		request.DstSnapshotId,
+		"snapshotID_1", // checkpointID
+		mock.Anything,  // createdAt
+		mock.Anything,  // snapshotSize
+		mock.Anything,  // snapshotStorageSize
+	).Return(nil)
+	nbsClient.On(
+		"DeleteCheckpointData", ctx, diskID, "snapshotID_1",
+	).Return(nil)
+
+	err = task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
+	require.Equal(t, task.state.FinalCheckpointID, "snapshotID_1")
+	mock.AssertExpectationsForObjects(t, scheduler, storage, nbsFactory, nbsClient, execCtx)
+
+	// Cancel the task.
+	// Use fresh nbs client in order not to interfere with previous calls.
+	nbsClientForCancel := nbs_mocks.NewClientMock()
+	nbsFactory.On(
+		"GetClient", ctx, zoneID,
+	).Unset().On(
+		"GetClient", ctx, zoneID,
+	).Return(nbsClientForCancel, nil)
+
+	nbsClientForCancel.On(
+		"DeleteCheckpoint", ctx, diskID, "snapshotID",
+	).Return(nil)
+	nbsClientForCancel.On(
+		"DeleteCheckpoint", ctx, diskID, "snapshotID_1",
+	).Return(nil)
+
+	var m *resources.SnapshotMeta
+	storage.On(
+		"DeleteSnapshot",
+		ctx,
+		request.DstSnapshotId,
+		"create_snapshot_from_disk_task",
+		mock.Anything, //deletingAt
+	).Return(m, nil)
+
+	err = task.Cancel(ctx, execCtx)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), task.state.FailedCheckpointsCount)
+	require.Equal(t, task.state.FinalCheckpointID, "snapshotID_1")
+	mock.AssertExpectationsForObjects(
+		t,
+		scheduler,
+		storage,
+		nbsFactory,
+		nbsClient,
+		nbsClientForCancel,
+		execCtx,
+	)
+}

--- a/cloud/disk_manager/internal/pkg/services/snapshots/protos/create_snapshot_from_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/protos/create_snapshot_from_disk_task.proto
@@ -26,6 +26,6 @@ message CreateSnapshotFromDiskTaskState {
     string DataplaneTaskID = 6;
 
     // Needed for shadow disk based checkpoints.
-    int32 FailedCheckpointsCount = 7;
-    string FinalCheckpointID = 8;
+    int32 CheckpointIteration = 7;
+    string CheckpointID = 8;
 }

--- a/cloud/disk_manager/internal/pkg/services/snapshots/protos/create_snapshot_from_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/protos/create_snapshot_from_disk_task.proto
@@ -24,4 +24,8 @@ message CreateSnapshotFromDiskTaskState {
     int64 SnapshotSize = 4;
     int64 SnapshotStorageSize = 5;
     string DataplaneTaskID = 6;
+
+    // Needed for shadow disk based checkpoints.
+    int32 FailedCheckpointsCount = 7;
+    string FinalCheckpointID = 8;
 }

--- a/cloud/disk_manager/internal/pkg/services/snapshots/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/tests/ya.make
@@ -1,0 +1,3 @@
+GO_TEST_FOR(cloud/disk_manager/internal/pkg/services/snapshots)
+
+END()

--- a/cloud/disk_manager/internal/pkg/services/snapshots/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/ya.make
@@ -9,6 +9,10 @@ SRCS(
     service.go
 )
 
+GO_TEST_SRCS(
+    create_snapshot_from_disk_task_test.go
+)
+
 END()
 
 RECURSE(
@@ -18,4 +22,5 @@ RECURSE(
 
 RECURSE_FOR_TESTS(
     mocks
+    tests
 )

--- a/cloud/disk_manager/test/recipe/nbs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nbs_launcher.py
@@ -75,6 +75,7 @@ class NbsLauncher:
         storage_config_patch.DisableLocalService = False
         storage_config_patch.InactiveClientsTimeout = 60000  # 1 min
         storage_config_patch.AgentRequestTimeout = 5000      # 5 sec
+        storage_config_patch.UseShadowDisksForNonreplDiskCheckpoints = True
         if destruction_allowed_only_for_disks_with_id_prefixes:
             storage_config_patch.DestructionAllowedOnlyForDisksWithIdPrefixes.extend(destruction_allowed_only_for_disks_with_id_prefixes)
 


### PR DESCRIPTION
#1950

Сейчас есть баг при создании снапшотов из disk registy based дисков. Чекпоинты для таких дисков делаются через теневой диск (shadow disk). Сейчас, если [вот тут](https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go#L94) мы от чекпоинта с теневым диском получаем статус Error, то мы удаляем чекпоинт и ретраим таск. При ретрае таск падает при попытке создать чекпоинт с тем же id, что был у удалённого чекпоинта.

Теперь вместо этого мы при ретрае создаём чекпоинт с новым checkpoint id.

Также для воспроизведения падений теневого диска в интеграционных тестах нам нужно ходить в disk registry. Добавляю в nbs client нужный для этого код.

См. больше деталей в комментариях в #1950

Надо понимать, что эта правка ещё не полностью решает проблему с падением теневого диска. Подробнее написал в issue #1950.