### PR TITLE
issue-3017: restore endpoints despite of missing socket directory

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -740,7 +740,10 @@ TFuture<NProto::TStartEndpointResponse> TEndpointManager::RestoreSingleEndpoint(
                 return promise.ExtractValue();
             }
 
-            auto socketPath = request->GetUnixSocketPath();
+            auto socketPath = TFsPath(request->GetUnixSocketPath());
+            if (!socketPath.Parent().Exists()) {
+                socketPath.Parent().MkDir();
+            }
 
             auto response = self->StartEndpointImpl(
                 std::move(ctx),

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -347,8 +347,6 @@ def test_restore_endpoint_when_socket_directory_does_not_exist():
     # 9. check that endpoint was restored
     env, run = init()
 
-    test_hash = hash(common.context.test_name)
-
     volume_name = "example-disk"
     block_size = 4096
     blocks_count = 10000


### PR DESCRIPTION
issue: #3017

blockstore-server must restore endpoints despite of missing endpoint directory. e.g. directory can be removed after host reboot if directory was mounted as tmpfs.