### PR TITLE
[Filestore] Change cleanup trigger condition based on UsedBlocks instead of UsedRanges

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -527,4 +527,9 @@ message TStorageConfig
 
     // Enable write-back cache on FUSE server
     optional bool ServerWriteBackCacheEnabled = 420;
+
+    // If enabled, GarbageCompactionThresholdAverage in Cleanup will be compared
+    // to the scaled ratio of DeletedMarkersCount to UsedBlocksCount instead of
+    // UsedRangesCount.
+    optional bool CalculateCleanupScoreBasedOnUsedBlocksCount = 421;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -36,6 +36,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(FlushThreshold,                     ui32,   4_MB                      )\
     xxx(CleanupThreshold,                   ui32,   512                       )\
     xxx(CleanupThresholdAverage,            ui32,   64                        )\
+    xxx(CalculateCleanupScoreBasedOnUsedBlocksCount, bool,   false            )\
     xxx(NewCleanupEnabled,                  bool,   false                     )\
     xxx(CompactionThreshold,                ui32,   20                        )\
     xxx(GarbageCompactionThreshold,         ui32,   100                       )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -75,6 +75,7 @@ public:
     ui32 GetFlushThreshold() const;
     ui32 GetCleanupThreshold() const;
     ui32 GetCleanupThresholdAverage() const;
+    bool GetCalculateCleanupScoreBasedOnUsedBlocksCount() const;
     bool GetNewCleanupEnabled() const;
     ui32 GetCompactionThreshold() const;
     ui32 GetGarbageCompactionThreshold() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -536,11 +536,13 @@ TCleanupInfo TIndexTabletActor::GetCleanupInfo() const
     // per used block. For the compatibility with the old condition, the
     // number of blocks is converted to the number of ranges taking the
     // assumption that the ranges are fully filled.
-    const auto rangeCount = static_cast<double>(stats.GetUsedBlocksCount()) /
-        (BlockGroupSize * NodeGroupSize);
+    const auto rangeCount =
+        Config->GetCalculateCleanupScoreBasedOnUsedBlocksCount()
+            ? static_cast<double>(stats.GetUsedBlocksCount()) /
+                  (BlockGroupSize * NodeGroupSize)
+            : compactionStats.UsedRangesCount;
     const auto avgCleanupScore = rangeCount > 0.0
-        ? static_cast<double>(stats.GetDeletionMarkersCount()) /
-        rangeCount
+        ? static_cast<double>(stats.GetDeletionMarkersCount()) / rangeCount
         : 0;
     const bool shouldCleanup =
         avgCleanupScore >= Config->GetCleanupThresholdAverage();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -536,11 +536,11 @@ TCleanupInfo TIndexTabletActor::GetCleanupInfo() const
     // per used block. For the compatibility with the old condition, the
     // number of blocks is converted to the number of ranges taking the
     // assumption that the ranges are fully filled.
-    const auto rangeCount =
+    const double rangeCount =
         Config->GetCalculateCleanupScoreBasedOnUsedBlocksCount()
             ? static_cast<double>(stats.GetUsedBlocksCount()) /
                   (BlockGroupSize * NodeGroupSize)
-            : compactionStats.UsedRangesCount;
+            : static_cast<double>(compactionStats.UsedRangesCount);
     const auto avgCleanupScore = rangeCount > 0.0
         ? static_cast<double>(stats.GetDeletionMarkersCount()) / rangeCount
         : 0;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -524,6 +524,13 @@ TCleanupInfo TIndexTabletActor::GetCleanupInfo() const
     auto [cleanupRangeId, cleanupScore] = GetRangeToCleanup();
     const auto& stats = GetFileSystemStats();
     const auto compactionStats = GetCompactionMapStats(0);
