### PR TITLE
[Blockstore] make precondition failed error on checkpoint request non silent

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -439,9 +439,7 @@ std::optional<NProto::TError> TCheckpointStore::ValidateCheckpointRequest(
 {
     auto makeErrorInvalid = [](TString message)
     {
-        ui32 flags = 0;
-        SetProtoFlag(flags, NProto::EF_SILENT);
-        return MakeError(E_PRECONDITION_FAILED, std::move(message), flags);
+        return MakeError(E_PRECONDITION_FAILED, std::move(message));
     };
 
     auto makeErrorAlready = [](TString message)


### PR DESCRIPTION
Checkpoint requests might return E_PRECONDITION_FAILED error in case of incorrect checkpoint request, e.g. if we create checkpoint that was already deleted.

Initially, we made these error silent: https://github.com/ydb-platform/nbs/pull/1134/files#r1598783313
The motivation was the following: such errors happen sometimes due to requests from dm tasks with old generation.

Nevertheless, such requests with old generation are quite rare. At the same time, these errors might be true positive if there is a bug in checkpoint logic on the client side. So it seems reasonable not to make such errors silent. 