### PR TITLE
issue-2947: add BS group connections warmup on process startup

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1117,4 +1117,6 @@ message TStorageServiceConfig
     // Minimum compacted blob size (in bytes) that lets us write the data as
     // a merged blob, otherwise it is written as a mixed blob.
     optional uint32 CompactionMergedBlobThresholdHDD = 406;
+
+    optional uint32 GroupsCountPerChannelToWarmup = 407;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1118,7 +1118,9 @@ message TStorageServiceConfig
     // a merged blob, otherwise it is written as a mixed blob.
     optional uint32 CompactionMergedBlobThresholdHDD = 406;
 
+    // The maximum number of BS groups that we can warm up for each channel at the bootstrap.
     optional uint32 BSGroupsPerChannelToWarmup = 407;
 
+    // Timeout to warm up connections to BS groups at the bootstrap.
     optional uint32 WarmupBSGroupConnectionsTimeout = 408;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1118,5 +1118,7 @@ message TStorageServiceConfig
     // a merged blob, otherwise it is written as a mixed blob.
     optional uint32 CompactionMergedBlobThresholdHDD = 406;
 
-    optional uint32 GroupsCountPerChannelToWarmup = 407;
+    optional uint32 BSGroupsPerChannelToWarmup = 407;
+
+    optional uint32 WarmupBSGroupConnectionsTimeout = 408;
 }

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -899,6 +899,10 @@ void TBootstrapBase::Start()
     // order
     START_COMMON_COMPONENT(Scheduler);
 
+    if (!Configs->Options->TemporaryServer) {
+        Warmup();
+    }
+
     auto restoreFuture = EndpointManager->RestoreEndpoints();
     if (!Configs->Options->TemporaryServer) {
         auto balancerSwitch = VolumeBalancerSwitch;

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -900,7 +900,7 @@ void TBootstrapBase::Start()
     START_COMMON_COMPONENT(Scheduler);
 
     if (!Configs->Options->TemporaryServer) {
-        WarmupBSGroupsConnections();
+        WarmupBSGroupConnections();
     }
 
     auto restoreFuture = EndpointManager->RestoreEndpoints();

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -900,7 +900,7 @@ void TBootstrapBase::Start()
     START_COMMON_COMPONENT(Scheduler);
 
     if (!Configs->Options->TemporaryServer) {
-        Warmup();
+        WarmupBSGroupsConnections();
     }
 
     auto restoreFuture = EndpointManager->RestoreEndpoints();

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -120,6 +120,8 @@ protected:
     virtual void InitKikimrService() = 0;
     virtual void InitAuthService() = 0;
 
+    virtual void Warmup() = 0;
+
     void InitLWTrace();
     void InitProfileLog();
 

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -120,7 +120,7 @@ protected:
     virtual void InitKikimrService() = 0;
     virtual void InitAuthService() = 0;
 
-    virtual void Warmup() = 0;
+    virtual void WarmupBSGroupsConnections() = 0;
 
     void InitLWTrace();
     void InitProfileLog();

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -120,7 +120,7 @@ protected:
     virtual void InitKikimrService() = 0;
     virtual void InitAuthService() = 0;
 
-    virtual void WarmupBSGroupsConnections() = 0;
+    virtual void WarmupBSGroupConnections() = 0;
 
     void InitLWTrace();
     void InitProfileLog();

--- a/cloud/blockstore/libs/daemon/local/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.cpp
@@ -47,7 +47,7 @@ void TBootstrapLocal::InitAuthService()
     // do nothing
 }
 
-void TBootstrapLocal::WarmupBSGroupsConnections()
+void TBootstrapLocal::WarmupBSGroupConnections()
 {
     // do nothing
 }

--- a/cloud/blockstore/libs/daemon/local/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.cpp
@@ -47,7 +47,7 @@ void TBootstrapLocal::InitAuthService()
     // do nothing
 }
 
-void TBootstrapLocal::Warmup()
+void TBootstrapLocal::WarmupBSGroupsConnections()
 {
     // do nothing
 }

--- a/cloud/blockstore/libs/daemon/local/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.cpp
@@ -47,6 +47,11 @@ void TBootstrapLocal::InitAuthService()
     // do nothing
 }
 
