### PR TITLE
[NBS] Fix NRD strict write ordering feature

### DIFF
--- a/cloud/blockstore/public/api/protos/headers.proto
+++ b/cloud/blockstore/public/api/protos/headers.proto
@@ -87,6 +87,7 @@ message THeaders
     // Only for STORAGE_MEDIA_SSD_MIRROR* disks.
     uint32 ReplicaCount = 12;
 
-    // Monotonously increasing request ID counter needed by the disk agent to order write requests.
-    uint32 VolumeRequestId = 13;
+    // Monotonously increasing request ID counter needed by the disk agent to
+    // order write requests.
+    uint64 VolumeRequestId = 13;
 }


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/3058
В поле VolumeRequestId должно ехать два uint32: поколение таблетки волума и номер запроса. Из-за опечатки поколение таблетки отбрасывалось и становилось нулём. 