### PR TITLE
[Blockstore] StatVolume should return checkpoints without data

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
@@ -297,7 +297,7 @@ void TVolumeActor::HandleStatVolume(
 
     TActiveCheckpointsMap activeCheckpoints = State->GetCheckpointStore().GetActiveCheckpoints();
     TVector<TString> checkpoints(Reserve(activeCheckpoints.size()));
-    for (const auto& [checkpoint, checkpointData] : activeCheckpoints) {
+    for (const auto& [checkpoint, _] : activeCheckpoints) {
         checkpoints.push_back(checkpoint);
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
@@ -295,8 +295,11 @@ void TVolumeActor::HandleStatVolume(
             partConfig->GetMaxTimedOutDeviceStateDuration().MilliSeconds());
     }
 
-    TVector<TString> checkpoints =
-        State->GetCheckpointStore().GetCheckpointsWithData();
+    TActiveCheckpointsMap activeCheckpoints = State->GetCheckpointStore().GetActiveCheckpoints();
+    TVector<TString> checkpoints(Reserve(activeCheckpoints.size()));
+    for (const auto& [checkpoint, checkpointData] : activeCheckpoints) {
+        checkpoints.push_back(checkpoint);
+    }
 
     TStringBuilder debugString;
     for (const auto& statInfo: State->GetPartitionStatInfos()) {

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -1938,14 +1938,6 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
             UNIT_ASSERT_VALUES_EQUAL(1, cp.size());
         }
 
-        volume.DeleteCheckpoint("c1");
-
-        {
-            auto stat = volume.StatVolume();
-            const auto& cp = stat->Record.GetCheckpoints();
-            UNIT_ASSERT_VALUES_EQUAL(0, cp.size());
-        }
-
         volume.RebootTablet();
         volume.AddClient(clientInfo);
         volume.WaitReady();
@@ -1953,7 +1945,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         {
             auto stat = volume.StatVolume();
             const auto& cp = stat->Record.GetCheckpoints();
-            UNIT_ASSERT_VALUES_EQUAL(0, cp.size());
+            UNIT_ASSERT_VALUES_EQUAL(1, cp.size());
         }
 
         {

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -1935,6 +1935,14 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         {
             auto stat = volume.StatVolume();
             const auto& cp = stat->Record.GetCheckpoints();
+            UNIT_ASSERT_VALUES_EQUAL(1, cp.size());
+        }
+
+        volume.DeleteCheckpoint("c1");
+
+        {
+            auto stat = volume.StatVolume();
+            const auto& cp = stat->Record.GetCheckpoints();
             UNIT_ASSERT_VALUES_EQUAL(0, cp.size());
         }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -916,6 +916,11 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         volume.DeleteCheckpointData("c1");
         {
             auto stat = volume.StatVolume();
+            UNIT_ASSERT_VALUES_EQUAL(1, stat->Record.GetCheckpoints().size());
+        }
+        volume.DeleteCheckpoint("c1");
+        {
+            auto stat = volume.StatVolume();
             UNIT_ASSERT(stat->Record.GetCheckpoints().empty());
         }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -917,6 +917,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         {
             auto stat = volume.StatVolume();
             UNIT_ASSERT_VALUES_EQUAL(1, stat->Record.GetCheckpoints().size());
+            UNIT_ASSERT_VALUES_EQUAL("c1", stat->Record.GetCheckpoints()[0]);
         }
         volume.DeleteCheckpoint("c1");
         {
@@ -1936,6 +1937,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
             auto stat = volume.StatVolume();
             const auto& cp = stat->Record.GetCheckpoints();
             UNIT_ASSERT_VALUES_EQUAL(1, cp.size());
+            UNIT_ASSERT_VALUES_EQUAL("c1", stat->Record.GetCheckpoints(0));
         }
 
         volume.RebootTablet();
@@ -1946,6 +1948,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
             auto stat = volume.StatVolume();
             const auto& cp = stat->Record.GetCheckpoints();
             UNIT_ASSERT_VALUES_EQUAL(1, cp.size());
+            UNIT_ASSERT_VALUES_EQUAL("c1", stat->Record.GetCheckpoints(0));
         }
 
         {


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/2008 — Исправлено поведение StatVolume. Теперь он возвращает и чекпоинты с данными, и чекпоинты без данных