### PR TITLE
[Filestore] issue-2806: support multiple aio engines in local filestore

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -32,6 +32,7 @@
 #include <cloud/filestore/libs/vfs/probes.h>
 #include <cloud/filestore/libs/vhost/server.h>
 
+#include <cloud/storage/core/libs/aio/service.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
@@ -285,6 +286,7 @@ void TBootstrapVhost::InitEndpoints()
         auto serviceConfig = std::make_shared<TLocalFileStoreConfig>(
             *localServiceConfig);
         ThreadPool = CreateThreadPool("svc", serviceConfig->GetNumThreads());
+        FileIOService = CreateThreadedAIOService(serviceConfig->GetNumThreads());
         LocalService = CreateLocalFileStore(
             std::move(serviceConfig),
             Timer,

--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -19,7 +19,7 @@ constexpr TDuration AsyncHandleOpsPeriod = TDuration::MilliSeconds(50);
     xxx(PathPrefix,                  TString,       "nfs_"                    )\
     xxx(DefaultPermissions,          ui32,          0775                      )\
     xxx(IdleSessionTimeout,          TDuration,     TDuration::Seconds(30)    )\
-    xxx(NumThreads,                  ui32,          4                         )\
+    xxx(NumThreads,                  ui32,          8                         )\
     xxx(StatePath,                   TString,       "./"                      )\
     xxx(MaxNodeCount,                ui32,          1000000                   )\
     xxx(MaxHandlePerSessionCount,    ui32,          10000                     )\

--- a/cloud/filestore/libs/service_local/service.cpp
+++ b/cloud/filestore/libs/service_local/service.cpp
@@ -207,7 +207,9 @@ public:
         std::shared_ptr<NProto::T##name##Request> request) override            \
     {                                                                          \
         Y_UNUSED(callContext);                                                 \
-        return ExecuteWithProfileLogAsync<T##name##Method>(*request);          \
+        return TaskQueue->Execute([this, request = std::move(request)] {       \
+            return ExecuteWithProfileLogAsync<T##name##Method>(*request);      \
+        });                                                                    \
     }                                                                          \
 // FILESTORE_IMPLEMENT_METHOD_ASYNC
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -474,7 +474,8 @@ private:
     {
         STORAGE_INFO("starting FUSE loop");
 
-        ::NCloud::SetCurrentThreadName("FUSE");
+        static std::atomic<ui64> index = 0;
+        ::NCloud::SetCurrentThreadName("FUSE" + ToString(index++));
 
         AtomicSet(ThreadId, pthread_self());
         fuse_session_loop(Session);

--- a/cloud/storage/core/libs/aio/service.cpp
+++ b/cloud/storage/core/libs/aio/service.cpp
@@ -6,9 +6,9 @@
 
 #include <util/stream/file.h>
 #include <util/string/builder.h>
+#include <util/string/cast.h>
 #include <util/system/file.h>
 #include <util/system/thread.h>
-#include <util/string/cast.h>
 
 #include <atomic>
 
@@ -263,6 +263,8 @@ private:
 public:
     TThreadedAIOService(ui32 threadCount, size_t maxEvents)
     {
+        Y_ABORT_UNLESS(threadCount > 0);
+
         for (ui32 i = 0; i < threadCount; i++) {
             IoServices.push_back(CreateAIOService(maxEvents));
         }
@@ -292,14 +294,14 @@ public:
 
     void Start() override
     {
-        for (auto& ioService : IoServices) {
+        for (auto& ioService: IoServices) {
             ioService->Start();
         }
     }
 
     void Stop() override
     {
-        for (auto& ioService : IoServices) {
+        for (auto& ioService: IoServices) {
             ioService->Stop();
         }
     }

--- a/cloud/storage/core/libs/aio/service.h
+++ b/cloud/storage/core/libs/aio/service.h
@@ -8,4 +8,6 @@ namespace NCloud {
 
 IFileIOServicePtr CreateAIOService(size_t maxEvents = 1024);
 
+IFileIOServicePtr CreateThreadedAIOService(ui32 threadCount, size_t maxEvents = 1024);
+
 }   // namespace NCloud


### PR DESCRIPTION
#2806 

Additionally dispatch async read/write into thread pool and increase default
number of worker threads to 8
