### PR TITLE
[Blockstore, Filestore] Enable turning on secure connection to node broker via config file

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1151,4 +1151,7 @@ message TStorageServiceConfig
 
     // Local disk async deallocation and sync allocation
     optional bool LocalDiskAsyncDeallocationEnabled = 416;
+
+    // Use SSL for dynamic node registration.
+    optional bool NodeRegistrationUseSsl = 417;
 }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -415,7 +415,7 @@ void TBootstrapYdb::InitKikimrService()
         .SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir(),
         .NodeBrokerAddress = Configs->Options->NodeBrokerAddress,
         .NodeBrokerPort = Configs->Options->NodeBrokerPort,
-        .NodeBrokerSslPort = Configs->Options->NodeBrokerSslPort,
+        .NodeBrokerSecurePort = Configs->Options->NodeBrokerSecurePort,
         .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl
             || Configs->StorageConfig->GetNodeRegistrationUseSsl(),
         .InterconnectPort = Configs->Options->InterconnectPort,

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -415,7 +415,9 @@ void TBootstrapYdb::InitKikimrService()
         .SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir(),
         .NodeBrokerAddress = Configs->Options->NodeBrokerAddress,
         .NodeBrokerPort = Configs->Options->NodeBrokerPort,
-        .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl,
+        .NodeBrokerSslPort = Configs->Options->NodeBrokerSslPort,
+        .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl
+            || Configs->StorageConfig->GetNodeRegistrationUseSsl(),
         .InterconnectPort = Configs->Options->InterconnectPort,
         .LoadCmsConfigs = loadCmsConfigs,
         .Settings = std::move(settings)

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -374,7 +374,7 @@ bool TBootstrap::InitKikimrService()
         .SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir(),
         .NodeBrokerAddress = Configs->Options->NodeBrokerAddress,
         .NodeBrokerPort = Configs->Options->NodeBrokerPort,
-        .NodeBrokerSslPort = Configs->Options->NodeBrokerSslPort,
+        .NodeBrokerSecurePort = Configs->Options->NodeBrokerSecurePort,
         .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl
             || Configs->StorageConfig->GetNodeRegistrationUseSsl(),
         .InterconnectPort = Configs->Options->InterconnectPort,

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -374,7 +374,9 @@ bool TBootstrap::InitKikimrService()
         .SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir(),
         .NodeBrokerAddress = Configs->Options->NodeBrokerAddress,
         .NodeBrokerPort = Configs->Options->NodeBrokerPort,
-        .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl,
+        .NodeBrokerSslPort = Configs->Options->NodeBrokerSslPort,
+        .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl
+            || Configs->StorageConfig->GetNodeRegistrationUseSsl(),
         .InterconnectPort = Configs->Options->InterconnectPort,
         .LoadCmsConfigs = Configs->Options->LoadCmsConfigs,
         .Settings = std::move(settings)

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -123,6 +123,7 @@ TDuration MSeconds(ui32 value)
     xxx(NodeType,                             TString,               {}       )\
     xxx(NodeRegistrationRootCertsFile,        TString,               {}       )\
     xxx(NodeRegistrationCert,                 TCertificate,          {}       )\
+    xxx(NodeRegistrationUseSsl,               bool,                  false    )\
     xxx(ConfigDispatcherSettings,                                              \
         NCloud::NProto::TConfigDispatcherSettings,                             \
         {}                                                                    )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -620,9 +620,9 @@ public:
     ui32 GetNodeRegistrationMaxAttempts() const;
     TDuration GetNodeRegistrationTimeout() const;
     TDuration GetNodeRegistrationErrorTimeout() const;
+    TString GetNodeType() const;
     TString GetNodeRegistrationRootCertsFile() const;
     TCertificate GetNodeRegistrationCert() const;
-    TString GetNodeType() const;
     bool GetNodeRegistrationUseSsl() const;
 
     [[nodiscard]] bool GetLaggingDevicesForMirror2DisksEnabled() const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -623,6 +623,7 @@ public:
     TString GetNodeRegistrationRootCertsFile() const;
     TCertificate GetNodeRegistrationCert() const;
     TString GetNodeType() const;
