### PR TITLE
issue-2674: cross-shard RenameNode implementation

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -31,6 +31,9 @@ namespace NCloud::NFileStore{
     xxx(LocalFsMissingHandleNode)                                              \
     xxx(ShardStatsRetrievalTimeout)                                            \
     xxx(CreateNodeRequestResponseMismatchInShard)                              \
+    xxx(RenameNodeRequestSentToWrongShard)                                     \
+    xxx(RenameNodeRequestForLocalNode)                                         \
+    xxx(InvalidShardNo)                                                        \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \
@@ -47,6 +50,8 @@ namespace NCloud::NFileStore{
     xxx(IndexOutOfBounds)                                                      \
     xxx(CheckFreshBytesFailed)                                                 \
     xxx(LocalFsDuplicateFileHandle)                                            \
+    xxx(UnexpectedLocalNode)                                                   \
+    xxx(NoRenameNodeInDestinationRequest)                                      \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -52,6 +52,7 @@ namespace NCloud::NFileStore{
     xxx(LocalFsDuplicateFileHandle)                                            \
     xxx(UnexpectedLocalNode)                                                   \
     xxx(NoRenameNodeInDestinationRequest)                                      \
+    xxx(BadChildRefUponCommitRenameNodeInSource)                               \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -38,6 +38,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ForcedOperationStatus,      __VA_ARGS__)                               \
     xxx(GetFileSystemTopology,      __VA_ARGS__)                               \
     xxx(RestartTablet,              __VA_ARGS__)                               \
+    xxx(RenameNodeInDestination,    __VA_ARGS__)                               \
 // FILESTORE_TABLET_REQUESTS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -120,6 +121,9 @@ struct TEvIndexTablet
 
         EvRestartTabletRequest = EvBegin + 45,
         EvRestartTabletResponse,
+
+        EvRenameNodeInDestinationRequest = EvBegin + 47,
+        EvRenameNodeInDestinationResponse,
 
         EvEnd
     };

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -416,6 +416,7 @@ void TAlterFileStoreActor::ConfigureShards(const TActorContext& ctx)
         request->Record.SetFileSystemId(
             FileStoreConfig.ShardConfigs[i].GetFileSystemId());
         request->Record.SetShardNo(i + 1);
+        request->Record.SetMainFileSystemId(FileSystemId);
         if (StorageConfig->GetDirectoryCreationInShardsEnabled()) {
             for (const auto& shard: FileStoreConfig.ShardConfigs) {
                 request->Record.AddShardFileSystemIds(shard.GetFileSystemId());

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -207,6 +207,7 @@ void TCreateFileStoreActor::ConfigureShards(const TActorContext& ctx)
         request->Record.SetFileSystemId(
             FileStoreConfig.ShardConfigs[i].GetFileSystemId());
         request->Record.SetShardNo(i + 1);
+        request->Record.SetMainFileSystemId(Request.GetFileSystemId());
         if (StorageConfig->GetDirectoryCreationInShardsEnabled()) {
             for (const auto& shard: FileStoreConfig.ShardConfigs) {
                 request->Record.AddShardFileSystemIds(shard.GetFileSystemId());

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -47,6 +47,7 @@ message TFileSystem
     uint32 ShardNo = 14;
     bool AutomaticShardCreationEnabled = 15;
     uint64 ShardAllocationUnit = 16;
+    string MainFileSystemId = 17;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "cloud/filestore/private/api/protos/tablet.proto";
 import "cloud/filestore/public/api/protos/data.proto";
 import "cloud/filestore/public/api/protos/fs.proto";
 import "cloud/filestore/public/api/protos/locks.proto";
@@ -203,5 +204,6 @@ message TOpLogEntry
     oneof Request {
         TCreateNodeRequest CreateNodeRequest = 101;
         TUnlinkNodeRequest UnlinkNodeRequest = 102;
+        NProtoPrivate.TRenameNodeInDestinationRequest RenameNodeInDestinationRequest = 103;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/protos/ya.make
+++ b/cloud/filestore/libs/storage/tablet/protos/ya.make
@@ -7,6 +7,7 @@ SRCS(
 )
 
 PEERDIR(
+    cloud/filestore/private/api/protos
     cloud/filestore/public/api/protos
 )
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -944,6 +944,9 @@ STFUNC(TIndexTabletActor::StateInit)
             TEvIndexTabletPrivate::TEvNodeUnlinkedInShard,
             HandleNodeUnlinkedInShard);
         HFunc(
+            TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
+            HandleNodeRenamedInDestination);
+        HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
         HFunc(
@@ -993,6 +996,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(
             TEvIndexTabletPrivate::TEvNodeUnlinkedInShard,
             HandleNodeUnlinkedInShard);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
+            HandleNodeRenamedInDestination);
         HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
@@ -1069,6 +1075,9 @@ STFUNC(TIndexTabletActor::StateZombie)
             TEvIndexTabletPrivate::TEvNodeUnlinkedInShard,
             HandleNodeUnlinkedInShard);
         HFunc(
+            TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
+            HandleNodeRenamedInDestination);
+        HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);
         HFunc(
@@ -1117,6 +1126,9 @@ STFUNC(TIndexTabletActor::StateBroken)
         HFunc(
             TEvIndexTabletPrivate::TEvNodeUnlinkedInShard,
             HandleNodeUnlinkedInShard);
+        HFunc(
+            TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
+            HandleNodeRenamedInDestination);
         HFunc(
             TEvIndexTabletPrivate::TEvGetShardStatsCompleted,
             HandleGetShardStatsCompleted);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -741,6 +741,10 @@ private:
         const TEvIndexTabletPrivate::TEvNodeUnlinkedInShard::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleNodeRenamedInDestination(
+        const TEvIndexTabletPrivate::TEvNodeRenamedInDestination::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleGetShardStatsCompleted(
         const TEvIndexTabletPrivate::TEvGetShardStatsCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -612,6 +612,13 @@ private:
         ui64 opLogEntryId,
         TUnlinkNodeInShardResult result);
 
+    void RegisterRenameNodeInDestinationActor(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr requestInfo,
+        NProtoPrivate::TRenameNodeInDestinationRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId);
+
     void ReplayOpLog(
         const NActors::TActorContext& ctx,
         const TVector<NProto::TOpLogEntry>& opLog);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -461,6 +461,9 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
 {
     Y_UNUSED(ctx);
 
+    const bool isMainWithLocalNodes =
+        IsMainTablet() && GetLastNodeId() > RootNodeId;
+
     if (!BehaveAsShard(args.Request.GetHeaders())
             && Config->GetShardIdSelectionInLeaderEnabled()
             && !GetFileSystem().GetShardFileSystemIds().empty()
@@ -468,7 +471,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
                 || Config->GetDirectoryCreationInShardsEnabled()
                 // otherwise there might be some local nodes which breaks
                 // current cross-shard RenameNode implementation
-                && GetLastNodeId() == RootNodeId))
+                && !isMainWithLocalNodes))
     {
         args.Error = SelectShard(args.Attrs.GetSize(), &args.ShardId);
         if (HasError(args.Error)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -465,7 +465,10 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
             && Config->GetShardIdSelectionInLeaderEnabled()
             && !GetFileSystem().GetShardFileSystemIds().empty()
             && (args.Attrs.GetType() == NProto::E_REGULAR_NODE
-                || Config->GetDirectoryCreationInShardsEnabled()))
+                || Config->GetDirectoryCreationInShardsEnabled()
+                // otherwise there might be some local nodes which breaks
+                // current cross-shard RenameNode implementation
+                && GetLastNodeId() == RootNodeId))
     {
         args.Error = SelectShard(args.Attrs.GetSize(), &args.ShardId);
         if (HasError(args.Error)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -39,6 +39,8 @@ void TIndexTabletActor::ReplayOpLog(
                 op.GetEntryId(),
                 {} // result
             );
+        } else if (op.HasRenameNodeInDestinationRequest()) {
+            // TODO(#2674): lock SourceNodeRef, send request
         } else {
             TABLET_VERIFY_C(
                 0,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -72,6 +72,50 @@ void TIndexTabletActor::HandleRenameNode(
 
     AddTransaction<TEvService::TRenameNodeMethod>(*requestInfo);
 
+    // we have separate logic for cross-shard move ops, see the following link
+    // for more details:
+    // https://github.com/ydb-platform/nbs/issues/2674#issuecomment-2578785398
+    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
+    if (!shardIds.empty()) {
+        const auto shardNo = GetFileSystem().GetShardNo();
+        const auto parentShardNo = ExtractShardNo(msg->Record.GetNodeId());
+        if (parentShardNo != shardNo) {
+            auto message = ReportRenameNodeRequestSentToWrongShard(
+                TStringBuilder() << "RenameNode: "
+                    << msg->Record.ShortDebugString() << " received by shard "
+                    << shardNo << ", expected: " << parentShardNo);
+            auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(
+                MakeError(E_ARGUMENT, std::move(message)));
+            NCloud::Reply(ctx, *requestInfo, std::move(response));
+            return;
+        }
+
+        const auto newParentShardNo =
+            ExtractShardNo(msg->Record.GetNewParentId());
+        if (newParentShardNo > static_cast<ui32>(shardIds.size())
+                || newParentShardNo == 0)
+        {
+            auto message = ReportInvalidShardNo(
+                TStringBuilder() << "RenameNode: "
+                    << msg->Record.ShortDebugString() << " newParentShardNo: "
+                    << newParentShardNo << ", shard count: "
+                    << shardIds.size());
+            auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(
+                MakeError(E_ARGUMENT, std::move(message)));
+            NCloud::Reply(ctx, *requestInfo, std::move(response));
+            return;
+        }
+
+        if (newParentShardNo != GetFileSystem().GetShardNo()) {
+            ExecuteTx<TPrepareRenameNodeInSource>(
+                ctx,
+                std::move(requestInfo),
+                std::move(msg->Record),
+                shardIds[newParentShardNo - 1]);
+            return;
+        }
+    }
+
     ExecuteTx<TRenameNode>(
         ctx,
         std::move(requestInfo),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -1,0 +1,327 @@
+#include "tablet_actor.h"
+
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError ValidateRequest(
+    const NProtoPrivate::TRenameNodeInDestinationRequest& request)
+{
+    Y_UNUSED(request);
+
+    return {};
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleRenameNodeInDestination(
+    const TEvIndexTablet::TEvRenameNodeInDestinationRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    using TMethod = TEvIndexTablet::TRenameNodeInDestinationMethod;
+    auto* session = AcceptRequest<TMethod>(ev, ctx, ValidateRequest);
+    if (!session) {
+        return;
+    }
+
+    auto* msg = ev->Get();
+    // TODO(#2674): DupCache
+    // DupCache is necessary not only to implement the non-idempotent checks
+    // but to prevent the following race:
+    // 1. source directory shard sends RenameNodeInDestinationRequest
+    // 2. the request is successfully processed
+    // 3. network connectivity breaks, source directory shard gets E_REJECTED
+    // 4. meanwhile <NewParentNodeId, NewChildName> pair gets unlinked in the
+    //  destination shard and then a completely new file is created under the
+    //  same name in NewParentId
+    // 5. source directory shard retries the RenameNodeInDestinationRequest
+    //  leading to the deletion of the file created in p.4 and the
+    //  <NewParentNodeId, NewChildName> now points to the file unlinked in p.4
+    //  So both the new and the old file are now deleted plus we have a NodeRef
+    //  pointing to a deleted file
+    /*
+    const auto requestId = GetRequestId(msg->Record);
+    if (const auto* e = session->LookupDupEntry(requestId)) {
+        auto response = std::make_unique<TMethod::TResponse>();
+        if (GetDupCacheEntry(e, response->Record)) {
+            return NCloud::Reply(ctx, *ev, std::move(response));
+        }
+
+        session->DropDupEntry(requestId);
+    }
+    */
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
+
+    AddTransaction<TMethod>(*requestInfo);
+
+    ExecuteTx<TRenameNodeInDestination>(
+        ctx,
+        std::move(requestInfo),
+        std::move(msg->Record));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TRenameNodeInDestination& args)
+{
+    Y_UNUSED(ctx);
+
+    // TODO(#2674): DupCache
+    // FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
+
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GetCurrentCommitId();
+
+    // validate new parent node exists
+    if (!ReadNode(
+            db,
+            args.NewParentNodeId,
+            args.CommitId,
+            args.NewParentNode))
+    {
+        return false;   // not ready
+    }
+
+    if (!args.NewParentNode) {
+        args.Error = ErrorInvalidTarget(args.NewParentNodeId, args.NewName);
+        return true;
+    }
+
+    // TODO: AccessCheck
+
+    // check if new ref exists
+    if (!ReadNodeRef(
+            db,
+            args.NewParentNodeId,
+            args.CommitId,
+            args.NewName,
+            args.NewChildRef))
+    {
+        return false;   // not ready
+    }
+
+    if (args.NewChildRef) {
+        if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_NOREPLACE)) {
+            args.Error = ErrorAlreadyExists(args.NewName);
+            return true;
+        }
+
+        if (args.NewChildRef->ShardId.empty()) {
+            auto message = ReportRenameNodeRequestForLocalNode(TStringBuilder()
+                << "RenameNodeInDestination: "
+                << args.Request.ShortDebugString());
+            args.Error = MakeError(E_ARGUMENT, std::move(message));
+            return true;
+        }
+
+        // oldpath and newpath are existing hard links to the same file, then
+        // rename() does nothing
+        const bool isSameExternalNode =
+            args.Request.GetSourceNodeShardId() == args.NewChildRef->ShardId
+            && args.Request.GetSourceNodeShardNodeName()
+                == args.NewChildRef->ShardNodeName;
+        if (isSameExternalNode) {
+            args.Error = MakeError(S_ALREADY, "is the same file");
+            return true;
+        }
+
+        // EXCHANGE allows to rename any nodes
+        if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
+            return true;
+        }
+
+        // TODO(#2674): implement this check - will need to make a GetNodeAttr
+        // call to find out node types
+        // oldpath directory: newpath must either not exist, or it must specify
+        // an empty directory.
+    } else if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
+        args.Error = ErrorInvalidTarget(args.NewParentNodeId, args.NewName);
+        return true;
+    }
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TRenameNodeInDestination& args)
+{
+    FILESTORE_VALIDATE_TX_ERROR(RenameNode, args);
+    if (args.Error.GetCode() == S_ALREADY) {
+        return; // nothing to do
+    }
+
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GenerateCommitId();
+    if (args.CommitId == InvalidCommitId) {
+        return RebootTabletOnCommitOverflow(ctx, "RenameNode");
+    }
+
+    if (args.NewChildRef) {
+        if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
+            // remove existing target ref
+            RemoveNodeRef(
+                db,
+                args.NewParentNodeId,
+                args.NewChildRef->MinCommitId,
+                args.CommitId,
+                args.NewName,
+                args.NewChildRef->NodeId,
+                args.NewChildRef->ShardId,
+                args.NewChildRef->ShardNodeName);
+
+            args.Response.SetOldTargetNodeShardId(args.NewChildRef->ShardId);
+            args.Response.SetOldTargetNodeShardNodeName(
+                args.NewChildRef->ShardNodeName);
+        } else if (args.NewChildRef->ShardId.empty()) {
+            auto message = ReportUnexpectedLocalNode(TStringBuilder()
+                << "RenameNodeInDestination: "
+                << args.Request.ShortDebugString());
+            // here the code is E_INVALID_STATE since we should've checked this
+            // thing before - in HandleRenameNodeInDestination
+            args.Error = MakeError(E_INVALID_STATE, std::move(message));
+            return;
+        } else {
+            // remove target ref
+            UnlinkExternalNode(
+                db,
+                args.NewParentNode->NodeId,
+                args.NewName,
+                args.NewChildRef->ShardId,
+                args.NewChildRef->ShardNodeName,
+                args.NewChildRef->MinCommitId,
+                args.CommitId);
+
+            // OpLogEntryId doesn't have to be a CommitId - it's just convenient
+            // to use CommitId here in order not to generate some other unique
+            // ui64
+            args.OpLogEntry.SetEntryId(args.CommitId);
+            auto* shardRequest = args.OpLogEntry.MutableUnlinkNodeRequest();
+            shardRequest->MutableHeaders()->CopyFrom(
+                args.Request.GetHeaders());
+            shardRequest->SetFileSystemId(args.NewChildRef->ShardId);
+            shardRequest->SetNodeId(RootNodeId);
+            shardRequest->SetName(args.NewChildRef->ShardNodeName);
+
+            db.WriteOpLogEntry(args.OpLogEntry);
+        }
+    }
+
+    // create target ref to source node
+    CreateNodeRef(
+        db,
+        args.NewParentNodeId,
+        args.CommitId,
+        args.NewName,
+        InvalidNodeId, // ChildNodeId
+        args.Request.GetSourceNodeShardId(),
+        args.Request.GetSourceNodeShardNodeName());
+
+    auto newParent = CopyAttrs(args.NewParentNode->Attrs, E_CM_CMTIME);
+    UpdateNode(
+        db,
+        args.NewParentNode->NodeId,
+        args.NewParentNode->MinCommitId,
+        args.CommitId,
+        newParent,
+        args.NewParentNode->Attrs);
+
+    auto* session = FindSession(args.SessionId);
+    if (!session) {
+        auto message = ReportSessionNotFoundInTx(TStringBuilder()
+            << "RenameNode: " << args.Request.ShortDebugString());
+        args.Error = MakeError(E_INVALID_STATE, std::move(message));
+        return;
+    }
+
+    // TODO(#2674): DupCache
+    /*
+    AddDupCacheEntry(
+        db,
+        session,
+        args.RequestId,
+        NProto::TRenameNodeResponse{},
+        Config->GetDupCacheEntryCount());
+        */
+
+    EnqueueTruncateIfNeeded(ctx);
+}
+
+void TIndexTabletActor::CompleteTx_RenameNodeInDestination(
+    const TActorContext& ctx,
+    TTxIndexTablet::TRenameNodeInDestination& args)
+{
+    InvalidateNodeCaches(args.NewParentNodeId);
+    if (args.NewChildRef) {
+        InvalidateNodeCaches(args.NewChildRef->ChildNodeId);
+    }
+    if (args.NewParentNode) {
+        InvalidateNodeCaches(args.NewParentNode->NodeId);
+    }
+
+    if (!HasError(args.Error)) {
+        auto& op = args.OpLogEntry;
+        if (op.HasUnlinkNodeRequest()) {
+            // rename + unlink is pretty rare so let's keep INFO level here
+            LOG_INFO(ctx, TFileStoreComponents::TABLET,
+                "%s Unlinking node in shard upon RenameNode: %s, %s",
+                LogTag.c_str(),
+                op.GetUnlinkNodeRequest().GetFileSystemId().c_str(),
+                op.GetUnlinkNodeRequest().GetName().c_str());
+
+            RegisterUnlinkNodeInShardActor(
+                ctx,
+                args.RequestInfo,
+                std::move(*op.MutableUnlinkNodeRequest()),
+                args.RequestId,
+                args.OpLogEntry.GetEntryId(),
+                std::move(args.Response));
+
+            return;
+        }
+
+        CommitDupCacheEntry(args.SessionId, args.RequestId);
+
+        // TODO(#1350): support session events for external nodes
+    }
+
+    RemoveTransaction(*args.RequestInfo);
+
+    Metrics.RenameNode.Update(
+        1,
+        0,
+        ctx.Now() - args.RequestInfo->StartedTs);
+
+    using TMethod = TEvIndexTablet::TRenameNodeInDestinationMethod;
+    auto response = std::make_unique<TMethod::TResponse>(args.Error);
+    CompleteResponse<TMethod>(
+        response->Record,
+        args.RequestInfo->CallContext,
+        ctx);
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -1,0 +1,198 @@
+#include "tablet_actor.h"
+
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TPrepareRenameNodeInSource& args)
+{
+    Y_UNUSED(ctx);
+
+    FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
+
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GetCurrentCommitId();
+
+    // validate parent node exists
+    if (!ReadNode(db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
+        return false;   // not ready
+    }
+
+    if (!args.ParentNode) {
+        args.Error = ErrorInvalidParent(args.ParentNodeId);
+        return true;
+    }
+
+    // TODO: AccessCheck
+
+    // validate old ref exists
+    if (!ReadNodeRef(
+            db,
+            args.ParentNodeId,
+            args.CommitId,
+            args.Name,
+            args.ChildRef))
+    {
+        return false;   // not ready
+    }
+
+    // read old node
+    if (!args.ChildRef) {
+        args.Error = ErrorInvalidTarget(args.ParentNodeId);
+        return true;
+    }
+
+    if (args.ChildRef->ShardId.empty()) {
+        auto message = ReportRenameNodeRequestForLocalNode(TStringBuilder()
+            << "PrepareRenameNodeInSource: "
+            << args.Request.ShortDebugString());
+        args.Error = MakeError(E_ARGUMENT, std::move(message));
+        return true;
+    }
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TPrepareRenameNodeInSource& args)
+{
+    FILESTORE_VALIDATE_TX_ERROR(RenameNode, args);
+    if (args.Error.GetCode() == S_ALREADY) {
+        return; // nothing to do
+    }
+
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GenerateCommitId();
+    if (args.CommitId == InvalidCommitId) {
+        return RebootTabletOnCommitOverflow(ctx, "RenameNode");
+    }
+
+    // TODO(#2674): lock NodeRef for any modifications
+
+    // OpLogEntryId doesn't have to be a CommitId - it's just convenient
+    // to use CommitId here in order not to generate some other unique
+    // ui64
+    args.OpLogEntry.SetEntryId(args.CommitId);
+    auto* shardRequest =
+        args.OpLogEntry.MutableRenameNodeInDestinationRequest();
+    shardRequest->MutableHeaders()->CopyFrom(
+        args.Request.GetHeaders());
+    shardRequest->SetFileSystemId(args.NewParentShardId);
+    shardRequest->SetNewParentId(args.Request.GetNewParentId());
+    shardRequest->SetNewName(args.Request.GetNewName());
+    shardRequest->SetFlags(args.Request.GetFlags());
+    shardRequest->SetSourceNodeShardId(args.ChildRef->ShardId);
+    shardRequest->SetSourceNodeShardNodeName(args.ChildRef->ShardNodeName);
+    shardRequest->SetSourceNodeShardNodeName(args.ChildRef->ShardNodeName);
+
+    db.WriteOpLogEntry(args.OpLogEntry);
+
+    // update old parent timestamps
+    auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
+    UpdateNode(
+        db,
+        args.ParentNode->NodeId,
+        args.ParentNode->MinCommitId,
+        args.CommitId,
+        parent,
+        args.ParentNode->Attrs);
+
+    auto* session = FindSession(args.SessionId);
+    if (!session) {
+        auto message = ReportSessionNotFoundInTx(TStringBuilder()
+            << "RenameNode: " << args.Request.ShortDebugString());
+        args.Error = MakeError(E_INVALID_STATE, std::move(message));
+        return;
+    }
+
+    AddDupCacheEntry(
+        db,
+        session,
+        args.RequestId,
+        NProto::TRenameNodeResponse{},
+        Config->GetDupCacheEntryCount());
+
+    EnqueueTruncateIfNeeded(ctx);
+}
+
+void TIndexTabletActor::CompleteTx_PrepareRenameNodeInSource(
+    const TActorContext& ctx,
+    TTxIndexTablet::TPrepareRenameNodeInSource& args)
+{
+    InvalidateNodeCaches(args.ParentNodeId);
+    if (args.ChildRef) {
+        InvalidateNodeCaches(args.ChildRef->ChildNodeId);
+    }
+    if (args.ParentNode) {
+        InvalidateNodeCaches(args.ParentNode->NodeId);
+    }
+
+    if (!HasError(args.Error) && !args.ChildRef) {
+        auto message = ReportChildRefIsNull(TStringBuilder()
+            << "RenameNode: " << args.Request.ShortDebugString());
+        args.Error = MakeError(E_INVALID_STATE, std::move(message));
+    }
+
+    RemoveTransaction(*args.RequestInfo);
+
+    if (!HasError(args.Error)) {
+        auto& op = args.OpLogEntry;
+
+        if (!op.HasRenameNodeInDestinationRequest()) {
+            auto message = ReportNoRenameNodeInDestinationRequest(
+                TStringBuilder() << "RenameNode: "
+                    << args.Request.ShortDebugString());
+            args.Error = MakeError(E_INVALID_STATE, std::move(message));
+        } else {
+            auto& shardRequest = *op.MutableRenameNodeInDestinationRequest();
+            LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+                "%s Renaming node in dst shard upon RenameNode: %s, %lu",
+                LogTag.c_str(),
+                shardRequest.GetFileSystemId().c_str(),
+                shardRequest.GetNewParentId());
+
+            RegisterRenameNodeInDestinationActor(
+                ctx,
+                args.RequestInfo,
+                std::move(shardRequest),
+                args.RequestId,
+                args.OpLogEntry.GetEntryId());
+            return;
+        }
+    }
+
+    Metrics.RenameNode.Update(
+        1,
+        0,
+        ctx.Now() - args.RequestInfo->StartedTs);
+
+    auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(args.Error);
+    CompleteResponse<TEvService::TRenameNodeMethod>(
+        response->Record,
+        args.RequestInfo->CallContext,
+        ctx);
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -1,6 +1,7 @@
 #include "tablet_actor.h"
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
+#include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -12,6 +13,186 @@ using namespace NKikimr::NTabletFlatExecutor;
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+class TRenameNodeInDestinationActor final
+    : public TActorBootstrapped<TRenameNodeInDestinationActor>
+{
+private:
+    const TString LogTag;
+    TRequestInfoPtr RequestInfo;
+    const TActorId ParentId;
+    const NProtoPrivate::TRenameNodeInDestinationRequest Request;
+    const ui64 RequestId;
+    const ui64 OpLogEntryId;
+
+public:
+    TRenameNodeInDestinationActor(
+        TString logTag,
+        TRequestInfoPtr requestInfo,
+        const TActorId& parentId,
+        NProtoPrivate::TRenameNodeInDestinationRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void SendRequest(const TActorContext& ctx);
+
+    void HandleRenameNodeInDestinationResponse(
+        const TEvIndexTablet::TEvRenameNodeInDestinationResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        NProtoPrivate::TRenameNodeInDestinationResponse response);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TRenameNodeInDestinationActor::TRenameNodeInDestinationActor(
+        TString logTag,
+        TRequestInfoPtr requestInfo,
+        const TActorId& parentId,
+        NProtoPrivate::TRenameNodeInDestinationRequest request,
+        ui64 requestId,
+        ui64 opLogEntryId)
+    : LogTag(std::move(logTag))
+    , RequestInfo(std::move(requestInfo))
+    , ParentId(parentId)
+    , Request(std::move(request))
+    , RequestId(requestId)
+    , OpLogEntryId(opLogEntryId)
+{}
+
+void TRenameNodeInDestinationActor::Bootstrap(const TActorContext& ctx)
+{
+    SendRequest(ctx);
+    Become(&TThis::StateWork);
+}
+
+void TRenameNodeInDestinationActor::SendRequest(const TActorContext& ctx)
+{
+    auto request =
+        std::make_unique<TEvIndexTablet::TEvRenameNodeInDestinationRequest>();
+    request->Record = Request;
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s Sending RenameNodeInDestination to shard %s, %lu, %s",
+        LogTag.c_str(),
+        Request.GetFileSystemId().c_str(),
+        Request.GetNewParentId(),
+        Request.GetNewName().c_str());
+
+    ctx.Send(
+        MakeIndexTabletProxyServiceId(),
+        request.release());
+}
+
+void TRenameNodeInDestinationActor::HandleRenameNodeInDestinationResponse(
+    const TEvIndexTablet::TEvRenameNodeInDestinationResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::TABLET_WORKER,
+                "%s RenameNodeInDestination failed for %s, %lu, %s with error"
+                " %s, retrying",
+                LogTag.c_str(),
+                Request.GetFileSystemId().c_str(),
+                Request.GetNewParentId(),
+                Request.GetNewName().c_str(),
+                FormatError(msg->GetError()).Quote().c_str());
+
+            SendRequest(ctx);
+            return;
+        }
+
+        const auto message = Sprintf(
+            "RenameNodeInDestination failed for %s, %lu, %s with error %s"
+            ", will not retry",
+            Request.GetFileSystemId().c_str(),
+            Request.GetNewParentId(),
+            Request.GetNewName().c_str(),
+            FormatError(msg->GetError()).Quote().c_str());
+
+        LOG_ERROR(
+            ctx,
+            TFileStoreComponents::TABLET_WORKER,
+            "%s %s",
+            LogTag.c_str(),
+            message.c_str());
+
+        ReportReceivedNodeOpErrorFromShard(message);
+
+        ReplyAndDie(ctx, std::move(msg->Record));
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET_WORKER,
+        "%s RenameNodeInDestination succeeded for %s, %lu, %s",
+        LogTag.c_str(),
+        Request.GetFileSystemId().c_str(),
+        Request.GetNewParentId(),
+        Request.GetNewName().c_str());
+
+    ReplyAndDie(ctx, std::move(msg->Record));
+}
+
+void TRenameNodeInDestinationActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    NProtoPrivate::TRenameNodeInDestinationResponse response;
+    *response.MutableError() = MakeError(E_REJECTED, "tablet is shutting down");
+    ReplyAndDie(ctx, std::move(response));
+}
+
+void TRenameNodeInDestinationActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProtoPrivate::TRenameNodeInDestinationResponse response)
+{
+    using TResponse = TEvIndexTabletPrivate::TEvNodeRenamedInDestination;
+    ctx.Send(ParentId, std::make_unique<TResponse>(
+        std::move(RequestInfo),
+        Request.GetHeaders().GetSessionId(),
+        RequestId,
+        OpLogEntryId,
+        Request.GetOriginalRequest(), // TODO: move
+        std::move(response)));
+
+    Die(ctx);
+}
+
+STFUNC(TRenameNodeInDestinationActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvIndexTablet::TEvRenameNodeInDestinationResponse,
+            HandleRenameNodeInDestinationResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            break;
+    }
+}
 
 }   // namespace
 
