### PR TITLE
Disk registry benchmarks

### DIFF
--- a/cloud/blockstore/libs/.gitignore
+++ b/cloud/blockstore/libs/.gitignore
@@ -41,6 +41,7 @@ storage/disk_agent/ut/cloud-blockstore-libs-storage-disk_agent-ut
 storage/disk_registry_proxy/ut/blockstore-libs-storage-disk_registry_proxy-ut
 storage/disk_registry/actors/ut/libs-storage-disk_registry-actors-ut
 storage/disk_registry/model/ut/blockstore-libs-storage-disk_registry-model-ut
+storage/disk_registry/benchmark/benchmark
 storage/disk_registry/ut_allocation/libs-storage-disk_registry-ut_allocation
 storage/disk_registry/ut_checkpoint/libs-storage-disk_registry-ut_checkpoint
 storage/disk_registry/ut_cms/blockstore-libs-storage-disk_registry-ut_cms

--- a/cloud/blockstore/libs/storage/disk_registry/benchmark/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/benchmark/ya.make
@@ -1,0 +1,18 @@
+G_BENCHMARK()
+
+IF (SANITIZER_TYPE)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ENDIF()
+
+SRCS(
+    ../disk_registry_state_benchmark.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/disk_registry/testlib
+)
+
+
+END()

--- a/cloud/blockstore/libs/storage/disk_registry/benchmark/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/benchmark/ya.make
@@ -1,5 +1,7 @@
 G_BENCHMARK()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/disk-registry-state/recipe.inc)
+
 IF (SANITIZER_TYPE)
     INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/large.inc)
 ELSE()

--- a/cloud/blockstore/libs/storage/disk_registry/benchmark/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/benchmark/ya.make
@@ -16,5 +16,4 @@ PEERDIR(
     cloud/blockstore/libs/storage/disk_registry/testlib
 )
 
-
 END()

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -502,6 +502,8 @@ private:
     }                                                                          \
 // BLOCKSTORE_DISK_REGISTRY_COUNTER
 
+TDiskRegistryStateSnapshot MakeNewLoadState(
+    NProto::TDiskRegistryStateBackup&& backup);
 bool ToLogicalBlocks(NProto::TDeviceConfig& device, ui32 logicalBlockSize);
 TString LogDevices(const TVector<NProto::TDeviceConfig>& devices);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
