### PR TITLE
issue-1751: add test for close to open consistency; suppress warnings of ssh command in qemu tests; always prepare test enviroment in qemu test recipes; return result of ssh command in qemu tests

### DIFF
--- a/cloud/filestore/tests/close_to_open_consistency/test.py
+++ b/cloud/filestore/tests/close_to_open_consistency/test.py
@@ -4,19 +4,19 @@ import string
 
 from cloud.storage.core.tools.testing.qemu.lib.common import env_with_guest_index, SshToGuest
 
-TEST_FILE_PREFIX = "test"
+TEST_FILE_PREFIX = "close_to_open_consistency_test"
 
 
-def createFile(ssh: SshToGuest, dir: str, fileName: str):
-    return ssh(f"sudo touch {dir}/{fileName}")
+def create_file(ssh: SshToGuest, dir: str, file_name: str):
+    return ssh(f"sudo touch {dir}/{file_name}")
 
 
-def writeToFile(ssh: SshToGuest, dir: str, fileName: str, data: str):
-    return ssh(f"sudo bash -c 'echo {data} >> {dir}/{fileName}'")
+def write_to_file(ssh: SshToGuest, dir: str, file_name: str, data: str):
+    return ssh(f"sudo bash -c 'echo {data} >> {dir}/{file_name}'")
 
 
-def readFromFile(ssh: SshToGuest, dir: str, fileName: str):
-    return ssh(f"sudo bash -c 'cat {dir}/{fileName}'")
+def read_from_file(ssh: SshToGuest, dir: str, file_name: str):
+    return ssh(f"sudo bash -c 'cat {dir}/{file_name}'")
 
 
 def test():
@@ -29,22 +29,22 @@ def test():
     ssh2 = SshToGuest(user="qemu", port=port2, key=ssh_key)
 
     for i in range(3):
-        filename = f"{TEST_FILE_PREFIX}_{i}.txt"
-        res1 = createFile(ssh1, mount_dir, filename)
+        file_name = f"{TEST_FILE_PREFIX}_{i}.txt"
+        res1 = create_file(ssh1, mount_dir, file_name)
         assert 0 == res1.returncode
 
         expected = ''
         for j in range(10):
-            randomStr = ''.join(
+            random_str = ''.join(
                 random.choices(string.ascii_letters + string.digits, k=10))
 
-            res1 = writeToFile(ssh1, mount_dir, filename, randomStr)
+            res1 = write_to_file(ssh1, mount_dir, file_name, random_str)
             assert 0 == res1.returncode
 
-            expected += randomStr + '\n'
+            expected += random_str + '\n'
 
-            res1 = readFromFile(ssh1, mount_dir, filename)
-            res2 = readFromFile(ssh2, mount_dir, filename)
+            res1 = read_from_file(ssh1, mount_dir, file_name)
+            res2 = read_from_file(ssh2, mount_dir, file_name)
 
             assert 0 == res1.returncode
             assert 0 == res2.returncode

--- a/cloud/filestore/tests/close_to_open_consistency/test.py
+++ b/cloud/filestore/tests/close_to_open_consistency/test.py
@@ -1,0 +1,52 @@
+import os
+import random
+import string
+
+from cloud.storage.core.tools.testing.qemu.lib.common import env_with_guest_index, SshToGuest
+
+TEST_FILE_PREFIX = "test"
+
+
+def createFile(ssh: SshToGuest, dir: str, fileName: str):
+    return ssh(f"sudo touch {dir}/{fileName}")
+
+
+def writeToFile(ssh: SshToGuest, dir: str, fileName: str, data: str):
+    return ssh(f"sudo bash -c 'echo {data} >> {dir}/{fileName}'")
+
+
+def readFromFile(ssh: SshToGuest, dir: str, fileName: str):
+    return ssh(f"sudo bash -c 'cat {dir}/{fileName}'")
+
+
+def test():
+    port1 = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 0)))
+    port2 = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 1)))
+    ssh_key = os.getenv("QEMU_SSH_KEY")
+    mount_dir = os.getenv("NFS_MOUNT_PATH")
+
+    ssh1 = SshToGuest(user="qemu", port=port1, key=ssh_key)
+    ssh2 = SshToGuest(user="qemu", port=port2, key=ssh_key)
+
+    for i in range(3):
+        filename = f"{TEST_FILE_PREFIX}_{i}.txt"
+        res1 = createFile(ssh1, mount_dir, filename)
+        assert 0 == res1.returncode
+
+        expected = ''
+        for j in range(10):
+            randomStr = ''.join(
+                random.choices(string.ascii_letters + string.digits, k=10))
+
+            res1 = writeToFile(ssh1, mount_dir, filename, randomStr)
+            assert 0 == res1.returncode
+
+            expected += randomStr + '\n'
+
+            res1 = readFromFile(ssh1, mount_dir, filename)
+            res2 = readFromFile(ssh2, mount_dir, filename)
+
+            assert 0 == res1.returncode
+            assert 0 == res2.returncode
+            assert expected == res1.stdout.decode('utf8')
+            assert expected == res2.stdout.decode('utf8')

