### PR TITLE
issue-176: create an encrypted disk via EncryptionSpec

### DIFF
--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -794,7 +794,7 @@ private:
             return MakeFuture<TResultOrError<IBlockStorePtr>>(Client);
         }
 
-        if (desc.GetMode() != NProto::ENCRYPTION_DEFAULT_AES_XTS) {
+        if (desc.GetMode() != NProto::ENCRYPTION_AT_REST) {
             return MakeFuture<TResultOrError<IBlockStorePtr>>(
                 MakeError(E_ARGUMENT, "Unexpected encryption mode"));
         }

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -1298,7 +1298,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 volume.SetBlockSize(BlockSize);
 
                 NProto::TEncryptionDesc& desc = *volume.MutableEncryptionDesc();
-                desc.SetMode(NProto::ENCRYPTION_DEFAULT_AES_XTS);
+                desc.SetMode(NProto::ENCRYPTION_AT_REST);
                 desc.MutableEncryptionKey()->SetKekId(KekId);
                 desc.MutableEncryptionKey()->SetEncryptedDEK(EncryptionKey);
 

--- a/cloud/blockstore/libs/encryption/encryption_key.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_key.cpp
@@ -39,7 +39,7 @@ ui32 GetExpectedKeyLength(NProto::EEncryptionMode mode)
         case NProto::NO_ENCRYPTION:
             return 0;
         case NProto::ENCRYPTION_AES_XTS:
-        case NProto::ENCRYPTION_DEFAULT_AES_XTS:
+        case NProto::ENCRYPTION_AT_REST:
             return 32;
         default:
             ythrow TServiceError(E_ARGUMENT)
@@ -81,7 +81,7 @@ public:
         }
 
         if (keyPath.HasKmsKey()) {
-            if (spec.GetMode() == NProto::ENCRYPTION_DEFAULT_AES_XTS) {
+            if (spec.GetMode() == NProto::ENCRYPTION_AT_REST) {
                 return ReadKeyFromRootKMS(keyPath.GetKmsKey(), diskId, len);
             }
 

--- a/cloud/blockstore/libs/encryption/encryption_key_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_key_ut.cpp
@@ -81,7 +81,7 @@ Y_UNIT_TEST_SUITE(TEncryptionKeyTest)
         const TString encryptionKey = "01234567890123456789012345678901";
 
         NProto::TEncryptionSpec spec;
-        spec.SetMode(NProto::ENCRYPTION_DEFAULT_AES_XTS);
+        spec.SetMode(NProto::ENCRYPTION_AT_REST);
         auto& keyPath = *spec.MutableKeyPath();
         keyPath.MutableKmsKey()->SetKekId("nbs");
         keyPath.MutableKmsKey()->SetEncryptedDEK("42");

--- a/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
@@ -325,9 +325,7 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
             keyRequested = true;
 
             UNIT_ASSERT_VALUES_EQUAL(testDiskId, diskId);
-            UNIT_ASSERT_EQUAL(
-                NProto::ENCRYPTION_DEFAULT_AES_XTS,
-                spec.GetMode());
+            UNIT_ASSERT_EQUAL(NProto::ENCRYPTION_AT_REST, spec.GetMode());
 
             UNIT_ASSERT_C(spec.HasKeyPath(), spec);
             UNIT_ASSERT_C(spec.GetKeyPath().HasKmsKey(), spec);
@@ -370,8 +368,7 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
             volume.SetBlockSize(DefaultBlockSize);
             volume.SetBlocksCount(volumeBlocksCount);
 
-            volume.MutableEncryptionDesc()->SetMode(
-                NProto::ENCRYPTION_DEFAULT_AES_XTS);
+            volume.MutableEncryptionDesc()->SetMode(NProto::ENCRYPTION_AT_REST);
 
             NProto::TKmsKey& key =
                 *volume.MutableEncryptionDesc()->MutableEncryptionKey();

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -119,7 +119,7 @@ IOutputStream& operator <<(
                 break;
             }
 
-            case NProto::ENCRYPTION_DEFAULT_AES_XTS: {
+            case NProto::ENCRYPTION_AT_REST: {
                 const auto& key = desc.GetEncryptedDataKey();
                 DIV() { out << "Kek Id: " << key.GetKekId().Quote(); }
                 DIV() {

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -285,7 +285,7 @@ bool TVolumeState::ShouldTrackUsedBlocks() const
     const auto mode = Meta.GetVolumeConfig().GetEncryptionDesc().GetMode();
 
     return mode != NProto::NO_ENCRYPTION &&
-           mode != NProto::ENCRYPTION_DEFAULT_AES_XTS;
+           mode != NProto::ENCRYPTION_AT_REST;
 }
 
 void TVolumeState::Reset()

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -1910,7 +1910,7 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
         {
             auto state = makeState(
                 NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-                NProto::ENCRYPTION_DEFAULT_AES_XTS);
+                NProto::ENCRYPTION_AT_REST);
 
             UNIT_ASSERT(!state.GetTrackUsedBlocks());
         }

--- a/cloud/blockstore/public/api/protos/encryption.proto
+++ b/cloud/blockstore/public/api/protos/encryption.proto
@@ -12,8 +12,9 @@ enum EEncryptionMode
     NO_ENCRYPTION = 0;
     ENCRYPTION_AES_XTS = 1;
 
-    // Default AES XTS encryption. Encrypted DEK is stored in VolumeConfig.
-    ENCRYPTION_DEFAULT_AES_XTS = 2;
+    // Encryption at rest. Encrypted DEK is stored in VolumeConfig.
+    // AES XTS is used.
+    ENCRYPTION_AT_REST = 2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/public/sdk/python/client/safe_client.py
+++ b/cloud/blockstore/public/sdk/python/client/safe_client.py
@@ -2,6 +2,7 @@ from concurrent import futures
 from datetime import datetime
 
 import cloud.blockstore.public.sdk.python.protos as protos
+from cloud.blockstore.public.api.protos.encryption_pb2 import TEncryptionSpec
 
 from google.protobuf.json_format import ParseDict
 
@@ -65,6 +66,7 @@ class _SafeClient(object):
             base_disk_id: str = "",
             base_disk_checkpoint_id: str = "",
             partitions_count: int = 1,
+            encryption_spec: TEncryptionSpec | None = None,
             storage_pool_name: str | None = None,
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
@@ -84,6 +86,7 @@ class _SafeClient(object):
             BaseDiskId=base_disk_id,
             BaseDiskCheckpointId=base_disk_checkpoint_id,
             PartitionsCount=partitions_count,
+            EncryptionSpec=encryption_spec,
             StoragePoolName=storage_pool_name
         )
         return self.__impl.create_volume_async(
@@ -108,6 +111,7 @@ class _SafeClient(object):
             base_disk_id: str = "",
             base_disk_checkpoint_id: str = "",
             partitions_count: int = 1,
+            encryption_spec: TEncryptionSpec | None = None,
             storage_pool_name: str | None = None,
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
@@ -127,6 +131,7 @@ class _SafeClient(object):
             BaseDiskId=base_disk_id,
             BaseDiskCheckpointId=base_disk_checkpoint_id,
             PartitionsCount=partitions_count,
+            EncryptionSpec=encryption_spec,
             StoragePoolName=storage_pool_name
         )
         self.__impl.create_volume(

--- a/cloud/blockstore/public/sdk/python/client/ya.make
+++ b/cloud/blockstore/public/sdk/python/client/ya.make
@@ -2,6 +2,7 @@ PY3_LIBRARY()
 
 PEERDIR(
     cloud/blockstore/public/api/grpc
+    cloud/blockstore/public/api/protos
     cloud/blockstore/public/sdk/python/protos
     contrib/python/requests/py3
 )

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -36,8 +36,8 @@ IOutputStream& operator<<(
         case NCloud::NBlockStore::NProto::ENCRYPTION_AES_XTS:
             out << "ENCRYPTION_AES_XTS";
             return out;
-        case NCloud::NBlockStore::NProto::ENCRYPTION_DEFAULT_AES_XTS:
-            out << "ENCRYPTION_DEFAULT_AES_XTS";
+        case NCloud::NBlockStore::NProto::ENCRYPTION_AT_REST:
+            out << "ENCRYPTION_AT_REST";
             return out;
         default:
             break;


### PR DESCRIPTION
#176

Now one can create a disk with encryption at rest by specifying `ENCRYPTION_AT_REST` mode in the create request.