### PR TITLE
issue-1444: request stats for tgid

### DIFF
--- a/cloud/storage/core/libs/diagnostics/task_stats_fetcher.cpp
+++ b/cloud/storage/core/libs/diagnostics/task_stats_fetcher.cpp
@@ -62,14 +62,14 @@ struct TTaskStatsRequest
 {
     ::nlmsghdr MessageHeader;
     ::genlmsghdr GenericHeader;
-    ::nlattr PidAttr;
-    ui32 Pid;
+    ::nlattr TgidAttr;
+    ui32 Tgid;
 
-    TTaskStatsRequest(ui16 familyId, ui32 pid)
+    TTaskStatsRequest(ui16 familyId, ui32 tgid)
         : MessageHeader{sizeof(TTaskStatsRequest), familyId, NLM_F_REQUEST, 0, 0}
         , GenericHeader{TASKSTATS_CMD_GET, 1, 0}
-        , PidAttr{sizeof(Pid) + NLA_HDRLEN, TASKSTATS_CMD_ATTR_PID}
-        , Pid(pid)
+        , TgidAttr{sizeof(Tgid) + NLA_HDRLEN, TASKSTATS_CMD_ATTR_TGID}
+        , Tgid(tgid)
     {}
 };
 
@@ -77,16 +77,16 @@ struct TTaskStatsResponse
 {
     ::nlmsghdr MessageHeader;
     ::genlmsghdr GenericHeader;
-    ::nlattr AggrPidAttr;
-    ::nlattr PidAttr;
-    ui32 Pid;
+    ::nlattr AggrTgidAttr;
+    ::nlattr TgidAttr;
+    ui32 Tgid;
     ::nlattr TaskStatsAttr;
     ::taskstats TaskStats;
 
     void Validate()
     {
-        ValidateAttribute(AggrPidAttr, TASKSTATS_TYPE_AGGR_PID);
-        ValidateAttribute(PidAttr, TASKSTATS_TYPE_PID);
+        ValidateAttribute(AggrTgidAttr, TASKSTATS_TYPE_AGGR_TGID);
+        ValidateAttribute(TgidAttr, TASKSTATS_TYPE_TGID);
         ValidateAttribute(TaskStatsAttr, TASKSTATS_TYPE_STATS);
     }
 };


### PR DESCRIPTION
Specify tgid attribute to request stats for all threads

https://docs.kernel.org/accounting/taskstats.html

> To get statistics during a task's lifetime, userspace opens a unicast netlink socket (NETLINK_GENERIC family) and sends commands specifying a pid or a tgid. The response contains statistics for a task (if pid is specified) or the sum of statistics for all tasks of the process (if tgid is specified).