### PR TITLE
[Disk Manager] set maxRetriableErrorCount for testing S3 client to make dataplane/snapshot/storage/storage_ydb_test.go more stable

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/test/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/test/common.go
@@ -28,7 +28,7 @@ func NewS3Client() (*persistence.S3Client, error) {
 		credentials,
 		callTimeout,
 		metrics.NewEmptyRegistry(),
-		0, // maxRetriableErrorCount
+		100, // maxRetriableErrorCount
 	)
 }
 

--- a/cloud/tasks/persistence/s3.go
+++ b/cloud/tasks/persistence/s3.go
@@ -67,7 +67,7 @@ func NewS3Client(
 		),
 		Endpoint:         &endpoint,
 		Region:           &region,
-		S3ForcePathStyle: aws.Bool(true), // Without it we get DNS DDOS errors in tests. This option is fine for production too.
+		S3ForcePathStyle: aws.Bool(true), // otherwise, we get DNS DDOS errors in tests
 		Retryer: &s3ClientRetryer{
 			DefaultRetryer: client.DefaultRetryer{
 				NumMaxRetries: int(maxRetriableErrorCount),


### PR DESCRIPTION
```
2025-02-24T01:20:25.723Z	ERROR	persistence/s3_metrics.go:66	S3 call with name CreateBucket ended with error Retriable error, IgnoreRetryLimit=false: RequestError: send request failed
caused by: Put "http://localhost:15832/test": dial tcp [::1]:15832: connect: connection refused, bucket test, key 	{"SYSLOG_IDENTIFIER": "disk-manager", "COMPONENT": "S3"}
2025-02-24T01:20:25.723Z	WARN	persistence/s3_metrics.go:86	failed to process aws go sdk error Retriable error, IgnoreRetryLimit=false: RequestError: send request failed
caused by: Put "http://localhost:15832/test": dial tcp [::1]:15832: connect: connection refused	{"SYSLOG_IDENTIFIER": "disk-manager", "COMPONENT": "S3"}
    storage_ydb_test.go:317: 
        	Error Trace:	/-S/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go:317
        	            				/-S/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go:373
        	            				/-S/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go:1250
        	Error:      	Received unexpected error:
        	            	Retriable error, IgnoreRetryLimit=false: RequestError: send request failed
        	            	caused by: Put "http://localhost:15832/test": dial tcp [::1]:15832: connect: connection refused
        	Test:       	TestReadChunk/store_chunks_in_s3
```