### PR TITLE
Fix arcadia sync

### DIFF
--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -33,6 +33,7 @@ CHECK_DEPENDENT_DIRS(ALLOW_ONLY PEERDIRS
     logbroker
     tools/enum_parser
     util
+    yql/essentials
 )
 
 END()


### PR DESCRIPTION
```
Error[-WBadDep]: in $B/cloud/blockstore/apps/server_lightweight/nbsd-lightweight: forbids direct or indirect PEERDIR dependency to module $B/yql/essentials/public/issue/protos/libpublic-issue-protos.a via CHECK_DEPENDENT_DIRS
    $B/cloud/blockstore/apps/server_lightweight/nbsd-lightweight -> $B/cloud/blockstore/libs/daemon/local/liblibs-daemon-local.a
    $B/cloud/blockstore/libs/daemon/local/liblibs-daemon-local.a -> $B/cloud/blockstore/libs/daemon/common/liblibs-daemon-common.a
    $B/cloud/blockstore/libs/daemon/common/liblibs-daemon-common.a -> $B/cloud/blockstore/libs/endpoints/libblockstore-libs-endpoints.a
    $B/cloud/blockstore/libs/endpoints/libblockstore-libs-endpoints.a -> $B/contrib/ydb/core/protos/libydb-core-protos.a
    $B/contrib/ydb/core/protos/libydb-core-protos.a -> $B/contrib/ydb/core/fq/libs/config/protos/liblibs-config-protos.a
    $B/contrib/ydb/core/fq/libs/config/protos/liblibs-config-protos.a -> $B/contrib/ydb/library/yql/dq/actors/protos/libdq-actors-protos.a
    $B/contrib/ydb/library/yql/dq/actors/protos/libdq-actors-protos.a -> $B/yql/essentials/core/issue/protos/libcore-issue-protos.a
    $B/yql/essentials/core/issue/protos/libcore-issue-protos.a -> $B/yql/essentials/public/issue/protos/libpublic-issue-protos.
```