### PR TITLE
[Blockstore] Do not check health of disabled devices

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
@@ -1,0 +1,255 @@
+#include "device_health_check_actor.h"
+
+#include <cloud/blockstore/libs/kikimr/components.h>
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
+#include <cloud/storage/core/libs/actors/helpers.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <util/random/fast.h>
+
+using namespace NActors;
+
+namespace NCloud::NBlockStore::NStorage::NDiskAgent {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EDeviceHealthStatus
+{
+    Healthy,
+    Broken,
+    Unknown,
+};
+
+EDeviceHealthStatus GetHealthStatus(EWellKnownResultCodes code)
+{
+    switch (code) {
+        case EWellKnownResultCodes::S_OK:
+            return EDeviceHealthStatus::Healthy;
+        case EWellKnownResultCodes::E_ARGUMENT:
+        case EWellKnownResultCodes::E_CANCELLED:
+        case EWellKnownResultCodes::E_REJECTED:
+            return EDeviceHealthStatus::Unknown;
+        default:
+            return EDeviceHealthStatus::Broken;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDeviceHealthCheckActor
+    : public TActorBootstrapped<TDeviceHealthCheckActor>
+{
+private:
+    constexpr static ui64 RndSeed = 12345;
+
+    const TActorId DiskAgent;
+    const TVector<NProto::TDeviceConfig> Devices;
+
+    TVector<EDeviceHealthStatus> DevicesHealth;
+    TFastRng32 Rng{RndSeed, 0};
+
+    int PendingRequests = 0;
+
+public:
+    TDeviceHealthCheckActor(
+        const TActorId& diskAgent,
+        TVector<NProto::TDeviceConfig> devices);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ScheduleHealthCheck(const TActorContext& ctx);
+    void CheckDevicesHealth(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleWakeup(
+        const TEvents::TEvWakeup::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleReadDeviceBlocksResponse(
+        const TEvDiskAgent::TEvReadDeviceBlocksResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDeviceHealthCheckActor::TDeviceHealthCheckActor(
+        const TActorId& diskAgent,
+        TVector<NProto::TDeviceConfig> devices)
+    : DiskAgent{diskAgent}
+    , Devices(std::move(devices))
+    , DevicesHealth(Devices.size(), EDeviceHealthStatus::Healthy)
+{}
+
+void TDeviceHealthCheckActor::Bootstrap(const TActorContext& ctx)
+{
+    Become(&TThis::StateWork);
+    ScheduleHealthCheck(ctx);
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_AGENT_WORKER,
+        "Device Health Check Actor started");
+}
+
+void TDeviceHealthCheckActor::ScheduleHealthCheck(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::DISK_AGENT_WORKER,
+        "Schedule health check");
+
+    ctx.Schedule(UpdateCountersInterval, new TEvents::TEvWakeup());
+}
+
+void TDeviceHealthCheckActor::CheckDevicesHealth(const TActorContext& ctx)
+{
+    for (size_t i = 0; i < Devices.size(); ++i) {
+        const auto& device = Devices[i];
+        auto request =
+            std::make_unique<TEvDiskAgent::TEvReadDeviceBlocksRequest>();
+        auto& rec = request->Record;
+        rec.MutableHeaders()->SetClientId(TString(CheckHealthClientId));
+        rec.SetDeviceUUID(device.GetDeviceUUID());
+        rec.SetStartIndex(Rng.Uniform(device.GetBlocksCount()));
+        rec.SetBlockSize(device.GetBlockSize());
+        rec.SetBlocksCount(1);
+
+        LOG_DEBUG_S(
+            ctx, TBlockStoreComponents::DISK_AGENT_WORKER,
+            "Checking device: " << rec.DebugString());
+
+        ctx.Send(DiskAgent, request.release(), TEventFlags{}, i);
+        ++PendingRequests;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDeviceHealthCheckActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    Die(ctx);
+}
+
+void TDeviceHealthCheckActor::HandleWakeup(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    CheckDevicesHealth(ctx);
+}
+
+void TDeviceHealthCheckActor::HandleReadDeviceBlocksResponse(
+    const TEvDiskAgent::TEvReadDeviceBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    const size_t deviceIndex = ev->Cookie;
+    Y_DEBUG_ABORT_UNLESS(
+        deviceIndex < DevicesHealth.size(),
+        "Invalid device index");
+    const auto& deviceUUID = Devices[deviceIndex].GetDeviceUUID();
+
+    auto currentHealth = GetHealthStatus(
+        static_cast<EWellKnownResultCodes>(msg->GetError().GetCode()));
+    auto lastHealth = DevicesHealth[deviceIndex];
+
+    // Device has changed state only if reads status changed from healthy to
+    // broken or vice versa. Ignore the "unknown" state.
+    const bool deviceHealthChanged =
+        currentHealth != lastHealth &&
+        currentHealth != EDeviceHealthStatus::Unknown;
+
+    if (currentHealth != EDeviceHealthStatus::Unknown) {
+        // We save only the "healthy" and "broken" states. This allows us not to
+        // trigger when transitions with "unknown" state occur.
+        DevicesHealth[deviceIndex] = currentHealth;
+    }
+
+    switch (currentHealth) {
+        case EDeviceHealthStatus::Healthy: {
+            LOG_TRACE_S(
+                ctx,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                "Everything fine!");
+            if (deviceHealthChanged) {
+                LOG_WARN_S(
+                    ctx,
+                    TBlockStoreComponents::DISK_AGENT_WORKER,
+                    "A miracle happened, the device " << deviceUUID.Quote()
+                                                      << " was healed.");
+            }
+            break;
+        }
+        case EDeviceHealthStatus::Broken: {
+            auto priority = deviceHealthChanged ? NActors::NLog::PRI_ERROR
+                                                : NActors::NLog::PRI_INFO;
+            LOG_LOG_S(
+                ctx,
+                priority,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                "The device " << deviceUUID.Quote() << " broke down. "
+                              << FormatError(msg->GetError()));
+            break;
+        }
+        case EDeviceHealthStatus::Unknown: {
+            LOG_DEBUG_S(
+                ctx,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                "Got error when reading from the device "
+                    << deviceUUID.Quote() << ". "
+                    << FormatError(msg->GetError()));
+            break;
+        }
+    }
+
+    if (--PendingRequests == 0) {
+        ScheduleHealthCheck(ctx);
+    }
+}
+
+STFUNC(TDeviceHealthCheckActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvWakeup, HandleWakeup);
+        HFunc(TEvDiskAgent::TEvReadDeviceBlocksResponse,
+            HandleReadDeviceBlocksResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT_WORKER);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<IActor> CreateDeviceHealthCheckActor(
+    const TActorId& diskAgent,
+    TVector<NProto::TDeviceConfig> devices)
+{
+    return std::make_unique<TDeviceHealthCheckActor>(
+        diskAgent,
+        std::move(devices));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NDiskAgent

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
@@ -52,7 +52,7 @@ private:
     const TVector<NProto::TDeviceConfig> Devices;
 
     TVector<EDeviceHealthStatus> DevicesHealth;
-    TFastRng32 Rng{RndSeed, 0};
+    TFastRng<ui64> Rng{RndSeed};
 
     int PendingRequests = 0;
 

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
@@ -9,7 +9,11 @@
 #include <contrib/ydb/library/actors/core/events.h>
 #include <contrib/ydb/library/actors/core/log.h>
 
+#include <util/datetime/base.h>
+#include <util/generic/vector.h>
 #include <util/random/fast.h>
+
+#include <optional>
 
 using namespace NActors;
 

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
@@ -98,10 +98,10 @@ void TDeviceHealthCheckActor::Bootstrap(const TActorContext& ctx)
     Become(&TThis::StateWork);
     ScheduleHealthCheck(ctx);
 
-    LOG_INFO(
+    LOG_INFO_S(
         ctx,
         TBlockStoreComponents::DISK_AGENT_WORKER,
-        "Device Health Check Actor started");
+        "Device Health Check Actor started. Devices: " << Devices.size());
 }
 
 void TDeviceHealthCheckActor::ScheduleHealthCheck(const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+#include <contrib/ydb/library/actors/core/actor.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NStorage::NDiskAgent {
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<NActors::IActor> CreateDeviceHealthCheckActor(
+    const NActors::TActorId& diskAgent,
+    TVector<NProto::TDeviceConfig> devices);
+
+}   // namespace NCloud::NBlockStore::NStorage::NDiskAgent

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.h
@@ -11,6 +11,7 @@ namespace NCloud::NBlockStore::NStorage::NDiskAgent {
 
 std::unique_ptr<NActors::IActor> CreateDeviceHealthCheckActor(
     const NActors::TActorId& diskAgent,
-    TVector<NProto::TDeviceConfig> devices);
+    TVector<NProto::TDeviceConfig> devices,
+    TDuration healthCheckDelay);
 
 }   // namespace NCloud::NBlockStore::NStorage::NDiskAgent

--- a/cloud/blockstore/libs/storage/disk_agent/actors/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    device_health_check_actor.cpp
     direct_copy_actor.cpp
     io_request_parser.cpp
     session_cache_actor.cpp

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -176,7 +176,8 @@ void TDiskAgentActor::RestartDeviceHealthChecking(const TActorContext& ctx)
             ctx,
             NDiskAgent::CreateDeviceHealthCheckActor(
                 ctx.SelfID,
-                State->GetEnabledDevices()));
+                State->GetEnabledDevices(),
+                UpdateCountersInterval));
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -161,6 +161,11 @@ TString TDiskAgentActor::GetCachedSessionsPath() const
 
 void TDiskAgentActor::RestartDeviceHealthChecking(const TActorContext& ctx)
 {
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_AGENT,
+        "Restart device health checking");
+
     if (HealthCheckActor) {
         NCloud::Send<TEvents::TEvPoisonPill>(ctx, HealthCheckActor);
         HealthCheckActor = {};
@@ -171,7 +176,7 @@ void TDiskAgentActor::RestartDeviceHealthChecking(const TActorContext& ctx)
             ctx,
             NDiskAgent::CreateDeviceHealthCheckActor(
                 ctx.SelfID,
-                State->GetDevices()));
+                State->GetEnabledDevices()));
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -90,6 +90,8 @@ private:
     TVector<NActors::TActorId> IOParserActors;
     ui32 ParserActorIdx = 0;
 
