### PR TITLE
[Filestore] increase verbosity of fio_index/qemu-kikimr-multishard-tablets-restart-test

### DIFF
--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
@@ -22,6 +22,8 @@ SET(
     cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
 )
 
+SET(NFS_FORCE_VERBOSE 1)
+
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)


### PR DESCRIPTION
For failure like this: https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(ubsan)/13191220677/1/nebius-x86-64-ubsan/summary/ya-test.html#FAIL