--- a/cloud/filestore/tests/close_to_open_consistency/ya.make
+++ b/cloud/filestore/tests/close_to_open_consistency/ya.make
@@ -1,0 +1,29 @@
+PY3TEST()
+
+TEST_SRCS(
+    test.py
+)
+
+PEERDIR(
+    cloud/filestore/tests/python/lib
+
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INSTANCE_COUNT 2)
+SET(FILESTORE_VHOST_ENDPOINT_COUNT 2)
+SET(VIRTIOFS_SERVER_COUNT 2)
+SET(QEMU_INVOKE_TEST NO)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/close_to_open_consistency/ya.make
+++ b/cloud/filestore/tests/close_to_open_consistency/ya.make
@@ -1,5 +1,7 @@
 PY3TEST()
 
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+
 TEST_SRCS(
     test.py
 )

--- a/cloud/storage/core/tools/testing/qemu/lib/common.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/common.py
@@ -29,6 +29,7 @@ class SshToGuest(object):
             "-i", self.key,
             "-l", self.user,
             "-p", str(self.port),
+            "-o LogLevel=error",
             "127.0.0.1",
             command
         ]
@@ -38,7 +39,7 @@ class SshToGuest(object):
         return cmd
 
     def __call__(self, command, timeout=None):
-        common.execute(self.get_command(command, timeout))
+        return common.execute(self.get_command(command, timeout))
 
 
 def env_with_guest_index(env, guest_index):

--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -367,8 +367,8 @@ def _prepare_test_environment(ssh, virtio):
         # Mount virtiofs directory
         mount_path = "/mnt/fs0"
         vm_env["NFS_MOUNT_PATH"] = mount_path
-
         library.python.testing.recipe.set_env("NFS_MOUNT_PATH", mount_path)
+
         ssh("sudo mkdir -p {}".format(mount_path))
         ssh("sudo mount -t virtiofs fs0 {} -o rw".format(mount_path),
             timeout=300)

--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -121,8 +121,7 @@ def start_instance(args, inst_index):
             ssh("sudo mkdir -p {} && sudo ln -s {} {}".format(
                 os.path.dirname(real_path), path, real_path))
 
-    if args.invoke_test:
-        _prepare_test_environment(ssh, virtio)
+    _prepare_test_environment(ssh, virtio)
 
     if args.invoke_test:
         recipe_set_env("TEST_COMMAND_WRAPPER",
@@ -369,6 +368,7 @@ def _prepare_test_environment(ssh, virtio):
         mount_path = "/mnt/fs0"
         vm_env["NFS_MOUNT_PATH"] = mount_path
 
+        library.python.testing.recipe.set_env("NFS_MOUNT_PATH", mount_path)
         ssh("sudo mkdir -p {}".format(mount_path))
         ssh("sudo mount -t virtiofs fs0 {} -o rw".format(mount_path),
             timeout=300)
@@ -379,10 +379,13 @@ def _prepare_test_environment(ssh, virtio):
         # Use virtio-blk device
         ssh("sudo lsblk")
         vm_env["NBS_DEVICE_PATH"] = _get_nbs_device_path()
+        library.python.testing.recipe.set_env(
+            "NBS_DEVICE_PATH", _get_nbs_device_path())
     elif virtio == "nfs":
         # Mount NFS share
         mount_path = "/mnt/nfs0"
         vm_env["NFS_MOUNT_PATH"] = mount_path
+        library.python.testing.recipe.set_env("NFS_MOUNT_PATH", mount_path)
         nfs_port = os.getenv("NFS_GANESHA_PORT")
 
         ssh("sudo mkdir -p {}".format(mount_path))


### PR DESCRIPTION
in #1751 FUSE_CAP_WRITEBACK_CACHE works not as expected and break close to open consistency. Clients reads data from cache as well, so if one client write to file and flush, second will read its own copy in cache. This test simulate this behavior. With `WriteBackCacheEnabled: true` in config test fails.