### PR TITLE
[Disk Manager] check number of inflight tasks properly in test

### DIFF
--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -726,6 +726,7 @@ func TestTasksInflightLimit(t *testing.T) {
 	config.StalkingRunnersCount = &runnersCount
 
 	registry := mocks.NewIgnoreUnknownCallsRegistryMock()
+	defer registry.AssertAllExpectations(t)
 
 	s := createServicesWithConfig(t, ctx, db, config, registry)
 
@@ -809,11 +810,7 @@ func TestTasksInflightLimit(t *testing.T) {
 			// So long tasks can be taken by listerReadyToRun or
 			// listerStallingWhileRunning lister.
 			// Thus we need to compare runningLongTaskCount with doubled inflightLongTaskPerNodeLimit.
-			require.LessOrEqual(
-				t,
-				count,
-				2*inflightLongTaskPerNodeLimit,
-			)
+			require.LessOrEqual(t, count, 2*inflightLongTaskPerNodeLimit)
 		case err := <-doublerTaskErrs:
 			require.NoError(t, err)
 			endedDoublerTaskCount++
@@ -823,7 +820,6 @@ func TestTasksInflightLimit(t *testing.T) {
 
 			if endedLongTaskCount == scheduledLongTaskCount {
 				require.EqualValues(t, scheduledDoublerTaskCount, endedDoublerTaskCount)
-				registry.AssertAllExpectations(t)
 				return
 			}
 		}

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -180,7 +180,7 @@ func createServicesWithConfig(
 	}
 }
 
-func createServicesWithSchedulerMetricsRegistry(
+func createServicesWithMetricsRegistry(
 	t *testing.T,
 	ctx context.Context,
 	db *persistence.YDBClient,
@@ -208,7 +208,7 @@ func createServices(
 	runnersCount uint64,
 ) services {
 
-	return createServicesWithSchedulerMetricsRegistry(
+	return createServicesWithMetricsRegistry(
 		t,
 		ctx,
 		db,
@@ -741,7 +741,7 @@ func TestTasksInflightLimit(t *testing.T) {
 	registry := mocks.NewIgnoreUnknownCallsRegistryMock()
 	defer registry.AssertAllExpectations(t)
 
-	s := createServicesWithSchedulerMetricsRegistry(
+	s := createServicesWithMetricsRegistry(
 		t,
 		ctx,
 		db,

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -824,7 +824,8 @@ func TestTasksInflightLimit(t *testing.T) {
 		select {
 		case <-ticker.C:
 			// Note that inflight task is not the same as task with status 'running'.
-			// The task with status 'running' might not be executing right now.
+			// The task with status 'running' might not be executing right now
+			// in case of retriable or interrupt execution error.
 			count := int(inflightLongTasksCount.Load())
 			logging.Debug(ctx, "There are %v inflight tasks of type long", count)
 			// We have separate inflight per node limit for each lister.

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -180,12 +180,12 @@ func createServicesWithConfig(
 	}
 }
 
-func createServicesWithMetricsRegistry(
+func createServicesWithSchedulerMetricsRegistry(
 	t *testing.T,
 	ctx context.Context,
 	db *persistence.YDBClient,
 	runnersCount uint64,
-	schedulerRegistry metrics.Registry,
+	metricsRegistry metrics.Registry,
 ) services {
 
 	config := proto.Clone(newDefaultConfig()).(*tasks_config.TasksConfig)
@@ -197,7 +197,7 @@ func createServicesWithMetricsRegistry(
 		ctx,
 		db,
 		config,
-		schedulerRegistry,
+		metricsRegistry,
 	)
 }
 
@@ -208,7 +208,7 @@ func createServices(
 	runnersCount uint64,
 ) services {
 
-	return createServicesWithMetricsRegistry(
+	return createServicesWithSchedulerMetricsRegistry(
 		t,
 		ctx,
 		db,
@@ -223,14 +223,14 @@ func (s *services) startRunners(ctx context.Context) error {
 
 func (s *services) startRunnersWithMetricsRegistry(
 	ctx context.Context,
-	runnerMetricsRegistry metrics.Registry,
+	metricsRegistry metrics.Registry,
 ) error {
 
 	return tasks.StartRunners(
 		ctx,
 		s.storage,
 		s.registry,
-		runnerMetricsRegistry,
+		metricsRegistry,
 		s.config,
 		"localhost",
 	)
@@ -741,7 +741,7 @@ func TestTasksInflightLimit(t *testing.T) {
 	registry := mocks.NewIgnoreUnknownCallsRegistryMock()
 	defer registry.AssertAllExpectations(t)
 
-	s := createServicesWithMetricsRegistry(
+	s := createServicesWithSchedulerMetricsRegistry(
 		t,
 		ctx,
 		db,

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -824,7 +824,7 @@ func TestTasksInflightLimit(t *testing.T) {
 		select {
 		case <-ticker.C:
 			// Note that inflight task is not the same as task with status 'running'.
-			// The task with status 'running' might not be executed right now.
+			// The task with status 'running' might not be executing right now.
 			count := int(inflightLongTasksCount.Load())
 			logging.Debug(ctx, "There are %v inflight tasks of type long", count)
 			// We have separate inflight per node limit for each lister.


### PR DESCRIPTION
Test on inflight tasks limit should check the number of inflight tasks. This is not the same at the number of tasks in status 'running' because a task can be running but not inflight.