### PR TITLE
[Filestore] issue-2819: Forget deleted directory node if it has <= 2 links

### DIFF
--- a/cloud/filestore/libs/service_local/fs_node.cpp
+++ b/cloud/filestore/libs/service_local/fs_node.cpp
@@ -111,8 +111,7 @@ NProto::TUnlinkNodeResponse TLocalFileSystem::UnlinkNode(
     auto stat = parent->Stat(request.GetName());
     parent->Unlink(request.GetName(), request.GetUnlinkDirectory());
 
-    // FIXME
-    if ((!stat.IsDir() && stat.NLinks == 1) || (stat.IsDir() && stat.NLinks == 2)) {
+    if ((!stat.IsDir() && stat.NLinks == 1) || (stat.IsDir() && stat.NLinks <= 2)) {
         session->ForgetNode(stat.INode);
     }
 


### PR DESCRIPTION
#2819 
Some proprietary file systems report the links count incorrectly as 1
