### PR TITLE
issue-176: disable used block tracking

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -734,6 +734,8 @@ private:
     bool ShouldForceTabletRestart(const NProto::TVolumeClientInfo& info) const;
 
     THashSet<TString> MakeFilteredDeviceIds() const;
+
+    [[nodiscard]] bool ShouldTrackUsedBlocks() const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/tests/encryption_at_rest/test.py
+++ b/cloud/blockstore/tests/encryption_at_rest/test.py
@@ -192,3 +192,19 @@ def test_create_volume_with_default_ecnryption(nbs, disk_agent):
     assert raw_data != expected_data
 
     session.unmount_volume()
+
+    # check that the volume doesn't tack used blocks
+
+    response = json.loads(client.execute_action(
+            action="UpdateUsedBlocks",
+            input_bytes=json.dumps({
+                "DiskId": "vol0",
+                "StartIndices": [0],
+                "BlockCounts": [1],
+                "Used": True
+            }).encode()))
+
+    error = response.get("Error", {})
+
+    assert error.get("Code") == 1   # S_FALSE
+    assert error.get("Message") == "Used block tracking not set up"

--- a/cloud/blockstore/tests/encryption_at_rest/test.py
+++ b/cloud/blockstore/tests/encryption_at_rest/test.py
@@ -196,13 +196,13 @@ def test_create_volume_with_default_ecnryption(nbs, disk_agent):
     # check that the volume doesn't tack used blocks
 
     response = json.loads(client.execute_action(
-            action="UpdateUsedBlocks",
-            input_bytes=json.dumps({
-                "DiskId": "vol0",
-                "StartIndices": [0],
-                "BlockCounts": [1],
-                "Used": True
-            }).encode()))
+        action="UpdateUsedBlocks",
+        input_bytes=json.dumps({
+            "DiskId": "vol0",
+            "StartIndices": [0],
+            "BlockCounts": [1],
+            "Used": True
+        }).encode()))
 
     error = response.get("Error", {})
 


### PR DESCRIPTION
#176
Tracking of used blocks should be disabled in case of volumes with encryption at rest: assume that unencrypted blocks are completely filled with zeros.