+void TBootstrapLocal::Warmup()
+{
+    // do nothing
+}
+
 TProgramShouldContinue& TBootstrapLocal::GetShouldContinue()
 {
     return ShouldContinue;

--- a/cloud/blockstore/libs/daemon/local/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.h
@@ -43,6 +43,8 @@ protected:
     void InitRdmaServer() override;
     void InitKikimrService() override;
     void InitAuthService() override;
+
+    void Warmup() override;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/daemon/local/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.h
@@ -44,7 +44,7 @@ protected:
     void InitKikimrService() override;
     void InitAuthService() override;
 
-    void Warmup() override;
+    void WarmupBSGroupsConnections() override;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/daemon/local/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.h
@@ -44,7 +44,7 @@ protected:
     void InitKikimrService() override;
     void InitAuthService() override;
 
-    void WarmupBSGroupsConnections() override;
+    void WarmupBSGroupConnections() override;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -150,6 +150,11 @@ private:
         const NActors::TActorContext& ctx)
     {
         Y_UNUSED(ev);
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "TWarmupBSGroupConnectionsActor timed out while waiting for "
+            "the TEvListTabletBootInfoBackupResponse");
         Promise.SetValue();
         Die(ctx);
     }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -178,18 +178,16 @@ private:
             for (const auto& channel: tabletBootInfo.StorageInfo->Channels) {
                 auto relevantHistoryEntrys =
                     channel.History | std::views::reverse |
+                    std::views::filter(
+                        [&](const auto& el)
+                        { return groupIds.insert(el.GroupID).second; }) |
                     std::views::take(GroupsPerChannelToWarmup);
                 for (const auto& historyEntry: relevantHistoryEntrys) {
-                    auto groupId = historyEntry.GroupID;
-                    auto [_, inserted] = groupIds.insert(groupId);
-                    if (inserted) {
-                        NCloud::Send(
-                            ctx,
-                            NKikimr::MakeBlobStorageProxyID(groupId),
-                            std::make_unique<
-                                NKikimr::TEvBlobStorage::TEvStatus>(
-                                TInstant::Max()));
-                    }
+                    NCloud::Send(
+                        ctx,
+                        NKikimr::MakeBlobStorageProxyID(historyEntry.GroupID),
+                        std::make_unique<NKikimr::TEvBlobStorage::TEvStatus>(
+                            TInstant::Max()));
                 }
             }
         }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -150,7 +150,7 @@ private:
         const NActors::TActorContext& ctx)
     {
         Y_UNUSED(ev);
-        LOG_ERROR(
+        LOG_WARN(
             ctx,
             TBlockStoreComponents::SERVICE,
             "TWarmupBSGroupConnectionsActor timed out while waiting for "

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -633,7 +633,7 @@ void TBootstrapYdb::InitAuthService()
     }
 }
 
-void TBootstrapYdb::Warmup()
+void TBootstrapYdb::WarmupBSGroupsConnections()
 {
     if (!Configs->StorageConfig ||
         !Configs->StorageConfig->GetTabletBootInfoBackupFilePath())
@@ -647,7 +647,7 @@ void TBootstrapYdb::Warmup()
         TStringBuilder()
         << "trying to read groupIds from tablet boot info file: "
         << tabletBootInfoBackupFilePath);
-    ::NCloud::NStorage::NHiveProxy::NProto::TTabletBootInfoBackup backupProto;
+    NCloud::NStorage::NHiveProxy::NProto::TTabletBootInfoBackup backupProto;
 
     try {
         TFileLock lock(tabletBootInfoBackupFilePath);
@@ -677,13 +677,13 @@ void TBootstrapYdb::Warmup()
 
     STORAGE_INFO("Sending ping messages to groups");
 
-    THashSet<ui32> groupIdsToPing;
+    THashSet<ui32> groupIdsToWarmup;
     for (const auto& [_, tabletBootInfo]: backupProto.GetData()) {
         for (const auto& channel: tabletBootInfo.GetStorageInfo().GetChannels())
         {
             for (const auto& historyEntry: channel.GetHistory()) {
                 auto groupId = historyEntry.GetGroupID();
-                auto [_, inserted] = groupIdsToPing.insert(groupId);
+                auto [_, inserted] = groupIdsToWarmup.insert(groupId);
                 if (inserted) {
                     ActorSystem->Send(
                         NKikimr::MakeBlobStorageProxyID(groupId),

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -52,8 +52,8 @@
 #include <cloud/storage/core/libs/common/proto_helpers.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
-#include <cloud/storage/core/libs/diagnostics/stats_fetcher.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
+#include <cloud/storage/core/libs/diagnostics/stats_fetcher.h>
 #include <cloud/storage/core/libs/diagnostics/trace_serializer.h>
 #include <cloud/storage/core/libs/hive_proxy/protos/tablet_boot_info_backup.pb.h>
 #include <cloud/storage/core/libs/iam/iface/client.h>

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -127,6 +127,8 @@ protected:
     void InitKikimrService() override;
     void InitAuthService() override;
 
+    void Warmup() override;
+
 private:
     void InitConfigs();
 };

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -127,7 +127,7 @@ protected:
     void InitKikimrService() override;
     void InitAuthService() override;
 
-    void WarmupBSGroupsConnections() override;
+    void WarmupBSGroupConnections() override;
 
 private:
     void InitConfigs();

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -127,7 +127,7 @@ protected:
     void InitKikimrService() override;
     void InitAuthService() override;
 
-    void Warmup() override;
+    void WarmupBSGroupsConnections() override;
 
 private:
     void InitConfigs();

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -532,6 +532,7 @@ TDuration MSeconds(ui32 value)
                                                                                \
     xxx(DestroyVolumeTimeout,                      TDuration, Seconds(30)     )\
     xxx(CompactionMergedBlobThresholdHDD,          ui32,      0               )\
+    xxx(GroupsCountPerChannelToWarmup,             ui32,      1               )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -532,7 +532,9 @@ TDuration MSeconds(ui32 value)
                                                                                \
     xxx(DestroyVolumeTimeout,                      TDuration, Seconds(30)     )\
     xxx(CompactionMergedBlobThresholdHDD,          ui32,      0               )\
-    xxx(GroupsCountPerChannelToWarmup,             ui32,      1               )\
+                                                                               \
+    xxx(BSGroupsPerChannelToWarmup,                ui32,      1               )\
+    xxx(WarmupBSGroupConnectionsTimeout,           TDuration, Seconds(1)      )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -638,7 +638,8 @@ public:
 
     ui32 GetCompactionMergedBlobThresholdHDD() const;
 
-    [[nodiscard]] ui32 GetGroupsCountPerChannelToWarmup() const;
+    [[nodiscard]] ui32 GetBSGroupsPerChannelToWarmup() const;
+    [[nodiscard]] TDuration GetWarmupBSGroupConnectionsTimeout() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -637,6 +637,8 @@ public:
     [[nodiscard]] TDuration GetDestroyVolumeTimeout() const;
 
     ui32 GetCompactionMergedBlobThresholdHDD() const;
+
+    [[nodiscard]] ui32 GetGroupsCountPerChannelToWarmup() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/ss_proxy/path_description_backup.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/path_description_backup.cpp
@@ -67,6 +67,9 @@ NProto::TError TPathDescriptionBackup::Backup(const TActorContext& ctx)
         TFileLock lock(TmpBackupFilePath);
 
         if (lock.TryAcquire()) {
+            Y_DEFER {
+                lock.Release();
+            };
             TFileOutput output(TmpBackupFilePath);
             SerializeToTextFormat(BackupProto, output);
             TmpBackupFilePath.RenameTo(BackupFilePath);

--- a/cloud/storage/core/libs/api/hive_proxy.h
+++ b/cloud/storage/core/libs/api/hive_proxy.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <cloud/storage/core/libs/hive_proxy/tablet_boot_info.h>
 #include <cloud/storage/core/libs/kikimr/components.h>
 #include <cloud/storage/core/libs/kikimr/events.h>
 
@@ -25,7 +26,8 @@ namespace NCloud::NStorage {
     xxx(LookupTablet,   __VA_ARGS__)                                           \
     xxx(DrainNode,      __VA_ARGS__)                                           \
                                                                                \
-    xxx(BackupTabletBootInfos, __VA_ARGS__)                                    \
+    xxx(BackupTabletBootInfos,     __VA_ARGS__)                                \
+    xxx(ListTabletBootInfoBackups, __VA_ARGS__)                                \
 // STORAGE_HIVE_PROXY_REQUESTS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -256,6 +258,24 @@ struct TEvHiveProxy
     };
 
     //
+    // ListTabletBootInfoBackups
+    //
+
+    struct TListTabletBootInfoBackupsRequest
+    {
+    };
+
+    struct TListTabletBootInfoBackupsResponse
+    {
+        TVector<TTabletBootInfo> TabletBootInfos;
+
+        explicit TListTabletBootInfoBackupsResponse(
+                TVector<TTabletBootInfo> tabletBootInfos = {})
+            : TabletBootInfos(std::move(tabletBootInfos))
+        {}
+    };
+
+    //
     // Events declaration
     //
 
@@ -291,6 +311,9 @@ struct TEvHiveProxy
 
         EvBackupTabletBootInfosRequest = EvBegin + 18,
         EvBackupTabletBootInfosResponse = EvBegin + 19,
+
+        EvListTabletBootInfoBackupsRequest = EvBegin + 20,
+        EvListTabletBootInfoBackupsResponse = EvBegin + 21,
 
         EvEnd
     };

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
@@ -569,9 +569,9 @@ void THiveProxyActor::HandleListTabletBootInfoBackups(
     if (TabletBootInfoBackup) {
         ctx.Send(ev->Forward(TabletBootInfoBackup));
     } else {
-        auto response =
-            std::make_unique<TEvHiveProxy::TEvBackupTabletBootInfosResponse>(
-                MakeError(S_FALSE));
+        auto response = std::make_unique<
+            TEvHiveProxy::TEvListTabletBootInfoBackupsResponse>(
+            MakeError(S_FALSE));
         NCloud::Reply(ctx, *ev, std::move(response));
     }
 }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
@@ -562,4 +562,18 @@ void THiveProxyActor::HandleBackupTabletBootInfos(
     }
 }
 
+void THiveProxyActor::HandleListTabletBootInfoBackups(
+    const TEvHiveProxy::TEvListTabletBootInfoBackupsRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (TabletBootInfoBackup) {
+        ctx.Send(ev->Forward(TabletBootInfoBackup));
+    } else {
+        auto response =
+            std::make_unique<TEvHiveProxy::TEvBackupTabletBootInfosResponse>(
+                MakeError(S_FALSE));
+        NCloud::Reply(ctx, *ev, std::move(response));
+    }
+}
+
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_events_private.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_events_private.h
@@ -130,8 +130,6 @@ struct TEvHiveProxyPrivate
         EvReadTabletBootInfoBackupRequest,
         EvReadTabletBootInfoBackupResponse,
         EvUpdateTabletBootInfoBackupRequest,
-        EvListTabletBootInfoBackupsRequest,
-        EvListTabletBootInfoBackupsResponse,
 
         EvEnd
     };
@@ -150,10 +148,6 @@ struct TEvHiveProxyPrivate
         TReadTabletBootInfoBackupResponse, EvReadTabletBootInfoBackupResponse>;
     using TEvUpdateTabletBootInfoBackupRequest = TRequestEvent<
         TUpdateTabletBootInfoBackupRequest, EvUpdateTabletBootInfoBackupRequest>;
-    using TEvListTabletBootInfoBackupsRequest = TRequestEvent<
-        TListTabletBootInfoBackupsRequest, EvListTabletBootInfoBackupsRequest>;
-    using TEvListTabletBootInfoBackupsResponse = TRequestEvent<
-        TListTabletBootInfoBackupsResponse, EvListTabletBootInfoBackupsResponse>;
 };
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
@@ -329,9 +329,9 @@ void THiveProxyFallbackActor::HandleListTabletBootInfoBackups(
     if (TabletBootInfoBackup) {
         ctx.Send(ev->Forward(TabletBootInfoBackup));
     } else {
-        auto response =
-            std::make_unique<TEvHiveProxy::TEvBackupTabletBootInfosResponse>(
-                MakeError(S_FALSE));
+        auto response = std::make_unique<
+            TEvHiveProxy::TEvListTabletBootInfoBackupsResponse>(
+            MakeError(S_FALSE));
         NCloud::Reply(ctx, *ev, std::move(response));
     }
 }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
@@ -322,4 +322,18 @@ void THiveProxyFallbackActor::HandleBackupTabletBootInfos(
     }
 }
 
+void THiveProxyFallbackActor::HandleListTabletBootInfoBackups(
+    const TEvHiveProxy::TEvListTabletBootInfoBackupsRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (TabletBootInfoBackup) {
+        ctx.Send(ev->Forward(TabletBootInfoBackup));
+    } else {
+        auto response =
+            std::make_unique<TEvHiveProxy::TEvBackupTabletBootInfosResponse>(
+                MakeError(S_FALSE));
+        NCloud::Reply(ctx, *ev, std::move(response));
+    }
+}
+
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
@@ -63,11 +63,11 @@ void TTabletBootInfoBackup::Bootstrap(const TActorContext& ctx)
         InitialBackupProto.reset();
     }
 
-    if (!ReadOnlyMode) {
-        ScheduleBackup(ctx);
-    } else if (InitialBackupProto) {
+    if (ReadOnlyMode && InitialBackupProto) {
         BackupProto = std::move(InitialBackupProto.value());
         InitialBackupProto.reset();
+    } else if (!ReadOnlyMode) {
+        ScheduleBackup(ctx);
     }
 
     LOG_INFO_S(ctx, LogComponent,

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
@@ -65,6 +65,9 @@ void TTabletBootInfoBackup::Bootstrap(const TActorContext& ctx)
 
     if (!ReadOnlyMode) {
         ScheduleBackup(ctx);
+    } else if (InitialBackupProto) {
+        BackupProto = std::move(InitialBackupProto.value());
+        InitialBackupProto.reset();
     }
 
     LOG_INFO_S(ctx, LogComponent,
@@ -177,11 +180,6 @@ void TTabletBootInfoBackup::HandleUpdateTabletBootInfoBackup(
     NKikimr::TabletStorageInfoToProto(
         *msg->StorageInfo, info.MutableStorageInfo());
     info.SetSuggestedGeneration(msg->SuggestedGeneration);
-
-    if (ReadOnlyMode && InitialBackupProto) {
-        BackupProto = std::move(InitialBackupProto.value());
-        InitialBackupProto.reset();
-    }
 
     auto& data = *BackupProto.MutableData();
     data[msg->StorageInfo->TabletID] = info;

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
@@ -63,10 +63,12 @@ void TTabletBootInfoBackup::Bootstrap(const TActorContext& ctx)
         InitialBackupProto.reset();
     }
 
-    if (ReadOnlyMode && InitialBackupProto) {
-        BackupProto = std::move(InitialBackupProto.value());
-        InitialBackupProto.reset();
-    } else if (!ReadOnlyMode) {
+    if (ReadOnlyMode) {
+        if (InitialBackupProto) {
+            BackupProto = std::move(InitialBackupProto.value());
+            InitialBackupProto.reset();
+        }
+    } else {
         ScheduleBackup(ctx);
     }
 

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.h
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.h
@@ -29,8 +29,9 @@ private:
     const TFsPath BackupFilePath;
     const bool ReadOnlyMode = false;
 
-    std::optional<NHiveProxy::NProto::TTabletBootInfoBackup>
-        LoadedFromDiskBackupProto;
+    // Proto from BackupFilePath will be loaded into this variable. After the
+    // first backup, this information will be overwritten and not used.
+    std::optional<NHiveProxy::NProto::TTabletBootInfoBackup> InitialBackupProto;
     NHiveProxy::NProto::TTabletBootInfoBackup BackupProto;
     const TFsPath TmpBackupFilePath;
 

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.h
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.h
@@ -29,6 +29,8 @@ private:
     const TFsPath BackupFilePath;
     const bool ReadOnlyMode = false;
 
+    std::optional<NHiveProxy::NProto::TTabletBootInfoBackup>
+        LoadedFromDiskBackupProto;
     NHiveProxy::NProto::TTabletBootInfoBackup BackupProto;
     const TFsPath TmpBackupFilePath;
 
@@ -63,7 +65,7 @@ private:
         const NActors::TActorContext& ctx);
 
     void HandleListTabletBootInfoBackups(
-        const TEvHiveProxyPrivate::TEvListTabletBootInfoBackupsRequest::TPtr& ev,
+        const TEvHiveProxy::TEvListTabletBootInfoBackupsRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.h
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.h
@@ -29,8 +29,9 @@ private:
     const TFsPath BackupFilePath;
     const bool ReadOnlyMode = false;
 
-    // Proto from BackupFilePath will be loaded into this variable. After the
-    // first backup, this information will be overwritten and not used.
+    // Proto from BackupFilePath is loaded into this variable.
+    // Tablet boot info backups are served from this variable until
+    // the first scheduled backup happens.
     std::optional<NHiveProxy::NProto::TTabletBootInfoBackup> InitialBackupProto;
     NHiveProxy::NProto::TTabletBootInfoBackup BackupProto;
     const TFsPath TmpBackupFilePath;

--- a/cloud/storage/core/libs/ss_proxy/path_description_backup.cpp
+++ b/cloud/storage/core/libs/ss_proxy/path_description_backup.cpp
@@ -75,6 +75,9 @@ NProto::TError TPathDescriptionBackup::Backup(const TActorContext& ctx)
         TFileLock lock(TmpBackupFilePath);
 
         if (lock.TryAcquire()) {
+            Y_DEFER {
+                lock.Release();
+            };
             TFileOutput output(TmpBackupFilePath);
             SerializeToTextFormat(BackupProto, output);
             TmpBackupFilePath.RenameTo(BackupFilePath);


### PR DESCRIPTION
#2947
Провели пару замеров на проде и прогрев соеденений дал улучшение в пару секунд для максимального летенси на пользовательской стороне во время рестарта. 
Уже есть тест cloud/blockstore/tests/loadtest/local-emergency/test.py который делает BackupTabletBootInfos и затем рестартит nbs, поэтому наш случай уже покрыт тестами.