### PR TITLE
Issue 2854: add split read request in mirror partition by device borders

### DIFF
--- a/cloud/blockstore/libs/service_local/compound_storage.cpp
+++ b/cloud/blockstore/libs/service_local/compound_storage.cpp
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/storage.h>
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/sglist_block_range.h>
 
 #include <util/generic/algorithm.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
@@ -108,41 +109,6 @@ private:
     ui64 Blocks(ui32 storage) const
     {
         return Offsets[storage] - StartOffset(storage);
-    }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TSgListBlockRange
-{
-    const ui32 BlockSize;
-
-    TSgList::const_iterator It;
-    ui64 Offset = 0;
-
-    TSgListBlockRange(const TSgList& sglist, ui32 blockSize)
-         : BlockSize(blockSize)
-         , It(sglist.begin())
-    {}
-
-    TSgList Next(ui64 blockCount)
-    {
-        TSgList sglist;
-        while (blockCount) {
-            const auto remains = It->Size() / BlockSize - Offset;
-            const auto n = std::min(remains, blockCount);
-
-            sglist.push_back({ It->Data() + Offset * BlockSize, n * BlockSize });
-            blockCount -= n;
-            Offset += n;
-
-            if (n == remains) {
-                Offset = 0;
-                ++It;
-            }
-        }
-
-        return sglist;
     }
 };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -283,6 +283,25 @@ public:
         return MakeError(code, std::move(message), flags);
     }
 
+    auto SplitBlockRangeByDevicesBorder(const TBlockRange64 blockRange)
+        -> TVector<TBlockRange64>
+    {
+        TVector<TBlockRange64> result;
+        VisitDeviceRequests(
+            blockRange,
+            [&](const ui32 i,
+                const TBlockRange64 requestRange,
+                const TBlockRange64 relativeRange)
+            {
+                Y_UNUSED(relativeRange);
+                Y_UNUSED(i);
+                result.emplace_back(requestRange);
+                return false;
+            });
+
+        return result;
+    }
+
 private:
     TBlockRange64 DeviceRange(ui32 i) const
     {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -283,7 +283,7 @@ public:
         return MakeError(code, std::move(message), flags);
     }
 
