### PR TITLE
issue-2674: filestore-client ln command + support for RenameNode, UnlinkNode + basic support for RenameNode in filesystems with directories in shards

### DIFF
--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -532,6 +532,20 @@ NProto::TListNodesResponse TFileStoreCommand::ListAll(
     return fullResult;
 }
 
+TString TFileStoreCommand::ReadLink(ISession& session, ui64 nodeId)
+{
+    auto request = CreateRequest<NProto::TReadLinkRequest>();
+    request->SetNodeId(nodeId);
+
+    auto response = WaitFor(session.ReadLink(
+        PrepareCallContext(),
+        std::move(request)));
+
+    CheckResponse(response);
+
+    return response.GetSymLink();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TEndpointCommand::TEndpointCommand()

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -198,6 +198,7 @@ protected:
         const TString& fsId,
         ui64 parentId,
         bool disableMultiTabletForwarding);
+    TString ReadLink(ISession& session, ui64 nodeId);
 
     class TSessionGuard final
     {

--- a/cloud/filestore/apps/client/lib/diff.cpp
+++ b/cloud/filestore/apps/client/lib/diff.cpp
@@ -183,6 +183,17 @@ public:
                 DumpLine(RDiff() + "DATA: ", rhash);
             }
         }
+
+        if (lattr.GetType() == NProto::E_LINK_NODE
+                && rattr.GetType() == NProto::E_LINK_NODE)
+        {
+            const auto lcontent = ReadLink(lsession, lattr.GetId());
+            const auto rcontent = ReadLink(rsession, rattr.GetId());
+            if (lcontent != rcontent) {
+                DumpLine(LDiff() + "LINK: ", lcontent);
+                DumpLine(RDiff() + "LINK: ", rcontent);
+            }
+        }
     }
 
     bool Execute() override

--- a/cloud/filestore/apps/client/lib/factory.cpp
+++ b/cloud/filestore/apps/client/lib/factory.cpp
@@ -17,6 +17,7 @@ TCommandPtr NewKickEndpointCommand();
 TCommandPtr NewListClusterNodesCommand();
 TCommandPtr NewListEndpointsCommand();
 TCommandPtr NewListFileStoresCommand();
+TCommandPtr NewLnCommand();
 TCommandPtr NewLsCommand();
 TCommandPtr NewMkDirCommand();
 TCommandPtr NewMountCommand();
@@ -61,6 +62,7 @@ static const TMap<TString, TFactoryFunc> Commands = {
     { "listclusternodes", NewListClusterNodesCommand },
     { "listendpoints", NewListEndpointsCommand },
     { "listfilestores", NewListFileStoresCommand },
+    { "ln", NewLnCommand },
     { "ls", NewLsCommand },
     { "mkdir", NewMkDirCommand },
     { "mount", NewMountCommand },

--- a/cloud/filestore/apps/client/lib/ln.cpp
+++ b/cloud/filestore/apps/client/lib/ln.cpp
@@ -1,0 +1,67 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/fs.pb.h>
+
+#include <util/stream/file.h>
+#include <util/system/sysstat.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLnCommand final
+    : public TFileStoreCommand
+{
+private:
+    TString Path;
+    TString SymLink;
+
+public:
+    TLnCommand()
+    {
+        Opts.AddLongOption("path")
+            .Required()
+            .RequiredArgument("PATH")
+            .StoreResult(&Path);
+
+        Opts.AddLongOption("symlink")
+            .Required()
+            .RequiredArgument("PATH")
+            .StoreResult(&SymLink);
+    }
+
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto resolved = ResolvePath(session, Path, true);
+
+        Y_ENSURE(resolved.size() >= 2, "root node can't be ln target");
+
+        auto request = CreateRequest<NProto::TCreateNodeRequest>();
+        request->SetNodeId(resolved[resolved.size() - 2].Node.GetId());
+        request->SetName(TString(resolved.back().Name));
+        request->MutableSymLink()->SetTargetPath(SymLink);
+
+        auto response = WaitFor(session.CreateNode(
+            PrepareCallContext(),
+            std::move(request)));
+
+        CheckResponse(response);
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewLnCommand()
+{
+    return std::make_shared<TLnCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/ya.make
+++ b/cloud/filestore/apps/client/lib/ya.make
@@ -20,6 +20,7 @@ SRCS(
     list_cluster_nodes.cpp
     list_endpoints.cpp
     list_filestores.cpp
+    ln.cpp
     ls.cpp
     mkdir.cpp
     mount.cpp

--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -31,9 +31,6 @@ namespace NCloud::NFileStore::NStorage {
     xxx(DestroyCheckpoint,                  __VA_ARGS__)                       \
                                                                                \
     xxx(ResolvePath,                        __VA_ARGS__)                       \
-    xxx(UnlinkNode,                         __VA_ARGS__)                       \
-    xxx(RenameNode,                         __VA_ARGS__)                       \
-    xxx(ReadLink,                           __VA_ARGS__)                       \
                                                                                \
 // FILESTORE_SERVICE_REQUESTS_FWD
 
@@ -44,6 +41,10 @@ namespace NCloud::NFileStore::NStorage {
     xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
     xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
     xxx(RemoveNodeXAttr,                    __VA_ARGS__)                       \
+                                                                               \
+    xxx(UnlinkNode,                         __VA_ARGS__)                       \
+    xxx(RenameNode,                         __VA_ARGS__)                       \
+    xxx(ReadLink,                           __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_FWD_TO_SHARD_BY_NODE_ID
 
 #define FILESTORE_SERVICE_REQUESTS_FWD_TO_SHARD_BY_HANDLE(xxx, ...)            \

--- a/cloud/filestore/tests/client_sharded_dir/canondata/test.test_nonsharded_vs_sharded_fs/results.txt
+++ b/cloud/filestore/tests/client_sharded_dir/canondata/test.test_nonsharded_vs_sharded_fs/results.txt
@@ -22,4 +22,5 @@
         "ShardFileSystemId": "masked_for_test_stability",
         "Name": "a1"
     }
-]
+][22;31m-	LINK: [0m[0;39m/does/not/matter/2
+[22;32m+	LINK: [0m[0;39m/does/not/matter/3

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -354,6 +354,10 @@ class FilestoreCliClient:
     def rm(self, cmd):
         return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
 
+    @standard_command("ln")
+    def ln(self, cmd):
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
 
 def create_endpoint(client, filesystem, socket_path, socket_prefix, endpoint_storage_dir, mount_seqno=0, readonly=False):
     _uid = str(uuid.uuid4())


### PR DESCRIPTION
#2674 