### PR TITLE
[Filestore] Remove unused  RECURSE_FOR_TESTS

### DIFF
--- a/cloud/filestore/libs/storage/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/model/ut/ya.make
@@ -9,5 +9,3 @@ SRCS(
 )
 
 END()
-
-RECURSE_FOR_TESTS(ut)


### PR DESCRIPTION
`Error[-WBadDir]: in $S/cloud/filestore/libs/storage/model/ut/ya.make: DEPENDS to missing directory: $S/cloud/filestore/libs/storage/model/ut/ut`