### PR TITLE
issue-2727: use mount-utils/FormatAndMount to check and repair FS before mounting

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -523,13 +523,9 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 		NbdDeviceFile: nbdDeviceFile,
 	}, nil)
 
-	mounter.On("IsFilesystemExisted", nbdDeviceFile).Return(false, nil)
-
-	mounter.On("MakeFilesystem", nbdDeviceFile, "ext4").Return([]byte{}, nil)
-
 	mockCallIsMountPoint := mounter.On("IsMountPoint", stagingTargetPath).Return(false, nil)
 
-	mounter.On("Mount", nbdDeviceFile, stagingTargetPath, "ext4",
+	mounter.On("FormatAndMount", nbdDeviceFile, stagingTargetPath, "ext4",
 		[]string{"grpid", "errors=remount-ro"}).Return(nil)
 
 	_, err = nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
@@ -4,6 +4,8 @@ package mounter
 
 type Interface interface {
 	Mount(source string, target string, fsType string, options []string) error
+	FormatAndMount(source string, target string, fsType string, options []string) error
+
 	IsMountPoint(file string) (bool, error)
 	CleanupMountPoint(target string) error
 

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
@@ -50,6 +50,11 @@ func (c *Mock) Resize(devicePath string, deviceMountPath string) (bool, error) {
 	return args.Get(0).(bool), args.Error(1)
 }
 
+func (c *Mock) FormatAndMount(source string, target string, fsType string, options []string) error {
+	args := c.Called(source, target, fsType, options)
+	return args.Error(0)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewMock() *Mock {

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/mounter.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/mounter.go
@@ -89,3 +89,22 @@ func (m *mounter) NeedResize(devicePath string, deviceMountPath string) (bool, e
 func (m *mounter) Resize(devicePath string, deviceMountPath string) (bool, error) {
 	return mount.NewResizeFs(m.exec).Resize(devicePath, deviceMountPath)
 }
+
+func (m *mounter) FormatAndMount(source string, target string, fsType string, options []string) error {
+	formatOptions := []string{"-t", fsType}
+	if fsType == "ext4" {
+		formatOptions = append(formatOptions, "-E", "nodiscard")
+	}
+	if fsType == "xfs" {
+		formatOptions = append(formatOptions, "-K")
+	}
+
+	safeFormatAndMount := mount.NewSafeFormatAndMount(m.mnt, m.exec)
+	return safeFormatAndMount.FormatAndMountSensitiveWithFormatOptions(
+		source,
+		target,
+		fsType,
+		options,
+		nil,
+		formatOptions)
+}


### PR DESCRIPTION
issue: #2727 

formatAndMount [implementation](https://github.com/kubernetes/mount-utils/blob/master/mount_linux.go#L555):
1. check that fs already exists
2. if fs doesn't exist:
      - make fs
      - mount fs
3. if fs exists:
      - check that required fs type is the same as existing fs type
      - check and repair fs
      - mount fs