### PR TITLE
issue-1932: use ceil instead of floor for calculating shards count

### DIFF
--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -507,7 +507,12 @@ ui32 ComputeShardCount(
 {
     const double fileStoreSize = blocksCount * blockSize;
 
-    const ui32 shardCount = std::floor(fileStoreSize / shardAllocationUnit);
+    if (fileStoreSize < shardAllocationUnit) {
+        // No need in using sharding for small enough filesystems
+        return 0;
+    }
+
+    const ui32 shardCount = std::ceil(fileStoreSize / shardAllocationUnit);
     return Min(shardCount, MaxShardCount);
 }
 

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -2293,19 +2293,35 @@ Y_UNIT_TEST_SUITE(TModel)
     {
         using namespace ::NCloud::NProto;
         KikimrConfig.SetBlockSize(4_KB);
-        KikimrConfig.SetBlocksCount(4_TB / 4_KB);
 
         // Disable media type override.
         StorageConfig.SetAutomaticShardCreationEnabled(true);
         StorageConfig.SetShardAllocationUnit(4_TB);
         StorageConfig.SetAutomaticallyCreatedShardSize(5_TB);
 
+        KikimrConfig.SetBlocksCount(4_TB / 4_KB);
         auto fs = SetupMultiShardFileStorePerformanceAndChannels(
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
             0);
         UNIT_ASSERT_VALUES_EQUAL(1, fs.ShardConfigs.size());
+
+        KikimrConfig.SetBlocksCount(4_TB / 4_KB + 1);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile,
+            0);
+        UNIT_ASSERT_VALUES_EQUAL(2, fs.ShardConfigs.size());
+
+        KikimrConfig.SetBlocksCount(5_TB / 4_KB);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile,
+            0);
+        UNIT_ASSERT_VALUES_EQUAL(2, fs.ShardConfigs.size());
 
         KikimrConfig.SetBlocksCount(16_TB / 4_KB);
         fs = SetupMultiShardFileStorePerformanceAndChannels(

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -3717,6 +3717,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         service.ResizeFileStore(fsId, (4_GB - 4_KB) / 4_KB);
 
+        expected = TVector<TString>{
+            fsId, fsId + "_s1", fsId + "_s2", fsId + "_s3", fsId + "_s4"
+        };
         listing = service.ListFileStores();
         fsIds = listing->Record.GetFileStores();
         ids = TVector<TString>(fsIds.begin(), fsIds.end());
@@ -3725,9 +3728,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         service.ResizeFileStore(fsId, 4_GB / 4_KB);
 
-        expected = TVector<TString>{
-            fsId, fsId + "_s1", fsId + "_s2", fsId + "_s3", fsId + "_s4"
-        };
         listing = service.ListFileStores();
         fsIds = listing->Record.GetFileStores();
         ids = TVector<TString>(fsIds.begin(), fsIds.end());


### PR DESCRIPTION
References #1932

Currently a shard of 5TiB is created per each 4TiB in the filesystem (rounding the number of shards down). So if the filesystem is the size of 7TiB, only one shard of size 5TiB will be created. In this PR rounding down is replaced with rounding up.