### PR TITLE
Make eternal_tests/eternal-load/lib/ut medium as it uses local disk and sometimes hits the 30 sec deadline

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/ut/ya.make
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/ut/ya.make
@@ -1,6 +1,6 @@
 UNITTEST_FOR(cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
 SRCS(
     config_ut.cpp


### PR DESCRIPTION
```
2025-02-03 11:02:17,774 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2025-02-03 11:02:17,775 - INFO - ya.test - pytest_runtest_setup: test_load_fails
2025-02-03 11:02:17,775 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2025-02-03 11:02:17,775 - INFO - ya.test - pytest_runtest_setup: Test setup
2025-02-03 11:02:17,777 - INFO - ya.test - pytest_runtest_call: Test call (class_name: test.py, test_name: test_load_fails)
2025-02-03 11:02:17,778 - DEBUG - ya.test - get_binary: Binary was found by /home/github/.ya/build/build_root/m4op/00084b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load
2025-02-03 11:02:48,433 - ERROR - ya.test - logreport: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py:52: in test_load_fails
    result = future.result()
contrib/tools/python3/src/Lib/concurrent/futures/_base.py:449: in result
    return self.__get_result()
contrib/tools/python3/src/Lib/concurrent/futures/_base.py:401: in __get_result
    raise self._exception
contrib/tools/python3/src/Lib/concurrent/futures/thread.py:58: in run
    result = self.fn(*self.args, **self.kwargs)
cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py:34: in __run_load_test
    return run(params, stdout=PIPE, stderr=PIPE, universal_newlines=True, timeout=_TIMEOUT)
contrib/tools/python3/src/Lib/subprocess.py:550: in run
    stdout, stderr = process.communicate(input, timeout=timeout)
contrib/tools/python3/src/Lib/subprocess.py:1209: in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
contrib/tools/python3/src/Lib/subprocess.py:2109: in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
contrib/tools/python3/src/Lib/subprocess.py:1253: in _check_timeout
    raise TimeoutExpired(
E   subprocess.TimeoutExpired: Command '['/home/github/.ya/build/build_root/m4op/00084b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load', '--config-type', 'generated', '--blocksize', '4096', '--request-block-count', '3', '--file', '/home/github/.ya/build/build_root/m4op/00084b/r3tmp/tmp93xvmaqa.test', '--filesize', '1', '--iodepth', '8', '--write-rate', '70']' timed out after 30 seconds
2025-02-03 11:02:48,434 - INFO - ya.test - pytest_runtest_teardown: Test teardown
```