### PR TITLE
[Filestore] Fix inconsistency in compaction metrics calculation when adding data #3096

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -27,7 +27,8 @@ private:
 
     struct TCompactionRangeInfo
     {
-        TCompactionStats Stats;
+        ui32 BlobsCount = 0;
+        ui32 GarbageBlocksCount = 0;
         bool Compacted = false;
     };
     THashMap<ui32, TCompactionRangeInfo> RangeId2CompactionStats;
@@ -147,7 +148,7 @@ private:
                 block.NodeId,
                 block.BlockIndex,
                 blob.BlocksCount);
-            AccessCompactionRangeInfo(rangeId).Stats.BlobsCount += 1;
+            AccessCompactionRangeInfo(rangeId).BlobsCount += 1;
         }
 
         for (const auto& part: args.UnalignedDataParts) {
@@ -221,8 +222,8 @@ private:
             auto writeBlocksResult = Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks);
             if (writeBlocksResult.NewBlob) {
                 ui32 rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-                AccessCompactionRangeInfo(rangeId).Stats.BlobsCount += 1;
-                AccessCompactionRangeInfo(rangeId).Stats.GarbageBlocksCount +=
+                AccessCompactionRangeInfo(rangeId).BlobsCount += 1;
+                AccessCompactionRangeInfo(rangeId).GarbageBlocksCount +=
                     writeBlocksResult.GarbageBlocksCount;
             }
         }
@@ -257,7 +258,7 @@ private:
             Tablet.DeleteFreshBlocks(db, blob.Blocks);
 
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
+            auto& stats = AccessCompactionRangeInfo(rangeId);
             auto writeBlocksResult =
                 Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks);
             if (writeBlocksResult.NewBlob) {
@@ -277,7 +278,7 @@ private:
 
         for (auto& blob: args.SrcBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
+            auto& stats = AccessCompactionRangeInfo(rangeId);
             if (!Tablet.UpdateBlockLists(db, blob)) {
                 stats.BlobsCount = Max(stats.BlobsCount, 1U) - 1;
                 // no proper way to reliably decrement stats.GarbageBlocksCount
@@ -298,7 +299,7 @@ private:
 
         for (auto& blob: args.MixedBlobs) {
             const auto rangeId = Tablet.GetMixedRangeIndex(blob.Blocks);
-            auto& stats = AccessCompactionRangeInfo(rangeId).Stats;
+            auto& stats = AccessCompactionRangeInfo(rangeId);
             auto writeBlocksResult =
                 Tablet.WriteMixedBlocks(db, blob.BlobId, blob.Blocks);
             if (writeBlocksResult.NewBlob) {
@@ -324,9 +325,9 @@ private:
             // The counter is not guaranteed to be perfectly in sync with the
             // actual blob count in range so a check for moving below zero is
             // needed.
-            rangeInfo.Stats.BlobsCount =
-                Max(1U, rangeInfo.Stats.BlobsCount) - 1;
-            if (rangeInfo.Stats.BlobsCount == 0) {
+            rangeInfo.BlobsCount =
+                Max(1U, rangeInfo.BlobsCount) - 1;
+            if (rangeInfo.BlobsCount == 0) {
                 // this range will be fully compacted after this Compaction
                 // iteration
                 rangeInfo.Compacted = true;
@@ -354,12 +355,12 @@ private:
             // <nodeId, blockIndex> -> rangeId mapping. We don't want such
             // situations to cause extra compactions and we thus treat such
             // a group of blobs as a single "logical" blob in CompactionMap.
-            ++AccessCompactionRangeInfo(rangeId).Stats.BlobsCount;
+            ++AccessCompactionRangeInfo(rangeId).BlobsCount;
         }
 
         // recalculating GarbageBlocksCount for each of the affected ranges
         for (const auto rangeId: rangeIds) {
-            AccessCompactionRangeInfo(rangeId).Stats.GarbageBlocksCount =
+            AccessCompactionRangeInfo(rangeId).GarbageBlocksCount =
                 Tablet.CalculateMixedIndexRangeGarbageBlockCount(rangeId);
         }
     }
@@ -368,25 +369,26 @@ private:
         TIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
-        for (const auto& x: RangeId2CompactionStats) {
+        for (const auto& [rangeId, updatedStats]: RangeId2CompactionStats) {
+            auto stats = Tablet.GetCompactionStats(rangeId);
             db.WriteCompactionMap(
-                x.first,
-                x.second.Stats.BlobsCount,
-                x.second.Stats.DeletionsCount,
-                x.second.Stats.GarbageBlocksCount);
+                rangeId,
+                updatedStats.BlobsCount,
+                stats.DeletionsCount,
+                updatedStats.GarbageBlocksCount);
             Tablet.UpdateCompactionMap(
-                x.first,
-                x.second.Stats.BlobsCount,
-                x.second.Stats.DeletionsCount,
-                x.second.Stats.GarbageBlocksCount,
-                x.second.Compacted);
+                rangeId,
+                updatedStats.BlobsCount,
+                stats.DeletionsCount,
+                updatedStats.GarbageBlocksCount,
+                updatedStats.Compacted);
 
             AddCompactionRange(
                 args.CommitId,
-                x.first,
-                x.second.Stats.BlobsCount,
-                x.second.Stats.DeletionsCount,
-                x.second.Stats.GarbageBlocksCount,
+                rangeId,
+                updatedStats.BlobsCount,
+                stats.DeletionsCount,
+                updatedStats.GarbageBlocksCount,
                 args.ProfileLogRequest);
         }
     }
@@ -419,12 +421,13 @@ private:
         THashMap<ui32, TCompactionRangeInfo>::insert_ctx ctx;
         auto it = RangeId2CompactionStats.find(rangeId, ctx);
         if (it == RangeId2CompactionStats.end()) {
+            const auto& stats = Tablet.GetCompactionStats(rangeId);
             it = RangeId2CompactionStats.emplace_direct(
                 ctx,
                 rangeId,
                 TCompactionRangeInfo{
-                    Tablet.GetCompactionStats(rangeId),
-                    false});
+                    .BlobsCount = stats.BlobsCount,
+                    .GarbageBlocksCount = stats.GarbageBlocksCount});
         }
 
         return it->second;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -7040,6 +7040,60 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetDeletionMarkersCount());
         }
     }