+    NActors::TActorId HealthCheckActor;
+
 public:
     TDiskAgentActor(
         TStorageConfigPtr config,
@@ -128,6 +130,7 @@ private:
     void InitLocalStorageProvider(const NActors::TActorContext& ctx);
 
     void ScheduleUpdateStats(const NActors::TActorContext& ctx);
+    void RestartDeviceHealthChecking(const NActors::TActorContext& ctx);
 
     void SendRegisterRequest(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -165,6 +165,8 @@ void TDiskAgentActor::HandleInitAgentCompleted(
     ScheduleUpdateStats(ctx);
 
     RunSessionCacheActor(ctx);
+
+    RestartDeviceHealthChecking(ctx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
@@ -235,6 +235,7 @@ void TDiskAgentActor::HandleRegisterAgentResponse(
         RegistrationState = ERegistrationState::Registered;
         LOG_INFO(ctx, TBlockStoreComponents::DISK_AGENT, "Register completed");
         ProcessDevicesToDisableIO(ctx, std::move(msg->DevicesToDisableIO));
+        RestartDeviceHealthChecking(ctx);
     } else {
         LOG_WARN(ctx, TBlockStoreComponents::DISK_AGENT,
             "Register failed: %s. Try later", FormatError(msg->GetError()).c_str());

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp
@@ -327,6 +327,20 @@ TVector<NProto::TDeviceConfig> TDiskAgentState::GetDevices() const
     return devices;
 }
 
+TVector<NProto::TDeviceConfig> TDiskAgentState::GetEnabledDevices() const
+{
+    TVector<NProto::TDeviceConfig> devices;
+    devices.reserve(Devices.size());
+
+    for (const auto& [uuid, state]: Devices) {
+        if (DeviceClient->IsDeviceEnabled(uuid)) {
+            devices.push_back(state.Config);
+        }
+    }
+
+    return devices;
+}
+
 TVector<TString> TDiskAgentState::GetDeviceIds() const
 {
     TVector<TString> uuids;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -118,6 +118,8 @@ public:
     TString GetDeviceName(const TString& uuid) const;
 
     TVector<NProto::TDeviceConfig> GetDevices() const;
+    TVector<NProto::TDeviceConfig> GetEnabledDevices() const;
+
     TVector<TString> GetDeviceIds() const;
 
     ui32 GetDevicesCount() const;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -29,18 +29,32 @@
 #include <util/string/join.h>
 #include <util/system/file.h>
 
+#include <chrono>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NThreading;
+using namespace std::chrono_literals;
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr TDuration WaitTimeout = TDuration::Seconds(5);
-constexpr ui32 DefaultDeviceBlockSize = 4096;
-constexpr ui64 DefaultBlocksCount = 1024*1024;
+constexpr TDuration WaitTimeout = 5s;
+constexpr ui32 DefaultDeviceBlockSize = 4_KB;
+constexpr ui64 DefaultBlocksCount = 1_MB;
 constexpr bool LockingEnabled = true;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TByDeviceUUID
+{
+    template <typename T>
+    bool operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs.GetDeviceUUID() < rhs.GetDeviceUUID();
+    }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1944,9 +1958,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
             [](auto& e) { return e.GetCode() == E_IO; });
 
         stats = state->CollectStats().GetValueSync();
-        SortBy(
-            *stats.MutableDeviceStats(),
-            [](const auto& s) { return s.GetDeviceUUID(); });
+        Sort(*stats.MutableDeviceStats(), TByDeviceUUID());
 
         UNIT_ASSERT_VALUES_EQUAL(3, stats.DeviceStatsSize());
         UNIT_ASSERT_VALUES_EQUAL(3, stats.GetDeviceStats(0).GetErrors()); // uuid-1
@@ -1971,9 +1983,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
             [](auto& e) { return e.GetCode() == E_REJECTED; });
 
         stats = state->CollectStats().GetValueSync();
-        SortBy(
-            *stats.MutableDeviceStats(),
-            [](const auto& s) { return s.GetDeviceUUID(); });
+        Sort(*stats.MutableDeviceStats(), TByDeviceUUID());
 
         UNIT_ASSERT_VALUES_EQUAL(3, stats.DeviceStatsSize());
         UNIT_ASSERT_VALUES_EQUAL(3, stats.GetDeviceStats(0).GetErrors()); // uuid-1
@@ -2010,14 +2020,85 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
         }
 
         stats = state->CollectStats().GetValueSync();
-        SortBy(
-            *stats.MutableDeviceStats(),
-            [](const auto& s) { return s.GetDeviceUUID(); });
+        Sort(*stats.MutableDeviceStats(), TByDeviceUUID());
 
         UNIT_ASSERT_VALUES_EQUAL(3, stats.DeviceStatsSize());
         UNIT_ASSERT_VALUES_EQUAL(3, stats.GetDeviceStats(0).GetErrors()); // uuid-1
         UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeviceStats(1).GetErrors());
         UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeviceStats(2).GetErrors());
