### PR TITLE
issue-2765: backport grpc pr #35064

### DIFF
--- a/contrib/libs/grpc/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/contrib/libs/grpc/src/core/lib/iomgr/tcp_client_posix.cc
@@ -329,6 +329,7 @@ int64_t grpc_tcp_client_create_from_prepared_fd(
     err = connect(fd, reinterpret_cast<const grpc_sockaddr*>(addr->addr),
                   addr->len);
   } while (err < 0 && errno == EINTR);
+  int connect_errno = (err < 0) ? errno : 0;
 
   auto addr_uri = grpc_sockaddr_to_uri(addr);
   if (!addr_uri.ok()) {
@@ -340,7 +341,7 @@ int64_t grpc_tcp_client_create_from_prepared_fd(
   TString name = y_absl::StrCat("tcp-client:", addr_uri.value());
   grpc_fd* fdobj = grpc_fd_create(fd, name.c_str(), true);
   int64_t connection_id = 0;
-  if (errno == EWOULDBLOCK || errno == EINPROGRESS) {
+  if (connect_errno == EWOULDBLOCK || connect_errno == EINPROGRESS) {
     // Connection is still in progress.
     connection_id = g_connection_id.fetch_add(1, std::memory_order_acq_rel);
   }
@@ -352,10 +353,10 @@ int64_t grpc_tcp_client_create_from_prepared_fd(
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, y_absl::OkStatus());
     return 0;
   }
-  if (errno != EWOULDBLOCK && errno != EINPROGRESS) {
+  if (connect_errno != EWOULDBLOCK && connect_errno != EINPROGRESS) {
     // Connection already failed. Return 0 to discourage any cancellation
     // attempts.
-    grpc_error_handle error = GRPC_OS_ERROR(errno, "connect");
+    grpc_error_handle error = GRPC_OS_ERROR(connect_errno, "connect");
     error = grpc_error_set_str(
         error, grpc_core::StatusStrProperty::kTargetAddress, addr_uri.value());
     grpc_fd_orphan(fdobj, nullptr, nullptr, "tcp_client_connect_error");


### PR DESCRIPTION
backport https://github.com/grpc/grpc/pull/35064

probably related to e2e tests failures: https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/PR-check/13010898098/1/nebius-x86-64/test_data/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test-results/py3test/testing_out_stuff/test.py__test_publish_volume_twice_on_the_same_node[mount-True]/ydbd_output.log