### PR TITLE
Add possibility to load Compaction map asynchronously

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1127,4 +1127,7 @@ message TStorageServiceConfig
     // Allow SysViewProcessor and StatisticsAggregator tablets for compatibility
     // with newer versions of ydb (24-2 and older)
     optional bool AllowAdditionalSystemTablets = 409;
+
+    // If 'false' compaction map will be loaded asynchronously
+    optional bool CompactionMapLoadingSynchronously = 410;
 }

--- a/cloud/blockstore/libs/storage/core/compaction_map.h
+++ b/cloud/blockstore/libs/storage/core/compaction_map.h
@@ -53,6 +53,9 @@ public:
     TCompactionMap(ui32 rangeSize, ICompactionPolicyPtr policy);
     ~TCompactionMap();
 
+    TCompactionMap(TCompactionMap&& cm);
+    TCompactionMap& operator=(TCompactionMap&& cm) noexcept;
+
     static void UpdateCompactionCounter(ui32 source, ui16* target)
     {
         *target = source > Max<ui16>() ? Max<ui16>() : source;
@@ -61,13 +64,14 @@ public:
     void Update(
         const TVector<TCompactionCounter>& counters,
         const TCompressedBitmap* used);
-
     void Update(
         ui32 blockIndex,
         ui32 blobCount,
         ui32 blockCount,
         ui32 usedBlockCount,
         bool compacted);
+    void Update(TCompactionMap& cm);
+
     void RegisterRead(ui32 blockIndex, ui32 blobCount, ui32 blockCount);
     void Clear();
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -536,6 +536,8 @@ TDuration MSeconds(ui32 value)
     xxx(BSGroupsPerChannelToWarmup,                ui32,      1               )\
     xxx(WarmupBSGroupConnectionsTimeout,           TDuration, Seconds(1)      )\
     xxx(AllowAdditionalSystemTablets,              bool,      false           )\
+                                                                               \
+    xxx(CompactionMapLoadingSynchronously,         bool,      true            )\
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -641,6 +641,8 @@ public:
     [[nodiscard]] ui32 GetBSGroupsPerChannelToWarmup() const;
     [[nodiscard]] TDuration GetWarmupBSGroupConnectionsTimeout() const;
     [[nodiscard]] bool GetAllowAdditionalSystemTablets() const;
+
+    bool GetCompactionMapLoadingSynchronously() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -868,6 +868,7 @@ STFUNC(TPartitionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvFlushCompleted, HandleFlushCompleted);
         HFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted, HandleTrimFreshLogCompleted);
         HFunc(TEvPartitionPrivate::TEvCompactionCompleted, HandleCompactionCompleted);
+        HFunc(TEvPartitionPrivate::TEvLoadCompactionMapCompleted, HandleLoadCompactionMapCompleted);
         HFunc(TEvPartitionPrivate::TEvMetadataRebuildCompleted, HandleMetadataRebuildCompleted);
         HFunc(TEvPartitionPrivate::TEvScanDiskCompleted, HandleScanDiskCompleted);
         HFunc(TEvPartitionPrivate::TEvCollectGarbageCompleted, HandleCollectGarbageCompleted);

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -588,6 +588,10 @@ private:
         const TEvPartitionPrivate::TEvCompactionCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleLoadCompactionMapCompleted(
+        const TEvPartitionPrivate::TEvLoadCompactionMapCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleMetadataRebuildCompleted(
         const TEvPartitionPrivate::TEvMetadataRebuildCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -9,6 +9,7 @@
 #include <cloud/blockstore/libs/storage/core/compaction_options.h>
 #include <cloud/blockstore/libs/storage/core/compaction_type.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/core/compaction_map.h>
 #include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
 #include <cloud/blockstore/libs/storage/model/channel_permissions.h>
 #include <cloud/blockstore/libs/storage/partition/model/blob_to_confirm.h>
@@ -863,6 +864,15 @@ struct TEvPartitionPrivate
     };
 
     //
+    // LoadCompactionMapCompleted
+    //
+
+    struct TLoadCompactionMapCompleted
+    {
+        TCompactionMap CompactionMap;
+    };
+
+    //
     // Events declaration
     //
 
@@ -892,6 +902,7 @@ struct TEvPartitionPrivate
         EvPatchBlobCompleted,
         EvAddConfirmedBlobsCompleted,
         EvConfirmBlobsCompleted,
+        EvLoadCompactionMapCompleted,
 
         EvEnd
     };
@@ -921,6 +932,7 @@ struct TEvPartitionPrivate
     using TEvPatchBlobCompleted = TResponseEvent<TPatchBlobCompleted, EvPatchBlobCompleted>;
     using TEvAddConfirmedBlobsCompleted = TResponseEvent<TOperationCompleted, EvAddConfirmedBlobsCompleted>;
     using TEvConfirmBlobsCompleted = TResponseEvent<TConfirmBlobsCompleted, EvConfirmBlobsCompleted>;
+    using TEvLoadCompactionMapCompleted = TResponseEvent<TLoadCompactionMapCompleted, EvLoadCompactionMapCompleted>;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition


### PR DESCRIPTION
For huge volumes the load/update of the compaction map take a long time so this change adds possibility to load/update the compaction map in asynchronous mode.