### PR TITLE
[Filestore] fix qemu-kikimr-multishard-tablets-restart-test test: handle TFlushBytesResponse in the zombie state

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1052,6 +1052,7 @@ STFUNC(TIndexTabletActor::StateZombie)
         IgnoreFunc(TEvIndexTabletPrivate::TEvCleanupResponse);
         IgnoreFunc(TEvIndexTabletPrivate::TEvCollectGarbageResponse);
         IgnoreFunc(TEvIndexTabletPrivate::TEvFlushResponse);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvFlushBytesResponse);
 
         IgnoreFunc(TEvFileStore::TEvUpdateConfig);
 


### PR DESCRIPTION
Same as https://github.com/ydb-platform/nbs/pull/2653

Failure seen here: https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/PR-check/13508037474/1/nebius-x86-64/summary/ya-test.html#FAIL