+    }
+
+    Y_UNIT_TEST_F(ShouldFilterOutDisableDevice, TFiles)
+    {
+        auto state = CreateDiskAgentStateNull(
+            CreateNullConfig({ .Files = Nvme3s, .AcquireRequired = true })
+        );
+
+        auto future = state->Initialize();
+        const auto& r = future.GetValueSync();
+
+        UNIT_ASSERT(r.Errors.empty());
+        UNIT_ASSERT_VALUES_EQUAL(3, r.Configs.size());
+        {
+            auto devices = state->GetEnabledDevices();
+            Sort(devices, TByDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(3, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-1", devices[0].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[1].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-3", devices[2].GetDeviceUUID());
+        }
+
+        state->SuspendDevice("uuid-1");
+        {
+            auto devices = state->GetEnabledDevices();
+            Sort(devices, TByDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(2, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[0].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-3", devices[1].GetDeviceUUID());
+        }
+
+        state->DisableDevice("uuid-3");
+        {
+            auto devices = state->GetEnabledDevices();
+            UNIT_ASSERT_VALUES_EQUAL(1, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[0].GetDeviceUUID());
+        }
+
+        state->SuspendDevice("uuid-3");
+        {
+            auto devices = state->GetEnabledDevices();
+            UNIT_ASSERT_VALUES_EQUAL(1, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[0].GetDeviceUUID());
+        }
+
+        state->SuspendDevice("uuid-2");
+        UNIT_ASSERT_VALUES_EQUAL(0, state->GetEnabledDevices().size());
+
+        state->EnableDevice("uuid-1");
+        {
+            auto devices = state->GetEnabledDevices();
+            UNIT_ASSERT_VALUES_EQUAL(1, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-1", devices[0].GetDeviceUUID());
+        }
+
+        state->EnableDevice("uuid-2");
+        {
+            auto devices = state->GetEnabledDevices();
+            Sort(devices, TByDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(2, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-1", devices[0].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[1].GetDeviceUUID());
+        }
+
+        state->EnableDevice("uuid-3");
+        {
+            auto devices = state->GetEnabledDevices();
+            Sort(devices, TByDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(3, devices.size());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-1", devices[0].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[1].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-3", devices[2].GetDeviceUUID());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -42,7 +42,7 @@ namespace {
 
 constexpr TDuration WaitTimeout = 5s;
 constexpr ui32 DefaultDeviceBlockSize = 4_KB;
-constexpr ui64 DefaultBlocksCount = 1_MB;
+constexpr ui64 DefaultBlocksCount = 1024*1024;
 constexpr bool LockingEnabled = true;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp
@@ -393,6 +393,11 @@ bool TDeviceClient::IsDeviceSuspended(const TString& uuid) const
     return GetDeviceIOErrorCode(uuid).value_or(S_OK) == E_REJECTED;
 }
 
+bool TDeviceClient::IsDeviceEnabled(const TString& uuid) const
+{
+    return !GetDeviceIOErrorCode(uuid).has_value();
+}
+
 // static
 TDeviceClient::TDevicesState TDeviceClient::MakeDevices(TVector<TString> uuids)
 {

--- a/cloud/blockstore/libs/storage/disk_agent/model/device_client.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/device_client.h
@@ -94,6 +94,7 @@ public:
 
     bool IsDeviceDisabled(const TString& uuid) const;
     bool IsDeviceSuspended(const TString& uuid) const;
+    bool IsDeviceEnabled(const TString& uuid) const;
     std::optional<ui32> GetDeviceIOErrorCode(const TString& uuid) const;
 
     TVector<NProto::TDiskAgentDeviceSession> GetSessions() const;

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -323,6 +323,7 @@ TTestEnv TTestEnvBuilder::Build()
     // Runtime.SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
 
     Runtime.SetLogPriority(TBlockStoreComponents::DISK_AGENT, NLog::PRI_INFO);
+    Runtime.SetLogPriority(TBlockStoreComponents::DISK_AGENT_WORKER, NLog::PRI_INFO);
 
     Runtime.SetRegistrationObserverFunc(
         [] (auto& runtime, const auto& parentId, const auto& actorId)


### PR DESCRIPTION
Device health checking was moved to TDeviceHealthCheckActor.

Health check is only performed for enabled devices to reduce noisy error log messages:
```
2024-12-10T14:37:37.223534Z :BLOCKSTORE_DISK_AGENT ERROR: cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp:557: [foo/check-health] Device disabled. Drop request.
2024-12-10T14:37:37.232994Z :BLOCKSTORE_DISK_AGENT_WORKER INFO: The device "foo" broke down. E_IO cloud/blockstore/libs/storage/disk_agent/disk_agent_state.cpp:566: Device disabled
```

To handle actual list of devices TDeviceHealthCheckActor is restarted every time when Disk Agent is registered in Disk Registy.
