### PR TITLE
Initialize PartConfig with params struct

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -54,6 +54,19 @@ public:
 
     struct TNonreplicatedPartitionConfigInitParams
     {
+        TDevices Devices;
+        TVolumeInfo VolumeInfo;
+        TString Name;
+        ui32 BlockSize;
+        NActors::TActorId ParentActorId;
+        NProto::EVolumeIOMode IOMode = NProto::VOLUME_IO_OK;
+        bool MuteIOErrors = false;
+        THashSet<TString> FreshDeviceIds;
+        THashSet<TString> LaggingDeviceIds;
+        TDuration MaxTimedOutDeviceStateDuration;
+        bool MaxTimedOutDeviceStateDurationOverridden = false;
+        bool UseSimpleMigrationBandwidthLimiter = true;
+
         TNonreplicatedPartitionConfigInitParams(
                 TDevices devices,
                 TVolumeInfo volumeInfo,
@@ -97,19 +110,6 @@ public:
         {}
 
         ~TNonreplicatedPartitionConfigInitParams() = default;
-
-        TDevices Devices;
-        TVolumeInfo VolumeInfo;
-        TString Name;
-        ui32 BlockSize;
-        NActors::TActorId ParentActorId;
-        NProto::EVolumeIOMode IOMode = NProto::VOLUME_IO_OK;
-        bool MuteIOErrors = false;
-        THashSet<TString> FreshDeviceIds;
-        THashSet<TString> LaggingDeviceIds;
-        TDuration MaxTimedOutDeviceStateDuration;
-        bool MaxTimedOutDeviceStateDurationOverridden = false;
-        bool UseSimpleMigrationBandwidthLimiter = true;
     };
 
 private:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -131,7 +131,7 @@ private:
 
 public:
     explicit TNonreplicatedPartitionConfig(
-        TNonreplicatedPartitionConfigInitParams params)
+            TNonreplicatedPartitionConfigInitParams params)
         : Devices(std::move(params.Devices))
         , IOMode(params.IOMode)
         , Name(std::move(params.Name))

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -52,6 +52,66 @@ public:
         NProto::EStorageMediaKind MediaKind;
     };
 
+    struct TNonreplicatedPartitionConfigInitParams
+    {
+        TNonreplicatedPartitionConfigInitParams(
+                TDevices devices,
+                TVolumeInfo volumeInfo,
+                TString name,
+                ui32 blockSize,
+                NActors::TActorId parentActorId)
+            : Devices(std::move(devices))
+            , VolumeInfo(volumeInfo)
+            , Name(std::move(name))
+            , BlockSize(blockSize)
+            , ParentActorId(parentActorId)
+        {}
+
+        TNonreplicatedPartitionConfigInitParams(
+                TDevices devices,
+                TVolumeInfo volumeInfo,
+                TString name,
+                ui32 blockSize,
+                NActors::TActorId parentActorId,
+                NProto::EVolumeIOMode iOMode,
+                bool muteIOErrors,
+                THashSet<TString> freshDeviceIds,
+                THashSet<TString> laggingDeviceIds,
+                TDuration maxTimedOutDeviceStateDuration,
+                bool maxTimedOutDeviceStateDurationOverridden,
+                bool useSimpleMigrationBandwidthLimiter)
+            : Devices(std::move(devices))
+            , VolumeInfo(volumeInfo)
+            , Name(std::move(name))
+            , BlockSize(blockSize)
+            , ParentActorId(parentActorId)
+            , IOMode(iOMode)
+            , MuteIOErrors(muteIOErrors)
+            , FreshDeviceIds(std::move(freshDeviceIds))
+            , LaggingDeviceIds(std::move(laggingDeviceIds))
+            , MaxTimedOutDeviceStateDuration(maxTimedOutDeviceStateDuration)
+            , MaxTimedOutDeviceStateDurationOverridden(
+                  maxTimedOutDeviceStateDurationOverridden)
+            , UseSimpleMigrationBandwidthLimiter(
+                  useSimpleMigrationBandwidthLimiter)
+        {}
+
+        ~TNonreplicatedPartitionConfigInitParams() = default;
+
+        TDevices Devices;
+        TVolumeInfo VolumeInfo;
+        TString Name;
+        ui32 BlockSize;
+        NActors::TActorId ParentActorId;
+        NProto::EVolumeIOMode IOMode = NProto::VOLUME_IO_OK;
+        bool MuteIOErrors = false;
+        THashSet<TString> FreshDeviceIds;
+        THashSet<TString> LaggingDeviceIds;
+        TDuration MaxTimedOutDeviceStateDuration;
+        bool MaxTimedOutDeviceStateDurationOverridden = false;
+        bool UseSimpleMigrationBandwidthLimiter = true;
+    };
+
 private:
     TDevices Devices;
     const NProto::EVolumeIOMode IOMode;
