### PR TITLE
FIx restoration shadow disk from backup

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/actors/restore_validator_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/actors/restore_validator_actor.cpp
@@ -545,7 +545,7 @@ void TRestoreValidationActor::HandleListVolumesResponse(
                     ctx,
                     Component,
                     RESTORE_PREFIX << " DiskID " << itr->GetDiskId().Quote()
-                                   << " is found in backup but not in SS");
+                                   << " is found in backup, but not in SS");
             }
             SetErrorDevicesInBackup(itr->GetDeviceUUIDs(), ctx.Now());
             DisksInBackup.erase(itr->GetDiskId());

--- a/cloud/blockstore/libs/storage/disk_registry/actors/restore_validator_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/actors/restore_validator_actor.cpp
@@ -233,7 +233,7 @@ TStringBuf NormalizeMirrorId(TStringBuf diskId) {
 
 bool CheckMirrorDiskId(
     const TSet<TString>& disksInSS,
-    const TVector<NProto::TDiskConfig> disksInBackup,
+    const TVector<NProto::TDiskConfig>& disksInBackup,
     const NProto::TDiskConfig& disk)
 {
     const TString& diskId = disk.GetDiskId();
@@ -532,12 +532,21 @@ void TRestoreValidationActor::HandleListVolumesResponse(
                 ValidSnapshot.DisksToCleanup,
                 NormalizeMirrorId(itr->GetDiskId())))
         {
-            LOG_WARN_S(
-                ctx,
-                Component,
-                RESTORE_PREFIX
-                    << " DiskID " << itr->GetDiskId().Quote()
-                    << " is found in backup but not in SS");
+            const bool isShadowDisk =
+                !itr->GetCheckpointReplica().GetCheckpointId().empty();
+            if (isShadowDisk) {
+                LOG_WARN_S(
+                    ctx,
+                    Component,
+                    RESTORE_PREFIX << " ShadowDisk " << itr->GetDiskId().Quote()
+                                   << " is found in backup");
+            } else {
+                LOG_WARN_S(
+                    ctx,
+                    Component,
+                    RESTORE_PREFIX << " DiskID " << itr->GetDiskId().Quote()
+                                   << " is found in backup but not in SS");
+            }
             SetErrorDevicesInBackup(itr->GetDeviceUUIDs(), ctx.Now());
             DisksInBackup.erase(itr->GetDiskId());
             itr = ValidSnapshot.Disks.erase(itr);

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -775,7 +775,9 @@ void TShadowDiskActor::HandleShadowDiskAcquired(
     }
 
     if (HasError(msg->Error)) {
-        if (acquireReason != EAcquireReason::PeriodicalReAcquire) {
+        if (msg->Error.GetCode() == E_NOT_FOUND ||
+            acquireReason != EAcquireReason::PeriodicalReAcquire)
+        {
             SetErrorState(ctx);
         }
         return;

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -3772,7 +3772,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         // Reconnect pipe since partition has restarted.
         volume.ReconnectPipe();
 
-        // Shadow disk enter to the error state.
+        // Shadow disk entered the error state.
         auto status =
             volume.GetCheckpointStatus("c1")->Record.GetCheckpointStatus();
 


### PR DESCRIPTION
When restoring from backup, shadow disks are deleted, this is normal, since the backup may be old.

1. corrected the warning message
2. The shadow disk in the volume will immediately go into error state as soon as there disk registry restarted