### PR TITLE
[Disk Manager] Fix flappy test for snapshot service

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -616,6 +616,8 @@ func TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, createOperation.Id)
 	require.NoError(t, err)
 
+	testcommon.RequireCheckpoint(t, ctx, diskID, snapshotID1)
+
 	snapshotID2 := t.Name() + "2"
 
 	// Check that it's possible to create another incremental snapshot.
@@ -818,6 +820,8 @@ func TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating(t *testing.T) {
 
 	err = internal_client.WaitOperation(ctx, client, createOperation.Id)
 	require.NoError(t, err)
+
+	testcommon.RequireCheckpoint(t, ctx, diskID, snapshotID1)
 
 	deleteRequest := disk_manager.DeleteSnapshotRequest{
 		SnapshotId: snapshotID1,

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -597,6 +597,8 @@ func TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
 
+	testcommon.RequireCheckpoint(t, ctx, diskID, baseSnapshotID)
+
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	createOperation, err := client.CreateSnapshot(
 		reqCtx,
@@ -800,10 +802,6 @@ func TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating(t *testing.T) {
 
 	snapshotID1 := t.Name() + "1"
 
-	deleteRequest := disk_manager.DeleteSnapshotRequest{
-		SnapshotId: snapshotID1,
-	}
-
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	createOperation, err := client.CreateSnapshot(
 		reqCtx,
@@ -821,12 +819,18 @@ func TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, createOperation.Id)
 	require.NoError(t, err)
 
+	deleteRequest := disk_manager.DeleteSnapshotRequest{
+		SnapshotId: snapshotID1,
+	}
+
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	deleteOperation, err := client.DeleteSnapshot(reqCtx, &deleteRequest)
 	require.NoError(t, err)
 	require.NotEmpty(t, deleteOperation)
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
+
+	testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)
 
 	snapshotID2 := t.Name() + "2"
 

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -569,7 +569,6 @@ func TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating(t *testing.T) {
 	require.NoError(t, err)
 
 	baseSnapshotID := t.Name() + "_base"
-
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
 		Src: &disk_manager.DiskId{
@@ -585,18 +584,15 @@ func TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating(t *testing.T) {
 	require.NoError(t, err)
 
 	snapshotID1 := t.Name() + "1"
-
 	deleteRequest := disk_manager.DeleteSnapshotRequest{
 		SnapshotId: snapshotID1,
 	}
-
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	deleteOperation, err := client.DeleteSnapshot(reqCtx, &deleteRequest)
 	require.NoError(t, err)
 	require.NotEmpty(t, deleteOperation)
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
-
 	testcommon.RequireCheckpoint(t, ctx, diskID, baseSnapshotID)
 
 	reqCtx = testcommon.GetRequestContext(t, ctx)
@@ -612,14 +608,11 @@ func TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating(t *testing.T) {
 		})
 	require.NoError(t, err)
 	require.NotEmpty(t, createOperation)
-
 	err = internal_client.WaitOperation(ctx, client, createOperation.Id)
 	require.NoError(t, err)
-
 	testcommon.RequireCheckpoint(t, ctx, diskID, snapshotID1)
 
 	snapshotID2 := t.Name() + "2"
-
 	// Check that it's possible to create another incremental snapshot.
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	operation, err = client.CreateSnapshot(
@@ -706,9 +699,7 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, deleteOperation)
-
 	creationErr := internal_client.WaitOperation(ctx, client, createOperation.Id)
-
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
 
@@ -739,7 +730,6 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 	}
 
 	snapshotID2 := t.Name() + "2"
-
 	// Check that it's possible to create another incremental snapshot
 	// (NBS-3192).
 	reqCtx = testcommon.GetRequestContext(t, ctx)
@@ -787,7 +777,6 @@ func TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating(t *testing.T) {
 	require.NoError(t, err)
 
 	baseSnapshotID := t.Name() + "_base"
-
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
 		Src: &disk_manager.DiskId{
@@ -803,7 +792,6 @@ func TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating(t *testing.T) {
 	require.NoError(t, err)
 
 	snapshotID1 := t.Name() + "1"
-
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	createOperation, err := client.CreateSnapshot(
 		reqCtx,
@@ -817,27 +805,22 @@ func TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating(t *testing.T) {
 		})
 	require.NoError(t, err)
 	require.NotEmpty(t, createOperation)
-
 	err = internal_client.WaitOperation(ctx, client, createOperation.Id)
 	require.NoError(t, err)
-
 	testcommon.RequireCheckpoint(t, ctx, diskID, snapshotID1)
 
 	deleteRequest := disk_manager.DeleteSnapshotRequest{
 		SnapshotId: snapshotID1,
 	}
-
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	deleteOperation, err := client.DeleteSnapshot(reqCtx, &deleteRequest)
 	require.NoError(t, err)
 	require.NotEmpty(t, deleteOperation)
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
-
 	testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)
 
 	snapshotID2 := t.Name() + "2"
-
 	// Check that it's possible to create another incremental snapshot.
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	operation, err = client.CreateSnapshot(

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -708,9 +708,11 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
 
-	// If snapshot creation ends up successfuly, snapshot creation and
-	// deletion operations were performed sequentially.
-	// These cases are checked in other tests.
+	// If snapshot creation and it's deletion ends up successfuly it means
+	// snapshot creation and deletion operations were performed sequentially.
+	// These cases are checked in other tests:
+	// TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating and
+	// TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating.
 	if creationErr != nil {
 		snapshotID, _, err := testcommon.GetIncremental(ctx, &types.Disk{
 			ZoneId: "zone-a",

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -614,7 +614,6 @@ func TestSnapshotServiceSequentionalDeletionOfIncrementalSnapshot(t *testing.T) 
 
 	err = internal_client.WaitOperation(ctx, client, createOperation.Id)
 	require.NoError(t, err)
-	// Need to add some variance for better testing.
 
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	deleteOperation, err = client.DeleteSnapshot(reqCtx, &deleteRequest)

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -624,15 +624,17 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// Should wait here because checkpoint is deleted on |createOperation|
+		// operation cancel (and exact time of this event is unknown).
+		testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID, snapshotID1)
 		// In case of snapshot1 creation failure base snapshot may be already
 		// deleted from incremental table and then checkpoint should not exist
 		// on the disk. Otherwise base snapshot checkpoint should exist.
 		if len(snapshotID) > 0 {
-			testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID, snapshotID1)
 			require.Equal(t, snapshotID, baseSnapshotID)
 			testcommon.RequireCheckpoint(t, ctx, diskID, baseSnapshotID)
 		} else {
-			testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID)
+			testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)
 		}
 	}
 

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -178,7 +178,8 @@ func TestSnapshotServiceCancelCreateSnapshotFromDisk(t *testing.T) {
 
 	// Should wait here because checkpoint is deleted on operation cancel (and
 	// exact time of this event is unknown).
-	testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID)
+	testcommon.WaitForCheckpointDoesNotExist(t, ctx, diskID, snapshotID)
+	testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)
 
 	testcommon.CheckConsistency(t, ctx)
 }
@@ -612,10 +613,10 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, deleteOperation.Id)
 	require.NoError(t, err)
 
-	// If snapshot creation ends up successfuly, there may be two cases:
-	// Snapshot was created and then deleted, so should be no checkpoints left
-	// or snapshot deletion ended up before creation, snapshot was not deleted,
-	// so there should be a checkpoint.
+	// If snapshot creation ends up successfuly we don't care because,
+	// there may be two cases: Snapshot was created and then deleted,
+	// so should be no checkpoints left or snapshot deletion ended up before
+	// creation, snapshot was not deleted, so there should be a checkpoint.
 	if creationErr != nil {
 		snapshotID, _, err := testcommon.GetIncremental(ctx, &types.Disk{
 			ZoneId: "zone-a",
@@ -623,8 +624,8 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Should wait here because checkpoint is deleted on |createOperation|
-		// operation cancel (and exact time of this event is unknown).
+		// Should wait here because checkpoint is deleted on snapshotID1
+		// creation operation cancel (and exact time of this event is unknown).
 		testcommon.WaitForCheckpointDoesNotExist(t, ctx, diskID, snapshotID1)
 		// In case of snapshot1 creation failure base snapshot may be already
 		// deleted from incremental table and then checkpoint should not exist
@@ -787,7 +788,8 @@ func TestSnapshotServiceDeleteSnapshotWhenCreationIsInFlight(t *testing.T) {
 	if err != nil {
 		// Should wait here because checkpoint is deleted on |createOp|
 		// operation cancel (and exact time of this event is unknown).
-		testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID)
+		testcommon.WaitForCheckpointDoesNotExist(t, ctx, diskID, snapshotID)
+		testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)
 	}
 
 	testcommon.CheckConsistency(t, ctx)

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -625,7 +625,7 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 
 		// Should wait here because checkpoint is deleted on |createOperation|
 		// operation cancel (and exact time of this event is unknown).
-		testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID, snapshotID1)
+		testcommon.WaitForCheckpointDoesNotExist(t, ctx, diskID, snapshotID1)
 		// In case of snapshot1 creation failure base snapshot may be already
 		// deleted from incremental table and then checkpoint should not exist
 		// on the disk. Otherwise base snapshot checkpoint should exist.

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -631,7 +631,7 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 		// deleted from incremental table and then checkpoint should not exist
 		// on the disk. Otherwise base snapshot checkpoint should exist.
 		if len(snapshotID) > 0 {
-			require.Equal(t, snapshotID, baseSnapshotID)
+			require.Equal(t, baseSnapshotID, snapshotID)
 			testcommon.RequireCheckpoint(t, ctx, diskID, baseSnapshotID)
 		} else {
 			testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -599,7 +599,6 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 
 	// Need to add some variance for better testing.
 	common.WaitForRandomDuration(1*time.Millisecond, 3*time.Second)
-	// common.WaitForRandomDuration(2000*time.Millisecond, 3*time.Second)
 
 	reqCtx = testcommon.GetRequestContext(t, ctx)
 	deleteOperation, err := client.DeleteSnapshot(reqCtx, &disk_manager.DeleteSnapshotRequest{

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -623,10 +623,14 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 			DiskId: diskID,
 		})
 		require.NoError(t, err)
-		// If snapshot creation is cancelled, there may be two cases:
-		// it was cancelled before or after changing base snapshot
-		if snapshotID == baseSnapshotID {
-			testcommon.RequireCheckpoint(t, ctx, diskID, snapshotID)
+
+		// In case of snapshot1 creation failure base snapshot may be already
+		// deleted from incremental table and then checkpoint should not exist
+		// on the disk. Otherwise base snapshot checkpoint should exist.
+		if len(snapshotID) > 0 {
+			testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID, snapshotID1)
+			require.Equal(t, snapshotID, baseSnapshotID)
+			testcommon.RequireCheckpoint(t, ctx, diskID, baseSnapshotID)
 		} else {
 			testcommon.WaitForCheckpointsDoNotExist(t, ctx, diskID)
 		}

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -366,31 +366,6 @@ func RequireCheckpointsDoNotExist(
 	require.Empty(t, checkpoints)
 }
 
-func WaitForCheckpointsDoNotExist(
-	t *testing.T,
-	ctx context.Context,
-	diskID string,
-) {
-
-	nbsClient := NewNbsTestingClient(t, ctx, "zone-a")
-
-	for {
-		checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
-		require.NoError(t, err)
-
-		if len(checkpoints) == 0 {
-			return
-		}
-
-		logging.Warn(
-			ctx,
-			"WaitForCheckpointsDoNotExist proceeding to next iteration",
-		)
-
-		<-time.After(100 * time.Millisecond)
-	}
-}
-
 func WaitForCheckpointDoesNotExist(
 	t *testing.T,
 	ctx context.Context,
@@ -399,8 +374,10 @@ func WaitForCheckpointDoesNotExist(
 ) {
 
 	nbsClient := NewNbsTestingClient(t, ctx, "zone-a")
+	ticker := time.NewTicker(time.Millisecond * 100)
+	defer ticker.Stop()
 
-	for {
+	for range ticker.C {
 		checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
 		require.NoError(t, err)
 
@@ -408,12 +385,10 @@ func WaitForCheckpointDoesNotExist(
 			return
 		}
 
-		logging.Warn(
+		logging.Debug(
 			ctx,
 			"WaitForCheckpointDoesNotExist proceeding to next iteration",
 		)
-
-		<-time.After(100 * time.Millisecond)
 	}
 }
 

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -378,21 +378,20 @@ func WaitForCheckpointsDoNotExist(
 		checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
 		require.NoError(t, err)
 
-		found := false
+		checkpointSet := make(map[string]struct{}, len(checkpoints))
+		for _, checkpoint := range checkpoints {
+			checkpointSet[checkpoint] = struct{}{}
+		}
 
+		found := false
 		for _, awaitedCheckpoint := range awaitedCheckpoints {
-			for _, checkpoint := range checkpoints {
-				if awaitedCheckpoint == checkpoint {
-					found = true
-					break
-				}
-			}
-			if found {
+			if _, exists := checkpointSet[awaitedCheckpoint]; exists {
+				found = true
 				break
 			}
 		}
 
-		if !found {
+		if len(checkpoints) == 0 || (!found && len(awaitedCheckpoints) > 0) {
 			return
 		}
 

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -369,6 +369,7 @@ func WaitForCheckpointsDoNotExist(
 	t *testing.T,
 	ctx context.Context,
 	diskID string,
+	awaitedCheckpoints ...string,
 ) {
 
 	nbsClient := NewNbsTestingClient(t, ctx, "zone-a")
@@ -377,7 +378,21 @@ func WaitForCheckpointsDoNotExist(
 		checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
 		require.NoError(t, err)
 
-		if len(checkpoints) == 0 {
+		found := false
+
+		for _, awaitedCheckpoint := range awaitedCheckpoints {
+			for _, checkpoint := range checkpoints {
+				if awaitedCheckpoint == checkpoint {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+
+		if !found {
 			return
 		}
 


### PR DESCRIPTION
One of the tests affected by https://github.com/ydb-platform/nbs/issues/2008 was not correct.
One of it's flaps: https://github.com/ydb-platform/nbs/actions/runs/13579009298

Also changed WaitForCheckpointsDoNotExist method for better testing