@@ -70,31 +130,22 @@ private:
     TVector<ui64> BlockIndices;
 
 public:
-    TNonreplicatedPartitionConfig(
-            TDevices devices,
-            NProto::EVolumeIOMode ioMode,
-            TString name,
-            ui32 blockSize,
-            TVolumeInfo volumeInfo,
-            NActors::TActorId parentActorId,
-            bool muteIOErrors,
-            THashSet<TString> freshDeviceIds,
-            THashSet<TString> laggingDeviceIds,
-            TDuration maxTimedOutDeviceStateDuration,
-            bool maxTimedOutDeviceStateDurationOverridden,
-            bool useSimpleMigrationBandwidthLimiter)
-        : Devices(std::move(devices))
-        , IOMode(ioMode)
-        , Name(std::move(name))
-        , BlockSize(blockSize)
-        , VolumeInfo(volumeInfo)
-        , ParentActorId(std::move(parentActorId))
-        , MuteIOErrors(muteIOErrors)
-        , FreshDeviceIds(std::move(freshDeviceIds))
-        , LaggingDeviceIds(std::move(laggingDeviceIds))
-        , MaxTimedOutDeviceStateDuration(maxTimedOutDeviceStateDuration)
-        , MaxTimedOutDeviceStateDurationOverridden(maxTimedOutDeviceStateDurationOverridden)
-        , UseSimpleMigrationBandwidthLimiter(useSimpleMigrationBandwidthLimiter)
+    explicit TNonreplicatedPartitionConfig(
+        TNonreplicatedPartitionConfigInitParams params)
+        : Devices(std::move(params.Devices))
+        , IOMode(params.IOMode)
+        , Name(std::move(params.Name))
+        , BlockSize(params.BlockSize)
+        , VolumeInfo(params.VolumeInfo)
+        , ParentActorId(std::move(params.ParentActorId))
+        , MuteIOErrors(params.MuteIOErrors)
+        , FreshDeviceIds(std::move(params.FreshDeviceIds))
+        , LaggingDeviceIds(std::move(params.LaggingDeviceIds))
+        , MaxTimedOutDeviceStateDuration(params.MaxTimedOutDeviceStateDuration)
+        , MaxTimedOutDeviceStateDurationOverridden(
+              params.MaxTimedOutDeviceStateDurationOverridden)
+        , UseSimpleMigrationBandwidthLimiter(
+              params.UseSimpleMigrationBandwidthLimiter)
     {
         Y_ABORT_UNLESS(Devices.size());
 
@@ -121,20 +172,21 @@ public:
             }
         }
 
-        return std::make_shared<TNonreplicatedPartitionConfig>(
+        TNonreplicatedPartitionConfigInitParams params{
             std::move(devices),
-            IOMode,
+            VolumeInfo,
             Name,
             BlockSize,
-            VolumeInfo,
             ParentActorId,
+            IOMode,
             MuteIOErrors,
             std::move(freshDeviceIds),
             std::move(laggingDeviceIds),
             MaxTimedOutDeviceStateDuration,
             MaxTimedOutDeviceStateDurationOverridden,
-            UseSimpleMigrationBandwidthLimiter
-        );
+            UseSimpleMigrationBandwidthLimiter};
+        return std::make_shared<TNonreplicatedPartitionConfig>(
+            std::move(params));
     }
 
     const auto& GetDevices() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -27,6 +27,8 @@ using namespace NActors;
 
 namespace {
 
+////////////////////////////////////////////////////////////////////////////////
+
 constexpr ui64 DeviceBlockCount = 8192;
 constexpr ui32 DeviceCountPerReplica = 3;
 constexpr ui32 ReplicaCount = 3;
@@ -175,23 +177,20 @@ struct TTestEnv
             std::make_shared<NFeatures::TFeaturesConfig>(
                 NCloud::NProto::TFeaturesConfig()));
 
