### PR TITLE
[Filestore] issue-3061: blocks with garbage should be compacted after cleanup

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/blob.h
+++ b/cloud/filestore/libs/storage/tablet/model/blob.h
@@ -16,8 +16,8 @@ namespace NCloud::NFileStore::NStorage {
 
 struct TMixedBlobStats
 {
-    ui32 GarbageBlocks = 0;
-    ui32 CheckpointBlocks = 0;
+    ui32 GarbageBlocksCount = 0;
+    ui32 CheckpointBlocksCount = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/rebase_logic.cpp
+++ b/cloud/filestore/libs/storage/tablet/rebase_logic.cpp
@@ -34,7 +34,7 @@ TRebaseResult RebaseBlocks(
 
                 if (minCommitId < maxCommitId) {
                     // this version still referenced by checkpoint
-                    ++result.CheckpointBlocks;
+                    ++result.CheckpointBlocksCount;
 
                     referencedByCheckpoint = true;
                     result.UsedCheckpoints.insert(minCommitId);
@@ -43,7 +43,7 @@ TRebaseResult RebaseBlocks(
         }
 
         if (maxCommitId == InvalidCommitId || referencedByCheckpoint) {
-            ++result.LiveBlocks;
+            ++result.LiveBlocksCount;
 
             // we should not change relative order of the block versions
             if (!findBlock(block.NodeId, block.BlockIndex)) {
@@ -51,7 +51,7 @@ TRebaseResult RebaseBlocks(
                 block.MaxCommitId = maxCommitId;
             }
         } else {
-            ++result.GarbageBlocks;
+            ++result.GarbageBlocksCount;
 
             // block is not visible anymore and could be safely deleted
             block.MinCommitId = 0;

--- a/cloud/filestore/libs/storage/tablet/rebase_logic.h
+++ b/cloud/filestore/libs/storage/tablet/rebase_logic.h
@@ -15,9 +15,9 @@ namespace NCloud::NFileStore::NStorage {
 
 struct TRebaseResult
 {
-    ui32 LiveBlocks = 0;
-    ui32 GarbageBlocks = 0;
-    ui32 CheckpointBlocks = 0;
+    ui32 LiveBlocksCount = 0;
+    ui32 GarbageBlocksCount = 0;
+    ui32 CheckpointBlocksCount = 0;
 
     TSet<ui64> UsedCheckpoints;
 };

--- a/cloud/filestore/libs/storage/tablet/rebase_logic_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/rebase_logic_ut.cpp
@@ -60,9 +60,9 @@ Y_UNIT_TEST_SUITE(TRebaseLogicTest)
             findCheckpoint,
             findBlock);
 
-        UNIT_ASSERT_VALUES_EQUAL(5, rebaseResult.LiveBlocks);
-        UNIT_ASSERT_VALUES_EQUAL(1, rebaseResult.GarbageBlocks);
-        UNIT_ASSERT_VALUES_EQUAL(2, rebaseResult.CheckpointBlocks);
+        UNIT_ASSERT_VALUES_EQUAL(5, rebaseResult.LiveBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, rebaseResult.GarbageBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(2, rebaseResult.CheckpointBlocksCount);
         UNIT_ASSERT_VALUES_EQUAL(2, rebaseResult.UsedCheckpoints.size());
         UNIT_ASSERT(rebaseResult.UsedCheckpoints.contains(c2));
         UNIT_ASSERT(rebaseResult.UsedCheckpoints.contains(c3));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -479,7 +479,6 @@ TCompactionInfo TIndexTabletActor::GetCompactionInfo() const
     // TODO: use GarbageCompactionThreshold
 
     bool shouldCompactByGarbage = Config->GetNewCompactionEnabled()
-        && compactionScore > 1
         && avgGarbagePercentage
             >= Config->GetGarbageCompactionThresholdAverage();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -148,6 +148,17 @@ struct TMiscNodeStats
     i64 OrphanNodesCount{0};
 };
 
+struct TWriteMixedBlocksResult
+{
+    ui32 GarbageBlocksCount = 0;
+    bool NewBlob = false;
+};
+
+struct TDeleteMixedBlocksResult
+{
+    ui32 GarbageBlocksCount = 0;
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TIndexTabletState
@@ -894,7 +905,7 @@ public:
         const TBlock& block,
         ui32 blocksCount);
 
-    bool WriteMixedBlocks(
+    TWriteMixedBlocksResult WriteMixedBlocks(
         TIndexTabletDatabase& db,
         const TPartialBlobId& blobId,
         /*const*/ TVector<TBlock>& blocks);
@@ -939,13 +950,13 @@ public:
     ui32 CalculateMixedIndexRangeGarbageBlockCount(ui32 rangeId) const;
 
 private:
-    bool WriteMixedBlocks(
+    TWriteMixedBlocksResult WriteMixedBlocks(
         TIndexTabletDatabase& db,
         ui32 rangeId,
         const TPartialBlobId& blobId,
         /*const*/ TVector<TBlock>& blocks);
 
-    void DeleteMixedBlocks(
+    TDeleteMixedBlocksResult DeleteMixedBlocks(
         TIndexTabletDatabase& db,
         ui32 rangeId,
         const TPartialBlobId& blobId,


### PR DESCRIPTION
The amount of garbage blocks in filesystem statistics consistently exceeds the garbage compaction threshold.
It was found that the deletion of blocks in a range does not result in marking the deleted blocks as garbage, therefore such ranges have zero score and are not subject for compaction.

#3061

The issue is resolved in this PR by the following approach:
1. Garbage block count is now increased in the cleanup operation.
2. The condition `compactionScore > 1` was removed for blocks to be compacted by garbage threshold.