### PR TITLE
issue-2727: check block device before mounting FS

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -772,6 +772,13 @@ func (s *nodeService) nodeStageDiskAsFilesystem(
 
 	logVolume(req.VolumeId, "endpoint started with device: %q", resp.NbdDeviceFile)
 
+	// startNbsEndpointForNBD is async function. Kubelet will retry
+	// NodeStageVolume request if nbd device is not available yet.
+	hasBlockDevice, err := s.mounter.HasBlockDevice(resp.NbdDeviceFile)
+	if !hasBlockDevice {
+		return fmt.Errorf("Nbd device is not available: %w", err)
+	}
+
 	mnt := req.VolumeCapability.GetMount()
 
 	fsType := req.VolumeContext["fsType"]

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -523,6 +523,8 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 		NbdDeviceFile: nbdDeviceFile,
 	}, nil)
 
+	mounter.On("HasBlockDevice", nbdDeviceFile).Return(true, nil)
+
 	mockCallIsMountPoint := mounter.On("IsMountPoint", stagingTargetPath).Return(false, nil)
 
 	mounter.On("FormatAndMount", nbdDeviceFile, stagingTargetPath, "ext4",

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
@@ -9,6 +9,8 @@ type Interface interface {
 	IsMountPoint(file string) (bool, error)
 	CleanupMountPoint(target string) error
 
+	HasBlockDevice(device string) (bool, error)
+
 	IsFilesystemExisted(device string) (bool, error)
 	MakeFilesystem(device string, fsType string) ([]byte, error)
 

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
@@ -30,6 +30,11 @@ func (c *Mock) CleanupMountPoint(target string) error {
 	return args.Error(0)
 }
 
+func (c *Mock) HasBlockDevice(device string) (bool, error) {
+	args := c.Called(device)
+	return args.Get(0).(bool), args.Error(1)
+}
+
 func (c *Mock) IsFilesystemExisted(device string) (bool, error) {
 	args := c.Called(device)
 	return args.Get(0).(bool), args.Error(1)


### PR DESCRIPTION
issue: #2727

In this [pr](https://github.com/ydb-platform/nbs/pull/2728/files#diff-021fd610a4ef17348cd72682382ac75500e3207f4f055627a06300ba7c962f9eL785) I removed makeFilsystemIfNeeded call. Inside it calls IsFilesystemExisted and checks existence of block device. It's important because startEndpoint is an async function and in some cases block device is not available immediately. Kubelet will retry NodeStageVolume call if block device is not avaiable.

I moved this logic to separate function HasBlockDevice and added comment to avoid removing of this logic again. 