### PR TITLE
NBSDUTY-214: fix ShouldReportSufferMetrics test (add warmup timer)

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -10,6 +10,7 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/metrics/metric_consumer.h>
 #include <library/cpp/monlib/metrics/metric_registry.h>
+#include <library/cpp/testing/hook/hook.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/datetime/cputimer.h>
@@ -83,6 +84,12 @@ void Mount(
 
 Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 {
+    Y_TEST_HOOK_BEFORE_RUN(InitTest)
+    {
+        // NHPTimer warmup, see issue #2830 for more information
+        Y_UNUSED(GetCyclesPerMillisecond());
+    }
+
     Y_UNIT_TEST(ShouldTrackRequestsPerVolume)
     {
         auto monitoring = CreateMonitoringServiceStub();
@@ -625,8 +632,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         const TVector<TString>& strictSLACloudIds,
         bool reportStrictSLA)
     {
-        // NHPTimer warmup, see issue #2830 for more information
-        Y_UNUSED(GetCyclesPerMillisecond());
 
         auto inactivityTimeout = TDuration::MilliSeconds(10);
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -632,7 +632,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         const TVector<TString>& strictSLACloudIds,
         bool reportStrictSLA)
     {
-
         auto inactivityTimeout = TDuration::MilliSeconds(10);
 
         auto monitoring = CreateMonitoringServiceStub();

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -625,8 +625,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         const TVector<TString>& strictSLACloudIds,
         bool reportStrictSLA)
     {
-        auto warmupTimer = GetCyclesPerMillisecond();
-        Y_UNUSED(warmupTimer);
+        // warming up NHPTimer, see issue #2830 for more info
+        Y_UNUSED(GetCyclesPerMillisecond());
 
         auto inactivityTimeout = TDuration::MilliSeconds(10);
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -625,7 +625,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         const TVector<TString>& strictSLACloudIds,
         bool reportStrictSLA)
     {
-        // warming up NHPTimer, see issue #2830 for more info
+        // NHPTimer warmup, see issue #2830 for more information
         Y_UNUSED(GetCyclesPerMillisecond());
 
         auto inactivityTimeout = TDuration::MilliSeconds(10);

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -625,6 +625,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         const TVector<TString>& strictSLACloudIds,
         bool reportStrictSLA)
     {
+        auto warmupTimer = GetCyclesPerMillisecond();
+        Y_UNUSED(warmupTimer);
+
         auto inactivityTimeout = TDuration::MilliSeconds(10);
 
         auto monitoring = CreateMonitoringServiceStub();

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -681,8 +681,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
     Y_UNIT_TEST(ShouldReportHistogramAsMultipleSensors)
     {
-        auto warmupTimer = GetCyclesPerMillisecond();
-        Y_UNUSED(warmupTimer);
+        // warming up NHPTimer, see issue #2830 for more info
+        Y_UNUSED(GetCyclesPerMillisecond());
 
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = MakeRequestCountersPtr(
@@ -722,8 +722,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
     Y_UNIT_TEST(ShouldReportHistogramAsSingleSensor)
     {
-        auto warmupTimer = GetCyclesPerMillisecond();
-        Y_UNUSED(warmupTimer);
+        // warming up NHPTimer, see issue #2830 for more info
+        Y_UNUSED(GetCyclesPerMillisecond());
 
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = MakeRequestCountersPtr(

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -726,9 +726,6 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
     Y_UNIT_TEST(ShouldReportHistogramAsSingleSensor)
     {
-        // NHPTimer warmup, see issue #2830 for more information
-        Y_UNUSED(GetCyclesPerMillisecond());
-
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = MakeRequestCountersPtr(
             TRequestCounters::EOption::ReportDataPlaneHistogram,

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -7,6 +7,7 @@
 #include "cloud/storage/core/libs/diagnostics/histogram_types.h"
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/hook/hook.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/datetime/cputimer.h>
@@ -131,6 +132,12 @@ auto MakeRequestCountersPtr(
 
 Y_UNIT_TEST_SUITE(TRequestCountersTest)
 {
+    Y_TEST_HOOK_BEFORE_RUN(InitTest)
+    {
+        // NHPTimer warmup, see issue #2830 for more information
+        Y_UNUSED(GetCyclesPerMillisecond());
+    }
+
     Y_UNIT_TEST(ShouldTrackRequestsInProgress)
     {
         auto monitoring = CreateMonitoringServiceStub();
@@ -681,9 +688,6 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
     Y_UNIT_TEST(ShouldReportHistogramAsMultipleSensors)
     {
-        // NHPTimer warmup, see issue #2830 for more information
-        Y_UNUSED(GetCyclesPerMillisecond());
-
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = MakeRequestCountersPtr(
             TRequestCounters::EOption::ReportDataPlaneHistogram,

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -681,7 +681,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
     Y_UNIT_TEST(ShouldReportHistogramAsMultipleSensors)
     {
-        // warming up NHPTimer, see issue #2830 for more info
+        // NHPTimer warmup, see issue #2830 for more information
         Y_UNUSED(GetCyclesPerMillisecond());
 
         auto monitoring = CreateMonitoringServiceStub();
@@ -722,7 +722,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
     Y_UNIT_TEST(ShouldReportHistogramAsSingleSensor)
     {
-        // warming up NHPTimer, see issue #2830 for more info
+        // NHPTimer warmup, see issue #2830 for more information
         Y_UNUSED(GetCyclesPerMillisecond());
 
         auto monitoring = CreateMonitoringServiceStub();


### PR DESCRIPTION
Test fails due to long timer initialization resulting in erroneous measurement of the request times
https://github.com/ydb-platform/nbs/blob/aaac99648c06e24c3f158b8373c97e7381a79edd/util/system/hp_timer.cpp#L105

#2830 