### PR TITLE
fix flapping test

### DIFF
--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -1456,13 +1456,11 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         for (ui32 i = 0; i < LookupCount; ++i) {
             env.SendLookupTabletRequestAsync(sender, FakeHiveTablet, 0, 1);
         }
-        runtime.DispatchEvents([&] () {
-            TDispatchOptions opts;
-            opts.CustomFinalCondition = [&] () {
+        runtime.DispatchEvents(TDispatchOptions{
+            .CustomFinalCondition = [&]()
+            {
                 return hiveLookupCount && lookupCount == LookupCount;
-            };
-            return opts;
-        }());
+            }});
 
         UNIT_ASSERT_VALUES_EQUAL(1, hiveLookupCount);
 
@@ -1475,7 +1473,7 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
                     sender);
             UNIT_ASSERT(ev);
             const auto* msg = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(msg->GetStatus(), E_REJECTED);
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, msg->GetStatus());
         }
 
         auto sendReply =
@@ -1500,7 +1498,6 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
                 switch (ev->GetTypeRewrite()) {
                     case TEvHive::EvLookupTablet: {
                         sendReply(runtime, ev);
-
                         return true;
                     }
                 }
@@ -1511,7 +1508,7 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         for (ui32 i = 0; i < LookupCount; ++i) {
             const auto& response =
                 env.SendLookupTabletRequest(sender, FakeHiveTablet, 0, 1, S_OK);
-            UNIT_ASSERT_VALUES_EQUAL(response.TabletId, FakeTablet2);
+            UNIT_ASSERT_VALUES_EQUAL(FakeTablet2, response.TabletId);
         }
     }
 


### PR DESCRIPTION
ShouldRejectLookupEventsOnPipeReset test frequently flaps

`[fail] THiveProxyTest::ShouldRejectLookupEventsOnPipeReset [default-linux-x86_64-relwithdebinfo] (0.27s)
assertion failed at cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:1491, virtual void NCloud::NStorage::NTestSuiteTHiveProxyTest::TTestCaseShouldRejectLookupEventsOnPipeReset::Execute_(NUnitTest::TTestContext &): (receivedlookupCount == 2) failed: (3 != 2) 
Get at /-S/util/generic/ptr.h:579:16
~TStringBuilder at /-S/util/string/builder.h:8:11
NCloud::NStorage::NTestSuiteTHiveProxyTest::TCurrentTest::Execute()::'lambda'()::operator()() const at /-S/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:0:1
~__value_func at /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:395:16
UnRef at /-S/util/generic/ptr.h:624:13
NUnitTest::TTestFactory::Execute() at /-S/library/cpp/testing/unittest/registar.cpp:0:19
NUnitTest::RunMain(int, char**) at /-S/library/cpp/testing/unittest/utmain.cpp:0:0
?? at ??:0:0
_start at ??:0:0`