### PR TITLE
[filestore] add more debug information for the filestore `fio_index/mount-local-test` test hangs

### DIFF
--- a/cloud/filestore/tests/recipes/service-local/__main__.py
+++ b/cloud/filestore/tests/recipes/service-local/__main__.py
@@ -64,6 +64,13 @@ def stop(argv):
 
     with open(PID_FILE_NAME) as f:
         pid = int(f.read())
+
+        # Used for debugging filestore-server hangs
+        bt = subprocess.getoutput(
+            f'sudo gdb --batch -p {pid} -ex "thread apply all bt"'
+        )
+        logger.warning(f"PID {pid}: backtrace:\n{bt}")
+
         shutdown(pid)
 
 


### PR DESCRIPTION
Needed for better diagnosing of the issue with the following test:


https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/12344495831/1/nebius-x86-64-tsan/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/fio_index/mount-local-test/test-results/py3test/chunk2/testing_out_stuff/

By the looks of it (the profile log), the server was running fine for approximately 42 seconds, then it got stuck and no more requests were processed except for the PingSession requests

```
1970-01-01T01:24:16.469000Z     nfs_share       CreateFileStore 0.008421s       S_OK    {no_info}
1970-01-01T01:24:16.646000Z     nfs_share       CreateSession   2.586112s       S_OK    {no_info}
1970-01-01T01:24:19.262000Z     nfs_share       ResetSession    4.225906s       S_OK    {no_info}
1970-01-01T01:24:20.239000Z     nfs_share       PingSession     3.249144s       S_OK    {no_info}
1970-01-01T01:24:23.498000Z     nfs_share       GetNodeAttr     0.001523s       S_OK    {parent_node_id=1, node_name=, flags=0, mode=509, node_id=13119501, handle=0, size=4096}
1970-01-01T01:24:24.492000Z     nfs_share       PingSession     0.001578s       S_OK    {no_info}
1970-01-01T01:24:25.496000Z     nfs_share       PingSession     0.001131s       S_OK    {no_info}
1970-01-01T01:24:26.504000Z     nfs_share       PingSession     0.001177s       S_OK    {no_info}
1970-01-01T01:24:12.695000Z                     Ping            0.000912s       S_OK    {no_info}

...

1970-01-01T01:24:58.148000Z     nfs_share       GetNodeAttr     0.000873s       S_OK    {parent_node_id=13119618, node_name=randrw_4K_16_fsync_16_fdatasync_8_write_barrier_4_unlink_end-fsync.0.0, fla
gs=0, mode=420, node_id=13119619, handle=0, size=104857600}
1970-01-01T01:24:58.153000Z     nfs_share       UnlinkNode      0.001136s       S_OK    {parent_node_id=13119618, node_name=randrw_4K_16_fsync_16_fdatasync_8_write_barrier_4_unlink_end-fsync.0.0}
1970-01-01T01:24:58.159000Z     nfs_share       GetNodeAttr     0.006205s       S_OK    {parent_node_id=13119618, node_name=randrw_4K_16_fsync_16_fdatasync_8_write_barrier_4_unlink_end-fsync.0.0, fla
gs=0, mode=0, node_id=0, handle=0, size=0}
1970-01-01T01:24:58.159000Z     nfs_share       DestroyHandle   0.015125s       S_OK    {node_id=13119619, handle=2}
1970-01-01T01:24:58.995000Z     nfs_share       PingSession     0.001728s       S_OK    {no_info}
1970-01-01T01:25:00.000000Z     nfs_share       PingSession     0.004441s       S_OK    {no_info}
1970-01-01T01:25:01.007000Z     nfs_share       PingSession     0.001143s       S_OK    {no_info}
1970-01-01T01:25:02.012000Z     nfs_share       PingSession     0.003616s       S_OK    {no_info}
1970-01-01T01:25:03.019000Z     nfs_share       PingSession     0.002096s       S_OK    {no_info}
1970-01-01T01:25:04.028000Z     nfs_share       PingSession     0.001381s       S_OK    {no_info}
1970-01-01T01:25:05.032000Z     nfs_share       PingSession     0.003798s       S_OK    {no_info}
1970-01-01T01:25:06.039000Z     nfs_share       PingSession     0.000817s       S_OK    {no_info}
1970-01-01T01:25:07.042000Z     nfs_share       PingSession     0.001204s       S_OK    {no_info}
1970-01-01T01:25:08.053000Z     nfs_share       PingSession     0.001313s       S_OK    {no_info}
1970-01-01T01:25:09.058000Z     nfs_share       PingSession     0.004086s       S_OK    {no_info}
...

1970-01-01T01:35:01.561000Z     nfs_share       PingSession     0.001156s       S_OK    {no_info}
1970-01-01T01:35:02.565000Z     nfs_share       PingSession     0.001060s       S_OK    {no_info}
1970-01-01T01:35:03.572000Z     nfs_share       PingSession     0.001468s       S_OK    {no_info}
1970-01-01T01:35:04.576000Z     nfs_share       PingSession     0.011736s       S_OK    {no_info}
1970-01-01T01:35:05.592000Z     nfs_share       PingSession     0.001021s       S_OK    {no_info}
1970-01-01T01:35:06.601000Z     nfs_share       PingSession     0.005459s       S_OK    {no_info}
1970-01-01T01:35:07.610000Z     nfs_share       PingSession     0.001919s       S_OK    {no_info}
1970-01-01T01:35:08.617000Z     nfs_share       PingSession     0.001819s       S_OK    {no_info}
1970-01-01T01:35:09.624000Z     nfs_share       PingSession     0.009840s       S_OK    {no_info}
1970-01-01T01:35:10.640000Z     nfs_share       PingSession     0.003232s       S_OK    {no_info}
1970-01-01T01:35:11.647000Z     nfs_share       PingSession     0.004140s       S_OK    {no_info}
1970-01-01T01:35:12.656000Z     nfs_share       PingSession     0.002225s       S_OK    {no_info}
1970-01-01T01:35:13.665000Z     nfs_share       PingSession     0.021535s       S_OK    {no_info}
1970-01-01T01:35:15.738000Z     nfs_share       ResetSession    3.596880s       S_OK    {no_info}
1970-01-01T01:35:16.732000Z     nfs_share       PingSession     2.602808s       S_OK    {no_info}
1970-01-01T01:35:19.412000Z     nfs_share       DestroySession  0.174110s       S_OK    {no_info}
```