### PR TITLE
issue-1932: set performance profile of the main tablet based on the filesystem size

### DIFF
--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -458,13 +458,15 @@ ui32 NodesLimit(
     xxx(BoostPercentage,                        __VA_ARGS__)                   \
 // PERFORMANCE_PROFILE_PARAMETERS_AU
 
+}   // namespace
+
 void SetupFileStorePerformanceAndChannels(
     bool allocateMixed0Channel,
-    const ui32 allocationUnitCount,
     const TStorageConfig& config,
     NKikimrFileStore::TConfig& fileStore,
     const NProto::TFileStorePerformanceProfile& clientProfile)
 {
+    ui32 allocationUnitCount = ComputeAllocationUnitCount(config, fileStore);
     OverrideStorageMediaKind(config, fileStore);
 
 #define SETUP_PARAMETER_SIMPLE(name, ...)                                      \
@@ -496,8 +498,6 @@ void SetupFileStorePerformanceAndChannels(
         fileStore);
 }
 
-}   // namespace
-
 ////////////////////////////////////////////////////////////////////////////////
 
 ui32 ComputeShardCount(
@@ -511,20 +511,6 @@ ui32 ComputeShardCount(
     return Min(shardCount, MaxShardCount);
 }
 
-void SetupFileStorePerformanceAndChannels(
-    bool allocateMixed0Channel,
-    const TStorageConfig& config,
-    NKikimrFileStore::TConfig& fileStore,
-    const NProto::TFileStorePerformanceProfile& clientProfile)
-{
-    SetupFileStorePerformanceAndChannels(
-        allocateMixed0Channel,
-        ComputeAllocationUnitCount(config, fileStore),
-        config,
-        fileStore,
-        clientProfile);
-}
-
 TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
     const TStorageConfig& config,
     const NKikimrFileStore::TConfig& fileStore,
@@ -535,7 +521,6 @@ TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
     result.MainFileSystemConfig = fileStore;
     SetupFileStorePerformanceAndChannels(
         false, // allocateMixed0Channel
-        1, // allocationUnitCount
         config,
         result.MainFileSystemConfig,
         clientProfile);

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -2299,6 +2299,10 @@ Y_UNIT_TEST_SUITE(TModel)
         StorageConfig.SetAutomaticShardCreationEnabled(true);
         StorageConfig.SetShardAllocationUnit(4_TB);
         StorageConfig.SetAutomaticallyCreatedShardSize(5_TB);
+        StorageConfig.SetSSDMaxWriteIops(Max<ui32>());
+
+        auto OldMaxWriteIops = ClientPerformanceProfile.GetMaxWriteIops();
+        ClientPerformanceProfile.ClearMaxWriteIops();
 
         auto fs = SetupMultiShardFileStorePerformanceAndChannels(
             StorageConfig,
@@ -2306,6 +2310,10 @@ Y_UNIT_TEST_SUITE(TModel)
             ClientPerformanceProfile,
             0);
         UNIT_ASSERT_VALUES_EQUAL(1, fs.ShardConfigs.size());
+        // MaxWriteIops per allocation unit is 1000, so 1000 * (4096 GiB / 32 GiB) = 128000
+        UNIT_ASSERT_VALUES_EQUAL(128000, fs.MainFileSystemConfig.GetPerformanceProfileMaxWriteIops());
+
+        ClientPerformanceProfile.SetMaxWriteIops(OldMaxWriteIops);
 
         KikimrConfig.SetBlocksCount(16_TB / 4_KB);
         fs = SetupMultiShardFileStorePerformanceAndChannels(


### PR DESCRIPTION
Right now if the filesystem is 3TiB, for example, it gets performance of only one allocation unit:

https://github.com/ydb-platform/nbs/blob/28c2ad48eb361d704fbcb3110e6d7607f3765df3/cloud/filestore/libs/storage/core/model.cpp#L536-L541