### PR TITLE
[Disk Manager] fix ydb binary path

### DIFF
--- a/cloud/disk_manager/test/recipe/__main__.py
+++ b/cloud/disk_manager/test/recipe/__main__.py
@@ -6,6 +6,7 @@ import contrib.ydb.tests.library.common.yatest_common as yatest_common
 from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 from library.python.testing.recipe import declare_recipe, set_env
 
+from cloud.disk_manager.test.recipe.common import get_ydb_binary_path
 from cloud.disk_manager.test.recipe.compute_launcher import ComputeLauncher
 from cloud.disk_manager.test.recipe.disk_manager_launcher import DiskManagerLauncher
 from cloud.disk_manager.test.recipe.kms_launcher import KmsLauncher
@@ -79,9 +80,7 @@ def start(argv):
     s3.start()
     set_env("DISK_MANAGER_RECIPE_S3_PORT", str(s3.port))
 
-    ydb_binary_path = yatest_common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
-    if ydb_binary_path is None:
-        ydb_binary_path = yatest_common.binary_path("contrib/ydb/apps/ydbd/ydbd")
+    ydb_binary_path = get_ydb_binary_path()
     nbs_binary_path = yatest_common.binary_path("cloud/blockstore/apps/server/nbsd")
     disk_agent_binary_path = yatest_common.binary_path("cloud/blockstore/apps/disk_agent/diskagentd")
     nfs_binary_path = yatest_common.binary_path("cloud/filestore/apps/server/filestore-server")

--- a/cloud/disk_manager/test/recipe/common.py
+++ b/cloud/disk_manager/test/recipe/common.py
@@ -1,0 +1,14 @@
+import contrib.ydb.tests.library.common.yatest_common as yatest_common
+from yatest_lib.ya import TestMisconfigurationException
+
+
+def get_ydb_binary_path():
+    try:
+        path = yatest_common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
+    except TestMisconfigurationException:
+        path = None
+
+    if path is None:
+        path = yatest_common.binary_path("contrib/ydb/apps/ydbd/ydbd")
+
+    return path

--- a/cloud/disk_manager/test/recipe/ya.make
+++ b/cloud/disk_manager/test/recipe/ya.make
@@ -2,6 +2,7 @@ PY3_PROGRAM()
 
 PY_SRCS(
     __main__.py
+    common.py
     compute_launcher.py
     disk_manager_launcher.py
     kms_launcher.py

--- a/cloud/disk_manager/test/snapshot_migration_test/test.py
+++ b/cloud/disk_manager/test/snapshot_migration_test/test.py
@@ -13,6 +13,7 @@ import contrib.ydb.tests.library.common.yatest_common as yatest_common
 
 from contrib.ydb.tests.library.harness.kikimr_runner import get_unique_path_for_current_test, ensure_path_exists
 
+from cloud.disk_manager.test.recipe.common import get_ydb_binary_path
 from cloud.disk_manager.test.recipe.disk_manager_launcher import DiskManagerLauncher
 from cloud.disk_manager.test.recipe.metadata_service_launcher import MetadataServiceLauncher
 from cloud.disk_manager.test.recipe.nbs_launcher import NbsLauncher
@@ -50,9 +51,7 @@ class _MigrationTestSetup:
         self._cert_key_file = certs_dir / "server.key"
         _logger.info(self._cert_key_file.exists())
 
-        ydb_binary_path = yatest_common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
-        if ydb_binary_path is None:
-            ydb_binary_path = yatest_common.binary_path("contrib/ydb/apps/ydbd/ydbd")
+        ydb_binary_path = get_ydb_binary_path()
         nbs_binary_path = yatest_common.binary_path("cloud/blockstore/apps/server/nbsd")
         disk_agent_binary_path = yatest_common.binary_path("cloud/blockstore/apps/disk_agent/diskagentd")
         self.disk_manager_binary_path = yatest_common.binary_path("cloud/disk_manager/cmd/disk-manager/disk-manager")


### PR DESCRIPTION
Should handle exception when search for ydb binary path with yatest_common.binary_path.

```
yatest_lib.ya.TestMisconfigurationException: Cannot find binary '['cloud/storage/core/tools/testing/ydb/bin/ydbd']': make sure it was added in the DEPENDS section
```

This binary should not be found if we build without OPENSOURCE option https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/test/snapshot_migration_test/ya.make#L62. The problem was the following: yatest_common.binary_path might throw exception instead of returning None.