### PR TITLE
issue-2869: implement netlink_device without libnl

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -556,7 +556,9 @@ void TBootstrapBase::Init()
             Logging,
             Configs->ServerConfig->GetNbdRequestTimeout(),
             Configs->ServerConfig->GetNbdConnectionTimeout(),
-            true);  // reconfigure
+            true,   // reconfigure
+            false   // without libnl
+        );
     }
 
     // The only case we want kernel to retry requests is when the socket is dead

--- a/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/bootstrap.cpp
@@ -30,6 +30,7 @@ void TBootstrap::Init()
         Options.StoredEndpointsPath,
         Options.NbdRequestTimeout,
         Options.NbdReconnectDelay,
+        Options.WithoutLibnl,
     },
     CreateWallClockTimer(),
     Scheduler,

--- a/cloud/blockstore/libs/endpoint_proxy/server/options.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/options.cpp
@@ -43,6 +43,10 @@ TOptions::TOptions()
         .Handler1T<TString>([this] (const auto& s) {
             NbdReconnectDelay = TDuration::Parse(s);
         });
+
+    Opts.AddLongOption("without-libnl")
+        .NoArgument()
+        .SetFlag(&WithoutLibnl);
 }
 
 void TOptions::Parse(int argc, char** argv)

--- a/cloud/blockstore/libs/endpoint_proxy/server/options.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/options.h
@@ -20,6 +20,7 @@ struct TOptions final: TOptionsBase
     TString StoredEndpointsPath;
     TDuration NbdRequestTimeout = TDuration::Minutes(10);
     TDuration NbdReconnectDelay = TDuration::MilliSeconds(100);
+    bool WithoutLibnl = false;
 
     TOptions();
 

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -977,7 +977,8 @@ struct TServer: IEndpointProxyServer
                 ep.NbdDevicePath,
                 Config.NbdRequestTimeout,
                 NBD_CONNECTION_TIMEOUT,
-                NBD_RECONFIGURE_CONNECTED);
+                NBD_RECONFIGURE_CONNECTED,
+                Config.WithoutLibnl);
         } else {
             // The only case we want kernel to retry requests is when the socket
             // is dead due to nbd server restart. And since we can't configure

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.h
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.h
@@ -29,6 +29,7 @@ struct TEndpointProxyServerConfig
     TString StoredEndpointsPath;
     TDuration NbdRequestTimeout;
     TDuration NbdReconnectDelay;
+    bool WithoutLibnl;
 
     TEndpointProxyServerConfig(
             ui16 port,
@@ -40,7 +41,8 @@ struct TEndpointProxyServerConfig
             bool netlink,
             TString storedEndpointsPath,
             TDuration nbdRequestTimeout,
-            TDuration nbdReconnectDelay)
+            TDuration nbdReconnectDelay,
+            bool withoutLibnl)
         : Port(port)
         , SecurePort(securePort)
         , RootCertsFile(std::move(rootCertsFile))
@@ -51,6 +53,7 @@ struct TEndpointProxyServerConfig
         , StoredEndpointsPath(std::move(storedEndpointsPath))
         , NbdRequestTimeout(nbdRequestTimeout)
         , NbdReconnectDelay(nbdReconnectDelay)
+        , WithoutLibnl(withoutLibnl)
     {
     }
 };

--- a/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server_ut.cpp
@@ -59,7 +59,8 @@ Y_UNIT_TEST_SUITE(TServerTest)
             false,
             "",
             TDuration::Seconds(1),
-            TDuration::MilliSeconds(100));
+            TDuration::MilliSeconds(100),
+            true);
 
         auto server = CreateServer(
             serverConfig,

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -209,7 +209,7 @@ void TNetlinkDevice::DisconnectSocket()
     Socket.Close();
 }
 
-// queries device status eand registers callback that will connect
+// queries device status and registers callback that will connect
 // or reconfigure (if Reconfigure == true) specified device
 void TNetlinkDevice::Connect()
 {
@@ -701,8 +701,7 @@ void TNetlinkDevice::DisconnectSocket()
     Socket.Close();
 }
 
