### PR TITLE
Fix eternal_tests/eternal-load/bin/tests/test_load_fails: don't use 30 sec timeout when running eternal-load, use default suite timeout instead

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
@@ -14,10 +14,9 @@ _REQUEST_BLOCK_COUNT = 3
 _REQUEST_SIZE = _REQUEST_BLOCK_COUNT * _BLOCKSIZE
 _REQUEST_COUNT = (_FILE_SIZE * 1024 ** 3) / _REQUEST_SIZE
 _BINARY_PATH = 'cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load'
-_TIMEOUT = 30
 
 
-def __run_load_test(file_name):
+def __run_load_test(file_name, timeout=None):
     eternal_load = yatest_common.binary_path(_BINARY_PATH)
 
     params = [
@@ -31,7 +30,7 @@ def __run_load_test(file_name):
         '--write-rate', '70'
     ]
 
-    return run(params, stdout=PIPE, stderr=PIPE, universal_newlines=True, timeout=_TIMEOUT)
+    return run(params, stdout=PIPE, stderr=PIPE, universal_newlines=True, timeout=timeout)
 
 
 def test_load_fails():
@@ -39,7 +38,7 @@ def test_load_fails():
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(__run_load_test, tmp_file.name)
-        time.sleep(_TIMEOUT / 2)
+        time.sleep(10)
 
         cnt = 0
         while future.running():
@@ -54,10 +53,11 @@ def test_load_fails():
 
 
 def test_load_works():
+    timeout = 30
     tmp_file = tempfile.NamedTemporaryFile(suffix=".test")
     try:
-        assert __run_load_test(tmp_file.name).returncode == 0
+        assert __run_load_test(tmp_file.name, timeout).returncode == 0
     except TimeoutExpired:
         pass
     else:
-        pytest.fail(f"Eternal load should not have finished in {_TIMEOUT} seconds")
+        pytest.fail(f"Eternal load should not have finished within {timeout} seconds")


### PR DESCRIPTION
```
2025-02-05 01:52:08,814 - INFO - ya.test - pytest_collection_modifyitems: Modulo 0 tests are: [[<Function test_load_fails>]]
2025-02-05 01:52:08,817 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2025-02-05 01:52:08,817 - INFO - ya.test - pytest_runtest_setup: test_load_fails
2025-02-05 01:52:08,817 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2025-02-05 01:52:08,817 - INFO - ya.test - pytest_runtest_setup: Test setup
2025-02-05 01:52:08,818 - INFO - ya.test - pytest_runtest_call: Test call (class_name: test.py, test_name: test_load_fails)
2025-02-05 01:52:08,819 - DEBUG - ya.test - get_binary: Binary was found by /home/github/.ya/build/build_root/nhjj/000784/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load
2025-02-05 01:52:39,284 - ERROR - ya.test - logreport: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py:52: in test_load_fails
    result = future.result()
contrib/tools/python3/src/Lib/concurrent/futures/_base.py:449: in result
    return self.__get_result()
contrib/tools/python3/src/Lib/concurrent/futures/_base.py:401: in __get_result
    raise self._exception
contrib/tools/python3/src/Lib/concurrent/futures/thread.py:58: in run
    result = self.fn(*self.args, **self.kwargs)
cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py:34: in __run_load_test
    return run(params, stdout=PIPE, stderr=PIPE, universal_newlines=True, timeout=_TIMEOUT)
contrib/tools/python3/src/Lib/subprocess.py:550: in run
    stdout, stderr = process.communicate(input, timeout=timeout)
contrib/tools/python3/src/Lib/subprocess.py:1209: in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
contrib/tools/python3/src/Lib/subprocess.py:2109: in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
contrib/tools/python3/src/Lib/subprocess.py:1253: in _check_timeout
    raise TimeoutExpired(
E   subprocess.TimeoutExpired: Command '['/home/github/.ya/build/build_root/nhjj/000784/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load', '--config-type', 'generated', '--blocksize', '4096', '--request-block-count', '3', '--file', '/home/github/.ya/build/build_root/nhjj/000784/r3tmp/tmp0p2iwzzc.test', '--filesize', '1', '--iodepth', '8', '--write-rate', '70']' timed out after 30 seconds
2025-02-05 01:52:39,285 - INFO - ya.test - pytest_runtest_teardown: Test teardown
```