### PR TITLE
Fix flapping test filestore/tests/profile_log/qemu-local-test

### DIFF
--- a/cloud/filestore/libs/daemon/server/config_initializer.cpp
+++ b/cloud/filestore/libs/daemon/server/config_initializer.cpp
@@ -33,6 +33,10 @@ void TConfigInitializerServer::InitAppConfig()
     }
 
     ServerConfig = std::make_shared<NServer::TServerConfig>(serverConfig);
+
+    if (Options->DiagnosticsConfig) {
+        InitDiagnosticsConfig();
+    }
 }
 
 void TConfigInitializerServer::ApplyServerAppConfig(const TString& text)

--- a/cloud/filestore/libs/daemon/vhost/config_initializer.cpp
+++ b/cloud/filestore/libs/daemon/vhost/config_initializer.cpp
@@ -38,6 +38,10 @@ void TConfigInitializerVhost::InitAppConfig()
 
     VhostServiceConfig = std::make_shared<TVhostServiceConfig>(
         AppConfig.GetVhostServiceConfig());
+
+    if (Options->DiagnosticsConfig) {
+        InitDiagnosticsConfig();
+    }
 }
 
 void TConfigInitializerVhost::ApplyVHostAppConfig(const TString& text)

--- a/cloud/filestore/libs/diagnostics/profile_log.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log.cpp
@@ -41,6 +41,11 @@ public:
     {
     }
 
+    ~TProfileLog() override
+    {
+        Flush();
+    }
+
 public:
     void Start() override;
     void Stop() override;


### PR DESCRIPTION
With reducing ProfileLogTimeThreshold to 100ms
Also flush profile log on destruct