### PR TITLE
issue-2693: properly tracking old versions of the same deletion marker to clear those old versions upon Cleanup

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -29,31 +29,26 @@ struct TMarkerInfoLess
 {
     using is_transparent = void;
 
-    bool operator()(const auto& lhs, const auto& rhs) const
+    bool operator()(const TMarkerInfo& lhs, const TMarkerInfo& rhs) const
     {
-        return std::make_pair(GetEnd(lhs), GetCommitId(lhs)) <
-            std::make_pair(GetEnd(rhs), GetCommitId(rhs));
+        return std::make_tuple(
+            GetEnd(lhs),
+            lhs.Marker.BlockIndex,
+            lhs.Marker.CommitId
+        ) < std::make_tuple(
+            GetEnd(rhs),
+            rhs.Marker.BlockIndex,
+            rhs.Marker.CommitId);
+    }
+
+    bool operator()(const ui64 lhs, const TMarkerInfo& rhs) const
+    {
+        return lhs < GetEnd(rhs);
     }
 
     static ui64 GetEnd(const TMarkerInfo& markerInfo)
     {
         return markerInfo.Marker.BlockIndex + markerInfo.Marker.BlockCount;
-    }
-
-    static ui64 GetCommitId(const TMarkerInfo& markerInfo)
-    {
-        return markerInfo.Marker.CommitId;
-    }
-
-    static ui64 GetEnd(ui64 end)
-    {
-        return end;
-    }
-
-    static ui64 GetCommitId(ui64 end)
-    {
-        Y_UNUSED(end);
-        return Max<ui64>();
     }
 };
 

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.cpp
@@ -31,7 +31,8 @@ struct TMarkerInfoLess
 
     bool operator()(const auto& lhs, const auto& rhs) const
     {
-        return GetEnd(lhs) < GetEnd(rhs);
+        return std::make_pair(GetEnd(lhs), GetCommitId(lhs)) <
+            std::make_pair(GetEnd(rhs), GetCommitId(rhs));
     }
 
     static ui64 GetEnd(const TMarkerInfo& markerInfo)
@@ -39,9 +40,20 @@ struct TMarkerInfoLess
         return markerInfo.Marker.BlockIndex + markerInfo.Marker.BlockCount;
     }
 
+    static ui64 GetCommitId(const TMarkerInfo& markerInfo)
+    {
+        return markerInfo.Marker.CommitId;
+    }
+
     static ui64 GetEnd(ui64 end)
     {
         return end;
+    }
+
+    static ui64 GetCommitId(ui64 end)
+    {
+        Y_UNUSED(end);
+        return Max<ui64>();
     }
 };
 


### PR DESCRIPTION
TLargeBlocks in-memory structure forgets about older versions of a deletion marker whose range is the same as some newer deletion marker's range (for the same nodeId). This leads to not cleaning up the older versions until tablet restart (deletion markers are re-read from the local db upon tablet restart). Causes excessive Cleanups, causes extra backpressure errors, etc. Doesn't cause data loss or corruption.

#2693 