### PR TITLE
[Disk Manager] Turn off disk manager tests influenced by StatVolume

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -762,7 +762,9 @@ func TestSnapshotServiceDeleteSnapshotWhenCreationIsInFlight(t *testing.T) {
 
 	// Should wait here because checkpoint is deleted on |createOp| operation
 	// cancel (and exact time of this event is unknown).
-	testcommon.WaitForCheckpointsAreEmpty(t, ctx, diskID)
+	// TODO: enable this check after resolving issue
+	// https://github.com/ydb-platform/nbs/issues/2008.
+	// testcommon.WaitForCheckpointsAreEmpty(t, ctx, diskID)
 
 	testcommon.CheckConsistency(t, ctx)
 }

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -358,7 +358,9 @@ func RequireCheckpointsAreEmpty(
 	ctx context.Context,
 	diskID string,
 ) {
-
+	// TODO: enable this method after resolving this issue
+	// https://github.com/ydb-platform/nbs/issues/2008.
+	return
 	nbsClient := NewNbsTestingClient(t, ctx, "zone-a")
 	checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
 	require.NoError(t, err)


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/2008
Turning off some checkpoint disk manager checks that would be influenced by future changes in StatVolume logic