### PR TITLE
Fix TAioTest::ShouldRetryIoSetupErrors

### DIFF
--- a/cloud/storage/core/libs/aio/service_ut.cpp
+++ b/cloud/storage/core/libs/aio/service_ut.cpp
@@ -106,7 +106,7 @@ Y_UNIT_TEST_SUITE(TAioTest)
         promise1.GetFuture().GetValueSync();
         Sleep(TDuration::Seconds(1));
         service1.reset();
-        promise2.GetFuture().GetValue(TDuration::Seconds(5));
+        promise2.GetFuture().GetValueSync();
     }
 }
 


### PR DESCRIPTION
```
retrying EAGAIN from io_setup, aio-nr/max: 33792/65536
[[bad]](NThreading::TFutureException) library/cpp/threading/future/core/future-inl.h:309: wait timeout[[rst]]
[[alt1]][[rst]]
###subtest-finished:TAioTest::ShouldRetryIoSetupErrors
retrying EAGAIN from io_setup, aio-nr/max: 33792/65536
```