### PR TITLE
issue-1146: load nodes upon the tablet startup as well

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -910,6 +910,7 @@ STFUNC(TIndexTabletActor::StateBoot)
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodesRequest);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 
@@ -952,6 +953,9 @@ STFUNC(TIndexTabletActor::StateInit)
         HFunc(
             TEvIndexTabletPrivate::TEvLoadNodeRefsRequest,
             HandleLoadNodeRefsRequest);
+        HFunc(
+            TEvIndexTabletPrivate::TEvLoadNodesRequest,
+            HandleLoadNodesRequest);
 
         FILESTORE_HANDLE_REQUEST(WaitReady, TEvIndexTablet)
 
@@ -1002,6 +1006,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(
             TEvIndexTabletPrivate::TEvLoadNodeRefsRequest,
             HandleLoadNodeRefsRequest);
+        HFunc(
+            TEvIndexTabletPrivate::TEvLoadNodesRequest,
+            HandleLoadNodesRequest);
 
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
@@ -1050,6 +1057,7 @@ STFUNC(TIndexTabletActor::StateZombie)
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodesRequest);
 
         IgnoreFunc(TEvIndexTabletPrivate::TEvReadDataCompleted);
         IgnoreFunc(TEvIndexTabletPrivate::TEvWriteDataCompleted);
@@ -1095,6 +1103,7 @@ STFUNC(TIndexTabletActor::StateBroken)
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodesRequest);
 
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -476,17 +476,6 @@ private:
 
     TVector<ui32> GenerateForceDeleteZeroCompactionRanges() const;
 
-    /**
-     * @brief If necessary, code can iteratively call ReadNodeRefs for all
-     * nodes. This will populate cache with node refs and allow us to perform
-     * ListNodes using in-memory index state by knowing that the nodeRefs cache
-     * is exhaustive.
-     */
-    void LoadNodeRefs(
-        const NActors::TActorContext& ctx,
-        ui64 nodeId,
-        const TString& name);
-
     void AddTransaction(
         TRequestInfo& transaction,
         TRequestInfo::TCancelRoutine cancelRoutine);
@@ -724,6 +713,10 @@ private:
 
     void HandleLoadNodeRefsRequest(
         const TEvIndexTabletPrivate::TEvLoadNodeRefsRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleLoadNodesRequest(
+        const TEvIndexTabletPrivate::TEvLoadNodesRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleNodeCreatedInShard(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -311,15 +311,23 @@ void TIndexTabletActor::CompleteTx_LoadState(
     if (Config->GetInMemoryIndexCacheEnabled() &&
         Config->GetInMemoryIndexCacheLoadOnTabletStart())
     {
-        const ui64 maxNodeRefs =
+        const ui64 maxRows =
             Config->GetInMemoryIndexCacheLoadOnTabletStartRowsPerTx();
 
+        // If necessary, code can iteratively call ReadNodeRefs for all nodes.
+        // This will populate cache with node refs and allow us to perform
+        // ListNodes using in-memory index state by knowing that the nodeRefs
+        // cache is exhaustive
         ctx.Send(
             SelfId(),
-            new TEvIndexTabletPrivate::TEvLoadNodeRefsRequest(
-                0,
-                "",
-                maxNodeRefs));
+            new TEvIndexTabletPrivate::TEvLoadNodeRefsRequest(0, "", maxRows));
+
+        // Same logic is performed for batch loading nodes as well. The only
+        // difference is that we do not need to keep track of the exhaustiveness
+        // of the cache
+        ctx.Send(
+            SelfId(),
+            new TEvIndexTabletPrivate::TEvLoadNodesRequest(0, maxRows));
     }
 
     ScheduleSyncSessions(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_nodes.cpp
@@ -1,0 +1,100 @@
+#include "tablet_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::ValidateTx_LoadNodes(
+    const TActorContext& ctx,
+    TTxIndexTablet::TLoadNodes& args)
+{
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s LoadingNodes (nodeId: %lu, maxNodes: %lu)",
+        LogTag.c_str(),
+        args.NodeId,
+        args.MaxNodes);
+    return true;
+}
+
+bool TIndexTabletActor::PrepareTx_LoadNodes(
+    const TActorContext& ctx,
+    IIndexTabletDatabase& db,
+    TTxIndexTablet::TLoadNodes& args)
+{
+    Y_UNUSED(ctx, db, args);
+    TVector<TIndexTabletDatabase::TNode> nodes;
+
+    bool ready =
+        db.ReadNodes(args.NodeId, args.MaxNodes, args.NextNodeId, nodes);
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s LoadingNodes (nodeId: %lu, maxNodes: %lu), read %lu nodes: %s",
+        LogTag.c_str(),
+        args.NodeId,
+        args.MaxNodes,
+        nodes.size(),
+        ready ? "finished" : "restarted");
+
+    return ready;
+}
+
+void TIndexTabletActor::CompleteTx_LoadNodes(
+    const TActorContext& ctx,
+    TTxIndexTablet::TLoadNodes& args)
+{
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s LoadNodes iteration completed, next nodeId: %lu",
+        LogTag.c_str(),
+        args.NextNodeId);
+
+    if (args.NextNodeId) {
+        ctx.Send(
+            SelfId(),
+            new TEvIndexTabletPrivate::TEvLoadNodesRequest(
+                args.NextNodeId,
+                args.MaxNodes));
+    } else {
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s LoadNodes completed",
+            LogTag.c_str());
+    }
+}
+
+// ////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleLoadNodesRequest(
+    const TEvIndexTabletPrivate::TEvLoadNodesRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s LoadNodes iteration started (nodeId: %lu, maxNodes: %lu)",
+        LogTag.c_str(),
+        msg->NodeId,
+        msg->MaxNodes);
+
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
+
+    ExecuteTx<TLoadNodes>(
+        ctx,
+        std::move(requestInfo),
+        msg->NodeId,
+        msg->MaxNodes);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -109,6 +109,11 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 nodeId,
         ui64 commitId,
         TMaybe<IIndexTabletDatabase::TNode>& node) override;
