### PR TITLE
issue-2277: move copying of the request buffer to TIORequestParserActor

### DIFF
--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -297,7 +297,7 @@ message TDiskAgentConfig
 
     // If enabled, IOParserActor allocates a storage buffer and copies the
     // request data into it.
-    optional uint32 IOParserActorAllocateStorageEnabled = 39;
+    optional bool IOParserActorAllocateStorageEnabled = 39;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -294,6 +294,10 @@ message TDiskAgentConfig
 
     // Settings for traffic shaping.
     optional TDiskAgentThrottlingConfig ThrottlingConfig = 38;
+
+    // If enabled, IOParserActor allocates a storage buffer and copies the
+    // request data into it.
+    optional uint32 IOParserActorAllocateStorageEnabled = 39;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -414,15 +414,21 @@ TBlockRange64 BuildRequestBlockRange(
 TBlockRange64 BuildRequestBlockRange(
     const TEvDiskAgent::TEvWriteDeviceBlocksRequest& request)
 {
+    return BuildRequestBlockRange(request.Record);
+}
+
+TBlockRange64 BuildRequestBlockRange(
+    const NProto::TWriteDeviceBlocksRequest& request)
+{
     ui64 totalSize = 0;
-    for (const auto& buffer: request.Record.GetBlocks().GetBuffers()) {
+    for (const auto& buffer: request.GetBlocks().GetBuffers()) {
         totalSize += buffer.length();
     }
-    Y_ABORT_UNLESS(totalSize % request.Record.GetBlockSize() == 0);
+    Y_ABORT_UNLESS(totalSize % request.GetBlockSize() == 0);
 
     return TBlockRange64::WithLength(
-        request.Record.GetStartIndex(),
-        totalSize / request.Record.GetBlockSize());
+        request.GetStartIndex(),
+        totalSize / request.GetBlockSize());
 }
 
 TBlockRange64 BuildRequestBlockRange(
@@ -436,7 +442,12 @@ TBlockRange64 BuildRequestBlockRange(
 ui64 GetVolumeRequestId(
     const TEvDiskAgent::TEvWriteDeviceBlocksRequest& request)
 {
-    return request.Record.GetVolumeRequestId();
+    return GetVolumeRequestId(request.Record);
+}
+
+ui64 GetVolumeRequestId(const NProto::TWriteDeviceBlocksRequest& request)
+{
+    return request.GetVolumeRequestId();
 }
 
 ui64 GetVolumeRequestId(const TEvDiskAgent::TEvZeroDeviceBlocksRequest& request)

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -218,9 +218,13 @@ TBlockRange64 BuildRequestBlockRange(
     const TEvDiskAgent::TEvWriteDeviceBlocksRequest& request);
 
 TBlockRange64 BuildRequestBlockRange(
+    const NProto::TWriteDeviceBlocksRequest& request);
+
+TBlockRange64 BuildRequestBlockRange(
     const TEvDiskAgent::TEvZeroDeviceBlocksRequest& request);
 
 ui64 GetVolumeRequestId(const TEvDiskAgent::TEvWriteDeviceBlocksRequest& request);
+ui64 GetVolumeRequestId(const NProto::TWriteDeviceBlocksRequest& request);
 ui64 GetVolumeRequestId(const TEvDiskAgent::TEvZeroDeviceBlocksRequest& request);
 
 TString LogDevices(const TVector<NProto::TDeviceConfig>& devices);

--- a/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.cpp
@@ -24,7 +24,7 @@ private:
     TStorageBufferAllocator Allocator;
 
 public:
-    explicit TIORequestParserActor(
+    TIORequestParserActor(
             const TActorId& owner,
             TStorageBufferAllocator allocator)
         : TActor(&TIORequestParserActor::StateWork)
@@ -81,8 +81,10 @@ private:
         request->Record.Swap(&msg->Record);
 
         if (Allocator) {
+            const auto& buffers = request->Record.GetBlocks().GetBuffers();
+
             ui64 bytesCount = 0;
-            for (const auto& buffer: request->Record.GetBlocks().GetBuffers()) {
+            for (const auto& buffer: buffers) {
                 bytesCount += buffer.size();
             }
 
@@ -90,7 +92,7 @@ private:
             request->StorageSize = bytesCount;
 
             char* dst = request->Storage.get();
-            for (const auto& buffer: request->Record.GetBlocks().GetBuffers()) {
+            for (const auto& buffer: buffers) {
                 std::memcpy(dst, buffer.data(), buffer.size());
                 dst += buffer.size();
             }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.h
@@ -10,7 +10,7 @@ namespace NCloud::NBlockStore::NStorage::NDiskAgent {
 ////////////////////////////////////////////////////////////////////////////////
 
 using TStorageBufferAllocator =
-    std::function<std::shared_ptr<char>(ui32 blockSize, ui64 bytesCount)>;
+    std::function<std::shared_ptr<char>(ui64 bytesCount)>;
 
 std::unique_ptr<NActors::IActor> CreateIORequestParserActor(
     const NActors::TActorId& owner,

--- a/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.h
@@ -2,13 +2,18 @@
 
 #include <contrib/ydb/library/actors/core/actor.h>
 
+#include <functional>
 #include <memory>
 
 namespace NCloud::NBlockStore::NStorage::NDiskAgent {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TStorageBufferAllocator =
+    std::function<std::shared_ptr<char>(ui32 blockSize, ui64 bytesCount)>;
+
 std::unique_ptr<NActors::IActor> CreateIORequestParserActor(
-    const NActors::TActorId& owner);
+    const NActors::TActorId& owner,
+    TStorageBufferAllocator allocator);
 
 }   // namespace NCloud::NBlockStore::NStorage::NDiskAgent

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -372,13 +372,9 @@ STFUNC(TDiskAgentActor::StateWork)
             TEvDiskAgent::TEvDisableConcreteAgentRequest,
             HandleDisableConcreteAgent);
 
-        case TEvDiskAgentPrivate::EvParsedWriteDeviceBlocksRequest:
-            HandleWriteDeviceBlocks(
-                *reinterpret_cast<
-                    typename TEvDiskAgent::TEvWriteDeviceBlocksRequest::TPtr*>(
-                    &ev),
-                ActorContext());
-            break;
+        HFunc(
+            TEvDiskAgentPrivate::TEvParsedWriteDeviceBlocksRequest,
+            HandleParsedWriteDeviceBlocks);
 
         case TEvDiskAgentPrivate::EvParsedReadDeviceBlocksRequest:
             HandleReadDeviceBlocks(

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -137,10 +137,10 @@ private:
 
     void SendRegisterRequest(const NActors::TActorContext& ctx);
 
-    template <typename TMethod, typename TOp>
+    template <typename TMethod, typename TEv, typename TOp>
     void PerformIO(
         const NActors::TActorContext& ctx,
-        const typename TMethod::TRequest::TPtr& ev,
+        const TEv& ev,
         TOp operation);
 
     template <typename TMethod, typename TRequestPtr>
@@ -223,6 +223,10 @@ private:
 
     void HandleCancelSuspension(
         const TEvDiskAgentPrivate::TEvCancelSuspensionRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleParsedWriteDeviceBlocks(
+        const TEvDiskAgentPrivate::TEvParsedWriteDeviceBlocksRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     bool HandleRequests(STFUNC_SIG);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -144,7 +144,16 @@ void TDiskAgentActor::HandleInitAgentCompleted(
             "Create " << count << " IORequestParserActor actors");
         IOParserActors.reserve(count);
         for (ui32 i = 0; i != count; ++i) {
-            auto actor = NDiskAgent::CreateIORequestParserActor(ctx.SelfID);
+            auto actor = NDiskAgent::CreateIORequestParserActor(
+                ctx.SelfID,
+                [](ui32 blockSize, ui64 byteCount)
+                {
+                    return std::shared_ptr<char>(
+                        static_cast<char*>(
+                            std::aligned_alloc(blockSize, byteCount)),
+                        std::free);
+                });
+
             IOParserActors.push_back(ctx.Register(
                 actor.release(),
                 TMailboxType::TinyReadAsFilled,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -142,17 +142,24 @@ void TDiskAgentActor::HandleInitAgentCompleted(
             ctx,
             TBlockStoreComponents::DISK_AGENT,
             "Create " << count << " IORequestParserActor actors");
+
+        NDiskAgent::TStorageBufferAllocator allocator;
+        if (AgentConfig->GetIOParserActorAllocateStorageEnabled() &&
+            AgentConfig->GetBackend() == NProto::DISK_AGENT_BACKEND_AIO)
+        {
+            allocator = [](ui64 byteCount)
+            {
+                return std::shared_ptr<char>(
+                    static_cast<char*>(
+                        std::aligned_alloc(DefaultBlockSize, byteCount)),
+                    std::free);
+            };
+        }
+
         IOParserActors.reserve(count);
         for (ui32 i = 0; i != count; ++i) {
-            auto actor = NDiskAgent::CreateIORequestParserActor(
-                ctx.SelfID,
-                [](ui32 blockSize, ui64 byteCount)
-                {
-                    return std::shared_ptr<char>(
-                        static_cast<char*>(
-                            std::aligned_alloc(blockSize, byteCount)),
-                        std::free);
-                });
+            auto actor =
+                NDiskAgent::CreateIORequestParserActor(ctx.SelfID, allocator);
 
             IOParserActors.push_back(ctx.Register(
                 actor.release(),

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -380,7 +380,7 @@ void TDiskAgentActor::HandleParsedWriteDeviceBlocks(
             writeRequest->MutableHeaders()->Swap(request.MutableHeaders());
             writeRequest->SetStartIndex(request.GetStartIndex());
 
-            TStringBuf buffer {writeRequest->Storage.get(), byteCount};
+            TStringBuf buffer{writeRequest->Storage.get(), byteCount};
 
             return self.WriteBlocks(
                 now,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -20,7 +20,7 @@ namespace {
 ui64 GetVolumeRequestId(
     const TEvDiskAgentPrivate::TParsedWriteDeviceBlocksRequest& request)
 {
-    return request.Record.GetVolumeRequestId();
+    return NStorage::GetVolumeRequestId(request.Record);
 }
 
 TBlockRange64 BuildRequestBlockRange(

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -4847,6 +4847,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             auto config = DiskAgentConfig({deviceId});
             config.SetIOParserActorCount(4);
             config.SetOffloadAllIORequestsParsingEnabled(true);
+            config.SetIOParserActorAllocateStorageEnabled(true);
 
             return config;
         }();

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
@@ -165,7 +165,7 @@ struct TEvDiskAgentPrivate
     {
         NProto::TWriteDeviceBlocksRequest Record;
         TStorageBuffer Storage;
-        ui64 ByteCount = 0;
+        ui64 StorageSize = 0;
     };
 
     //

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
@@ -158,6 +158,17 @@ struct TEvDiskAgentPrivate
     {};
 
     //
+    // ParsedWriteDeviceBlocksRequest
+    //
+
+    struct TParsedWriteDeviceBlocksRequest
+    {
+        NProto::TWriteDeviceBlocksRequest Record;
+        TStorageBuffer Storage;
+        ui64 ByteCount = 0;
+    };
+
+    //
     // Events declaration
     //
 
@@ -206,6 +217,10 @@ struct TEvDiskAgentPrivate
     using TEvCancelSuspensionRequest = TRequestEvent<
         TCancelSuspensionRequest,
         EvCancelSuspensionRequest>;
+
+    using TEvParsedWriteDeviceBlocksRequest = TRequestEvent<
+        TParsedWriteDeviceBlocksRequest,
+        EvParsedWriteDeviceBlocksRequest>;
 
     BLOCKSTORE_DECLARE_EVENTS(UpdateSessionCache)
 };

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state.h
@@ -103,6 +103,13 @@ public:
         TInstant now,
         NProto::TWriteDeviceBlocksRequest request);
 
+    NThreading::TFuture<NProto::TWriteDeviceBlocksResponse> WriteBlocks(
+        TInstant now,
+        const TString& deviceUUID,
+        std::shared_ptr<NProto::TWriteBlocksRequest> request,
+        ui32 blockSize,
+        TStringBuf buffer);
+
     NThreading::TFuture<NProto::TZeroDeviceBlocksResponse> WriteZeroes(
         TInstant now,
         NProto::TZeroDeviceBlocksRequest request);

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.cpp
@@ -49,6 +49,7 @@ namespace {
     xxx(MaxAIOContextEvents,                ui32,       1024                  )\
     xxx(PathsPerFileIOService,              ui32,       0                     )\
     xxx(DisableBrokenDevices,               bool,       0                     )\
+    xxx(IOParserActorAllocateStorageEnabled, bool,       0                    )\
 // BLOCKSTORE_AGENT_CONFIG
 
 #define BLOCKSTORE_DECLARE_CONFIG(name, type, value)                           \

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -108,6 +108,7 @@ public:
 
     ui32 GetIOParserActorCount() const;
     bool GetOffloadAllIORequestsParsingEnabled() const;
+    bool GetIOParserActorAllocateStorageEnabled() const;
     bool GetDisableNodeBrokerRegistrationOnDevicelessAgent() const;
     ui32 GetMaxAIOContextEvents() const;
     ui32 GetPathsPerFileIOService() const;

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -721,6 +721,7 @@ NProto::TDiskAgentConfig CreateDefaultAgentConfig()
 
     config.SetIOParserActorCount(4);
     config.SetOffloadAllIORequestsParsingEnabled(true);
+    config.SetIOParserActorAllocateStorageEnabled(true);
 
     return config;
 }

--- a/cloud/blockstore/tests/python/lib/config.py
+++ b/cloud/blockstore/tests/python/lib/config.py
@@ -316,6 +316,7 @@ def generate_disk_agent_txt(
     config.ShutdownTimeout = 0
     config.IOParserActorCount = 4
     config.OffloadAllIORequestsParsingEnabled = True
+    config.IOParserActorAllocateStorageEnabled = True
     config.PathsPerFileIOService = 1
 
     if device_erase_method is not None:

--- a/cloud/blockstore/tests/python/lib/nonreplicated_setup.py
+++ b/cloud/blockstore/tests/python/lib/nonreplicated_setup.py
@@ -222,6 +222,7 @@ def setup_disk_agent_config(
     config.ShutdownTimeout = get_shutdown_agent_interval()
     config.IOParserActorCount = 4
     config.OffloadAllIORequestsParsingEnabled = True
+    config.IOParserActorAllocateStorageEnabled = True
     config.PathsPerFileIOService = 2
 
     if cached_sessions_path is not None:


### PR DESCRIPTION
#2277

Aio has a buffer alignment requirement. To meet this requirement, TStorageAdapter [allocates an additional buffer and copies the data from the request into it](https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/service/storage.cpp#L434-L442). The copying takes place in a single TDiskAgentActor thread, which creates scalability issues.
In order to improve scalability, the allocation and copying of data has been moved to the IORequestParserActor.