### PR TITLE
Fix cloud/disk_manager/internal/pkg/dataplane/url/common.TestHTTPClientTimeout

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/url/common/http_client_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/common/http_client_test.go
@@ -112,5 +112,5 @@ func TestHTTPClientTimeout(t *testing.T) {
 
 	_, err := httpClient.Head(ctx)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "deadline exceeded")
+	require.ErrorContains(t, err, "Timeout exceeded")
 }


### PR DESCRIPTION
```
2025-02-14T02:09:00.903Z	DEBUG	common/http_client.go:191	Sending http get header request to "http://127.0.0.1:42951"	{"SYSLOG_IDENTIFIER": "disk-manager"}
2025-02-14T02:09:00.903Z	DEBUG	go-retryablehttp/client.go:597	performing request, [method HEAD url http://127.0.0.1:42951]:	{"SYSLOG_IDENTIFIER": "disk-manager", "SYSLOG_IDENTIFIER": "disk-manager"}
2025-02-14T02:09:00.905Z	ERROR	go-retryablehttp/client.go:654	request failed, [error Head "http://127.0.0.1:42951": context deadline exceeded (Client.Timeout exceeded while awaiting headers) method HEAD url http://127.0.0.1:42951]:	{"SYSLOG_IDENTIFIER": "disk-manager", "SYSLOG_IDENTIFIER": "disk-manager"}
2025-02-14T02:09:00.905Z	DEBUG	go-retryablehttp/client.go:698	retrying request, [request HEAD http://127.0.0.1:42951 timeout 1ms remaining 1]:	{"SYSLOG_IDENTIFIER": "disk-manager", "SYSLOG_IDENTIFIER": "disk-manager"}
2025-02-14T02:09:00.911Z	ERROR	go-retryablehttp/client.go:654	request failed, [error Head "http://127.0.0.1:42951": dial tcp 127.0.0.1:42951: i/o timeout (Client.Timeout exceeded while awaiting headers) method HEAD url http://127.0.0.1:42951]:	{"SYSLOG_IDENTIFIER": "disk-manager", "SYSLOG_IDENTIFIER": "disk-manager"}
    http_client_test.go:115: 
        	Error Trace:	/-S/cloud/disk_manager/internal/pkg/dataplane/url/common/http_client_test.go:115
        	Error:      	Error "Retriable error, IgnoreRetryLimit=false: Head \"http://127.0.0.1:42951\": HEAD http://127.0.0.1:42951 giving up after 2 attempt(s): Head \"http://127.0.0.1:42951\": dial tcp 127.0.0.1:42951: i/o timeout (Client.Timeout exceeded while awaiting headers)" does not contain "deadline exceeded"
        	Test:       	TestHTTPClientTimeout
```