### PR TITLE
[Disk Manager] use more disk agents in blockstore client tests

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/tests/ya.make
@@ -2,7 +2,7 @@ GO_TEST_FOR(cloud/disk_manager/internal/pkg/clients/nbs)
 
 SET_APPEND(RECIPE_ARGS --nbs-only)
 SET_APPEND(RECIPE_ARGS --multiple-nbs)
-SET_APPEND(RECIPE_ARGS --disk-agent-count 3)
+SET_APPEND(RECIPE_ARGS --disk-agent-count 5)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/test/recipe/recipe.inc)
 
 GO_XTEST_SRCS(


### PR DESCRIPTION
Tests on blockstore client might run out of devices and fail with E_DISK_ALLOCATION_FAILED.

In order to prevent this, incresae number of disk agents used in these tests. 