### PR TITLE
Authorizer should not crash when TicketParser returns fatal error with empty ticket in result

### DIFF
--- a/cloud/storage/core/libs/auth/authorizer.cpp
+++ b/cloud/storage/core/libs/auth/authorizer.cpp
@@ -253,13 +253,12 @@ private:
             return;
         }
 
-        Y_ABORT_UNLESS(Token == msg->Ticket);
-
         const bool allow = PermissionsMatch(Permissions, *msg);
 
         auto logLevel = allow ? NLog::PRI_DEBUG : NLog::PRI_WARN;
         LOG_LOG_S(ctx, logLevel, Component,
-            "Permissions response: "
+            "Token = '" << MaskSecret(Token) << "'"
+            << ", Permissions response: "
             << TResponsePermissionsInfo(RequestId, *msg, allow));
 
         Counters->ReportAuthorizationStatus(allow


### PR DESCRIPTION
`TicketParser` can return fatal error with empty ticket, for example [there](https://github.com/ydb-platform/nbs/blob/b5c6c7763e995162f75752ded679be85c53d1662/contrib/ydb/core/security/ticket_parser_impl.h#L1097). 
That will cause a crash:
```
VERIFY failed (2025-01-03T17:18:07.587479Z): 
  cloud/storage/core/libs/auth/authorizer.cpp:256
  HandleParseTicketResult(): requirement Token == msg->Ticket failed
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+557 (0x5597D1AFA02D)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+268 (0x5597D1AF04CC)
??+0 (0x5597E333D2B6)
NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TRevolvingMailbox>(NActors::TMailboxTable::TRevolvingMailbox*, unsigned int, bool)+1648 (0x5597D2687360)
??+0 (0x5597D2681FE7)
NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)+452 (0x5597D2681984)
NActors::TExecutorThread::ThreadProc()+215 (0x5597D2682837)
??+0 (0x5597D1AFBACA)
??+0 (0x7F00A4A86AC3)
??+0 (0x7F00A4B18850)
```