### PR TITLE
issue-3129: Add flag to enable/disable throttling of zero block requests

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1145,6 +1145,7 @@ message TStorageServiceConfig
     // Lagging devices are monitored by periodic requests at this interval.
     optional uint32 LaggingDevicePingInterval = 414;
 
-    // Disable throttling ZeroBlock requests for YDB-based disks.
+    // Disable throttling of ZeroBlocks requests for
+    // YDB-based ('network-ssd', 'network-hdd') disks.
     optional bool DisableZeroBlocksThrottlingForYDBBasedDisks = 415;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1145,6 +1145,6 @@ message TStorageServiceConfig
     // Lagging devices are monitored by periodic requests at this interval.
     optional uint32 LaggingDevicePingInterval = 414;
 
-    // Throttle ZeroBlock requests for YDB-based disks
-    optional bool ThrottlingZeroBlocksEnabledYDBBasedDisks = 415;
+    // Disable throttling ZeroBlock requests for YDB-based disks.
+    optional bool DisableZeroBlocksThrottlingForYDBBasedDisks = 415;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1144,4 +1144,7 @@ message TStorageServiceConfig
 
     // Lagging devices are monitored by periodic requests at this interval.
     optional uint32 LaggingDevicePingInterval = 414;
+
+    // Throttle ZeroBlock requests for SSD drives
+    optional bool ThrottlingEnabledSSDZeroBlocks = 415;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1145,6 +1145,6 @@ message TStorageServiceConfig
     // Lagging devices are monitored by periodic requests at this interval.
     optional uint32 LaggingDevicePingInterval = 414;
 
-    // Throttle ZeroBlock requests for SSD drives
-    optional bool ThrottlingEnabledSSDZeroBlocks = 415;
+    // Throttle ZeroBlock requests for YDB-based disks
+    optional bool ThrottlingZeroBlocksEnabledYDBBasedDisks = 415;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -543,6 +543,7 @@ TDuration MSeconds(ui32 value)
     xxx(AllowAdditionalSystemTablets,              bool,      false           )\
                                                                                \
     xxx(CheckRangeMaxRangeSize,                    ui32,      4_MB            )\
+    xxx(ThrottlingEnabledSSDZeroBlocks,            bool,      true            )
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -543,7 +543,7 @@ TDuration MSeconds(ui32 value)
     xxx(AllowAdditionalSystemTablets,              bool,      false           )\
                                                                                \
     xxx(CheckRangeMaxRangeSize,                    ui32,      4_MB            )\
-    xxx(ThrottlingEnabledSSDZeroBlocks,            bool,      true            )
+    xxx(ThrottlingZeroBlocksEnabledYDBBasedDisks,  bool,      true            )
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -543,7 +543,8 @@ TDuration MSeconds(ui32 value)
     xxx(AllowAdditionalSystemTablets,              bool,      false           )\
                                                                                \
     xxx(CheckRangeMaxRangeSize,                    ui32,      4_MB            )\
-    xxx(ThrottlingZeroBlocksEnabledYDBBasedDisks,  bool,      true            )
+                                                                               \
+    xxx(DisableZeroBlocksThrottlingForYDBBasedDisks,       bool,   false       )
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -657,6 +657,8 @@ public:
     [[nodiscard]] bool GetAllowAdditionalSystemTablets() const;
 
     [[nodiscard]] ui32 GetCheckRangeMaxRangeSize() const;
+
+    [[nodiscard]] bool GetThrottlingEnabledSSDZeroBlocks() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -658,7 +658,7 @@ public:
 
     [[nodiscard]] ui32 GetCheckRangeMaxRangeSize() const;
 
-    [[nodiscard]] bool GetThrottlingZeroBlocksEnabledYDBBasedDisks() const;
+    [[nodiscard]] bool GetDisableZeroBlocksThrottlingForYDBBasedDisks() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -658,7 +658,7 @@ public:
 
     [[nodiscard]] ui32 GetCheckRangeMaxRangeSize() const;
 
