### PR TITLE
Disable FullPlacementGroupCount calculation

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1074,4 +1074,7 @@ message TStorageServiceConfig
 
     // Enabling direct copying of data between disk agents.
     optional bool UseDirectCopyRange = 394;
+
+    // Disables the calculation of the FullPlacementGroups counter.
+    optional bool DisableFullPlacementGroupCountCalculation = 395;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -519,6 +519,8 @@ TDuration MSeconds(ui32 value)
     xxx(BlobStorageAsyncGetTimeoutSSD,                  TDuration, Seconds(0)    )\
                                                                                \
     xxx(EncryptionAtRestForDiskRegistryBasedDisksEnabled, bool,    false      )\
+    xxx(DisableFullPlacementGroupCountCalculation,        bool,    false      )\
+
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -619,6 +619,8 @@ public:
     TDuration GetBlobStorageAsyncGetTimeoutSSD() const;
 
     [[nodiscard]] bool GetEncryptionAtRestForDiskRegistryBasedDisksEnabled() const;
+
+    [[nodiscard]] bool GetDisableFullPlacementGroupCountCalculation() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4044,6 +4044,9 @@ void TDiskRegistryState::PublishCounters(TInstant now)
         return;
     }
 
+    const auto startAt = TMonotonic::Now();
+    STORAGE_LOG(TLOG_INFO, "DiskRegistry started PublishCounters");
+
     AgentList.PublishCounters(now);
 
     THashMap<TString, TDevicePoolCounters> poolName2Counters;
@@ -4202,6 +4205,10 @@ void TDiskRegistryState::PublishCounters(TInstant now)
         }
 
         if (!logicalBlockSize) {
+            continue;
+        }
+
+        if (StorageConfig->GetDisableFullPlacementGroupCountCalculation()) {
             continue;
         }
 
@@ -4409,6 +4416,11 @@ void TDiskRegistryState::PublishCounters(TInstant now)
 
     SelfCounters.QueryAvailableStorageErrors.Publish(now);
     SelfCounters.QueryAvailableStorageErrors.Reset();
+
+    STORAGE_LOG(
+        TLOG_INFO,
+        "DiskRegistry finished PublishCounters in %s",
+        (TMonotonic::Now() - startAt).ToString().c_str());
 }
 
 NProto::TError TDiskRegistryState::CreatePlacementGroup(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4045,7 +4045,7 @@ void TDiskRegistryState::PublishCounters(TInstant now)
     }
 
     const auto startAt = TMonotonic::Now();
-    STORAGE_LOG(TLOG_INFO, "DiskRegistry started PublishCounters");
+    STORAGE_LOG(TLOG_DEBUG, "DiskRegistry started PublishCounters");
 
     AgentList.PublishCounters(now);
 
@@ -4417,10 +4417,11 @@ void TDiskRegistryState::PublishCounters(TInstant now)
     SelfCounters.QueryAvailableStorageErrors.Publish(now);
     SelfCounters.QueryAvailableStorageErrors.Reset();
 
+    auto executionTime = TMonotonic::Now() - startAt;
     STORAGE_LOG(
-        TLOG_INFO,
+        executionTime > TDuration::Seconds(1) ? TLOG_WARNING : TLOG_DEBUG,
         "DiskRegistry finished PublishCounters in %s",
-        (TMonotonic::Now() - startAt).ToString().c_str());
+        executionTime.ToString().c_str());
 }
 
 NProto::TError TDiskRegistryState::CreatePlacementGroup(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -1389,7 +1389,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
         };
 
-        NProto::TStorageServiceConfig proto;
+        NProto::TStorageServiceConfig proto = CreateDefaultStorageConfigProto();
         proto.SetDisableFullPlacementGroupCountCalculation(
             disableFullGroupsCountCalculation);
 
@@ -1690,7 +1690,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, disksInTemporarilyUnavailableState->Val());
         UNIT_ASSERT_VALUES_EQUAL(0, disksInErrorState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, placementGroups->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, fullPlacementGroups->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            disableFullGroupsCountCalculation ? 0 : 1,
+            fullPlacementGroups->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, allocatedDisksInGroups->Val());
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -1739,7 +1741,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, disksInTemporarilyUnavailableState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, disksInErrorState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, placementGroups->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, fullPlacementGroups->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            disableFullGroupsCountCalculation ? 0 : 1,
+            fullPlacementGroups->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, allocatedDisksInGroups->Val());
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -1778,7 +1782,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, disksInTemporarilyUnavailableState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, disksInErrorState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, placementGroups->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, fullPlacementGroups->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            disableFullGroupsCountCalculation ? 0 : 1,
+            fullPlacementGroups->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, allocatedDisksInGroups->Val());
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -1815,7 +1821,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, disksInTemporarilyUnavailableState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, disksInErrorState->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, placementGroups->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, fullPlacementGroups->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            disableFullGroupsCountCalculation ? 0 : 1,
+            fullPlacementGroups->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, allocatedDisksInGroups->Val());
 
         UNIT_ASSERT_VALUES_EQUAL(10_GB, localPool.FreeBytes->Val());


### PR DESCRIPTION
При большом количестве групп размещения, подсчет статистики, сколько групп уже полны - занимает непозволительно много времени. 
До того как сделали оптимально, делаю флаг для выключения.