### PR TITLE
issue-3017: create all directories for unix socket before restoring endpoint

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -741,9 +741,7 @@ TFuture<NProto::TStartEndpointResponse> TEndpointManager::RestoreSingleEndpoint(
             }
 
             auto socketPath = TFsPath(request->GetUnixSocketPath());
-            if (!socketPath.Parent().Exists()) {
-                socketPath.Parent().MkDir();
-            }
+            socketPath.Parent().MkDirs();
 
             auto response = self->StartEndpointImpl(
                 std::move(ctx),

--- a/cloud/filestore/libs/endpoint/endpoint_manager.cpp
+++ b/cloud/filestore/libs/endpoint/endpoint_manager.cpp
@@ -221,9 +221,7 @@ private:
             request->MutableHeaders()->SetOriginFqdn(originFqdn);
 
             auto socketPath = TFsPath(request->GetEndpoint().GetSocketPath());
-            if (!socketPath.Parent().Exists()) {
-                socketPath.Parent().MkDir();
-            }
+            socketPath.Parent().MkDirs();
 
             auto future = StartEndpoint(
                 MakeIntrusive<TCallContext>(requestId),

--- a/cloud/filestore/libs/endpoint/endpoint_manager_ut.cpp
+++ b/cloud/filestore/libs/endpoint/endpoint_manager_ut.cpp
@@ -473,7 +473,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
     {
         TString id = "id";
         TTempDir socketDir("./" + CreateGuidAsString());
-        auto unixSocketPath = socketDir.Path() / TFsPath("socket1/fs1.sock");
+        auto unixSocketPath = socketDir.Path() / TFsPath("socket1/disk1/fs1.sock");
         TString unixSocket = unixSocketPath.GetPath();
 
         UNIT_ASSERT(!unixSocketPath.Parent().Exists());


### PR DESCRIPTION
1. create all directories for socket
2. skip exist check as Mkdirs has the same check inside.