### PR TITLE
issue-1444: fix conversion from nanoseconds

### DIFF
--- a/cloud/storage/core/libs/diagnostics/task_stats_fetcher.cpp
+++ b/cloud/storage/core/libs/diagnostics/task_stats_fetcher.cpp
@@ -217,7 +217,7 @@ public:
             TNetlinkResponse<TTaskStatsResponse> response;
             socket.Receive(response);
             response.Msg.Validate();
-            auto cpuLack = TDuration::MilliSeconds(
+            auto cpuLack = TDuration::MicroSeconds(
                 response.Msg.TaskStats.cpu_delay_total / 1000);
             auto retval = cpuLack - Last;
             Last = cpuLack;


### PR DESCRIPTION
cpu_delay_total is cumulative delay in nanoseconds: https://github.com/torvalds/linux/blob/master/Documentation/accounting/taskstats-struct.rst?plain=1#L106