-// queries device status eand registers callback that will connect
-// or reconfigure (if Reconfigure == true) specified device
+// queries device status and configure/reconfigure device
 void TNetlinkDevice::Connect()
 {
     try {

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -371,16 +371,6 @@ int TNetlinkDevice::StatusHandler(nl_msg* nlmsg)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void ValidateAttribute(const ::nlattr& attribute, ui16 expectedAttribute)
-{
-    if (attribute.nla_type != expectedAttribute) {
-        throw TIoException() << "Invalid attribute type: " << attribute.nla_type
-                           << " Expected attribute type: " << expectedAttribute;
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 using NNetlink::TNetlinkHeader;
 
 #pragma pack(push, NLMSG_ALIGNTO)
@@ -413,8 +403,8 @@ struct TNetlinkFamilyIdResponse
 
     void Validate()
     {
-        ValidateAttribute(FamilyNameAttr, CTRL_ATTR_FAMILY_NAME);
-        ValidateAttribute(FamilyIdAttr, CTRL_ATTR_FAMILY_ID);
+        NNetlink::ValidateAttribute(FamilyNameAttr, CTRL_ATTR_FAMILY_NAME);
+        NNetlink::ValidateAttribute(FamilyIdAttr, CTRL_ATTR_FAMILY_ID);
     }
 };
 
@@ -442,9 +432,9 @@ struct TNbdStatusResponse {
 
     void Validate()
     {
-        ValidateAttribute(NbdDeviceListAttr, NBD_ATTR_DEVICE_LIST);
-        ValidateAttribute(NbdDeviceItemAttr, NBD_DEVICE_ITEM);
-        ValidateAttribute(NbdDeviceIndex, NBD_DEVICE_INDEX);
+        NNetlink::ValidateAttribute(NbdDeviceListAttr, NBD_ATTR_DEVICE_LIST);
+        NNetlink::ValidateAttribute(NbdDeviceItemAttr, NBD_DEVICE_ITEM);
+        NNetlink::ValidateAttribute(NbdDeviceIndex, NBD_DEVICE_INDEX);
     }
 };
 

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -391,8 +391,7 @@ struct TNetlinkFamilyIdRequest
     TNetlinkHeader Headers = {
         sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>),
         GENL_ID_CTRL,
-        CTRL_CMD_GETFAMILY,
-        false};
+        CTRL_CMD_GETFAMILY};
     ::nlattr FamilyNameAttr = {
         sizeof(FamilyName) + NLA_HDRLEN,
         CTRL_ATTR_FAMILY_NAME};
@@ -426,7 +425,7 @@ struct TNbdStatusRequest
     ui32 DeviceIndex;
 
     TNbdStatusRequest(ui16 familyId, ui32 deviceIndex)
-        : Headers{sizeof(TNbdStatusRequest), familyId, NBD_CMD_STATUS, false}
+        : Headers{sizeof(TNbdStatusRequest), familyId, NBD_CMD_STATUS}
         , DeviceIndexAttr{sizeof(DeviceIndex) + NLA_HDRLEN, NBD_ATTR_INDEX}
         , DeviceIndex(deviceIndex)
     {}
@@ -479,7 +478,7 @@ struct TNbdConfigureDeviceRequest
         ui64 requestTimeout,
         ui64 connectionTimeout,
         ui32 socketFd)
-        : Headers{sizeof(TNbdConfigureDeviceRequest), familyId, static_cast<ui8>(connected ? NBD_CMD_RECONFIGURE : NBD_CMD_CONNECT), connected}
+        : Headers{sizeof(TNbdConfigureDeviceRequest), familyId, static_cast<ui8>(connected ? NBD_CMD_RECONFIGURE : NBD_CMD_CONNECT)}
         , DeviceIndexAttr{sizeof(DeviceIndex) + NLA_HDRLEN, NBD_ATTR_INDEX}
         , DeviceIndex(deviceIndex)
         , DeviceSizeAttr{sizeof(DeviceSizeInBytes) + NLA_HDRLEN, NBD_ATTR_SIZE_BYTES}
@@ -506,7 +505,7 @@ struct TNbdDisconnectRequest
     ui32 DeviceIndex;
 
     TNbdDisconnectRequest(ui16 familyId, ui32 deviceIndex)
-        : Headers{sizeof(TNbdStatusRequest), familyId, NBD_CMD_DISCONNECT, true}
+        : Headers{sizeof(TNbdStatusRequest), familyId, NBD_CMD_DISCONNECT}
         , DeviceIndexAttr{sizeof(DeviceIndex) + NLA_HDRLEN, NBD_ATTR_INDEX}
         , DeviceIndex(deviceIndex)
     {}

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -448,6 +448,8 @@ struct TNbdConfigureDeviceRequest
         , RequestTimeout(requestTimeout)
         , ConnectionTimeoutAttr{sizeof(ConnectionTimeout) + NLA_HDRLEN, NBD_ATTR_DEAD_CONN_TIMEOUT}
         , ConnectionTimeout(connectionTimeout)
+        // attribute length is calculated as size of payload + number of nested
+        // attributes * attribute header length
         , SocketsAttr{sizeof(SocketFd) + 3 * NLA_HDRLEN, NBD_ATTR_SOCKETS}
         , SocketItemAttr{sizeof(SocketFd) + 2 * NLA_HDRLEN, NBD_SOCK_ITEM}
         , SocketFdAttr{sizeof(SocketFd) + NLA_HDRLEN, NBD_SOCK_FD}

