### PR TITLE
issue-2854: rm request ident by cookie at part mirror actor

### DIFF
--- a/cloud/blockstore/libs/storage/model/requests_in_progress.h
+++ b/cloud/blockstore/libs/storage/model/requests_in_progress.h
@@ -108,25 +108,24 @@ public:
 
     bool RemoveRequest(const TKey& key)
     {
-        TValue v;
-        return ExtractRequest(key, &v);
+        return ExtractRequest(key).has_value();
     }
 
-    bool ExtractRequest(const TKey& key, TValue* value)
+    std::optional<TValue> ExtractRequest(const TKey& key)
     {
         auto it = RequestsInProgress.find(key);
 
         if (it == RequestsInProgress.end()) {
             Y_DEBUG_ABORT_UNLESS(0);
-            return false;
+            return std::nullopt;
         }
 
         if (it->second.Write) {
             --WriteRequestCount;
         }
-        *value = std::move(it->second.Value);
+        TValue res = std::move(it->second.Value);
         RequestsInProgress.erase(it);
-        return true;
+        return res;
     }
 
     const TRequests& AllRequests() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -302,7 +302,7 @@ void TMirrorPartitionActor::ReplyAndDie(const TActorContext& ctx)
     Die(ctx);
 }
 
-auto TMirrorPartitionActor::GetNextRequestIdentifier() -> ui64
+auto TMirrorPartitionActor::TakeNextRequestIdentifier() -> ui64
 {
     return RequestIdentifierCounter++;
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -302,6 +302,11 @@ void TMirrorPartitionActor::ReplyAndDie(const TActorContext& ctx)
     Die(ctx);
 }
 
+auto TMirrorPartitionActor::GetNextRequestIdentifier() -> ui64
+{
+    return RequestIdentifierCounter++;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TMirrorPartitionActor::HandlePoisonPill(
@@ -400,7 +405,7 @@ void TMirrorPartitionActor::HandleScrubbingNextRange(
         if (!requestInfo.Write) {
             continue;
         }
-        const auto& requestRange = requestInfo.Value;
+        const auto& requestRange = requestInfo.Value.BlockRange;
         if (scrubbingRange.Overlaps(requestRange)) {
             LOG_DEBUG(
                 ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -44,7 +44,6 @@ TDuration CalculateScrubbingInterval(
 class TMirrorPartitionActor final
     : public NActors::TActorBootstrapped<TMirrorPartitionActor>
 {
-private:
     struct TRequestCtx {
         TBlockRange64 BlockRange;
         ui64 Cookie = 0;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -44,7 +44,8 @@ TDuration CalculateScrubbingInterval(
 class TMirrorPartitionActor final
     : public NActors::TActorBootstrapped<TMirrorPartitionActor>
 {
-    struct TRequestCtx {
+    struct TRequestCtx
+    {
         TBlockRange64 BlockRange;
         ui64 Cookie = 0;
     };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -45,6 +45,12 @@ class TMirrorPartitionActor final
     : public NActors::TActorBootstrapped<TMirrorPartitionActor>
 {
 private:
+    struct TRequestCtx {
+        TBlockRange64 BlockRange;
+        ui64 Cookie = 0;
+    };
+
+private:
     const TStorageConfigPtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
@@ -62,7 +68,7 @@ private:
     TDuration CpuUsage;
 
     THashSet<ui64> DirtyReadRequestIds;
-    TRequestsInProgress<ui64, TBlockRange64> RequestsInProgress{
+    TRequestsInProgress<ui64, TRequestCtx> RequestsInProgress{
         EAllowedRequests::ReadWrite};
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
@@ -84,6 +90,7 @@ private:
     bool ScrubbingRangeRescheduled  = false;
     bool ResyncRangeStarted = false;
     ui32 ChecksumMismatches = 0;
+    ui64 RequestIdentifierCounter = 0;
 
 public:
     TMirrorPartitionActor(
@@ -117,6 +124,7 @@ private:
         ui64 scrubbingRangeId);
     void StartResyncRange(const NActors::TActorContext& ctx);
     void AddTagForBufferCopying(const NActors::TActorContext& ctx);
+    ui64 GetNextRequestIdentifier();
 
 private:
     STFUNC(StateWork);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -124,7 +124,7 @@ private:
         ui64 scrubbingRangeId);
     void StartResyncRange(const NActors::TActorContext& ctx);
     void AddTagForBufferCopying(const NActors::TActorContext& ctx);
-    ui64 GetNextRequestIdentifier();
+    ui64 TakeNextRequestIdentifier();
 
 private:
     STFUNC(StateWork);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -96,7 +96,7 @@ void TMirrorPartitionActor::MirrorRequest(
     const auto range = BuildRequestBlockRange(
         *ev->Get(),
         State.GetBlockSize());
-    const auto requestIdentityKey = GetNextRequestIdentifier();
+    const auto requestIdentityKey = TakeNextRequestIdentifier();
     if (GetScrubbingRange().Overlaps(range)) {
         if (ResyncRangeStarted) {
             auto response = std::make_unique<typename TMethod::TResponse>(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -486,8 +486,10 @@ void TMirrorPartitionActor::ReadBlocks(
         DescribeRange(blockRange).c_str(),
         replicaActorIds.size());
 
-    const auto requestIdentityKey = ev->Cookie;
-    RequestsInProgress.AddReadRequest(requestIdentityKey, blockRange);
+    const auto requestIdentityKey = GetNextRequestIdentifier();
+    RequestsInProgress.AddReadRequest(
+        requestIdentityKey,
+        {blockRange, ev->Cookie});
 
     NCloud::Register<TRequestActor<TMethod>>(
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -486,7 +486,7 @@ void TMirrorPartitionActor::ReadBlocks(
         DescribeRange(blockRange).c_str(),
         replicaActorIds.size());
 
-    const auto requestIdentityKey = GetNextRequestIdentifier();
+    const auto requestIdentityKey = TakeNextRequestIdentifier();
     RequestsInProgress.AddReadRequest(
         requestIdentityKey,
         {blockRange, ev->Cookie});


### PR DESCRIPTION
Для задачи #2854 в пре #2943 нужно распиливать один запрос на несколько и посылать обратно в TMirrorPartitionActor, чтобы распиливать запросы надо сделать так, чтобы идентификация запроса происходила не по кукам