### PR TITLE
Introduce actors for resolving lagging agents

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1130,4 +1130,18 @@ message TStorageServiceConfig
 
     // Maximum size of CheckRange request
     optional uint32 CheckRangeMaxRangeSize = 410;
+
+    // Enables lagging devices feature for mirror2 disks.
+    optional bool LaggingDevicesForMirror2DisksEnabled = 411;
+
+    // Enables lagging devices feature for mirror3 disks.
+    optional bool LaggingDevicesForMirror3DisksEnabled = 412;
+
+    // Devices that are not responding for more than this value considered as
+    // candidates to become lagging.
+    // See doc/blockstore/storage/dynamic_io_mirroring_proposal.md
+    optional uint32 LaggingDeviceTimeoutThreshold = 413;
+
+    // Lagging devices are monitored by periodic requests at this interval.
+    optional uint32 LaggingDevicePingInterval = 414;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -101,6 +101,7 @@ namespace NCloud::NBlockStore {
     xxx(OverlappingRangesDuringMigrationDetected)                              \
     xxx(StartExternalEndpointError)                                            \
     xxx(EmptyRequestSgList)                                                    \
+    xxx(LaggingAgentsProxyWrongRecipientActor)                                 \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/api/partition.h
+++ b/cloud/blockstore/libs/storage/api/partition.h
@@ -96,34 +96,6 @@ struct TEvPartition
     };
 
     //
-    // AddLaggingAgent
-    //
-
-    struct TAddLaggingAgentRequest
-    {
-        // 0 - for main devices; 1,2 - for mirror replicas
-        ui32 ReplicaIndex;
-        TString AgentId;
-        TAddLaggingAgentRequest(ui32 replicaIndex, TString agentId)
-            : ReplicaIndex(replicaIndex)
-            , AgentId(std::move(agentId))
-        {}
-    };
-
-    //
-    // RemoveLaggingAgent
-    //
-
-    struct TRemoveLaggingReplicaRequest
-    {
-        // 0 - for main devices; 1,2 - for mirror replicas
-        const ui32 ReplicaIndex;
-        explicit TRemoveLaggingReplicaRequest(ui32 replicaIndex)
-            : ReplicaIndex(replicaIndex)
-        {}
-    };
-
-    //
     // Events declaration
     //
 
@@ -163,16 +135,6 @@ struct TEvPartition
     using TEvGarbageCollectorCompleted = TRequestEvent<
         TGarbageCollectorCompleted,
         EvGarbageCollectorCompleted
-    >;
-
-    using TEvAddLaggingAgentRequest = TRequestEvent<
-        TAddLaggingAgentRequest,
-        EvAddLaggingAgentRequest
-    >;
-
-    using TEvRemoveLaggingReplicaRequest = TRequestEvent<
-        TRemoveLaggingReplicaRequest,
-        EvRemoveLaggingReplicaRequest
     >;
 };
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -515,6 +515,11 @@ TDuration MSeconds(ui32 value)
     xxx(MinScrubbingBandwidth,                          ui64,      5             )\
     xxx(AutomaticallyEnableBufferCopyingAfterChecksumMismatch, bool, false       )\
                                                                                   \
+    xxx(LaggingDevicesForMirror2DisksEnabled,     bool,      false               )\
+    xxx(LaggingDevicesForMirror3DisksEnabled,     bool,      false               )\
+    xxx(LaggingDeviceTimeoutThreshold,            TDuration, Seconds(5)          )\
+    xxx(LaggingDevicePingInterval,                TDuration, MSeconds(500)       )\
+                                                                                  \
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\
     xxx(IdleAgentDeployByCmsDelay,                      TDuration, Hours(1)      )\
@@ -568,6 +573,8 @@ BLOCKSTORE_STORAGE_CONFIG(BLOCKSTORE_STORAGE_DECLARE_CONFIG)
     xxx(UseNonReplicatedHDDInsteadOfReplicated)                                \
     xxx(AddingUnconfirmedBlobs)                                                \
     xxx(EncryptionAtRestForDiskRegistryBasedDisks)                             \
+    xxx(LaggingDevicesForMirror2Disks)                                         \
+    xxx(LaggingDevicesForMirror3Disks)                                         \
 
 // BLOCKSTORE_BINARY_FEATURES
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -366,6 +366,15 @@ public:
         const TString& folderId,
         const TString& diskId) const;
 
