### PR TITLE
issue-1146: allow other operations to complete during noderefs loading

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -909,6 +909,7 @@ STFUNC(TIndexTabletActor::StateBoot)
         IgnoreFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters);
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 
@@ -948,6 +949,9 @@ STFUNC(TIndexTabletActor::StateInit)
         HFunc(
             TEvIndexTabletPrivate::TEvShardRequestCompleted,
             HandleShardRequestCompleted);
+        HFunc(
+            TEvIndexTabletPrivate::TEvLoadNodeRefsRequest,
+            HandleLoadNodeRefsRequest);
 
         FILESTORE_HANDLE_REQUEST(WaitReady, TEvIndexTablet)
 
@@ -995,6 +999,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(
             TEvIndexTabletPrivate::TEvShardRequestCompleted,
             HandleShardRequestCompleted);
+        HFunc(
+            TEvIndexTabletPrivate::TEvLoadNodeRefsRequest,
+            HandleLoadNodeRefsRequest);
 
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
@@ -1042,6 +1049,7 @@ STFUNC(TIndexTabletActor::StateZombie)
 
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
 
         IgnoreFunc(TEvIndexTabletPrivate::TEvReadDataCompleted);
         IgnoreFunc(TEvIndexTabletPrivate::TEvWriteDataCompleted);
@@ -1086,6 +1094,7 @@ STFUNC(TIndexTabletActor::StateBroken)
         IgnoreFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters);
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
 
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -722,6 +722,10 @@ private:
         const TEvIndexTabletPrivate::TEvForcedRangeOperationProgress::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleLoadNodeRefsRequest(
+        const TEvIndexTabletPrivate::TEvLoadNodeRefsRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleNodeCreatedInShard(
         const TEvIndexTabletPrivate::TEvNodeCreatedInShard::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -311,7 +311,15 @@ void TIndexTabletActor::CompleteTx_LoadState(
     if (Config->GetInMemoryIndexCacheEnabled() &&
         Config->GetInMemoryIndexCacheLoadOnTabletStart())
     {
-        LoadNodeRefs(ctx, 0, "");
+        const ui64 maxNodeRefs =
+            Config->GetInMemoryIndexCacheLoadOnTabletStartRowsPerTx();
+
+        ctx.Send(
+            SelfId(),
+            new TEvIndexTabletPrivate::TEvLoadNodeRefsRequest(
+                0,
+                "",
+                maxNodeRefs));
     }
 
     ScheduleSyncSessions(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_noderefs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_noderefs.cpp
@@ -71,7 +71,6 @@ void TIndexTabletActor::CompleteTx_LoadNodeRefs(
                 args.NextNodeId,
                 args.NextCookie,
                 args.MaxNodeRefs));
-
     } else {
         LOG_INFO(
             ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -525,6 +525,26 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // LoadNodeRefs
+    //
+
+    struct TLoadNodeRefsRequest
+    {
+        const ui64 NodeId;
+        const TString Cookie;
+        const ui32 MaxNodeRefs;
+
+        TLoadNodeRefsRequest(
+                ui64 nodeId,
+                TString cookie,
+                ui32 maxNodeRefs)
+            : NodeId(nodeId)
+            , Cookie(std::move(cookie))
+            , MaxNodeRefs(maxNodeRefs)
+        {}
+    };
+
+    //
     // ForcedRangeOperation
     //
 
@@ -858,6 +878,8 @@ struct TEvIndexTabletPrivate
 
         EvShardRequestCompleted,
 
+        EvLoadNodeRefs,
+
         EvEnd
     };
 
@@ -896,6 +918,9 @@ struct TEvIndexTabletPrivate
 
     using TEvShardRequestCompleted =
         TResponseEvent<TEmpty, EvShardRequestCompleted>;
+
+    using TEvLoadNodeRefsRequest =
+        TRequestEvent<TLoadNodeRefsRequest, EvLoadNodeRefs>;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -2111,8 +2111,6 @@ struct TTxIndexTablet
 
     struct TLoadNodeRefs: TIndexStateNodeUpdates
     {
-        // actually unused, needed in tablet_tx.h to avoid sophisticated
-        // template tricks
         const TRequestInfoPtr RequestInfo;
 
         const ui64 NodeId;
@@ -2123,10 +2121,12 @@ struct TTxIndexTablet
         TString NextCookie;
 
         TLoadNodeRefs(
+                TRequestInfoPtr requestInfo,
                 ui64 nodeId,
                 TString cookie,
                 ui64 maxNodeRefs)
-            : NodeId(nodeId)
+            : RequestInfo(std::move(requestInfo))
+            , NodeId(nodeId)
             , Cookie(std::move(cookie))
             , MaxNodeRefs(maxNodeRefs)
         {}

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
@@ -919,6 +919,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesCache)
         storageConfig.SetInMemoryIndexCacheNodesCapacity(100);
         storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(100);
         storageConfig.SetInMemoryIndexCacheLoadOnTabletStart(true);
+        storageConfig.SetInMemoryIndexCacheLoadOnTabletStartRowsPerTx(1);
         TTestEnv env({}, storageConfig);
         env.CreateSubDomain("nfs");
 
@@ -939,6 +940,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesCache)
 
         tablet.RebootTablet();
         tablet.InitSession("client", "session");
+
+        // It will take 3 iterations to load all the nodes
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            env.GetRuntime().GetCounter(
+                TEvIndexTabletPrivate::EEvents::EvLoadNodeRefs));
 
         auto statsBefore = GetTxStats(env, tablet);
 


### PR DESCRIPTION
References #1146
Fixes after https://github.com/ydb-platform/nbs/pull/2241

Earlier LoadNodeRefs executed transaction that upon completion immediately executed transaction for the next batch. In this approach there were no gaps allowing for a concurrent operation to complete. In this PR this issue is resolved by sending messages to trigger another batch loading