### PR TITLE
reduce number of tests threads in nightly to avoid disk pressure that can lead to timeouts

### DIFF
--- a/.github/actions/nebius_threads_calculator/action.yaml
+++ b/.github/actions/nebius_threads_calculator/action.yaml
@@ -34,11 +34,11 @@ runs:
         if [[ $tests_size == *"large"* ]]; then
           case "$vm_preset" in
             "80vcpu-320gb")
-                test_threads=24
+                test_threads=20
                 build_threads=80
             ;;
             "64vcpu-256gb")
-                test_threads=20
+                test_threads=18
                 build_threads=64
             ;;
             "48vcpu-192gb")


### PR DESCRIPTION
we want to see if reducing number of parallel tests during nightly run will help get rid off timeouts in tests for example [here](https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/12738760869/1/nebius-x86-64/summary/ya-test.html#FAIL)