### PR TITLE
[Filestore] Do not increment garbage blocks count when writing new blobs

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -148,9 +148,6 @@ private:
                 block.BlockIndex,
                 blob.BlocksCount);
             AccessCompactionRangeInfo(rangeId).Stats.BlobsCount += 1;
-            // conservative estimate
-            AccessCompactionRangeInfo(rangeId).Stats.GarbageBlocksCount +=
-                blob.BlocksCount;
         }
 
         for (const auto& part: args.UnalignedDataParts) {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -695,13 +695,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         TTestRegistryVisitor visitor;
 
         const auto deletions = countrRewrites * BlockGroupSize;
-        const auto garbage = countrRewrites * BlockGroupSize;
         registry->Visit(TInstant::Zero(), visitor);
         // clang-format off
         visitor.ValidateExpectedCounters({
             {{{"sensor", "MaxBlobsInRange"}}, countrRewrites},
             {{{"sensor", "MaxDeletionsInRange"}}, deletions},
-            {{{"sensor", "MaxGarbageBlocksInRange"}}, garbage},
+            {{{"sensor", "MaxGarbageBlocksInRange"}}, 0},
         });
         // clang-format on
     }
@@ -742,7 +741,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             {{{"sensor", "DeletionMarkersCount"}, {"filesystem", "test"}}, 64},
             {{{"sensor", "CMDeletionMarkersCount"}, {"filesystem", "test"}}, 64},
             {{{"sensor", "MixedBytesCount"}, {"filesystem", "test"}}, sz},
-            {{{"sensor", "CMGarbageBlocksCount"}, {"filesystem", "test"}}, 64},
+            {{{"sensor", "CMGarbageBlocksCount"}, {"filesystem", "test"}}, 0},
         });
         // clang-format on
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -6755,6 +6755,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             tablet.DestroyHandle(handle);
         }
 
+        // Before compaction
         {
             auto response = tablet.GetStorageStats(1);
             const auto& stats = response->Record.GetStats();

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1632,8 +1632,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(
                 256,
                 stats.GetAllocatedCompactionRanges());
-            // only two ranges are returned since other one is marked with the
-            // 'compacted' flag and thus skipped during top ranges gathering
             UNIT_ASSERT_VALUES_EQUAL(3, stats.CompactionRangeStatsSize());
             UNIT_ASSERT_VALUES_EQUAL(
                 "r=1177944064 b=4 d=0 g=57",

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -463,15 +463,14 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
             UNIT_ASSERT_VALUES_EQUAL(
                 256,
                 stats.GetAllocatedCompactionRanges());
-            // CompactionRangeStatsSize is 0 since all ranges are marked with
-            // the 'compacted' flag and thus not returned
             UNIT_ASSERT_VALUES_EQUAL(1, stats.CompactionRangeStatsSize());
+            // The amount of GarbageBlocksCount is 0 since the blocks
+            // were not overwritten
             UNIT_ASSERT_VALUES_EQUAL(
                 Sprintf(
-                    "r=1177944064 b=%u d=%u g=%u",
+                    "r=1177944064 b=%u d=%u g=0",
                     (compactionThreshold - 1),
-                    deletionMarkers,
-                    expectedExcessBlobCount * BlockGroupSize),
+                    deletionMarkers),
                 CompactionRangeToString(stats.GetCompactionRangeStats(0)));
         }
     }


### PR DESCRIPTION
Incrementing GarbageBlocksCount when writing new data unnecessary triggers compaction operation.

https://github.com/ydb-platform/nbs/issues/3061