-    auto SplitBlockRangeByDevicesBorder(const TBlockRange64 blockRange)
+    auto SplitBlockRangeByDevicesBorder(const TBlockRange64 blockRange) const
         -> TVector<TBlockRange64>
     {
         TVector<TBlockRange64> result;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -197,11 +197,11 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    template <typename TMethod>
     TResultOrError<TVector<NActors::TActorId>> SelectReplicasToReadFrom(
         std::optional<ui32> replicaIndex,
         std::optional<ui32> replicaCount,
-        TBlockRange64 blockRange,
-        const TStringBuf& methodName);
+        TBlockRange64 blockRange);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocks, TEvService);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -197,11 +197,11 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    template <typename TMethod>
     TResultOrError<TVector<NActors::TActorId>> SelectReplicasToReadFrom(
         std::optional<ui32> replicaIndex,
         std::optional<ui32> replicaCount,
-        TBlockRange64 blockRange);
+        TBlockRange64 blockRange,
+        const TStringBuf methodName);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocks, TEvService);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -192,7 +192,12 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    TResultOrError<TSet<NActors::TActorId>> SelectReplicasToReadFrom(
+    template <typename TMethod>
+    NProto::TError SplitReadBlocks(
+        const typename TMethod::TRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    TResultOrError<TVector<NActors::TActorId>> SelectReplicasToReadFrom(
         std::optional<ui32> replicaIndex,
         std::optional<ui32> replicaCount,
         TBlockRange64 blockRange,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_read_blocks_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_read_blocks_actor.h
@@ -54,11 +54,7 @@ public:
         for (size_t i = 0; i < Requests.size(); ++i) {
             auto req = std::make_unique<typename TMethod::TRequest>();
             req->Record = std::move(Requests[i]);
-            NCloud::Send(
-                ctx,
-                ParentActorId,
-                std::move(req),
-                RequestInfo->Cookie + i);
+            NCloud::Send(ctx, ParentActorId, std::move(req), i);
             ++PendingRequests;
         }
 
@@ -94,7 +90,7 @@ private:
             return;
         }
 
-        auto responseIdx = ev->Cookie - RequestInfo->Cookie;
+        const auto responseIdx = ev->Cookie;
         Responses[responseIdx] = std::move(msg->Record);
 
         if (--PendingRequests == 0) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_read_blocks_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_read_blocks_actor.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "part_mirror_split_request_helpers.h"
+#include "part_nonrepl_events_private.h"
+
+#include <cloud/blockstore/libs/storage/core/request_info.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/actorid.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TMethod>
+class TSplitReadBlocksActor final
+    : public NActors::TActorBootstrapped<TSplitReadBlocksActor<TMethod>>
+{
+private:
+    using TRequestProtoType = TMethod::TRequest::ProtoRecordType;
+    using TResponseProtoType = TMethod::TResponse::ProtoRecordType;
+
+private:
+    const TRequestInfoPtr RequestInfo;
+    TVector<TRequestProtoType> Requests;
+    const NActors::TActorId ParentActorId;
+    const ui64 BlockSize;
+    const ui64 RequestIdentityKey;
+
+    ui32 PendingRequests = 0;
+    TVector<TResponseProtoType> Responses;
+
+    using TBase = NActors::TActorBootstrapped<TSplitReadBlocksActor<TMethod>>;
+
+public:
+    TSplitReadBlocksActor(
+            TRequestInfoPtr requestInfo,
+            TVector<TRequestProtoType> requests,
+            NActors::TActorId parentActorId,
+            ui64 blockSize,
+            ui64 requestIdentityKey)
+        : RequestInfo(std::move(requestInfo))
+        , Requests(std::move(requests))
+        , ParentActorId(parentActorId)
+        , BlockSize(blockSize)
+        , RequestIdentityKey(requestIdentityKey)
+    {}
+
+    void Bootstrap(const NActors::TActorContext& ctx)
+    {
+        Responses.resize(Requests.size());
+        for (size_t i = 0; i < Requests.size(); ++i) {
+            auto req = std::make_unique<typename TMethod::TRequest>();
+            req->Record = std::move(Requests[i]);
+            NCloud::Send(
+                ctx,
+                ParentActorId,
+                std::move(req),
+                RequestInfo->Cookie + i);
+            ++PendingRequests;
+        }
+
+        TBase::Become(&TBase::TThis::StateWork);
+    }
+
+private:
+    void ReplyAndDie(const NActors::TActorContext& ctx, NProto::TError error)
+    {
+        auto response =
+            std::make_unique<typename TMethod::TResponse>(std::move(error));
+        if (!HasError(response->GetError())) {
+            response->Record = MergeReadResponses(Responses);
+        }
+
+        auto completion = std::make_unique<
+            TEvNonreplPartitionPrivate::TEvMirroredReadCompleted>(
+            RequestIdentityKey,
+            false);
+        NCloud::Send(ctx, ParentActorId, std::move(completion));
+
+        NCloud::Reply(ctx, *RequestInfo, std::move(response));
+        TBase::Die(ctx);
+    }
+
+    void OnActorResponse(
+        const TMethod::TResponse::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        auto* msg = ev->Get();
+        if (HasError(msg->GetError())) {
+            ReplyAndDie(ctx, msg->GetError());
+            return;
+        }
+
+        auto responseIdx = ev->Cookie - RequestInfo->Cookie;
+        Responses[responseIdx] = std::move(msg->Record);
+
+        if (--PendingRequests == 0) {
+            ReplyAndDie(ctx, {});
+        }
+    }
+
+private:
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(NActors::TEvents::TEvPoisonPill, HandlePoisonPill);
+
+            HFunc(TMethod::TResponse, HandleActorResponse);
+
+            default:
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION_WORKER);
+                break;
+        }
+    }
+
+    void HandleActorResponse(
+        const TMethod::TResponse::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        OnActorResponse(ev, ctx);
+    }
+
+    void HandlePoisonPill(
+        const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        Y_UNUSED(ev);
+
+        ReplyAndDie(ctx, MakeTabletIsDeadError(E_REJECTED, __LOCATION__));
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.cpp
@@ -34,12 +34,12 @@ auto SplitReadRequest(
 {
     auto guard = originalRequest.Sglist.Acquire();
     if (!guard) {
-        return MakeError(E_FAIL, "can't acquire sglist guard");
+        return MakeError(E_CANCELLED, "can't acquire sglist guard");
     }
 
     const auto& originalSglist = guard.Get();
     if (originalSglist.empty()) {
-        return MakeError(E_FAIL, "empty sglist");
+        return MakeError(E_ARGUMENT, "empty sglist");
     }
 
     TVector<NProto::TReadBlocksLocalRequest> result;
@@ -56,7 +56,7 @@ auto SplitReadRequest(
         {
             // It means that we doesn't have enough buffers in original request,
             // so it is incorrect.
-            return MakeError(E_FAIL, "not enough buffers size for request");
+            return MakeError(E_ARGUMENT, "not enough buffers size for request");
         }
 
         auto& copyRequest = result.emplace_back(originalRequest);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.cpp
@@ -1,0 +1,109 @@
+#include "part_mirror_split_request_helpers.h"
+
+#include <cloud/storage/core/libs/common/sglist_block_range.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto SplitReadRequest(
+    const NProto::TReadBlocksRequest& originalRequest,
+    std::span<const TBlockRange64> requestBlockRanges)
+    -> TVector<NProto::TReadBlocksRequest>
+{
+    auto result = TVector<NProto::TReadBlocksRequest>();
+    result.reserve(requestBlockRanges.size());
+
+    for (auto blockRange: requestBlockRanges) {
+        auto copyRequest = originalRequest;
+        copyRequest.SetBlocksCount(blockRange.Size());
+        copyRequest.SetStartIndex(blockRange.Start);
+
+        result.push_back(std::move(copyRequest));
+    }
+
+    return result;
+}
+
+auto SplitReadRequest(
+    const NProto::TReadBlocksLocalRequest& originalRequest,
+    std::span<const TBlockRange64> requestBlockRanges)
+    -> TVector<NProto::TReadBlocksLocalRequest>
+{
+    auto guard = originalRequest.Sglist.Acquire();
+    if (!guard) {
+        return {};
+    }
+
+    const auto& originalSglist = guard.Get();
+    if (originalSglist.empty()) {
+        return {};
+    }
+
+    auto result = TVector<NProto::TReadBlocksLocalRequest>();
+    result.reserve(requestBlockRanges.size());
+
+    auto sglistBlockRange =
+        TSgListBlockRange(originalSglist, originalRequest.BlockSize);
+    for (const auto& blockRange: requestBlockRanges) {
+        auto blocksNeeded = blockRange.Size();
+
+        auto newSglist = sglistBlockRange.Next(blocksNeeded);
+        if (SgListGetSize(newSglist) !=
+            blocksNeeded * originalRequest.BlockSize)
+        {
+            // It means that we doesn't have enough buffers in original request,
+            // so it is incorrect.
+            return {};
+        }
+
+        auto& copyRequest = result.emplace_back(originalRequest);
+        copyRequest.SetBlocksCount(blockRange.Size());
+        copyRequest.SetStartIndex(blockRange.Start);
+        copyRequest.Sglist =
+            originalRequest.Sglist.Create(std::move(newSglist));
+    }
+
+    return result;
+}
+
+auto MergeReadResponses(std::span<NProto::TReadBlocksResponse> responsesToMerge)
+    -> NProto::TReadBlocksResponse
+{
+    NProto::TReadBlocksResponse result;
+
+    ui64 throttlerDelaySum = 0;
+    bool allZeros = true;
+    bool allBlocksEmpty = true;
+    for (const auto& response: responsesToMerge) {
+        if (HasError(response)) {
+            return response;
+        }
+        allZeros &= response.GetAllZeroes();
+        allBlocksEmpty &= response.GetBlocks().BuffersSize() == 0;
+        throttlerDelaySum += response.GetThrottlerDelay();
+    }
+
+    result.SetThrottlerDelay(throttlerDelaySum);
+    result.SetAllZeroes(allZeros);
+
+    if (allBlocksEmpty) {
+        return result;
+    }
+
+    auto& dst = *result.MutableBlocks()->MutableBuffers();
+    for (auto& response: responsesToMerge) {
+        auto& src = *response.MutableBlocks()->MutableBuffers();
+        dst.Add(
+            std::make_move_iterator(src.begin()),
+            std::make_move_iterator(src.end()));
+    }
+
+    // The unencrypted block mask is not used (Check pr #1771), so we don't have
+    // to fill it out.
+    return result;
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NSplitRequest

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/blockstore/libs/storage/api/service.h>
+
+#include <contrib/ydb/library/actors/core/actorid.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto SplitReadRequest(
+    const NProto::TReadBlocksRequest& originalRequest,
+    std::span<const TBlockRange64> requestBlockRanges)
+    -> TVector<NProto::TReadBlocksRequest>;
+
+auto SplitReadRequest(
+    const NProto::TReadBlocksLocalRequest& originalRequest,
+    std::span<const TBlockRange64> requestBlockRanges)
+    -> TVector<NProto::TReadBlocksLocalRequest>;
+
+auto MergeReadResponses(std::span<NProto::TReadBlocksResponse> responsesToMerge)
+    -> NProto::TReadBlocksResponse;
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers.h
@@ -12,12 +12,12 @@ namespace NCloud::NBlockStore::NStorage {
 auto SplitReadRequest(
     const NProto::TReadBlocksRequest& originalRequest,
     std::span<const TBlockRange64> requestBlockRanges)
-    -> TVector<NProto::TReadBlocksRequest>;
+    -> TResultOrError<TVector<NProto::TReadBlocksRequest>>;
 
 auto SplitReadRequest(
     const NProto::TReadBlocksLocalRequest& originalRequest,
     std::span<const TBlockRange64> requestBlockRanges)
-    -> TVector<NProto::TReadBlocksLocalRequest>;
+    -> TResultOrError<TVector<NProto::TReadBlocksLocalRequest>>;
 
 auto MergeReadResponses(std::span<NProto::TReadBlocksResponse> responsesToMerge)
     -> NProto::TReadBlocksResponse;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_request_helpers_ut.cpp
@@ -1,0 +1,354 @@
+#include "part_mirror_split_request_helpers.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+TActorId MakeActorId(ui32 num)
+{
+    return TActorId(num, num, num, num);
+}
+
+TSgList MergeSglist(const TSgList& sglist)
+{
+    TSgList result = {sglist[0]};
+    for (size_t i = 1; i < sglist.size(); ++i) {
+        if ((result.back().Data() + result.back().Size()) == sglist[i].Data()) {
+            result.back() = TBlockDataRef(
+                result.back().Data(),
+                result.back().Size() + sglist[i].Size());
+        } else {
+            result.emplace_back(sglist[i]);
+        }
+    }
+
+    return result;
+}
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TSplitRequestTest)
+{
+    Y_UNIT_TEST(ShouldSplitReadRequest)
+    {
+        NProto::TReadBlocksRequest request;
+
+        const ui32 startBlock = 2;
+        const ui32 blocksCount = 10;
+
+        request.SetDiskId("disk-1");
+        request.SetStartIndex(startBlock);
+        request.SetBlocksCount(blocksCount);
+        request.SetFlags(1234);   // just some random number
+        request.SetCheckpointId("checkpoint-1");
+        request.SetSessionId("session-1");
+
+        TVector<TBlockRange64> blockRangeSplittedByDeviceBorders{
+            // block range splitted by device borders, sizeof device == 4 blocks
+            TBlockRange64::WithLength(2, 2),
+            TBlockRange64::WithLength(4, 4),
+            TBlockRange64::WithLength(8, 4),
+            TBlockRange64::WithLength(12, 1),
+        };
+
+        TVector<TVector<TActorId>> actorsForEachRequests{
+            {MakeActorId(0), MakeActorId(1)},
+            {MakeActorId(2), MakeActorId(3)},
+            {MakeActorId(4), MakeActorId(5)},
+            {MakeActorId(6), MakeActorId(7)},
+        };
+
+        auto splitRequest =
+            SplitReadRequest(request, blockRangeSplittedByDeviceBorders);
+
+        UNIT_ASSERT(splitRequest);
+        UNIT_ASSERT_VALUES_EQUAL(
+            splitRequest.size(),
+            actorsForEachRequests.size());
+
+        for (size_t i = 0; i < splitRequest.size(); ++i) {
+            const auto& partSplit = splitRequest[i];
+            UNIT_ASSERT_VALUES_EQUAL(
+                TBlockRange64::WithLength(
+                    partSplit.GetStartIndex(),
+                    partSplit.GetBlocksCount()),
+                blockRangeSplittedByDeviceBorders[i]);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetDiskId(),
+                partSplit.GetDiskId());
+            UNIT_ASSERT_VALUES_EQUAL(request.GetFlags(), partSplit.GetFlags());
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetCheckpointId(),
+                partSplit.GetCheckpointId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetSessionId(),
+                partSplit.GetSessionId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                partSplit.GetStartIndex(),
+                blockRangeSplittedByDeviceBorders[i].Start);
+            UNIT_ASSERT_VALUES_EQUAL(
+                partSplit.GetBlocksCount(),
+                blockRangeSplittedByDeviceBorders[i].Size());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldSplitReadLocalRequest)
+    {
+        NProto::TReadBlocksLocalRequest request;
+
+        const ui32 startBlock = 2;
+        const ui32 blocksCount = 10;
+        // const auto deviceSizeInBlocks = 4;
+        const auto blockSize = 100;
+
+        request.SetDiskId("disk-1");
+        request.SetStartIndex(startBlock);
+        request.SetBlocksCount(blocksCount);
+        request.SetFlags(1234);   // just some random number
+        request.SetCheckpointId("checkpoint-1");
+        request.SetSessionId("session-1");
+        request.BlockSize = blockSize;
+        request.CommitId = 12345;
+
+        // SplitRequest function doesn't access memory, so it's must be safe to
+        // use random values
+        TSgList sglist{
+            TBlockDataRef(reinterpret_cast<const char*>(100), 1 * blockSize),
+            TBlockDataRef(reinterpret_cast<const char*>(3000), 1 * blockSize),
+            TBlockDataRef(reinterpret_cast<const char*>(5000), 5 * blockSize),
+            TBlockDataRef(reinterpret_cast<const char*>(11000), 4 * blockSize),
+        };
+
+        request.Sglist = TGuardedSgList(sglist);
+
+        TVector<TBlockRange64> blockRangeSplittedByDeviceBorders{
+            // block range splitted by device borders, sizeof device == 4
+            // blocks
+            TBlockRange64::WithLength(2, 2),
+            TBlockRange64::WithLength(4, 4),
+            TBlockRange64::WithLength(8, 4),
+            TBlockRange64::WithLength(12, 1),
+        };
+
+        auto splitRequest =
+            SplitReadRequest(request, blockRangeSplittedByDeviceBorders);
+
+        UNIT_ASSERT(splitRequest);
+        UNIT_ASSERT_VALUES_EQUAL(
+            splitRequest.size(),
+            blockRangeSplittedByDeviceBorders.size());
+
+        TSgList overallSglist;
+        for (size_t i = 0; i < splitRequest.size(); ++i) {
+            const auto& partSplit = splitRequest[i];
+            UNIT_ASSERT_VALUES_EQUAL(
+                TBlockRange64::WithLength(
+                    partSplit.GetStartIndex(),
+                    partSplit.GetBlocksCount()),
+                blockRangeSplittedByDeviceBorders[i]);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetDiskId(),
+                partSplit.GetDiskId());
+            UNIT_ASSERT_VALUES_EQUAL(request.GetFlags(), partSplit.GetFlags());
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetCheckpointId(),
+                partSplit.GetCheckpointId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetSessionId(),
+                partSplit.GetSessionId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blockRangeSplittedByDeviceBorders[i].Start,
+                partSplit.GetStartIndex());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blockRangeSplittedByDeviceBorders[i].Size(),
+                partSplit.GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(request.BlockSize, partSplit.BlockSize);
+            UNIT_ASSERT_VALUES_EQUAL(request.CommitId, partSplit.CommitId);
+
+            auto guard = partSplit.Sglist.Acquire();
+            const auto& splittedSglist = guard.Get();
+            size_t overallSize = 0;
+            for (auto buf: splittedSglist) {
+                UNIT_ASSERT_VALUES_EQUAL(buf.Size() % request.BlockSize, 0);
+                overallSize += buf.Size();
+                overallSglist.emplace_back(buf);
+            }
+            UNIT_ASSERT_VALUES_EQUAL(
+                overallSize,
+                partSplit.BlockSize * partSplit.GetBlocksCount());
+        }
+
+        auto mergedSglist = MergeSglist(overallSglist);
+        UNIT_ASSERT_VALUES_EQUAL(mergedSglist.size(), sglist.size());
+        for (size_t i = 0; i < mergedSglist.size(); ++i) {
+            UNIT_ASSERT_EQUAL(mergedSglist[i].Data(), sglist[i].Data());
+            UNIT_ASSERT_VALUES_EQUAL(mergedSglist[i].Size(), sglist[i].Size());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleNotEnoughSglistBuffers)
+    {
+        NProto::TReadBlocksLocalRequest request;
+
+        const ui32 startBlock = 0;
+        const ui32 blocksCount = 3;
+        const auto blockSize = 100;
+
+        request.SetDiskId("disk-1");
+        request.SetStartIndex(startBlock);
+        request.SetBlocksCount(blocksCount);
+        request.SetFlags(1234);   // just some random number
+        request.SetCheckpointId("checkpoint-1");
+        request.SetSessionId("session-1");
+        request.BlockSize = blockSize;
+        request.CommitId = 12345;
+
+        // SplitRequest function doesn't access memory, so it's must be safe to
+        // use random values
+        TSgList sglist{
+            TBlockDataRef(reinterpret_cast<const char*>(100), 2 * blockSize),
+        };
+
+        request.Sglist = TGuardedSgList(sglist);
+
+        TVector<TBlockRange64> blockRangeSplittedByDeviceBorders{
+            // block range splitted by device borders, sizeof device == 4
+            // blocks
+            TBlockRange64::WithLength(0, 3),
+        };
+
+        auto splitRequest =
+            SplitReadRequest(request, blockRangeSplittedByDeviceBorders);
+
+        UNIT_ASSERT(!splitRequest);
+    }
+
+    Y_UNIT_TEST(ShouldHandleClosedSglist)
+    {
+        NProto::TReadBlocksLocalRequest request;
+
+        const ui32 startBlock = 0;
+        const ui32 blocksCount = 3;
+        const auto blockSize = 100;
+
+        request.SetDiskId("disk-1");
+        request.SetStartIndex(startBlock);
+        request.SetBlocksCount(blocksCount);
+        request.SetFlags(1234);   // just some random number
+        request.SetCheckpointId("checkpoint-1");
+        request.SetSessionId("session-1");
+        request.BlockSize = blockSize;
+        request.CommitId = 12345;
+
+        // SplitRequest function doesn't access memory, so it's must be safe to
+        // use random values
+        TSgList sglist{
+            TBlockDataRef(reinterpret_cast<const char*>(100), 3 * blockSize),
+        };
+
+        TGuardedSgList guardedSglist(sglist);
+
+        request.Sglist = guardedSglist;
+
+        TVector<TBlockRange64> blockRangeSplittedByDeviceBorders{
+            // block range splitted by device borders, sizeof device == 4
+            // blocks
+            TBlockRange64::WithLength(0, 3),
+        };
+
+        TVector<TVector<TActorId>> actorsForEachRequests{
+            {MakeActorId(0), MakeActorId(1)},
+        };
+
+        guardedSglist.Close();
+
+        auto splitRequest =
+            SplitReadRequest(request, blockRangeSplittedByDeviceBorders);
+
+        UNIT_ASSERT(!splitRequest);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyMergeReadResponses)
+    {
+        TVector<NProto::TReadBlocksResponse> responses;
+
+        const size_t iterationsCount = 20;
+
+        const size_t blockSize = 100;
+        size_t throttlerDelaySum = 0;
+        for (size_t blocksCount = 1; blocksCount <= iterationsCount;
+             ++blocksCount)
+        {
+            NProto::TReadBlocksResponse response;
+
+            for (size_t blockI = 0; blockI < blocksCount; ++blockI) {
+                response.MutableBlocks()->AddBuffers(
+                    TString(blockSize, '0' + blocksCount));
+            }
+
+            TDynBitMap map;
+            map.Reserve(blocksCount);
+            map.Clear();
+            if (blocksCount % 2) {
+                map.Flip();
+            }
+
+            response.SetThrottlerDelay(blocksCount);
+            throttlerDelaySum += blocksCount;
+            response.SetAllZeroes(false);
+            responses.emplace_back(std::move(response));
+        }
+
+        auto mergedResponse = MergeReadResponses(responses);
+        UNIT_ASSERT(!HasError(mergedResponse.GetError()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            mergedResponse.GetThrottlerDelay(),
+            throttlerDelaySum);
+        UNIT_ASSERT(!mergedResponse.GetAllZeroes());
+
+        size_t blocksReviewed = 0;
+        for (size_t blocksCount = 1; blocksCount <= iterationsCount;
+             ++blocksCount)
+        {
+            for (size_t blockI = 0; blockI < blocksCount; ++blockI) {
+                const auto& block =
+                    mergedResponse.GetBlocks().GetBuffers(blocksReviewed);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    block,
+                    TString(blockSize, '0' + blocksCount));
+
+                ++blocksReviewed;
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyProcessErrors)
+    {
+        NProto::TReadBlocksResponse resp1;
+        resp1.MutableError()->CopyFrom(MakeError(E_REJECTED, "reject"));
+
+        NProto::TReadBlocksResponse resp2;
+        resp2.ClearBlocks();
+        resp2.SetAllZeroes(true);
+
+        TVector<NProto::TReadBlocksResponse> responses{resp1, resp2};
+
+        auto mergedResponse = MergeReadResponses(responses);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            mergedResponse.GetError().GetCode(),
+            E_REJECTED);
+        UNIT_ASSERT_VALUES_EQUAL(
+            mergedResponse.GetError().GetMessage(),
+            "reject");
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NSplitRequest

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -202,7 +202,7 @@ NProto::TError TMirrorPartitionState::NextReadReplica(
 }
 
 auto TMirrorPartitionState::SplitRangeByDeviceBorders(
-    const TBlockRange64 readRange) -> TVector<TBlockRange64>
+    const TBlockRange64 readRange) const -> TVector<TBlockRange64>
 {
     return PartConfig->SplitBlockRangeByDevicesBorder(readRange);
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -201,6 +201,12 @@ NProto::TError TMirrorPartitionState::NextReadReplica(
         << DescribeRange(readRange) << " targets only fresh/dummy devices");
 }
 
+auto TMirrorPartitionState::SplitRangeByDeviceBorders(
+    const TBlockRange64 readRange) -> TVector<TBlockRange64>
+{
+    return PartConfig->SplitBlockRangeByDevicesBorder(readRange);
+}
+
 ui32 TMirrorPartitionState::GetBlockSize() const
 {
     return PartConfig->GetBlockSize();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
@@ -92,7 +92,7 @@ public:
     ui64 GetBlockCount() const;
 
     TVector<TBlockRange64> SplitRangeByDeviceBorders(
-        const TBlockRange64 readRange);
+        const TBlockRange64 readRange) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
@@ -90,6 +90,9 @@ public:
     ui32 GetBlockSize() const;
 
     ui64 GetBlockCount() const;
+
+    TVector<TBlockRange64> SplitRangeByDeviceBorders(
+        const TBlockRange64 readRange);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -850,6 +850,137 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         }
     }
 
+    void DoShouldTryToSplitReadRequest(const THashSet<TString>& freshDeviceIds)
+    {
+        using namespace std::chrono_literals;
+        TTestRuntime runtime;
+
+        TTestEnv env(
+            runtime,
+            TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
+            TVector<TDevices>{
+                TTestEnv::DefaultReplica(runtime.GetNodeId(0), 1),
+                TTestEnv::DefaultReplica(runtime.GetNodeId(0), 2),
+            },
+            {},   // migrations
+            freshDeviceIds);
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        runtime.AdvanceCurrentTime(100ms);
+        runtime.DispatchEvents({}, 100ms);
+
+        const TVector<TBlockRange64> diskRanges = {
+            TBlockRange64::WithLength(2047, 1),
+            TBlockRange64::WithLength(2048, 1),
+            TBlockRange64::WithLength(2049, 1),
+            TBlockRange64::WithLength(2050, 1),
+            TBlockRange64::WithLength(2051, 1),
+        };
+
+        for (size_t i = 0; i < diskRanges.size(); ++i) {
+            client.WriteBlocksLocal(
+                diskRanges[i],
+                TString(DefaultBlockSize, '0' + i));
+        }
+
+        {
+            auto nodeId = runtime.GetNodeId(0);
+            auto diskAgentActorId = MakeDiskAgentServiceId(nodeId);
+
+            for (const auto& deviceId: freshDeviceIds) {
+                auto sender = runtime.AllocateEdgeActor();
+
+                auto request = std::make_unique<
+                    TEvDiskAgent::TEvZeroDeviceBlocksRequest>();
+
+                request->Record.SetStartIndex(0);
+                request->Record.SetBlocksCount(Max<ui32>());
+                request->Record.SetBlockSize(4_KB);
+                request->Record.SetDeviceUUID(deviceId);
+
+                runtime.Send(new IEventHandle(
+                    diskAgentActorId,
+                    sender,
+                    request.release()));
+            }
+
+            runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        }
+
+#define TEST_READ(blockRange)                                    \
+    {                                                            \
+        TVector<TString> blocks;                                 \
+                                                                 \
+        client.ReadBlocksLocal(                                  \
+            blockRange,                                          \
+            TGuardedSgList(ResizeBlocks(                         \
+                blocks,                                          \
+                blockRange.Size(),                               \
+                TString(DefaultBlockSize, '\0'))));              \
+                                                                 \
+        ui64 blockIndex = diskRanges.front().Start;              \
+        for (const auto& block: blocks) {                        \
+            for (auto c: block) {                                \
+                for (size_t i = 0; i < diskRanges.size(); ++i) { \
+                    if (diskRanges[i].Contains(blockIndex)) {    \
+                        UNIT_ASSERT_VALUES_EQUAL('0' + i, c);    \
+                    }                                            \
+                }                                                \
+            }                                                    \
+            ++blockIndex;                                        \
+        }                                                        \
+    }                                                            \
+    // TEST_READ
+
+        // doing multiple reads to check that none of them targets fresh devices
+        TEST_READ(TBlockRange64::WithLength(2047, 5));
+        TEST_READ(TBlockRange64::WithLength(2047, 5));
+        TEST_READ(TBlockRange64::WithLength(2047, 5));
+
+#undef TEST_READ
+    }
+
+    Y_UNIT_TEST(ShouldTryToSplitReadRequest)
+    {
+        auto getDeviceUUID = [](TString base, auto idx)
+        {
+            if (idx == 0) {
+                return base;
+            }
+
+            return base + "#" + ToString(idx);
+        };
+
+        for (size_t vasyaFreshDeviceFirst = 0; vasyaFreshDeviceFirst < 3;
+             ++vasyaFreshDeviceFirst)
+        {
+            for (size_t vasyaFreshDeviceSecond = vasyaFreshDeviceFirst + 1;
+                 vasyaFreshDeviceSecond < 3;
+                 ++vasyaFreshDeviceSecond)
+            {
+                for (size_t petyaFreshDeviceFirst = 0;
+                     petyaFreshDeviceFirst < 3;
+                     ++petyaFreshDeviceFirst)
+                {
+                    for (size_t petyaFreshDeviceSecond =
+                             petyaFreshDeviceFirst + 1;
+                         petyaFreshDeviceSecond < 3;
+                         ++petyaFreshDeviceSecond)
+                    {
+                        THashSet<TString> freshDeviceIds = {
+                            getDeviceUUID("vasya", vasyaFreshDeviceFirst),
+                            getDeviceUUID("vasya", vasyaFreshDeviceSecond),
+                            getDeviceUUID("petya", petyaFreshDeviceFirst),
+                            getDeviceUUID("petya", petyaFreshDeviceSecond),
+                        };
+                        DoShouldTryToSplitReadRequest(freshDeviceIds);
+                    }
+                }
+            }
+        }
+    }
+
     struct TMigrationTestRuntime
     {
         TTestRuntime Runtime;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 SRCS(
     migration_timeout_calculator_ut.cpp
     part_mirror_resync_ut.cpp
+    part_mirror_split_request_helpers_ut.cpp
     part_mirror_state_ut.cpp
     part_mirror_ut.cpp
     part_nonrepl_common_ut.cpp

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -16,6 +16,7 @@ SRCS(
     part_mirror_actor_mirror.cpp
     part_mirror_actor_readblocks.cpp
     part_mirror_actor_stats.cpp
+    part_mirror_split_request_helpers.cpp
     part_mirror_state.cpp
 
     part_mirror_resync.cpp

--- a/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-column.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-column.txt
@@ -1,0 +1,66 @@
+Vertices {
+    ControlPlaneAction {
+        Name: "create_volume"
+
+        CreateVolumeRequest {
+            DiskId: "vol0"
+            BlocksCount: 524288
+            BlockSize: 4096
+            StorageMediaKind: STORAGE_MEDIA_SSD_MIRROR2
+        }
+    }
+}
+
+Vertices {
+    ControlPlaneAction {
+        Name: "make_devices_fresh"
+
+        ReplaceDevicesRequest {
+            DiskId: "vol0"
+            DevicesToReplace {
+                ReplicaIndex: 1
+                DeviceIndex: 0
+            }
+            DevicesToReplace {
+                ReplicaIndex: 1
+                DeviceIndex: 1
+            }
+        }
+    }
+}
+
+Vertices {
+    Test {
+        Name: "shoot_vol0"
+        VolumeName: "vol0"
+
+        ArtificialLoadSpec {
+            Ranges {
+                Start: 261644
+                End: 262644
+                WriteRate: 100
+                ReadRate: 100
+                ZeroRate: 100
+                LoadType: LOAD_TYPE_RANDOM
+                IoDepth: 20
+                MaxRequestSize: 100
+            }
+        }
+        TestDuration: 60
+        Verify: true
+    }
+}
+
+Dependencies {
+    key: "make_devices_fresh",
+    value {
+        Names: "create_volume"
+    }
+}
+
+Dependencies {
+    key: "shoot_vol0",
+    value {
+        Names: "make_devices_fresh"
+    }
+}

--- a/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-cross.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-cross.txt
@@ -1,0 +1,66 @@
+Vertices {
+    ControlPlaneAction {
+        Name: "create_volume"
+
+        CreateVolumeRequest {
+            DiskId: "vol0"
+            BlocksCount: 524288
+            BlockSize: 4096
+            StorageMediaKind: STORAGE_MEDIA_SSD_MIRROR2
+        }
+    }
+}
+
+Vertices {
+    ControlPlaneAction {
+        Name: "make_devices_fresh"
+
+        ReplaceDevicesRequest {
+            DiskId: "vol0"
+            DevicesToReplace {
+                ReplicaIndex: 0
+                DeviceIndex: 0
+            }
+            DevicesToReplace {
+                ReplicaIndex: 1
+                DeviceIndex: 1
+            }
+        }
+    }
+}
+
+Vertices {
+    Test {
+        Name: "shoot_vol0"
+        VolumeName: "vol0"
+
+        ArtificialLoadSpec {
+            Ranges {
+                Start: 261644
+                End: 262644
+                WriteRate: 100
+                ReadRate: 100
+                ZeroRate: 100
+                LoadType: LOAD_TYPE_RANDOM
+                IoDepth: 20
+                MaxRequestSize: 100
+            }
+        }
+        TestDuration: 60
+        Verify: true
+    }
+}
+
+Dependencies {
+    key: "make_devices_fresh",
+    value {
+        Names: "create_volume"
+    }
+}
+
+Dependencies {
+    key: "shoot_vol0",
+    value {
+        Names: "make_devices_fresh"
+    }
+}

--- a/cloud/blockstore/tools/testing/loadtest/lib/control_plane_action_runner.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/control_plane_action_runner.h
@@ -59,6 +59,8 @@ private:
         const NProto::TActionGraph::TControlPlaneAction& action);
     int RunCmsRemoveDeviceAction(
         const NProto::TActionGraph::TControlPlaneAction& action);
+    int RunReplaceDevicesRequest(
+        const NProto::TActionGraph::TControlPlaneAction& action);
 
     int CmsRemoveHostHard(
         ui32 agentNo,

--- a/cloud/blockstore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/blockstore/tools/testing/loadtest/protos/loadtest.proto
@@ -245,6 +245,23 @@ message TCmsRemoveDeviceRequest
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Replace devices
+
+message TDeviceCoordinate {
+    uint64 ReplicaIndex = 1;
+    uint64 DeviceIndex = 2;
+}
+
+message TReplaceDevicesRequest {
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    string DiskId = 2;
+
+    repeated TDeviceCoordinate DevicesToReplace = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Graph of tests
 
 message TActionGraph
@@ -273,6 +290,7 @@ message TActionGraph
             TDescribeVolumeRequest DescribeVolumeRequest = 13;
             TCmsRemoveHostRequest CmsRemoveHostRequest = 14;
             TCmsRemoveDeviceRequest CmsRemoveDeviceRequest = 15;
+            TReplaceDevicesRequest ReplaceDevicesRequest = 16;
         }
     }
 

--- a/cloud/blockstore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/blockstore/tools/testing/loadtest/protos/loadtest.proto
@@ -247,12 +247,14 @@ message TCmsRemoveDeviceRequest
 ////////////////////////////////////////////////////////////////////////////////
 // Replace devices
 
-message TDeviceCoordinate {
+message TDeviceCoordinate
+{
     uint64 ReplicaIndex = 1;
     uint64 DeviceIndex = 2;
 }
 
-message TReplaceDevicesRequest {
+message TReplaceDevicesRequest
+{
     // Optional request headers.
     THeaders Headers = 1;
 

--- a/cloud/storage/core/libs/common/sglist_block_range.cpp
+++ b/cloud/storage/core/libs/common/sglist_block_range.cpp
@@ -1,0 +1,35 @@
+#include "sglist_block_range.h"
+
+namespace NCloud {
+
+TSgListBlockRange::TSgListBlockRange(const TSgList& sglist, ui32 blockSize)
+    : BlockSize(blockSize)
+    , It(sglist.begin())
+    , End(sglist.end())
+{}
+
+TSgList TSgListBlockRange::Next(ui64 blockCount)
+{
+    TSgList sglist;
+    while (blockCount) {
+        if (It == End) {
+            return sglist;
+        }
+
+        const auto remains = It->Size() / BlockSize - Offset;
+        const auto n = std::min(remains, blockCount);
+
+        sglist.push_back({It->Data() + Offset * BlockSize, n * BlockSize});
+        blockCount -= n;
+        Offset += n;
+
+        if (n == remains) {
+            Offset = 0;
+            ++It;
+        }
+    }
+
+    return sglist;
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/sglist_block_range.cpp
+++ b/cloud/storage/core/libs/common/sglist_block_range.cpp
@@ -2,6 +2,8 @@
 
 namespace NCloud {
 
+////////////////////////////////////////////////////////////////////////////////
+
 TSgListBlockRange::TSgListBlockRange(const TSgList& sglist, ui32 blockSize)
     : BlockSize(blockSize)
     , It(sglist.begin())

--- a/cloud/storage/core/libs/common/sglist_block_range.h
+++ b/cloud/storage/core/libs/common/sglist_block_range.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "sglist.h"
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TSgListBlockRange
+{
+    const ui32 BlockSize;
+
+    TSgList::const_iterator It;
+    TSgList::const_iterator End;
+    ui64 Offset = 0;
+
+    TSgListBlockRange(const TSgList& sglist, ui32 blockSize);
+
+    TSgList Next(ui64 blockCount);
+};
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/ya.make
+++ b/cloud/storage/core/libs/common/ya.make
@@ -29,6 +29,7 @@ SRCS(
     scheduler.cpp
     scheduler_test.cpp
     scoped_handle.cpp
+    sglist_block_range.cpp
     sglist.cpp
     sglist_iter.cpp
     sglist_test.cpp


### PR DESCRIPTION
#2854 
На самом деле проблема возникает в следующей конфигурации
```
┌───────────────────────────────┐
│ uuid-1 (Fresh)   │ uuid-3           
│──────────────────┼────────────│
│ uuid-2 (Fresh)   │ uuid-4   
└───────────────────────────────┘
```
Это происходит из-за  изменений в ReplicasInfo, которые происходят при налитии свежих девайсов в этой функции https://github.com/ydb-platform/nbs/blob/8dd237560b9179b8f6c238d51c70cc2fa12eaf1d/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp#L129
Из-за этого в тестах TMirrorPartitionTest::ShouldTryToSplitReadRequest
и в https://github.com/ydb-platform/nbs/blob/9686d14430d09ce06590bf2cafe60679f7547742/cloud/blockstore/tests/loadtest/local-mirror/test.py#L87-L103
Пришлось перебрать разные топологии свежих девайсов из-за изменений в ReplicasInfo,

Сама проблема в данном пре решается следующим образом: если мы не можем прочитать запрос стандартным образом мы его пилим по границам девайсов, проверяем, что есть возможность прочитать каждый отдельный запрос, создаем актора, который  эти кусочки пошлет опять в MirrorPartitionActor, дождется завершения запросов, склеит их и ответит на изначальный запрос.