### PR TITLE
Add GarbageCompactionRangeCountPerRun and ForcedCompactionRangeCountPerRun parameters to batch compaction feature

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -682,7 +682,8 @@ message TStorageServiceConfig
     // Number of ranges to process in a single Compaction run.
     optional uint32 CompactionRangeCountPerRun = 264;
 
-    // Specifies whether to use CompactionRangeCountPerRun.
+    // Specifies whether to use CompactionRangeCountPerRun,
+    // GarbageCompactionRangeCountPerRun and ForcedCompactionRangeCountPerRun.
     optional bool BatchCompactionEnabled = 265;
 
     // Timeout before allowing infra to withdraw our unavailable agents.
@@ -1089,7 +1090,15 @@ message TStorageServiceConfig
 
     // Enable buttons for device state changing, when they in error state.
     optional bool EnableToChangeErrorStatesFromDiskRegistryMonpage = 398;
-    
+
     // Enabling UsedQuota calculation as UsedIopsQuota + UsedBandwidthQuota
     optional bool CalculateSplittedUsedQuotaMetric = 399;
+
+    // Number of ranges to process in a single Compaction run
+    // in the garbage mode if batch compaction enabled.
+    optional uint32 GarbageCompactionRangeCountPerRun = 400;
+
+    // Number of ranges to process in a single Compaction run
+    // in the range mode if batch compaction enabled.
+    optional uint32 ForcedCompactionRangeCountPerRun = 401;
 }

--- a/cloud/blockstore/libs/storage/core/compaction_map.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map.cpp
@@ -524,6 +524,40 @@ TVector<ui32> TCompactionMap::GetNonEmptyRanges() const
     return result;
 }
 
+TVector<TCompactionCounter> TCompactionMap::GetNonEmptyRanges(
+    ui32 blockIndex,
+    ui32 rangesCount) const
+{
+    if (!rangesCount) {
+        return {};
+    }
+
+    const ui32 groupStart = GetGroupStart(blockIndex, Impl->RangeSize);
+    auto rangeIndex = (blockIndex - groupStart) / Impl->RangeSize;
+
+    TVector<TCompactionCounter> result(Reserve(rangesCount));
+
+    for (auto groupIt = TImpl::TGroupByBlockIndexTree::TIterator(
+             Impl->GroupByBlockIndex.Find(groupStart));
+         groupIt != Impl->GroupByBlockIndex.End();
+         ++groupIt, rangeIndex = 0)
+    {
+        const auto& group = static_cast<TImpl::TGroupNode&>(*groupIt);
+        for (; rangeIndex < group.Stats.size(); ++rangeIndex) {
+            if (group.Stats[rangeIndex].BlobCount > 0) {
+                const auto groupRangeStart =
+                    group.BlockIndex + (rangeIndex * Impl->RangeSize);
+                result.emplace_back(groupRangeStart, group.Stats[rangeIndex]);
+                if (result.size() == rangesCount) {
+                    return result;
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
 ui32 TCompactionMap::GetNonEmptyRangeCount() const
 {
     return Impl->GetNonEmptyRangeCount();

--- a/cloud/blockstore/libs/storage/core/compaction_map.h
+++ b/cloud/blockstore/libs/storage/core/compaction_map.h
@@ -79,6 +79,8 @@ public:
     TVector<TCompactionCounter> GetTop(size_t count) const;
     TVector<TCompactionCounter> GetTopByGarbageBlockCount(size_t count) const;
     TVector<ui32> GetNonEmptyRanges() const;
+    // Returns non-empty ranges, starting from the blockIndex
+    TVector<TCompactionCounter> GetNonEmptyRanges(ui32 blockIndex, ui32 rangesCount) const;
     ui32 GetNonEmptyRangeCount() const;
     ui32 GetRangeStart(ui32 blockIndex) const;
     ui32 GetRangeIndex(ui32 blockIndex) const;

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -156,10 +156,12 @@ TDuration MSeconds(ui32 value)
     xxx(TargetCompactionBytesPerOp,             ui64,   64_KB                 )\
     xxx(MaxSkippedBlobsDuringCompaction,        ui32,   3                     )\
     xxx(IncrementalCompactionEnabled,           bool,   false                 )\
-    xxx(CompactionRangeCountPerRun,             ui32,   3                     )\
     xxx(CompactionCountPerRunIncreasingThreshold, ui32, 0                     )\
     xxx(CompactionCountPerRunDecreasingThreshold, ui32, 0                     )\
+    xxx(CompactionRangeCountPerRun,             ui32,   3                     )\
     xxx(MaxCompactionRangeCountPerRun,          ui32,   8                     )\
+    xxx(GarbageCompactionRangeCountPerRun,      ui32,   1                     )\
+    xxx(ForcedCompactionRangeCountPerRun,       ui32,   1                     )\
     xxx(CompactionCountPerRunChangingPeriod,    TDuration, Seconds(60)        )\
     xxx(BatchCompactionEnabled,                 bool,   false                 )\
     xxx(BlobPatchingEnabled,                    bool,   false                 )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -95,6 +95,8 @@ public:
     ui32 GetCompactionCountPerRunDecreasingThreshold() const;
     ui32 GetCompactionRangeCountPerRun() const;
     ui32 GetMaxCompactionRangeCountPerRun() const;
+    ui32 GetGarbageCompactionRangeCountPerRun() const;
+    ui32 GetForcedCompactionRangeCountPerRun() const;
     TDuration GetCompactionCountPerRunChangingPeriod() const;
     bool GetBatchCompactionEnabled() const;
     bool GetBlobPatchingEnabled() const;

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -43,6 +43,19 @@ def storage_config_with_incremental_batch_compaction():
     return storage
 
 
+def storage_config_with_garbage_batch_compaction():
+    storage = default_storage_config()
+    storage.BatchCompactionEnabled = True
+    storage.GarbageCompactionRangeCountPerRun = 20
+    storage.V1GarbageCompactionEnabled = True
+    storage.CompactionGarbageThreshold = 20
+    storage.CompactionRangeGarbageThreshold = 999999
+    storage.SSDMaxBlobsPerRange = 5
+    storage.HDDMaxBlobsPerRange = 5
+
+    return storage
+
+
 def storage_config_with_incremental_compaction_and_patching():
     storage = storage_config_with_incremental_compaction()
     storage.BlobPatchingEnabled = True


### PR DESCRIPTION
Добавляются новые параметры для управления batch compaction:
- GarbageCompactionRangeCountPerRun - сколько ренджей обрабатывать за один компакшн в режиме garbage compaction;
- ForceCompactionRangeCountPerRun - сколько ренджей обрабатывать за один компакшн по команде от оператора (force).
Эти параметры учитываются только если BatchCompactionEnabled == true, т.е. batch compaction включен.