-        PartConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            Devices,
-            NProto::VOLUME_IO_OK,
-            "vol0",
-            DefaultBlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{
-                Now(),
-                // only SSD/HDD distinction matters
-                NProto::STORAGE_MEDIA_SSD_MIRROR3},
-            VolumeActorId,
-            false,   // muteIOErrors
-            std::move(freshDeviceIds),
-            std::move(laggingDeviceIds),
-            TDuration::Zero(),   // maxTimedOutDeviceStateDuration
-            false,               // maxTimedOutDeviceStateDurationOverridden
-            true                 // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                Devices,
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    // only SSD/HDD distinction matters
+                    NProto::STORAGE_MEDIA_SSD_MIRROR3},
+                "vol0",
+                DefaultBlockSize,
+                VolumeActorId};
+        params.FreshDeviceIds = std::move(freshDeviceIds);
+        params.LaggingDeviceIds = std::move(laggingDeviceIds);
+        PartConfig =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         auto mirrorPartition = std::make_unique<TMirrorPartitionActor>(
             Config,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator_ut.cpp
@@ -169,22 +169,20 @@ TNonreplicatedPartitionConfigPtr MakePartitionConfig(
     TDevices devices,
     bool useSimpleMigrationBandwidthLimiter)
 {
-    return std::make_shared<TNonreplicatedPartitionConfig>(
-        devices,
-        NProto::VOLUME_IO_OK,
-        "vol0",
-        4_KB,
-        TNonreplicatedPartitionConfig::TVolumeInfo{
-            Now(),
-            // only SSD/HDD distinction matters
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
-        NActors::TActorId(),
-        false,                 // muteIOErrors
-        THashSet<TString>(),   // freshDeviceIds
-        THashSet<TString>(),   // laggingDeviceIds
-        TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-        false,                 // maxTimedOutDeviceStateDurationOverridden
-        useSimpleMigrationBandwidthLimiter);
+    TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+        params{
+            std::move(devices),
+            TNonreplicatedPartitionConfig::TVolumeInfo{
+                Now(),
+                // only SSD/HDD distinction matters
+                NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
+            "vol0",
+            DefaultBlockSize,
+            NActors::TActorId()};
+    params.UseSimpleMigrationBandwidthLimiter =
+        useSimpleMigrationBandwidthLimiter;
+
+    return std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
@@ -176,23 +176,21 @@ struct TTestEnv
             std::make_shared<NFeatures::TFeaturesConfig>(
                 NCloud::NProto::TFeaturesConfig()));
 
-        auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            Devices,
-            NProto::VOLUME_IO_OK,
-            "vol0",
-            DefaultBlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{
-                Now(),
-                // only SSD/HDD distinction matters
-                NProto::STORAGE_MEDIA_SSD_MIRROR3},
-            VolumeActorId,
-            false,   // muteIOErrors
-            std::move(freshDeviceIds),
-            std::move(laggingDeviceIds),
-            TDuration::Zero(),   // maxTimedOutDeviceStateDuration
-            false,               // maxTimedOutDeviceStateDurationOverridden
-            false                // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                Devices,
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    // only SSD/HDD distinction matters
+                    NProto::STORAGE_MEDIA_SSD_MIRROR3},
+                "vol0",
+                DefaultBlockSize,
+                VolumeActorId};
+        params.FreshDeviceIds = std::move(freshDeviceIds);
+        params.LaggingDeviceIds = std::move(laggingDeviceIds);
+        params.UseSimpleMigrationBandwidthLimiter = false;
+        auto partConfig =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         auto mirrorPartition = std::make_unique<TMirrorPartitionActor>(
             Config,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
@@ -257,23 +257,19 @@ struct TTestEnv
             )
         );
 
-        PartConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            ToLogicalBlocks(devices, BlockSize),
-            NProto::VOLUME_IO_OK,
-            "test",
-            BlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{
-                Now(),
-                // only SSD/HDD distinction matters
-                NProto::STORAGE_MEDIA_SSD_MIRROR3},
-            VolumeActorId,
-            false,   // muteIOErrors
-            std::move(freshDeviceIds),
-            THashSet<TString>(),   // laggingDeviceIds
-            TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-            false,                 // maxTimedOutDeviceStateDurationOverridden
-            true                   // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                ToLogicalBlocks(devices, BlockSize),
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    // only SSD/HDD distinction matters
+                    NProto::STORAGE_MEDIA_SSD_MIRROR3},
+                "test",
+                BlockSize,
+                VolumeActorId};
+        params.FreshDeviceIds = std::move(freshDeviceIds);
+        PartConfig =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         for (auto& replica: Replicas) {
             replica = ToLogicalBlocks(replica, BlockSize);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
@@ -53,20 +53,16 @@ struct TEnv
             device->SetDeviceUUID("1_3");
         }
 
