### PR TITLE
[NBS] Increase logging verbosity: include group ID

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblob.cpp
@@ -107,8 +107,10 @@ void TPartitionActor::HandleReadBlobCompleted(
                 >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
-                "[%lu] Stop tablet because of too many ReadBlob errors: %s",
+                "[%lu] Stop tablet because of too many ReadBlob errors (actor %s, group %u): %s",
                 TabletID(),
+                ev->Sender.ToString().c_str(),
+                msg->GroupId,
                 FormatError(msg->GetError()).data());
 
             ReportTabletBSFailure();

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblob.cpp
@@ -429,8 +429,10 @@ void TPartitionActor::HandleWriteBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
-            "[%lu] Stop tablet because of WriteBlob error: %s",
+            "[%lu] Stop tablet because of WriteBlob error (actor %s, group %u): %s",
             TabletID(),
+            ev->Sender.ToString().c_str(),
+            groupId,
             FormatError(msg->GetError()).data());
 
         ReportTabletBSFailure();

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
@@ -429,8 +429,10 @@ void TPartitionActor::HandleReadBlobCompleted(
                 >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
-                "[%lu] Stop tablet because of too many ReadBlob errors: %s",
+                "[%lu] Stop tablet because of too many ReadBlob errors (actor %s, group %u): %s",
                 TabletID(),
+                ev->Sender.ToString().c_str(),
+                msg->GroupId,
                 FormatError(msg->GetError()).data());
 
             ReportTabletBSFailure();

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
@@ -359,8 +359,10 @@ void TPartitionActor::HandleWriteBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
-            "[%lu] Stop tablet because of WriteBlob error: %s",
+            "[%lu] Stop tablet because of WriteBlob error (actor %s, group %u): %s",
             TabletID(),
+            ev->Sender.ToString().c_str(),
+            group,
             FormatError(msg->GetError()).data());
 
         ReportTabletBSFailure();


### PR DESCRIPTION
Increase logging verbosity: include group ID in (Read|Write)Blob logs

This is useful when multiple partition tablets fail due to corresponding groups failure because it allows to indicate number of unique failing groups