### PR TITLE
issue-2947: don't backup tablet info in temporary server

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -575,6 +575,8 @@ void TBootstrapYdb::InitKikimrService()
     args.EndpointEventHandler = EndpointEventHandler;
     args.RootKmsKeyProvider = RootKmsKeyProvider;
 
+    args.TemporaryServer = Configs->Options->TemporaryServer;
+
     ActorSystem = NStorage::CreateActorSystem(args);
 
     if (args.IsDiskRegistrySpareNode) {

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -574,7 +574,6 @@ void TBootstrapYdb::InitKikimrService()
     args.VolumeBalancerSwitch = VolumeBalancerSwitch;
     args.EndpointEventHandler = EndpointEventHandler;
     args.RootKmsKeyProvider = RootKmsKeyProvider;
-
     args.TemporaryServer = Configs->Options->TemporaryServer;
 
     ActorSystem = NStorage::CreateActorSystem(args);

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -140,17 +140,22 @@ public:
 
         auto hiveProxy = CreateHiveProxy(
             {
-                .PipeClientRetryCount = Args.StorageConfig->GetPipeClientRetryCount(),
-                .PipeClientMinRetryTime = Args.StorageConfig->GetPipeClientMinRetryTime(),
-                .HiveLockExpireTimeout = Args.StorageConfig->GetHiveLockExpireTimeout(),
+                .PipeClientRetryCount =
+                    Args.StorageConfig->GetPipeClientRetryCount(),
+                .PipeClientMinRetryTime =
+                    Args.StorageConfig->GetPipeClientMinRetryTime(),
+                .HiveLockExpireTimeout =
+                    Args.StorageConfig->GetHiveLockExpireTimeout(),
                 .LogComponent = TBlockStoreComponents::HIVE_PROXY,
-                .TabletBootInfoBackupFilePath = Args.StorageConfig->GetTabletBootInfoBackupFilePath(),
+                .TabletBootInfoBackupFilePath =
+                    Args.TemporaryServer
+                        ? ""
+                        : Args.StorageConfig->GetTabletBootInfoBackupFilePath(),
                 .FallbackMode = Args.StorageConfig->GetHiveProxyFallbackMode(),
-                .TenantHiveTabletId = Args.StorageConfig->GetTenantHiveTabletId(),
+                .TenantHiveTabletId =
+                    Args.StorageConfig->GetTenantHiveTabletId(),
             },
-            appData
-                ->Counters
-                ->GetSubgroup("counters", "blockstore")
+            appData->Counters->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service"));
 
         setup->LocalServices.emplace_back(

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.h
@@ -71,6 +71,7 @@ struct TServerActorSystemArgs
     TVector<NCloud::NStorage::IUserMetricsSupplierPtr> UserCounterProviders;
 
     bool IsDiskRegistrySpareNode = false;
+    bool TemporaryServer = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -1107,10 +1107,10 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
 
     Y_UNIT_TEST(DontBackupWithEmptyBootInfoFilePath)
     {
-        TString cacheFilePath = "";
+        TString backupFilePath = "";
 
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, cacheFilePath);
+        TTestEnv env(runtime, backupFilePath);
 
         auto sender = runtime.AllocateEdgeActor();
 
@@ -1119,13 +1119,13 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
 
     Y_UNIT_TEST(BootExternalInFallbackMode)
     {
-        TString cacheFilePath =
-            "BootExternalInFallbackMode.tablet_boot_info_cache.txt";;
+        TString backupFilePath =
+            "BootExternalInFallbackMode.tablet_boot_info_backup.txt";
         bool fallbackMode = false;
 
         {
             TTestBasicRuntime runtime;
-            TTestEnv env(runtime, cacheFilePath, fallbackMode);
+            TTestEnv env(runtime, backupFilePath, fallbackMode);
 
             TTabletStorageInfoPtr expected = CreateTestTabletInfo(
                 FakeTablet2,
@@ -1151,7 +1151,7 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         fallbackMode = true;
         {
             TTestBasicRuntime runtime;
-            TTestEnv env(runtime, cacheFilePath, fallbackMode);
+            TTestEnv env(runtime, backupFilePath, fallbackMode);
 
             auto sender = runtime.AllocateEdgeActor();
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -1105,6 +1105,18 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         UNIT_ASSERT(env.HiveState->DownNodeIds.contains(sender.NodeId()));
     }
 
+    Y_UNIT_TEST(DontBackupWithEmptyBootInfoFilePath)
+    {
+        TString cacheFilePath = "";
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, cacheFilePath);
+
+        auto sender = runtime.AllocateEdgeActor();
+
+        env.SendBackupTabletBootInfos(sender, S_FALSE);
+    }
+
     Y_UNIT_TEST(BootExternalInFallbackMode)
     {
         TString cacheFilePath =


### PR DESCRIPTION
#2947 показалось странным, что временный сервер тоже бэкапит информацию о таблетках. Плюс это может помешать во время рестарта при прогреве соедений в задачке #2947

#2100 