### PR TITLE
[Filestore] add gRPC logs for TServerTest to investigate problem with ShouldHandleAuthRequestsWithMultipleCertificates test

### DIFF
--- a/cloud/filestore/libs/server/server_ut.cpp
+++ b/cloud/filestore/libs/server/server_ut.cpp
@@ -15,6 +15,7 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/grpc/init.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -301,6 +302,9 @@ public:
             NCloud::NStorage::NUserStats::CreateUserCounterSupplierStub());
 
         ServerConfig = CreateConfig(serverConfig);
+
+        auto grpcLog = Logging->CreateLog("GRPC");
+        GrpcLoggerInit(grpcLog, true /* enableTracing */);
 
         Server = TSetup::CreateTestServer(
             ServerConfig,


### PR DESCRIPTION
Not enough logs:
```
2025-02-20T01:40:21.749759Z :NFS_SERVER INFO: cloud/filestore/libs/server/server.cpp:1197: Start listening on insecure localhost:8872
2025-02-20T01:40:21.749810Z :NFS_SERVER INFO: cloud/filestore/libs/server/server.cpp:1203: Listen on (secure control) localhost:21571
2025-02-20T01:40:22.417055Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:755: Connect to localhost:8872
2025-02-20T01:40:22.417926Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:755: Connect to localhost:21571
2025-02-20T01:40:22.901876Z :NFS_SERVER INFO: cloud/filestore/libs/server/server.cpp:1258: Shutting down
2025-02-20T01:40:22.908179Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:630: Shutting down
2025-02-20T01:40:22.909100Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:630: Shutting down
[[bad]]assertion failed at cloud/filestore/libs/server/server_ut.cpp:575, virtual void NCloud::NFileStore::NServer::NTestSuiteTServerTest::TTestCaseShouldHandleAuthRequestsWithMultipleCertificates::Execute_(NUnitTest::TTestContext &): (!HasError(response)) { Code: 2147614734 Message: "failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:21571: connection attempt timed out before receiving SETTINGS frame" }[[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char> > const&, bool)+170 (0x2457C4A)
NCloud::NFileStore::NServer::NTestSuiteTServerTest::TTestCaseShouldHandleAuthRequestsWithMultipleCertificates::Execute_(NUnitTest::TTestContext&)+3325 (0x201AC2D)
NCloud::NFileStore::NServer::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()::operator()() const+415 (0x2026C5F)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char> > const&, char const*, bool)+474 (0x245D1FA)
NCloud::NFileStore::NServer::NTestSuiteTServerTest::TCurrentTest::Execute()+1383 (0x2025067)
NUnitTest::TTestFactory::Execute()+2765 (0x245EB1D)
NUnitTest::RunMain(int, char**)+7485 (0x248893D)
??+0 (0x7F437525DD90)
__libc_start_main+128 (0x7F437525DE40)
??+0 (0x1FBC029)
[[rst]]
```