+    [[nodiscard]] bool IsLaggingDevicesForMirror2DisksFeatureEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& diskId) const;
+    [[nodiscard]] bool IsLaggingDevicesForMirror3DisksFeatureEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& diskId) const;
+
     TDuration GetMaxTimedOutDeviceStateDurationFeatureValue(
         const TString& cloudId,
         const TString& folderId,
@@ -614,6 +623,11 @@ public:
     TString GetNodeRegistrationRootCertsFile() const;
     TCertificate GetNodeRegistrationCert() const;
     TString GetNodeType() const;
+
+    [[nodiscard]] bool GetLaggingDevicesForMirror2DisksEnabled() const;
+    [[nodiscard]] bool GetLaggingDevicesForMirror3DisksEnabled() const;
+    [[nodiscard]] TDuration GetLaggingDeviceTimeoutThreshold() const;
+    [[nodiscard]] TDuration GetLaggingDevicePingInterval() const;
 
     NCloud::NProto::TConfigDispatcherSettings GetConfigDispatcherSettings() const;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.cpp
@@ -1,0 +1,168 @@
+#include "agent_availability_monitoring_actor.h"
+
+#include "part_nonrepl_events_private.h"
+
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
+#include <cloud/storage/core/libs/actors/helpers.h>
+
+#include <contrib/ydb/library/actors/core/log.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+///////////////////////////////////////////////////////////////////////////////
+
+TAgentAvailabilityMonitoringActor::TAgentAvailabilityMonitoringActor(
+        TStorageConfigPtr config,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        TActorId nonreplPartitionActorId,
+        TActorId parentActorId,
+        TString agentId)
+    : Config(std::move(config))
+    , PartConfig(std::move(partConfig))
+    , NonreplPartitionActorId(nonreplPartitionActorId)
+    , ParentActorId(parentActorId)
+    , AgentId(std::move(agentId))
+{
+    for (const auto& device: PartConfig->GetDevices()) {
+        if (device.GetAgentId() == AgentId) {
+            break;
+        }
+
+        ReadBlockIndex += device.GetBlocksCount();
+    }
+}
+
+TAgentAvailabilityMonitoringActor::~TAgentAvailabilityMonitoringActor() =
+    default;
+
+void TAgentAvailabilityMonitoringActor::Bootstrap(const TActorContext& ctx)
+{
+    Become(&TThis::StateWork);
+
+    ScheduleCheckAvailabilityRequest(ctx);
+}
+
+void TAgentAvailabilityMonitoringActor::ScheduleCheckAvailabilityRequest(
+    const TActorContext& ctx)
+{
+    ctx.Schedule(
+        Config->GetLaggingDevicePingInterval(),
+        new TEvents::TEvWakeup());
+}
+
+void TAgentAvailabilityMonitoringActor::CheckAgentAvailability(
+    const TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Checking lagging agent %s availability by reading block %lu",
+        PartConfig->GetName().c_str(),
+        AgentId.c_str(),
+        ReadBlockIndex);
+
+    auto request = std::make_unique<TEvService::TEvReadBlocksRequest>();
+
+    request->Record.SetStartIndex(ReadBlockIndex);
+    request->Record.SetBlocksCount(1);
+    auto* headers = request->Record.MutableHeaders();
+    headers->SetIsBackgroundRequest(true);
+    headers->SetClientId(TString(CheckHealthClientId));
+
+    auto event = std::make_unique<IEventHandle>(
+        NonreplPartitionActorId,
+        ctx.SelfID,
+        request.release(),
+        IEventHandle::FlagForwardOnNondelivery,
+        0,            // cookie
+        &ctx.SelfID   // forwardOnNondelivery
+    );
+    ctx.Send(event.release());
+}
+
+void TAgentAvailabilityMonitoringActor::HandleWakeup(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    CheckAgentAvailability(ctx);
+    ScheduleCheckAvailabilityRequest(ctx);
+}
+
+void TAgentAvailabilityMonitoringActor::HandleReadBlocksUndelivery(
+    const TEvService::TEvReadBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Couldn't read block from lagging agent %s due to undelivered "
+        "request",
+        PartConfig->GetName().c_str(),
+        AgentId.c_str());
+}
+
+void TAgentAvailabilityMonitoringActor::HandleReadBlocksResponse(
+    const TEvService::TEvReadBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::PARTITION_WORKER,
+            "[%s] Couldn't read block from lagging agent %s due to error: %s",
+            PartConfig->GetName().c_str(),
+            AgentId.c_str(),
+            FormatError(msg->GetError()).c_str());
+
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Successfully read one block from lagging agent %s",
+        PartConfig->GetName().c_str(),
+        AgentId.c_str());
+
+    NCloud::Send<TEvNonreplPartitionPrivate::TEvAgentIsBackOnline>(
+        ctx,
+        ParentActorId,
+        0,   // cookie
+        AgentId);
+}
+
+void TAgentAvailabilityMonitoringActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    NCloud::Reply(ctx, *ev, std::make_unique<TEvents::TEvPoisonTaken>());
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TAgentAvailabilityMonitoringActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvService::TEvReadBlocksResponse, HandleReadBlocksResponse);
+        HFunc(TEvService::TEvReadBlocksRequest, HandleReadBlocksUndelivery);
+        HFunc(TEvents::TEvWakeup, HandleWakeup);
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            break;
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// This actor is used to monitor the availability of a lagging agent by
+// periodically sending ReadBlocks requests to it.
+class TAgentAvailabilityMonitoringActor final
+    : public NActors::TActorBootstrapped<TAgentAvailabilityMonitoringActor>
+{
+private:
+    const TStorageConfigPtr Config;
+    const TNonreplicatedPartitionConfigPtr PartConfig;
+    const NActors::TActorId NonreplPartitionActorId;
+    const NActors::TActorId ParentActorId;
+    const TString AgentId;
+
+    ui64 ReadBlockIndex = 0;
+
+public:
+    TAgentAvailabilityMonitoringActor(
+        TStorageConfigPtr config,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        NActors::TActorId nonreplPartitionActorId,
+        NActors::TActorId parentActorId,
+        TString agentId);
+
+    ~TAgentAvailabilityMonitoringActor() override;
+
+    void Bootstrap(const NActors::TActorContext& ctx);
+
+private:
+    void ScheduleCheckAvailabilityRequest(const NActors::TActorContext& ctx);
+    void CheckAgentAvailability(const NActors::TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleReadBlocksUndelivery(
+        const TEvService::TEvReadBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleReadBlocksResponse(
+        const TEvService::TEvReadBlocksResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleWakeup(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.h
@@ -2,7 +2,8 @@
 
 #include "public.h"
 
-#include <cloud/blockstore/libs/storage/api/service.h>
+#include "part_nonrepl_events_private.h"
+
 #include <cloud/blockstore/libs/storage/core/config.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -46,12 +47,12 @@ private:
 private:
     STFUNC(StateWork);
 
-    void HandleReadBlocksUndelivery(
-        const TEvService::TEvReadBlocksRequest::TPtr& ev,
+    void HandleChecksumBlocksUndelivery(
+        const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    void HandleReadBlocksResponse(
-        const TEvService::TEvReadBlocksResponse::TPtr& ev,
+    void HandleChecksumBlocksResponse(
+        const TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleWakeup(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -234,20 +234,28 @@ public:
 
     bool DevicesReadyForReading(const TBlockRange64 blockRange) const
     {
-        return VisitDeviceRequests(
+        return DevicesReadyForReading(blockRange, {});
+    }
+
+    bool DevicesReadyForReading(
+        const TBlockRange64 blockRange,
+        const THashSet<ui32>& excludeIndexes) const
+    {
+        const bool result = VisitDeviceRequests(
             blockRange,
-            [&] (
-                const ui32 i,
+            [&](const ui32 i,
                 const TBlockRange64 requestRange,
                 const TBlockRange64 relativeRange)
             {
                 Y_UNUSED(requestRange);
                 Y_UNUSED(relativeRange);
 
-                return !Devices[i].GetDeviceUUID()
-                    || FreshDeviceIds.contains(Devices[i].GetDeviceUUID())
-                    || LaggingDeviceIds.contains(Devices[i].GetDeviceUUID());
+                return !Devices[i].GetDeviceUUID() ||
+                       excludeIndexes.contains(i) ||
+                       FreshDeviceIds.contains(Devices[i].GetDeviceUUID()) ||
+                       LaggingDeviceIds.contains(Devices[i].GetDeviceUUID());
             });
+        return result;
     }
 
     void AugmentErrorFlags(NCloud::NProto::TError& error) const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -1,0 +1,104 @@
+#include "lagging_agent_migration_actor.h"
+
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+#include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLaggingAgentMigrationActor::TLaggingAgentMigrationActor(
+        TStorageConfigPtr config,
+        TDiagnosticsConfigPtr diagnosticsConfig,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        IProfileLogPtr profileLog,
+        IBlockDigestGeneratorPtr blockDigestGenerator,
+        TString rwClientId,
+        TActorId targetActorId,
+        TActorId sourceActorId,
+        TCompressedBitmap migrationBlockMap,
+        TString agentId)
+    : TNonreplicatedPartitionMigrationCommonActor(
+          this,
+          config,
+          std::move(diagnosticsConfig),
+          partConfig->GetName(),
+          partConfig->GetBlockCount(),
+          partConfig->GetBlockSize(),
+          std::move(profileLog),
+          std::move(blockDigestGenerator),
+          std::move(migrationBlockMap),
+          std::move(rwClientId),
+          // Since this actor doesn't own source or destination actors, it won't
+          // receive any stats and shouldn't send any either.
+          TActorId(),   //  statActorId
+          config->GetMaxMigrationIoDepth())
+    , Config(std::move(config))
+    , PartConfig(std::move(partConfig))
+    , TargetActorId(targetActorId)
+    , SourceActorId(sourceActorId)
+    , AgentId(std::move(agentId))
+{}
+
+TLaggingAgentMigrationActor::~TLaggingAgentMigrationActor() = default;
+
+void TLaggingAgentMigrationActor::OnBootstrap(const TActorContext& ctx)
+{
+    InitWork(
+        ctx,
+        SourceActorId,
+        TargetActorId,
+        false,   // takeOwnershipOverActors
+        std::make_unique<TMigrationTimeoutCalculator>(
+            Config->GetMaxMigrationBandwidth(),
+            Config->GetExpectedDiskAgentSize(),
+            PartConfig));
+    StartWork(ctx);
+}
+
+bool TLaggingAgentMigrationActor::OnMessage(
+    const TActorContext& ctx,
+    TAutoPtr<IEventHandle>& ev)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(ev);
+    return false;
+}
+
+void TLaggingAgentMigrationActor::OnMigrationProgress(
+    const TActorContext& ctx,
+    ui64 migrationIndex)
+{
+    Y_UNUSED(migrationIndex);
+
+    ctx.Send(
+        PartConfig->GetParentActorId(),
+        std::make_unique<TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState>(
+            AgentId,
+            GetProcessedBlockCount(),
+            GetBlockCountNeedToBeProcessed()));
+}
+
+void TLaggingAgentMigrationActor::OnMigrationFinished(const TActorContext& ctx)
+{
+    ctx.Send(
+        PartConfig->GetParentActorId(),
+        std::make_unique<TEvVolumePrivate::TEvLaggingAgentMigrationFinished>(
+            AgentId));
+}
+
+void TLaggingAgentMigrationActor::OnMigrationError(const TActorContext& ctx)
+{
+    LOG_ERROR(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Lagging agent %s migration failed",
+        PartConfig->GetName().c_str(),
+        AgentId.c_str());
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "public.h"
+
+#include "part_nonrepl_migration_common_actor.h"
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// This actor is used to restore lagging agent data and make it consistent with
+// other replicas. It does this by copying dirty ranges using a bitmap.
+class TLaggingAgentMigrationActor final
+    : public TNonreplicatedPartitionMigrationCommonActor
+    , public IMigrationOwner
+{
+private:
+    const TStorageConfigPtr Config;
+    const TNonreplicatedPartitionConfigPtr PartConfig;
+    const NActors::TActorId TargetActorId;
+    const NActors::TActorId SourceActorId;
+    const TString AgentId;
+
+public:
+    TLaggingAgentMigrationActor(
+        TStorageConfigPtr config,
+        TDiagnosticsConfigPtr diagnosticsConfig,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        IProfileLogPtr profileLog,
+        IBlockDigestGeneratorPtr blockDigestGenerator,
+        TString rwClientId,
+        NActors::TActorId targetActorId,
+        NActors::TActorId sourceActorId,
+        TCompressedBitmap migrationBlockMap,
+        TString agentId);
+
+    ~TLaggingAgentMigrationActor() override;
+
+private:
+    // IMigrationOwner implementation
+    void OnBootstrap(const NActors::TActorContext& ctx) override;
+    bool OnMessage(
+        const NActors::TActorContext& ctx,
+        TAutoPtr<NActors::IEventHandle>& ev) override;
+    void OnMigrationProgress(
+        const NActors::TActorContext& ctx,
+        ui64 migrationIndex) override;
+    void OnMigrationFinished(const NActors::TActorContext& ctx) override;
+    void OnMigrationError(const NActors::TActorContext& ctx) override;
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include "public.h"
+
+#include "config.h"
+#include "part_nonrepl_events_private.h"
+
+#include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/storage/core/libs/actors/poison_pill_helper.h>
+#include <cloud/storage/core/libs/common/compressed_bitmap.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The main purpose of this class is to handle lagging agents for a single
+// replica of a mirrored disk. When an agent becomes unavailable, it creates
+// TAgentAvailabilityMonitoringActor and maintains the dirty blocks bitmap by
+// proxying all write requests from the mirror partition. Once the agent becomes
+// responsive again, it starts migration from the mirror to the non-replicated
+// partition using the dirty blocks bitmap.
+class TLaggingAgentsReplicaProxyActor final
+    : public NActors::TActorBootstrapped<TLaggingAgentsReplicaProxyActor>
+    , public IPoisonPillHelperOwner
+{
+private:
+    using TBase = NActors::TActorBootstrapped<TLaggingAgentsReplicaProxyActor>;
+
+    const TStorageConfigPtr Config;
+    const TDiagnosticsConfigPtr DiagnosticsConfig;
+    const TNonreplicatedPartitionConfigPtr PartConfig;
+    const IProfileLogPtr ProfileLog;
+    const IBlockDigestGeneratorPtr BlockDigestGenerator;
+    TString RwClientId;
+    const NActors::TActorId NonreplPartitionActorId;
+    const NActors::TActorId MirrorPartitionActorId;
+
+    enum class EAgentState : ui8
+    {
+        Unavailable,
+        Resyncing
+    };
+    struct TAgentState
+    {
+        EAgentState State;
+        NProto::TLaggingAgent LaggingAgent;
+        NActors::TActorId AvailabilityMonitoringActorId;
+        NActors::TActorId MigrationActorId;
+        std::unique_ptr<TCompressedBitmap> CleanBlocksMap;
+    };
+    THashMap<TString, TAgentState> AgentState;
+
+    TPoisonPillHelper PoisonPillHelper;
+
+public:
+    struct TSplitRequest
+    {
+        std::unique_ptr<NActors::IEventBase> Request;
+        TCallContextPtr CallContext;
+        NActors::TActorId RecipientActorId;
+        TString DeviceUUID;
+    };
+
+    TLaggingAgentsReplicaProxyActor(
+        TStorageConfigPtr config,
+        TDiagnosticsConfigPtr diagnosticsConfig,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        IProfileLogPtr profileLog,
+        IBlockDigestGeneratorPtr blockDigestGenerator,
+        TString rwClientId,
+        NActors::TActorId nonreplPartitionActorId,
+        NActors::TActorId mirrorPartitionActorId);
+
+    ~TLaggingAgentsReplicaProxyActor() override;
+
+    void Bootstrap(const NActors::TActorContext& ctx);
+
+private:
+    [[nodiscard]] bool AgentIsUnavailable(const TString& agentId) const;
+
+    template <typename TMethod>
+    TVector<TSplitRequest> SplitRequest(
+        const TMethod::TRequest::TPtr& ev,
+        const TVector<TDeviceRequest>& deviceRequests);
+
+    [[nodiscard]] TVector<TSplitRequest> DoSplitRequest(
+        const TEvService::TEvWriteBlocksRequest::TPtr& ev,
+        const TVector<TDeviceRequest>& deviceRequests);
+    [[nodiscard]] TVector<TSplitRequest> DoSplitRequest(
+        const TEvService::TEvWriteBlocksLocalRequest::TPtr& ev,
+        const TVector<TDeviceRequest>& deviceRequests);
+    [[nodiscard]] TVector<TSplitRequest> DoSplitRequest(
+        const TEvService::TEvZeroBlocksRequest::TPtr& ev,
+        const TVector<TDeviceRequest>& deviceRequests);
+
+    [[nodiscard]] bool ShouldSplitWriteRequest(
+        const TVector<TDeviceRequest>& requests) const;
+    [[nodiscard]] NActors::TActorId GetRecipientActorId(
+        const TString& agentId) const;
+
+    void MarkBlocksAsDirty(
+        const NActors::TActorContext& ctx,
+        const TString& unavailableAgentId,
+        TBlockRange64 range);
+
+    void DestroyChildActor(
+        const NActors::TActorContext& ctx,
+        NActors::TActorId* actorId);
+
+    // IPoisonPillHelperOwner implementation:
+    void Die(const NActors::TActorContext& ctx) override;
+
+private:
+    STFUNC(StateWork);
+    STFUNC(StateZombie);
+
+    void HandleAgentIsUnavailable(
+        const TEvNonreplPartitionPrivate::TEvAgentIsUnavailable::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAgentIsBackOnline(
+        const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleWriteOrZeroCompleted(
+        const TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAddLaggingAgent(
+        const TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleRWClientIdChanged(
+        const TEvVolume::TEvRWClientIdChanged::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    template <typename TMethod>
+    void WriteBlocks(
+        const typename TMethod::TRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    template <typename TMethod>
+    void ReadBlocks(
+        const typename TMethod::TRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void ForwardUnhandledEvent(
+        TAutoPtr<NActors::IEventHandle>& ev,
+        const NActors::TActorContext& ctx);
+
+    BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocks, TEvService);
+    BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocksLocal, TEvService);
+    BLOCKSTORE_IMPLEMENT_REQUEST(ZeroBlocks, TEvService);
+    BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
+    BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocksLocal, TEvService);
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -1,0 +1,819 @@
+#include "lagging_agents_replica_proxy_actor.h"
+#include "part_mirror_actor.h"
+#include "ut_env.h"
+
+#include <cloud/blockstore/libs/diagnostics/block_digest.h>
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+#include <cloud/blockstore/libs/storage/testlib/diagnostics.h>
+#include <cloud/blockstore/libs/storage/testlib/disk_agent_mock.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+#include <cloud/storage/core/libs/common/sglist_test.h>
+
+#include <contrib/ydb/core/testlib/basics/runtime.h>
+#include <contrib/ydb/core/testlib/tablet_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+namespace {
+
+constexpr ui64 DeviceBlockCount = 8192;
+constexpr ui32 DeviceCountPerReplica = 3;
+constexpr ui32 ReplicaCount = 3;
+constexpr ui32 AgentCount = DeviceCountPerReplica * ReplicaCount;
+
+[[nodiscard]] TBlockRange64 UnifyClosedIntervals(
+    const TBlockRange64& first,
+    const TBlockRange64& second)
+{
+    Y_DEBUG_ABORT_UNLESS(
+        first.Start - 1 <= second.End && second.Start - 1 <= first.End);
+    auto start = Min(first.Start, second.Start);
+    auto end = Max(first.End, second.End);
+    return TBlockRange64::MakeClosedInterval(start, end);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestEnv
+{
+    TTestBasicRuntime& Runtime;
+    const TDevices Devices;
+    const TVector<TDevices> Replicas;
+    const TMigrations Migrations;
+    const bool LocalRequests;
+    TStorageConfigPtr Config;
+    TActorId MirrorPartActorId;
+    TActorId VolumeActorId;
+    TStorageStatsServiceStatePtr StorageStatsServiceState;
+    TVector<TDiskAgentStatePtr> DiskAgentStates;
+    TVector<TActorId> ReplicaActors;
+    TVector<TActorId> DiskAgentActors;
+
+    TNonreplicatedPartitionConfigPtr PartConfig;
+    THashMap<ui32, TActorId> Controllers;
+    TVector<NProto::TLaggingAgent> LaggingAgents;
+
+    static void AddDevice(
+        ui32 nodeId,
+        ui32 blockCount,
+        TString name,
+        TString agentId,
+        TDevices& devices)
+    {
+        auto& device = *devices.Add();
+        device.SetNodeId(nodeId);
+        device.SetBlocksCount(blockCount);
+        device.SetDeviceUUID(std::move(name));
+        device.SetBlockSize(DefaultBlockSize);
+        device.SetAgentId(std::move(agentId));
+    }
+
+    static TDevices ReplicaDevices(
+        TTestBasicRuntime& runtime,
+        ui32 replicaIndex)
+    {
+        TDevices devices;
+        for (ui32 i = 0; i < DeviceCountPerReplica; i++) {
+            const ui32 index = replicaIndex * DeviceCountPerReplica + i;
+            AddDevice(
+                runtime.GetNodeId(index),
+                DeviceBlockCount,
+                Sprintf("uuid-%u", index),
+                Sprintf("agent-%u", index),
+                devices);
+        }
+
+        return devices;
+    }
+
+    explicit TTestEnv(TTestBasicRuntime& runtime, bool localRequests)
+        : TTestEnv(
+              runtime,
+              ReplicaDevices(runtime, 0),
+              TVector<TDevices>{
+                  ReplicaDevices(runtime, 1),
+                  ReplicaDevices(runtime, 2),
+              },
+              {},   // migrations
+              localRequests,
+              {},   // freshDeviceIds
+              {},   // laggingDeviceIds
+              {}    // configBase
+          )
+    {}
+
+    TTestEnv(
+        TTestBasicRuntime& runtime,
+        TDevices devices,
+        TVector<TDevices> replicas,
+        TMigrations migrations,
+        bool localRequests,
+        THashSet<TString> freshDeviceIds,
+        THashSet<TString> laggingDeviceIds,
+        NProto::TStorageServiceConfig configBase)
+        : Runtime(runtime)
+        , Devices(std::move(devices))
+        , Replicas(std::move(replicas))
+        , Migrations(std::move(migrations))
+        , LocalRequests(localRequests)
+        , MirrorPartActorId(Runtime.GetNodeId(0), "mirror-part")
+        , VolumeActorId(Runtime.GetNodeId(0), "volume")
+        , StorageStatsServiceState(MakeIntrusive<TStorageStatsServiceState>())
+    {
+        SetupLogging();
+
+        Runtime.SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase& runtime,
+                const auto& parentId,
+                const auto& actorId)
+            {
+                runtime.EnableScheduleForActor(actorId);
+                auto mirrorActorId =
+                    runtime.GetLocalServiceId(MirrorPartActorId);
+                if (mirrorActorId && parentId == mirrorActorId &&
+                    ReplicaActors.size() < 3)
+                {
+                    AddReplica(actorId);
+                }
+            });
+
+        auto volume = std::make_unique<TDummyActor>();
+        Runtime.AddLocalService(
+            VolumeActorId,
+            TActorSetupCmd(volume.release(), TMailboxType::Simple, 0));
+
+        auto diskRegistry = std::make_unique<TDummyActor>();
+        Runtime.AddLocalService(
+            MakeDiskRegistryProxyServiceId(),
+            TActorSetupCmd(diskRegistry.release(), TMailboxType::Simple, 0));
+
+        Runtime.AddLocalService(
+            MakeStorageStatsServiceId(),
+            TActorSetupCmd(
+                new TStorageStatsServiceMock(StorageStatsServiceState),
+                TMailboxType::Simple,
+                0));
+
+        NProto::TStorageServiceConfig storageConfig = std::move(configBase);
+        storageConfig.SetMaxMigrationBandwidth(1);
+        storageConfig.SetMaxMigrationIoDepth(1);
+        storageConfig.SetLaggingDevicePingInterval(
+            TDuration::Seconds(5).MilliSeconds());
+        Config = std::make_shared<TStorageConfig>(
+            std::move(storageConfig),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig()));
+
+        PartConfig = std::make_shared<TNonreplicatedPartitionConfig>(
+            Devices,
+            NProto::VOLUME_IO_OK,
+            "vol0",
+            DefaultBlockSize,
+            TNonreplicatedPartitionConfig::TVolumeInfo{
+                Now(),
+                // only SSD/HDD distinction matters
+                NProto::STORAGE_MEDIA_SSD_MIRROR3},
+            VolumeActorId,
+            false,   // muteIOErrors
+            std::move(freshDeviceIds),
+            std::move(laggingDeviceIds),
+            TDuration::Zero(),   // maxTimedOutDeviceStateDuration
+            false,               // maxTimedOutDeviceStateDurationOverridden
+            true                 // useSimpleMigrationBandwidthLimiter
+        );
+
+        auto mirrorPartition = std::make_unique<TMirrorPartitionActor>(
+            Config,
+            CreateDiagnosticsConfig(),
+            CreateProfileLogStub(),
+            CreateBlockDigestGeneratorStub(),
+            "",   // rwClientId
+            PartConfig,
+            std::move(migrations),
+            Replicas,
+            nullptr,   // rdmaClient
+            VolumeActorId,
+            TActorId()   // resyncActorId
+        );
+
+        Runtime.AddLocalService(
+            MirrorPartActorId,
+            TActorSetupCmd(mirrorPartition.release(), TMailboxType::Simple, 0));
+
+        NKikimr::SetupTabletServices(Runtime);
+        TDevices allDevices;
+        for (const auto& d: Devices) {
+            allDevices.Add()->CopyFrom(d);
+        }
+        for (const auto& r: Replicas) {
+            for (const auto& d: r) {
+                allDevices.Add()->CopyFrom(d);
+            }
+        }
+        for (auto& m: migrations) {
+            allDevices.Add()->CopyFrom(m.GetTargetDevice());
+        }
+
+        Sort(
+            allDevices,
+            [](const NProto::TDeviceConfig& lhs,
+               const NProto::TDeviceConfig& rhs)
+            { return lhs.GetNodeId() < rhs.GetNodeId(); });
+        for (ui32 i = 0; i < AgentCount; i++) {
+            struct TByNodeId
+            {
+                auto operator()(const NProto::TDeviceConfig& device) const
+                {
+                    return device.GetNodeId();
+                }
+            };
+            const ui32 nodeId = Runtime.GetNodeId(i);
+            auto begin = LowerBoundBy(
+                allDevices.begin(),
+                allDevices.end(),
+                nodeId,
+                TByNodeId());
+            auto end = UpperBoundBy(
+                allDevices.begin(),
+                allDevices.end(),
+                nodeId,
+                TByNodeId());
+
+            const auto actorId = Runtime.Register(
+                new TDiskAgentMock(
+                    {
+                        begin,
+                        end,
+                    },
+                    std::make_shared<TDiskAgentState>()),
+                i);
+            DiskAgentActors.push_back(actorId);
+            Runtime.RegisterService(MakeDiskAgentServiceId(nodeId), actorId, i);
+        }
+    }
+
+    void SetupLogging()
+    {
+        Runtime.AppendToLogSettings(
+            TBlockStoreComponents::START,
+            TBlockStoreComponents::END,
+            GetComponentName);
+
+        for (ui32 i = TBlockStoreComponents::START;
+             i < TBlockStoreComponents::END;
+             ++i)
+        {
+            Runtime.SetLogPriority(i, NLog::PRI_DEBUG);
+        }
+    }
+
+    void AddReplica(TActorId partActorId)
+    {
+        ReplicaActors.push_back(partActorId);
+    }
+
+    void WriteBlocksToPartition(TBlockRange64 range, char content)
+    {
+        if (LocalRequests) {
+            WriteBlocksLocal(MirrorPartActorId, range, content);
+        } else {
+            WriteBlocks(MirrorPartActorId, range, content);
+        }
+    }
+
+    void
+    WriteBlocksToReplica(ui32 replicaIndex, TBlockRange64 range, char content)
+    {
+        if (LocalRequests) {
+            WriteBlocksLocal(ReplicaActors[replicaIndex], range, content);
+        } else {
+            WriteBlocks(ReplicaActors[replicaIndex], range, content);
+        }
+    }
+
+    void WriteBlocksToController(
+        ui32 replicaIndex,
+        TBlockRange64 range,
+        char content)
+    {
+        if (LocalRequests) {
+            WriteBlocksLocal(
+                GetControllerActorId(replicaIndex),
+                range,
+                content);
+        } else {
+            WriteBlocks(GetControllerActorId(replicaIndex), range, content);
+        }
+    }
+
+    void ReadFromPartitionAndCheckContents(TBlockRange64 range, char content)
+    {
+        ReadAndCheckContents(MirrorPartActorId, range, content);
+    }
+
+    void ReadFromControllerAndCheckContents(
+        ui32 index,
+        TBlockRange64 range,
+        char content)
+    {
+        ReadAndCheckContents(GetControllerActorId(index), range, content);
+    }
+
+    void ReadFromReplicaAndCheckContents(
+        ui32 replicaIndex,
+        TBlockRange64 range,
+        char content)
+    {
+        ReadAndCheckContents(ReplicaActors[replicaIndex], range, content);
+    }
+
+    const TDevices& GetReplicaDevices(ui32 replicaIndex)
+    {
+        if (replicaIndex == 0) {
+            return Devices;
+        }
+        return Replicas[replicaIndex - 1];
+    }
+
+    NProto::TLaggingAgent AddLaggingAgent(ui32 nodeId, ui32 replicaIndex)
+    {
+        const auto& devices = GetReplicaDevices(replicaIndex);
+        NProto::TLaggingAgent laggingAgent;
+        for (int i = 0; i < devices.size(); i++) {
+            const auto& device = devices[i];
+            if (device.GetNodeId() == nodeId) {
+                laggingAgent.SetAgentId(device.GetAgentId());
+                laggingAgent.SetReplicaIndex(0);
+
+                NProto::TLaggingDevice* laggingDevice =
+                    laggingAgent.AddDevices();
+                laggingDevice->SetDeviceUUID(device.GetDeviceUUID());
+                laggingDevice->SetRowIndex(i);
+            }
+        }
+
+        Y_DEBUG_ABORT_UNLESS(!laggingAgent.GetAgentId().empty());
+        LaggingAgents.push_back(laggingAgent);
+
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        client.SendRequest(
+            GetControllerActorId(replicaIndex),
+            std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+                laggingAgent));
+        return laggingAgent;
+    }
+
+    TActorId GetControllerActorId(ui32 replicaIndex)
+    {
+        if (!Controllers.contains(replicaIndex)) {
+            auto controller =
+                std::make_unique<TLaggingAgentsReplicaProxyActor>(
+                    Config,
+                    CreateDiagnosticsConfig(),
+                    PartConfig->Fork(GetReplicaDevices(replicaIndex)),
+                    CreateProfileLogStub(),
+                    CreateBlockDigestGeneratorStub(),
+                    "",   // rwClientId
+                    ReplicaActors[replicaIndex],
+                    // Normally this would be mirror actor, but for testing
+                    // purposes easier to read data from next replica.
+                    ReplicaActors[(replicaIndex + 1) % ReplicaCount]);
+
+            const auto actorId = Runtime.Register(controller.release(), 0);
+            Runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            return Controllers[replicaIndex] = actorId;
+        }
+        return Controllers[replicaIndex];
+    }
+
+    void DeleteControllerActorId(ui32 replicaIndex)
+    {
+        if (!Controllers.contains(replicaIndex)) {
+            return;
+        }
+
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        client.SendRequest(
+            Controllers[replicaIndex],
+            std::make_unique<TEvents::TEvPoisonPill>());
+        Controllers.erase(replicaIndex);
+    }
+
+    void WaitForMigrationFinishEvent()
+    {
+        Runtime.AdvanceCurrentTime(Config->GetLaggingDevicePingInterval());
+        bool migrationFinished = false;
+        for (int i = 0; i < 100; i++) {
+            migrationFinished = Runtime.DispatchEvents(
+                {.FinalEvents =
+                     {{TEvVolumePrivate::EvLaggingAgentMigrationFinished}}},
+                TDuration::MilliSeconds(10));
+            if (migrationFinished) {
+                break;
+            }
+            Runtime.AdvanceCurrentTime(TDuration::Seconds(4));
+        }
+        if (!migrationFinished) {
+            Runtime.DispatchEvents(
+                {.FinalEvents = {
+                     {TEvVolumePrivate::EvLaggingAgentMigrationFinished}}});
+        }
+    }
+
+private:
+    std::unique_ptr<TEvService::TEvWriteBlocksResponse>
+    WriteBlocks(TActorId actorId, TBlockRange64 range, char content)
+    {
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        auto request = client.CreateWriteBlocksRequest(range, content);
+        // request->MutableHeaders()->SetClientId("")
+        client.SendRequest(actorId, std::move(request));
+        auto response =
+            client.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+        UNIT_ASSERT_C(
+            SUCCEEDED(response->GetStatus()),
+            FormatError(response->GetError()));
+        return response;
+    }
+
+    std::unique_ptr<TEvService::TEvWriteBlocksLocalResponse>
+    WriteBlocksLocal(TActorId actorId, TBlockRange64 range, char content)
+    {
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        const TString data(DefaultBlockSize, content);
+        auto request = client.CreateWriteBlocksLocalRequest(range, data);
+        client.SendRequest(actorId, std::move(request));
+        auto response =
+            client.RecvResponse<TEvService::TEvWriteBlocksLocalResponse>();
+        UNIT_ASSERT_C(
+            SUCCEEDED(response->GetStatus()),
+            response->GetErrorReason());
+        return response;
+    }
+
+    void
+    ReadAndCheckContents(TActorId actorId, TBlockRange64 range, char content)
+    {
+        const int iterations = actorId == MirrorPartActorId ? ReplicaCount : 1;
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        for (int i = 0; i < iterations; i++) {
+            auto request = client.CreateReadBlocksRequest(range);
+            client.SendRequest(actorId, std::move(request));
+            auto response =
+                client.RecvResponse<TEvService::TEvReadBlocksResponse>();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+
+            const auto& blocks = response->Record.GetBlocks();
+            UNIT_ASSERT_VALUES_EQUAL(range.Size(), blocks.BuffersSize());
+            for (ui32 j = 0; j < blocks.BuffersSize(); ++j) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    TString(DefaultBlockSize, content),
+                    blocks.GetBuffers(j),
+                    TStringBuilder() << "Block number: " << j);
+            }
+        }
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLaggingAgentsReplicaProxyActorTest)
+{
+    void ShouldMigrateDirtyBlocks(bool localRequests)
+    {
+        TTestBasicRuntime runtime(AgentCount);
+        TTestEnv env(runtime, localRequests);
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange = TBlockRange64::WithLength(
+            0,
+            DeviceBlockCount * DeviceCountPerReplica);
+        env.WriteBlocksToPartition(fullDiskRange, 'A');
+
+        // Second row in the first column is lagging.
+        env.AddLaggingAgent(runtime.GetNodeId(1), 0);
+
+        // Writes across the first and second devices should write only to the
+        // first one.
+        const auto firstAndSecondDevices =
+            TBlockRange64::WithLength(DeviceBlockCount - 1, 2);
+        const auto firstDevice =
+            TBlockRange64::WithLength(DeviceBlockCount - 1, 1);
+        const auto secondDeviceOneBlock =
+            TBlockRange64::WithLength(DeviceBlockCount, 1);
+        env.WriteBlocksToController(0, firstAndSecondDevices, 'B');
+        env.ReadFromReplicaAndCheckContents(0, firstDevice, 'B');
+        env.ReadFromReplicaAndCheckContents(0, secondDeviceOneBlock, 'A');
+
+        // Fill other replicas to validate migration results below.
+        env.WriteBlocksToReplica(1, secondDeviceOneBlock, 'B');
+        env.WriteBlocksToReplica(2, secondDeviceOneBlock, 'B');
+
+        bool seenHealthCheck = false;
+        bool seenMigrationReads = false;
+        bool seenMigrationWrites = false;
+        bool seenMigrationFinish = false;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadBlocksRequest: {
+                        if (!FindPtr(env.ReplicaActors, event->Recipient)) {
+                            break;
+                        }
+                        auto* msg =
+                            event->Get<TEvService::TEvReadBlocksRequest>();
+                        auto clientId = msg->Record.GetHeaders().GetClientId();
+                        if (clientId == CheckHealthClientId) {
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                env.ReplicaActors[0],
+                                event->Recipient);
+                            seenHealthCheck = true;
+                        } else if (clientId == BackgroundOpsClientId) {
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                env.ReplicaActors[1],
+                                event->Recipient);
+                            seenMigrationReads = true;
+                        }
+                        break;
+                    }
+                    case TEvService::EvWriteBlocksRequest: {
+                        if (event->Recipient != env.ReplicaActors[0]) {
+                            break;
+                        }
+                        auto* msg =
+                            event->Get<TEvService::TEvWriteBlocksRequest>();
+                        if (msg->Record.GetHeaders().GetClientId() ==
+                            BackgroundOpsClientId)
+                        {
+                            UNIT_ASSERT(seenMigrationReads);
+                            seenMigrationWrites = true;
+                        }
+                        break;
+                    }
+                    case TEvVolumePrivate::EvLaggingAgentMigrationFinished: {
+                        UNIT_ASSERT(seenMigrationWrites);
+                        seenMigrationFinish = true;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        runtime.AdvanceCurrentTime(env.Config->GetLaggingDevicePingInterval());
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        UNIT_ASSERT(seenHealthCheck);
+        UNIT_ASSERT(seenMigrationReads);
+        UNIT_ASSERT(seenMigrationWrites);
+        UNIT_ASSERT(seenMigrationFinish);
+        env.ReadFromReplicaAndCheckContents(0, firstAndSecondDevices, 'B');
+    }
+
+    Y_UNIT_TEST(ShouldMigrateDirtyBlocks)
+    {
+        ShouldMigrateDirtyBlocks(false);
+        ShouldMigrateDirtyBlocks(true);
+    }
+
+    void ShouldNotWriteToLaggingDevices(bool localRequests)
+    {
+        TTestBasicRuntime runtime(AgentCount);
+        TTestEnv env(runtime, localRequests);
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange = TBlockRange64::WithLength(
+            0,
+            DeviceBlockCount * DeviceCountPerReplica);
+        env.WriteBlocksToPartition(fullDiskRange, 'A');
+
+        // Second row in the third column is lagging.
+        env.AddLaggingAgent(runtime.GetNodeId(7), 2);
+
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvWriteBlocksRequest: {
+                        UNIT_ASSERT_VALUES_UNEQUAL(
+                            event->Recipient,
+                            env.ReplicaActors[2]);
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // Writes across the first and second devices should write only to the
+        // first one.
+        const auto secondDeviceStart =
+            TBlockRange64::WithLength(DeviceBlockCount, 1);
+        const auto secondDeviceEnd =
+            TBlockRange64::WithLength(DeviceBlockCount * 2 - 1, 1);
+        env.WriteBlocksToController(2, secondDeviceStart, 'B');
+        env.WriteBlocksToController(2, secondDeviceEnd, 'C');
+
+        // Write to the first replica for migration validation.
+        env.WriteBlocksToReplica(0, secondDeviceStart, 'Y');
+        env.WriteBlocksToReplica(0, secondDeviceEnd, 'Z');
+
+        runtime.SetEventFilter([&](TTestActorRuntimeBase&,
+                                   TAutoPtr<IEventHandle>&) { return false; });
+
+        // Migration should copy the data from first replica to the third.
+        env.WaitForMigrationFinishEvent();
+        env.ReadFromReplicaAndCheckContents(2, secondDeviceStart, 'Y');
+        env.ReadFromReplicaAndCheckContents(2, secondDeviceEnd, 'Z');
+    }
+
+    Y_UNIT_TEST(ShouldNotWriteToLaggingDevices)
+    {
+        ShouldNotWriteToLaggingDevices(false);
+        ShouldNotWriteToLaggingDevices(true);
+    }
+
+    void LaggingAgentTwice(bool localRequests)
+    {
+        TTestBasicRuntime runtime(AgentCount);
+        TTestEnv env(runtime, localRequests);
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange = TBlockRange64::WithLength(
+            0,
+            DeviceBlockCount * DeviceCountPerReplica);
+        env.WriteBlocksToPartition(fullDiskRange, '0');
+
+        // Second row in the first column is lagging.
+        auto laggingAgent = env.AddLaggingAgent(runtime.GetNodeId(1), 0);
+
+        // Mark first half as dirty.
+        const auto secondDeviceFirstHalf =
+            TBlockRange64::WithLength(DeviceBlockCount, DeviceBlockCount / 2);
+        env.WriteBlocksToController(0, secondDeviceFirstHalf, 'A');
+
+        bool seenHealthCheck = false;
+        bool seenMigrationReads = false;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadBlocksRequest: {
+                        if (event->Recipient != env.ReplicaActors[0]) {
+                            break;
+                        }
+                        auto* msg =
+                            event->Get<TEvService::TEvReadBlocksRequest>();
+                        auto clientId = msg->Record.GetHeaders().GetClientId();
+                        if (clientId == CheckHealthClientId) {
+                            seenHealthCheck = true;
+                        } else if (clientId == BackgroundOpsClientId) {
+                            UNIT_ASSERT(seenHealthCheck);
+                            seenMigrationReads = true;
+                        }
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // Health check should happen and notify the controller that the replica
+        // is back online. Migration should start immediately after that.
+        env.WaitForMigrationFinishEvent();
+
+        // The agent is lagging again.
+        seenHealthCheck = seenMigrationReads = false;
+        env.AddLaggingAgent(runtime.GetNodeId(1), 0);
+
+        // Mark second half as dirty.
+        const auto secondDeviceSecondHalf = TBlockRange64::MakeClosedInterval(
+            DeviceBlockCount * 1.5,
+            DeviceBlockCount * 2 - 1);
+        env.WriteBlocksToController(0, secondDeviceSecondHalf, 'B');
+
+        // Initialize good replica to validate migration.
+        const auto secondDevice =
+            TBlockRange64::WithLength(DeviceBlockCount, DeviceBlockCount);
+        env.WriteBlocksToReplica(1, secondDevice, 'C');
+
+        // Wait for migration finish.
+        env.WaitForMigrationFinishEvent();
+
+        // Migration should migrate whole second device.
+        env.ReadFromReplicaAndCheckContents(0, secondDevice, 'C');
+
+        const auto firstDevice = TBlockRange64::WithLength(0, DeviceBlockCount);
+        const auto thirdDevice =
+            TBlockRange64::WithLength(DeviceBlockCount * 2, DeviceBlockCount);
+        env.ReadFromReplicaAndCheckContents(0, firstDevice, '0');
+        env.ReadFromReplicaAndCheckContents(0, thirdDevice, '0');
+    }
+
+    Y_UNIT_TEST(LaggingAgentTwice)
+    {
+        LaggingAgentTwice(false);
+        LaggingAgentTwice(true);
+    }
+
+    void MultipleLaggingAgentsOnOneReplica(bool localRequests)
+    {
+        TTestBasicRuntime runtime(AgentCount);
+        TTestEnv env(runtime, localRequests);
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange = TBlockRange64::WithLength(
+            0,
+            DeviceBlockCount * DeviceCountPerReplica);
+        env.WriteBlocksToPartition(fullDiskRange, '0');
+
+        TVector<TActorId> writeBlocksRecipients;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvWriteBlocksLocalRequest:
+                    case TEvService::EvWriteBlocksRequest: {
+                        if (event->Sender != env.GetControllerActorId(0)) {
+                            break;
+                        }
+                        auto* msg =
+                            event->Get<TEvService::TEvReadBlocksRequest>();
+                        auto clientId = msg->Record.GetHeaders().GetClientId();
+                        if (clientId == BackgroundOpsClientId) {
+                            break;
+                        }
+                        writeBlocksRecipients.push_back(event->Recipient);
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // First row in the first column is lagging.
+        env.AddLaggingAgent(runtime.GetNodeId(0), 0);
+
+        // Wait for migration finish of the first row.
+        env.WaitForMigrationFinishEvent();
+
+        // Third row in the first column is lagging.
+        env.AddLaggingAgent(runtime.GetNodeId(2), 0);
+
+        constexpr int HalfRangeCount = DeviceCountPerReplica * 2;
+        std::array<TBlockRange64, HalfRangeCount> ranges;
+        for (int i = 0; i < HalfRangeCount; i++) {
+            ranges[i] = TBlockRange64::WithLength(
+                DeviceBlockCount * i / 2,
+                DeviceBlockCount / 2);
+        }
+        // Migrating controller should write data to replica.
+        env.WriteBlocksToController(
+            0,
+            UnifyClosedIntervals(ranges[1], ranges[2]),
+            'A');
+        env.ReadFromReplicaAndCheckContents(
+            0,
+            UnifyClosedIntervals(ranges[1], ranges[2]),
+            'A');
+
+        // When an agent is unavailable, we just mark the dirty blocks.
+        env.WriteBlocksToController(
+            0,
+            UnifyClosedIntervals(ranges[3], ranges[4]),
+            'B');
+        env.ReadFromReplicaAndCheckContents(0, ranges[3], 'B');
+        env.ReadFromReplicaAndCheckContents(0, ranges[4], '0');
+
+        // Second row in the first column is lagging.
+        env.AddLaggingAgent(runtime.GetNodeId(1), 0);
+
+        // Controller should write data to replica with migrating agent and skip
+        // unavailable one.
+        env.WriteBlocksToController(
+            0,
+            UnifyClosedIntervals(ranges[1], ranges[2]),
+            'C');
+        env.ReadFromReplicaAndCheckContents(0, ranges[1], 'C');
+        env.ReadFromReplicaAndCheckContents(0, ranges[2], 'A');
+    }
+
+    Y_UNIT_TEST(MultipleLaggingAgentsOnOneReplica)
+    {
+        MultipleLaggingAgentsOnOneReplica(false);
+        MultipleLaggingAgentsOnOneReplica(true);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h
@@ -108,7 +108,9 @@ TMirrorRequestActor<TMethod>::TMirrorRequestActor(
     , DiskId(std::move(diskId))
     , ParentActorId(parentActorId)
     , NonreplicatedRequestCounter(nonreplicatedRequestCounter)
-{}
+{
+    Y_DEBUG_ABORT_UNLESS(GetTotalPartitionCount() > 0);
+}
 
 template <typename TMethod>
 void TMirrorRequestActor<TMethod>::Bootstrap(const NActors::TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
@@ -19,6 +19,23 @@ TProcessingBlocks::TProcessingBlocks(
     }
 }
 
+TProcessingBlocks::TProcessingBlocks(
+        ui64 blockCount,
+        ui32 blockSize,
+        TCompressedBitmap blockMap)
+    : BlockCount(blockCount)
+    , BlockSize(blockSize)
+    , BlockMap(std::make_unique<TCompressedBitmap>(std::move(blockMap)))
+{
+    SkipProcessedRanges();
+}
+
+TProcessingBlocks::TProcessingBlocks(
+    TProcessingBlocks&& other) noexcept = default;
+
+TProcessingBlocks& TProcessingBlocks::operator=(
+    TProcessingBlocks&& other) noexcept = default;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TProcessingBlocks::AbortProcessing()
@@ -101,7 +118,7 @@ ui64 TProcessingBlocks::GetBlockCountNeedToBeProcessed() const
 
 ui64 TProcessingBlocks::GetProcessedBlockCount() const
 {
-    if (BlockMap) {
+    if (IsProcessing()) {
         return BlockMap->Count();
     }
     return BlockCount;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
@@ -19,8 +19,8 @@ constexpr ui64 ProcessingRangeSize = 4_MB;
 class TProcessingBlocks
 {
 private:
-    const ui64 BlockCount;
-    const ui32 BlockSize;
+    ui64 BlockCount;
+    ui32 BlockSize;
     std::unique_ptr<TCompressedBitmap> BlockMap;
     std::optional<ui64> LastReportedProcessingIndex;
     ui64 CurrentProcessingIndex = 0;
@@ -31,6 +31,14 @@ public:
         ui64 blockCount,
         ui32 blockSize,
         ui64 initialProcessingIndex);
+
+    TProcessingBlocks(
+        ui64 blockCount,
+        ui32 blockSize,
+        TCompressedBitmap blockMap);
+
+    TProcessingBlocks(TProcessingBlocks&& other) noexcept;
+    TProcessingBlocks& operator=(TProcessingBlocks&& other) noexcept;
 
 public:
     void AbortProcessing();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
@@ -1,0 +1,907 @@
+#include "part_mirror.h"
+
+#include "part_mirror_actor.h"
+#include "ut_env.h"
+
+#include <cloud/blockstore/libs/diagnostics/block_digest.h>
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+#include <cloud/blockstore/libs/storage/testlib/diagnostics.h>
+#include <cloud/blockstore/libs/storage/testlib/disk_agent_mock.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+#include <cloud/storage/core/libs/common/sglist_test.h>
+
+#include <contrib/ydb/core/testlib/basics/runtime.h>
+#include <contrib/ydb/core/testlib/tablet_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui64 DeviceBlockCount = 4096;
+
+[[nodiscard]] TBlockRange64 UnifyClosedIntervals(
+    const TBlockRange64& first,
+    const TBlockRange64& second)
+{
+    Y_DEBUG_ABORT_UNLESS(
+        first.Start - 1 <= second.End && second.Start - 1 <= first.End);
+    auto start = Min(first.Start, second.Start);
+    auto end = Max(first.End, second.End);
+    return TBlockRange64::MakeClosedInterval(start, end);
+}
+
+struct TTestEnv
+{
+    TTestBasicRuntime& Runtime;
+    const TDevices Devices;
+    const TVector<TDevices> Replicas;
+    const TMigrations Migrations;
+    TStorageConfigPtr Config;
+    TActorId MirrorPartActorId;
+    TActorId VolumeActorId;
+    TStorageStatsServiceStatePtr StorageStatsServiceState;
+    TVector<TDiskAgentStatePtr> DiskAgentStates;
+    TVector<TActorId> ReplicaActors;
+    TVector<TActorId> DiskAgentActors;
+
+    TVector<NProto::TLaggingAgent> LaggingAgents;
+
+    static void AddDevice(
+        ui32 nodeId,
+        ui32 blockCount,
+        TString name,
+        TString agentId,
+        TDevices& devices)
+    {
+        auto& device = *devices.Add();
+        device.SetNodeId(nodeId);
+        device.SetBlocksCount(blockCount);
+        device.SetDeviceUUID(std::move(name));
+        device.SetBlockSize(DefaultBlockSize);
+        device.SetAgentId(std::move(agentId));
+    }
+
+    static TDevices DefaultDevices(ui64 nodeId, TString agentId)
+    {
+        TDevices devices;
+        AddDevice(nodeId, DeviceBlockCount, "uuid-1", agentId, devices);
+        AddDevice(nodeId, DeviceBlockCount, "uuid-2", agentId, devices);
+        AddDevice(nodeId, DeviceBlockCount, "uuid-3", agentId, devices);
+
+        return devices;
+    }
+
+    static TDevices DefaultReplica(ui64 nodeId, ui32 replicaId, TString agentId)
+    {
+        auto devices = DefaultDevices(nodeId, std::move(agentId));
+        for (auto& device: devices) {
+            if (device.GetDeviceUUID()) {
+                device.SetDeviceUUID(
+                    TStringBuilder()
+                    << device.GetDeviceUUID() << "/" << replicaId);
+            }
+        }
+        return devices;
+    }
+
+    explicit TTestEnv(TTestBasicRuntime& runtime)
+        : TTestEnv(
+              runtime,
+              DefaultDevices(runtime.GetNodeId(0), "agent-1"),
+              TVector<TDevices>{
+                  DefaultReplica(runtime.GetNodeId(1), 1, "agent-2"),
+                  DefaultReplica(runtime.GetNodeId(2), 2, "agent-3"),
+              },
+              {},   // migrations
+              {},   // freshDeviceIds
+              {},   // laggingDeviceIds
+              {std::make_shared<TDiskAgentState>(),
+               std::make_shared<TDiskAgentState>(),
+               std::make_shared<TDiskAgentState>()},
+              {}   // configBase
+          )
+    {}
+
+    TTestEnv(
+        TTestBasicRuntime& runtime,
+        TDevices devices,
+        TVector<TDevices> replicas,
+        TMigrations migrations = {},
+        THashSet<TString> freshDeviceIds = {},
+        THashSet<TString> laggingDeviceIds = {},
+        TVector<TDiskAgentStatePtr> diskAgentStates = {},
+        NProto::TStorageServiceConfig configBase = {})
+        : Runtime(runtime)
+        , Devices(std::move(devices))
+        , Replicas(std::move(replicas))
+        , Migrations(std::move(migrations))
+        , MirrorPartActorId(Runtime.GetNodeId(0), "mirror-part")
+        , VolumeActorId(Runtime.GetNodeId(0), "volume")
+        , StorageStatsServiceState(MakeIntrusive<TStorageStatsServiceState>())
+        , DiskAgentStates(std::move(diskAgentStates))
+    {
+        SetupLogging();
+
+        Runtime.SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase& runtime,
+                const auto& parentId,
+                const auto& actorId)
+            {
+                runtime.EnableScheduleForActor(actorId);
+                auto mirrorActorId =
+                    runtime.GetLocalServiceId(MirrorPartActorId);
+                if (mirrorActorId && parentId == mirrorActorId &&
+                    ReplicaActors.size() < 3)
+                {
+                    AddReplica(actorId);
+                }
+            });
+
+        auto volume = std::make_unique<TDummyActor>();
+        Runtime.AddLocalService(
+            VolumeActorId,
+            TActorSetupCmd(volume.release(), TMailboxType::Simple, 0));
+
+        auto diskRegistry = std::make_unique<TDummyActor>();
+        Runtime.AddLocalService(
+            MakeDiskRegistryProxyServiceId(),
+            TActorSetupCmd(diskRegistry.release(), TMailboxType::Simple, 0));
+
+        Runtime.AddLocalService(
+            MakeStorageStatsServiceId(),
+            TActorSetupCmd(
+                new TStorageStatsServiceMock(StorageStatsServiceState),
+                TMailboxType::Simple,
+                0));
+
+        NProto::TStorageServiceConfig storageConfig = std::move(configBase);
+        storageConfig.SetMaxMigrationIoDepth(4);
+        storageConfig.SetLaggingDevicePingInterval(100);
+        storageConfig.SetLaggingDevicePingInterval(
+            TDuration::Seconds(30).MilliSeconds());
+        Config = std::make_shared<TStorageConfig>(
+            std::move(storageConfig),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig()));
+
+        auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
+            Devices,
+            NProto::VOLUME_IO_OK,
+            "vol0",
+            DefaultBlockSize,
+            TNonreplicatedPartitionConfig::TVolumeInfo{
+                Now(),
+                // only SSD/HDD distinction matters
+                NProto::STORAGE_MEDIA_SSD_MIRROR3},
+            VolumeActorId,
+            false,   // muteIOErrors
+            std::move(freshDeviceIds),
+            std::move(laggingDeviceIds),
+            TDuration::Zero(),   // maxTimedOutDeviceStateDuration
+            false,               // maxTimedOutDeviceStateDurationOverridden
+            false                // useSimpleMigrationBandwidthLimiter
+        );
+
+        auto mirrorPartition = std::make_unique<TMirrorPartitionActor>(
+            Config,
+            CreateDiagnosticsConfig(),
+            CreateProfileLogStub(),
+            CreateBlockDigestGeneratorStub(),
+            "",   // rwClientId
+            partConfig,
+            std::move(migrations),
+            Replicas,
+            nullptr,   // rdmaClient
+            VolumeActorId,
+            TActorId()   // resyncActorId
+        );
+
+        Runtime.AddLocalService(
+            MirrorPartActorId,
+            TActorSetupCmd(mirrorPartition.release(), TMailboxType::Simple, 0));
+
+        NKikimr::SetupTabletServices(Runtime);
+        TDevices allDevices;
+        for (const auto& d: Devices) {
+            allDevices.Add()->CopyFrom(d);
+        }
+        for (const auto& r: Replicas) {
+            for (const auto& d: r) {
+                allDevices.Add()->CopyFrom(d);
+            }
+        }
+        for (auto& m: migrations) {
+            allDevices.Add()->CopyFrom(m.GetTargetDevice());
+        }
+
+        Sort(
+            allDevices,
+            [](const NProto::TDeviceConfig& lhs,
+               const NProto::TDeviceConfig& rhs)
+            { return lhs.GetNodeId() < rhs.GetNodeId(); });
+        const ui32 agentCount = DiskAgentStates.size();
+        for (ui32 i = 0; i < agentCount; i++) {
+            struct TByNodeId
+            {
+                auto operator()(const NProto::TDeviceConfig& device) const
+                {
+                    return device.GetNodeId();
+                }
+            };
+            const ui32 nodeId = Runtime.GetNodeId(i);
+            auto begin = LowerBoundBy(
+                allDevices.begin(),
+                allDevices.end(),
+                nodeId,
+                TByNodeId());
+            auto end = UpperBoundBy(
+                allDevices.begin(),
+                allDevices.end(),
+                nodeId,
+                TByNodeId());
+
+            const auto actorId = Runtime.Register(
+                new TDiskAgentMock(
+                    {
+                        begin,
+                        end,
+                    },
+                    DiskAgentStates[i]),
+                i);
+            DiskAgentActors.push_back(MakeDiskAgentServiceId(nodeId));
+            Runtime.RegisterService(MakeDiskAgentServiceId(nodeId), actorId, i);
+        }
+    }
+
+    void AddReplica(TActorId partActorId)
+    {
+        ReplicaActors.push_back(partActorId);
+    }
+
+    void ReadAndCheckContents(TBlockRange64 range, char content)
+    {
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        for (int i = 0; i < 3; i++) {
+            auto response = client.ReadBlocks(range);
+            const auto& blocks = response->Record.GetBlocks();
+            UNIT_ASSERT_VALUES_EQUAL(range.Size(), blocks.BuffersSize());
+            for (ui32 j = 0; j < blocks.BuffersSize(); ++j) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    TString(DefaultBlockSize, content),
+                    blocks.GetBuffers(j),
+                    TStringBuilder() << "Block number: " << j);
+            }
+        }
+    }
+
+    void
+    ReadAndCheckContents(ui32 replicaIndex, TBlockRange64 range, char content)
+    {
+        TPartitionClient client(Runtime, ReplicaActors[replicaIndex]);
+        auto response = client.ReadBlocks(range);
+        const auto& blocks = response->Record.GetBlocks();
+        UNIT_ASSERT_VALUES_EQUAL(range.Size(), blocks.BuffersSize());
+        for (ui32 j = 0; j < blocks.BuffersSize(); ++j) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                TString(DefaultBlockSize, content),
+                blocks.GetBuffers(j),
+                TStringBuilder() << "Block number: " << j);
+        }
+    }
+
+    void SetupLogging()
+    {
+        Runtime.AppendToLogSettings(
+            TBlockStoreComponents::START,
+            TBlockStoreComponents::END,
+            GetComponentName);
+
+        for (int i = TBlockStoreComponents::START;
+             i < TBlockStoreComponents::END;
+             ++i)
+        {
+            Runtime.SetLogPriority(i, NLog::PRI_DEBUG);
+        }
+    }
+
+    void AddLaggingAgent(const TString& agentId)
+    {
+        NProto::TLaggingAgent laggingAgent;
+        for (int i = 0; i < Devices.size(); i++) {
+            const auto& device = Devices[i];
+            if (device.GetAgentId() == agentId) {
+                laggingAgent.SetAgentId(device.GetAgentId());
+                laggingAgent.SetReplicaIndex(0);
+
+                NProto::TLaggingDevice* laggingDevice =
+                    laggingAgent.AddDevices();
+                laggingDevice->SetDeviceUUID(device.GetDeviceUUID());
+                laggingDevice->SetRowIndex(i);
+            }
+        }
+
+        for (size_t replicaIndex = 0; replicaIndex < Replicas.size();
+             replicaIndex++)
+        {
+            for (int i = 0; i < Replicas[replicaIndex].size(); i++) {
+                const auto& device = Replicas[replicaIndex][i];
+                if (device.GetAgentId() == agentId) {
+                    laggingAgent.SetAgentId(device.GetAgentId());
+                    laggingAgent.SetReplicaIndex(replicaIndex + 1);
+
+                    NProto::TLaggingDevice* laggingDevice =
+                        laggingAgent.AddDevices();
+                    laggingDevice->SetDeviceUUID(device.GetDeviceUUID());
+                    laggingDevice->SetRowIndex(i);
+                }
+            }
+        }
+
+        Y_DEBUG_ABORT_UNLESS(!laggingAgent.GetAgentId().empty());
+        LaggingAgents.push_back(laggingAgent);
+
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        client.SendRequest(
+            MirrorPartActorId,
+            std::make_unique<
+                TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest>(
+                std::move(laggingAgent)));
+        Runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+    }
+
+    void RemoveLaggingAgent(const TString& agentId)
+    {
+        auto* laggingAgent = FindIfPtr(
+            LaggingAgents,
+            [&agentId](const NProto::TLaggingAgent& laggingAgent)
+            { return laggingAgent.GetAgentId() == agentId; });
+        Y_DEBUG_ABORT_UNLESS(laggingAgent);
+
+        TPartitionClient client(Runtime, MirrorPartActorId);
+        client.SendRequest(
+            MirrorPartActorId,
+            std::make_unique<
+                TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest>(
+                *laggingAgent));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
+{
+    Y_UNIT_TEST(ShouldDisableIOForOutdatedDevices)
+    {
+        constexpr ui32 AgentCount = 3;
+        TTestBasicRuntime runtime(AgentCount);
+
+        TTestEnv env(
+            runtime,
+            TTestEnv::DefaultDevices(runtime.GetNodeId(0), "agent-1"),
+            TVector<TDevices>{
+                TTestEnv::DefaultReplica(runtime.GetNodeId(1), 1, "agent-2"),
+                TTestEnv::DefaultReplica(runtime.GetNodeId(2), 2, "agent-3"),
+            },
+            {},                       // migrations
+            {},                       // freshDeviceIds
+            {"uuid-1", "uuid-2/1"},   // laggingDeviceIds
+            {std::make_shared<TDiskAgentState>(),
+             std::make_shared<TDiskAgentState>(),
+             std::make_shared<TDiskAgentState>()},
+            NProto::TStorageServiceConfig{});
+
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        constexpr ui32 RequestSize = 1024;
+        const auto firstRow = TBlockRange64::WithLength(0, RequestSize);
+        const auto secondRow =
+            TBlockRange64::WithLength(DeviceBlockCount, RequestSize);
+        const auto thirdRow =
+            TBlockRange64::WithLength(DeviceBlockCount * 2, RequestSize);
+        const auto secondAndThirdRow =
+            TBlockRange64::WithLength((DeviceBlockCount * 2) - 1, RequestSize);
+
+        TVector<TActorId> readActors;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadBlocksRequest: {
+                        if (event->Recipient == env.MirrorPartActorId) {
+                            break;
+                        }
+                        readActors.push_back(event->Recipient);
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // Read blocks three times from the first row. Mirror partition should
+        // read from the 1st and 2nd replicas.
+        for (int i = 0; i < 3; i++) {
+            client.ReadBlocks(firstRow);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(3, readActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[1]) +
+                Count(readActors, env.ReplicaActors[2]));
+        readActors.clear();
+
+        // Read blocks three times from the second row. Mirror partition should
+        // read from the 0th and 2nd replicas.
+        for (int i = 0; i < 3; i++) {
+            client.ReadBlocks(secondRow);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(3, readActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[2]));
+        readActors.clear();
+
+        // Read blocks three times from the third row. Mirror partition should
+        // read once from each replica.
+        for (int i = 0; i < 3; i++) {
+            client.ReadBlocks(thirdRow);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(3, readActors.size());
+        ASSERT_VECTOR_CONTENTS_EQUAL(env.ReplicaActors, readActors);
+        readActors.clear();
+
+        // Read blocks three times from the both second and third rows. Mirror
+        // partition should read from the 0th and 2nd replicas.
+        for (int i = 0; i < 3; i++) {
+            client.ReadBlocks(secondAndThirdRow);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(3, readActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[2]));
+        readActors.clear();
+
+        // Write blocks into the first row. The request should be rejected since
+        // uuid-1 is lagging.
+        {
+            client.SendWriteBlocksRequest(firstRow, 'A');
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // Write blocks into the second row. The request should be rejected
+        // since uuid-2/1 is lagging.
+        {
+            client.SendWriteBlocksRequest(secondRow, 'B');
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // Write blocks into the third row.
+        {
+            client.SendWriteBlocksRequest(thirdRow, 'C');
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // Write blocks into the second and third rows. The request should be
+        // rejected since uuid-2/1 is lagging.
+        {
+            client.SendWriteBlocksRequest(secondAndThirdRow, 'D');
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldNotReadFromLaggingDevices)
+    {
+        constexpr ui32 AgentCount = 3;
+        TTestBasicRuntime runtime(AgentCount);
+
+        TTestEnv env(runtime);
+
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange =
+            TBlockRange64::WithLength(0, DeviceBlockCount * 3);
+        client.WriteBlocks(fullDiskRange, 'A');
+
+        TVector<TActorId> readActors;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadBlocksRequest: {
+                        if (event->Recipient == env.MirrorPartActorId) {
+                            break;
+                        }
+                        readActors.push_back(event->Recipient);
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // Read blocks three times. Mirror partition should read one time from
+        // each replica.
+        env.ReadAndCheckContents(fullDiskRange, 'A');
+        UNIT_ASSERT_VALUES_EQUAL(3, readActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(env.ReplicaActors.size(), readActors.size());
+        ASSERT_VECTOR_CONTENTS_EQUAL(env.ReplicaActors, readActors);
+        readActors.clear();
+
+        // First replica is lagging.
+        env.AddLaggingAgent(env.Devices[0].GetAgentId());
+
+        // Read blocks three times. We should not read from the lagging replica.
+        env.ReadAndCheckContents(fullDiskRange, 'A');
+        UNIT_ASSERT_VALUES_EQUAL(3, readActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[1]) +
+                Count(readActors, env.ReplicaActors[2]));
+    }
+
+    Y_UNIT_TEST(ShouldNotWriteOnLaggingAgents)
+    {
+        constexpr ui32 AgentCount = 3;
+        TTestBasicRuntime runtime(AgentCount);
+
+        TTestEnv env(runtime);
+
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange =
+            TBlockRange64::WithLength(0, DeviceBlockCount * 3);
+        client.WriteBlocks(fullDiskRange, 'A');
+
+        TVector<TActorId> readActors;
+        TVector<TActorId> writeDiskAgentActors;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadBlocksRequest: {
+                        if (event->Recipient == env.MirrorPartActorId) {
+                            break;
+                        }
+                        readActors.push_back(event->Recipient);
+                        break;
+                    }
+                    case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
+                        writeDiskAgentActors.push_back(event->Recipient);
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // First replica is lagging.
+        env.AddLaggingAgent(env.Replicas[0][0].GetAgentId());
+
+        constexpr ui32 RequestSize = 1024;
+        const auto firstRow = TBlockRange64::WithLength(0, RequestSize);
+        const auto secondRow =
+            TBlockRange64::WithLength(DeviceBlockCount, RequestSize);
+        const auto thirdRow =
+            TBlockRange64::WithLength(DeviceBlockCount * 2, RequestSize);
+        const auto secondAndThirdRow =
+            TBlockRange64::WithLength((DeviceBlockCount * 2) - 1, RequestSize);
+
+        client.WriteBlocks(firstRow, 'B');
+        UNIT_ASSERT_VALUES_EQUAL(2, writeDiskAgentActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            writeDiskAgentActors.size(),
+            Count(writeDiskAgentActors, env.DiskAgentActors[0]) +
+                Count(writeDiskAgentActors, env.DiskAgentActors[2]));
+        env.ReadAndCheckContents(firstRow, 'B');
+        writeDiskAgentActors.clear();
+
+        client.WriteBlocks(secondRow, 'C');
+        UNIT_ASSERT_VALUES_EQUAL(2, writeDiskAgentActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            writeDiskAgentActors.size(),
+            Count(writeDiskAgentActors, env.DiskAgentActors[0]) +
+                Count(writeDiskAgentActors, env.DiskAgentActors[2]));
+        env.ReadAndCheckContents(secondRow, 'C');
+        writeDiskAgentActors.clear();
+
+        client.WriteBlocks(thirdRow, 'D');
+        UNIT_ASSERT_VALUES_EQUAL(2, writeDiskAgentActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            writeDiskAgentActors.size(),
+            Count(writeDiskAgentActors, env.DiskAgentActors[0]) +
+                Count(writeDiskAgentActors, env.DiskAgentActors[2]));
+        env.ReadAndCheckContents(thirdRow, 'D');
+        writeDiskAgentActors.clear();
+
+        client.WriteBlocks(secondAndThirdRow, 'E');
+        UNIT_ASSERT_VALUES_EQUAL(4, writeDiskAgentActors.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            writeDiskAgentActors.size(),
+            Count(writeDiskAgentActors, env.DiskAgentActors[0]) +
+                Count(writeDiskAgentActors, env.DiskAgentActors[2]));
+        env.ReadAndCheckContents(secondAndThirdRow, 'E');
+        writeDiskAgentActors.clear();
+    }
+
+    Y_UNIT_TEST(ShouldAddAndRemoveLaggingAgents)
+    {
+        constexpr ui32 AgentCount = 10;
+        TTestBasicRuntime runtime(AgentCount);
+
+        TVector<TDiskAgentStatePtr> diskAgentStates;
+        for (ui32 i = 0; i < AgentCount; i++) {
+            diskAgentStates.push_back(std::make_shared<TDiskAgentState>());
+        }
+
+        TDevices devices;
+        for (int i = 0; i < 3; i++) {
+            TTestEnv::AddDevice(
+                runtime.GetNodeId(i),
+                DeviceBlockCount,
+                Sprintf("uuid-%u", i),
+                Sprintf("agent-%u", i),
+                devices);
+        }
+
+        TVector<TDevices> replicas;
+        for (int i = 0; i < 2; i++) {
+            replicas.push_back(TDevices());
+            for (int j = 0; j < 3; j++) {
+                auto& devices = replicas.back();
+                const ui32 num = (i + 1) * 3 + j;
+                TTestEnv::AddDevice(
+                    runtime.GetNodeId(num),
+                    DeviceBlockCount,
+                    Sprintf("uuid-%u", num),
+                    Sprintf("agent-%u", num),
+                    devices);
+            }
+        }
+
+        TMigrations migrations;
+        {
+            NProto::TDeviceMigration* migration = migrations.Add();
+            migration->SetSourceDeviceId("uuid-3");
+
+            auto& targetDevice = *migration->MutableTargetDevice();
+            targetDevice.SetNodeId(runtime.GetNodeId(AgentCount - 1));
+            targetDevice.SetBlocksCount(DeviceBlockCount);
+            targetDevice.SetDeviceUUID("uuid-m");
+            targetDevice.SetBlockSize(DefaultBlockSize);
+            targetDevice.SetAgentId("agent-m");
+        }
+
+        TTestEnv env(
+            runtime,
+            std::move(devices),
+            std::move(replicas),
+            std::move(migrations),
+            {"uuid-7"},   // freshDeviceIds
+            {},           // laggingDeviceIds
+            std::move(diskAgentStates),
+            {});
+
+        // Migrate all the ranges.
+        for (int i = 0; i < 10; i++) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(4));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+
+        // Current disk config:
+        // ┌──────────────────┬──────────────────┬────────────────┐
+        // │ uuid-0           │ uuid-3 -> uuid-m │ uuid-6         │
+        // │──────────────────┼──────────────────┼────────────────│
+        // │ uuid-1           │ uuid-4           │ uuid-7 (Fresh) │
+        // │──────────────────┼──────────────────┼────────────────│
+        // │ uuid-2           │ uuid-5           │ uuid-8         │
+        // └──────────────────┴──────────────────┴────────────────┘
+
+        TPartitionClient client(runtime, env.MirrorPartActorId);
+
+        const auto fullDiskRange =
+            TBlockRange64::WithLength(0, DeviceBlockCount * 3);
+        client.WriteBlocks(fullDiskRange, 'A');
+
+        TVector<TActorId> mirrorActorChildren;
+        runtime.SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase&,
+                const auto& parentId,
+                const auto& actorId)
+            {
+                runtime.EnableScheduleForActor(actorId);
+                auto mirrorActorId =
+                    runtime.GetLocalServiceId(env.MirrorPartActorId);
+                Y_DEBUG_ABORT_UNLESS(mirrorActorId);
+                if (parentId == mirrorActorId) {
+                    mirrorActorChildren.push_back(actorId);
+                }
+            });
+
+        TVector<TActorId> readActors;
+        TVector<NProto::TLaggingAgent> unavailableAgents;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvReadBlocksRequest: {
+                        if (event->Recipient == env.MirrorPartActorId) {
+                            break;
+                        }
+                        readActors.push_back(event->Recipient);
+                        break;
+                    }
+                    case TEvNonreplPartitionPrivate::EvAgentIsUnavailable: {
+                        const auto* msg =
+                            event->Get<TEvNonreplPartitionPrivate::
+                                           TEvAgentIsUnavailable>();
+                        unavailableAgents.push_back(msg->LaggingAgent);
+                        break;
+                    }
+                    case TEvents::TEvPoisonPill::EventType: {
+                        auto it = Find(mirrorActorChildren, event->Recipient);
+                        if (it != mirrorActorChildren.end()) {
+                            mirrorActorChildren.erase(it);
+                        }
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        runtime.SetScheduledEventFilter(
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                auto&& delay,
+                auto&& deadline)
+            {
+                Y_UNUSED(runtime);
+                Y_UNUSED(delay);
+                Y_UNUSED(deadline);
+                switch (event->GetTypeRewrite()) {
+                    case TEvents::TEvPoisonPill::EventType: {
+                        auto it = Find(mirrorActorChildren, event->Recipient);
+                        if (it != mirrorActorChildren.end()) {
+                            mirrorActorChildren.erase(it);
+                        }
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // uuid-7 is lagging
+        env.AddLaggingAgent("agent-7");
+        // 1 from mirror partition, 1 from lagging proxy, 2 from migration
+        // partition
+        UNIT_ASSERT_VALUES_EQUAL(4, unavailableAgents.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, mirrorActorChildren.size());
+        TActorId replica2Proxy = mirrorActorChildren.back();
+        unavailableAgents.clear();
+
+        // uuid-8 is lagging
+        env.AddLaggingAgent("agent-8");
+        UNIT_ASSERT_VALUES_EQUAL(4, unavailableAgents.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, mirrorActorChildren.size());
+        unavailableAgents.clear();
+
+        // uuid-3 is lagging
+        env.AddLaggingAgent("agent-3");
+        UNIT_ASSERT_VALUES_EQUAL(2, unavailableAgents.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, mirrorActorChildren.size());
+        TActorId replica1Proxy = mirrorActorChildren.back();
+        unavailableAgents.clear();
+
+        // The first and second replicas
+        const auto firstRow = TBlockRange64::MakeOneBlock(DeviceBlockCount - 1);
+        const auto secondRow = TBlockRange64::MakeOneBlock(DeviceBlockCount);
+        const auto firstAndSecondRows =
+            UnifyClosedIntervals(firstRow, secondRow);
+        client.WriteBlocks(firstAndSecondRows, 'B');
+        env.ReadAndCheckContents(firstRow, 'B');
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[2]));
+        readActors.clear();
+        env.ReadAndCheckContents(secondRow, 'B');
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[1]));
+        readActors.clear();
+
+        env.ReadAndCheckContents(
+            TBlockRange64::MakeOneBlock(firstRow.Start - 1),
+            'A');
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[2]));
+        readActors.clear();
+
+        env.ReadAndCheckContents(
+            TBlockRange64::MakeOneBlock(secondRow.End + 1),
+            'A');
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[1]));
+        readActors.clear();
+
+        // uuid-3 is ok now.
+        env.RemoveLaggingAgent("agent-3");
+        UNIT_ASSERT(FindPtr(mirrorActorChildren, replica1Proxy));
+        env.ReadAndCheckContents(0, firstRow, 'B');
+        env.ReadAndCheckContents(2, firstRow, 'B');
+        // Lagging device still has old data.
+        env.ReadAndCheckContents(1, firstRow, 'A');
+        // Second row is ok.
+        env.ReadAndCheckContents(secondRow, 'B');
+        // Fix the discrepancy.
+        client.WriteBlocks(firstRow, 'B');
+
+        readActors.clear();
+        env.ReadAndCheckContents(firstAndSecondRows, 'B');
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[1]));
+        readActors.clear();
+
+        // Scheduled poison pill has killed the proxy actor.
+        runtime.AdvanceCurrentTime(TDuration::MilliSeconds(50));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        UNIT_ASSERT(!FindPtr(mirrorActorChildren, replica1Proxy));
+
+        // uuid-7 is ok now.
+        env.RemoveLaggingAgent("agent-7");
+        runtime.AdvanceCurrentTime(TDuration::MilliSeconds(50));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        UNIT_ASSERT(FindPtr(mirrorActorChildren, replica2Proxy));
+
+        env.ReadAndCheckContents(TBlockRange64::MakeOneBlock(0), 'A');
+        UNIT_ASSERT_VALUES_EQUAL(1, Count(readActors, env.ReplicaActors[0]));
+        UNIT_ASSERT_VALUES_EQUAL(1, Count(readActors, env.ReplicaActors[1]));
+        UNIT_ASSERT_VALUES_EQUAL(1, Count(readActors, env.ReplicaActors[2]));
+        readActors.clear();
+
+        // uuid-8 is ok now.
+        env.RemoveLaggingAgent("agent-8");
+
+        // Scheduled poison pill has killed the proxy actor.
+        runtime.AdvanceCurrentTime(TDuration::MilliSeconds(50));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        UNIT_ASSERT(!FindPtr(mirrorActorChildren, replica2Proxy));
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -562,6 +562,9 @@ STFUNC(TNonreplicatedPartitionActor::StateWork)
 
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
+        IgnoreFunc(TEvNonreplPartitionPrivate::TEvAgentIsUnavailable);
+        IgnoreFunc(TEvNonreplPartitionPrivate::TEvAgentIsBackOnline);
+
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
 
         default:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
@@ -89,36 +89,6 @@ void TDeviceRequestBuilder::BuildNextRequest(TSgList* sglist)
     ++CurrentDeviceIdx;
 }
 
-void TDeviceRequestBuilder::BuildNextRequest(
-    NProto::TWriteDeviceBlocksRequest& r)
-{
-    Y_ABORT_UNLESS(CurrentDeviceIdx < DeviceRequests.size());
-
-    const auto& deviceRequest = DeviceRequests[CurrentDeviceIdx];
-    for (ui32 i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
-        auto& deviceBuffer = *r.MutableBlocks()->AddBuffers();
-        if (CurrentOffsetInBuffer == 0 && Buffer().size() == BlockSize) {
-            deviceBuffer = std::move(Buffer());
-            ++CurrentBufferIdx;
-        } else {
-            const ui32 rem = Buffer().size() - CurrentOffsetInBuffer;
-            Y_ABORT_UNLESS(rem >= BlockSize);
-            deviceBuffer.resize(BlockSize);
-            memcpy(
-                deviceBuffer.begin(),
-                Buffer().data() + CurrentOffsetInBuffer,
-                BlockSize);
-            CurrentOffsetInBuffer += BlockSize;
-            if (CurrentOffsetInBuffer == Buffer().size()) {
-                CurrentOffsetInBuffer = 0;
-                ++CurrentBufferIdx;
-            }
-        }
-    }
-
-    ++CurrentDeviceIdx;
-}
-
 TString& TDeviceRequestBuilder::Buffer()
 {
     return (*Request.MutableBlocks()->MutableBuffers())[CurrentBufferIdx];

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -239,6 +239,72 @@ struct TEvNonreplPartitionPrivate
     };
 
     //
+    // CancelRequest
+    //
+
+    struct TCancelRequest
+    {
+        enum class EReason {
+            Timeouted,
+            Canceled
+        };
+
+        EReason Reason = EReason::Timeouted;
+    };
+
+    //
+    // AddLaggingAgent
+    //
+
+    struct TAddLaggingAgentRequest
+    {
+        NProto::TLaggingAgent LaggingAgent;
+
+        explicit TAddLaggingAgentRequest(NProto::TLaggingAgent laggingAgent)
+            : LaggingAgent(std::move(laggingAgent))
+        {}
+    };
+
+    //
+    // RemoveLaggingAgent
+    //
+
+    struct TRemoveLaggingAgentRequest
+    {
+        NProto::TLaggingAgent LaggingAgent;
+
+        explicit TRemoveLaggingAgentRequest(NProto::TLaggingAgent laggingAgent)
+            : LaggingAgent(std::move(laggingAgent))
+        {}
+    };
+
+    //
+    // AgentIsUnavailable
+    //
+
+    struct TAgentIsUnavailable
+    {
+        const NProto::TLaggingAgent LaggingAgent;
+
+        explicit TAgentIsUnavailable(NProto::TLaggingAgent laggingAgent)
+            : LaggingAgent(std::move(laggingAgent))
+        {}
+    };
+
+    //
+    // AgentIsBackOnline
+    //
+
+    struct TAgentIsBackOnline
+    {
+        const TString AgentId;
+
+        explicit TAgentIsBackOnline(TString agentId)
+            : AgentId(std::move(agentId))
+        {}
+    };
+
+    //
     // Events declaration
     //
 
@@ -261,6 +327,11 @@ struct TEvNonreplPartitionPrivate
         EvReadResyncFastPathResponse,
         EvGetDeviceForRangeRequest,
         EvGetDeviceForRangeResponse,
+        EvCancelRequest,
+        EvAddLaggingAgentRequest,
+        EvRemoveLaggingAgentRequest,
+        EvAgentIsUnavailable,
+        EvAgentIsBackOnline,
 
         BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(BLOCKSTORE_DECLARE_EVENT_IDS)
 
@@ -319,6 +390,28 @@ struct TEvNonreplPartitionPrivate
     using TEvGetDeviceForRangeResponse = TResponseEvent<
         TGetDeviceForRangeResponse,
         EvGetDeviceForRangeResponse
+    >;
+
+    using TEvCancelRequest = TRequestEvent<TCancelRequest, EvCancelRequest>;
+
+    using TEvAddLaggingAgentRequest = TRequestEvent<
+        TAddLaggingAgentRequest,
+        EvAddLaggingAgentRequest
+    >;
+
+    using TEvRemoveLaggingAgentRequest = TRequestEvent<
+        TRemoveLaggingAgentRequest,
+        EvRemoveLaggingAgentRequest
+    >;
+
+    using TEvAgentIsUnavailable = TRequestEvent<
+        TAgentIsUnavailable,
+        EvAgentIsUnavailable
+    >;
+
+    using TEvAgentIsBackOnline = TRequestEvent<
+        TAgentIsBackOnline,
+        EvAgentIsBackOnline
     >;
 
     BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(BLOCKSTORE_DECLARE_PROTO_EVENTS)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -51,6 +51,7 @@ void TNonreplicatedPartitionMigrationActor::OnBootstrap(
         ctx,
         CreateSrcActor(ctx),
         CreateDstActor(ctx),
+        true,   // takeOwnershipOverActors
         std::make_unique<TMigrationTimeoutCalculator>(
             GetConfig()->GetMaxMigrationBandwidth(),
             GetConfig()->GetExpectedDiskAgentSize(),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -41,10 +41,42 @@ TNonreplicatedPartitionMigrationCommonActor::
     , MaxIoDepth(maxIoDepth)
     , RWClientId(std::move(rwClientId))
     , ProcessingBlocks(blockCount, blockSize, initialMigrationIndex)
-    , ChangedRangesMap(blockCount, blockSize, ProcessingRangeSize)
+    , NonZeroRangesMap(blockCount, blockSize, ProcessingRangeSize)
     , StatActorId(statActorId)
     , PoisonPillHelper(this)
-{}
+{
+}
+
+TNonreplicatedPartitionMigrationCommonActor::
+    TNonreplicatedPartitionMigrationCommonActor(
+        IMigrationOwner* migrationOwner,
+        TStorageConfigPtr config,
+        TDiagnosticsConfigPtr diagnosticsConfig,
+        TString diskId,
+        ui64 blockCount,
+        ui64 blockSize,
+        IProfileLogPtr profileLog,
+        IBlockDigestGeneratorPtr digestGenerator,
+        TCompressedBitmap migrationBlockMap,
+        TString rwClientId,
+        NActors::TActorId statActorId,
+        ui32 maxIoDepth)
+    : MigrationOwner(migrationOwner)
+    , Config(std::move(config))
+    , DiagnosticsConfig(std::move(diagnosticsConfig))
+    , ProfileLog(std::move(profileLog))
+    , DiskId(std::move(diskId))
+    , BlockSize(blockSize)
+    , BlockCount(blockCount)
+    , BlockDigestGenerator(std::move(digestGenerator))
+    , MaxIoDepth(maxIoDepth)
+    , RWClientId(std::move(rwClientId))
+    , ProcessingBlocks(blockCount, blockSize, std::move(migrationBlockMap))
+    , NonZeroRangesMap(blockCount, blockSize, ProcessingRangeSize)
+    , StatActorId(statActorId)
+    , PoisonPillHelper(this)
+{
+}
 
 TNonreplicatedPartitionMigrationCommonActor::
     ~TNonreplicatedPartitionMigrationCommonActor() = default;
@@ -71,6 +103,11 @@ ui64 TNonreplicatedPartitionMigrationCommonActor::
     return ProcessingBlocks.GetBlockCountNeedToBeProcessed();
 }
 
+ui64 TNonreplicatedPartitionMigrationCommonActor::GetProcessedBlockCount() const
+{
+    return ProcessingBlocks.GetProcessedBlockCount();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TNonreplicatedPartitionMigrationCommonActor::HandlePoisonPill(
@@ -82,6 +119,40 @@ void TNonreplicatedPartitionMigrationCommonActor::HandlePoisonPill(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TNonreplicatedPartitionMigrationCommonActor::HandleAgentIsUnavailable(
+    const TEvNonreplPartitionPrivate::TEvAgentIsUnavailable::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    NCloud::Send(
+        ctx,
+        SrcActorId,
+        std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+            msg->LaggingAgent));
+    NCloud::Send(
+        ctx,
+        DstActorId,
+        std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+            msg->LaggingAgent));
+}
+
+void TNonreplicatedPartitionMigrationCommonActor::HandleAgentIsBackOnline(
+    const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    NCloud::Send(
+        ctx,
+        SrcActorId,
+        std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsBackOnline>(
+            msg->AgentId));
+    NCloud::Send(
+        ctx,
+        DstActorId,
+        std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsBackOnline>(
+            msg->AgentId));
+}
 
 void TNonreplicatedPartitionMigrationCommonActor::ScheduleCountersUpdate(
     const TActorContext& ctx)
@@ -165,6 +236,9 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateWork)
 
         HFunc(TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest, HandleChecksumBlocks);
 
+        HFunc(TEvNonreplPartitionPrivate::TEvAgentIsUnavailable, HandleAgentIsUnavailable);
+        HFunc(TEvNonreplPartitionPrivate::TEvAgentIsBackOnline, HandleAgentIsBackOnline);
+
         HFunc(
             NPartition::TEvPartition::TEvDrainRequest,
             DrainActorCompanion.HandleDrain);
@@ -207,7 +281,7 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_NONREPL);
             break;
     }
 }
@@ -264,7 +338,7 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateZombie)
         HFunc(TEvents::TEvPoisonTaken, PoisonPillHelper.HandlePoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_NONREPL);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -98,6 +98,7 @@ private:
 
     NActors::TActorId SrcActorId;
     NActors::TActorId DstActorId;
+    bool ActorOwner = false;
     std::unique_ptr<TMigrationTimeoutCalculator> TimeoutCalculator;
 
     TProcessingBlocks ProcessingBlocks;
@@ -108,7 +109,7 @@ private:
     TDisjointRangeSet MigrationsInProgress;
     TDisjointRangeSet DeferredMigrations;
 
-    TChangedRangesMap ChangedRangesMap;
+    TChangedRangesMap NonZeroRangesMap;
 
     // Current migration progress is persistently stored inside a volume tablet.
     // Once we migrated a range that exceeds currently stored one by configured
@@ -166,6 +167,20 @@ public:
         NActors::TActorId statActorId,
         ui32 maxIoDepth);
 
+    TNonreplicatedPartitionMigrationCommonActor(
+        IMigrationOwner* migrationOwner,
+        TStorageConfigPtr config,
+        TDiagnosticsConfigPtr diagnosticsConfig,
+        TString diskId,
+        ui64 blockCount,
+        ui64 blockSize,
+        IProfileLogPtr profileLog,
+        IBlockDigestGeneratorPtr digestGenerator,
+        TCompressedBitmap migrationBlockMap,
+        TString rwClientId,
+        NActors::TActorId statActorId,
+        ui32 maxIoDepth);
+
     ~TNonreplicatedPartitionMigrationCommonActor() override;
 
     virtual void Bootstrap(const NActors::TActorContext& ctx);
@@ -175,6 +190,7 @@ public:
         const NActors::TActorContext& ctx,
         NActors::TActorId srcActorId,
         NActors::TActorId dstActorId,
+        bool takeOwnershipOverActors,
         std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator);
 
     // Called from the inheritor to start migration.
@@ -188,6 +204,10 @@ public:
     // processed.
     ui64 GetBlockCountNeedToBeProcessed() const;
 
+    // Called from the inheritor to get the number of blocks that were
+    // processed.
+    ui64 GetProcessedBlockCount() const;
+
     // IPoisonPillHelperOwner implementation
     void Die(const NActors::TActorContext& ctx) override
     {
@@ -195,7 +215,7 @@ public:
     }
 
 protected:
-    [[nodiscard]] TString GetChangedBlocks(TBlockRange64 range) const;
+    [[nodiscard]] TString GetNonZeroBlocks(TBlockRange64 range) const;
     const TStorageConfigPtr& GetConfig() const;
     const TDiagnosticsConfigPtr& GetDiagnosticsConfig() const;
 
@@ -241,6 +261,14 @@ private:
 
     void HandleWriteOrZeroCompleted(
         const TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAgentIsUnavailable(
+        const TEvNonreplPartitionPrivate::TEvAgentIsUnavailable::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAgentIsBackOnline(
+        const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleRWClientIdChanged(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -35,8 +35,8 @@ void TNonreplicatedPartitionMigrationCommonActor::InitWork(
 
     ActorOwner = takeOwnershipOverActors;
     if (ActorOwner) {
-    PoisonPillHelper.TakeOwnership(ctx, SrcActorId);
-    PoisonPillHelper.TakeOwnership(ctx, DstActorId);
+        PoisonPillHelper.TakeOwnership(ctx, SrcActorId);
+        PoisonPillHelper.TakeOwnership(ctx, DstActorId);
     }
 
     GetDeviceForRangeCompanion.SetDelegate(SrcActorId);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -97,15 +97,13 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         }
     }
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
     NCloud::Register<TMirrorRequestActor<TMethod>>(
         ctx,
         std::move(requestInfo),
-        TVector<TActorId>{SrcActorId},
+        ActorOwner ? TVector<TActorId>{SrcActorId} : TVector<TActorId>{},
         DstActorId,
         std::move(msg->Record),
         DiskId,
@@ -113,7 +111,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         WriteAndZeroRequestsInProgress.AddWriteRequest(range));
 
     if constexpr (IsExactlyWriteMethod<TMethod>) {
-        ChangedRangesMap.MarkChanged(range);
+        NonZeroRangesMap.MarkChanged(range);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_stats.cpp
@@ -35,6 +35,10 @@ void TNonreplicatedPartitionMigrationCommonActor::HandlePartCounters(
 void TNonreplicatedPartitionMigrationCommonActor::SendStats(
     const TActorContext& ctx)
 {
+    if (!StatActorId) {
+        return;
+    }
+
     auto stats = CreatePartitionDiskCounters(
         EPublishingPolicy::DiskRegistryBased,
         DiagnosticsConfig->GetHistogramCounterOptions());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/partition_nonrepl)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
 SRCS(
+    lagging_agents_replica_proxy_ut.cpp
     migration_timeout_calculator_ut.cpp
     part_mirror_resync_ut.cpp
     part_mirror_split_request_helpers_ut.cpp

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -11,10 +11,12 @@
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/stats_service/stats_service_events_private.h>
+#include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
 #include <cloud/storage/core/libs/common/sglist_test.h>
 #include <cloud/storage/core/libs/kikimr/helpers.h>
 
 #include <contrib/ydb/core/testlib/basics/runtime.h>
+#include <contrib/ydb/library/actors/core/log.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -147,6 +149,9 @@ private:
 
             HFunc(TEvVolume::TEvPreparePartitionMigrationRequest, HandlePreparePartitionMigration);
             HFunc(TEvVolume::TEvUpdateMigrationState, HandleUpdateMigrationState);
+
+            IgnoreFunc(TEvVolumePrivate::TEvLaggingAgentMigrationFinished);
+            IgnoreFunc(TEvVolumePrivate::TEvDeviceTimeoutedRequest);
 
             default:
                 Y_ABORT("Unexpected event %x", ev->GetTypeRewrite());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -1,10 +1,13 @@
 LIBRARY()
 
 SRCS(
+    agent_availability_monitoring_actor.cpp
     checksum_range.cpp
     config.cpp
     copy_range.cpp
     direct_copy_range.cpp
+    lagging_agent_migration_actor.cpp
+    lagging_agents_replica_proxy_actor.cpp
     migration_timeout_calculator.cpp
     mirror_request_actor.cpp
     replica_info.cpp

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -852,6 +852,7 @@ void TShadowDiskActor::CreateShadowDiskPartitionActor(
             ctx,
             SrcActorId,
             DstActorId,
+            true,   // takeOwnershipOverActors
             std::make_unique<TMigrationTimeoutCalculator>(
                 GetConfig()->GetMaxShadowDiskFillBandwidth(),
                 GetConfig()->GetExpectedDiskAgentSize(),
@@ -1226,7 +1227,7 @@ void TShadowDiskActor::HandleGetChangedBlocks(
     auto range = TBlockRange64::WithLength(
         msg->Record.GetStartIndex(),
         msg->Record.GetBlocksCount());
-    response->Record.SetMask(GetChangedBlocks(range));
+    response->Record.SetMask(GetNonZeroBlocks(range));
 
     NCloud::Reply(ctx, *ev, std::move(response));
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1095,11 +1095,11 @@ STFUNC(TVolumeActor::StateWork)
             TEvVolumePrivate::TEvDeviceTimeoutedRequest,
             HandleDeviceTimeouted);
         HFunc(
-            TEvVolumePrivate::TEvUpdateSmartMigrationState,
-            HandleUpdateSmartMigrationState);
+            TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState,
+            HandleUpdateLaggingAgentMigrationState);
         HFunc(
-            TEvVolumePrivate::TEvSmartMigrationFinished,
-            HandleSmartMigrationFinished);
+            TEvVolumePrivate::TEvLaggingAgentMigrationFinished,
+            HandleLaggingAgentMigrationFinished);
 
         HFunc(
             TEvPartitionCommonPrivate::TEvLongRunningOperation,
@@ -1143,9 +1143,9 @@ STFUNC(TVolumeActor::StateZombie)
         IgnoreFunc(TEvVolumePrivate::TEvRemoveExpiredVolumeParams);
         IgnoreFunc(TEvVolumePrivate::TEvReportLaggingDevicesToDR);
         IgnoreFunc(TEvVolumePrivate::TEvDeviceTimeoutedRequest);
-        IgnoreFunc(TEvVolumePrivate::TEvUpdateSmartMigrationState);
-        IgnoreFunc(TEvVolumePrivate::TEvSmartMigrationFinished);
         IgnoreFunc(TEvVolumePrivate::TEvAcquireDiskIfNeeded);
+        IgnoreFunc(TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState);
+        IgnoreFunc(TEvVolumePrivate::TEvLaggingAgentMigrationFinished);
 
         IgnoreFunc(TEvStatsService::TEvVolumePartCounters);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -1015,12 +1015,12 @@ private:
         const TEvService::TEvReadBlocksLocalResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    void HandleSmartMigrationFinished(
-        const TEvVolumePrivate::TEvSmartMigrationFinished::TPtr& ev,
+    void HandleLaggingAgentMigrationFinished(
+        const TEvVolumePrivate::TEvLaggingAgentMigrationFinished::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    void HandleUpdateSmartMigrationState(
-        const TEvVolumePrivate::TEvUpdateSmartMigrationState::TPtr& ev,
+    void HandleUpdateLaggingAgentMigrationState(
+        const TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleCheckRangeResponse(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
@@ -2,6 +2,7 @@
 
 #include "volume_tx.h"
 
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
 #include <cloud/blockstore/libs/storage/volume/model/helpers.h>
 #include <cloud/storage/core/libs/common/media.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
@@ -13,6 +14,36 @@ using namespace NKikimr;
 using namespace NCloud::NBlockStore::NStorage::NPartition;
 
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
+
+namespace {
+
+bool LaggingDevicesAreAllowed(
+    NProto::EStorageMediaKind mediaKind,
+    const TStorageConfigPtr& config,
+    const NProto::TPartitionConfig& partConfig)
+{
+    switch (mediaKind) {
+        case NProto::STORAGE_MEDIA_SSD_MIRROR2:
+            return config->GetLaggingDevicesForMirror2DisksEnabled() ||
+                   config->IsLaggingDevicesForMirror2DisksFeatureEnabled(
+                       partConfig.GetCloudId(),
+                       partConfig.GetFolderId(),
+                       partConfig.GetDiskId());
+
+        case NProto::STORAGE_MEDIA_SSD_MIRROR3:
+            return config->GetLaggingDevicesForMirror3DisksEnabled() ||
+                   config->IsLaggingDevicesForMirror3DisksFeatureEnabled(
+                       partConfig.GetCloudId(),
+                       partConfig.GetFolderId(),
+                       partConfig.GetDiskId());
+
+        default:
+            break;
+    }
+    return false;
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -79,16 +110,17 @@ void TVolumeActor::HandleDeviceTimeouted(
 {
     const auto* msg = ev->Get();
 
-    LOG_INFO(
+    LOG_DEBUG(
         ctx,
         TBlockStoreComponents::VOLUME,
         "[%lu] Device \"%s\" timeouted",
         TabletID(),
         msg->DeviceUUID.c_str());
 
-    const auto& meta = State->GetMeta();
-    if (!IsReliableDiskRegistryMediaKind(
-            State->GetConfig().GetStorageMediaKind()))
+    if (!LaggingDevicesAreAllowed(
+            State->GetConfig().GetStorageMediaKind(),
+            Config,
+            State->GetConfig()))
     {
         NCloud::Reply(
             ctx,
@@ -96,7 +128,7 @@ void TVolumeActor::HandleDeviceTimeouted(
             std::make_unique<TEvVolumePrivate::TEvDeviceTimeoutedResponse>(
                 MakeError(
                     E_PRECONDITION_FAILED,
-                    "Only DR mirror disks can have lagging devices")));
+                    "Disk can't have lagging devices")));
         return;
     }
 
@@ -106,6 +138,18 @@ void TVolumeActor::HandleDeviceTimeouted(
             *ev,
             std::make_unique<TEvVolumePrivate::TEvDeviceTimeoutedResponse>(
                 MakeError(E_REJECTED, "Volume config update in progress")));
+        return;
+    }
+
+    const auto& meta = State->GetMeta();
+    if (State->IsMirrorResyncNeeded() || meta.GetResyncIndex() > 0) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvVolumePrivate::TEvDeviceTimeoutedResponse>(
+                MakeError(
+                    E_INVALID_STATE,
+                    "Resync is in progress, can't have lagging devices")));
         return;
     }
 
@@ -155,9 +199,9 @@ void TVolumeActor::HandleDeviceTimeouted(
             NCloud::Send(
                 ctx,
                 State->GetDiskRegistryBasedPartitionActor(),
-                std::make_unique<TEvPartition::TEvAddLaggingAgentRequest>(
-                    *timeoutedDeviceReplicaIndex,
-                    timeoutedDeviceConfig->GetAgentId()));
+                std::make_unique<
+                    TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest>(
+                    laggingAgent));
 
             auto response =
                 std::make_unique<TEvVolumePrivate::TEvDeviceTimeoutedResponse>(
@@ -233,22 +277,25 @@ void TVolumeActor::HandleDeviceTimeouted(
         std::move(unavailableAgent));
 }
 
-void TVolumeActor::HandleUpdateSmartMigrationState(
-    const TEvVolumePrivate::TEvUpdateSmartMigrationState::TPtr& ev,
+void TVolumeActor::HandleUpdateLaggingAgentMigrationState(
+    const TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState::TPtr& ev,
     const TActorContext& ctx)
 {
+    const auto* msg = ev->Get();
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
-        "[%lu] UpdateSmartMigrationState %s",
+        "[%lu] Lagging agent %s migration progress: %lu/%lu blocks",
         TabletID(),
-        ev->Get()->AgentId.c_str());
+        msg->AgentId.c_str(),
+        msg->CleanBlockCount,
+        msg->CleanBlockCount + msg->DirtyBlockCount);
 
     // TODO(komarevtsev-d): Show the progress on the mon page.
 }
 
-void TVolumeActor::HandleSmartMigrationFinished(
-    const TEvVolumePrivate::TEvSmartMigrationFinished::TPtr& ev,
+void TVolumeActor::HandleLaggingAgentMigrationFinished(
+    const TEvVolumePrivate::TEvLaggingAgentMigrationFinished::TPtr& ev,
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
@@ -277,10 +324,10 @@ void TVolumeActor::HandleSmartMigrationFinished(
         return;
     }
 
-    ExecuteTx<TRemoveLaggingAgent>(
-        ctx,
-        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
-        msg->AgentId);
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+    AddTransaction(*requestInfo);
+    ExecuteTx<TRemoveLaggingAgent>(ctx, std::move(requestInfo), msg->AgentId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -336,9 +383,8 @@ void TVolumeActor::CompleteAddLaggingAgent(
     NCloud::Send(
         ctx,
         partActorId,
-        std::make_unique<TEvPartition::TEvAddLaggingAgentRequest>(
-            args.Agent.GetReplicaIndex(),
-            args.Agent.GetAgentId()));
+        std::make_unique<TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest>(
+            args.Agent));
 
     auto response =
         std::make_unique<TEvVolumePrivate::TEvDeviceTimeoutedResponse>();
@@ -388,16 +434,12 @@ void TVolumeActor::CompleteRemoveLaggingAgent(
         return;
     }
 
-    if (State->HasLaggingInReplica(args.RemovedLaggingAgent.GetReplicaIndex()))
-    {
-        return;
-    }
-
     NCloud::Send(
         ctx,
         State->GetDiskRegistryBasedPartitionActor(),
-        std::make_unique<TEvPartition::TEvRemoveLaggingReplicaRequest>(
-            args.RemovedLaggingAgent.GetReplicaIndex()));
+        std::make_unique<
+            TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest>(
+            std::move(args.RemovedLaggingAgent)));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
@@ -110,7 +110,7 @@ void TVolumeActor::HandleDeviceTimeouted(
 {
     const auto* msg = ev->Get();
 
-    LOG_DEBUG(
+    LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
         "[%lu] Device \"%s\" timeouted",

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -151,34 +151,34 @@ struct TEvVolumePrivate
     };
 
     //
-    // UpdateSmartMigrationState
+    // UpdateLaggingAgentMigrationState
     //
 
-    struct TUpdateSmartMigrationState
+    struct TUpdateLaggingAgentMigrationState
     {
         TString AgentId;
-        ui64 ProcessedBlockCount;
-        ui64 BlockCountNeedToBeProcessed;
+        ui64 CleanBlockCount;
+        ui64 DirtyBlockCount;
 
-        TUpdateSmartMigrationState(
-                TString agentId,
-                ui64 processedBlockCount,
-                ui64 blockCountNeedToBeProcessed)
+        TUpdateLaggingAgentMigrationState(
+            TString agentId,
+            ui64 cleanBlockCount,
+            ui64 dirtyBlockCount)
             : AgentId(std::move(agentId))
-            , ProcessedBlockCount(processedBlockCount)
-            , BlockCountNeedToBeProcessed(blockCountNeedToBeProcessed)
+            , CleanBlockCount(cleanBlockCount)
+            , DirtyBlockCount(dirtyBlockCount)
         {}
     };
 
     //
-    // SmartMigrationFinished
+    // LaggingAgentMigrationFinished
     //
 
-    struct TSmartMigrationFinished
+    struct TLaggingAgentMigrationFinished
     {
         const TString AgentId;
 
-        explicit TSmartMigrationFinished(TString agentId)
+        explicit TLaggingAgentMigrationFinished(TString agentId)
             : AgentId(std::move(agentId))
         {}
     };
@@ -411,8 +411,8 @@ struct TEvVolumePrivate
         EvDevicesAcquireFinished,
         EvDevicesReleaseFinished,
         EvReportLaggingDevicesToDR,
-        EvUpdateSmartMigrationState,
-        EvSmartMigrationFinished,
+        EvUpdateLaggingAgentMigrationState,
+        EvLaggingAgentMigrationFinished,
 
         EvEnd
     };
@@ -461,14 +461,14 @@ struct TEvVolumePrivate
         EvUpdateReadWriteClientInfo
     >;
 
-    using TEvUpdateSmartMigrationState = TRequestEvent<
-        TUpdateSmartMigrationState,
-        EvUpdateSmartMigrationState
+    using TEvUpdateLaggingAgentMigrationState = TRequestEvent<
+        TUpdateLaggingAgentMigrationState,
+        EvUpdateLaggingAgentMigrationState
     >;
 
-    using TEvSmartMigrationFinished = TRequestEvent<
-        TSmartMigrationFinished,
-        EvSmartMigrationFinished
+    using TEvLaggingAgentMigrationFinished = TRequestEvent<
+        TLaggingAgentMigrationFinished,
+        EvLaggingAgentMigrationFinished
     >;
 
     using TEvReportLaggingDevicesToDR = TRequestEvent<

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -161,9 +161,9 @@ struct TEvVolumePrivate
         ui64 DirtyBlockCount;
 
         TUpdateLaggingAgentMigrationState(
-            TString agentId,
-            ui64 cleanBlockCount,
-            ui64 dirtyBlockCount)
+                TString agentId,
+                ui64 cleanBlockCount,
+                ui64 dirtyBlockCount)
             : AgentId(std::move(agentId))
             , CleanBlockCount(cleanBlockCount)
             , DirtyBlockCount(dirtyBlockCount)

--- a/cloud/blockstore/libs/storage/volume/volume_lagging_agent_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_lagging_agent_ut.cpp
@@ -50,8 +50,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         for (ui32 i = 0; i < AgentCount; i++) {
             agentStates.push_back(TDiskAgentStatePtr{});
         }
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetLaggingDevicesForMirror3DisksEnabled(true);
         auto runtime = PrepareTestActorRuntime(
-            {},
+            std::move(storageServiceConfig),
             diskRegistryState,
             {},
             {},
@@ -96,26 +98,32 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             "agent-3",
             replicas[1].GetDevices(0).GetAgentId());
 
-        std::optional<TEvPartition::TAddLaggingAgentRequest>
+        std::optional<TEvNonreplPartitionPrivate::TAddLaggingAgentRequest>
             addLaggingAgentRequest;
         runtime->SetEventFilter(
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvPartition::EvAddLaggingAgentRequest: {
-                        auto* msg = event->Get<
-                            TEvPartition::TEvAddLaggingAgentRequest>();
+                    case TEvNonreplPartitionPrivate::EvAddLaggingAgentRequest: {
+                        auto* msg = event->Get<TEvNonreplPartitionPrivate::
+                                                   TEvAddLaggingAgentRequest>();
                         UNIT_ASSERT(!addLaggingAgentRequest.has_value());
                         addLaggingAgentRequest = *msg;
                         return true;
                     }
-                    case TEvPartition::EvRemoveLaggingReplicaRequest: {
-                        auto* msg = event->Get<
-                            TEvPartition::TEvRemoveLaggingReplicaRequest>();
+                    case TEvNonreplPartitionPrivate::
+                        EvRemoveLaggingAgentRequest: {
+                        auto* msg =
+                            event->Get<TEvNonreplPartitionPrivate::
+                                           TEvRemoveLaggingAgentRequest>();
                         UNIT_ASSERT(addLaggingAgentRequest.has_value());
                         UNIT_ASSERT_VALUES_EQUAL(
-                            msg->ReplicaIndex,
-                            addLaggingAgentRequest->ReplicaIndex);
+                            msg->LaggingAgent.GetAgentId(),
+                            addLaggingAgentRequest->LaggingAgent.GetAgentId());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            msg->LaggingAgent.GetReplicaIndex(),
+                            addLaggingAgentRequest->LaggingAgent
+                                .GetReplicaIndex());
                         addLaggingAgentRequest.reset();
                         return true;
                     }
@@ -129,8 +137,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         UNIT_ASSERT(addLaggingAgentRequest.has_value());
         UNIT_ASSERT_VALUES_EQUAL(
             replicas[0].GetDevices(0).GetAgentId(),
-            addLaggingAgentRequest->AgentId);
-        UNIT_ASSERT_VALUES_EQUAL(1, addLaggingAgentRequest->ReplicaIndex);
+            addLaggingAgentRequest->LaggingAgent.GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            addLaggingAgentRequest->LaggingAgent.GetReplicaIndex());
 
         // Can't add more lagging devices in the same row.
         volume.SendDeviceTimeoutedRequest("uuid-3.0");
@@ -141,8 +151,8 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
 
         // Agent devices are now up-to-date.
         volume.SendToPipe(
-            std::make_unique<TEvVolumePrivate::TEvSmartMigrationFinished>(
-                "agent-2"));
+            std::make_unique<
+                TEvVolumePrivate::TEvLaggingAgentMigrationFinished>("agent-2"));
         runtime->DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT(!addLaggingAgentRequest.has_value());
 
@@ -151,8 +161,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         UNIT_ASSERT(addLaggingAgentRequest.has_value());
         UNIT_ASSERT_VALUES_EQUAL(
             devices[0].GetAgentId(),
-            addLaggingAgentRequest->AgentId);
-        UNIT_ASSERT_VALUES_EQUAL(0, addLaggingAgentRequest->ReplicaIndex);
+            addLaggingAgentRequest->LaggingAgent.GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            addLaggingAgentRequest->LaggingAgent.GetReplicaIndex());
     }
 
     Y_UNIT_TEST(ShouldHandleTabletReboot)
@@ -168,8 +180,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         for (ui32 i = 0; i < AgentCount; i++) {
             agentStates.push_back(TDiskAgentStatePtr{});
         }
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetLaggingDevicesForMirror3DisksEnabled(true);
         auto runtime = PrepareTestActorRuntime(
-            {},
+            std::move(storageServiceConfig),
             diskRegistryState,
             {},
             {},
@@ -203,23 +217,35 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(2, replicas.size());
         const auto& replica1Devices = replicas[0].GetDevices();
         UNIT_ASSERT_VALUES_EQUAL(3, replica1Devices.size());
-        UNIT_ASSERT_VALUES_EQUAL("uuid-2.0", replica1Devices[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-2.0",
+            replica1Devices[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL("agent-2", replica1Devices[0].GetAgentId());
-        UNIT_ASSERT_VALUES_EQUAL("uuid-2.1", replica1Devices[1].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-2.1",
+            replica1Devices[1].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL("agent-2", replica1Devices[1].GetAgentId());
-        UNIT_ASSERT_VALUES_EQUAL("uuid-5.0", replica1Devices[2].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-5.0",
+            replica1Devices[2].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL("agent-5", replica1Devices[2].GetAgentId());
 
         const auto& replica2Devices = replicas[1].GetDevices();
         UNIT_ASSERT_VALUES_EQUAL(3, replica2Devices.size());
-        UNIT_ASSERT_VALUES_EQUAL("uuid-3.0", replica2Devices[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-3.0",
+            replica2Devices[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL("agent-3", replica2Devices[0].GetAgentId());
-        UNIT_ASSERT_VALUES_EQUAL("uuid-3.1", replica2Devices[1].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-3.1",
+            replica2Devices[1].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL("agent-3", replica2Devices[1].GetAgentId());
-        UNIT_ASSERT_VALUES_EQUAL("uuid-6.0", replica2Devices[2].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-6.0",
+            replica2Devices[2].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL("agent-6", replica2Devices[2].GetAgentId());
 
-        std::optional<TEvPartition::TAddLaggingAgentRequest>
+        std::optional<TEvNonreplPartitionPrivate::TAddLaggingAgentRequest>
             addLaggingAgentRequest;
         std::optional<NProto::TAddLaggingDevicesRequest>
             addLaggingDevicesRequest;
@@ -227,9 +253,9 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvPartition::EvAddLaggingAgentRequest: {
-                        auto* msg = event->Get<
-                            TEvPartition::TEvAddLaggingAgentRequest>();
+                    case TEvNonreplPartitionPrivate::EvAddLaggingAgentRequest: {
+                        auto* msg = event->Get<TEvNonreplPartitionPrivate::
+                                                   TEvAddLaggingAgentRequest>();
                         UNIT_ASSERT(!addLaggingAgentRequest.has_value());
                         addLaggingAgentRequest = *msg;
                         return true;
@@ -250,8 +276,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         UNIT_ASSERT(addLaggingAgentRequest.has_value());
         UNIT_ASSERT_VALUES_EQUAL(
             devices[1].GetAgentId(),
-            addLaggingAgentRequest->AgentId);
-        UNIT_ASSERT_VALUES_EQUAL(0, addLaggingAgentRequest->ReplicaIndex);
+            addLaggingAgentRequest->LaggingAgent.GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            addLaggingAgentRequest->LaggingAgent.GetReplicaIndex());
 
         {
             addLaggingAgentRequest.reset();
@@ -262,7 +290,7 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             UNIT_ASSERT(addLaggingAgentRequest.has_value());
             UNIT_ASSERT_VALUES_EQUAL(
                 devices[0].GetAgentId(),
-                addLaggingAgentRequest->AgentId);
+                addLaggingAgentRequest->LaggingAgent.GetAgentId());
         }
 
         {
@@ -281,7 +309,7 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         UNIT_ASSERT(addLaggingAgentRequest.has_value());
         UNIT_ASSERT_VALUES_EQUAL(
             replica2Devices[2].GetAgentId(),
-            addLaggingAgentRequest->AgentId);
+            addLaggingAgentRequest->LaggingAgent.GetAgentId());
 
         // Rebooting the volume tablet should report lagging devices to the DR.
         UNIT_ASSERT(!addLaggingDevicesRequest.has_value());
@@ -327,8 +355,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         for (ui32 i = 0; i < AgentCount; i++) {
             agentStates.push_back(TDiskAgentStatePtr{});
         }
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetLaggingDevicesForMirror3DisksEnabled(true);
         auto runtime = PrepareTestActorRuntime(
-            {},
+            std::move(storageServiceConfig),
             diskRegistryState,
             {},
             {},
@@ -358,7 +388,7 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvPartition::EvAddLaggingAgentRequest: {
+                    case TEvNonreplPartitionPrivate::EvAddLaggingAgentRequest: {
                         return true;
                     }
                     case TEvDiskRegistry::EvAddLaggingDevicesRequest: {
@@ -446,8 +476,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         for (ui32 i = 0; i < AgentCount; i++) {
             agentStates.push_back(TDiskAgentStatePtr{});
         }
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetLaggingDevicesForMirror3DisksEnabled(true);
         auto runtime = PrepareTestActorRuntime(
-            {},
+            std::move(storageServiceConfig),
             diskRegistryState,
             {},
             {},
@@ -520,7 +552,7 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             "uuid-migration-2",
             migrations[1].GetTargetDevice().GetDeviceUUID());
 
-        std::optional<TEvPartition::TAddLaggingAgentRequest>
+        std::optional<TEvNonreplPartitionPrivate::TAddLaggingAgentRequest>
             addLaggingAgentRequest;
         std::optional<NProto::TAddLaggingDevicesRequest>
             addLaggingDevicesRequest;
@@ -528,9 +560,9 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvPartition::EvAddLaggingAgentRequest: {
-                        auto* msg = event->Get<
-                            TEvPartition::TEvAddLaggingAgentRequest>();
+                    case TEvNonreplPartitionPrivate::EvAddLaggingAgentRequest: {
+                        auto* msg = event->Get<TEvNonreplPartitionPrivate::
+                                                   TEvAddLaggingAgentRequest>();
                         UNIT_ASSERT(!addLaggingAgentRequest.has_value());
                         addLaggingAgentRequest = *msg;
                         return true;
@@ -549,16 +581,24 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         volume.DeviceTimeouted("uuid-migration-1");
 
         UNIT_ASSERT(addLaggingAgentRequest.has_value());
-        UNIT_ASSERT_VALUES_EQUAL("agent-7", addLaggingAgentRequest->AgentId);
-        UNIT_ASSERT_VALUES_EQUAL(0, addLaggingAgentRequest->ReplicaIndex);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "agent-7",
+            addLaggingAgentRequest->LaggingAgent.GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            addLaggingAgentRequest->LaggingAgent.GetReplicaIndex());
         addLaggingAgentRequest.reset();
 
         // Device in the second replica is timeouted.
         volume.DeviceTimeouted("uuid-migration-2");
 
         UNIT_ASSERT(addLaggingAgentRequest.has_value());
-        UNIT_ASSERT_VALUES_EQUAL("agent-8", addLaggingAgentRequest->AgentId);
-        UNIT_ASSERT_VALUES_EQUAL(2, addLaggingAgentRequest->ReplicaIndex);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "agent-8",
+            addLaggingAgentRequest->LaggingAgent.GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            addLaggingAgentRequest->LaggingAgent.GetReplicaIndex());
 
         {
             addLaggingAgentRequest.reset();
@@ -597,6 +637,95 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
             metaHistoryResponse->MetaHistory.back()
                 .Meta.GetLaggingAgentsInfo()
                 .AgentsSize());
+    }
+
+    Y_UNIT_TEST(ShouldReturnErrorWhenFeatureIsDisabled)
+    {
+        constexpr ui32 AgentCount = 3;
+        constexpr ui32 DevicePerAgentCount = 3;
+        auto diskRegistryState = MakeIntrusive<TDiskRegistryState>();
+        diskRegistryState->Devices =
+            MakeDeviceList(AgentCount, DevicePerAgentCount);
+        diskRegistryState->AllocateDiskReplicasOnDifferentNodes = true;
+        diskRegistryState->ReplicaCount = 1;
+        TVector<TDiskAgentStatePtr> agentStates;
+        for (ui32 i = 0; i < AgentCount; i++) {
+            agentStates.push_back(TDiskAgentStatePtr{});
+        }
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetLaggingDevicesForMirror3DisksEnabled(false);
+        storageServiceConfig.SetLaggingDevicesForMirror2DisksEnabled(true);
+        auto runtime = PrepareTestActorRuntime(
+            std::move(storageServiceConfig),
+            diskRegistryState,
+            {},
+            {},
+            std::move(agentStates));
+
+        TVolumeClient volume(*runtime);
+        const ui64 blockCount = DefaultDeviceBlockCount *
+                                DefaultDeviceBlockSize / DefaultBlockSize * 3;
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,   // version
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2,
+            blockCount);
+        volume.WaitReady();
+
+        auto stat = volume.StatVolume();
+        const auto& replicas = stat->Record.GetVolume().GetReplicas();
+        UNIT_ASSERT_VALUES_EQUAL(1, replicas.size());
+
+        std::optional<TEvNonreplPartitionPrivate::TAddLaggingAgentRequest>
+            addLaggingAgentRequest;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvNonreplPartitionPrivate::EvAddLaggingAgentRequest: {
+                        auto* msg = event->Get<TEvNonreplPartitionPrivate::
+                                                   TEvAddLaggingAgentRequest>();
+                        UNIT_ASSERT(!addLaggingAgentRequest.has_value());
+                        addLaggingAgentRequest = *msg;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        // Lagging agent should be added.
+        {
+            volume.DeviceTimeouted("uuid-1.0");
+            UNIT_ASSERT(addLaggingAgentRequest.has_value());
+            addLaggingAgentRequest.reset();
+        }
+
+        // Make volume a mirror-3 type.
+        diskRegistryState->ReplicaCount = 2;
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            2,   // version
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3,
+            blockCount);
+        volume.WaitReady();
+
+        // Feature is disabled for mirror-3 disks.
+        {
+            volume.SendDeviceTimeoutedRequest("uuid-1.1");
+            auto response = volume.RecvDeviceTimeoutedResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_PRECONDITION_FAILED,
+                response->GetError().GetCode());
+            UNIT_ASSERT(!addLaggingAgentRequest.has_value());
+        }
     }
 }
 

--- a/cloud/storage/core/libs/common/compressed_bitmap.h
+++ b/cloud/storage/core/libs/common/compressed_bitmap.h
@@ -28,7 +28,7 @@ public:
         const TCompressedBitmap::TImpl* Parent = nullptr;
         ui64 First = 0;
         ui64 Last = 0;
-        char* Buffer = nullptr;
+        std::unique_ptr<char[]> Buffer;
         ui32 BufferPos = 0;
 
     public:
@@ -50,11 +50,11 @@ private:
     size_t Size = 0;
 
 public:
-    TCompressedBitmap(size_t size);
+    explicit TCompressedBitmap(size_t size);
     ~TCompressedBitmap();
 
-    TCompressedBitmap(TCompressedBitmap&& other);
-    TCompressedBitmap& operator=(TCompressedBitmap&& other);
+    TCompressedBitmap(TCompressedBitmap&& other) noexcept;
+    TCompressedBitmap& operator=(TCompressedBitmap&& other) noexcept;
 
     void Clear();
 
@@ -63,13 +63,13 @@ public:
     void Update(const TSerializedChunk& chunk);
     ui64 Update(const TCompressedBitmap& other, ui64 b);
     ui64 Merge(const TSerializedChunk& chunk);
-    ui64 Count() const;
-    ui64 Count(ui64 b, ui64 e) const;
-    bool Test(ui64 i) const;
-    ui64 Capacity() const;
-    ui64 MemSize() const;
+    [[nodiscard]] ui64 Count() const;
+    [[nodiscard]] ui64 Count(ui64 b, ui64 e) const;
+    [[nodiscard]] bool Test(ui64 i) const;
+    [[nodiscard]] ui64 Capacity() const;
+    [[nodiscard]] ui64 MemSize() const;
 
-    TRangeSerializer RangeSerializer(ui64 b, ui64 e) const;
+    [[nodiscard]] TRangeSerializer RangeSerializer(ui64 b, ui64 e) const;
 
     static bool IsZeroChunk(const TSerializedChunk& chunk);
     static std::pair<ui32, ui32> ChunkRange(ui64 b, ui64 e);

--- a/cloud/storage/core/libs/common/guarded_sglist.cpp
+++ b/cloud/storage/core/libs/common/guarded_sglist.cpp
@@ -252,6 +252,14 @@ TGuardedSgList TGuardedSgList::CreateDepender() const
         Sglist);
 }
 
+TGuardedSgList TGuardedSgList::CreateDepender(TSgList sglist) const
+{
+    Y_ABORT_UNLESS(GuardedObject);
+    return TGuardedSgList(
+        MakeIntrusive<TDependentGuardedObject>(GuardedObject),
+        std::move(sglist));
+}
+
 TGuardedSgList TGuardedSgList::Create(TSgList sglist) const
 {
     Y_ABORT_UNLESS(GuardedObject);

--- a/cloud/storage/core/libs/common/guarded_sglist.h
+++ b/cloud/storage/core/libs/common/guarded_sglist.h
@@ -101,15 +101,16 @@ public:
     // Creates a new TGuardedSgList that depends on the current one. The
     // connection is one-way, Close() called from a new object does not
     // terminate access to the original one.
-    TGuardedSgList CreateDepender() const;
+    [[nodiscard]] TGuardedSgList CreateDepender() const;
+    [[nodiscard]] TGuardedSgList CreateDepender(TSgList sglist) const;
 
     // Creates a new TGuardedSgList that is equal to the current one. A two-way
     // connection is created, Close() called on the new object also terminates
     // access to the original one.
-    TGuardedSgList Create(TSgList sglist) const;
+    [[nodiscard]] TGuardedSgList Create(TSgList sglist) const;
 
     // Checks if the sglist is empty.
-    bool Empty() const;
+    [[nodiscard]] bool Empty() const;
 
     // Sets a new sglist.
     void SetSgList(TSgList sglist);
@@ -135,7 +136,7 @@ public:
     // It is necessary to get access for a minimum time.
     // Always check whether access has been obtained.
     // This is non-blocking call.
-    TGuard Acquire() const;
+    [[nodiscard]] TGuard Acquire() const;
 
     // Terminates memory access of all associated TGuardedSgList on other
     // threads.

--- a/cloud/storage/core/libs/common/guarded_sglist_ut.cpp
+++ b/cloud/storage/core/libs/common/guarded_sglist_ut.cpp
@@ -341,7 +341,7 @@ Y_UNIT_TEST_SUITE(TGuardedSgListWithThreadsTest)
 
             const auto acquireTask = [&guardedSgList]() {
                 for (int i = 0; i < 5; ++i) {
-                    guardedSgList.Acquire();
+                    auto guard = guardedSgList.Acquire();
                 }
             };
             for (int i = 0; i < 5; ++i) {
@@ -369,7 +369,7 @@ Y_UNIT_TEST_SUITE(TGuardedSgListWithThreadsTest)
 
             const auto dependerTask = [&guardedSgList]() {
                 for (int i = 0; i < 5; ++i) {
-                    guardedSgList.CreateDepender();
+                    auto sglist = guardedSgList.CreateDepender();
                 }
             };
             for (int i = 0; i < 5; ++i) {
@@ -398,7 +398,7 @@ Y_UNIT_TEST_SUITE(TGuardedSgListWithThreadsTest)
 
             const auto dependerTask = [&depender]() {
                 for (int i = 0; i < 5; ++i) {
-                    depender.Acquire();
+                    auto guard = depender.Acquire();
                 }
             };
             for (int i = 0; i < 5; ++i) {
@@ -406,7 +406,7 @@ Y_UNIT_TEST_SUITE(TGuardedSgListWithThreadsTest)
             }
 
             const auto acquireTask = [&guardedSgList]() {
-                guardedSgList.Acquire();
+                auto guard = guardedSgList.Acquire();
             };
             for (int i = 0; i < 5; ++i) {
                 tasks.Add(acquireTask);

--- a/cloud/storage/core/libs/common/sglist_block_range.cpp
+++ b/cloud/storage/core/libs/common/sglist_block_range.cpp
@@ -6,15 +6,19 @@ namespace NCloud {
 
 TSgListBlockRange::TSgListBlockRange(const TSgList& sglist, ui32 blockSize)
     : BlockSize(blockSize)
-    , It(sglist.begin())
     , End(sglist.end())
+    , It(sglist.begin())
 {}
+
+[[nodiscard]] bool TSgListBlockRange::HasNext() const {
+    return It != End;
+}
 
 TSgList TSgListBlockRange::Next(ui64 blockCount)
 {
     TSgList sglist;
     while (blockCount) {
-        if (It == End) {
+        if (!HasNext()) {
             return sglist;
         }
 

--- a/cloud/storage/core/libs/common/sglist_block_range.h
+++ b/cloud/storage/core/libs/common/sglist_block_range.h
@@ -6,17 +6,20 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TSgListBlockRange
+class TSgListBlockRange
 {
     const ui32 BlockSize;
+    const TSgList::const_iterator End;
 
     TSgList::const_iterator It;
-    TSgList::const_iterator End;
     ui64 Offset = 0;
 
+public:
     TSgListBlockRange(const TSgList& sglist, ui32 blockSize);
+    ~TSgListBlockRange() = default;
 
     TSgList Next(ui64 blockCount);
+    [[nodiscard]] bool HasNext() const;
 };
 
 }   // namespace NCloud

--- a/cloud/storage/core/protos/error.proto
+++ b/cloud/storage/core/protos/error.proto
@@ -12,7 +12,9 @@ enum EErrorFlag
     // Note: sequential flag numbers starting from one are used, not powers of two
 
     EF_NONE = 0;
-    // A flag that makes the target error EErrorKind::ErrorSilent. Such an error does not increment the fatal error counter
+
+    // A flag that makes the target error EErrorKind::ErrorSilent. Such an error
+    // does not increment the fatal error counter.
     // Be careful using EF_SILENT with retriable errors. This flag changes error
     // kind to EErrorKind::ErrorSilent making the error non-retriable.
     EF_SILENT = 1;

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -11,9 +11,12 @@ UseShadowDisksForNonreplDiskCheckpoints: true
 MaxShadowDiskFillIoDepth: 4
 OptimizeVoidBuffersTransferForReadsEnabled: true
 MaxShadowDiskFillBandwidth: 1000
+MaxMigrationIoDepth: 1
 MaxMigrationBandwidth: 1000
 AssignIdToWriteAndZeroRequestsEnabled: true
 RejectLateRequestsAtDiskAgentEnabled: true
 UseDirectCopyRange: true
 EnableToChangeStatesFromDiskRegistryMonpage: true
 EnableToChangeErrorStatesFromDiskRegistryMonpage: true
+LaggingDevicesForMirror2DisksEnabled: true
+LaggingDevicesForMirror3DisksEnabled: true


### PR DESCRIPTION
#3
Добавляю 3 новых актора: 
`TAgentAvailabilityMonitoringActor` - актор, который переодически пытается читать один блок и уведомляет если это получилось.
`TLaggingAgentMigrationActor` - ещё один наследник migration_common актора. Принимает в конструкторе карту блоков, которую и нужно будет смигрировать.
`TLaggingAgentsReplicaProxyActor` - актор, который будет находится между MirrorPartition и NonreplicatedPartition. Он управляет жизнью первых двух и проксирует IO куда нужно. Если запись падает между двух агентов, то он распиливет её на две. На каждую запись в лагающего агента помечает номера блоков. По ним в дальнейшем будет происходить миграция.

Пока нигде не создаются и не используются.