### PR TITLE
Filestore: readahead cache invalidation should not evict all nodes

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/read_ahead.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead.cpp
@@ -156,7 +156,7 @@ TMaybe<TByteRange> TReadAheadCache::RegisterDescribe(
 
 void TReadAheadCache::InvalidateCache(ui64 nodeId)
 {
-    NodeStates.clear(nodeId);
+    NodeStates.erase(nodeId);
 }
 
 void TReadAheadCache::OnDestroyHandle(ui64 nodeId, ui64 handle)

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead_ut.cpp
@@ -713,6 +713,29 @@ Y_UNIT_TEST_SUITE(TReadAheadTest)
                 blobPieces[0].GetRanges(0).GetBlobOffset());
         }
     }
+
+    Y_UNIT_TEST(ShouldInvalidateNodes)
+    {
+        TDefaultCache cache;
+
+        RegisterResult(cache, 111, 0, 1_MB);
+        RegisterResult(cache, 111, 1_MB, 1_MB);
+        RegisterResult(cache, 111, 2_MB, 1_MB);
+        RegisterResult(cache, 222, 100_MB, 1_MB);
+        RegisterResult(cache, 222, 105_MB, 1_MB);
+
+        // both nodes should be present in cache
+        UNIT_ASSERT_VALUES_EQUAL(
+            Expected(111, 0, 128_KB, 0),
+            FillResult(cache, 111, 0, 128_KB));
+
+        cache.InvalidateCache(111);
+
+        // the first node should be evicted, the second should be present
+        UNIT_ASSERT_VALUES_EQUAL(
+            Expected(222, 100_MB, 128_KB, 0),
+            FillResult(cache, 222, 100_MB, 128_KB));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
typo fix causing entire cache eviction: `hashmap.clear(size_t)` is a clear with a downsize hint