+    // FIXME: the sparsity of range usage is not taken into account
+    // It is possible that there are a total of 64 blocks in a range,
+    // 63 or them marked as deleted and 1 is used. In this case the
+    // range will not be cleaned.
+    // It is better to take into account the number of used blocks in the range
+    // but this information is not available in the compaction stats.
+    // The total number of used blocks can be taken from the file system stats.
     const auto rangeCount = compactionStats.UsedRangesCount;
     const auto avgCleanupScore = rangeCount
         ? static_cast<double>(stats.GetDeletionMarkersCount()) / rangeCount

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -226,6 +226,8 @@ void TIndexTabletActor::CompleteTx_SetNodeAttr(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+
+    EnqueueBlobIndexOpIfNeeded(ctx);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
@@ -350,6 +350,7 @@ void TIndexTabletActor::CompleteTx_TruncateRange(
             std::move(args.Error));
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 
+    EnqueueBlobIndexOpIfNeeded(ctx);
     EnqueueCollectGarbageIfNeeded(ctx);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -6996,7 +6996,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // 3/61 scales to ~50/1024 < 64 deletion markers per fully filled range
         // Cleanup shouldn't have been run
         {
-            auto response = tablet.GetStorageStats(1);
+            auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(8 * 61, stats.GetUsedBlocksCount());
@@ -7017,7 +7017,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // After cleanup, there should remain 28 deletion markers in total
         // 28/480 scales to ~59/1024 => no more cleanup operations
         {
-            auto response = tablet.GetStorageStats(1);
+            auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(8 * 60, stats.GetUsedBlocksCount());
@@ -7034,9 +7034,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         // Cleanup should've been triggered automatically
         {
-            auto response = tablet.GetStorageStats(1);
+            auto response = tablet.GetStorageStats();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(8, stats.GetUsedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeletionMarkersCount());
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -6968,8 +6968,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         }
 
-        // Force run compaction
+        // Force run cleanup and compaction
         for (ui32 i = 0; i < groupCount; i++) {
+            tablet.Cleanup(GetMixedRangeIndex(ids[i * NodeGroupSize], 0));
             tablet.Compaction(GetMixedRangeIndex(ids[i * NodeGroupSize], 0));
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -1848,11 +1848,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         auto handle = CreateHandle(tablet, id);
 
-        // Allocating 16_MB of used data - this corresponds to the size of
-        // 4 fully filled compaction ranges
+        // allocating 4 compaction ranges
         TSetNodeAttrArgs args(id);
         args.SetFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
-        args.SetSize(16_MB);
+        args.SetSize(1_MB);
         tablet.SetNodeAttr(args);
 
         tablet.WriteData(handle, 0, 2 * block, 'a');
@@ -1868,7 +1867,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
 
         // Cleanup should've been triggered when the number of deletion markers
-        // hits 12 (an average of 3 markers per fully filled range)
+        // hits 12 (an average of 3 markers per range)
         tablet.WriteData(handle, 2 * block, 2 * block, 'e');
 
         {
@@ -6927,6 +6926,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCompactionThreshold(999'999);
         storageConfig.SetUseMixedBlocksInsteadOfAliveBlocksInCompaction(true);
         storageConfig.SetWriteBlobThreshold(block);
+        storageConfig.SetCalculateCleanupScoreBasedOnUsedBlocksCount(true);
 
         TTestEnv env({}, std::move(storageConfig));
         env.CreateSubDomain("nfs");

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -6915,6 +6915,140 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         tablet.DestroyHandle(handle);
     }
+
+    TABLET_TEST_4K_ONLY(ShouldAutomaticallyRunCleanupForSparselyPopulatedRanges)
+    {
+        const auto block = tabletConfig.BlockSize;
+        const int ignoredNodeCount = 14;
+        const int groupCount = 8;
+
+        // Disable conditions for automatic compaction and configure cleanup
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetNewCleanupEnabled(true);
+        storageConfig.SetCleanupThresholdAverage(64);
+        storageConfig.SetCompactionThresholdAverage(999'999);
+        storageConfig.SetGarbageCompactionThresholdAverage(999'999);
+        storageConfig.SetCompactionThreshold(999'999);
+        storageConfig.SetUseMixedBlocksInsteadOfAliveBlocksInCompaction(true);
+        storageConfig.SetWriteBlobThreshold(block);
+
+        TTestEnv env({}, std::move(storageConfig));
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        // Create 14 ignored nodes in the first range
+        std::array<ui64, ignoredNodeCount> ignoredIds;
+        for (ui32 i = 0; i < ignoredNodeCount; i++) {
+            auto name = Sprintf("ignored%u", i);
+            ignoredIds[i] =
+                CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, name));
+        }
+
+        // Create 8 groups of 16 files, 16_KB each
+        std::array<ui64, NodeGroupSize * groupCount> ids;
+        for (ui32 i = 0; i < NodeGroupSize * groupCount; i++) {
+            auto name = Sprintf("test%u", i);
+            ids[i] = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, name));
+            auto handle = CreateHandle(tablet, ids[i]);
+            tablet.WriteData(handle, 0, 16_KB, 'a');
+            tablet.DestroyHandle(handle);
+        }
+
+        // Ensure that all 16-node groups share the same range
+        for (ui32 i = 0; i < groupCount; i++) {
+            for (ui32 j = 1; j < NodeGroupSize; j++) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    GetMixedRangeIndex(ids[i * NodeGroupSize + j], 0),
+                    GetMixedRangeIndex(ids[i * NodeGroupSize], 0));
+            }
+        }
+
+        // Force run cleanup and compaction
+        for (ui32 i = 0; i < groupCount; i++) {
+            tablet.Compaction(GetMixedRangeIndex(ids[i * NodeGroupSize], 0));
+            tablet.Cleanup(GetMixedRangeIndex(ids[i * NodeGroupSize], 0));
+        }
+
+        // Check the statistics
+        // Each range should contains a single blob of 16 * 4 = 64 blocks
+        {
+            auto response = tablet.GetStorageStats(1);
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetUsedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeletionMarkersCount());
+        }
+
+        // Truncate one file in each group to 4_KB
+        for (ui32 i = 0; i < groupCount; i++) {
+            TSetNodeAttrArgs args(ids[i * NodeGroupSize]);
+            args.SetFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
+            args.SetSize(4_KB);
+            tablet.SetNodeAttr(args);
+        }
+
+        // There should be 3 deletion markers and 61 used blocks in each range
+        // 3/61 scales to ~50/1024 < 64 deletion markers per fully filled range
+        // Cleanup shouldn't have been run
+        {
+            auto response = tablet.GetStorageStats(1);
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 61, stats.GetUsedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 3, stats.GetDeletionMarkersCount());
+        }
+
+        // Truncate another file in each group to 12_KB
+        for (ui32 i = 0; i < groupCount; i++) {
+            TSetNodeAttrArgs args(ids[i * NodeGroupSize + 1]);
+            args.SetFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
+            args.SetSize(12_KB);
+            tablet.SetNodeAttr(args);
+        }
+
+        // There should be 4 deletion markers and 60 used blocks in each range
+        // 4/60 scales to ~68/1024 > 64 deletion markers per fully filled range
+        // Cleanup should've been run automatically for a single range
+        // After cleanup, there should remain 28 deletion markers in total
+        // 28/480 scales to ~59/1024 => no more cleanup operations
+        {
+            auto response = tablet.GetStorageStats(1);
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 60, stats.GetUsedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(28, stats.GetDeletionMarkersCount());
+        }
+
+        // Delete 15 files in each group
+        for (ui32 i = 0; i < groupCount; i++) {
+            for (ui32 j = 1; j < NodeGroupSize; j++) {
+                auto name = Sprintf("test%u", i * NodeGroupSize + j);
+                tablet.UnlinkNode(RootNodeId, name, false);
+            }
+        }
+
+        // Cleanup should've been triggered automatically
+        {
+            auto response = tablet.GetStorageStats(1);
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(8 * 64, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetUsedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeletionMarkersCount());
+        }
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -16,3 +16,4 @@ InMemoryIndexCacheLoadOnTabletStart: true
 InMemoryIndexCacheLoadOnTabletStartRowsPerTx: 1
 UseMixedBlocksInsteadOfAliveBlocksInCompaction: true
 MixedBlocksOffloadedRangesCapacity: 1024
+CalculateCleanupScoreBasedOnUsedBlocksCount: true

--- a/doc/filestore/design/storage/config.md
+++ b/doc/filestore/design/storage/config.md
@@ -32,4 +32,3 @@ Here is the list of these settings:
 * `GetNodeAttrBatchEnabled: true` - enables fetching NodeAttr (stat) in large batches for multitablet filesystems
 * `UnalignedThreeStageWriteEnabled: true` - causes unaligned writes to follow the efficient ThreeStageWrite datapath
 * `UseMixedBlocksInsteadOfAliveBlocksInCompaction: true` - see the description in storage.proto (this flag basically fixes garbage level-based compaction triggers)
-* `CalculateCleanupScoreBasedOnUsedBlocksCount` - makes Cleanup running more aggressive

--- a/doc/filestore/design/storage/config.md
+++ b/doc/filestore/design/storage/config.md
@@ -32,3 +32,4 @@ Here is the list of these settings:
 * `GetNodeAttrBatchEnabled: true` - enables fetching NodeAttr (stat) in large batches for multitablet filesystems
 * `UnalignedThreeStageWriteEnabled: true` - causes unaligned writes to follow the efficient ThreeStageWrite datapath
 * `UseMixedBlocksInsteadOfAliveBlocksInCompaction: true` - see the description in storage.proto (this flag basically fixes garbage level-based compaction triggers)
+* `CalculateCleanupScoreBasedOnUsedBlocksCount` - makes Cleanup running more aggressive


### PR DESCRIPTION
Initially, the condition for running cleanup was based on the average number of deletion markers per used range without taking sparsity into account. It could lead to the situation when the ranges are not cleaned because the number of deletion markers is low despite the fact that the ratio between the number of deletion markers and the number of used blocks is very high.

The new condition is based on the average number of deletion markers per used block. For the compatibility with the old condition, the number of blocks is converted to the number of ranges taking the assumption that the ranges are fully filled.

Also, a condition for running cleanup is added after truncation operations.

https://github.com/ydb-platform/nbs/issues/3061