--- a/cloud/blockstore/libs/nbd/netlink_device.cpp
+++ b/cloud/blockstore/libs/nbd/netlink_device.cpp
@@ -22,12 +22,14 @@ constexpr TStringBuf NBD_DEVICE_SUFFIX = "/dev/nbd";
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace NLibnl {
+
 class TNetlinkDevice final
     : public IDevice
     , public std::enable_shared_from_this<TNetlinkDevice>
 {
-    using TNetlinkMessage = NCloud::NNetlink::TMessage;
-    using TNetlinkSocket = NCloud::NNetlink::TSocket;
+    using TNetlinkMessage = NCloud::NNetlink::NLibnl::TMessage;
+    using TNetlinkSocket = NCloud::NNetlink::NLibnl::TSocket;
 private:
     const ILoggingServicePtr Logging;
     const TNetworkAddress ConnectAddress;
@@ -365,6 +367,424 @@ int TNetlinkDevice::StatusHandler(nl_msg* nlmsg)
     return NL_OK;
 }
 
+} // namespace NLibnl
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ValidateAttribute(const ::nlattr& attribute, ui16 expectedAttribute)
+{
+    if (attribute.nla_type != expectedAttribute) {
+        throw TIoException() << "Invalid attribute type: " << attribute.nla_type
+                           << " Expected attribute type: " << expectedAttribute;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+using NNetlink::TNetlinkHeader;
+
+#pragma pack(push, NLMSG_ALIGNTO)
+
+template<ui32 FamilyNameLength>
+struct TNetlinkFamilyIdRequest
+{
+    TNetlinkHeader Headers = {
+        sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>),
+        GENL_ID_CTRL,
+        CTRL_CMD_GETFAMILY,
+        false};
+    ::nlattr FamilyNameAttr = {
+        sizeof(FamilyName) + NLA_HDRLEN,
+        CTRL_ATTR_FAMILY_NAME};
+    std::array<char, FamilyNameLength> FamilyName;
+
+    TNetlinkFamilyIdRequest(const char* familyName) {
+        memcpy(&FamilyName[0], familyName, FamilyNameLength);
+    }
+};
+
+template<ui32 FamilyNameLength>
+struct TNetlinkFamilyIdResponse
+{
+    TNetlinkHeader Headers;
+    ::nlattr FamilyNameAttr;
+    std::array<char, FamilyNameLength> FamilyName;
+    alignas(NLMSG_ALIGNTO)::nlattr FamilyIdAttr;
+    ui16 FamilyId;
+
+    void Validate()
+    {
+        ValidateAttribute(FamilyNameAttr, CTRL_ATTR_FAMILY_NAME);
+        ValidateAttribute(FamilyIdAttr, CTRL_ATTR_FAMILY_ID);
+    }
+};
+
+struct TNbdStatusRequest
+{
+    TNetlinkHeader Headers;
+    ::nlattr DeviceIndexAttr;
+    ui32 DeviceIndex;
+
+    TNbdStatusRequest(ui16 familyId, ui32 deviceIndex)
+        : Headers{sizeof(TNbdStatusRequest), familyId, NBD_CMD_STATUS, false}
+        , DeviceIndexAttr{sizeof(DeviceIndex) + NLA_HDRLEN, NBD_ATTR_INDEX}
+        , DeviceIndex(deviceIndex)
+    {}
+};
+
+struct TNbdStatusResponse {
+    TNetlinkHeader Headers;
+    ::nlattr NbdDeviceListAttr;
+    ::nlattr NbdDeviceItemAttr;
+    ::nlattr NbdDeviceIndex;
+    ui32 Index;
+    ::nlattr NbdDeviceConnectedAttr;
+    ui8 Connected;
+
+    void Validate()
+    {
+        ValidateAttribute(NbdDeviceListAttr, NBD_ATTR_DEVICE_LIST);
+        ValidateAttribute(NbdDeviceItemAttr, NBD_DEVICE_ITEM);
+        ValidateAttribute(NbdDeviceIndex, NBD_DEVICE_INDEX);
+    }
+};
+
+struct TNbdConfigureDeviceRequest
+{
+    TNetlinkHeader Headers;
+    ::nlattr DeviceIndexAttr;
+    ui32 DeviceIndex;
+    ::nlattr DeviceSizeAttr;
+    ui64 DeviceSizeInBytes;
+    ::nlattr BlockSizeAttr;
+    ui64 BlockSizeInBytes;
+    ::nlattr ServerFlagsAttr;
+    ui64 ServerFlags;
+    ::nlattr RequestTimeoutAttr;
+    ui64 RequestTimeout;
+    ::nlattr ConnectionTimeoutAttr;
+    ui64 ConnectionTimeout;
+    ::nlattr SocketsAttr;
+    ::nlattr SocketItemAttr;
+    ::nlattr SocketFdAttr;
+    ui32 SocketFd;
+
+    TNbdConfigureDeviceRequest(
+        ui16 familyId,
+        bool connected,
+        ui32 deviceIndex,
+        ui64 deviceSizeInBytes,
+        ui64 blockSizeInBytes,
+        ui64 serverFlags,
+        ui64 requestTimeout,
+        ui64 connectionTimeout,
+        ui32 socketFd)
+        : Headers{sizeof(TNbdConfigureDeviceRequest), familyId, static_cast<ui8>(connected ? NBD_CMD_RECONFIGURE : NBD_CMD_CONNECT), connected}
+        , DeviceIndexAttr{sizeof(DeviceIndex) + NLA_HDRLEN, NBD_ATTR_INDEX}
+        , DeviceIndex(deviceIndex)
+        , DeviceSizeAttr{sizeof(DeviceSizeInBytes) + NLA_HDRLEN, NBD_ATTR_SIZE_BYTES}
+        , DeviceSizeInBytes(deviceSizeInBytes)
+        , BlockSizeAttr{sizeof(BlockSizeInBytes) + NLA_HDRLEN, NBD_ATTR_BLOCK_SIZE_BYTES}
+        , BlockSizeInBytes(blockSizeInBytes)
+        , ServerFlagsAttr{sizeof(ServerFlags) + NLA_HDRLEN, NBD_ATTR_SERVER_FLAGS}
+        , ServerFlags(serverFlags)
+        , RequestTimeoutAttr{sizeof(RequestTimeout) + NLA_HDRLEN, NBD_ATTR_TIMEOUT}
+        , RequestTimeout(requestTimeout)
+        , ConnectionTimeoutAttr{sizeof(ConnectionTimeout) + NLA_HDRLEN, NBD_ATTR_DEAD_CONN_TIMEOUT}
+        , ConnectionTimeout(connectionTimeout)
+        , SocketsAttr{sizeof(SocketFd) + 3 * NLA_HDRLEN, NBD_ATTR_SOCKETS}
+        , SocketItemAttr{sizeof(SocketFd) + 2 * NLA_HDRLEN, NBD_SOCK_ITEM}
+        , SocketFdAttr{sizeof(SocketFd) + NLA_HDRLEN, NBD_SOCK_FD}
+        , SocketFd(socketFd)
+    {}
+};
+
+struct TNbdDisconnectRequest
+{
+    TNetlinkHeader Headers;
+    ::nlattr DeviceIndexAttr;
+    ui32 DeviceIndex;
+
+    TNbdDisconnectRequest(ui16 familyId, ui32 deviceIndex)
+        : Headers{sizeof(TNbdStatusRequest), familyId, NBD_CMD_DISCONNECT, true}
+        , DeviceIndexAttr{sizeof(DeviceIndex) + NLA_HDRLEN, NBD_ATTR_INDEX}
+        , DeviceIndex(deviceIndex)
+    {}
+};
+
+#pragma pack(pop)
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TNetlinkDevice final
+    : public IDevice
+    , public std::enable_shared_from_this<TNetlinkDevice>
+{
+private:
+    const ILoggingServicePtr Logging;
+    const TNetworkAddress ConnectAddress;
+    const TString DeviceName;
+    const TDuration RequestTimeout;
+    const TDuration ConnectionTimeout;
+    const bool Reconfigure;
+
+    ui16 FamilyId;
+    TLog Log;
+    IClientHandlerPtr Handler;
+    TSocket Socket;
+    ui32 DeviceIndex;
+
+    TPromise<NProto::TError> StartResult;
+    TPromise<NProto::TError> StopResult;
+
+public:
+    TNetlinkDevice(
+        ILoggingServicePtr logging,
+        TNetworkAddress connectAddress,
+        TString deviceName,
+        TDuration requestTimeout,
+        TDuration connectionTimeout,
+        bool reconfigure);
+
+    ~TNetlinkDevice();
+
+    TFuture<NProto::TError> Start() override;
+    TFuture<NProto::TError> Stop(bool deleteDevice) override;
+    TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override;
+
+private:
+    void ParseIndex();
+
+    void ConnectSocket();
+    void DisconnectSocket();
+
+    void Connect();
+    void Disconnect();
+    void DoConnect(bool connected);
+
+    ui16 GetFamilyId();
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TNetlinkDevice::TNetlinkDevice(
+        ILoggingServicePtr logging,
+        TNetworkAddress connectAddress,
+        TString deviceName,
+        TDuration requestTimeout,
+        TDuration connectionTimeout,
+        bool reconfigure)
+    : Logging(std::move(logging))
+    , ConnectAddress(std::move(connectAddress))
+    , DeviceName(std::move(deviceName))
+    , RequestTimeout(requestTimeout)
+    , ConnectionTimeout(connectionTimeout)
+    , Reconfigure(reconfigure)
+    , FamilyId(0)
+{
+    Log = Logging->CreateLog("BLOCKSTORE_NBD");
+}
+
+TNetlinkDevice::~TNetlinkDevice()
+{
+    Stop(false).GetValueSync();
+}
+
+TFuture<NProto::TError> TNetlinkDevice::Start()
+{
+    if (StartResult.Initialized()) {
+        return StartResult.GetFuture();
+    }
+    StartResult = NewPromise<NProto::TError>();
+
+    try {
+        ParseIndex();
+        ConnectSocket();
+        Connect();
+
+    } catch (const std::exception& e) {
+        StartResult.SetValue(MakeError(
+            E_FAIL,
+            TStringBuilder()
+                << "unable to configure " << DeviceName << ": " << e.what()));
+    }
+
+    return StartResult.GetFuture();
+}
+
+TFuture<NProto::TError> TNetlinkDevice::Stop(bool deleteDevice)
+{
+    if (StopResult.Initialized()) {
+        return StopResult.GetFuture();
+    }
+    StopResult = NewPromise<NProto::TError>();
+
+    try {
+        DisconnectSocket();
+
+        if (deleteDevice) {
+            Disconnect();
+        } else {
+            StopResult.SetValue(MakeError(S_OK));
+        }
+
+    } catch (const TServiceError& e) {
+        StopResult.SetValue(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to disconnect " << DeviceName << ": " << e.what()));
+    }
+
+    return StopResult.GetFuture();
+}
+
+TFuture<NProto::TError> TNetlinkDevice::Resize(ui64 deviceSizeInBytes)
+{
+    try {
+        const auto& info = Handler->GetExportInfo();
+        NNetlink::TNetlinkSocket socket;
+        TNbdConfigureDeviceRequest request(
+            GetFamilyId(),
+            true,
+            DeviceIndex,
+            deviceSizeInBytes,
+            static_cast<ui64>(info.MinBlockSize),
+            static_cast<ui64>(info.Flags),
+            RequestTimeout.Seconds(),
+            ConnectionTimeout.Seconds(),
+            static_cast<ui32>(Socket));
+        socket.Send(request);
+        NNetlink::TNetlinkResponse<> response;
+        socket.Receive(response);
+    } catch (const TServiceError& e) {
+        return MakeFuture(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to resize " << DeviceName << ": " << e.what()));
+    }
+
+    return MakeFuture(MakeError(S_OK));
+}
+
+void TNetlinkDevice::ParseIndex()
+{
+    // accept dev/nbd* devices with prefix other than /
+    TStringBuf l, r;
+    TStringBuf(DeviceName).RSplit(NBD_DEVICE_SUFFIX, l, r);
+
+    if (!TryFromString(r, DeviceIndex)) {
+        throw TServiceError(E_ARGUMENT) << "unable to parse device index";
+    }
+}
+
+void TNetlinkDevice::ConnectSocket()
+{
+    STORAGE_DEBUG("connect socket");
+
+    TSocket socket(ConnectAddress);
+    if (IsTcpAddress(ConnectAddress)) {
+        socket.SetNoDelay(true);
+    }
+
+    TSocketInput in(socket);
+    TSocketOutput out(socket);
+
+    Handler = CreateClientHandler(Logging);
+    Y_ENSURE(Handler->NegotiateClient(in, out));
+
+    Socket = socket;
+}
+
+void TNetlinkDevice::DisconnectSocket()
+{
+    STORAGE_DEBUG("disconnect socket");
+
+    Socket.Close();
+}
+
+// queries device status eand registers callback that will connect
+// or reconfigure (if Reconfigure == true) specified device
+void TNetlinkDevice::Connect()
+{
+    try {
+        NNetlink::TNetlinkSocket socket;
+        TNbdStatusRequest request(GetFamilyId(), DeviceIndex);
+        socket.Send(request);
+        NNetlink::TNetlinkResponse<TNbdStatusResponse> response;
+        socket.Receive(response);
+        DoConnect(response.Msg.Connected);
+    } catch (const TServiceError& e) {
+        StartResult.SetValue(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to configure " << DeviceName << ": " << e.what()));
+    }
+}
+
+void TNetlinkDevice::Disconnect()
+{
+    STORAGE_INFO("disconnect " << DeviceName);
+    try {
+        NNetlink::TNetlinkSocket socket;
+        TNbdDisconnectRequest request(GetFamilyId(), DeviceIndex);
+        socket.Send(request);
+        NNetlink::TNetlinkResponse<> response;
+        socket.Receive(response);
+        StopResult.SetValue(MakeError(S_OK));
+    } catch (const TServiceError& e) {
+        StartResult.SetValue(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to disconnect " << DeviceName << ": " << e.what()));
+    }
+}
+
+void TNetlinkDevice::DoConnect(bool connected)
+{
+    try {
+        if (connected && !Reconfigure) {
+            throw TServiceError(E_FAIL) << "device is already in use";
+        }
+        const auto& info = Handler->GetExportInfo();
+        NNetlink::TNetlinkSocket socket;
+        TNbdConfigureDeviceRequest request(
+            GetFamilyId(),
+            connected,
+            DeviceIndex,
+            static_cast<ui64>(info.Size),
+            static_cast<ui64>(info.MinBlockSize),
+            static_cast<ui64>(info.Flags),
+            RequestTimeout.Seconds(),
+            ConnectionTimeout.Seconds(),
+            static_cast<ui32>(Socket));
+        socket.Send(request);
+        NNetlink::TNetlinkResponse<> response;
+        socket.Receive(response);
+        StartResult.SetValue(MakeError(S_OK));
+    } catch (const TServiceError& e) {
+        StartResult.SetValue(MakeError(
+            e.GetCode(),
+            TStringBuilder()
+                << "unable to configure " << DeviceName << ": " << e.what()));
+    }
+}
+
+ui16 TNetlinkDevice::GetFamilyId()
+{
+    if (FamilyId == 0) {
+        NNetlink::TNetlinkSocket socket;
+        socket.Send(TNetlinkFamilyIdRequest<sizeof(NBD_GENL_FAMILY_NAME)>(
+            NBD_GENL_FAMILY_NAME));
+        NNetlink::TNetlinkResponse<
+            TNetlinkFamilyIdResponse<sizeof(NBD_GENL_FAMILY_NAME)>>
+            response;
+        socket.Receive(response);
+        FamilyId = response.Msg.FamilyId;
+    }
+
+    return FamilyId;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TNetlinkDeviceFactory final
@@ -375,17 +795,20 @@ private:
     const TDuration RequestTimeout;
     const TDuration ConnectionTimeout;
     const bool Reconfigure;
+    const bool WithoutLibnl;
 
 public:
     TNetlinkDeviceFactory(
             ILoggingServicePtr logging,
             TDuration requestTimeout,
             TDuration connectionTimeout,
-            bool reconfigure)
+            bool reconfigure,
+            bool withoutLibnl)
         : Logging(std::move(logging))
         , RequestTimeout(requestTimeout)
         , ConnectionTimeout(connectionTimeout)
         , Reconfigure(reconfigure)
+        , WithoutLibnl(withoutLibnl)
     {}
 
     IDevicePtr Create(
@@ -403,7 +826,8 @@ public:
             std::move(deviceName),
             RequestTimeout,
             ConnectionTimeout,
-            Reconfigure);
+            Reconfigure,
+            WithoutLibnl);
     }
 };
 
@@ -417,28 +841,41 @@ IDevicePtr CreateNetlinkDevice(
     TString deviceName,
     TDuration requestTimeout,
     TDuration connectionTimeout,
-    bool reconfigure)
+    bool reconfigure,
+    bool withoutLibnl)
 {
-    return std::make_shared<TNetlinkDevice>(
-        std::move(logging),
-        std::move(connectAddress),
-        std::move(deviceName),
-        requestTimeout,
-        connectionTimeout,
-        reconfigure);
+    if (withoutLibnl) {
+        return std::make_shared<TNetlinkDevice>(
+            std::move(logging),
+            std::move(connectAddress),
+            std::move(deviceName),
+            requestTimeout,
+            connectionTimeout,
+            reconfigure);
+    } else {
+        return std::make_shared<NLibnl::TNetlinkDevice>(
+            std::move(logging),
+            std::move(connectAddress),
+            std::move(deviceName),
+            requestTimeout,
+            connectionTimeout,
+            reconfigure);
+    }
 }
 
 IDeviceFactoryPtr CreateNetlinkDeviceFactory(
     ILoggingServicePtr logging,
     TDuration requestTimeout,
     TDuration connectionTimeout,
-    bool reconfigure)
+    bool reconfigure,
+    bool withoutLibnl)
 {
     return std::make_shared<TNetlinkDeviceFactory>(
         std::move(logging),
         requestTimeout,
         connectionTimeout,
-        reconfigure);
+        reconfigure,
+        withoutLibnl);
 }
 
 }   // namespace NCloud::NBlockStore::NBD

