### PR TITLE
issue-3161: move the leader/follower stuff from TMirrorRequestActor to TMigrationRequestActor; add unit tests for TMirrorRequestActor and TMigrationRequestActor

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.cpp
@@ -1,0 +1,1 @@
+#include "migration_request_actor.h"

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
@@ -17,38 +17,38 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void ProcessMirrorActorError(NProto::TError& error);
-
-////////////////////////////////////////////////////////////////////////////////
-
-// The TMirrorRequestActor class is used to write to N replicas for the mirror
-// disk. It should process all errors from replicas into E_REJECTED. Because
-// sooner or later the disk agent will return to work, or the replica will be
-// replaced. All replicas are equivalent and are placed in the Replicas.
+// The TMigrationRequestActor class is used to migrate a new device, it has two
+// replicas, one is leader and the second is follower. If we receive a fatal
+// error from the follower partition, we do not respond to the client with an
+// error, but at the same time stop the migration. And if we receive a non-fatal
+// error, response it to the client. The client will retry the request.
 
 template <typename TMethod>
-class TMirrorRequestActor final
-    : public NActors::TActorBootstrapped<TMirrorRequestActor<TMethod>>
+class TMigrationRequestActor final
+    : public NActors::TActorBootstrapped<TMigrationRequestActor<TMethod>>
 {
 private:
-    using TBase = NActors::TActorBootstrapped<TMirrorRequestActor<TMethod>>;
+    using TBase = NActors::TActorBootstrapped<TMigrationRequestActor<TMethod>>;
     using TResponseProto = typename TMethod::TResponse::ProtoRecordType;
 
     const TRequestInfoPtr RequestInfo;
-    const TVector<NActors::TActorId> Replicas;
+    const NActors::TActorId LeaderPartition;
+    const NActors::TActorId FollowerPartition;
     const typename TMethod::TRequest::ProtoRecordType Request;
     const TString DiskId;
     const NActors::TActorId ParentActorId;
     const ui64 NonreplicatedRequestCounter;
 
     TVector<TCallContextPtr> ForkedCallContexts;
-    ui32 Responses = 0;
-    TResponseProto LeadersCollectiveResponse;
+    ui32 PendingRequests = 0;
+    TResponseProto LeaderResponse;
+    TResponseProto FollowerResponse;
 
 public:
-    TMirrorRequestActor(
+    TMigrationRequestActor(
         TRequestInfoPtr requestInfo,
-        TVector<NActors::TActorId> replicas,
+        NActors::TActorId leaderPartition,  // may be empty
+        NActors::TActorId followerPartition,
         typename TMethod::TRequest::ProtoRecordType request,
         TString diskId,
         NActors::TActorId parentActorId,
@@ -59,7 +59,10 @@ public:
 private:
     void SendRequests(const NActors::TActorContext& ctx);
     void Done(const NActors::TActorContext& ctx);
-    void UpdateResponse(TResponseProto&& response);
+
+    void UpdateResponse(
+        const NActors::TActorId& sender,
+        TResponseProto&& response);
 
 private:
     STFUNC(StateWork);
@@ -80,25 +83,27 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
-TMirrorRequestActor<TMethod>::TMirrorRequestActor(
+TMigrationRequestActor<TMethod>::TMigrationRequestActor(
         TRequestInfoPtr requestInfo,
-        TVector<NActors::TActorId> replicas,
+        NActors::TActorId leaderPartition,
+        NActors::TActorId followerPartition,
         typename TMethod::TRequest::ProtoRecordType request,
         TString diskId,
         NActors::TActorId parentActorId,
         ui64 nonreplicatedRequestCounter)
     : RequestInfo(std::move(requestInfo))
-    , Replicas(std::move(replicas))
+    , LeaderPartition(leaderPartition)
+    , FollowerPartition(followerPartition)
     , Request(std::move(request))
     , DiskId(std::move(diskId))
     , ParentActorId(parentActorId)
     , NonreplicatedRequestCounter(nonreplicatedRequestCounter)
 {
-    Y_DEBUG_ABORT_UNLESS(!Replicas.empty());
+    Y_DEBUG_ABORT_UNLESS(FollowerPartition);
 }
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::Bootstrap(const NActors::TActorContext& ctx)
+void TMigrationRequestActor<TMethod>::Bootstrap(const NActors::TActorContext& ctx)
 {
     TRequestScope timer(*RequestInfo);
 
@@ -114,9 +119,14 @@ void TMirrorRequestActor<TMethod>::Bootstrap(const NActors::TActorContext& ctx)
 }
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::SendRequests(const NActors::TActorContext& ctx)
+void TMigrationRequestActor<TMethod>::SendRequests(
+    const NActors::TActorContext& ctx)
 {
-    for (const auto& actorId: Replicas) {
+    for (const auto& actorId: {LeaderPartition, FollowerPartition}) {
+        if (!actorId) {
+            continue;
+        }
+
         auto request = std::make_unique<typename TMethod::TRequest>();
         auto& callContext = *RequestInfo->CallContext;
         if (!callContext.LWOrbit.Fork(request->CallContext->LWOrbit)) {
@@ -139,14 +149,26 @@ void TMirrorRequestActor<TMethod>::SendRequests(const NActors::TActorContext& ct
         );
 
         ctx.Send(std::move(event));
+
+        ++PendingRequests;
     }
 }
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::Done(const NActors::TActorContext& ctx)
+void TMigrationRequestActor<TMethod>::Done(const NActors::TActorContext& ctx)
 {
+    const bool isFollowerResponseError = HasError(FollowerResponse);
+    const bool isFollowerResponseFatal =
+        isFollowerResponseError &&
+        GetErrorKind(FollowerResponse.GetError()) == EErrorKind::ErrorFatal;
+
     auto response = std::make_unique<typename TMethod::TResponse>();
-    response->Record = std::move(LeadersCollectiveResponse);
+
+    if (isFollowerResponseError && !isFollowerResponseFatal) {
+        response->Record = std::move(FollowerResponse);
+    } else {
+        response->Record = std::move(LeaderResponse);
+    }
 
     auto& callContext = *RequestInfo->CallContext;
     for (auto& cc: ForkedCallContexts) {
@@ -165,27 +187,30 @@ void TMirrorRequestActor<TMethod>::Done(const NActors::TActorContext& ctx)
         std::make_unique<TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted>(
             NonreplicatedRequestCounter,
             RequestInfo->GetTotalCycles(),
-            false   // FollowerGotNonRetriableError
-        );
+            isFollowerResponseFatal);
     NCloud::Send(ctx, ParentActorId, std::move(completion));
 
     TBase::Die(ctx);
 }
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::UpdateResponse(TResponseProto&& response)
+void TMigrationRequestActor<TMethod>::UpdateResponse(
+    const NActors::TActorId& sender,
+    TResponseProto&& response)
 {
-    ProcessMirrorActorError(*response.MutableError());
-
-    if (!HasError(LeadersCollectiveResponse)) {
-        LeadersCollectiveResponse = std::move(response);
+    // TODO(sharpeye): use cookie to distinguish between a leader's and a
+    // follower's response
+    if (sender == FollowerPartition) {
+        FollowerResponse = std::move(response);
+    } else {
+        LeaderResponse = std::move(response);
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::HandleUndelivery(
+void TMigrationRequestActor<TMethod>::HandleUndelivery(
     const typename TMethod::TRequest::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
@@ -196,12 +221,12 @@ void TMirrorRequestActor<TMethod>::HandleUndelivery(
         DiskId.c_str(),
         TMethod::Name);
 
-    *LeadersCollectiveResponse.MutableError() = MakeError(
+    *LeaderResponse.MutableError() = MakeError(
         E_REJECTED,
         TStringBuilder() << TMethod::Name
                          << " request undelivered to some nonrepl partitions");
 
-    if (++Responses < Replicas.size()) {
+    if (--PendingRequests) {
         return;
     }
 
@@ -209,23 +234,25 @@ void TMirrorRequestActor<TMethod>::HandleUndelivery(
 }
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::HandleResponse(
+void TMigrationRequestActor<TMethod>::HandleResponse(
     const typename TMethod::TResponse::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
     auto* msg = ev->Get();
 
     if (HasError(msg->Record)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::PARTITION_WORKER,
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::PARTITION_WORKER,
             "[%s] %s got error from nonreplicated partition: %s",
             DiskId.c_str(),
             TMethod::Name,
             FormatError(msg->Record.GetError()).c_str());
     }
 
-    UpdateResponse(std::move(msg->Record));
+    UpdateResponse(ev->Sender, std::move(msg->Record));
 
-    if (++Responses < Replicas.size()) {
+    if (--PendingRequests) {
         return;
     }
 
@@ -233,20 +260,19 @@ void TMirrorRequestActor<TMethod>::HandleResponse(
 }
 
 template <typename TMethod>
-void TMirrorRequestActor<TMethod>::HandlePoisonPill(
+void TMigrationRequestActor<TMethod>::HandlePoisonPill(
     const NActors::TEvents::TEvPoisonPill::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
     Y_UNUSED(ev);
 
-    LeadersCollectiveResponse.MutableError()->CopyFrom(
-        MakeError(E_REJECTED, "Dead"));
+    LeaderResponse.MutableError()->CopyFrom(MakeError(E_REJECTED, "Dead"));
 
     Done(ctx);
 }
 
 template <typename TMethod>
-STFUNC(TMirrorRequestActor<TMethod>::StateWork)
+STFUNC(TMigrationRequestActor<TMethod>::StateWork)
 {
     TRequestScope timer(*RequestInfo);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
@@ -17,7 +17,7 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// The TMigrationRequestActor class is used to migrate a new device, it has two
+// The TMigrationRequestActor class is used to migrate a new device. It has two
 // replicas, one is leader and the second is follower. If we receive a fatal
 // error from the follower partition, we do not respond to the client with an
 // error, but at the same time stop the migration. And if we receive a non-fatal
@@ -122,8 +122,11 @@ template <typename TMethod>
 void TMigrationRequestActor<TMethod>::SendRequests(
     const NActors::TActorContext& ctx)
 {
+    PendingRequests = 2;
+
     for (const auto& actorId: {LeaderPartition, FollowerPartition}) {
         if (!actorId) {
+            --PendingRequests;
             continue;
         }
 
@@ -149,8 +152,6 @@ void TMigrationRequestActor<TMethod>::SendRequests(
         );
 
         ctx.Send(std::move(event));
-
-        ++PendingRequests;
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
@@ -1,0 +1,224 @@
+#include "migration_request_actor.h"
+
+#include "ut_env.h"
+
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/storage/core/libs/kikimr/helpers.h>
+
+#include <contrib/ydb/core/mind/bscontroller/bsc.h>
+#include <contrib/ydb/core/testlib/basics/runtime.h>
+#include <contrib/ydb/core/testlib/tablet_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace std::chrono_literals;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestMirrorPartition
+    : public TActor<TTestMirrorPartition>
+{
+private:
+    const TActorId Leader;
+    const TActorId Follower;
+
+    ui64 RequestIdentityKey = 0;
+
+public:
+    TTestMirrorPartition(const TActorId& leader, const TActorId& follower)
+        : TActor(&TThis::StateWork)
+        , Leader(leader)
+        , Follower(follower)
+    {}
+
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteBlocks);
+            IgnoreFunc(TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted);
+            default:
+                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                break;
+        }
+    }
+
+    void HandleWriteBlocks(
+        const TEvService::TEvWriteBlocksRequest::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        auto* msg = ev->Get();
+
+        auto requestInfo =
+            CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+
+        NCloud::Register<TMigrationRequestActor<TEvService::TWriteBlocksMethod>>(
+            ctx,
+            std::move(requestInfo),
+            Leader,
+            Follower,
+            msg->Record,
+            msg->Record.GetDiskId(),
+            SelfId(),   // parentActorId
+            ++RequestIdentityKey);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    TTestBasicRuntime Runtime;
+    TActorId PartitionId = TActorId{0, "partition"};
+    TActorId FakeLeader = TActorId{1, 1};
+    TActorId FakeFollower = TActorId{2, 2};
+
+    TPartitionClient PartitionClient()
+    {
+        return {Runtime, PartitionId, DefaultBlockSize};
+    }
+
+    void SetupRuntime()
+    {
+        Runtime.AddLocalService(
+            PartitionId,
+            TActorSetupCmd(
+                new TTestMirrorPartition(FakeLeader, FakeFollower),
+                TMailboxType::Simple,
+                0));
+
+        NKikimr::SetupTabletServices(Runtime);
+        Runtime.DispatchEvents({}, 10ms);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TMigrationRequestActorTest)
+{
+    Y_UNIT_TEST_F(ShouldForwardNonFatalErrorToClient, TFixture)
+    {
+        SetupRuntime();
+
+        std::optional<bool> followerGotNonRetriableError;
+
+        Runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvNonreplPartitionPrivate::EvWriteOrZeroCompleted)
+                {
+                    const auto* msg = event->template Get<
+                        TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted>();
+
+                    followerGotNonRetriableError =
+                        msg->FollowerGotNonRetriableError;
+
+                    return true;
+                }
+
+                if (event->GetTypeRewrite() !=
+                        TEvService::EvWriteBlocksRequest ||
+                    (event->Recipient != FakeLeader &&
+                     event->Recipient != FakeFollower))
+                {
+                    return false;
+                }
+
+                NProto::TError error;
+
+                if (FakeFollower == event->Recipient) {
+                    error = MakeError(
+                        E_RDMA_UNAVAILABLE,
+                        "unable to allocate request");
+                }
+
+                runtime.Send(new IEventHandle(
+                    event->Sender,
+                    event->Recipient,
+                    new TEvService::TEvWriteBlocksResponse(error),
+                    0,   // flags
+                    event->Cookie));
+
+                return true;
+            });
+
+        TPartitionClient client = PartitionClient();
+        client.SendWriteBlocksRequest(TBlockRange64::WithLength(0, 1024), 'X');
+        auto response = client.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_RDMA_UNAVAILABLE,
+            response->GetStatus(),
+            FormatError(response->GetError()));
+
+            UNIT_ASSERT(followerGotNonRetriableError.has_value());
+            UNIT_ASSERT(!followerGotNonRetriableError.value());
+    }
+
+    Y_UNIT_TEST_F(ShouldIgnoreFatalErrorFromFollower, TFixture)
+    {
+        SetupRuntime();
+
+        std::optional<bool> followerGotNonRetriableError;
+
+        Runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvNonreplPartitionPrivate::EvWriteOrZeroCompleted)
+                {
+                    const auto* msg = event->template Get<
+                        TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted>();
+
+                    followerGotNonRetriableError =
+                        msg->FollowerGotNonRetriableError;
+
+                    return true;
+                }
+
+                if (event->GetTypeRewrite() !=
+                        TEvService::EvWriteBlocksRequest ||
+                    (event->Recipient != FakeLeader &&
+                     event->Recipient != FakeFollower))
+                {
+                    return false;
+                }
+
+                NProto::TError error;
+
+                if (FakeFollower == event->Recipient) {
+                    error = MakeError(E_IO, "I/O error");
+                }
+
+                runtime.Send(new IEventHandle(
+                    event->Sender,
+                    event->Recipient,
+                    new TEvService::TEvWriteBlocksResponse(error),
+                    0,   // flags
+                    event->Cookie));
+
+                return true;
+            });
+
+        TPartitionClient client = PartitionClient();
+        client.SendWriteBlocksRequest(TBlockRange64::WithLength(0, 1024), 'X');
+        auto response = client.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetStatus(),
+            FormatError(response->GetError()));
+
+        UNIT_ASSERT(followerGotNonRetriableError.has_value());
+        UNIT_ASSERT(followerGotNonRetriableError.value());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor_ut.cpp
@@ -59,7 +59,6 @@ public:
             ctx,
             std::move(requestInfo),
             Partitions,
-            TActorId{},   // followerPartition
             msg->Record,
             msg->Record.GetDiskId(),
             SelfId(),   // parentActorId

--- a/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor_ut.cpp
@@ -1,0 +1,166 @@
+#include "mirror_request_actor.h"
+
+#include "ut_env.h"
+
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/storage/core/libs/kikimr/helpers.h>
+
+#include <contrib/ydb/core/mind/bscontroller/bsc.h>
+#include <contrib/ydb/core/testlib/basics/runtime.h>
+#include <contrib/ydb/core/testlib/tablet_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace std::chrono_literals;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestMirrorPartition
+    : public TActor<TTestMirrorPartition>
+{
+private:
+    const TVector<TActorId> Partitions;
+    ui64 RequestIdentityKey = 0;
+
+public:
+    explicit TTestMirrorPartition(TVector<TActorId> partitions)
+        : TActor(&TThis::StateWork)
+        , Partitions(std::move(partitions))
+    {}
+
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteBlocks);
+            IgnoreFunc(TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted);
+            default:
+                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                break;
+        }
+    }
+
+    void HandleWriteBlocks(
+        const TEvService::TEvWriteBlocksRequest::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        auto* msg = ev->Get();
+
+        auto requestInfo =
+            CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+
+        NCloud::Register<TMirrorRequestActor<TEvService::TWriteBlocksMethod>>(
+            ctx,
+            std::move(requestInfo),
+            Partitions,
+            TActorId{},   // followerPartition
+            msg->Record,
+            msg->Record.GetDiskId(),
+            SelfId(),   // parentActorId
+            ++RequestIdentityKey);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    TTestBasicRuntime Runtime;
+    TActorId PartitionId = TActorId{0, "partition"};
+    TVector<TActorId> FakeReplicaIds{
+        TActorId{1, 1},
+        TActorId{2, 2},
+        TActorId{3, 3},
+    };
+
+    [[nodiscard]] bool IsFakeReplica(TActorId actorId) const
+    {
+        return AnyOf(FakeReplicaIds, [&](auto r) { return r == actorId; });
+    }
+
+    TPartitionClient PartitionClient()
+    {
+        return {Runtime, PartitionId, DefaultBlockSize};
+    }
+
+    void SetUp(NUnitTest::TTestContext& /*testContext*/) override
+    {
+        Runtime.AddLocalService(
+            PartitionId,
+            TActorSetupCmd(
+                new TTestMirrorPartition(FakeReplicaIds),
+                TMailboxType::Simple,
+                0));
+
+        NKikimr::SetupTabletServices(Runtime);
+        Runtime.DispatchEvents({}, 10ms);
+    }
+
+    void ShouldHandleErrorFromReplica(bool emptySender)
+    {
+        Runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                if (event->GetTypeRewrite() !=
+                        TEvService::EvWriteBlocksRequest ||
+                    !IsFakeReplica(event->Recipient))
+                {
+                    return false;
+                }
+
+                NProto::TError error;
+
+                if (FakeReplicaIds[1] == event->Recipient) {
+                    error = MakeError(
+                        E_RDMA_UNAVAILABLE,
+                        "unable to allocate request");
+                }
+
+                const TActorId sender = emptySender
+                    ? TActorId{}
+                    : event->Recipient;
+
+                runtime.Send(new IEventHandle(
+                    event->Sender,
+                    sender,
+                    new TEvService::TEvWriteBlocksResponse(error),
+                    0,   // flags
+                    event->Cookie));
+
+                return true;
+            });
+
+        TPartitionClient client = PartitionClient();
+        client.SendWriteBlocksRequest(TBlockRange64::WithLength(0, 1024), 'X');
+        auto response = client.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            FormatError(response->GetError()));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TMirrorRequestActorTest)
+{
+    Y_UNIT_TEST_F(ShouldHandleErrorFromReplicaWithEmptySender, TFixture)
+    {
+        ShouldHandleErrorFromReplica(true);
+    }
+
+    Y_UNIT_TEST_F(ShouldHandleErrorFromReplica, TFixture)
+    {
+        ShouldHandleErrorFromReplica(false);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -127,10 +127,9 @@ void TMirrorPartitionActor::MirrorRequest(
         ctx,
         std::move(requestInfo),
         State.GetReplicaActors(),
-        TActorId{},
         std::move(msg->Record),
-        State.GetReplicaInfos()[0].Config->GetName(),
-        SelfId(),
+        State.GetReplicaInfos()[0].Config->GetName(),   // diskId
+        SelfId(),                                       // parentActorId
         requestIdentityKey);
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -5,7 +5,7 @@
 #include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
-#include <cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -97,17 +97,14 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         }
     }
 
-    auto requestInfo =
-        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
-
-    NCloud::Register<TMirrorRequestActor<TMethod>>(
+    NCloud::Register<TMigrationRequestActor<TMethod>>(
         ctx,
-        std::move(requestInfo),
-        ActorOwner ? TVector<TActorId>{SrcActorId} : TVector<TActorId>{},
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        ActorOwner ? SrcActorId : TActorId{},
         DstActorId,
         std::move(msg->Record),
         DiskId,
-        SelfId(),
+        SelfId(),   // parentActorId
         WriteAndZeroRequestsInProgress.AddWriteRequest(range));
 
     if constexpr (IsExactlyWriteMethod<TMethod>) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 SRCS(
     lagging_agents_replica_proxy_ut.cpp
     migration_timeout_calculator_ut.cpp
+    migration_request_actor_ut.cpp
     mirror_request_actor_ut.cpp
     part_mirror_resync_ut.cpp
     part_mirror_split_request_helpers_ut.cpp

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 SRCS(
     lagging_agents_replica_proxy_ut.cpp
     migration_timeout_calculator_ut.cpp
+    mirror_request_actor_ut.cpp
     part_mirror_resync_ut.cpp
     part_mirror_split_request_helpers_ut.cpp
     part_mirror_state_ut.cpp

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -8,6 +8,7 @@ SRCS(
     direct_copy_range.cpp
     lagging_agent_migration_actor.cpp
     lagging_agents_replica_proxy_actor.cpp
+    migration_request_actor.cpp
     migration_timeout_calculator.cpp
     mirror_request_actor.cpp
     replica_info.cpp


### PR DESCRIPTION
Now TMirrorRequestActor doesn't rely on the Sender field in the response: it just counts the responses and that's it.

#3161