### PR TITLE
[CSI] trigger StopEndpoint if StartEndpoint has failed with GRPC Timeout error

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -4,6 +4,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	nbs "github.com/ydb-platform/nbs/cloud/blockstore/public/api/protos"
+	nbsclient "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
 	"github.com/ydb-platform/nbs/cloud/blockstore/tools/csi_driver/internal/driver/mocks"
 	csimounter "github.com/ydb-platform/nbs/cloud/blockstore/tools/csi_driver/internal/mounter"
 	nfs "github.com/ydb-platform/nbs/cloud/filestore/public/api/protos"
@@ -934,6 +936,174 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 			},
 		},
 		VolumeContext: volumeContext,
+	})
+	require.Error(t, err)
+}
+
+func TestGrpcTimeoutForIKubevirt(t *testing.T) {
+	tempDir := t.TempDir()
+
+	nbsClient := mocks.NewNbsClientMock()
+	nfsClient := mocks.NewNfsEndpointClientMock()
+	nfsLocalClient := mocks.NewNfsEndpointClientMock()
+	mounter := csimounter.NewMock()
+
+	ctx := context.Background()
+	nodeId := "testNodeId"
+	clientId := "testClientId"
+	instanceId := "testInstanceId"
+	actualClientId := "testClientId-" + instanceId
+	diskId := "test-disk-id-42"
+	deviceName := diskId
+	volumeId := diskId + "#" + instanceId
+	backend := "nbs"
+
+	stagingTargetPath := filepath.Join(tempDir, "testStagingTargetPath")
+	socketsDir := filepath.Join(tempDir, "sockets")
+	sourcePath := filepath.Join(socketsDir, instanceId, diskId)
+	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
+	nbsSocketPath := filepath.Join(sourcePath, "nbs.sock")
+
+	nodeService := newNodeService(
+		nodeId,
+		clientId,
+		true,
+		socketsDir,
+		targetFsPathPattern,
+		"",
+		make(LocalFilestoreOverrideMap),
+		nbsClient,
+		nfsClient,
+		nfsLocalClient,
+		mounter,
+	)
+
+	accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+
+	volumeCapability := csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: accessMode,
+		},
+	}
+
+	volumeContext := map[string]string{
+		backendVolumeContextKey: backend,
+		instanceIdKey:           instanceId,
+	}
+
+	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
+	grpcError := nbsclient.ClientError{Code: nbsclient.E_GRPC_DEADLINE_EXCEEDED}
+	startEndpointError := fmt.Errorf("%w", grpcError)
+	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
+		UnixSocketPath:   nbsSocketPath,
+		DiskId:           diskId,
+		InstanceId:       instanceId,
+		ClientId:         actualClientId,
+		DeviceName:       deviceName,
+		IpcType:          nbs.EClientIpcType_IPC_VHOST,
+		VhostQueuesCount: 8,
+		VolumeAccessMode: nbs.EVolumeAccessMode_VOLUME_ACCESS_READ_WRITE,
+		VolumeMountMode:  nbs.EVolumeMountMode_VOLUME_MOUNT_LOCAL,
+		Persistent:       true,
+		NbdDevice: &nbs.TStartEndpointRequest_UseFreeNbdDeviceFile{
+			false,
+		},
+		ClientProfile: &nbs.TClientProfile{
+			HostType: &hostType,
+		},
+	}).Once().Return(&nbs.TStartEndpointResponse{}, startEndpointError)
+
+	nbsClient.On("StopEndpoint", ctx, &nbs.TStopEndpointRequest{
+		UnixSocketPath: nbsSocketPath,
+	}).Once().Return(&nbs.TStopEndpointResponse{}, nil)
+
+	_, err := nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
+		VolumeId:          volumeId,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability:  &volumeCapability,
+		VolumeContext:     volumeContext,
+	})
+	require.Error(t, err)
+}
+
+func TestGrpcTimeoutForInfrakuber(t *testing.T) {
+	tempDir := t.TempDir()
+
+	nbsClient := mocks.NewNbsClientMock()
+	mounter := csimounter.NewMock()
+
+	ipcType := nbs.EClientIpcType_IPC_NBD
+	nbdDeviceFile := filepath.Join(tempDir, "dev", "nbd3")
+	err := os.MkdirAll(nbdDeviceFile, fs.FileMode(0755))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	nodeId := "testNodeId"
+	clientId := "testClientId"
+	diskId := "test-disk-id-42"
+	actualClientId := "testClientId-testNodeId"
+	targetFsPathPattern := filepath.Join(tempDir, "pods/([a-z0-9-]+)/volumes/([a-z0-9-]+)/mount")
+	stagingTargetPath := "testStagingTargetPath"
+	socketsDir := filepath.Join(tempDir, "sockets")
+	socketPath := filepath.Join(socketsDir, diskId, "nbs.sock")
+
+	nodeService := newNodeService(
+		nodeId,
+		clientId,
+		false,
+		socketsDir,
+		targetFsPathPattern,
+		"",
+		make(LocalFilestoreOverrideMap),
+		nbsClient,
+		nil,
+		nil,
+		mounter,
+	)
+
+	volumeCapability := csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		},
+	}
+
+	volumeContext := map[string]string{}
+
+	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
+	grpcError := nbsclient.ClientError{Code: nbsclient.E_GRPC_DEADLINE_EXCEEDED}
+	startEndpointError := fmt.Errorf("%w", grpcError)
+	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
+		UnixSocketPath:   socketPath,
+		DiskId:           diskId,
+		InstanceId:       nodeId,
+		ClientId:         actualClientId,
+		DeviceName:       diskId,
+		IpcType:          ipcType,
+		VhostQueuesCount: 8,
+		VolumeAccessMode: nbs.EVolumeAccessMode_VOLUME_ACCESS_READ_WRITE,
+		VolumeMountMode:  nbs.EVolumeMountMode_VOLUME_MOUNT_LOCAL,
+		Persistent:       true,
+		NbdDevice: &nbs.TStartEndpointRequest_UseFreeNbdDeviceFile{
+			true,
+		},
+		ClientProfile: &nbs.TClientProfile{
+			HostType: &hostType,
+		},
+	}).Return(&nbs.TStartEndpointResponse{}, startEndpointError)
+
+	nbsClient.On("StopEndpoint", ctx, &nbs.TStopEndpointRequest{
+		UnixSocketPath: socketPath,
+	}).Return(&nbs.TStopEndpointResponse{}, nil)
+
+	_, err = nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
+		VolumeId:          diskId,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability:  &volumeCapability,
+		VolumeContext:     volumeContext,
 	})
 	require.Error(t, err)
 }


### PR DESCRIPTION
issue: #2801

All Start/StopEndpoint requests are landed into the same queue: [nbs/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp at main · ydb-platform/nbs](https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp#L1020) . NBS handles only one request at the same time.

StartEndpoint request from csi driver can fail by timeout however request in the queue will retry to start endpoint longer time. It leads to hanging delete volume operation as csi driver doesn’t send stop endpoint request(NodeVolume publish fails so we don’t need to send NodeUnpublishVolume).

Solution:
Send StopEndpoint request(in NodePublishVolume/NodeStageVolume) if StartEndpoint request fails with GRPC timeout error.