--- a/cloud/blockstore/libs/nbd/netlink_device.h
+++ b/cloud/blockstore/libs/nbd/netlink_device.h
@@ -12,12 +12,14 @@ IDevicePtr CreateNetlinkDevice(
     TString deviceName,
     TDuration requestTimeout,
     TDuration connectionTimeout,
-    bool reconfigure);
+    bool reconfigure,
+    bool withoutLibnl);
 
 IDeviceFactoryPtr CreateNetlinkDeviceFactory(
     ILoggingServicePtr logging,
     TDuration requestTimeout,
     TDuration connectionTimeout,
-    bool reconfigure);
+    bool reconfigure,
+    bool withoutLibnl);
 
 }   // namespace NCloud::NBlockStore::NBD

--- a/cloud/blockstore/tests/python/lib/endpoint_proxy.py
+++ b/cloud/blockstore/tests/python/lib/endpoint_proxy.py
@@ -16,7 +16,7 @@ class EndpointProxy(Daemon):
         command = [yatest_common.binary_path(
             "cloud/blockstore/apps/endpoint_proxy/blockstore-endpoint-proxy")]
         command += [
-            "--unix-socket-path", unix_socket_path, "--verbose"
+            "--unix-socket-path", unix_socket_path, "--verbose", "--without-libnl",
         ]
         if stored_endpoints_path:
             command += ["--stored-endpoints-path", stored_endpoints_path]

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -300,7 +300,8 @@ void TBootstrap::Start()
                 Options->ConnectDevice,
                 Options->RequestTimeout,
                 Options->ConnectionTimeout,
