### PR TITLE
[Filestore] issue-2783: fix local filestore chown to work when one of uid/gid is not provided

### DIFF
--- a/cloud/filestore/libs/service_local/fs_attrs.cpp
+++ b/cloud/filestore/libs/service_local/fs_attrs.cpp
@@ -42,8 +42,8 @@ NProto::TSetNodeAttrResponse TLocalFileSystem::SetNodeAttr(
         gid = request.GetUpdate().GetGid();
     }
 
-    if (uid.has_value() && gid.has_value()) {
-        node->Chown(*uid, *gid);
+    if (uid || gid) {
+        node->Chown(uid ? *uid : -1, gid ? *gid : -1);
     }
 
     //

--- a/cloud/filestore/libs/service_local/lowlevel.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel.cpp
@@ -307,7 +307,7 @@ void Chmod(const TFileHandle& handle, int mode)
     }
 }
 
-void Chown(const TFileHandle& handle, unsigned int uid, unsigned int gid)
+void Chown(const TFileHandle& handle, uid_t uid, gid_t gid)
 {
     char path[64] = {0};
     sprintf(path, "/proc/self/fd/%i", Fd(handle));


### PR DESCRIPTION
#2783 