### PR TITLE
[Filestore] make 'fio_index/qemu-kikimr-multishard-nemesis-test' large when running under sanitizers; make 'loadtest/service-kikimr-emergency-test' medium as it was before https://github.com/ydb-platform/nbs/pull/2334

### DIFF
--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
@@ -1,6 +1,10 @@
 PY3TEST()
 
-INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+ENDIF()
 
 DEPENDS(
     cloud/storage/core/tools/testing/fio/bin

--- a/cloud/filestore/tests/loadtest/service-kikimr-emergency-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-emergency-test/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
 
 TEST_SRCS(
     test.py


### PR DESCRIPTION
Here we can see that test is not hanging but simply slow under ASAN https://github-actions-s3.website.nemax.nebius.cloud/ydb-platform/nbs/Nightly-build-(asan)/12566246901/1/nebius-x86-64-asan/test_data/actions-runner/_work/nbs/nbs/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/test-results/py3test/chunk6/testing_out_stuff/

<img width="1713" alt="Screenshot 2025-01-01 at 14 01 01" src="https://github.com/user-attachments/assets/133f8888-8e2f-4545-862b-5a72a415388c" />