+    bool GetNodeRegistrationUseSsl() const;
 
     [[nodiscard]] bool GetLaggingDevicesForMirror2DisksEnabled() const;
     [[nodiscard]] bool GetLaggingDevicesForMirror3DisksEnabled() const;

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -532,4 +532,7 @@ message TStorageConfig
     // to the scaled ratio of DeletedMarkersCount to UsedBlocksCount instead of
     // UsedRangesCount.
     optional bool CalculateCleanupScoreBasedOnUsedBlocksCount = 421;
+
+    // Use SSL for dynamic node registration.
+    optional bool NodeRegistrationUseSsl = 422;
 }

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -246,9 +246,11 @@ void TBootstrapCommon::InitActorSystem()
     registerOpts.SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir();
     registerOpts.NodeBrokerAddress = Configs->Options->NodeBrokerAddress;
     registerOpts.NodeBrokerPort = Configs->Options->NodeBrokerPort;
+    registerOpts.NodeBrokerSslPort = Configs->Options->NodeBrokerSslPort;
     registerOpts.InterconnectPort = Configs->Options->InterconnectPort;
     registerOpts.LoadCmsConfigs = Configs->Options->LoadCmsConfigs;
-    registerOpts.UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl,
+    registerOpts.UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl
+        || Configs->StorageConfig->GetNodeRegistrationUseSsl();
     registerOpts.Settings = Configs->GetNodeRegistrationSettings();
 
     auto [nodeId, scopeId, cmsConfig] = RegisterDynamicNode(

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -246,7 +246,7 @@ void TBootstrapCommon::InitActorSystem()
     registerOpts.SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir();
     registerOpts.NodeBrokerAddress = Configs->Options->NodeBrokerAddress;
     registerOpts.NodeBrokerPort = Configs->Options->NodeBrokerPort;
-    registerOpts.NodeBrokerSslPort = Configs->Options->NodeBrokerSslPort;
+    registerOpts.NodeBrokerSecurePort = Configs->Options->NodeBrokerSecurePort;
     registerOpts.InterconnectPort = Configs->Options->InterconnectPort;
     registerOpts.LoadCmsConfigs = Configs->Options->LoadCmsConfigs;
     registerOpts.UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -203,6 +203,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(NodeRegistrationRootCertsFile,   TString,               {}            )\
     xxx(NodeRegistrationCert,            TCertificate,          {}            )\
     xxx(NodeRegistrationToken,           TString,               "root@builtin")\
+    xxx(NodeRegistrationUseSsl,          bool,                  false         )\
     xxx(NodeType,                        TString,               {}            )\
     xxx(BlobCompressionRate,             ui32,                  0             )\
     xxx(BlobCompressionCodec,            TString,               "lz4"         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -258,6 +258,7 @@ public:
     ui32 GetNodeRegistrationMaxAttempts() const;
     TDuration GetNodeRegistrationTimeout() const;
     TDuration GetNodeRegistrationErrorTimeout() const;
+    bool GetNodeRegistrationUseSsl() const;
 
     ui32 GetBlobCompressionRate() const;
     TString GetBlobCompressionCodec() const;

--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -389,8 +389,8 @@ TRegisterDynamicNodeResult RegisterDynamicNode(
     if (options.NodeBrokerAddress) {
         addrs.push_back(options.NodeBrokerAddress);
     } else {
-        auto port = options.UseNodeBrokerSsl && options.NodeBrokerSslPort
-            ? options.NodeBrokerSslPort
+        auto port = options.UseNodeBrokerSsl && options.NodeBrokerSecurePort
+            ? options.NodeBrokerSecurePort
             : options.NodeBrokerPort;
         if (port) {
             for (const auto& node: nsConfig.GetNode()) {

--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -388,11 +388,16 @@ TRegisterDynamicNodeResult RegisterDynamicNode(
     TVector<TString> addrs;
     if (options.NodeBrokerAddress) {
         addrs.push_back(options.NodeBrokerAddress);
-    } else if (options.NodeBrokerPort) {
-        for (const auto& node: nsConfig.GetNode()) {
-            addrs.emplace_back(Join(":", node.GetHost(), options.NodeBrokerPort));
+    } else {
+        auto port = options.UseNodeBrokerSsl && options.NodeBrokerSslPort
+            ? options.NodeBrokerSslPort
+            : options.NodeBrokerPort;
+        if (port) {
+            for (const auto& node: nsConfig.GetNode()) {
+                addrs.emplace_back(Join(":", node.GetHost(), port));
+            }
+            Shuffle(addrs.begin(), addrs.end());
         }
-        Shuffle(addrs.begin(), addrs.end());
     }
 
     if (!addrs) {

--- a/cloud/storage/core/libs/kikimr/node.h
+++ b/cloud/storage/core/libs/kikimr/node.h
@@ -23,7 +23,7 @@ struct TRegisterDynamicNodeOptions
 
     TString NodeBrokerAddress;
     ui32 NodeBrokerPort = 0;
-    ui32 NodeBrokerSslPort = 0;
+    ui32 NodeBrokerSecurePort = 0;
     bool UseNodeBrokerSsl = false;
 
     ui32 InterconnectPort = 0;

--- a/cloud/storage/core/libs/kikimr/node.h
+++ b/cloud/storage/core/libs/kikimr/node.h
@@ -23,6 +23,7 @@ struct TRegisterDynamicNodeOptions
 
     TString NodeBrokerAddress;
     ui32 NodeBrokerPort = 0;
+    ui32 NodeBrokerSslPort = 0;
     bool UseNodeBrokerSsl = false;
 
     ui32 InterconnectPort = 0;

--- a/cloud/storage/core/libs/kikimr/options.cpp
+++ b/cloud/storage/core/libs/kikimr/options.cpp
@@ -68,7 +68,7 @@ TOptionsYdbBase::TOptionsYdbBase()
 
     Opts.AddLongOption("node-broker-secure-port")
         .RequiredArgument("PORT")
-        .StoreResult(&NodeBrokerSslPort);
+        .StoreResult(&NodeBrokerSecurePort);
 
     Opts.AddLongOption(
         "use-secure-registration",

--- a/cloud/storage/core/libs/kikimr/options.cpp
+++ b/cloud/storage/core/libs/kikimr/options.cpp
@@ -66,6 +66,10 @@ TOptionsYdbBase::TOptionsYdbBase()
         .RequiredArgument("PORT")
         .StoreResult(&NodeBrokerPort);
 
+    Opts.AddLongOption("node-broker-secure-port")
+        .RequiredArgument("PORT")
+        .StoreResult(&NodeBrokerSslPort);
+
     Opts.AddLongOption(
         "use-secure-registration",
         "Use secure connection to node broker")

--- a/cloud/storage/core/libs/kikimr/options.h
+++ b/cloud/storage/core/libs/kikimr/options.h
@@ -31,6 +31,7 @@ struct TOptionsYdbBase
     TString SchemeShardDir;
     TString NodeBrokerAddress;
     ui32 NodeBrokerPort = 0;
+    ui32 NodeBrokerSslPort = 0;
     bool UseNodeBrokerSsl = false;
     TString LocationFile;
 

--- a/cloud/storage/core/libs/kikimr/options.h
+++ b/cloud/storage/core/libs/kikimr/options.h
@@ -31,7 +31,7 @@ struct TOptionsYdbBase
     TString SchemeShardDir;
     TString NodeBrokerAddress;
     ui32 NodeBrokerPort = 0;
-    ui32 NodeBrokerSslPort = 0;
+    ui32 NodeBrokerSecurePort = 0;
     bool UseNodeBrokerSsl = false;
     TString LocationFile;
 


### PR DESCRIPTION
1. Add argument `--node-broker-secure-port`.
2. Enable setting `UseNodeBrokerSsl` not only from command line arguments but also from config file.