### PR TITLE
Backport 'Allow to set "force tcp" and "keep-socket" options for dns resolver' from ydb-platform/ydb

### DIFF
--- a/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -598,6 +598,8 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
 
         NDnsResolver::TOnDemandDnsResolverOptions resolverOptions;
         resolverOptions.MonCounters = GetServiceCounters(counters, "utils")->GetSubgroup("subsystem", "dns_resolver");
+        resolverOptions.ForceTcp = nsConfig.GetForceTcp();
+        resolverOptions.KeepSocket = nsConfig.GetKeepSocket();
         IActor *resolver = NDnsResolver::CreateOnDemandDnsResolver(resolverOptions);
 
         setup->LocalServices.emplace_back(

--- a/contrib/ydb/core/protos/config.proto
+++ b/contrib/ydb/core/protos/config.proto
@@ -152,6 +152,8 @@ message TStaticNameserviceConfig {
     repeated string AcceptUUID = 3;
     optional bool SuppressVersionCheck = 4;
     optional ENameserviceType Type = 5;
+    optional bool KeepSocket = 6 [default = true];
+    optional bool ForceTcp = 7 [default = false];
 }
 
 message TDynamicNameserviceConfig {

--- a/contrib/ydb/library/actors/dnsresolver/dnsresolver.cpp
+++ b/contrib/ydb/library/actors/dnsresolver/dnsresolver.cpp
@@ -172,7 +172,13 @@ namespace NDnsResolver {
             memset(&options, 0, sizeof(options));
             int optmask = 0;
 
-            options.flags = ARES_FLAG_STAYOPEN;
+            if (Options.ForceTcp) {
+                options.flags |= ARES_FLAG_USEVC;
+            }
+            if (Options.KeepSocket) {
+                options.flags |= ARES_FLAG_STAYOPEN;
+            }
+
             optmask |= ARES_OPT_FLAGS;
 
             options.sock_state_cb = &TThis::SockStateCallback;

--- a/contrib/ydb/library/actors/dnsresolver/dnsresolver.h
+++ b/contrib/ydb/library/actors/dnsresolver/dnsresolver.h
@@ -89,6 +89,10 @@ namespace NDnsResolver {
         int Attempts = 2;
         // Optional list of custom dns servers (ip.v4[:port], ip::v6 or [ip::v6]:port format)
         TVector<TString> Servers;
+        // Keep soket open between dns requests
+        bool KeepSocket = true;
+        // Force tcp to perform dns requests
+        bool ForceTcp = false;
     };
 
     IActor* CreateSimpleDnsResolver(TSimpleDnsResolverOptions options = TSimpleDnsResolverOptions());


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/pull/4123