### PR TITLE
Fix race condition during gRPC shutdown

### DIFF
--- a/cloud/storage/core/libs/grpc/init_ut.cpp
+++ b/cloud/storage/core/libs/grpc/init_ut.cpp
@@ -1,5 +1,6 @@
 #include "init.h"
 
+#include <contrib/libs/grpc/include/grpc/grpc.h>
 #include <contrib/libs/grpc/include/grpc/support/log.h>
 
 #include <library/cpp/logger/backend.h>
@@ -182,6 +183,14 @@ Y_UNIT_TEST_SUITE(TInitTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, AliveLoggers.load());
         UNIT_ASSERT_LE(threadCount, Writes.load());
+    }
+
+    Y_UNIT_TEST(ShouldShutdownInAnotherThread)
+    {
+        grpc_init();
+        GrpcLoggerInit(CreateLogBackend("console"), false);
+
+        std::thread{grpc_shutdown}.detach();
     }
 }
 


### PR DESCRIPTION
A race condition occurs during gRPC shutdown when using a [dedicated](https://github.com/ydb-platform/nbs/blob/main/contrib/libs/grpc/src/core/lib/surface/init.cc#L200-L203) thread: the [TTempBufManager](https://github.com/ydb-platform/nbs/blob/main/util/memory/tempbuf.cpp#L152-L163) singleton (used by the logger: [TLog](https://github.com/ydb-platform/nbs/blob/main/library/cpp/logger/log.h#L98), [TLogElement](https://github.com/ydb-platform/nbs/blob/main/library/cpp/logger/element.h#L14), [TTempBufOutput](https://github.com/ydb-platform/nbs/blob/main/util/stream/tempbuf.h#L7), [TTempBuf](https://github.com/ydb-platform/nbs/blob/main/util/memory/tempbuf.cpp#L174)) may be deleted or in the process of deletion.

<details><summary>Logs</summary>

    2025-02-12T03:31:34.221545Z :GRPC INFO: contrib/libs/grpc/src/core/lib/iomgr/timer_generic.cc:443: TIMER 0x7b28000001e0: CANCEL pending=true
    2025-02-12T03:31:34.221683Z :GRPC INFO: contrib/libs/grpc/src/core/lib/surface/init.cc:177: grpc_shutdown(void)
    2025-02-12T03:31:34.221838Z :GRPC INFO: contrib/libs/grpc/src/core/lib/surface/init.cc:177: grpc_shutdown(void)
    2025-02-12T03:31:34.221889Z :GRPC INFO: contrib/libs/grpc/src/core/lib/surface/init.cc:209: grpc_shutdown_blocking(void)
    2025-02-12T03:31:34.259046Z :GRPC INFO: contrib/libs/grpc/src/core/lib/surface/init.cc:177: grpc_shutdown(void)
    2025-02-12T03:31:34.260277Z :GRPC INFO: contrib/libs/grpc/src/core/lib/surface/init.cc:177: grpc_shutdown(void)
    2025-02-12T03:31:34.261167Z :GRPC INFO: contrib/libs/grpc/src/core/lib/surface/init.cc:166: grpc_shutdown_internal
    warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
    warning: address range table at offset 0xf0 has a premature terminator entry at offset 0x100
    warning: address range table at offset 0x120 has a premature terminator entry at offset 0x130
    warning: address range table at offset 0x150 has a premature terminator entry at offset 0x160
    ==================
    WARNING: ThreadSanitizer: data race (pid=2396)
      Write of size 8 at 0x7b04000005d0 by main thread:
        #0 operator delete(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (blockstore-client+0xed365f) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #1 CheckedDelete<NTls::TKey::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (blockstore-client+0x108ffb6) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #2 TDelete::Destroy<NTls::TKey::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (blockstore-client+0x108ffb6)
        #3 THolder<NTls::TKey::TImpl, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (blockstore-client+0x108ffb6)
        #4 THolder<NTls::TKey::TImpl, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (blockstore-client+0x108ffb6)
        #5 NTls::TKey::~TKey() /actions-runner/_work/nbs/nbs/util/system/tls.cpp:247:13 (blockstore-client+0x108ffb6)
        #6 NTls::TValue<(anonymous namespace)::TTempBufManager>::~TValue /actions-runner/_work/nbs/nbs/util/system/tls.h:180:11 (blockstore-client+0xfe68cb) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #7 void NPrivate::Destroyer<NTls::TValue<(anonymous namespace)::TTempBufManager>>(void*) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:23:21 (blockstore-client+0xfe68cb)
        #8 (anonymous namespace)::TAtExit::Finish /actions-runner/_work/nbs/nbs/util/system/atexit.cpp:53:25 (blockstore-client+0x10213b7) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #9 (anonymous namespace)::OnExit() /actions-runner/_work/nbs/nbs/util/system/atexit.cpp:85:21 (blockstore-client+0x10213b7)
        #10 at_exit_callback_installed_at() /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:422:3 (blockstore-client+0xe8e658) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #11 (anonymous namespace)::Instance /actions-runner/_work/nbs/nbs/util/system/atexit.cpp:99:13 (blockstore-client+0x102173b) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #12 AtExit(void (*)(void*), void*, unsigned long) /actions-runner/_work/nbs/nbs/util/system/atexit.cpp:119:5 (blockstore-client+0x102173b)

      Previous read of size 8 at 0x7b04000005d0 by thread T12:
        #0 (anonymous namespace)::TGenericTlsBase::TPerThreadStorage::Value((anonymous namespace)::TGenericTlsBase::TPerThreadStorage::TKey const*) /actions-runner/_work/nbs/nbs/util/system/tls.cpp:68:61 (blockstore-client+0x10938b7) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #1 NTls::TKey::TImpl::Get /actions-runner/_work/nbs/nbs/util/system/tls.cpp:171:53 (blockstore-client+0x1090060) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #2 NTls::TKey::Get() const /actions-runner/_work/nbs/nbs/util/system/tls.cpp:250:19 (blockstore-client+0x1090060)
        #3 NTls::TValue<(anonymous namespace)::TTempBufManager>::GetPtr /actions-runner/_work/nbs/nbs/util/system/tls.h:266:43 (blockstore-client+0xfe6680) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #4 NPrivate::TFastThreadSingletonHelper<(anonymous namespace)::TTempBufManager, 2UL>::GetSlow /actions-runner/_work/nbs/nbs/util/thread/singleton.h:11:72 (blockstore-client+0xfe6680)
        #5 NPrivate::TFastThreadSingletonHelper<(anonymous namespace)::TTempBufManager, 2UL>::Get /actions-runner/_work/nbs/nbs/util/thread/singleton.h:19:24 (blockstore-client+0xfe6680)
        #6 FastTlsSingletonWithPriority<(anonymous namespace)::TTempBufManager, 2UL> /actions-runner/_work/nbs/nbs/util/thread/singleton.h:32:12 (blockstore-client+0xfe6680)
        #7 TempBufManager() /actions-runner/_work/nbs/nbs/util/memory/tempbuf.cpp:153:12 (blockstore-client+0xfe6680)
        #8 AcquireSmallBuffer /actions-runner/_work/nbs/nbs/util/memory/tempbuf.cpp:161:12 (blockstore-client+0xfe5bcb) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #9 TTempBuf::TTempBuf() /actions-runner/_work/nbs/nbs/util/memory/tempbuf.cpp:174:13 (blockstore-client+0xfe5bcb)
        #10 TTempBufOutput::TTempBufOutput /actions-runner/_work/nbs/nbs/util/stream/tempbuf.h:9:12 (blockstore-client+0x1ef927d) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #11 TLogElement::TLogElement(TLog const*) /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:7:14 (blockstore-client+0x1ef927d)
        #12 TLog::operator<<<ELogPriority> /actions-runner/_work/nbs/nbs/library/cpp/logger/log.h:98:21 (blockstore-client+0x23c0555) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #13 NCloud::(anonymous namespace)::AddLog(gpr_log_func_args*) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/grpc/init.cpp:57:9 (blockstore-client+0x23c0555)
        #14 gpr_log_message /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gpr/log.cc:95:3 (blockstore-client+0x14a13e8) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #15 gpr_log /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gpr/linux/log.cc:69:3 (blockstore-client+0x14a3406) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #16 grpc_shutdown_internal(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/surface/init.cc:166:3 (blockstore-client+0x157a329) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #17 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(const char *, void (*)(void *), void *, bool *, const grpc_core::Thread::Options &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:135:11 (blockstore-client+0x155d98c) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #18 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:117:9 (blockstore-client+0x155d98c)

      Thread T12 'grpc_shutdown' (tid=3893, finished) created by thread T4 at:
        #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (blockstore-client+0xe49e9b) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #1 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:115:30 (blockstore-client+0x155d42a) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #2 grpc_core::Thread::Thread(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:189:15 (blockstore-client+0x155d42a)
        #3 grpc_shutdown /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/surface/init.cc:200:25 (blockstore-client+0x157a4a6) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #4 grpc_core::KeepsGrpcInitialized::~KeepsGrpcInitialized /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/surface/init_internally.h:30:29 (blockstore-client+0x158a052) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #5 grpc_event_engine::experimental::PosixEventEngine::~PosixEventEngine() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/posix_engine/posix_engine.cc:439:1 (blockstore-client+0x158a052)
        #6 grpc_event_engine::experimental::PosixEventEngine::~PosixEventEngine() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/posix_engine/posix_engine.cc:418:39 (blockstore-client+0x158a2b9) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #7 std::__y1::default_delete<grpc_event_engine::experimental::EventEngine>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:49:5 (blockstore-client+0x15851c4) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #8 std::__y1::__shared_ptr_pointer<grpc_event_engine::experimental::EventEngine*, std::__y1::default_delete<grpc_event_engine::experimental::EventEngine>, std::__y1::allocator<grpc_event_engine::experimental::EventEngine>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:289:5 (blockstore-client+0x15851c4)
        #9 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (blockstore-client+0x15850f2) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #10 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (blockstore-client+0x15850f2)
        #11 std::__y1::shared_ptr<grpc_event_engine::experimental::EventEngine>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (blockstore-client+0x15850f2)
        #12 grpc_core::ChannelArgTypeTraits<std::__y1::shared_ptr<grpc_event_engine::experimental::EventEngine>, void>::VTable()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/channel/channel_args.h:143:23 (blockstore-client+0x15850f2)
        #13 grpc_core::ChannelArgTypeTraits<std::__y1::shared_ptr<grpc_event_engine::experimental::EventEngine>, void>::VTable()::'lambda0'(void*)::__invoke(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/channel/channel_args.h:143:9 (blockstore-client+0x15850f2)
        #14 grpc_core::ChannelArgs::Pointer::~Pointer /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/channel/channel_args.h:245:18 (blockstore-client+0x15635da) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #15 std::__y1::__variant_detail::__alt<2UL, grpc_core::ChannelArgs::Pointer>::~__alt /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:715:29 (blockstore-client+0x15635da)
        #16 std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy()::(anonymous class)::operator()<std::__y1::__variant_detail::__alt<2UL, grpc_core::ChannelArgs::Pointer> > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:854:1 (blockstore-client+0x15635da)
        #17 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:854:1), std::__y1::__variant_detail::__alt<2UL, grpc_core::ChannelArgs::Pointer> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (blockstore-client+0x15635da)
        #18 decltype(auto) std::__y1::__variant_detail::__visitation::__base::__dispatcher<2ul>::__dispatch[abi:v15000]<std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:v15000]()::'lambda'(auto&)&&, std::__y1::__variant_detail::__base<(std::__y1::__variant_detail::_Trait)1, int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>&>(auto, std::__y1::__variant_detail::__base<(std::__y1::__variant_detail::_Trait)1, int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:548:16 (blockstore-client+0x15635da)
        #19 std::__y1::__variant_detail::__visitation::__base::__visit_alt<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:854:1), std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:511:12 (blockstore-client+0x1565f36) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #20 std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:854:1 (blockstore-client+0x1565f36)
        #21 std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::~__dtor /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:854:1 (blockstore-client+0x1565f36)
        #22 std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>::~variant /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/variant:1375:22 (blockstore-client+0x1565f36)
        #23 std::__y1::pair<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::~pair /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/stlfwd:14:12 (blockstore-client+0x1565f36)
        #24 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node::~Node() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/avl/avl.h:91:10 (blockstore-client+0x1565f36)
        #25 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:170:15 (blockstore-client+0x1565bad) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #26 std::__y1::allocator_traits<std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::destroy<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:309:13 (blockstore-client+0x1565bad)
        #27 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:335:9 (blockstore-client+0x1565bad)
        #28 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (blockstore-client+0x1565f03) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #29 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (blockstore-client+0x1565f03)
        #30 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (blockstore-client+0x1565f03)
        #31 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node::~Node() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/avl/avl.h:91:10 (blockstore-client+0x1565f03)
        #32 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:170:15 (blockstore-client+0x1565bad) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #33 std::__y1::allocator_traits<std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::destroy<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:309:13 (blockstore-client+0x1565bad)
        #34 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:335:9 (blockstore-client+0x1565bad)
        #35 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (blockstore-client+0x1565ec0) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #36 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (blockstore-client+0x1565ec0)
        #37 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (blockstore-client+0x1565ec0)
        #38 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node::~Node() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/avl/avl.h:91:10 (blockstore-client+0x1565ec0)
        #39 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:170:15 (blockstore-client+0x1565bad) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #40 std::__y1::allocator_traits<std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::destroy<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:309:13 (blockstore-client+0x1565bad)
        #41 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:335:9 (blockstore-client+0x1565bad)
        #42 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (blockstore-client+0x1565f03) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #43 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (blockstore-client+0x1565f03)
        #44 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (blockstore-client+0x1565f03)
        #45 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node::~Node() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/avl/avl.h:91:10 (blockstore-client+0x1565f03)
        #46 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:170:15 (blockstore-client+0x1565bad) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #47 std::__y1::allocator_traits<std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::destroy<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:309:13 (blockstore-client+0x1565bad)
        #48 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char>>, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char>>, grpc_core::ChannelArgs::Pointer>>::Node>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:335:9 (blockstore-client+0x1565bad)
        #49 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (blockstore-client+0x155e84c) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #50 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (blockstore-client+0x155e84c)
        #51 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (blockstore-client+0x155e84c)
        #52 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::~AVL /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/avl/avl.h:31:7 (blockstore-client+0x155e84c)
        #53 grpc_core::ChannelArgs::~ChannelArgs() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/channel/channel_args.cc:71:27 (blockstore-client+0x155e84c)
        #54 grpc_core::SubchannelKey::~SubchannelKey /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel_pool_interface.h:43:7 (blockstore-client+0x173ce68) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #55 grpc_core::Subchannel::~Subchannel() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc:651:1 (blockstore-client+0x173ce68)
        #56 grpc_core::Subchannel::~Subchannel() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc:640:27 (blockstore-client+0x173cf39) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #57 grpc_core::DualRefCounted<grpc_core::Subchannel>::WeakUnref /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/dual_ref_counted.h:179:7 (blockstore-client+0x1742d32) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #58 grpc_core::WeakRefCountedPtr<grpc_core::Subchannel>::reset /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/ref_counted_ptr.h:254:42 (blockstore-client+0x1742d32)
        #59 grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20230802::Status)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc:913:18 (blockstore-client+0x1742d32)
        #60 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc:902:9) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (blockstore-client+0x1742d32)
        #61 std::__y1::invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc:902:9) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:540:12 (blockstore-client+0x1742d32)
        #62 y_absl::lts_y_20230802::internal_any_invocable::InvokeR<void, (lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc:902:9) &, void> /actions-runner/_work/nbs/nbs/contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h:132:3 (blockstore-client+0x1742d32)
        #63 void y_absl::lts_y_20230802::internal_any_invocable::LocalInvoker<false, void, grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20230802::Status)::$_0&>(y_absl::lts_y_20230802::internal_any_invocable::TypeErasedState*) /actions-runner/_work/nbs/nbs/contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h:310:10 (blockstore-client+0x1742d32)
        #64 y_absl::lts_y_20230802::internal_any_invocable::Impl<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h:868:1 (blockstore-client+0x158c270) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #65 grpc_event_engine::experimental::PosixEventEngine::ClosureData::Run() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/posix_engine/posix_engine.cc:413:5 (blockstore-client+0x158c270)
        #66 grpc_event_engine::experimental::ThreadPool::Run(grpc_event_engine::experimental::EventEngine::Closure *)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:207:30 (blockstore-client+0x15b452d) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #67 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:207:7) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (blockstore-client+0x15b452d)
        #68 std::__y1::invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:207:7) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:540:12 (blockstore-client+0x15b452d)
        #69 y_absl::lts_y_20230802::internal_any_invocable::InvokeR<void, (lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:207:7) &, void> /actions-runner/_work/nbs/nbs/contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h:132:3 (blockstore-client+0x15b452d)
        #70 void y_absl::lts_y_20230802::internal_any_invocable::LocalInvoker<false, void, grpc_event_engine::experimental::ThreadPool::Run(grpc_event_engine::experimental::EventEngine::Closure*)::$_0&>(y_absl::lts_y_20230802::internal_any_invocable::TypeErasedState*) /actions-runner/_work/nbs/nbs/contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h:310:10 (blockstore-client+0x15b452d)
        #71 y_absl::lts_y_20230802::internal_any_invocable::Impl<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h:868:1 (blockstore-client+0x15b2816) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #72 grpc_event_engine::experimental::ThreadPool::Queue::Step() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:170:3 (blockstore-client+0x15b2816)
        #73 grpc_event_engine::experimental::ThreadPool::ThreadFunc(std::__y1::shared_ptr<grpc_event_engine::experimental::ThreadPool::State>) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:140:23 (blockstore-client+0x15b248f) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #74 grpc_event_engine::experimental::ThreadPool::StartThread(std::__y1::shared_ptr<grpc_event_engine::experimental::ThreadPool::State>, grpc_event_engine::experimental::ThreadPool::StartThreadReason)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:132:9 (blockstore-client+0x15b3e8e) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #75 grpc_event_engine::experimental::ThreadPool::StartThread(std::__y1::shared_ptr<grpc_event_engine::experimental::ThreadPool::State>, grpc_event_engine::experimental::ThreadPool::StartThreadReason)::$_0::__invoke(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc:113:7 (blockstore-client+0x15b3e8e)
        #76 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(const char *, void (*)(void *), void *, bool *, const grpc_core::Thread::Options &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:135:11 (blockstore-client+0x155d98c) (BuildId: 062b0b9edbf586ca52bb3b02974d2d28a4849a8c)
        #77 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:117:9 (blockstore-client+0x155d98c)

    SUMMARY: ThreadSanitizer: data race /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 in operator delete(void*)

</details> 