### PR TITLE
ignore TEvVolumePrivate::TEvAcquireDiskIfNeeded in zombie state

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1138,6 +1138,7 @@ STFUNC(TVolumeActor::StateZombie)
         IgnoreFunc(TEvVolumePrivate::TEvDeviceTimeoutedRequest);
         IgnoreFunc(TEvVolumePrivate::TEvUpdateSmartMigrationState);
         IgnoreFunc(TEvVolumePrivate::TEvSmartMigrationFinished);
+        IgnoreFunc(TEvVolumePrivate::TEvAcquireDiskIfNeeded);
 
         IgnoreFunc(TEvStatsService::TEvVolumePartCounters);
 


### PR DESCRIPTION
TEvAcquireDiskIfNeeded is [scheduled](https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp#L140-L143) every 4s, there is a chance that the volume gets TEvAcquireDiskIfNeeded already in a zombie state:
```
VERIFY failed (2025-02-23T03:22:35.229069Z): [BLOCKSTORE_VOLUME] Unexpected event: (0x10620144) NCloud::NBlockStore::TRequestEvent<NCloud::NBlockStore::NStorage::TEvVolumePrivate::TAcquireDiskIfNeeded, 274858308u>
  cloud/storage/core/libs/actors/helpers.cpp:39
  HandleUnexpectedEvent(): requirement false failed
```