@@ -1,0 +1,173 @@
+#include "disk_registry_state.h"
+
+#include <cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h>
+#include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
+
+#include <library/cpp/testing/common/env.h>
+#include <library/cpp/testing/gbenchmark/benchmark.h>
+
+#include <util/stream/file.h>
+
+#include <google/protobuf/util/json_util.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+TString FilePath(TStringBuf fileName)
+{
+    auto arcRoot = ArcadiaSourceRoot();
+    return JoinFsPaths(
+        arcRoot ? arcRoot : "/work/nbs.3",
+        "cloud/blockstore/libs/storage/disk_registry/benchmark",
+        fileName);
+}
+
+TString ReadFile(const TString& fileName)
+{
+    TFile file(fileName, EOpenModeFlag::RdOnly);
+    return TFileInput(file).ReadAll();
+}
+
+TDiskRegistryState Load(const TString& fileName, bool disableFullGroupsCalc)
+{
+    auto filePath = FilePath(fileName);
+    TString backupData = ReadFile(filePath);
+
+    NProto::TBackupDiskRegistryStateResponse backup;
+
+    auto status =
+        google::protobuf::util::JsonStringToMessage(backupData, &backup);
+    if (!status.ok()) {
+        ythrow yexception() << "Error loading state: " << filePath
+                            << " error: " << status.ToString();
+    }
+    auto monitoring = CreateMonitoringServiceStub();
+    auto diskRegistryGroup = monitoring->GetCounters()
+                                 ->GetSubgroup("counters", "blockstore")
+                                 ->GetSubgroup("component", "disk_registry");
+
+    auto snapshot = MakeNewLoadState(std::move(*backup.MutableBackup()));
+
+    auto storeageConfigProto =
+        NDiskRegistryStateTest::CreateDefaultStorageConfigProto();
+    storeageConfigProto.SetDisableFullPlacementGroupCountCalculation(
+        disableFullGroupsCalc);
+    storeageConfigProto.SetAllocationUnitNonReplicatedSSD(93);
+
+    return TDiskRegistryState(
+        CreateLoggingService("console"),
+        NDiskRegistryStateTest::CreateStorageConfig(
+            std::move(storeageConfigProto)),
+        diskRegistryGroup,
+        std::move(snapshot.Config),
+        std::move(snapshot.Agents),
+        std::move(snapshot.Disks),
+        std::move(snapshot.PlacementGroups),
+        std::move(snapshot.BrokenDisks),
+        std::move(snapshot.DisksToReallocate),
+        std::move(snapshot.DiskStateChanges),
+        snapshot.LastDiskStateSeqNo,
+        std::move(snapshot.DirtyDevices),
+        std::move(snapshot.DisksToCleanup),
+        std::move(snapshot.ErrorNotifications),
+        std::move(snapshot.UserNotifications),
+        std::move(snapshot.OutdatedVolumeConfigs),
+        std::move(snapshot.SuspendedDevices),
+        std::move(snapshot.AutomaticallyReplacedDevices),
+        std::move(snapshot.DiskRegistryAgentListParams));
+}
+
+}   // namespace
+
+static void PublishCounters_All(benchmark::State& benchmarkState)
+{
+    auto state = Load("vla.json", false);
+    for (const auto _: benchmarkState) {
+        state.PublishCounters(TInstant::Now());
+    }
+}
+
+static void PublishCounters_DisableFullGroups(benchmark::State& benchmarkState)
+{
+    auto state = Load("vla.json", true);
+    for (const auto _: benchmarkState) {
+        state.PublishCounters(TInstant::Now());
+    }
+}
+
+void DoCreateDeleteDisk(
+    benchmark::State& benchmarkState,
+    const TDiskRegistryState::TAllocateDiskParams& diskParams)
+{
+    TTestExecutor executor;
+    executor.WriteTx([&](TDiskRegistryDatabase db) mutable
+                     { db.InitSchema(); });
+
+    auto state = Load("vla.json", true);
+    for (const auto _: benchmarkState) {
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TDiskRegistryState::TAllocateDiskResult result{};
+                auto error = state.AllocateDisk(
+                    TInstant::Now(),
+                    db,
+                    diskParams,
+                    &result);
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+            });
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                UNIT_ASSERT_SUCCESS(state.MarkDiskForCleanup(db, "disk-1"));
+                UNIT_ASSERT_SUCCESS(state.DeallocateDisk(db, "disk-1"));
+                for (const auto& device: state.GetDirtyDevices()) {
+                    state.MarkDeviceAsClean(Now(), db, device.GetDeviceUUID());
+                }
+            });
+    }
+}
+
+#define CREATE_AND_DELETE_NRD_DISK(deviceCount)                           \
+    void CreateDeleteDisk_##deviceCount(benchmark::State& benchmarkState) \
+    {                                                                     \
+        TDiskRegistryState::TAllocateDiskParams params{                   \
+            .DiskId = "disk-1",                                           \
+            .PlacementGroupId = {},                                       \
+            .BlockSize = 4_KB,                                            \
+            .BlocksCount = 93_GB * (deviceCount) / 4_KB,                  \
+        };                                                                \
+        DoCreateDeleteDisk(benchmarkState, params);                       \
+    }                                                                     \
+    BENCHMARK(CreateDeleteDisk_##deviceCount);
+
+#define CREATE_AND_DELETE_MIRROR_DISK(deviceCount)       \
+    void CreateDeleteMirrorDisk_##deviceCount(           \
+        benchmark::State& benchmarkState)                \
+    {                                                    \
+        TDiskRegistryState::TAllocateDiskParams params{  \
+            .DiskId = "disk-1",                          \
+            .PlacementGroupId = {},                      \
+            .BlockSize = 4_KB,                           \
+            .BlocksCount = 93_GB * (deviceCount) / 4_KB, \
+            .ReplicaCount = 2};                          \
+        DoCreateDeleteDisk(benchmarkState, params);      \
+    }                                                    \
+    BENCHMARK(CreateDeleteMirrorDisk_##deviceCount);
+
+BENCHMARK(PublishCounters_All);
+BENCHMARK(PublishCounters_DisableFullGroups);
+CREATE_AND_DELETE_NRD_DISK(1);
+CREATE_AND_DELETE_NRD_DISK(10);
+CREATE_AND_DELETE_NRD_DISK(100);
+CREATE_AND_DELETE_MIRROR_DISK(1);
+CREATE_AND_DELETE_MIRROR_DISK(10);
+CREATE_AND_DELETE_MIRROR_DISK(100);
+
+///////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
@@ -106,7 +106,7 @@ void DoCreateDeleteDisk(
     executor.WriteTx([&](TDiskRegistryDatabase db) mutable
                      { db.InitSchema(); });
 
-    auto state = Load("vla.json", true);
+    auto state = Load("vla.json", false);
     for (const auto _: benchmarkState) {
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
@@ -125,8 +125,10 @@ void DoCreateDeleteDisk(
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
             {
-                UNIT_ASSERT_SUCCESS(state.MarkDiskForCleanup(db, "disk-1"));
-                UNIT_ASSERT_SUCCESS(state.DeallocateDisk(db, "disk-1"));
+                UNIT_ASSERT_SUCCESS(
+                    state.MarkDiskForCleanup(db, diskParams.DiskId));
+                UNIT_ASSERT_SUCCESS(
+                    state.DeallocateDisk(db, diskParams.DiskId));
                 for (const auto& device: state.GetDirtyDevices()) {
                     state.MarkDeviceAsClean(Now(), db, device.GetDeviceUUID());
                 }

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -93,6 +93,7 @@ RECURSE(
 )
 
 RECURSE_FOR_TESTS(
+    benchmark
     ut
     ut_allocation
     ut_cms

--- a/cloud/blockstore/tests/.gitignore
+++ b/cloud/blockstore/tests/.gitignore
@@ -38,6 +38,8 @@ python_client/cloud-blockstore-tests-python_client
 rdma/image/cloud
 rdma/image/rootfs.img
 rdma/rdma-test/cloud-blockstore-tests-rdma-rdma-test
+recipes/disk-registry-state/recipe
+recipes/disk-registry-state/data/*
 recipes/endpoint/endpoint-recipe
 recipes/local-kikimr/local-kikimr-recipe
 recipes/local-null/local-null-recipe

--- a/cloud/blockstore/tests/recipes/disk-registry-state/__main__.py
+++ b/cloud/blockstore/tests/recipes/disk-registry-state/__main__.py
@@ -1,0 +1,26 @@
+import json
+import os
+import yatest.common as yatest_common
+
+from yatest.common import process
+from library.python.testing.recipe import declare_recipe, set_env
+
+BACKUP_PATH = "cloud/blockstore/tests/recipes/disk-registry-state/data/backup.json"
+GENERATOR_PATH = "cloud/blockstore/tools/testing/disk-registry-state-generator/disk-registry-state-generator"
+
+
+def start(argv):
+    backup_path = yatest_common.source_path(BACKUP_PATH)
+    process.execute([
+        yatest_common.binary_path(GENERATOR_PATH),
+        "--backup-path",
+        backup_path,
+    ])
+
+
+def stop(argv):
+    None
+
+
+if __name__ == "__main__":
+    declare_recipe(start, stop)

--- a/cloud/blockstore/tests/recipes/disk-registry-state/__main__.py
+++ b/cloud/blockstore/tests/recipes/disk-registry-state/__main__.py
@@ -1,9 +1,7 @@
-import json
-import os
 import yatest.common as yatest_common
 
 from yatest.common import process
-from library.python.testing.recipe import declare_recipe, set_env
+from library.python.testing.recipe import declare_recipe
 
 BACKUP_PATH = "cloud/blockstore/tests/recipes/disk-registry-state/data/backup.json"
 GENERATOR_PATH = "cloud/blockstore/tools/testing/disk-registry-state-generator/disk-registry-state-generator"

--- a/cloud/blockstore/tests/recipes/disk-registry-state/recipe.inc
+++ b/cloud/blockstore/tests/recipes/disk-registry-state/recipe.inc
@@ -1,0 +1,12 @@
+SET(RECIPE_DEPS_LIST
+    cloud/blockstore/tests/recipes/disk-registry-state
+    cloud/blockstore/tools/testing/disk-registry-state-generator
+)
+
+DEPENDS(${RECIPE_DEPS_LIST})
+
+DATA(
+    arcadia/cloud/blockstore/tests/recipes/disk-registry-state/data
+)
+
+USE_RECIPE(cloud/blockstore/tests/recipes/disk-registry-state/recipe)

--- a/cloud/blockstore/tests/recipes/disk-registry-state/ya.make
+++ b/cloud/blockstore/tests/recipes/disk-registry-state/ya.make
@@ -1,0 +1,13 @@
+PY3_PROGRAM(recipe)
+
+PY_SRCS(
+    __main__.py
+)
+
+PEERDIR(
+    cloud/blockstore/tests/python/lib
+    cloud/tasks/test/common
+    library/python/testing/recipe
+)
+
+END()

--- a/cloud/blockstore/tests/recipes/ya.make
+++ b/cloud/blockstore/tests/recipes/ya.make
@@ -1,4 +1,5 @@
 RECURSE(
+    disk-registry-state
     endpoint
     fake-root-kms
     local-kikimr

--- a/cloud/blockstore/tools/.gitignore
+++ b/cloud/blockstore/tools/.gitignore
@@ -48,6 +48,7 @@ testing/chaos-monkey/chaos-monkey
 testing/chaos-monkey/tests/tests
 testing/csi-sanity/bin/cloud
 testing/csi-sanity/bin/csi-sanity
+testing/disk-registry-state-generator/disk-registry-state-generator
 testing/eternal_tests/checkpoint-validator/bin/checkpoint-validator
 testing/eternal_tests/checkpoint-validator/lib/ut/lib-ut
 testing/eternal_tests/eternal-load/bin/eternal-load

--- a/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp
+++ b/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp
@@ -7,6 +7,7 @@
 #include <contrib/libs/protobuf/src/google/protobuf/util/json_util.h>
 
 #include <library/cpp/getopt/small/last_getopt.h>
+#include <library/cpp/monlib/dynamic_counters/encode.h>
 
 #include <util/random/fast.h>
 #include <util/stream/file.h>
@@ -20,17 +21,29 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr ui32 DefaultBlockSize = 4096;
+constexpr ui32 NrdBlockSize = 4096;
+constexpr ui32 LocalBlockSize = 512;
+constexpr size_t NrdDiskInPlacementGroups = 800;
 
 enum class EDevicePool
 {
-    Local,
     Nrd,
+    V1,
+    V3,
+    Chunk29,
+    Chunk58,
+};
+
+enum class EPlacementGroupType
+{
+    Spread,
+    Partition,
 };
 
 enum class EVolumeType
 {
-    Local,
+    V1,
+    V3,
     Nrd,
     Mirror3,
 };
@@ -49,21 +62,43 @@ constexpr TEntityInfo<bool> Racks[]{
 };
 
 constexpr TEntityInfo<EDevicePool> Hosts[]{
-    {.Count = 1000, .Min = 15, .Max = 16, .Tag = EDevicePool::Nrd},
-    {.Count = 1000, .Min = 31, .Max = 32, .Tag = EDevicePool::Nrd},
-    {.Count = 1000, .Min = 64, .Max = 64, .Tag = EDevicePool::Nrd},
-    {.Count = 1000, .Min = 80, .Max = 80, .Tag = EDevicePool::Nrd},
-    {.Count = 1000, .Min = 8, .Max = 8, .Tag = EDevicePool::Local},
+    {.Count = 550, .Min = 15, .Max = 16, .Tag = EDevicePool::Nrd},
+    {.Count = 3000, .Min = 31, .Max = 32, .Tag = EDevicePool::Nrd},
+    {.Count = 600, .Min = 64, .Max = 64, .Tag = EDevicePool::Nrd},
+    {.Count = 300, .Min = 15, .Max = 15, .Tag = EDevicePool::V1},
+    {.Count = 500, .Min = 8, .Max = 8, .Tag = EDevicePool::V3},
+    {.Count = 200, .Min = 4, .Max = 6, .Tag = EDevicePool::Chunk29},
+    {.Count = 25, .Min = 4, .Max = 4, .Tag = EDevicePool::Chunk58},
+};
+
+constexpr TEntityInfo<EPlacementGroupType> PlacementGroups[]{
+    {.Count = 2000, .Min = 0, .Max = 0, .Tag = EPlacementGroupType::Spread},
+    {.Count = 500, .Min = 3, .Max = 5, .Tag = EPlacementGroupType::Partition},
 };
 
 constexpr TEntityInfo<EVolumeType> Disks[]{
-    {.Count = 1000, .Min = 1, .Max = 3, .Tag = EVolumeType::Nrd},
-    {.Count = 1000, .Min = 1, .Max = 3, .Tag = EVolumeType::Mirror3},
+    {.Count = 250, .Min = 1, .Max = 1, .Tag = EVolumeType::V1},
+    {.Count = 2500, .Min = 1, .Max = 1, .Tag = EVolumeType::V3},
+    {.Count = 3000, .Min = 1, .Max = 1, .Tag = EVolumeType::Nrd},
+    {.Count = 2000, .Min = 2, .Max = 3, .Tag = EVolumeType::Nrd},
+    {.Count = 1500, .Min = 4, .Max = 11, .Tag = EVolumeType::Nrd},
+    {.Count = 400, .Min = 12, .Max = 22, .Tag = EVolumeType::Nrd},
+    {.Count = 400, .Min = 23, .Max = 150, .Tag = EVolumeType::Nrd},
+    {.Count = 25, .Min = 151, .Max = 800, .Tag = EVolumeType::Nrd},
+    {.Count = 750, .Min = 1, .Max = 1, .Tag = EVolumeType::Mirror3},
+    {.Count = 350, .Min = 2, .Max = 2, .Tag = EVolumeType::Mirror3},
+    {.Count = 150, .Min = 3, .Max = 3, .Tag = EVolumeType::Mirror3},
+    {.Count = 300, .Min = 4, .Max = 14, .Tag = EVolumeType::Mirror3},
+    {.Count = 150, .Min = 15, .Max = 40, .Tag = EVolumeType::Mirror3},
+    {.Count = 100, .Min = 41, .Max = 50, .Tag = EVolumeType::Mirror3},
+    {.Count = 20, .Min = 51, .Max = 100, .Tag = EVolumeType::Mirror3},
+    {.Count = 5, .Min = 101, .Max = 150, .Tag = EVolumeType::Mirror3},
 };
 
 struct TOptions
 {
-    TString BackupPath;
+    TString BackupPath = "backup.json";
+    ui64 Seed = 42;
 
     void Parse(int argc, char** argv)
     {
@@ -73,6 +108,10 @@ struct TOptions
         opts.AddLongOption("backup-path")
             .RequiredArgument()
             .StoreResult(&BackupPath);
+
+        opts.AddLongOption("seed")
+            .OptionalArgument("NUM")
+            .StoreResult(&Seed);
 
         NLastGetopt::TOptsParseResultException res(&opts, argc, argv);
     }
@@ -95,9 +134,16 @@ void Generate(
     }
 }
 
-auto GenerateAll()
+auto GenerateAll(ui64 seed)
 {
-    TFastRng64 Rand(GetCycleCount());
+    TMap<TString, ui64> AllocationUnit;
+    AllocationUnit[""] = 93_GB;
+    AllocationUnit["standard-v1"] = 98924756992;
+    AllocationUnit["standard-v3"] = 394062200832;
+    AllocationUnit["chunk-2.90TiB"] = 3198924357632;
+    AllocationUnit["chunk-5.82TiB"] = 6398924554240;
+
+    TFastRng64 rand(seed);
 
     TVector<TString> racks;
     auto makeRack = [&](size_t i, size_t val, bool tag)
@@ -110,13 +156,12 @@ auto GenerateAll()
     Generate(
         {std::begin(Racks), std::end(Racks)},
         std::function<void(size_t i, size_t val, bool tag)>(makeRack),
-        Rand);
+        rand);
 
     TVector<NProto::TAgentConfig> agents;
     auto makeHost = [&](size_t i, size_t deviceCount, EDevicePool tag)
     {
-        Y_UNUSED(tag);
-        auto rack = racks[Rand.GenRand() % racks.size()];
+        auto rack = racks[rand.GenRand() % racks.size()];
 
         NProto::TAgentConfig agent;
         agent.SetNodeId(i);
@@ -127,16 +172,79 @@ auto GenerateAll()
             device->SetDeviceName(
                 TStringBuilder() << "device_" << i << "_" << j);
             device->SetDeviceUUID(TStringBuilder() << "uuid_" << i << "_" << j);
-            device->SetBlockSize(DefaultBlockSize);
-            device->SetBlocksCount(24379392);
             device->SetRack(rack);
+            switch (tag) {
+                case EDevicePool::Nrd: {
+                    device->SetBlockSize(NrdBlockSize);
+                    device->SetBlocksCount(
+                        AllocationUnit[""] / DefaultBlockSize);
+                } break;
+                case EDevicePool::V1: {
+                    device->SetBlockSize(LocalBlockSize);
+                    device->SetBlocksCount(
+                        AllocationUnit["standard-v1"] / LocalBlockSize);
+                    device->SetPoolName("standard-v1");
+                    device->SetPoolKind(
+                        NProto::EDevicePoolKind::DEVICE_POOL_KIND_LOCAL);
+                } break;
+                case EDevicePool::V3: {
+                    device->SetBlockSize(LocalBlockSize);
+                    device->SetBlocksCount(
+                        AllocationUnit["standard-v3"] / LocalBlockSize);
+                    device->SetPoolName("standard-v3");
+                    device->SetPoolKind(
+                        NProto::EDevicePoolKind::DEVICE_POOL_KIND_LOCAL);
+                } break;
+                case EDevicePool::Chunk29: {
+                    device->SetBlockSize(LocalBlockSize);
+                    device->SetBlocksCount(
+                        AllocationUnit["chunk-2.90TiB"] / LocalBlockSize);
+                    device->SetPoolName("chunk-2.90TiB");
+                    device->SetPoolKind(
+                        NProto::EDevicePoolKind::DEVICE_POOL_KIND_LOCAL);
+                } break;
+                case EDevicePool::Chunk58: {
+                    device->SetBlockSize(LocalBlockSize);
+                    device->SetBlocksCount(
+                        AllocationUnit["chunk-5.82TiB"] / LocalBlockSize);
+                    device->SetPoolName("chunk-5.82TiB");
+                    device->SetPoolKind(
+                        NProto::EDevicePoolKind::DEVICE_POOL_KIND_LOCAL);
+                } break;
+            }
         }
         agents.push_back(std::move(agent));
     };
     Generate(
         {std::begin(Hosts), std::end(Hosts)},
         std::function<void(size_t i, size_t val, EDevicePool tag)>(makeHost),
-        Rand);
+        rand);
+
+    TVector<NProto::TPlacementGroupConfig> placementGroups;
+    auto makePlacementGroup =
+        [&](size_t i, size_t groupCount, EPlacementGroupType tag)
+    {
+        NProto::TPlacementGroupConfig config;
+        switch (tag) {
+            case EPlacementGroupType::Spread: {
+                config.SetGroupId(TStringBuilder() << "Spread_" << i);
+                config.SetPlacementStrategy(
+                    NProto::EPlacementStrategy::PLACEMENT_STRATEGY_SPREAD);
+            } break;
+            case EPlacementGroupType::Partition: {
+                config.SetGroupId(TStringBuilder() << "Partition_" << i);
+                config.SetPlacementStrategy(
+                    NProto::EPlacementStrategy::PLACEMENT_STRATEGY_PARTITION);
+                config.SetPlacementPartitionCount(groupCount);
+            } break;
+        }
+        placementGroups.push_back(std::move(config));
+    };
+    Generate(
+        {std::begin(PlacementGroups), std::end(PlacementGroups)},
+        std::function<void(size_t, size_t, EPlacementGroupType)>(
+            makePlacementGroup),
+        rand);
 
     auto monitoring = NCloud::CreateMonitoringServiceStub();
     auto diskRegistryGroup = monitoring->GetCounters()
@@ -147,25 +255,91 @@ auto GenerateAll()
             .AddDevicePoolConfig("", 93_GB, NProto::DEVICE_POOL_KIND_DEFAULT)
             .With(diskRegistryGroup)
             .WithAgents(std::move(agents))
+            .WithPlacementGroups(placementGroups)
+            .AddDevicePoolConfig(
+                "standard-v1",
+                AllocationUnit["standard-v1"],
+                NProto::DEVICE_POOL_KIND_LOCAL)
+            .AddDevicePoolConfig(
+                "standard-v3",
+                AllocationUnit["standard-v3"],
+                NProto::DEVICE_POOL_KIND_LOCAL)
+            .AddDevicePoolConfig(
+                "chunk-2.90TiB",
+                AllocationUnit["chunk-2.90TiB"],
+                NProto::DEVICE_POOL_KIND_LOCAL)
+            .AddDevicePoolConfig(
+                "chunk-5.82TiB",
+                AllocationUnit["chunk-5.82TiB"],
+                NProto::DEVICE_POOL_KIND_LOCAL)
             .Build();
 
     TTestExecutor executor;
     executor.WriteTx([&](TDiskRegistryDatabase db) mutable
                      { db.InitSchema(); });
 
+    // Count probability for placement group
+    const auto totalNrdCount = Accumulate(
+        Disks,
+        size_t{},
+        [](size_t acc, const TEntityInfo<EVolumeType>& diskInfo)
+        {
+            return acc +
+                   (diskInfo.Tag == EVolumeType::Nrd ? diskInfo.Count : 0);
+        });
+    const auto placementGroupProbability =
+        static_cast<double>(NrdDiskInPlacementGroups) / totalNrdCount;
+
     auto makeDisk = [&](size_t i, size_t deviceCount, EVolumeType tag)
     {
+        TString placementGroupId;
+        ui32 placementPartitionIndex = 0;
+        const bool isInPlacementGroup =
+            rand.GenRand() <
+            placementGroupProbability *
+                std::numeric_limits<decltype(rand.GenRand())>::max();
+        if (tag == EVolumeType::Nrd && isInPlacementGroup) {
+            auto indx = rand.GenRand() % placementGroups.size();
+            placementGroupId = placementGroups[indx].GetGroupId();
+            if (auto partCount =
+                    placementGroups[indx].GetPlacementPartitionCount())
+            {
+                placementPartitionIndex = rand.GenRand() % partCount;
+            }
+        }
+
+        auto mediaKind = NProto::STORAGE_MEDIA_SSD_NONREPLICATED;
+        TString poolName;
+        ui32 blockSize = DefaultBlockSize;
+        switch (tag) {
+            case EVolumeType::V1:
+                poolName = "standard-v1";
+                mediaKind = NProto::STORAGE_MEDIA_SSD_LOCAL;
+                blockSize = LocalBlockSize;
+                break;
+            case EVolumeType::V3:
+                poolName = "standard-v3";
+                mediaKind = NProto::STORAGE_MEDIA_SSD_LOCAL;
+                blockSize = LocalBlockSize;
+                break;
+            case EVolumeType::Mirror3:
+                mediaKind = NProto::STORAGE_MEDIA_SSD_MIRROR3;
+                break;
+            case EVolumeType::Nrd:
+                break;
+        }
+
         TDiskRegistryState::TAllocateDiskParams diskParams{
             .DiskId = TStringBuilder() << "disk_" << i,
-            .PlacementGroupId = {},
-            .BlockSize = 4_KB,
-            .BlocksCount = 93_GB * (deviceCount) / 4_KB,
+            .PlacementGroupId = placementGroupId,
+            .PlacementPartitionIndex = placementPartitionIndex,
+            .BlockSize = blockSize,
+            .BlocksCount = AllocationUnit[poolName] * deviceCount / blockSize,
             .ReplicaCount =
                 static_cast<ui32>(tag == EVolumeType::Mirror3 ? 2 : 0),
-            .MediaKind =
-                (tag == EVolumeType::Mirror3
-                     ? NProto::STORAGE_MEDIA_SSD_MIRROR3
-                     : NProto::STORAGE_MEDIA_SSD_NONREPLICATED)};
+            .PoolName = poolName,
+            .MediaKind = mediaKind,
+        };
 
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
@@ -181,8 +355,19 @@ auto GenerateAll()
     Generate(
         {std::begin(Disks), std::end(Disks)},
         std::function<void(size_t i, size_t val, EVolumeType tag)>(makeDisk),
-        Rand);
+        rand);
 
+    {   // Output stat.
+        state.PublishCounters(TInstant::Now());
+        for (size_t i = 0; i < state.GetAgents().size(); ++i) {
+            diskRegistryGroup->RemoveSubgroup(
+                "agent",
+                TStringBuilder() << "Agent_" << i);
+        }
+
+        Cout << "Finish generate state:\n";
+        diskRegistryGroup->OutputPlainText(Cout, "\t");
+    }
     return state;
 }
 
@@ -193,7 +378,7 @@ int main(int argc, char** argv)
     TOptions opts;
     opts.Parse(argc, argv);
 
-    auto state = GenerateAll();
+    auto state = GenerateAll(opts.Seed);
     NProto::TDiskRegistryStateBackup backupState = state.BackupState();
     NProto::TBackupDiskRegistryStateResponse backup;
     backup.MutableBackup()->Swap(&backupState);

--- a/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp
+++ b/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp
@@ -1,0 +1,204 @@
+#include <cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h>
+#include <cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h>
+#include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+
+#include <contrib/libs/protobuf/src/google/protobuf/stubs/port.h>
+#include <contrib/libs/protobuf/src/google/protobuf/util/json_util.h>
+
+#include <util/random/fast.h>
+#include <util/stream/file.h>
+
+#include <google/protobuf/util/json_util.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+constexpr ui32 DefaultBlockSize = 4096;
+
+enum class EDevicePool
+{
+    Local,
+    Nrd,
+};
+
+enum class EVolumeType
+{
+    Local,
+    Nrd,
+    Mirror3,
+};
+
+template <typename TTag>
+struct TEntityInfo
+{
+    size_t Count = 0;
+    size_t Min = 0;
+    size_t Max = 0;
+    TTag Tag{};
+};
+
+constexpr TEntityInfo<bool> Racks[]{
+    {.Count = 250},
+};
+
+constexpr TEntityInfo<EDevicePool> Hosts[]{
+    {.Count = 1000, .Min = 15, .Max = 16, .Tag = EDevicePool::Nrd},
+    {.Count = 1000, .Min = 31, .Max = 32, .Tag = EDevicePool::Nrd},
+    {.Count = 1000, .Min = 64, .Max = 64, .Tag = EDevicePool::Nrd},
+    {.Count = 1000, .Min = 80, .Max = 80, .Tag = EDevicePool::Nrd},
+    {.Count = 1000, .Min = 8, .Max = 8, .Tag = EDevicePool::Local},
+};
+
+constexpr TEntityInfo<EVolumeType> Disks[]{
+    {.Count = 1000, .Min = 1, .Max = 3, .Tag = EVolumeType::Nrd},
+    {.Count = 1000, .Min = 1, .Max = 3, .Tag = EVolumeType::Mirror3},
+};
+
+//////////////////////////////////////////////////////////////////
+
+template <typename TTag>
+void Generate(
+    const std::span<const TEntityInfo<TTag>>& entities,
+    std::function<void(size_t i, size_t val, TTag tag)> generator,
+    TFastRng64& rand)
+{
+    size_t i = 0;
+    for (const auto& entityInfo: entities) {
+        for (size_t cnt = 0; cnt < entityInfo.Count; ++cnt) {
+            auto val =
+                (rand.GenRand() % (entityInfo.Max - entityInfo.Min + 2)) +
+                entityInfo.Min;
+            generator(i++, val, entityInfo.Tag);
+        }
+    }
+}
+/*
+NProto::TDiskConfig Disk(
+    const TString& diskId,
+    const TVector<TString>& uuids,
+    NProto::EDiskState state)
+{
+    NProto::TDiskConfig config;
+
+    config.SetDiskId(diskId);
+    config.SetBlockSize(DefaultBlockSize);
+    config.SetState(state);
+
+    for (const auto& uuid: uuids) {
+        *config.AddDeviceUUIDs() = uuid;
+    }
+
+    return config;
+}
+*/
+auto GenerateAll()
+{
+    TFastRng64 Rand(GetCycleCount());
+
+    TVector<TString> racks;
+    auto makeRack = [&](size_t i, size_t val, bool tag)
+    {
+        Y_UNUSED(val);
+        Y_UNUSED(tag);
+
+        racks.push_back(TStringBuilder() << "Rack_" << i);
+    };
+    Generate(
+        {std::begin(Racks), std::end(Racks)},
+        std::function<void(size_t i, size_t val, bool tag)>(makeRack),
+        Rand);
+
+    TVector<NProto::TAgentConfig> agents;
+    auto makeHost = [&](size_t i, size_t deviceCount, EDevicePool tag)
+    {
+        Y_UNUSED(tag);
+        auto rack = racks[Rand.GenRand() % racks.size()];
+
+        NProto::TAgentConfig agent;
+        agent.SetNodeId(i);
+        agent.SetAgentId(TStringBuilder() << "Agent_" << i);
+        for (size_t j = 0; j < deviceCount; ++j) {
+            auto* device = agent.MutableDevices()->Add();
+            device->SetAgentId(agent.GetAgentId());
+            device->SetDeviceName(
+                TStringBuilder() << "device_" << i << "_" << j);
+            device->SetDeviceUUID(TStringBuilder() << "uuid_" << i << "_" << j);
+            device->SetBlockSize(DefaultBlockSize);
+            device->SetBlocksCount(24379392);
+            device->SetRack(rack);
+        }
+        agents.push_back(std::move(agent));
+    };
+    Generate(
+        {std::begin(Hosts), std::end(Hosts)},
+        std::function<void(size_t i, size_t val, EDevicePool tag)>(makeHost),
+        Rand);
+
+    auto monitoring = CreateMonitoringServiceStub();
+    auto diskRegistryGroup = monitoring->GetCounters()
+                                 ->GetSubgroup("counters", "blockstore")
+                                 ->GetSubgroup("component", "disk_registry");
+    auto state =
+        NDiskRegistryStateTest::TDiskRegistryStateBuilder()
+            .AddDevicePoolConfig("", 93_GB, NProto::DEVICE_POOL_KIND_DEFAULT)
+            .With(diskRegistryGroup)
+            .WithAgents(std::move(agents))
+            .Build();
+
+    TTestExecutor executor;
+    executor.WriteTx([&](TDiskRegistryDatabase db) mutable
+                     { db.InitSchema(); });
+
+    auto makeDisk = [&](size_t i, size_t deviceCount, EVolumeType tag)
+    {
+        TDiskRegistryState::TAllocateDiskParams diskParams{
+            .DiskId = TStringBuilder() << "disk_" << i,
+            .PlacementGroupId = {},
+            .BlockSize = 4_KB,
+            .BlocksCount = 93_GB * (deviceCount) / 4_KB,
+            .ReplicaCount =
+                static_cast<ui32>(tag == EVolumeType::Mirror3 ? 2 : 0),
+            .MediaKind =
+                (tag == EVolumeType::Mirror3
+                     ? NProto::STORAGE_MEDIA_SSD_MIRROR3
+                     : NProto::STORAGE_MEDIA_SSD_NONREPLICATED)};
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TDiskRegistryState::TAllocateDiskResult result{};
+                auto error = state.AllocateDisk(
+                    TInstant::Now(),
+                    db,
+                    diskParams,
+                    &result);
+            });
+    };
+    Generate(
+        {std::begin(Disks), std::end(Disks)},
+        std::function<void(size_t i, size_t val, EVolumeType tag)>(makeDisk),
+        Rand);
+
+    return state;
+}
+
+}   // namespace
+
+}   // namespace NCloud::NBlockStore::NStorage
+
+int main(int argc, char** argv)
+{
+    Y_UNUSED(argc);
+    Y_UNUSED(argv);
+
+    TString filePath = "backup.json";
+    auto state = NCloud::NBlockStore::NStorage::GenerateAll();
+    auto backup = state.BackupState();
+
+    TProtoStringType str;
+    google::protobuf::util::MessageToJsonString(backup, &str);
+    TFileOutput(filePath).Write(str.c_str());
+    return 0;
+}

--- a/cloud/blockstore/tools/testing/disk-registry-state-generator/ya.make
+++ b/cloud/blockstore/tools/testing/disk-registry-state-generator/ya.make
@@ -1,0 +1,12 @@
+PROGRAM()
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/disk_registry
+    cloud/blockstore/libs/storage/disk_registry/testlib
+)
+
+END()

--- a/cloud/blockstore/tools/testing/ya.make
+++ b/cloud/blockstore/tools/testing/ya.make
@@ -2,9 +2,11 @@ RECURSE(
     bad-guest
     build-fresh-blob
     chaos-monkey
+    disk-registry-state-generator
     eternal_tests
     fake-conductor
     fake-nbs
+    fake-root-kms
     fake-vhost-server
     generate-agents
     infra-client
@@ -14,7 +16,6 @@ RECURSE(
     pd-metadata-bench
     plugintest
     rdma-test
-    fake-root-kms
     stable-plugin
     verify-test
 )


### PR DESCRIPTION
Сделал бенчмарки для DiskRegistry.
Пока только:
 - публикация счетчиков (из-за чего у нас был инцидент)
 -  создание/удаление Nonrepl дисков разного размера
 -  создание/удаление Mirror дисков разного размера

Перед запуском теста через утилиту создается бэкап DR. Бэкап чем-то напоминает один из кластеров. Утилита запускается через рецепт.
Анонимизрованный бэкап тоже бы подошел, но генерация стейта позволит отвечать на вопрос: "что будет когда кластер вырастет до размера Х".

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
PublishCounters_All                869476645 ns    869360580 ns            1
PublishCounters_DisableFullGroups  110054493 ns    110037269 ns            7
CreateDeleteDisk_1                   1231569 ns      1231337 ns          527
CreateDeleteDisk_10                  1626632 ns      1626296 ns          409
CreateDeleteDisk_100                 4466892 ns      4466522 ns          152
CreateDeleteMirrorDisk_1             3772063 ns      3771956 ns          174
CreateDeleteMirrorDisk_10            5030665 ns      5030398 ns          100
CreateDeleteMirrorDisk_100          15163751 ns     15161019 ns           45
```