### PR TITLE
[Filestore] issue-1751: allow read when guest writeback cache enabled

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -326,13 +326,21 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         const ui64 nodeId = 123;
         const ui64 handleId = 456;
-        bootstrap.Service->CreateHandleHandler = [&] (auto callContext, auto request) {
+        bootstrap.Service->CreateHandleHandler =
+            [&](auto callContext, auto request)
+        {
             if (isWritebackCacheEnabled) {
-                UNIT_ASSERT(HasFlag(request->GetFlags(), NProto::TCreateHandleRequest::E_READ));
+                UNIT_ASSERT(HasFlag(
+                    request->GetFlags(),
+                    NProto::TCreateHandleRequest::E_READ));
             } else {
-                UNIT_ASSERT(!HasFlag(request->GetFlags(), NProto::TCreateHandleRequest::E_READ));
+                UNIT_ASSERT(!HasFlag(
+                    request->GetFlags(),
+                    NProto::TCreateHandleRequest::E_READ));
             }
-            UNIT_ASSERT(HasFlag(request->GetFlags(), NProto::TCreateHandleRequest::E_WRITE));
+            UNIT_ASSERT(HasFlag(
+                request->GetFlags(),
+                NProto::TCreateHandleRequest::E_WRITE));
             UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
 
             NProto::TCreateHandleResponse result;

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -312,6 +312,75 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT_VALUES_EQUAL(1, fsyncCalledWithDataSync.load());
     }
 
+    void CheckCreateOpenHandleRequest(bool isCreate, bool isWritebackCacheEnabled)
+    {
+        NProto::TFileStoreFeatures features;
+        if (isWritebackCacheEnabled) {
+            features.SetGuestWritebackCacheEnabled(true);
+        }
+
+        TBootstrap bootstrap(
+            CreateWallClockTimer(),
+            CreateScheduler(),
+            features);
+
+        const ui64 nodeId = 123;
+        const ui64 handleId = 456;
+        bootstrap.Service->CreateHandleHandler = [&] (auto callContext, auto request) {
+            if (isWritebackCacheEnabled) {
+                UNIT_ASSERT(HasFlag(request->GetFlags(), NProto::TCreateHandleRequest::E_READ));
+            } else {
+                UNIT_ASSERT(!HasFlag(request->GetFlags(), NProto::TCreateHandleRequest::E_READ));
+            }
+            UNIT_ASSERT(HasFlag(request->GetFlags(), NProto::TCreateHandleRequest::E_WRITE));
+            UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+            NProto::TCreateHandleResponse result;
+            result.SetHandle(handleId);
+            result.MutableNodeAttr()->SetId(nodeId);
+            return MakeFuture(result);
+        };
+
+        bootstrap.Start();
+
+
+        auto req = std::make_shared<TCreateHandleRequest>("/file1", RootNodeId);
+        req->In->Body.flags |= O_WRONLY;
+        auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(req);
+        UNIT_ASSERT_VALUES_EQUAL(handle.GetValue(WaitTimeout), handleId);
+
+        if (!isCreate) {
+            auto req = std::make_shared<TOpenHandleRequest>(handleId);
+            req->In->Body.flags |= O_WRONLY;
+            auto handle = bootstrap.Fuse->SendRequest<TOpenHandleRequest>(req);
+            UNIT_ASSERT_VALUES_EQUAL(handle.GetValue(WaitTimeout), handleId);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleCreateHandleRequestWithGuestWritebackCacheEnabled)
+    {
+        CheckCreateOpenHandleRequest(
+            true,   // Create Handle
+            false   // no guest writeback cache
+        );
+        CheckCreateOpenHandleRequest(
+            true,   // Create Handle
+            true    // guest writeback cache
+        );
+    }
+
+    Y_UNIT_TEST(ShouldHandleOpenHandleRequestWithGuestWritebackCacheEnabled)
+    {
+        CheckCreateOpenHandleRequest(
+            false,   // Open Handle
+            false    // no guest writeback cache
+        );
+        CheckCreateOpenHandleRequest(
+            false,   // Open Handle
+            true     // guest writeback cache
+        );
+    }
+
     Y_UNIT_TEST(ShouldPassSessionId)
     {
         TBootstrap bootstrap;

--- a/cloud/filestore/libs/vhost/request.h
+++ b/cloud/filestore/libs/vhost/request.h
@@ -177,6 +177,22 @@ struct TCreateHandleRequest
     }
 };
 
+struct TOpenHandleRequest
+    : public TRequestBase<fuse_open_in, fuse_open_out, ui64>
+{
+    explicit TOpenHandleRequest(ui64 nodeId)
+    {
+        In->Header.opcode = FUSE_OPEN;
+        In->Header.nodeid = nodeId;
+        In->Body.flags = 0;
+    }
+
+    void SetResult() override
+    {
+        Result.SetValue(Out->Body.fh);
+    }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TLookupRequest


### PR DESCRIPTION
When working with writeback cache on client we need to additionally allow  reads
for files which are open with write-only flag similar to virtiofsd
https://gitlab.com/virtio-fs/virtiofsd/blob/main/src/passthrough/mod.rs#L606

#1751 