### PR TITLE
issue-2722: add ability to read from certain replica of mirrored disk

### DIFF
--- a/cloud/blockstore/apps/client/lib/read_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/read_blocks.cpp
@@ -277,7 +277,7 @@ public:
         Opts.AddLongOption(
                 "replica-index",
                 "from which replica(numerate from 1) read data, only for "
-                "ssd-io disks")
+                "mirror* disks")
             .RequiredArgument("NUM")
             .StoreResult(&ReplicaIndex);
     }

--- a/cloud/blockstore/apps/client/lib/read_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/read_blocks.cpp
@@ -462,9 +462,7 @@ private:
             request->BlockSize = Volume.GetBlockSize();
             request->Sglist = holder.GetGuardedSgList();
             PrepareHeaders(*request->MutableHeaders());
-            if (ReplicaIndex) {
-                request->MutableHeaders()->SetReplicaIndex(ReplicaIndex);
-            }
+            request->MutableHeaders()->SetReplicaIndex(ReplicaIndex);
 
             auto future = Session->ReadBlocksLocal(
                 MakeIntrusive<TCallContext>(),

--- a/cloud/blockstore/apps/client/lib/read_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/read_blocks.cpp
@@ -274,7 +274,10 @@ public:
             .StoreResult(&IODepth)
             .DefaultValue(1);
 
-        Opts.AddLongOption("replica-index", "from which replica(numerate from 1) read data, only for ssd-io disks")
+        Opts.AddLongOption(
+                "replica-index",
+                "from which replica(numerate from 1) read data, only for "
+                "ssd-io disks")
             .RequiredArgument("NUM")
             .StoreResult(&ReplicaIndex);
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -183,7 +183,7 @@ private:
     TResultOrError<TSet<NActors::TActorId>> SelectReplicasToReadFrom(
         ui32 replicaIndex,
         TBlockRange64 blockRange,
-        const TString& methodName);
+        const TStringBuf& methodName);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocks, TEvService);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -180,6 +180,11 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    TResultOrError<TSet<NActors::TActorId>> SelectReplicasToReadFrom(
+        ui32 replicaIndex,
+        TBlockRange64 blockRange,
+        const TString& methodName);
+
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocksLocal, TEvService);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -438,8 +438,9 @@ void TMirrorPartitionActor::ReadBlocks(
                         << "Request " << TMethod::Name
                         << " has incorrect ReplicaIndex " << replicaIndex
                         << " disk has " << State.GetReplicaInfos().size()
-                        << "replicas"));
+                        << " replicas"));
             NCloud::Reply(ctx, *ev, std::move(response));
+            return;
         }
 
         const auto& replicaInfo = State.GetReplicaInfos()[replicaIndex - 1];
@@ -451,6 +452,7 @@ void TMirrorPartitionActor::ReadBlocks(
                                      << " cause replica " << replicaIndex
                                      << " has not ready devices"));
             NCloud::Reply(ctx, *ev, std::move(response));
+            return;
         }
         replicaActorIds.insert(State.GetReplicaActors()[replicaIndex - 1]);
     } else {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -408,7 +408,7 @@ auto TMirrorPartitionActor::SelectReplicasToReadFrom(
     }
 
     if (replicaIndex) {
-        const auto& replicaInfo = State.GetReplicaInfos()[replicaIndex - 1];
+        const auto& replicaInfo = replicaInfos[replicaIndex - 1];
         if (!replicaInfo.Config->DevicesReadyForReading(blockRange)) {
             return MakeError(
                 E_REJECTED,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_readblocks.cpp
@@ -31,6 +31,7 @@ void TMirrorPartitionResyncActor::ProcessReadRequestSyncPath(
     const auto range = BuildRequestBlockRange(
         *ev->Get(),
         PartConfig->GetBlockSize());
+
     if (ResyncFinished || State.IsResynced(range)) {
         ForwardRequestWithNondeliveryTracking(ctx, MirrorActorId, *ev);
         return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -801,13 +801,15 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         env.WriteReplica(1, range1, 'B');
         env.WriteReplica(2, range1, 'C');
 
+        // Check that with 0 replica index we read all replicas round-robin
+        for (char c: TVector{'A', 'B', 'C'})
         {
             auto response = client.ReadBlocks(range1, 0);
             const auto& blocks = response->Record.GetBlocks();
             UNIT_ASSERT_VALUES_EQUAL(100, blocks.BuffersSize());
             for (ui32 i = 0; i < 100; ++i) {
                 UNIT_ASSERT_VALUES_EQUAL(
-                    TString(DefaultBlockSize, 'A'),
+                    TString(DefaultBlockSize, c),
                     blocks.GetBuffers(i));
             }
         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -333,11 +333,16 @@ public:
         return std::unique_ptr<TResponse>(handle->Release<TResponse>().Release());
     }
 
-    auto CreateReadBlocksRequest(const TBlockRange64& blockRange)
+    auto CreateReadBlocksRequest(
+        const TBlockRange64& blockRange,
+        ui32 replicaIndex = 0)
     {
         auto request = std::make_unique<TEvService::TEvReadBlocksRequest>();
         request->Record.SetStartIndex(blockRange.Start);
         request->Record.SetBlocksCount(blockRange.Size());
+        if (replicaIndex) {
+            request->Record.MutableHeaders()->SetReplicaIndex(replicaIndex);
+        }
 
         return request;
     }

--- a/cloud/blockstore/public/api/protos/headers.proto
+++ b/cloud/blockstore/public/api/protos/headers.proto
@@ -78,4 +78,8 @@ message THeaders
 
     // This flag controls the optimization of data transmission over the network.
     EOptimizeNetworkTransfer OptimizeNetworkTransfer = 10;
+
+    // For which replica this request will be performed.
+    // Only for network-ssd-io-m* disks.
+    uint32 ReplicaIndex = 11;
 }


### PR DESCRIPTION
In order to provide better diagnostics for checksum mismatches in replicas, I want to add the ability for blockstore-client to read certain replica and compare it further in scripts