### PR TITLE
[Blockstore] preventing the rejection of a significant fraction of Disk Agents in the cluster

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1077,4 +1077,6 @@ message TStorageServiceConfig
 
     // Disables the calculation of the FullPlacementGroups counter.
     optional bool DisableFullPlacementGroupCountCalculation = 395;
+
+    optional double DiskRegistryInitialAgentRejectionThreshold = 396;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1078,5 +1078,6 @@ message TStorageServiceConfig
     // Disables the calculation of the FullPlacementGroups counter.
     optional bool DisableFullPlacementGroupCountCalculation = 395;
 
+    // Percentage of agents that can be rejected at the initial stage.
     optional double DiskRegistryInitialAgentRejectionThreshold = 396;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1078,6 +1078,9 @@ message TStorageServiceConfig
     // Disables the calculation of the FullPlacementGroups counter.
     optional bool DisableFullPlacementGroupCountCalculation = 395;
 
-    // Percentage of agents that can be rejected at the initial stage.
+    // The percentage of agents that it is acceptable to reject at the start.
+    // If the number of agents that did not reconnect is higher than this
+    // percentage, then the rejection of such agents does not occur - we assume
+    // a connectivity failure in the cluster.
     optional double DiskRegistryInitialAgentRejectionThreshold = 396;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1078,7 +1078,7 @@ message TStorageServiceConfig
     // Disables the calculation of the FullPlacementGroups counter.
     optional bool DisableFullPlacementGroupCountCalculation = 395;
 