-                Options->Reconfigure);
+                Options->Reconfigure,
+                false); // withoutLibnl
         } else {
             // The only case we want kernel to retry requests is when the socket
             // is dead due to nbd server restart. And since we can't configure

--- a/cloud/storage/core/libs/netlink/message.cpp
+++ b/cloud/storage/core/libs/netlink/message.cpp
@@ -1,6 +1,6 @@
 #include "message.h"
 
-namespace NCloud::NNetlink {
+namespace NCloud::NNetlink::NLibnl {
 
 TNestedAttribute::TNestedAttribute(nl_msg* message, int attribute)
     : Message(message)
@@ -52,4 +52,4 @@ void TMessage::Put(int attribute, void* data, size_t size)
     }
 }
 
-}   // namespace NCloud::NNetlink
+}   // namespace NCloud::NNetlink::NLibnl

--- a/cloud/storage/core/libs/netlink/message.cpp
+++ b/cloud/storage/core/libs/netlink/message.cpp
@@ -1,6 +1,8 @@
 #include "message.h"
 
-namespace NCloud::NNetlink::NLibnl {
+namespace NCloud::NNetlink {
+
+namespace NLibnl {
 
 TNestedAttribute::TNestedAttribute(nl_msg* message, int attribute)
     : Message(message)
@@ -52,4 +54,16 @@ void TMessage::Put(int attribute, void* data, size_t size)
     }
 }
 
-}   // namespace NCloud::NNetlink::NLibnl
+}   // namespace NLibnl
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ValidateAttribute(const ::nlattr& attribute, ui16 expectedAttribute)
+{
+    if (attribute.nla_type != expectedAttribute) {
+        throw TIoException() << "Invalid attribute type: " << attribute.nla_type
+                           << " Expected attribute type: " << expectedAttribute;
+    }
+}
+
+}   // namespace NCloud::NNetlink

