### PR TITLE
fix probes for describeblocks actor

### DIFF
--- a/cloud/blockstore/libs/storage/partition_common/actor_describe_base_disk_blocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_describe_base_disk_blocks.cpp
@@ -48,7 +48,7 @@ void TDescribeBaseDiskBlocksActor::Bootstrap(const TActorContext& ctx)
     LWTRACK(
         RequestReceived_PartitionWorker,
         RequestInfo->CallContext->LWOrbit,
-        "ReadBlocks",
+        "DescribeBlocks",
         RequestInfo->CallContext->RequestId);
 
     DescribeBlocks(ctx);
@@ -61,9 +61,9 @@ void TDescribeBaseDiskBlocksActor::ReplyAndDie(
     using TEvent = TEvPartitionCommonPrivate::TEvDescribeBlocksCompleted;
 
     LWTRACK(
-        RequestReceived_PartitionWorker,
+        ResponseSent_PartitionWorker,
         RequestInfo->CallContext->LWOrbit,
-        "ReadBlocks",
+        "DescribeBlocks",
         RequestInfo->CallContext->RequestId);
 
     if (NotifyActorId) {
@@ -244,4 +244,3 @@ STFUNC(TDescribeBaseDiskBlocksActor::StateWork)
 }
 
 }   // namespace NCloud::NBlockStore::NStorage
-


### PR DESCRIPTION
Probes for TDescribeBaseDiskBlocksActor refers to "ReadBlocks" not "DescribeBlocks" and look confusing in traces.