@@ -84,7 +265,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        return RebootTabletOnCommitOverflow(ctx, "RenameNode");
+        return RebootTabletOnCommitOverflow(ctx, "PrepareRenameNodeInSource");
     }
 
     // TODO(#2674): lock NodeRef for any modifications
@@ -104,6 +285,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
     shardRequest->SetSourceNodeShardId(args.ChildRef->ShardId);
     shardRequest->SetSourceNodeShardNodeName(args.ChildRef->ShardNodeName);
     shardRequest->SetSourceNodeShardNodeName(args.ChildRef->ShardNodeName);
+    *shardRequest->MutableOriginalRequest() = args.Request;
 
     db.WriteOpLogEntry(args.OpLogEntry);
 
@@ -153,8 +335,6 @@ void TIndexTabletActor::CompleteTx_PrepareRenameNodeInSource(
         args.Error = MakeError(E_INVALID_STATE, std::move(message));
     }
 
-    RemoveTransaction(*args.RequestInfo);
-
     if (!HasError(args.Error)) {
         auto& op = args.OpLogEntry;
 
@@ -186,13 +366,167 @@ void TIndexTabletActor::CompleteTx_PrepareRenameNodeInSource(
         0,
         ctx.Now() - args.RequestInfo->StartedTs);
 
-    auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(args.Error);
+    auto response =
+        std::make_unique<TEvService::TEvRenameNodeResponse>(args.Error);
     CompleteResponse<TEvService::TRenameNodeMethod>(
         response->Record,
         args.RequestInfo->CallContext,
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleNodeRenamedInDestination(
+    const TEvIndexTabletPrivate::TEvNodeRenamedInDestination::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    ExecuteTx<TCommitRenameNodeInSource>(
+        ctx,
+        std::move(msg->RequestInfo),
+        std::move(msg->Request),
+        std::move(msg->Response),
+        msg->OpLogEntryId);
+
+    WorkerActors.erase(ev->Sender);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::RegisterRenameNodeInDestinationActor(
+    const NActors::TActorContext& ctx,
+    TRequestInfoPtr requestInfo,
+    NProtoPrivate::TRenameNodeInDestinationRequest request,
+    ui64 requestId,
+    ui64 opLogEntryId)
+{
+    auto actor = std::make_unique<TRenameNodeInDestinationActor>(
+        LogTag,
+        std::move(requestInfo),
+        ctx.SelfID,
+        std::move(request),
+        requestId,
+        opLogEntryId);
+
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_CommitRenameNodeInSource(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCommitRenameNodeInSource& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GetCurrentCommitId();
+
+    // validate old ref exists
+    if (!ReadNodeRef(
+            db,
+            args.Request.GetNodeId(),
+            args.CommitId,
+            args.Request.GetName(),
+            args.ChildRef))
+    {
+        return false;   // not ready
+    }
+
+    if (!args.ChildRef || args.ChildRef->ShardId.empty()) {
+        auto message = ReportBadChildRefUponCommitRenameNodeInSource(
+            TStringBuilder() << "CommitRenameNodeInSource: "
+            << args.Request.ShortDebugString());
+        args.Error = MakeError(E_INVALID_STATE, std::move(message));
+        return true;
+    }
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCommitRenameNodeInSource& args)
+{
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GenerateCommitId();
+    if (args.CommitId == InvalidCommitId) {
+        return RebootTabletOnCommitOverflow(ctx, "CommitRenameNodeInSource");
+    }
+
+    if (HasError(args.Response)) {
+        // TODO(#2674): unlock NodeRef (or mb do it in CompleteTx?)
+
+        NProto::TRenameNodeResponse response;
+        *response.MutableError() = args.Response.GetError();
+        PatchDupCacheEntry(
+            db,
+            args.SessionId,
+            args.RequestId,
+            std::move(response));
+    } else {
+        RemoveNodeRef(
+            db,
+            args.Request.GetNodeId(),
+            args.ChildRef->MinCommitId,
+            args.CommitId,
+            args.Request.GetName(),
+            args.ChildRef->ChildNodeId,
+            args.ChildRef->ShardId,
+            args.ChildRef->ShardNodeName);
+
+        const bool isExchange = HasFlag(
+            args.Request.GetFlags(),
+            NProto::TRenameNodeRequest::F_EXCHANGE);
+
+        if (isExchange) {
+            // create source ref to target node
+            CreateNodeRef(
+                db,
+                args.Request.GetNodeId(),
+                args.CommitId,
+                args.Request.GetName(),
+                InvalidNodeId,
+                args.Response.GetOldTargetNodeShardId(),
+                args.Response.GetOldTargetNodeShardNodeName());
+        }
+    }
+
+    db.DeleteOpLogEntry(args.OpLogEntryId);
+}
+
+void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(
+    const TActorContext& ctx,
+    TTxIndexTablet::TCommitRenameNodeInSource& args)
+{
+    InvalidateNodeCaches(args.Request.GetNodeId());
+    CommitDupCacheEntry(args.SessionId, args.RequestId);
+
+    if (args.RequestInfo) {
+        RemoveTransaction(*args.RequestInfo);
+
+        Metrics.RenameNode.Update(
+            1,
+            0,
+            ctx.Now() - args.RequestInfo->StartedTs);
+
+        auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(
+            args.Response.GetError());
+        CompleteResponse<TEvService::TRenameNodeMethod>(
+            response->Record,
+            args.RequestInfo->CallContext,
+            ctx);
+
+        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -123,6 +123,7 @@ FILESTORE_GENERATE_IMPL(DescribeSessions, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(GenerateBlobIds, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(AddData, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(GetNodeAttrBatch, TEvIndexTablet)
+FILESTORE_GENERATE_IMPL(RenameNodeInDestination, TEvIndexTablet)
 
 #undef FILESTORE_GENERATE_IMPL
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -158,6 +158,7 @@ void TIndexTabletActor::HandleUpdateConfig(
     *newConfig.MutableShardFileSystemIds() =
         oldConfig.GetShardFileSystemIds();
     newConfig.SetShardNo(oldConfig.GetShardNo());
+    newConfig.SetMainFileSystemId(oldConfig.GetMainFileSystemId());
     newConfig.SetAutomaticShardCreationEnabled(
         oldConfig.GetAutomaticShardCreationEnabled());
     newConfig.SetShardAllocationUnit(oldConfig.GetShardAllocationUnit());
@@ -430,6 +431,7 @@ void TIndexTabletActor::ExecuteTx_ConfigureAsShard(
 
     auto config = GetFileSystem();
     config.SetShardNo(args.Request.GetShardNo());
+    config.SetMainFileSystemId(args.Request.GetMainFileSystemId());
     *config.MutableShardFileSystemIds() =
         std::move(*args.Request.MutableShardFileSystemIds());
 

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -646,6 +646,36 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // NodeRenamedInDestination
+    //
+
+    struct TNodeRenamedInDestination
+    {
+        const TRequestInfoPtr RequestInfo;
+        const TString SessionId;
+        const ui64 RequestId;
+        const ui64 OpLogEntryId;
+        NProto::TRenameNodeRequest Request;
+        NProtoPrivate::TRenameNodeInDestinationResponse Response;
+
+        TNodeRenamedInDestination(
+                TRequestInfoPtr requestInfo,
+                TString sessionId,
+                ui64 requestId,
+                ui64 opLogEntryId,
+                NProto::TRenameNodeRequest request,
+                NProtoPrivate::TRenameNodeInDestinationResponse response)
+            : RequestInfo(std::move(requestInfo))
+            , SessionId(std::move(sessionId))
+            , RequestId(requestId)
+            , OpLogEntryId(opLogEntryId)
+            , Request(std::move(request))
+            , Response(std::move(response))
+        {
+        }
+    };
+
+    //
     // DumpCompactionRange
     //
 
@@ -874,6 +904,7 @@ struct TEvIndexTabletPrivate
 
         EvNodeCreatedInShard,
         EvNodeUnlinkedInShard,
+        EvNodeRenamedInDestination,
 
         EvGetShardStatsCompleted,
 
@@ -913,6 +944,9 @@ struct TEvIndexTabletPrivate
 
     using TEvNodeUnlinkedInShard =
         TRequestEvent<TNodeUnlinkedInShard, EvNodeUnlinkedInShard>;
+
+    using TEvNodeRenamedInDestination =
+        TRequestEvent<TNodeRenamedInDestination, EvNodeRenamedInDestination>;
 
     using TEvGetShardStatsCompleted =
         TResponseEvent<TGetShardStatsCompleted, EvGetShardStatsCompleted>;

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -168,7 +168,8 @@ using TCreateNodeInShardResult = std::variant<
 
 using TUnlinkNodeInShardResult = std::variant<
     NProto::TUnlinkNodeResponse,
-    NProto::TRenameNodeResponse>;
+    NProto::TRenameNodeResponse,
+    NProtoPrivate::TRenameNodeInDestinationResponse>;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -230,6 +230,11 @@ public:
         return FileSystem.GetFileSystemId();
     }
 
+    TString GetMainFileSystemId() const
+    {
+        return FileSystem.GetMainFileSystemId();
+    }
+
     ui32 GetGeneration() const
     {
         return Generation;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -730,6 +730,12 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_DECLARE_DUPCACHE)
         ui64 requestId,
         NProto::TCreateNodeResponse response);
 
+    void PatchDupCacheEntry(
+        TIndexTabletDatabase& db,
+        const TString& sessionId,
+        ui64 requestId,
+        NProto::TRenameNodeResponse response);
+
     void CommitDupCacheEntry(
         const TString& sessionId,
         ui64 requestId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -940,6 +940,30 @@ void TIndexTabletState::PatchDupCacheEntry(
     db.WriteSessionDupCacheEntry(*entry);
 }
 
+void TIndexTabletState::PatchDupCacheEntry(
+    TIndexTabletDatabase& db,
+    const TString& sessionId,
+    ui64 requestId,
+    NProto::TRenameNodeResponse response)
+{
+    if (!requestId) {
+        return;
+    }
+
+    auto* session = FindSession(sessionId);
+    if (!session) {
+        return;
+    }
+
+    auto* entry = session->AccessDupEntry(requestId);
+    if (!entry) {
+        return;
+    }
+
+    *entry->MutableRenameNode() = std::move(response);
+    db.WriteSessionDupCacheEntry(*entry);
+}
+
 void TIndexTabletState::CommitDupCacheEntry(
     const TString& sessionId,
     ui64 requestId)

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -790,9 +790,9 @@ struct TTxIndexTablet
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , ParentNodeId(request.GetNodeId())
-            , Name(std::move(*request.MutableName()))
+            , Name(request.GetName())
             , NewParentNodeId(request.GetNewParentId())
-            , NewName(std::move(*request.MutableNewName()))
+            , NewName(request.GetNewName())
             , Flags(request.GetFlags())
             , Request(std::move(request))
         {}
@@ -847,7 +847,7 @@ struct TTxIndexTablet
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , ParentNodeId(request.GetNodeId())
-            , Name(std::move(*request.MutableName()))
+            , Name(request.GetName())
             , Request(std::move(request))
             , NewParentShardId(std::move(newParentShardId))
         {}
@@ -926,25 +926,23 @@ struct TTxIndexTablet
         , TIndexStateNodeUpdates
     {
         const TRequestInfoPtr RequestInfo;
-        const ui64 ParentNodeId;
-        const TString Name;
+        const NProto::TRenameNodeRequest Request;
+        const NProtoPrivate::TRenameNodeInDestinationResponse Response;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
         TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
 
         const ui64 OpLogEntryId;
-        NProto::TError Error;
 
         TCommitRenameNodeInSource(
                 TRequestInfoPtr requestInfo,
                 NProto::TRenameNodeRequest request,
+                NProtoPrivate::TRenameNodeInDestinationResponse response,
                 ui64 opLogEntryId)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
-            , ParentNodeId(request.GetNodeId())
-            , Name(std::move(*request.MutableName()))
+            , Request(std::move(request))
+            , Response(std::move(response))
             , OpLogEntryId(opLogEntryId)
         {}
 
@@ -952,8 +950,6 @@ struct TTxIndexTablet
         {
             TIndexStateNodeUpdates::Clear();
             CommitId = InvalidCommitId;
-            ParentNode.Clear();
-            ChildNode.Clear();
             ChildRef.Clear();
         }
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -99,6 +99,9 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateNode,                         __VA_ARGS__)                       \
     xxx(UnlinkNode,                         __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
+    xxx(PrepareRenameNodeInSource,          __VA_ARGS__)                       \
+    xxx(RenameNodeInDestination,            __VA_ARGS__)                       \
+    xxx(CommitRenameNodeInSource,           __VA_ARGS__)                       \
                                                                                \
     xxx(SetNodeAttr,                        __VA_ARGS__)                       \
     xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
@@ -812,6 +815,146 @@ struct TTxIndexTablet
 
             ShardIdForUnlink.clear();
             ShardNodeNameForUnlink.clear();
+        }
+    };
+
+    //
+    // PrepareRenameNodeInSource
+    //
+
+    struct TPrepareRenameNodeInSource
+        : TSessionAware
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const ui64 ParentNodeId;
+        const TString Name;
+        const NProto::TRenameNodeRequest Request;
+        const TString NewParentShardId;
+
+        ui64 CommitId = InvalidCommitId;
+        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+
+        NProto::TOpLogEntry OpLogEntry;
+        NProto::TError Error;
+
+        TPrepareRenameNodeInSource(
+                TRequestInfoPtr requestInfo,
+                NProto::TRenameNodeRequest request,
+                TString newParentShardId)
+            : TSessionAware(request)
+            , RequestInfo(std::move(requestInfo))
+            , ParentNodeId(request.GetNodeId())
+            , Name(std::move(*request.MutableName()))
+            , Request(std::move(request))
+            , NewParentShardId(std::move(newParentShardId))
+        {}
+
+        void Clear()
+        {
+            TIndexStateNodeUpdates::Clear();
+            CommitId = InvalidCommitId;
+            ParentNode.Clear();
+            ChildNode.Clear();
+            ChildRef.Clear();
+
+            OpLogEntry.Clear();
+            Error.Clear();
+        }
+    };
+
+    //
+    // RenameNodeInDestination
+    //
+
+    struct TRenameNodeInDestination
+        : TSessionAware
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const ui64 NewParentNodeId;
+        const TString NewName;
+        const ui32 Flags;
+        const NProtoPrivate::TRenameNodeInDestinationRequest Request;
+
+        ui64 CommitId = InvalidCommitId;
+        TMaybe<IIndexTabletDatabase::TNode> NewParentNode;
+        TMaybe<IIndexTabletDatabase::TNodeRef> NewChildRef;
+
+        NProto::TOpLogEntry OpLogEntry;
+        NProtoPrivate::TRenameNodeInDestinationResponse Response;
+
+        TString ShardIdForUnlink;
+        TString ShardNodeNameForUnlink;
+
+        TRenameNodeInDestination(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TRenameNodeInDestinationRequest request)
+            : TSessionAware(request)
+            , RequestInfo(std::move(requestInfo))
+            , NewParentNodeId(request.GetNewParentId())
+            , NewName(std::move(*request.MutableNewName()))
+            , Flags(request.GetFlags())
+            , Request(std::move(request))
+        {}
+
+        void Clear()
+        {
+            TIndexStateNodeUpdates::Clear();
+            CommitId = InvalidCommitId;
+
+            NewParentNode.Clear();
+            NewChildRef.Clear();
+
+            OpLogEntry.Clear();
+
+            Response.Clear();
+
+            ShardIdForUnlink.clear();
+            ShardNodeNameForUnlink.clear();
+        }
+    };
+
+    //
+    // CommitRenameNodeInSource
+    //
+
+    struct TCommitRenameNodeInSource
+        : TSessionAware
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const ui64 ParentNodeId;
+        const TString Name;
+
+        ui64 CommitId = InvalidCommitId;
+        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+
+        const ui64 OpLogEntryId;
+        NProto::TError Error;
+
+        TCommitRenameNodeInSource(
+                TRequestInfoPtr requestInfo,
+                NProto::TRenameNodeRequest request,
+                ui64 opLogEntryId)
+            : TSessionAware(request)
+            , RequestInfo(std::move(requestInfo))
+            , ParentNodeId(request.GetNodeId())
+            , Name(std::move(*request.MutableName()))
+            , OpLogEntryId(opLogEntryId)
+        {}
+
+        void Clear()
+        {
+            TIndexStateNodeUpdates::Clear();
+            CommitId = InvalidCommitId;
+            ParentNode.Clear();
+            ChildNode.Clear();
+            ChildRef.Clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -55,6 +55,8 @@ SRCS(
     tablet_actor_releaselock.cpp
     tablet_actor_removenodexattr.cpp
     tablet_actor_renamenode.cpp
+    tablet_actor_renamenode_destination.cpp
+    tablet_actor_renamenode_source.cpp
     tablet_actor_request.cpp
     tablet_actor_resetsession.cpp
     tablet_actor_resolvepath.cpp

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -779,6 +779,10 @@ message TRenameNodeInDestinationRequest
     // Source node info.
     string SourceNodeShardId = 6;
     string SourceNodeShardNodeName = 7;
+
+    // Passing the whole original request might be an overkill but it actually
+    // may help with debugging.
+    NProto.TRenameNodeRequest OriginalRequest = 8;
 }
 
 message TRenameNodeInDestinationResponse

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -748,3 +748,48 @@ message TRestartTabletResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// RenameNodeInDestination request/response
+
+message TRenameNodeInDestinationRequest
+{
+    enum EFlags
+    {
+        F_NONE = 0;
+        F_EXCHANGE = 1;
+        F_NOREPLACE = 2;
+    }
+
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+
+    // New parent Node
+    uint64 NewParentId = 3;
+
+    // New node name.
+    bytes NewName = 4;
+
+    // Optional linux specific flags.
+    uint32 Flags = 5;
+
+    // Source node info.
+    string SourceNodeShardId = 6;
+    string SourceNodeShardNodeName = 7;
+}
+
+message TRenameNodeInDestinationResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // Needed if F_EXCHANGE flag is used.
+    string OldTargetNodeShardId = 2;
+    string OldTargetNodeShardNodeName = 3;
+
+    // Optional response headers.
+    NProto.TResponseHeaders Headers = 1000;
+}

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -596,8 +596,10 @@ message TConfigureAsShardRequest
     // ShardNo (will be used for the high bits of NodeId and HandleId)
     uint32 ShardNo = 2;
 
-    // Shard FileSystem identifiers. Needed for directory creation in shards.
+    // Shard FileSystem identifiers and main FileSystem identifier (manages
+    // RootNode). Needed for directory creation in shards.
     repeated string ShardFileSystemIds = 3;
+    string MainFileSystemId = 4;
 }
 
 message TConfigureAsShardResponse

--- a/cloud/filestore/tests/client_sharded_dir/canondata/test.test_nonsharded_vs_sharded_fs/results.txt
+++ b/cloud/filestore/tests/client_sharded_dir/canondata/test.test_nonsharded_vs_sharded_fs/results.txt
@@ -12,6 +12,13 @@
         "Name": "a1",
         "Mode": 511,
         "Id": 17
+    },
+    {
+        "Type": 1,
+        "Links": 1,
+        "Size": 62,
+        "Name": "f18.txt",
+        "Id": 29
     }
 ][
     {
@@ -21,6 +28,10 @@
     {
         "ShardFileSystemId": "masked_for_test_stability",
         "Name": "a1"
+    },
+    {
+        "ShardFileSystemId": "masked_for_test_stability",
+        "Name": "f18.txt"
     }
 ][22;31m-	LINK: [0m[0;39m/does/not/matter/2
 [22;32m+	LINK: [0m[0;39m/does/not/matter/3

--- a/cloud/filestore/tests/client_sharded_dir/test.py
+++ b/cloud/filestore/tests/client_sharded_dir/test.py
@@ -129,6 +129,7 @@ def test_nonsharded_vs_sharded_fs():
         _f("/a1/b2/f15.txt", "ZZZZZZZZZZZ"),
         _l("/a1/b2/l1", "/does/not/matter"),
         _f("/a1/b2/f16.txt", "ZZZZZZZZZZZ2"),
+        _f("/f17.txt", "010101010101010101"),
         _d("/a1/b3"),
     ]
 
@@ -140,6 +141,19 @@ def test_nonsharded_vs_sharded_fs():
     client.mv("fs1", "/a0/b0/c0/d0/f9.txt", "/a0/b0/c0/d0/f9_moved.txt")
     client.rm("fs0", "/a1/b2/f16.txt")
     client.rm("fs1", "/a1/b2/f16.txt")
+    # checking that cross-directory mv works
+    client.mv("fs0", "/f17.txt", "/a0/f17.txt")
+    client.mv("fs0", "/a0/f17.txt", "/a0/b0/f17.txt")
+    client.mv("fs0", "/a0/b0/f17.txt", "/a0/b0/c0/f17.txt")
+    client.mv("fs0", "/a0/b0/c0/f17.txt", "/a0/b0/c0/d0/f17.txt")
+    client.mv("fs0", "/a0/b0/c0/d0/f17.txt", "/a1/f17.txt")
+    client.mv("fs0", "/a1/f17.txt", "/a1/b2/f17.txt")
+    client.mv("fs1", "/f17.txt", "/a0/f17.txt")
+    client.mv("fs1", "/a0/f17.txt", "/a0/b0/f17.txt")
+    client.mv("fs1", "/a0/b0/f17.txt", "/a0/b0/c0/f17.txt")
+    client.mv("fs1", "/a0/b0/c0/f17.txt", "/a0/b0/c0/d0/f17.txt")
+    client.mv("fs1", "/a0/b0/c0/d0/f17.txt", "/a1/f17.txt")
+    client.mv("fs1", "/a1/f17.txt", "/a1/b2/f17.txt")
     # checking that readlink works (indirectly - via diff)
     client.ln("fs0", "/a1/b2/l2", "--symlink", "/does/not/matter/2")
     client.ln("fs1", "/a1/b2/l2", "--symlink", "/does/not/matter/3")

--- a/cloud/filestore/tests/client_sharded_dir/test.py
+++ b/cloud/filestore/tests/client_sharded_dir/test.py
@@ -130,6 +130,7 @@ def test_nonsharded_vs_sharded_fs():
         _l("/a1/b2/l1", "/does/not/matter"),
         _f("/a1/b2/f16.txt", "ZZZZZZZZZZZ2"),
         _f("/f17.txt", "010101010101010101"),
+        _f("/a1/f18.txt", "xxxxxxxxxxxxxxxxxxxxxxxxxx"),
         _d("/a1/b3"),
     ]
 
@@ -154,6 +155,9 @@ def test_nonsharded_vs_sharded_fs():
     client.mv("fs1", "/a0/b0/c0/f17.txt", "/a0/b0/c0/d0/f17.txt")
     client.mv("fs1", "/a0/b0/c0/d0/f17.txt", "/a1/f17.txt")
     client.mv("fs1", "/a1/f17.txt", "/a1/b2/f17.txt")
+    # checking that cross-directory mv to root works
+    client.mv("fs0", "/a1/f18.txt", "/f18.txt")
+    client.mv("fs1", "/a1/f18.txt", "/f18.txt")
     # checking that readlink works (indirectly - via diff)
     client.ln("fs0", "/a1/b2/l2", "--symlink", "/does/not/matter/2")
     client.ln("fs1", "/a1/b2/l2", "--symlink", "/does/not/matter/3")


### PR DESCRIPTION
TODOs:
* DupCache for RenameNodeInDestination
* RenameNodeInDestination request replay from OpLog upon tablet start
* uts for non-happy path
* implement NodeType checks (via extra GetNodeAttr calls)

Happy path works (tested via https://github.com/ydb-platform/nbs/blob/83fa5e20b14073610e49f9ae722d85cef756ec75/cloud/filestore/tests/client_sharded_dir/test.py#L144)

#2674 