-        Config = std::make_shared<TNonreplicatedPartitionConfig>(
-            Devices,
-            NProto::VOLUME_IO_OK,
-            "vol0",
-            4_KB,
-            volumeInfo,
-            NActors::TActorId(),
-            false,   // muteIOErrors
-            FreshDeviceIds,
-            THashSet<TString>(),   // laggingDeviceIds
-            TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-            false,                 // maxTimedOutDeviceStateDurationOverridden
-            true                   // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                Devices,
+                volumeInfo,
+                "vol0",
+                DefaultBlockSize,
+                NActors::TActorId()};
+        params.FreshDeviceIds = FreshDeviceIds;
+        Config =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         {
             auto* device = ReplicaDevices.Add();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -191,23 +191,19 @@ struct TTestEnv
             )
         );
 
-        auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            ToLogicalBlocks(devices, DefaultBlockSize),
-            NProto::VOLUME_IO_OK,
-            "test",
-            DefaultBlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{
-                Now(),
-                // only SSD/HDD distinction matters
-                NProto::STORAGE_MEDIA_SSD_MIRROR3},
-            VolumeActorId,
-            false,   // muteIOErrors
-            std::move(freshDeviceIds),
-            THashSet<TString>(),   // laggingDeviceIds
-            TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-            false,                 // maxTimedOutDeviceStateDurationOverridden
-            true                   // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                ToLogicalBlocks(devices, DefaultBlockSize),
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    // only SSD/HDD distinction matters
+                    NProto::STORAGE_MEDIA_SSD_MIRROR3},
+                "test",
+                DefaultBlockSize,
+                VolumeActorId};
+        params.FreshDeviceIds = std::move(freshDeviceIds);
+        auto partConfig =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         for (auto& replica: replicas) {
             replica = ToLogicalBlocks(replica, DefaultBlockSize);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -194,23 +194,20 @@ struct TTestEnv
             )
         );
 
-        auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            ToLogicalBlocks(devices, DefaultBlockSize),
-            ioMode,
-            "test",
-            DefaultBlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{
-                Now(),
-                // only SSD/HDD distinction matters
-                NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
-            VolumeActorId,
-            false,                 // muteIOErrors
-            THashSet<TString>(),   // freshDeviceIds
-            THashSet<TString>(),   // laggingDeviceIds
-            TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-            false,                 // maxTimedOutDeviceStateDurationOverridden
-            false                  // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                ToLogicalBlocks(devices, DefaultBlockSize),
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    // only SSD/HDD distinction matters
+                    NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
+                "test",
+                DefaultBlockSize,
+                VolumeActorId};
+        params.IOMode = ioMode;
+        params.UseSimpleMigrationBandwidthLimiter = false;
+        auto partConfig =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         auto part = std::make_unique<TNonreplicatedPartitionMigrationActor>(
             std::move(config),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
@@ -120,23 +120,20 @@ struct TTestEnv
             )
         );
 
-        auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            ToLogicalBlocks(devices, DefaultBlockSize),
-            ioMode,
-            "test",
-            DefaultBlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{
-                Now(),
-                // only SSD/HDD distinction matters
-                NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
-            VolumeActorId,
-            false,                 // muteIOErrors
-            THashSet<TString>(),   // freshDeviceIds
-            THashSet<TString>(),   // laggingDeviceIds
-            TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-            false,                 // maxTimedOutDeviceStateDurationOverridden
-            false                  // useSimpleMigrationBandwidthLimiter
-        );
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            params{
+                ToLogicalBlocks(devices, DefaultBlockSize),
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    // only SSD/HDD distinction matters
+                    NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
+                "test",
+                DefaultBlockSize,
+                VolumeActorId};
+        params.IOMode = ioMode;
+        params.UseSimpleMigrationBandwidthLimiter = false;
+        auto partConfig =
+            std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
         auto part = std::make_unique<TNonreplicatedPartitionRdmaActor>(
             std::move(config),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -124,20 +124,20 @@ struct TTestEnv
             )
         );
 
+        TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+            partConfigInitParams{
+                ToLogicalBlocks(params.Devices, DefaultBlockSize),
+                TNonreplicatedPartitionConfig::TVolumeInfo{
+                    Now(),
+                    params.MediaKind},
+                "test",
+                DefaultBlockSize,
+                VolumeActorId};
+        partConfigInitParams.IOMode = params.IOMode;
+        partConfigInitParams.MuteIOErrors = params.MuteIOErrors;
+        partConfigInitParams.UseSimpleMigrationBandwidthLimiter = false;
         auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-            ToLogicalBlocks(params.Devices, DefaultBlockSize),
