### PR TITLE
Flush profile logs on destruct

### DIFF
--- a/cloud/blockstore/libs/diagnostics/profile_log.cpp
+++ b/cloud/blockstore/libs/diagnostics/profile_log.cpp
@@ -130,7 +130,7 @@ private:
 
 TProfileLog::~TProfileLog()
 {
-    Flush();
+    DoFlush();
 }
 
 void TProfileLog::Start()

--- a/cloud/blockstore/libs/diagnostics/profile_log.cpp
+++ b/cloud/blockstore/libs/diagnostics/profile_log.cpp
@@ -114,7 +114,7 @@ public:
     {
     }
 
-    ~TProfileLog();
+    ~TProfileLog() override;
 
 public:
     void Start() override;

--- a/cloud/blockstore/libs/diagnostics/profile_log.cpp
+++ b/cloud/blockstore/libs/diagnostics/profile_log.cpp
@@ -114,6 +114,8 @@ public:
     {
     }
 
+    ~TProfileLog();
+
 public:
     void Start() override;
     void Stop() override;
@@ -125,6 +127,11 @@ private:
     void ScheduleFlush();
     void DoFlush();
 };
+
+TProfileLog::~TProfileLog()
+{
+    Flush();
+}
 
 void TProfileLog::Start()
 {

--- a/cloud/blockstore/libs/diagnostics/profile_log_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/profile_log_ut.cpp
@@ -110,14 +110,12 @@ struct TEnv
 
     ~TEnv()
     {
-        if (ProfileLog) {
-            ProfileLog->Stop();
-        }
+        ProfileLog->Stop();
     }
 
-    void ProcessLog()
+    void ProcessLog(bool runScheduler = true)
     {
-        if (Scheduler) {
+        if (runScheduler) {
             Scheduler->RunAllScheduledTasks();
         }
 
@@ -405,9 +403,8 @@ Y_UNIT_TEST_SUITE(TProfileLogTest)
                  TDuration::MilliSeconds(42),
                  TBlockRange64::WithLength(10, 20),
              }});
-        env.Scheduler = nullptr;
-        env.ProfileLog = nullptr;
-        env.ProcessLog();
+        env.ProfileLog = CreateProfileLogStub();
+        env.ProcessLog(false);
         UNIT_ASSERT_VALUES_EQUAL(1, env.EventProcessor.FlatMessages.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "disk2\t3000000\tR\t9\t300000\t42000\t10,20",

--- a/cloud/filestore/libs/diagnostics/profile_log.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log.cpp
@@ -41,6 +41,8 @@ public:
     {
     }
 
+    ~TProfileLog();
+
 public:
     void Start() override;
     void Stop() override;
@@ -51,6 +53,11 @@ private:
     void ScheduleFlush();
     void Flush();
 };
+
+TProfileLog::~TProfileLog()
+{
+    Flush();
+}
 
 void TProfileLog::Start()
 {

--- a/cloud/filestore/libs/diagnostics/profile_log.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log.cpp
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    ~TProfileLog();
+    ~TProfileLog() override;
 
 public:
     void Start() override;

--- a/cloud/filestore/libs/diagnostics/profile_log_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_ut.cpp
@@ -128,22 +128,18 @@ struct TEnv
 
     void SetUp(NUnitTest::TTestContext& /*context*/) override
     {
-        if (ProfileLog) {
-            ProfileLog->Start();
-        }
+        ProfileLog->Start();
     }
 
     void TearDown(NUnitTest::TTestContext& /*context*/) override
     {
-        if (ProfileLog) {
-            ProfileLog->Stop();
-        }
+        ProfileLog->Stop();
         ProfilePath.DeleteIfExists();
     }
 
-    void ProcessLog()
+    void ProcessLog(bool runScheduler = true)
     {
-        if (Scheduler) {
+        if (runScheduler) {
             Scheduler->RunAllScheduledTasks();
         }
 
@@ -385,9 +381,8 @@ Y_UNIT_TEST_SUITE(TProfileLogTest)
                  .SetError(0)
                  .Build()});
 
-        ProfileLog = nullptr;
-        Scheduler = nullptr;
-        ProcessLog();
+        ProfileLog = CreateProfileLogStub();
+        ProcessLog(false);
 
         UNIT_ASSERT_VALUES_EQUAL(7, EventProcessor.FlatMessages.size());
         UNIT_ASSERT_VALUES_EQUAL(


### PR DESCRIPTION
To avoid losing up to 15 seconds of logs on server exit or soft crash 