+
+    TABLET_TEST_4K_ONLY(CheckCompactionStatsAddBlobWriteBatch)
+    {
+        const auto block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBatchEnabled(true);
+        storageConfig.SetWriteBatchTimeout(1); // 1 ms
+        storageConfig.SetWriteBlobThreshold(4_KB);
+        storageConfig.SetMaxBlobSize(8_KB);
+
+        TTestEnv env({}, std::move(storageConfig));
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        auto handle = CreateHandle(tablet, id);
+
+        for (ui32 i = 0; i < 4; i++) {
+            auto request =
+                tablet.CreateWriteDataRequest(handle, i * 2 * block, block, 'a');
+            tablet.SendRequest(std::move(request));
+        }
+
+        TDispatchOptions options;
+        env.GetRuntime().DispatchEvents(options);
+
+        {
+            auto response = tablet.GetStorageStats(1);
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                4,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.CompactionRangeStatsSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                stats.GetCompactionRangeStats(0).GetBlobCount());
+            /* TODO: https://github.com/ydb-platform/nbs/issues/3096
+            UNIT_ASSERT_VALUES_EQUAL(
+                4,
+                stats.GetCompactionRangeStats(0).GetDeletionCount()); */
+        }
+
+        tablet.DestroyHandle(handle);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -7086,10 +7086,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(
                 2,
                 stats.GetCompactionRangeStats(0).GetBlobCount());
-            /* TODO: https://github.com/ydb-platform/nbs/issues/3096
             UNIT_ASSERT_VALUES_EQUAL(
                 4,
-                stats.GetCompactionRangeStats(0).GetDeletionCount()); */
+                stats.GetCompactionRangeStats(0).GetDeletionCount());
         }
 
         tablet.DestroyHandle(handle);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -7041,15 +7041,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
     }
 
-    TABLET_TEST_4K_ONLY(CheckCompactionStatsAddBlobWriteBatch)
+    TABLET_TEST(CheckCompactionStatsAddBlobWriteBatch)
     {
         const auto block = tabletConfig.BlockSize;
 
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBatchEnabled(true);
         storageConfig.SetWriteBatchTimeout(1); // 1 ms
-        storageConfig.SetWriteBlobThreshold(4_KB);
-        storageConfig.SetMaxBlobSize(8_KB);
+        storageConfig.SetWriteBlobThreshold(block);
+        storageConfig.SetMaxBlobSize(2 * block);
 
         TTestEnv env({}, std::move(storageConfig));
         env.CreateSubDomain("nfs");


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/3096

The compaction map becomes inconsistent when:
1. WriteBatch is enabled.
2. The amount of data written to a range in a single batch is greater than the batch size.

Suggested workaround: do not overwrite DeletionsCount.