-    [[nodiscard]] bool GetThrottlingEnabledSSDZeroBlocks() const;
+    [[nodiscard]] bool GetThrottlingZeroBlocksEnabledYDBBasedDisks() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -6,6 +6,8 @@
 #include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
 #include <cloud/blockstore/libs/storage/protos/part.pb.h>
 
+#include <cloud/storage/core/libs/common/media.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 namespace {
@@ -274,6 +276,23 @@ bool GetThrottlingEnabled(
         default:
             return config.GetThrottlingEnabled();
     }
+}
+
+bool GetThrottlingEnabledZeroBlocks(
+    const TStorageConfig& config,
+    const NProto::TPartitionConfig& partitionConfig)
+{
+    bool throttlingEnabled = GetThrottlingEnabled(config, partitionConfig);
+
+    if (throttlingEnabled &&
+        !NCloud::IsDiskRegistryMediaKind(
+            partitionConfig.GetStorageMediaKind()) &&
+        config.GetDisableZeroBlocksThrottlingForYDBBasedDisks())
+    {
+        throttlingEnabled = false;
+    }
+
+    return throttlingEnabled;
 }
 
 ui32 GetWriteBlobThreshold(

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -144,6 +144,10 @@ bool GetThrottlingEnabled(
     const TStorageConfig& config,
     const NProto::TPartitionConfig& partitionConfig);
 
+bool GetThrottlingEnabledZeroBlocks(
+    const TStorageConfig& config,
+    const NProto::TPartitionConfig& partitionConfig);
+
 bool CompareVolumeConfigs(
     const NKikimrBlockStore::TVolumeConfig& prevConfig,
     const NKikimrBlockStore::TVolumeConfig& newConfig);

--- a/cloud/blockstore/libs/storage/core/proto_helpers_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers_ut.cpp
@@ -1,5 +1,6 @@
 #include "proto_helpers.h"
 
+#include <cloud/blockstore/libs/storage/core/config.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -133,6 +134,100 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
         UNIT_ASSERT_VALUES_EQUAL(
             "uuid-3-2-m",
             volume.GetMigrations(3).GetTargetDevice().GetDeviceUUID());
+    }
+
+    Y_UNIT_TEST(TestThrottling)
+    {
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            UNIT_ASSERT(!GetThrottlingEnabled(config, partitionConfig));
+            UNIT_ASSERT(
+                !GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
+
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            storageServiceConfig.SetThrottlingEnabled(true);
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            UNIT_ASSERT(!GetThrottlingEnabled(config, partitionConfig));
+            UNIT_ASSERT(
+                !GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
+
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            storageServiceConfig.SetThrottlingEnabled(true);
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            partitionConfig.mutable_performanceprofile()->SetThrottlingEnabled(
+                true);
+            UNIT_ASSERT(GetThrottlingEnabled(config, partitionConfig));
+            UNIT_ASSERT(
+                GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
+
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            storageServiceConfig.SetThrottlingEnabledSSD(true);
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            partitionConfig.mutable_performanceprofile()->SetThrottlingEnabled(
+                true);
+            partitionConfig.SetStorageMediaKind(
+                ::NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD);
+            UNIT_ASSERT(!GetThrottlingEnabled(config, partitionConfig));
+            UNIT_ASSERT(
+                !GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
+
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            storageServiceConfig.SetThrottlingEnabledSSD(true);
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            partitionConfig.mutable_performanceprofile()->SetThrottlingEnabled(
+                true);
+            partitionConfig.SetStorageMediaKind(
+                ::NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_SSD);
+            UNIT_ASSERT(GetThrottlingEnabled(config, partitionConfig));
+            UNIT_ASSERT(
+                GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
+
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            storageServiceConfig.SetThrottlingEnabled(true);
+            storageServiceConfig.SetThrottlingEnabledSSD(true);
+            storageServiceConfig.SetDisableZeroBlocksThrottlingForYDBBasedDisks(
+                true);
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            partitionConfig.mutable_performanceprofile()->SetThrottlingEnabled(
+                true);
+            partitionConfig.SetStorageMediaKind(
+                ::NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_SSD);
+            UNIT_ASSERT(
+                !GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
+
+        {
+            NProto::TStorageServiceConfig storageServiceConfig;
+            storageServiceConfig.SetThrottlingEnabled(true);
+            storageServiceConfig.SetThrottlingEnabledSSD(true);
+            storageServiceConfig.SetDisableZeroBlocksThrottlingForYDBBasedDisks(
+                true);
+            TStorageConfig config(storageServiceConfig, nullptr);
+            NProto::TPartitionConfig partitionConfig;
+            partitionConfig.mutable_performanceprofile()->SetThrottlingEnabled(
+                true);
+            partitionConfig.SetStorageMediaKind(
+                ::NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_SSD_MIRROR3);
+            UNIT_ASSERT(
+                GetThrottlingEnabledZeroBlocks(config, partitionConfig));
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -103,28 +103,17 @@ bool GetThrottlingEnabled(
     const TStorageConfig& config,
     const NProto::TPartitionConfig& partitionConfig)
 {
-    if (!partitionConfig.GetPerformanceProfile().GetThrottlingEnabled()) {
-        return false;
-    }
+    bool throttlingEnabled = GetThrottlingEnabled(config, partitionConfig);
 
-    if (NCloud::IsDiskRegistryMediaKind(partitionConfig.GetStorageMediaKind()))
-    {
-        return config.GetThrottlingEnabled();
-    }
-
-    bool thottlingEnabled =
-        partitionConfig.GetStorageMediaKind() ==
-                NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_SSD
-            ? config.GetThrottlingEnabledSSD()
-            : config.GetThrottlingEnabled();
-
-    if (IsZeroMethod<TMethod> &&
+    if (throttlingEnabled && IsZeroMethod<TMethod> &&
+        !NCloud::IsDiskRegistryMediaKind(
+            partitionConfig.GetStorageMediaKind()) &&
         config.GetDisableZeroBlocksThrottlingForYDBBasedDisks())
     {
-        thottlingEnabled = false;
+        throttlingEnabled = false;
     }
 
-    return thottlingEnabled;
+    return throttlingEnabled;
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -103,17 +103,11 @@ bool GetThrottlingEnabled(
     const TStorageConfig& config,
     const NProto::TPartitionConfig& partitionConfig)
 {
-    bool throttlingEnabled = GetThrottlingEnabled(config, partitionConfig);
-
-    if (throttlingEnabled && IsZeroMethod<TMethod> &&
-        !NCloud::IsDiskRegistryMediaKind(
-            partitionConfig.GetStorageMediaKind()) &&
-        config.GetDisableZeroBlocksThrottlingForYDBBasedDisks())
-    {
-        throttlingEnabled = false;
+    if constexpr (IsZeroMethod<TMethod>) {
+        return GetThrottlingEnabledZeroBlocks(config, partitionConfig);
     }
 
-    return throttlingEnabled;
+    return GetThrottlingEnabled(config, partitionConfig);
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -112,9 +112,19 @@ bool GetThrottlingEnabled(
         return config.GetThrottlingEnabled();
     }
 
-    return IsZeroMethod<TMethod>
-               ? config.GetThrottlingZeroBlocksEnabledYDBBasedDisks()
-               : config.GetThrottlingEnabledSSD();
+    bool thottlingEnabled =
+        partitionConfig.GetStorageMediaKind() ==
+                NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_SSD
+            ? config.GetThrottlingEnabledSSD()
+            : config.GetThrottlingEnabled();
+
+    if (IsZeroMethod<TMethod> &&
+        config.GetDisableZeroBlocksThrottlingForYDBBasedDisks())
+    {
+        thottlingEnabled = false;
+    }
+
+    return thottlingEnabled;
 }
 
 }   // namespace


### PR DESCRIPTION
#3129 

Filesystem can be mounted with discard option:

```
discard
   If set, causes discard/TRIM commands to be issued to the block
   device when blocks are freed. This is useful for SSD devices
   and sparse/thinly-provisioned LUNs.
```

As a result, we see spikes in zero block requests, leading to throttling of all write requests and causing users to experience disk hangs.

In this pull request I introduced config parameter to disable throttling of zero blocks requests.