### PR TITLE
Add parameters WriteMixedBlobThreshold and WriteMixedBlobThresholdSSD

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1103,4 +1103,11 @@ message TStorageServiceConfig
     optional uint32 ForcedCompactionRangeCountPerRun = 401;
 
     optional bool YdbViewerServiceEnabled = 402;
+
+    // Minimum write request size (in bytes) that lets us write the data
+    // to the mixed channel. If 0 then disabled.
+    optional uint32 WriteMixedBlobThreshold = 403;
+
+    // Overrides WriteMixedBlobThreshold for SSD volumes.
+    optional uint32 WriteMixedBlobThresholdSSD = 404;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -132,6 +132,8 @@ TDuration MSeconds(ui32 value)
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \
     xxx(WriteBlobThreshold,            ui32,      1_MB                        )\
     xxx(WriteBlobThresholdSSD,         ui32,      128_KB                      )\
+    xxx(WriteMixedBlobThreshold,       ui32,      0                           )\
+    xxx(WriteMixedBlobThresholdSSD,    ui32,      0                           )\
     xxx(FlushThreshold,                ui32,      4_MB                        )\
     xxx(FreshBlobCountFlushThreshold,  ui32,      3200                        )\
     xxx(FreshBlobByteCountFlushThreshold,   ui32,      16_MB                  )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -69,6 +69,8 @@ public:
     TString GetSchemeShardDir() const;
     ui32 GetWriteBlobThreshold() const;
     ui32 GetWriteBlobThresholdSSD() const;
+    ui32 GetWriteMixedBlobThreshold() const;
+    ui32 GetWriteMixedBlobThresholdSSD() const;
     ui32 GetFlushThreshold() const;
     ui32 GetFreshBlobCountFlushThreshold() const;
     ui32 GetFreshBlobByteCountFlushThreshold() const;

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -287,6 +287,15 @@ ui32 GetWriteBlobThreshold(
     return config.GetWriteBlobThreshold();
 }
 
+ui32 GetWriteMixedBlobThreshold(
+    const TStorageConfig& config,
+    const NCloud::NProto::EStorageMediaKind mediaKind)
+{
+    return mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD
+               ? config.GetWriteMixedBlobThresholdSSD()
+               : config.GetWriteMixedBlobThreshold();
+}
+
 bool CompareVolumeConfigs(
     const NKikimrBlockStore::TVolumeConfig& prevConfig,
     const NKikimrBlockStore::TVolumeConfig& newConfig)

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -152,6 +152,10 @@ ui32 GetWriteBlobThreshold(
     const TStorageConfig& config,
     const NCloud::NProto::EStorageMediaKind mediaKind);
 
+ui32 GetWriteMixedBlobThreshold(
+    const TStorageConfig& config,
+    const NCloud::NProto::EStorageMediaKind mediaKind);
+
 inline bool RequiresCheckpointSupport(const NProto::TReadBlocksRequest& request)
 {
     return !request.GetCheckpointId().empty();


### PR DESCRIPTION
Добавляет параметры WriteMixedBlobThreshold и WriteMixedBlobThresholdSSD. Это размер запроса в байтах.
С размером меньше WriteMixedBlobThreshold(SSD) будут записаны в fresh канал.
Данные с размером от WriteMixedBlobThreshold(SSD) до WriteBlobThreshold(SSD) будут записаны в mixed канал.
С размером больше WriteBlobThreshold(SSD) будут записаны в merged канал.
По умолчанию выставлены 0, что рассматривается, как фича отключена и надо работать по-старому.
 Это первый шаг, далее будет добавлена логика для Compaction.

#2875