-            params.IOMode,
-            "test",
-            DefaultBlockSize,
-            TNonreplicatedPartitionConfig::TVolumeInfo{Now(), params.MediaKind},
-            VolumeActorId,
-            params.MuteIOErrors,
-            THashSet<TString>(),   // freshDeviceIds
-            THashSet<TString>(),   // laggingDeviceIds
-            TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-            false,                 // maxTimedOutDeviceStateDurationOverridden
-            false                  // useSimpleMigrationBandwidthLimiter
-        );
+            std::move(partConfigInitParams));
 
         auto part = std::make_unique<TNonreplicatedPartitionActor>(
             std::move(config),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -125,23 +125,19 @@ struct TTestEnv
 
             TString name = Sprintf("replica-%d", i);
 
+            TNonreplicatedPartitionConfig::
+                TNonreplicatedPartitionConfigInitParams params{
+                    ToLogicalBlocks(replicaDevices, DefaultBlockSize),
+                    TNonreplicatedPartitionConfig::TVolumeInfo{
+                        Now(),
+                        // only SSD/HDD distinction matters
+                        NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
+                    name,
+                    DefaultBlockSize,
+                    VolumeActorId};
+            params.IOMode = ioMode;
             auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-                ToLogicalBlocks(replicaDevices, DefaultBlockSize),
-                ioMode,
-                name,
-                DefaultBlockSize,
-                TNonreplicatedPartitionConfig::TVolumeInfo{
-                    Now(),
-                    // only SSD/HDD distinction matters
-                    NProto::STORAGE_MEDIA_SSD_NONREPLICATED},
-                VolumeActorId,
-                false,                 // muteIOErrors
-                THashSet<TString>(),   // freshDeviceIds
-                THashSet<TString>(),   // laggingDeviceIds
-                TDuration::Zero(),     // maxTimedOutDeviceStateDuration
-                false,   // maxTimedOutDeviceStateDurationOverridden
-                true     // useSimpleMigrationBandwidthLimiter
-            );
+                std::move(params));
 
             auto part = std::make_unique<TNonreplicatedPartitionActor>(
                 config,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
@@ -17,6 +17,8 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 namespace {
 
+////////////////////////////////////////////////////////////////////////////////
+
 bool LaggingDevicesAreAllowed(
     NProto::EStorageMediaKind mediaKind,
     const TStorageConfigPtr& config,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -167,21 +167,25 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
     const bool useSimpleMigrationBandwidthLimiter =
         IsReliableDiskRegistryMediaKind(mediaKind);
 
-    auto nonreplicatedConfig = std::make_shared<TNonreplicatedPartitionConfig>(
-        State->GetMeta().GetDevices(),
-        State->GetMeta().GetIOMode(),
-        State->GetDiskId(),
-        State->GetMeta().GetConfig().GetBlockSize(),
-        TNonreplicatedPartitionConfig::TVolumeInfo{
-            State->GetCreationTs(),
-            mediaKind},
-        SelfId(),
-        State->GetMeta().GetMuteIOErrors(),
-        State->GetFilteredFreshDevices(),
-        State->GetLaggingDevices(),
-        maxTimedOutDeviceStateDuration,
-        maxTimedOutDeviceStateDurationOverridden,
-        useSimpleMigrationBandwidthLimiter);
+    TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
+        params{
+            State->GetMeta().GetDevices(),
+            TNonreplicatedPartitionConfig::TVolumeInfo{
+                State->GetCreationTs(),
+                mediaKind},
+            State->GetDiskId(),
+            State->GetMeta().GetConfig().GetBlockSize(),
+            SelfId(),
+            State->GetMeta().GetIOMode(),
+            State->GetMeta().GetMuteIOErrors(),
+            State->GetFilteredFreshDevices(),
+            State->GetLaggingDevices(),
+            maxTimedOutDeviceStateDuration,
+            maxTimedOutDeviceStateDurationOverridden,
+            useSimpleMigrationBandwidthLimiter,
+        };
+    auto nonreplicatedConfig =
+        std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
     TActorId nonreplicatedActorId;
 


### PR DESCRIPTION
#3
Изменений в логике нет. 
Переделываю инициализацию `TNonreplicatedPartitionConfig` через структуру чтобы не править все конструирования в кодовой базе при добавлении параметра