### PR TITLE
zero-filling fuse_session structure if session is not yet initialized

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -277,6 +277,8 @@ public:
     {
         NProto::TVfsSessionState proto;
         if (!state || !proto.ParseFromString(state)) {
+            memset(Session, 0, sizeof(*Session));
+
             return;
         }
 


### PR DESCRIPTION
to fix msan issues like this:
https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(msan)/12404651235/1/nebius-x86-64-msan/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/test-results/py3test/chunk4/testing_out_stuff/filestore-vhost.err

```
==465640==WARNING: MemorySanitizer: use-of-uninitialized-value

    ... куча наших логов + gdb bt ... 

    #0 0x3987aa48 in process_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
    #1 0x3987aa48 in virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:426:19
    #2 0x397a64f6  (/home/github/.ya/build/build_root/snjo/002a89/cloud/filestore/apps/vhost/filestore-vhost+0x397a64f6) (BuildId: f8e58c8c86d9a034d54ab2fa48f434506868888c)
    #3 0x101d3ea2 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20
    #4 0x7f7737968ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #5 0x7f77379fa84f  (/lib/x86_64-linux-gnu/libc.so.6+0x12684f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)

```

it's hard to say how exactly we run into such a situation
most probably se->bufsize actually __is__ initialized but in a way that's not seen by msan