--- a/cloud/storage/core/libs/netlink/message.h
+++ b/cloud/storage/core/libs/netlink/message.h
@@ -66,7 +66,7 @@ struct TNetlinkHeader
 
     TNetlinkHeader() = default;
 
-    TNetlinkHeader(uint32_t len, uint16_t type, uint8_t cmd)
+    TNetlinkHeader(ui32 len, ui16 type, ui8 cmd)
         : MessageHeader{len, type, NLM_F_REQUEST | NLM_F_ACK, 0, 0}
         , GenericHeader{cmd, 1, 0}
     {
@@ -92,6 +92,10 @@ union TNetlinkResponse {
         static_assert(sizeof(TMessage) < MaxMsgSize);
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ValidateAttribute(const ::nlattr& attribute, ui16 expectedAttribute);
 
 #pragma pack(pop)
 

--- a/cloud/storage/core/libs/netlink/message.h
+++ b/cloud/storage/core/libs/netlink/message.h
@@ -97,7 +97,7 @@ union TNetlinkResponse {
     }
 };
 
-template<ui32 FamilyNameLength>
+template <size_t FamilyNameLength>
 struct TNetlinkFamilyIdRequest
 {
     TNetlinkHeader Headers = {
@@ -109,12 +109,13 @@ struct TNetlinkFamilyIdRequest
         CTRL_ATTR_FAMILY_NAME};
     std::array<char, FamilyNameLength> FamilyName;
 
-    TNetlinkFamilyIdRequest(const char* familyName) {
+    TNetlinkFamilyIdRequest(const char (&familyName)[FamilyNameLength])
+    {
         memcpy(&FamilyName[0], familyName, FamilyNameLength);
     }
 };
 
-template<ui32 FamilyNameLength>
+template<size_t FamilyNameLength>
 struct TNetlinkFamilyIdResponse
 {
     TNetlinkHeader Headers;

--- a/cloud/storage/core/libs/netlink/message.h
+++ b/cloud/storage/core/libs/netlink/message.h
@@ -66,13 +66,10 @@ struct TNetlinkHeader
 
     TNetlinkHeader() = default;
 
-    TNetlinkHeader(uint32_t len, uint16_t type, uint8_t cmd, bool ack)
-        : MessageHeader{len, type, NLM_F_REQUEST, 0, 0}
+    TNetlinkHeader(uint32_t len, uint16_t type, uint8_t cmd)
+        : MessageHeader{len, type, NLM_F_REQUEST | NLM_F_ACK, 0, 0}
         , GenericHeader{cmd, 1, 0}
     {
-        if (ack) {
-            MessageHeader.nlmsg_flags |= NLM_F_ACK;
-        }
     }
 };
 

--- a/cloud/storage/core/libs/netlink/socket.cpp
+++ b/cloud/storage/core/libs/netlink/socket.cpp
@@ -1,6 +1,6 @@
 #include "socket.h"
 
-namespace NCloud::NNetlink {
+namespace NCloud::NNetlink::NLibnl {
 
 TSocket::TSocket(TString family)
     : Socket(nl_socket_alloc(), [](auto* socket) { nl_socket_free(socket); })

--- a/cloud/storage/core/libs/netlink/socket.h
+++ b/cloud/storage/core/libs/netlink/socket.h
@@ -5,12 +5,17 @@
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/generic/string.h>
+#include <util/generic/yexception.h>
+#include <util/network/socket.h>
+#include <util/system/error.h>
 
 #include <netlink/genl/ctrl.h>
 #include <netlink/genl/genl.h>
 #include <netlink/netlink.h>
 
 namespace NCloud::NNetlink {
+
+namespace NLibnl {
 
 using TResponseHandler = std::function<int(nl_msg*)>;
 
@@ -34,6 +39,65 @@ public:
     static int ResponseHandler(nl_msg* msg, void* arg);
 
     void Send(nl_msg* message);
+};
+
+}  // namespace NLibnl
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TNetlinkSocket
+{
+private:
+    TSocket Socket;
+    ui32 SocketTimeoutMs;
+
+public:
+    TNetlinkSocket(ui32 socketTimeoutMs = 100)
+        : Socket(::socket(PF_NETLINK, SOCK_RAW, NETLINK_GENERIC))
+        , SocketTimeoutMs(socketTimeoutMs)
+    {
+        if (Socket < 0) {
+            ythrow TServiceError(MAKE_SYSTEM_ERROR(LastSystemError()))
+                << "Failed to create netlink socket";
+        }
+        Socket.SetSocketTimeout(0, SocketTimeoutMs);
+    }
+
+    template <typename TNetlinkMessage>
+    void Send(const TNetlinkMessage& msg)
+    {
+        auto ret = Socket.Send(&msg, sizeof(msg));
+        if (ret == -1) {
+            ythrow TServiceError(MAKE_SYSTEM_ERROR(LastSystemError()))
+                << "Failed to send netlink message";
+        }
+    }
+
+    template <typename T>
+    void Receive(TNetlinkResponse<T>& response)
+    {
+        auto ret = Socket.Recv(&response, sizeof(response));
+        if (ret < 0) {
+            ythrow TServiceError(MAKE_SYSTEM_ERROR(LastSystemError()))
+                << "Failed to receive netlink message";
+        }
+
+        if (response.NetlinkError.MessageHeader.nlmsg_type == NLMSG_ERROR) {
+            if (response.NetlinkError.MessageError.error != 0) {
+                throw TServiceError(
+                    MAKE_SYSTEM_ERROR(response.NetlinkError.MessageError.error))
+                    << "Netlink error";
+            }
+        }
+
+        if (!NLMSG_OK(&response.NetlinkError.MessageHeader, ret)) {
+            throw TServiceError(MAKE_ERROR(E_FAIL))
+                << "Netlink message has incorrect format";
+        }
+
+        response.Msg.Validate();
+        return;
+    }
 };
 
 }   // namespace NCloud::NNetlink

--- a/cloud/storage/core/libs/netlink/socket.h
+++ b/cloud/storage/core/libs/netlink/socket.h
@@ -100,4 +100,16 @@ public:
     }
 };
 
+template <size_t FamilyNameLength>
+ui16 GetFamilyId(const char (&familyName)[FamilyNameLength])
+{
+    NNetlink::TNetlinkSocket socket;
+    socket.Send(NNetlink::TNetlinkFamilyIdRequest(familyName));
+    NNetlink::TNetlinkResponse<
+        NNetlink::TNetlinkFamilyIdResponse<FamilyNameLength>>
+        response;
+    socket.Receive(response);
+    return response.Msg.FamilyId;
+}
+
 }   // namespace NCloud::NNetlink


### PR DESCRIPTION
issue: #2869

1. Implement NetlinkDevice without using libnl
2. Add WithoutLibnl option to endpoint_proxy
