### PR TITLE
Backport https://github.com/ydb-platform/ydb/pull/12693

### DIFF
--- a/contrib/ydb/core/protos/filestore_config.proto
+++ b/contrib/ydb/core/protos/filestore_config.proto
@@ -52,6 +52,9 @@ message TConfig {
     optional uint32 PerformanceProfileMaxWriteCostMultiplier = 45;
     optional uint32 PerformanceProfileMaxPostponedTime = 46;
     optional uint32 PerformanceProfileMaxPostponedCount = 47;
+
+    // Indicates that filestore does not belong to user directly, but used for system needs
+    optional bool IsSystem = 48;
 }
 
 message TUpdateConfig {

--- a/contrib/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/contrib/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2430,6 +2430,7 @@ struct TFileStoreInfo : public TSimpleRefCount<TFileStoreInfo> {
             const auto alterSpace = GetFileStoreSpace(*AlterConfig);
             space.SSD = Max(space.SSD, alterSpace.SSD);
             space.HDD = Max(space.HDD, alterSpace.HDD);
+            space.SSDSystem = Max(space.SSDSystem, alterSpace.SSDSystem);
         }
 
         return space;
@@ -2443,7 +2444,11 @@ private:
         TFileStoreSpace space;
         switch (config.GetStorageMediaKind()) {
             case 1: // STORAGE_MEDIA_SSD
-                space.SSD += blockCount * blockSize;
+                if (config.GetIsSystem()) {
+                    space.SSDSystem += blockCount * blockSize;
+                } else {
+                    space.SSD += blockCount * blockSize;
+                }
                 break;
             case 2: // STORAGE_MEDIA_HYBRID
             case 3: // STORAGE_MEDIA_HDD

--- a/contrib/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/contrib/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -304,6 +304,7 @@ void TPathElement::ApplySpecialAttributes() {
     VolumeSpaceSSDSystem.Limit = Max<ui64>();
     FileStoreSpaceSSD.Limit = Max<ui64>();
     FileStoreSpaceHDD.Limit = Max<ui64>();
+    FileStoreSpaceSSDSystem.Limit = Max<ui64>();
     ExtraPathSymbolsAllowed = TString();
     DocumentApiVersion = 0;
     AsyncReplication = NJson::TJsonValue();
@@ -330,6 +331,9 @@ void TPathElement::ApplySpecialAttributes() {
                 break;
             case EAttribute::FILESTORE_SPACE_LIMIT_HDD:
                 HandleAttributeValue(value, FileStoreSpaceHDD.Limit);
+                break;
+            case EAttribute::FILESTORE_SPACE_LIMIT_SSD_SYSTEM:
+                HandleAttributeValue(value, FileStoreSpaceSSDSystem.Limit);
                 break;
             case EAttribute::EXTRA_PATH_SYMBOLS_ALLOWED:
                 HandleAttributeValue(value, ExtraPathSymbolsAllowed);
@@ -391,16 +395,19 @@ bool TPathElement::CheckVolumeSpaceChange(TVolumeSpace newSpace, TVolumeSpace ol
 void TPathElement::ChangeFileStoreSpaceBegin(TFileStoreSpace newSpace, TFileStoreSpace oldSpace) {
     UpdateSpaceBegin(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD);
     UpdateSpaceBegin(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD);
+    UpdateSpaceBegin(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
 }
 
 void TPathElement::ChangeFileStoreSpaceCommit(TFileStoreSpace newSpace, TFileStoreSpace oldSpace) {
     UpdateSpaceCommit(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD);
     UpdateSpaceCommit(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD);
+    UpdateSpaceCommit(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
 }
 
 bool TPathElement::CheckFileStoreSpaceChange(TFileStoreSpace newSpace, TFileStoreSpace oldSpace, TString& errStr) {
     return (CheckSpaceChanged(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD, errStr, "filestore", " (ssd)") &&
-            CheckSpaceChanged(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD, errStr, "filestore", " (hdd)"));
+            CheckSpaceChanged(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD, errStr, "filestore", " (hdd)") &&
+            CheckSpaceChanged(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem, errStr, "filestore", " (ssd_system)"));
 }
 
 bool TPathElement::HasRuntimeAttrs() const {
@@ -410,7 +417,8 @@ bool TPathElement::HasRuntimeAttrs() const {
             VolumeSpaceSSDNonrepl.Allocated > 0 ||
             VolumeSpaceSSDSystem.Allocated > 0 ||
             FileStoreSpaceSSD.Allocated > 0 ||
-            FileStoreSpaceHDD.Allocated > 0);
+            FileStoreSpaceHDD.Allocated > 0 ||
+            FileStoreSpaceSSDSystem.Allocated > 0);
 }
 
 void TPathElement::SerializeRuntimeAttrs(
@@ -434,6 +442,7 @@ void TPathElement::SerializeRuntimeAttrs(
     // filestore
     process(FileStoreSpaceSSD, "__filestore_space_allocated_ssd");
     process(FileStoreSpaceHDD, "__filestore_space_allocated_hdd");
+    process(FileStoreSpaceSSDSystem, "__filestore_space_allocated_ssd_system");
 }
 
 }

--- a/contrib/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/contrib/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -25,6 +25,7 @@ struct TVolumeSpace {
 struct TFileStoreSpace {
     ui64 SSD = 0;
     ui64 HDD = 0;
+    ui64 SSDSystem = 0;
 };
 
 struct TSpaceLimits {
@@ -77,6 +78,7 @@ struct TPathElement : TSimpleRefCount<TPathElement> {
     TSpaceLimits VolumeSpaceSSDSystem;
     TSpaceLimits FileStoreSpaceSSD;
     TSpaceLimits FileStoreSpaceHDD;
+    TSpaceLimits FileStoreSpaceSSDSystem;
     ui64 DocumentApiVersion = 0;
     NJson::TJsonValue AsyncReplication;
 

--- a/contrib/ydb/core/tx/schemeshard/user_attributes.cpp
+++ b/contrib/ydb/core/tx/schemeshard/user_attributes.cpp
@@ -53,6 +53,7 @@ inline bool IsValidPathName_WeakCheck(const TString& name) {
                 HANDLE_ATTR(VOLUME_SPACE_LIMIT_SSD_SYSTEM);
                 HANDLE_ATTR(FILESTORE_SPACE_LIMIT_SSD);
                 HANDLE_ATTR(FILESTORE_SPACE_LIMIT_HDD);
+                HANDLE_ATTR(FILESTORE_SPACE_LIMIT_SSD_SYSTEM);
                 HANDLE_ATTR(EXTRA_PATH_SYMBOLS_ALLOWED);
                 HANDLE_ATTR(DOCUMENT_API_VERSION);
                 HANDLE_ATTR(ASYNC_REPLICATION);
@@ -128,6 +129,7 @@ inline bool IsValidPathName_WeakCheck(const TString& name) {
             case EAttribute::VOLUME_SPACE_LIMIT_SSD_SYSTEM:
             case EAttribute::FILESTORE_SPACE_LIMIT_SSD:
             case EAttribute::FILESTORE_SPACE_LIMIT_HDD:
+            case EAttribute::FILESTORE_SPACE_LIMIT_SSD_SYSTEM:
                 return CheckValueUint64(name, value, errStr);
             case EAttribute::EXTRA_PATH_SYMBOLS_ALLOWED:
                 return CheckValueStringWeak(name, value, errStr);
@@ -167,6 +169,7 @@ inline bool IsValidPathName_WeakCheck(const TString& name) {
             case EAttribute::VOLUME_SPACE_LIMIT_SSD_SYSTEM:
             case EAttribute::FILESTORE_SPACE_LIMIT_SSD:
             case EAttribute::FILESTORE_SPACE_LIMIT_HDD:
+            case EAttribute::FILESTORE_SPACE_LIMIT_SSD_SYSTEM:
             case EAttribute::EXTRA_PATH_SYMBOLS_ALLOWED:
                 return true;
             case EAttribute::DOCUMENT_API_VERSION:

--- a/contrib/ydb/core/tx/schemeshard/user_attributes.h
+++ b/contrib/ydb/core/tx/schemeshard/user_attributes.h
@@ -15,6 +15,7 @@ constexpr TStringBuf ATTR_VOLUME_SPACE_LIMIT_SSD_NONREPL = "__volume_space_limit
 constexpr TStringBuf ATTR_VOLUME_SPACE_LIMIT_SSD_SYSTEM = "__volume_space_limit_ssd_system";
 constexpr TStringBuf ATTR_FILESTORE_SPACE_LIMIT_SSD = "__filestore_space_limit_ssd";
 constexpr TStringBuf ATTR_FILESTORE_SPACE_LIMIT_HDD = "__filestore_space_limit_hdd";
+constexpr TStringBuf ATTR_FILESTORE_SPACE_LIMIT_SSD_SYSTEM = "__filestore_space_limit_ssd_system";
 constexpr TStringBuf ATTR_EXTRA_PATH_SYMBOLS_ALLOWED = "__extra_path_symbols_allowed";
 constexpr TStringBuf ATTR_DOCUMENT_API_VERSION = "__document_api_version";
 constexpr TStringBuf ATTR_ASYNC_REPLICATION = "__async_replication";
@@ -32,6 +33,7 @@ enum class EAttribute {
     ASYNC_REPLICATION,
     FILESTORE_SPACE_LIMIT_SSD,
     FILESTORE_SPACE_LIMIT_HDD,
+    FILESTORE_SPACE_LIMIT_SSD_SYSTEM,
 };
 
 enum class EUserAttributesOp {

--- a/contrib/ydb/core/tx/schemeshard/ut_filestore_reboots/ut_filestore_reboots.cpp
+++ b/contrib/ydb/core/tx/schemeshard/ut_filestore_reboots/ut_filestore_reboots.cpp
@@ -46,8 +46,11 @@ void InitAlterFileStoreConfig(NKikimrFileStore::TConfig& vc, bool channels = fal
     }
 }
 
-void CheckLimits(ui64 correctType, ui64 incorrectType) {
-    const TString typeStr = correctType == 1 ? "ssd" : "hdd";
+void CheckLimits(ui64 correctType, ui64 incorrectType, bool isSystem = false) {
+    const TString typeStr =
+        correctType == 1 ?
+            (isSystem ? "ssd_system" : "ssd") :
+            "hdd";
 
     TTestBasicRuntime runtime;
     TTestEnv env(runtime);
@@ -71,6 +74,7 @@ void CheckLimits(ui64 correctType, ui64 incorrectType) {
     vc.SetBlockSize(4_KB);
     vc.SetBlocksCount(100500);
     vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+    vc.SetIsSystem(isSystem);
 
     vdescr.SetName("FSOther");
     TestCreateFileStore(runtime, ++txId, "/MyRoot", vdescr.DebugString());
@@ -351,8 +355,10 @@ Y_UNIT_TEST_SUITE(TFileStoreWithReboots) {
     }
 
     Y_UNIT_TEST(CheckFileStoreSSDLimits) {
-        CheckLimits(1, 3);  // ssd, hdd
-        CheckLimits(1, 2);  // ssd, hybrid
+        CheckLimits(1, 3, false); // ssd, hdd
+        CheckLimits(1, 3, true);  // ssd_system, hdd
+        CheckLimits(1, 2, false); // ssd, hybrid
+        CheckLimits(1, 2, true);  // ssd_system, hybrid
     }
 
     Y_UNIT_TEST(CheckFileStoreHDDLimits) {


### PR DESCRIPTION
Manually applied https://github.com/ydb-platform/ydb/pull/12693 because of conflicts.
Tests were run locally:
```
root@bh2qurg7qaaevd7tte2i:~/reps/nbs_stable/contrib/ydb/core/tx/schemeshard# ~/reps/nbs_stable/ya make -tt ut_filestore_reboots/ -F=*CheckFileStoreSSDLimits*
------- [TM] {debug, default-linux-x86_64} contrib/ydb/core/tx/schemeshard/ut_filestore_reboots/unittest >> TFileStoreWithReboots::CheckFileStoreSSDLimits
Test command err:
No Keys in KeyConfig! Encrypted group DsProxies will not start
Leader for TabletID 8751008 is [0:0:0] sender: [1:101:2042] recipient: [1:95:12303]
IGNORE Leader for TabletID 8751008 is [0:0:0] sender: [1:101:2042] recipient: [1:95:12303]
Leader for TabletID 8751008 is [1:110:12290] sender: [1:112:2042] recipient: [1:95:12303]
2024-12-23T21:18:20.386604Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: BackgroundCompactionQueue configured: Timeout# 600.000000s, compact single parted# no, Rate# 1, WakeupInterval# 60.000000s, RoundInterval# 172800.000000s, InflightLimit# 1, MinCompactionRepeatDelaySeconds# 600.000000s, MaxRate# 1
2024-12-23T21:18:20.386725Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: BorrowedCompactionQueue configured: Timeout# 15.000000s, Rate# 0, WakeupInterval# 1.000000s, InflightLimit# 10
2024-12-23T21:18:20.386751Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: StatsBatching config: StatsBatchTimeout# 0.100000s, StatsMaxBatchSize# 100, StatsMaxExecuteTime# 0.010000s
2024-12-23T21:18:20.386846Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: OperationsProcessing config: using default configuration
2024-12-23T21:18:20.386897Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: OperationsProcessing config: type TxMergeTablePartition, limit 10000
2024-12-23T21:18:20.386913Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: OperationsProcessing config: type TxSplitTablePartition, limit 10000
2024-12-23T21:18:20.386990Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: BackgroundCleaningQueue configured: Timeout# 15.000000s, Rate# 0, WakeupInterval# 1.000000s, InflightLimit# 10
2024-12-23T21:18:20.387346Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TxInitSchema.Execute
2024-12-23T21:18:20.490074Z node 1 :FLAT_TX_SCHEMESHARD WARN: Cannot subscribe to console configs
2024-12-23T21:18:20.490151Z node 1 :IMPORT WARN: Table profiles were not loaded
2024-12-23T21:18:20.513612Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TxInitSchema.Complete
2024-12-23T21:18:20.514707Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxUpgradeSchema.Execute
2024-12-23T21:18:20.514940Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: UpgradeInitState as Uninitialized, schemeshardId: 8751008
2024-12-23T21:18:20.520303Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxUpgradeSchema.Complete
2024-12-23T21:18:20.520787Z node 1 :FLAT_TX_SCHEMESHARD INFO: Clear TempTablesState with owners number: 0
2024-12-23T21:18:20.521542Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: TTxInit, SS hasn't been configured yet, state: 1, at schemeshard: 8751008
2024-12-23T21:18:20.522261Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: TTxInitRoot DoExecute, path: MyRoot, pathId: [OwnerId: 8751008, LocalPathId: 1], at schemeshard: 8751008
2024-12-23T21:18:20.524752Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: TTxInitRoot DoComplete, at schemeshard: 8751008
2024-12-23T21:18:20.526646Z node 1 :FLAT_TX_SCHEMESHARD INFO: TTxPublishToSchemeBoard DoExecute, at schemeshard: 8751008
2024-12-23T21:18:20.526686Z node 1 :FLAT_TX_SCHEMESHARD INFO: TTxPublishToSchemeBoard DoComplete, at schemeshard: 8751008
2024-12-23T21:18:20.526726Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxServerlessStorageBilling.Execute
2024-12-23T21:18:20.526752Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: TTxServerlessStorageBilling: unable to make a bill, domain is not a serverless db, schemeshardId: 8751008, domainId: [OwnerId: 8751008, LocalPathId: 1]
2024-12-23T21:18:20.526774Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxServerlessStorageBilling.Complete
2024-12-23T21:18:20.527017Z node 1 :FLAT_TX_SCHEMESHARD INFO: Handle: TEvAllocateResult: Cookie# 0, at schemeshard: 8751008
2024-12-23T21:18:20.532490Z node 1 :HIVE INFO: [40961] started, primary subdomain 0:0
Leader for TabletID 8751008 is [1:110:12290] sender: [1:222:2042] recipient: [1:13:2044]
2024-12-23T21:18:20.594770Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationPropose Execute, message: Transaction { WorkingDir: "/" OperationType: ESchemeOpAlterSubDomain SubDomain { Name: "MyRoot" StoragePools { Name: "pool-1" Kind: "pool-kind-1" } StoragePools { Name: "pool-2" Kind: "pool-kind-2" } } } TxId: 1 TabletId: 8751008 , at schemeshard: 8751008
2024-12-23T21:18:20.595204Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: TAlterSubDomain Propose, path: //MyRoot, opId: 1:0, at schemeshard: 8751008
2024-12-23T21:18:20.595655Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: IncrementPathDbRefCount reason transaction target path for pathId [OwnerId: 8751008, LocalPathId: 1] was 0
2024-12-23T21:18:20.595901Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: IgniteOperation, opId: 1:0, propose status:StatusAccepted, reason: , at schemeshard: 8751008
2024-12-23T21:18:20.598645Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationPropose Complete, txId: 1, response: Status: StatusAccepted TxId: 1 SchemeshardId: 8751008 PathId: 1, at schemeshard: 8751008
2024-12-23T21:18:20.598790Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: AUDIT: txId: 1, subject: , status: StatusAccepted, operation: ALTER DATABASE, path: //MyRoot
2024-12-23T21:18:20.598990Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 1:0, at schemeshard: 8751008
2024-12-23T21:18:20.599053Z node 1 :FLAT_TX_SCHEMESHARD INFO: TCreateParts opId# 1:0 ProgressState, operation type: TxAlterSubDomain, at tablet8751008
2024-12-23T21:18:20.599074Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TCreateParts opId# 1:0 ProgressState no shards to create, do next state
2024-12-23T21:18:20.599089Z node 1 :FLAT_TX_SCHEMESHARD INFO: Change state for txid 1:0 2 -> 3
2024-12-23T21:18:20.601014Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 1:0, at schemeshard: 8751008
2024-12-23T21:18:20.601045Z node 1 :FLAT_TX_SCHEMESHARD INFO: NSubDomainState::TConfigureParts operationId#1:0 ProgressState, at schemeshard: 8751008
2024-12-23T21:18:20.601100Z node 1 :FLAT_TX_SCHEMESHARD INFO: Change state for txid 1:0 3 -> 128
2024-12-23T21:18:20.602744Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 1:0, at schemeshard: 8751008
2024-12-23T21:18:20.602790Z node 1 :FLAT_TX_SCHEMESHARD INFO: NSubDomainState::TPropose ProgressState, operationId: 1:0, at schemeshard: 8751008
2024-12-23T21:18:20.602869Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: NSubDomainState::TPropose ProgressState leave, operationId 1:0, at tablet 8751008
2024-12-23T21:18:20.602953Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToPropose , TxId: 1 ready parts: 1/1
2024-12-23T21:18:20.605620Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TOperation DoPropose send propose to coordinator: 8388609 message:Transaction { AffectedSet { TabletId: 8751008 Flags: 2 } ExecLevel: 0 TxId: 1 MinStep: 0 MaxStep: 18446744073709551615 IgnoreLowDiskSpace: true } CoordinatorID: 8388609
2024-12-23T21:18:20.607231Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: Send tablet strongly msg  operationId: 1:4294967295 from tablet: 8751008 to tablet: 8388609 cookie: 0:1 msg type: 269090816
2024-12-23T21:18:20.607458Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TOperation RegisterRelationByTabletId, TxId: 1, partId: 4294967295, tablet: 8388609
FAKE_COORDINATOR: Add transaction: 1 at step: 5000001
FAKE_COORDINATOR: advance: minStep5000001 State->FrontStep: 0
FAKE_COORDINATOR:  Send Plan to tablet 8751008 for txId: 1 at step: 5000001
2024-12-23T21:18:20.608371Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: TTxOperationPlanStep Execute, stepId: 5000001, transactions count in step: 1, at schemeshard: 8751008
2024-12-23T21:18:20.608433Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationPlanStep Execute, message: Transactions { TxId: 1 Coordinator: 8388609 AckTo { RawX1: 122 RawX2: 4294979610 } } Step: 5000001 MediatorID: 0 TabletID: 8751008, at schemeshard: 8751008
2024-12-23T21:18:20.608467Z node 1 :FLAT_TX_SCHEMESHARD INFO: NSubDomainState::TPropose HandleReply TEvOperationPlan, operationId 1:0, at tablet 8751008
2024-12-23T21:18:20.608735Z node 1 :FLAT_TX_SCHEMESHARD INFO: Change state for txid 1:0 128 -> 240
2024-12-23T21:18:20.608773Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: NSubDomainState::TPropose HandleReply TEvOperationPlan, operationId 1:0, at tablet 8751008
2024-12-23T21:18:20.609026Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: IncrementPathDbRefCount reason publish path for pathId [OwnerId: 8751008, LocalPathId: 1] was 1
2024-12-23T21:18:20.609093Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: DoUpdateTenant no IsExternalSubDomainRoot, pathId: : [OwnerId: 8751008, LocalPathId: 1], at schemeshard: 8751008
FAKE_COORDINATOR: Erasing txId 1
2024-12-23T21:18:20.610895Z node 1 :FLAT_TX_SCHEMESHARD INFO: TTxPublishToSchemeBoard DoExecute, at schemeshard: 8751008
2024-12-23T21:18:20.610920Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxPublishToSchemeBoard DescribePath, at schemeshard: 8751008, txId: 1, path id: [OwnerId: 8751008, LocalPathId: 1]
2024-12-23T21:18:20.611040Z node 1 :FLAT_TX_SCHEMESHARD INFO: TTxPublishToSchemeBoard DoComplete, at schemeshard: 8751008
2024-12-23T21:18:20.611061Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxPublishToSchemeBoard Send, to populator: [1:190:8271], at schemeshard: 8751008, txId: 1, path id: 1
2024-12-23T21:18:20.611103Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 1:0, at schemeshard: 8751008
2024-12-23T21:18:20.611125Z node 1 :FLAT_TX_SCHEMESHARD INFO: [8751008] TDone opId# 1:0ProgressState
2024-12-23T21:18:20.611258Z node 1 :FLAT_TX_SCHEMESHARD INFO: Part operation is done id#1:0 progress is 1/1
2024-12-23T21:18:20.611282Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToDone  TxId: 1 ready parts: 1/1
2024-12-23T21:18:20.611326Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToNotify, TxId: 1, ready parts: 1/1, is published: false
2024-12-23T21:18:20.611357Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToDone  TxId: 1 ready parts: 1/1
2024-12-23T21:18:20.611379Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: Operation and all the parts is done, operation id: 1:0
2024-12-23T21:18:20.611392Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: RemoveTx for txid 1:0
2024-12-23T21:18:20.611434Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: DecrementPathDbRefCount reason remove txstate target path for pathId [OwnerId: 8751008, LocalPathId: 1] was 2
2024-12-23T21:18:20.611464Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: Publication still in progress, tx: 1, publications: 1, subscribers: 0
2024-12-23T21:18:20.611480Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: Publication details:  tx: 1, [OwnerId: 8751008, LocalPathId: 1], 3
2024-12-23T21:18:20.612994Z node 1 :FLAT_TX_SCHEMESHARD INFO: Handle TEvUpdateAck, at schemeshard: 8751008, msg: Owner: 8751008 Generation: 2 LocalPathId: 1 Version: 3 PathOwnerId: 8751008, cookie: 1
2024-12-23T21:18:20.613068Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Execute, at schemeshard: 8751008, msg: Owner: 8751008 Generation: 2 LocalPathId: 1 Version: 3 PathOwnerId: 8751008, cookie: 1
2024-12-23T21:18:20.613087Z node 1 :FLAT_TX_SCHEMESHARD INFO: Publication in-flight, count: 1, at schemeshard: 8751008, txId: 1
2024-12-23T21:18:20.613103Z node 1 :FLAT_TX_SCHEMESHARD INFO: AckPublish, at schemeshard: 8751008, txId: 1, pathId: [OwnerId: 8751008, LocalPathId: 1], version: 3
2024-12-23T21:18:20.613119Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: DecrementPathDbRefCount reason remove publishing for pathId [OwnerId: 8751008, LocalPathId: 1] was 1
2024-12-23T21:18:20.613175Z node 1 :FLAT_TX_SCHEMESHARD NOTICE: Publication complete, notify & remove, at schemeshard: 8751008, txId: 1, subscribers: 0
2024-12-23T21:18:20.615664Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Complete, at schemeshard: 8751008, cookie: 1
2024-12-23T21:18:20.616125Z node 1 :FLAT_TX_SCHEMESHARD WARN: NotifyTxCompletion, unknown transaction, txId: 1, at schemeshard: 8751008
TestModificationResults wait txId: 101
2024-12-23T21:18:20.616670Z node 1 :TX_PROXY DEBUG: actor# [1:252:12319] Bootstrap
2024-12-23T21:18:20.622024Z node 1 :TX_PROXY DEBUG: actor# [1:252:12319] Become StateWork (SchemeCache [1:256:8316])
2024-12-23T21:18:20.624231Z node 1 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationPropose Execute, message: Transaction { WorkingDir: "" OperationType: ESchemeOpAlterUserAttributes AlterUserAttributes { PathName: "MyRoot" UserAttrib
...
Publish, at schemeshard: 8751008, txId: 110, pathId: [OwnerId: 8751008, LocalPathId: 5], version: 1
2024-12-23T21:18:22.937283Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: DecrementPathDbRefCount reason remove publishing for pathId [OwnerId: 8751008, LocalPathId: 5] was 4
2024-12-23T21:18:22.937331Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToNotify, TxId: 110, ready parts: 0/1, is published: true
2024-12-23T21:18:22.939350Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: Send tablet strongly msg  operationId: 110:0 from tablet: 8751008 to tablet: 40961 cookie: 8751008:4 msg type: 268697601
2024-12-23T21:18:22.939418Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation RegisterRelationByTabletId, TxId: 110, partId: 0, tablet: 40961
2024-12-23T21:18:22.939449Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation RegisterRelationByShardIdx, TxId: 110, shardIdx: 8751008:4, partId: 0
2024-12-23T21:18:22.939754Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Complete, at schemeshard: 8751008, cookie: 110
2024-12-23T21:18:22.939868Z node 4 :HIVE INFO: [40961] TEvCreateTablet, msg: Owner: 8751008 OwnerIdx: 4 TabletType: FileStore ObjectDomain { SchemeShard: 8751008 PathId: 1 } ObjectId: 5 BindedChannels { StoragePoolName: "pool-1" IOPS: 0 Throughput: 0 Size: 0 } AllowedDomains { SchemeShard: 8751008 PathId: 1 }
2024-12-23T21:18:22.939973Z node 4 :HIVE INFO: [40961] TEvCreateTablet, Owner 8751008, OwnerIdx 4, type FileStore, boot OK, tablet id 9437197
2024-12-23T21:18:22.940054Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: Handle TEvCreateTabletReply at schemeshard: 8751008 message: Status: OK Owner: 8751008 OwnerIdx: 4 TabletID: 9437197 Origin: 40961
2024-12-23T21:18:22.940074Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation FindRelatedPartByShardIdx, TxId: 110, shardIdx: 8751008:4, partId: 0
2024-12-23T21:18:22.940177Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationReply<NKikimr::TEvHive::TEvCreateTabletReply> execute, operationId: 110:0, at schemeshard: 8751008, message: Status: OK Owner: 8751008 OwnerIdx: 4 TabletID: 9437197 Origin: 40961
2024-12-23T21:18:22.940200Z node 4 :FLAT_TX_SCHEMESHARD INFO: TCreateParts opId# 110:0 HandleReply TEvCreateTabletReply, at tabletId: 8751008
2024-12-23T21:18:22.940231Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TCreateParts opId# 110:0 HandleReply TEvCreateTabletReply, message: Status: OK Owner: 8751008 OwnerIdx: 4 TabletID: 9437197 Origin: 40961
2024-12-23T21:18:22.940290Z node 4 :FLAT_TX_SCHEMESHARD INFO: Change state for txid 110:0 2 -> 3
2024-12-23T21:18:22.941593Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Complete, at schemeshard: 8751008, cookie: 110
2024-12-23T21:18:22.943762Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationReply<NKikimr::TEvHive::TEvCreateTabletReply> complete, operationId: 110:0, at schemeshard: 8751008
2024-12-23T21:18:22.943890Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 110:0, at schemeshard: 8751008
2024-12-23T21:18:22.943914Z node 4 :FLAT_TX_SCHEMESHARD INFO: TCreateFileStore::TConfigureParts operationId#110:0 ProgressState, at schemeshard: 8751008
2024-12-23T21:18:22.946037Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: Send tablet strongly msg  operationId: 110:0 from tablet: 8751008 to tablet: 9437197 cookie: 8751008:4 msg type: 275054593
2024-12-23T21:18:22.946121Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation RegisterRelationByTabletId, TxId: 110, partId: 0, tablet: 9437197
2024-12-23T21:18:22.949485Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation FindRelatedPartByTabletId, TxId: 110, tablet: 9437197, partId: 0
2024-12-23T21:18:22.949563Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationReply<NKikimr::TEvFileStore::TEvUpdateConfigResponse> execute, operationId: 110:0, at schemeshard: 8751008, message: TxId: 110 Origin: 9437197 Status: OK
2024-12-23T21:18:22.949584Z node 4 :FLAT_TX_SCHEMESHARD INFO: TCreateFileStore::TConfigureParts operationId#110:0 HandleReply TEvUpdateConfigResponse, at schemeshard: 8751008
2024-12-23T21:18:22.949602Z node 4 :FLAT_TX_SCHEMESHARD INFO: Change state for txid 110:0 3 -> 128
2024-12-23T21:18:22.953381Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationReply<NKikimr::TEvFileStore::TEvUpdateConfigResponse> complete, operationId: 110:0, at schemeshard: 8751008
2024-12-23T21:18:22.953486Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 110:0, at schemeshard: 8751008
2024-12-23T21:18:22.953508Z node 4 :FLAT_TX_SCHEMESHARD INFO: TCreateFileStore::TPropose operationId#110:0 ProgressState, at schemeshard: 8751008
2024-12-23T21:18:22.953532Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToPropose , TxId: 110 ready parts: 1/1
2024-12-23T21:18:22.953591Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation DoPropose send propose to coordinator: 8388609 message:Transaction { AffectedSet { TabletId: 8751008 Flags: 2 } ExecLevel: 0 TxId: 110 MinStep: 0 MaxStep: 18446744073709551615 IgnoreLowDiskSpace: true } CoordinatorID: 8388609
2024-12-23T21:18:22.955207Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: Send tablet strongly msg  operationId: 110:4294967295 from tablet: 8751008 to tablet: 8388609 cookie: 0:110 msg type: 269090816
2024-12-23T21:18:22.955273Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation RegisterRelationByTabletId, TxId: 110, partId: 4294967295, tablet: 8388609
FAKE_COORDINATOR: Add transaction: 110 at step: 5000009
FAKE_COORDINATOR: advance: minStep5000009 State->FrontStep: 5000008
FAKE_COORDINATOR:  Send Plan to tablet 8751008 for txId: 110 at step: 5000009
2024-12-23T21:18:22.955515Z node 4 :FLAT_TX_SCHEMESHARD NOTICE: TTxOperationPlanStep Execute, stepId: 5000009, transactions count in step: 1, at schemeshard: 8751008
2024-12-23T21:18:22.955571Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationPlanStep Execute, message: Transactions { TxId: 110 Coordinator: 8388609 AckTo { RawX1: 122 RawX2: 17179881498 } } Step: 5000009 MediatorID: 0 TabletID: 8751008, at schemeshard: 8751008
2024-12-23T21:18:22.955595Z node 4 :FLAT_TX_SCHEMESHARD INFO: TCreateFileStore::TPropose operationId#110:0 HandleReply TEvOperationPlan, step: 5000009, at schemeshard: 8751008
2024-12-23T21:18:22.955657Z node 4 :FLAT_TX_SCHEMESHARD INFO: Change state for txid 110:0 128 -> 240
2024-12-23T21:18:22.955747Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: IncrementPathDbRefCount reason publish path for pathId [OwnerId: 8751008, LocalPathId: 1] was 3
2024-12-23T21:18:22.955792Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: IncrementPathDbRefCount reason publish path for pathId [OwnerId: 8751008, LocalPathId: 5] was 3
FAKE_COORDINATOR: Erasing txId 110
2024-12-23T21:18:22.957526Z node 4 :FLAT_TX_SCHEMESHARD INFO: TTxPublishToSchemeBoard DoExecute, at schemeshard: 8751008
2024-12-23T21:18:22.957549Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxPublishToSchemeBoard DescribePath, at schemeshard: 8751008, txId: 110, path id: [OwnerId: 8751008, LocalPathId: 1]
2024-12-23T21:18:22.957629Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxPublishToSchemeBoard DescribePath, at schemeshard: 8751008, txId: 110, path id: [OwnerId: 8751008, LocalPathId: 5]
2024-12-23T21:18:22.957689Z node 4 :FLAT_TX_SCHEMESHARD INFO: TTxPublishToSchemeBoard DoComplete, at schemeshard: 8751008
2024-12-23T21:18:22.957708Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxPublishToSchemeBoard Send, to populator: [4:192:8283], at schemeshard: 8751008, txId: 110, path id: 1
2024-12-23T21:18:22.957728Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxPublishToSchemeBoard Send, to populator: [4:192:8283], at schemeshard: 8751008, txId: 110, path id: 5
2024-12-23T21:18:22.957833Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxOperationProgress Execute, operationId: 110:0, at schemeshard: 8751008
2024-12-23T21:18:22.957855Z node 4 :FLAT_TX_SCHEMESHARD INFO: [8751008] TDone opId# 110:0ProgressState
2024-12-23T21:18:22.957885Z node 4 :FLAT_TX_SCHEMESHARD INFO: Part operation is done id#110:0 progress is 1/1
2024-12-23T21:18:22.957899Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToDone  TxId: 110 ready parts: 1/1
2024-12-23T21:18:22.957930Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToNotify, TxId: 110, ready parts: 1/1, is published: false
2024-12-23T21:18:22.957951Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TOperation IsReadyToDone  TxId: 110 ready parts: 1/1
2024-12-23T21:18:22.957968Z node 4 :FLAT_TX_SCHEMESHARD NOTICE: Operation and all the parts is done, operation id: 110:0
2024-12-23T21:18:22.957981Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: RemoveTx for txid 110:0
2024-12-23T21:18:22.958045Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: DecrementPathDbRefCount reason remove txstate target path for pathId [OwnerId: 8751008, LocalPathId: 5] was 4
2024-12-23T21:18:22.958062Z node 4 :FLAT_TX_SCHEMESHARD NOTICE: Publication still in progress, tx: 110, publications: 2, subscribers: 0
2024-12-23T21:18:22.958076Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: Publication details:  tx: 110, [OwnerId: 8751008, LocalPathId: 1], 15
2024-12-23T21:18:22.958089Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: Publication details:  tx: 110, [OwnerId: 8751008, LocalPathId: 5], 2
2024-12-23T21:18:22.958805Z node 4 :FLAT_TX_SCHEMESHARD INFO: Handle TEvUpdateAck, at schemeshard: 8751008, msg: Owner: 8751008 Generation: 2 LocalPathId: 1 Version: 15 PathOwnerId: 8751008, cookie: 110
2024-12-23T21:18:22.958867Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Execute, at schemeshard: 8751008, msg: Owner: 8751008 Generation: 2 LocalPathId: 1 Version: 15 PathOwnerId: 8751008, cookie: 110
2024-12-23T21:18:22.958885Z node 4 :FLAT_TX_SCHEMESHARD INFO: Publication in-flight, count: 2, at schemeshard: 8751008, txId: 110
2024-12-23T21:18:22.958900Z node 4 :FLAT_TX_SCHEMESHARD INFO: AckPublish, at schemeshard: 8751008, txId: 110, pathId: [OwnerId: 8751008, LocalPathId: 1], version: 15
2024-12-23T21:18:22.958915Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: DecrementPathDbRefCount reason remove publishing for pathId [OwnerId: 8751008, LocalPathId: 1] was 4
2024-12-23T21:18:22.959890Z node 4 :FLAT_TX_SCHEMESHARD INFO: Handle TEvUpdateAck, at schemeshard: 8751008, msg: Owner: 8751008 Generation: 2 LocalPathId: 5 Version: 2 PathOwnerId: 8751008, cookie: 110
2024-12-23T21:18:22.959954Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Execute, at schemeshard: 8751008, msg: Owner: 8751008 Generation: 2 LocalPathId: 5 Version: 2 PathOwnerId: 8751008, cookie: 110
2024-12-23T21:18:22.959973Z node 4 :FLAT_TX_SCHEMESHARD INFO: Publication in-flight, count: 1, at schemeshard: 8751008, txId: 110
2024-12-23T21:18:22.959989Z node 4 :FLAT_TX_SCHEMESHARD INFO: AckPublish, at schemeshard: 8751008, txId: 110, pathId: [OwnerId: 8751008, LocalPathId: 5], version: 2
2024-12-23T21:18:22.960004Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: DecrementPathDbRefCount reason remove publishing for pathId [OwnerId: 8751008, LocalPathId: 5] was 3
2024-12-23T21:18:22.960054Z node 4 :FLAT_TX_SCHEMESHARD NOTICE: Publication complete, notify & remove, at schemeshard: 8751008, txId: 110, subscribers: 0
2024-12-23T21:18:22.962959Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Complete, at schemeshard: 8751008, cookie: 110
2024-12-23T21:18:22.963287Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: TTxAckPublishToSchemeBoard Complete, at schemeshard: 8751008, cookie: 110
TestModificationResult got TxId: 110, wait until txId: 110
TestWaitNotification wait txId: 110
2024-12-23T21:18:22.963463Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: tests -- TTxNotificationSubscriber for txId 110: send EvNotifyTxCompletion
2024-12-23T21:18:22.963480Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: tests -- TTxNotificationSubscriber, SendToSchemeshard, txId 110
2024-12-23T21:18:22.963717Z node 4 :FLAT_TX_SCHEMESHARD WARN: NotifyTxCompletion, unknown transaction, txId: 110, at schemeshard: 8751008
2024-12-23T21:18:22.963779Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: tests -- TTxNotificationSubscriber for txId 110: got EvNotifyTxCompletionResult
2024-12-23T21:18:22.963796Z node 4 :FLAT_TX_SCHEMESHARD DEBUG: tests -- TTxNotificationSubscriber for txId 110: satisfy waiter [4:655:12369]
TestWaitNotification: OK eventTxId 110
Number of suites by filter *CheckFileStoreSSDLimits*

Total 1 suite:
	1 - GOOD
Total 1 test:
	1 - GOOD
Ok
```