-    // The percentage of agents that it is acceptable to reject at the start.
+    // The percentage of agents that is acceptable to reject at the start.
     // If the number of agents that did not reconnect is higher than this
     // percentage, then the rejection of such agents does not occur - we assume
     // a connectivity failure in the cluster.

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -65,6 +65,7 @@ namespace NCloud::NBlockStore {
     xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
     xxx(MirroredDiskChecksumMismatchUponRead)                                  \
     xxx(DiskRegistryWrongMigratedDeviceOwnership)                              \
+    xxx(DiskRegistryInitialAgentRejectionThresholdExceeded)                    \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -520,7 +520,7 @@ TDuration MSeconds(ui32 value)
                                                                                \
     xxx(EncryptionAtRestForDiskRegistryBasedDisksEnabled, bool,    false      )\
     xxx(DisableFullPlacementGroupCountCalculation,        bool,    false      )\
-    xxx(DiskRegistryInitialAgentRejectionThreshold,       double,  0.5        )\
+    xxx(DiskRegistryInitialAgentRejectionThreshold,       double,    50       )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -520,8 +520,7 @@ TDuration MSeconds(ui32 value)
                                                                                \
     xxx(EncryptionAtRestForDiskRegistryBasedDisksEnabled, bool,    false      )\
     xxx(DisableFullPlacementGroupCountCalculation,        bool,    false      )\
-
-
+    xxx(DiskRegistryInitialAgentRejectionThreshold,       double,  0.5        )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -621,6 +621,7 @@ public:
     [[nodiscard]] bool GetEncryptionAtRestForDiskRegistryBasedDisksEnabled() const;
 
     [[nodiscard]] bool GetDisableFullPlacementGroupCountCalculation() const;
+    [[nodiscard]] double GetDiskRegistryInitialAgentRejectionThreshold() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -480,9 +480,9 @@ void TDiskRegistryActor::ProcessInitialAgentRejectionPhase(
     }
 
     const double k =
-        static_cast<double>(agentsToReject.size()) / expectedToBeOnline;
+        100.0 * static_cast<double>(agentsToReject.size()) / expectedToBeOnline;
 
-    if (k >= Config->GetDiskRegistryInitialAgentRejectionThreshold()) {
+    if (k > Config->GetDiskRegistryInitialAgentRejectionThreshold()) {
         ReportDiskRegistryInitialAgentRejectionThresholdExceeded(
             TStringBuilder()
             << "Too many agents haven't reconnected: " << agentsToReject.size()

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -434,14 +434,7 @@ void TDiskRegistryActor::ScheduleRejectAgent(
     TString agentId,
     ui64 seqNo)
 {
-    auto timeout = Config->GetNonReplicatedAgentMaxTimeout();
-
-    // if there is no State it means that this is our initial agent rejection
-    // phase that happens during the LoadState tx => we should use max timeout
-    // in order not to reject all agents at once
-    if (State) {
-        timeout = State->GetRejectAgentTimeout(ctx.Now(), agentId);
-    }
+    auto timeout = State->GetRejectAgentTimeout(ctx.Now(), agentId);
 
     if (!timeout) {
         return;
@@ -458,11 +451,65 @@ void TDiskRegistryActor::ScheduleRejectAgent(
     ctx.Schedule(deadline, request.release());
 }
 
+void TDiskRegistryActor::ProcessInitialAgentRejectionPhase(
+    const TActorContext& ctx)
+{
+    LOG_INFO_S(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "Process the initial agents rejection phase");
+
+    ui32 expectedToBeOnline = 0;
+    TVector<TString> agentsToReject;
+
+    for (const auto& agent: State->GetAgents()) {
+        if (agent.GetState() == NProto::AGENT_STATE_UNAVAILABLE) {
+            continue;
+        }
+        ++expectedToBeOnline;
+
+        const auto& agentId = agent.GetAgentId();
+
+        if (!AgentRegInfo.contains(agentId)) {
+            agentsToReject.push_back(agentId);
+        }
+    }
+
+    if (agentsToReject.empty() || !expectedToBeOnline) {
+        return;
+    }
+
+    const double k =
+        static_cast<double>(agentsToReject.size()) / expectedToBeOnline;
+
+    if (k >= Config->GetDiskRegistryInitialAgentRejectionThreshold()) {
+        ReportDiskRegistryInitialAgentRejectionThresholdExceeded(
+            TStringBuilder()
+            << "Too many agents haven't reconnected: " << agentsToReject.size()
+            << "/" << expectedToBeOnline);
+        return;
+    }
+
+    for (const auto& agentId: agentsToReject) {
+        NCloud::Send(
+            ctx,
+            ctx.SelfID,
+            std::make_unique<TEvDiskRegistryPrivate::TEvAgentConnectionLost>(
+                agentId,
+                0));
+    }
+}
+
 void TDiskRegistryActor::HandleAgentConnectionLost(
     const TEvDiskRegistryPrivate::TEvAgentConnectionLost::TPtr& ev,
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
+
+    if (msg->AgentId.empty()) {
+        ProcessInitialAgentRejectionPhase(ctx);
+        return;
+    }
 
     auto it = AgentRegInfo.find(msg->AgentId);
     if (it != AgentRegInfo.end() && msg->SeqNo < it->second.SeqNo) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -76,7 +76,7 @@ void TDiskRegistryActor::ScheduleMakeBackup(
         - (ctx.Now() - lastBackupTs);
 
     LOG_DEBUG_S(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "Schedule backup at " << backupPeriod.ToDeadLine());
+        "Schedule backup at " << backupPeriod.ToDeadLine(ctx.Now()));
 
     TString hostPrefix = Config->GetDiskRegistryCountersHost();
     if (!hostPrefix.empty()) {
@@ -103,7 +103,7 @@ void TDiskRegistryActor::ScheduleCleanup(const TActorContext& ctx)
     const auto recyclingPeriod = Config->GetNonReplicatedDiskRecyclingPeriod();
 
     LOG_DEBUG_S(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "Schedule cleanup at " << recyclingPeriod.ToDeadLine());
+        "Schedule cleanup at " << recyclingPeriod.ToDeadLine(ctx.Now()));
 
     auto request = std::make_unique<TEvDiskRegistryPrivate::TEvCleanupDisksRequest>();
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -310,6 +310,8 @@ private:
 
     void InitializeState(TDiskRegistryStateSnapshot snapshot);
 
+    void ProcessInitialAgentRejectionPhase(const NActors::TActorContext& ctx);
+
 private:
     STFUNC(StateBoot);
     STFUNC(StateInit);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -492,7 +492,9 @@ struct TEvDiskRegistryPrivate
     struct TAgentConnectionLost
     {
         TString AgentId;
-        ui64 SeqNo;
+        ui64 SeqNo = 0;
+
+        TAgentConnectionLost() = default;
 
         TAgentConnectionLost(
                 TString agentId,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -2140,6 +2140,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         auto config = CreateDefaultStorageConfig();
         config.SetNonReplicatedDiskSwitchToReadOnlyTimeout(
             TDuration{5s}.MilliSeconds());
+        config.SetDiskRegistryInitialAgentRejectionThreshold(100.0);
+
         auto runtime = TTestRuntimeBuilder()
             .With(config)
             .WithAgents(agents)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -1056,9 +1056,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         }
 
         auto config = CreateDefaultStorageConfig();
-        config.SetNonReplicatedAgentMinTimeout(10'000);
-        config.SetNonReplicatedAgentMaxTimeout(50'000);
-        config.SetNonReplicatedAgentDisconnectRecoveryInterval(100'000);
+        config.SetNonReplicatedAgentMinTimeout(10'000); // 10s
+        config.SetNonReplicatedAgentMaxTimeout(50'000); // 50s
+        config.SetNonReplicatedAgentDisconnectRecoveryInterval(100'000); // 100s
         config.SetNonReplicatedAgentTimeoutGrowthFactor(2);
 
         auto runtime =
@@ -1123,6 +1123,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             pipeEv->Rewrite(NKikimr::TEvTabletPipe::EvSend, pipe);
 
             runtime->Send(pipeEv, agentNo, true);
+            runtime->DispatchEvents({}, 10ms);
 
             return pipe;
         };
@@ -1132,20 +1133,19 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 pipe,
                 agentActors[agentNo],
                 new TEvTabletPipe::TEvShutdown()), agentNo, true);
+            runtime->DispatchEvents({}, 10ms);
         };
 
         auto pipe = registerAgent(0);
-
-        runtime->DispatchEvents({}, 10ms);
-
         disconnectAgent(pipe, 0);
 
-        runtime->DispatchEvents({}, 1s);
-        runtime->DispatchEvents({}, 5s);
+        runtime->AdvanceCurrentTime(6s);
+        runtime->DispatchEvents({}, 10ms);
 
-        UNIT_ASSERT_VALUES_EQUAL(TString(), agentId);
+        UNIT_ASSERT_C(agentId.empty(), agentId);
 
-        runtime->DispatchEvents({}, 5s);
+        runtime->AdvanceCurrentTime(4s);
+        runtime->DispatchEvents({}, 10ms);
 
         UNIT_ASSERT_VALUES_EQUAL(agents[0].GetAgentId(), agentId);
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1157,16 +1157,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         pipe = registerAgent(1);
 
-        runtime->DispatchEvents({}, 10ms);
-
         disconnectAgent(pipe, 1);
 
-        runtime->DispatchEvents({}, 1s);
-        runtime->DispatchEvents({}, 10s);
+        runtime->AdvanceCurrentTime(11s);
+        runtime->DispatchEvents({}, 10ms);
 
         UNIT_ASSERT_VALUES_EQUAL(TString(), agentId);
 
-        runtime->DispatchEvents({}, 10s);
+        runtime->AdvanceCurrentTime(9s);
+        runtime->DispatchEvents({}, 10ms);
 
         UNIT_ASSERT_VALUES_EQUAL(agents[1].GetAgentId(), agentId);
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1179,13 +1178,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         pipe = registerAgent(2);
 
         runtime->AdvanceCurrentTime(200s);
-        runtime->DispatchEvents({}, 10ms);
 
         disconnectAgent(pipe, 2);
 
         // disconnect timeout should've been completely recovered
-        runtime->DispatchEvents({}, 1s);
-        runtime->DispatchEvents({}, 10s);
+        runtime->AdvanceCurrentTime(10s);
+        runtime->DispatchEvents({}, 10ms);
 
         UNIT_ASSERT_VALUES_EQUAL(agents[2].GetAgentId(), agentId);
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1203,29 +1201,31 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             pipe = registerAgent(3);
 
             runtime->AdvanceCurrentTime(200s);
-            runtime->DispatchEvents({}, 10ms);
 
             diskRegistry.UpdateDiskRegistryAgentListParams(
                 TVector<TString>{agents[3].GetAgentId()},
                 100s,
                 500s,
                 1000s);
-            runtime->DispatchEvents({}, 1s);
+            runtime->DispatchEvents({}, 10ms);
+            runtime->AdvanceCurrentTime(1s);
             // diskRegistry.RebootTablet();
             // diskRegistry.WaitReady();
 
             disconnectAgent(pipe, 3);
 
-            runtime->DispatchEvents({}, 1s);
-            runtime->DispatchEvents({}, 5s);
+            runtime->AdvanceCurrentTime(6s);
+            runtime->DispatchEvents({}, 10ms);
 
             UNIT_ASSERT_VALUES_EQUAL(TString(), agentId);
 
-            runtime->DispatchEvents({}, 5s);
+            runtime->AdvanceCurrentTime(5s);
+            runtime->DispatchEvents({}, 10ms);
 
             UNIT_ASSERT_VALUES_EQUAL(TString(), agentId);
 
-            runtime->DispatchEvents({}, 90s);
+            runtime->AdvanceCurrentTime(90s);
+            runtime->DispatchEvents({}, 10ms);
 
             UNIT_ASSERT_VALUES_EQUAL(agents[3].GetAgentId(), agentId);
             UNIT_ASSERT_VALUES_EQUAL(
@@ -1245,13 +1245,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
             disconnectAgent(pipe, 4);
 
-            runtime->DispatchEvents({}, 1s);
-            runtime->DispatchEvents({}, 5s);
+            runtime->AdvanceCurrentTime(6s);
+            runtime->DispatchEvents({}, 10ms);
 
             UNIT_ASSERT_VALUES_EQUAL(TString(), agentId);
 
-            runtime->DispatchEvents({}, 5s);
-            runtime->DispatchEvents({}, 5s);
+            runtime->AdvanceCurrentTime(10s);
+            runtime->DispatchEvents({}, 10ms);
 
             UNIT_ASSERT_VALUES_EQUAL(agents[4].GetAgentId(), agentId);
             UNIT_ASSERT_VALUES_EQUAL(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -2605,7 +2605,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         UNIT_ASSERT_VALUES_EQUAL(x->GetDeviceUUID(), devicesToSuspendIO[0]);
     }
 
-    Y_UNIT_TEST(ShouldRefrainFromRejectingHalfOfTheCluster)
+    Y_UNIT_TEST(ShouldRefrainFromRejectingBigPartOfTheCluster)
     {
         const TVector agents {
             CreateAgentConfig("agent-1", {Device("dev", "uuid-1")}),
@@ -2630,7 +2630,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 auto config = CreateDefaultStorageConfig();
                 config.SetDiskRegistryCountersHost("test");
 
-                config.SetNonReplicatedAgentMaxTimeout(50'000); // 50s
+                config.SetNonReplicatedAgentMaxTimeout(50'000);           // 50s
+                config.SetDiskRegistryInitialAgentRejectionThreshold(50); // 50%
 
                 return config;
             }())
@@ -2651,6 +2652,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         diskRegistry.RebootTablet();
         diskRegistry.WaitReady();
+
+        // Only 33% of agents are reconnected
+        RegisterAgents(*runtime, 2);
 
         UNIT_ASSERT_VALUES_EQUAL(0, crits->Val());
 


### PR DESCRIPTION
#2752
If the percentage of agents that did not reconnect after Disk Registry' reboot is higher than DiskRegistryInitialAgentRejectionThreshold, then the rejection of such agents does not occur - we assume a connectivity failure in the cluster.