+    virtual bool ReadNodes(
+        ui64 startNodeId,
+        ui64 maxNodes,
+        ui64& nextNodeId,
+        TVector<IIndexTabletDatabase::TNode>& nodes) override;
 
     //
     // Nodes_Ver
@@ -553,6 +558,12 @@ public:
         ui64 nodeId,
         ui64 commitId,
         TMaybe<IIndexTabletDatabase::TNode>& node) final;
+
+    bool ReadNodes(
+        ui64 startNodeId,
+        ui64 maxNodes,
+        ui64& nextNodeId,
+        TVector<IIndexTabletDatabase::TNode>& nodes) final;
 
     void WriteNode(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -545,6 +545,23 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // LoadNodes
+    //
+
+    struct TLoadNodesRequest
+    {
+        const ui64 NodeId;
+        const ui32 MaxNodes;
+
+        TLoadNodesRequest(
+                ui64 nodeId,
+                ui32 maxNodes)
+            : NodeId(nodeId)
+            , MaxNodes(maxNodes)
+        {}
+    };
+
+    //
     // ForcedRangeOperation
     //
 
@@ -879,6 +896,7 @@ struct TEvIndexTabletPrivate
         EvShardRequestCompleted,
 
         EvLoadNodeRefs,
+        EvLoadNodes,
 
         EvEnd
     };
@@ -921,6 +939,9 @@ struct TEvIndexTabletPrivate
 
     using TEvLoadNodeRefsRequest =
         TRequestEvent<TLoadNodeRefsRequest, EvLoadNodeRefs>;
+
+    using TEvLoadNodesRequest =
+        TRequestEvent<TLoadNodesRequest, EvLoadNodes>;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -82,6 +82,18 @@ bool TInMemoryIndexState::ReadNode(
     return true;
 }
 
+bool TInMemoryIndexState::ReadNodes(
+    ui64 startNodeId,
+    ui64 maxNodes,
+    ui64& nextNodeId,
+    TVector<TNode>& nodes)
+{
+    Y_UNUSED(startNodeId, maxNodes, nextNodeId, nodes);
+    // TInMemoryIndexState is a preemptive cache, thus it is impossible to
+    // determine, whether the set of stored nodes is complete.
+    return false;
+}
+
 void TInMemoryIndexState::WriteNode(
     ui64 nodeId,
     ui64 commitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -52,6 +52,12 @@ public:
         ui64 commitId,
         TMaybe<IIndexTabletDatabase::TNode>& node) override;
 
+    bool ReadNodes(
+        ui64 startNodeId,
+        ui64 maxNodes,
+        ui64& nextNodeId,
+        TVector<IIndexTabletDatabase::TNode>& nodes) override;
+
 private:
     void WriteNode(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -58,6 +58,12 @@ public:
 
     virtual bool ReadNode(ui64 nodeId, ui64 commitId, TMaybe<TNode>& node) = 0;
 
+    virtual bool ReadNodes(
+        ui64 startNodeId,
+        ui64 maxNodes,
+        ui64& nextNodeId,
+        TVector<TNode>& nodes) = 0;
+
     //
     // Nodes_Ver
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -79,6 +79,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(UnsafeGetNode,                      __VA_ARGS__)                       \
                                                                                \
     xxx(LoadNodeRefs,                       __VA_ARGS__)                       \
+    xxx(LoadNodes,                          __VA_ARGS__)                       \
 // FILESTORE_TABLET_RO_TRANSACTIONS
 
 #define FILESTORE_TABLET_RW_TRANSACTIONS(xxx, ...)                             \
@@ -2102,13 +2103,13 @@ struct TTxIndexTablet
         }
     };
 
+    // The whole point of these transactions is to observe some data in NodeRefs
+    // and Nodes tables and populate the contents of TIndexStateNodeUpdates with
+    // it
+
     //
     // LoadNodeRefs
     //
-
-    // The whole point of this transaction is to observe some data in the
-    // NodeRefs table and populate the contents of TIndexStateNodeUpdates with it
-
     struct TLoadNodeRefs: TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
@@ -2137,6 +2138,34 @@ struct TTxIndexTablet
 
             NextNodeId = 0;
             NextCookie.clear();
+        }
+    };
+
+    //
+    // LoadNodes
+    //
+
+    struct TLoadNodes: TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const ui64 NodeId;
+        const ui64 MaxNodes;
+
+        ui64 NextNodeId = 0;
+
+        TLoadNodes(
+                TRequestInfoPtr requestInfo,
+                ui64 nodeId,
+                ui64 maxNodes)
+            : RequestInfo(std::move(requestInfo))
+            , NodeId(nodeId)
+            , MaxNodes(maxNodes)
+        {}
+
+        void Clear()
+        {
+            TIndexStateNodeUpdates::Clear();
+            NextNodeId = 0;
         }
     };
 };

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -47,6 +47,7 @@ SRCS(
     tablet_actor_listnodexattr.cpp
     tablet_actor_loadstate.cpp
     tablet_actor_loadstate_noderefs.cpp
+    tablet_actor_loadstate_nodes.cpp
     tablet_actor_monitoring.cpp
     tablet_actor_oplog.cpp
     tablet_actor_readblob.cpp


### PR DESCRIPTION
References #1146 
Similar to #2241: Upon the filestore index tablet startup load not only NodeRefs table to the in-memory cache, but Nodes table as well