### PR TITLE
Allow nonreplicated partition to timeout devices

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -252,7 +252,8 @@ public:
         return OutdatedDeviceIds;
     }
 
-    bool GetLaggingDevicesAllowed() const {
+    bool GetLaggingDevicesAllowed() const
+    {
         return LaggingDevicesAllowed;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -252,6 +252,10 @@ public:
         return OutdatedDeviceIds;
     }
 
+    bool GetLaggingDevicesAllowed() const {
+        return LaggingDevicesAllowed;
+    }
+
     auto GetMaxTimedOutDeviceStateDuration() const
     {
         return MaxTimedOutDeviceStateDuration;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.cpp
@@ -30,13 +30,13 @@ TDuration TMigrationTimeoutCalculator::CalculateTimeout(
     }
 
     // migration range is 4_MB
-    const double processingRangeSizeMiBs =
-        static_cast<double>(ProcessingRangeSize) / (1024 * 1024);
+    constexpr double ProcessingRangeSizeMiBs =
+        static_cast<double>(ProcessingRangeSize) / 1_MB;
 
     const ui32 limitedBandwidthMiBs =
         Min(MaxMigrationBandwidthMiBs, LimitedBandwidthMiBs);
     const double migrationFactorPerAgent =
-        limitedBandwidthMiBs / processingRangeSizeMiBs;
+        limitedBandwidthMiBs / ProcessingRangeSizeMiBs;
 
     if (PartitionConfig->GetUseSimpleMigrationBandwidthLimiter()) {
         return TDuration::Seconds(1) / migrationFactorPerAgent;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -253,7 +253,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request)
+    TRequestData* requestData)
 {
     auto reply = [=] (
         const TActorContext& ctx,
@@ -333,7 +333,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
             return false;
         }
 
-        request->DeviceIndices.push_back(dr.DeviceIdx);
+        requestData->DeviceIndices.push_back(dr.DeviceIdx);
 
         TDeviceStat& deviceStat = DeviceStats[dr.DeviceIdx];
         if (dr.Device.GetNodeId() == 0) {
@@ -378,7 +378,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TWriteBlock
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request);
+    TRequestData* requestData);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TWriteBlocksLocalMethod>(
     const TEvService::TWriteBlocksLocalMethod::TRequest& msg,
@@ -387,7 +387,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TWriteBlock
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request);
+    TRequestData* requestData);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TZeroBlocksMethod>(
     const TEvService::TZeroBlocksMethod::TRequest& msg,
@@ -396,7 +396,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TZeroBlocks
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request);
+    TRequestData* requestData);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocksMethod>(
     const TEvService::TReadBlocksMethod::TRequest& msg,
@@ -405,7 +405,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocks
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request);
+    TRequestData* requestData);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocksLocalMethod>(
     const TEvService::TReadBlocksLocalMethod::TRequest& msg,
@@ -414,7 +414,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocks
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request);
+    TRequestData* requestData);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvNonreplPartitionPrivate::TChecksumBlocksMethod>(
     const TEvNonreplPartitionPrivate::TChecksumBlocksMethod::TRequest& msg,
@@ -423,7 +423,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvNonreplPartitionPriv
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
     TRequestTimeoutPolicy* timeoutPolicy,
-    TRequest* request);
+    TRequestData* requestData);
 
 void TNonreplicatedPartitionActor::OnRequestCompleted(
     const TEvNonreplPartitionPrivate::TOperationCompleted& operation,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -329,7 +329,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
                     E_REJECTED,
                     TStringBuilder() << "Device " << dr.Device.GetDeviceUUID()
                                      << "is lagging behind on data. All IO "
-                                        "operations, are prohibited."));
+                                        "operations are prohibited."));
             return false;
         }
 
@@ -522,8 +522,7 @@ void TNonreplicatedPartitionActor::HandleDeviceTimeoutedResponse(
         "[%s] Attempted to deem device %s as lagging. Result: %s",
         PartConfig->GetName().c_str(),
         PartConfig->GetDevices()[ev->Cookie].GetDeviceUUID().c_str(),
-        (HasError(msg->GetError()) ? FormatError(msg->GetError()).c_str()
-                                   : "Ok"));
+        FormatError(msg->GetError()).c_str());
 }
 
 void TNonreplicatedPartitionActor::HandleAgentIsUnavailable(
@@ -544,8 +543,8 @@ void TNonreplicatedPartitionActor::HandleAgentIsUnavailable(
             EDeviceStatus::Unavailable;
     }
 
-    for (const auto& [actorId, requestInfo]: RequestsInProgress.AllRequests()) {
-        for (int deviceIndex: requestInfo.Value.DeviceIndices) {
+    for (const auto& [actorId, requestData]: RequestsInProgress.AllRequests()) {
+        for (int deviceIndex: requestData.Value.DeviceIndices) {
             if (PartConfig->GetDevices()[deviceIndex].GetAgentId() ==
                 msg->LaggingAgent.GetAgentId())
             {
@@ -575,7 +574,7 @@ void TNonreplicatedPartitionActor::HandleAgentIsBackOnline(
         msg->AgentId.Quote().c_str());
 
     for (int i = 0; i < PartConfig->GetDevices().size(); ++i) {
-        const auto& device = PartConfig->GetDevices().at(i);
+        const auto& device = PartConfig->GetDevices()[i];
         if (device.GetAgentId() == msg->AgentId &&
             DeviceStats[i].DeviceStatus <= EDeviceStatus::Unavailable)
         {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -17,6 +17,8 @@ using namespace NActors;
 
 using namespace NKikimr;
 
+using EReason = TEvNonreplPartitionPrivate::TCancelRequest::EReason;
+
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,6 +46,7 @@ bool TNonreplicatedPartitionActor::TDeviceStat::CooldownPassed(
 {
     switch (DeviceStatus) {
         case EDeviceStatus::Ok:
+        case EDeviceStatus::Unavailable:
             return false;
         case EDeviceStatus::SilentBroken:
             return BrokenTransitionTs + cooldownTimeout < now;
@@ -155,7 +158,9 @@ TRequestTimeoutPolicy TNonreplicatedPartitionActor::MakeTimeoutPolicyForRequest(
 
     const bool hasTimeouts = worstDeviceStatus != EDeviceStatus::Ok ||
                              longestTimedOutStateDuration != TDuration();
-    if (!hasTimeouts) {
+    // When a device is unavailable, we shouldn't increase timeouts. There won't
+    // be any huge requests, just small probings.
+    if (!hasTimeouts || worstDeviceStatus == EDeviceStatus::Unavailable) {
         // If there were no timeouts, then we slightly increase the timeout for
         // the time of the longest response among the last ones.
         return TRequestTimeoutPolicy{
@@ -193,7 +198,8 @@ TRequestTimeoutPolicy TNonreplicatedPartitionActor::MakeTimeoutPolicyForRequest(
     };
 
     switch (worstDeviceStatus) {
-        case EDeviceStatus::Ok: {
+        case EDeviceStatus::Ok:
+        case EDeviceStatus::Unavailable: {
             break;
         }
         case EDeviceStatus::SilentBroken: {
@@ -246,7 +252,8 @@ bool TNonreplicatedPartitionActor::InitRequests(
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy)
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request)
 {
     auto reply = [=] (
         const TActorContext& ctx,
@@ -312,10 +319,27 @@ bool TNonreplicatedPartitionActor::InitRequests(
     }
 
     for (const auto& dr: *deviceRequests) {
+        if (PartConfig->GetOutdatedDeviceIds().contains(
+                dr.Device.GetDeviceUUID()))
+        {
+            reply(
+                ctx,
+                requestInfo,
+                PartConfig->MakeError(
+                    E_REJECTED,
+                    TStringBuilder() << "Device " << dr.Device.GetDeviceUUID()
+                                     << "is lagging behind on data. All IO "
+                                        "operations, are prohibited."));
+            return false;
+        }
+
+        request->DeviceIndices.push_back(dr.DeviceIdx);
+
+        TDeviceStat& deviceStat = DeviceStats[dr.DeviceIdx];
         if (dr.Device.GetNodeId() == 0) {
             // Accessing a non-allocated device causes the disk to break.
-            DeviceStats[dr.DeviceIdx].BrokenTransitionTs = ctx.Now();
-            DeviceStats[dr.DeviceIdx].DeviceStatus = EDeviceStatus::Broken;
+            deviceStat.BrokenTransitionTs = ctx.Now();
+            deviceStat.DeviceStatus = EDeviceStatus::Broken;
 
             reply(
                 ctx,
@@ -324,6 +348,18 @@ bool TNonreplicatedPartitionActor::InitRequests(
                     TStringBuilder() << "unavailable device requested: "
                                      << dr.Device.GetDeviceUUID()));
             return false;
+        }
+
+        if (PartConfig->GetLaggingDevicesAllowed() &&
+            deviceStat.DeviceStatus == EDeviceStatus::Ok &&
+            deviceStat.GetTimedOutStateDuration(ctx.Now()) >
+                Config->GetLaggingDeviceTimeoutThreshold())
+        {
+            NCloud::Send(
+                ctx,
+                PartConfig->GetParentActorId(),
+                std::make_unique<TEvVolumePrivate::TEvDeviceTimeoutedRequest>(
+                    dr.Device.GetDeviceUUID()));
         }
     }
 
@@ -341,7 +377,8 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TWriteBlock
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy);
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TWriteBlocksLocalMethod>(
     const TEvService::TWriteBlocksLocalMethod::TRequest& msg,
@@ -349,7 +386,8 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TWriteBlock
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy);
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TZeroBlocksMethod>(
     const TEvService::TZeroBlocksMethod::TRequest& msg,
@@ -357,7 +395,8 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TZeroBlocks
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy);
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocksMethod>(
     const TEvService::TReadBlocksMethod::TRequest& msg,
@@ -365,7 +404,8 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocks
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy);
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocksLocalMethod>(
     const TEvService::TReadBlocksLocalMethod::TRequest& msg,
@@ -373,7 +413,8 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvService::TReadBlocks
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy);
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request);
 
 template bool TNonreplicatedPartitionActor::InitRequests<TEvNonreplPartitionPrivate::TChecksumBlocksMethod>(
     const TEvNonreplPartitionPrivate::TChecksumBlocksMethod::TRequest& msg,
@@ -381,7 +422,8 @@ template bool TNonreplicatedPartitionActor::InitRequests<TEvNonreplPartitionPriv
     const TRequestInfo& requestInfo,
     const TBlockRange64& blockRange,
     TVector<TDeviceRequest>* deviceRequests,
-    TRequestTimeoutPolicy* timeoutPolicy);
+    TRequestTimeoutPolicy* timeoutPolicy,
+    TRequest* request);
 
 void TNonreplicatedPartitionActor::OnRequestCompleted(
     const TEvNonreplPartitionPrivate::TOperationCompleted& operation,
@@ -430,7 +472,8 @@ void TNonreplicatedPartitionActor::OnRequestTimeout(
     }
 
     switch (stat.DeviceStatus) {
-        case EDeviceStatus::Ok: {
+        case EDeviceStatus::Ok:
+        case EDeviceStatus::Unavailable: {
             if (stat.GetTimedOutStateDuration(now) >
                 GetMaxTimedOutDeviceStateDuration())
             {
@@ -466,6 +509,80 @@ void TNonreplicatedPartitionActor::HandleUpdateCounters(
 
     SendStats(ctx);
     ScheduleCountersUpdate(ctx);
+}
+
+void TNonreplicatedPartitionActor::HandleDeviceTimeoutedResponse(
+    const TEvVolumePrivate::TEvDeviceTimeoutedResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Attempted to deem device %s as lagging. Result: %s",
+        PartConfig->GetName().c_str(),
+        PartConfig->GetDevices()[ev->Cookie].GetDeviceUUID().c_str(),
+        (HasError(msg->GetError()) ? FormatError(msg->GetError()).c_str()
+                                   : "Ok"));
+}
+
+void TNonreplicatedPartitionActor::HandleAgentIsUnavailable(
+    const TEvNonreplPartitionPrivate::TEvAgentIsUnavailable::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Agent %s has become unavailable",
+        PartConfig->GetName().c_str(),
+        msg->LaggingAgent.GetAgentId().Quote().c_str());
+
+    for (const auto& laggingDevice: msg->LaggingAgent.GetDevices()) {
+        Y_DEBUG_ABORT_UNLESS(DeviceStats.size() > laggingDevice.GetRowIndex());
+        DeviceStats[laggingDevice.GetRowIndex()].DeviceStatus =
+            EDeviceStatus::Unavailable;
+    }
+
+    for (const auto& [actorId, requestInfo]: RequestsInProgress.AllRequests()) {
+        for (int deviceIndex: requestInfo.Value.DeviceIndices) {
+            if (PartConfig->GetDevices()[deviceIndex].GetAgentId() ==
+                msg->LaggingAgent.GetAgentId())
+            {
+                // TODO(komarevtsev-d): implement fast reject (via error flags).
+                NCloud::Send<TEvNonreplPartitionPrivate::TEvCancelRequest>(
+                    ctx,
+                    actorId,
+                    0,   // cookie
+                    EReason::Canceled);
+                break;
+            }
+        }
+    }
+}
+
+void TNonreplicatedPartitionActor::HandleAgentIsBackOnline(
+    const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Agent %s is back online",
+        PartConfig->GetName().c_str(),
+        msg->AgentId.Quote().c_str());
+
+    for (int i = 0; i < PartConfig->GetDevices().size(); ++i) {
+        const auto& device = PartConfig->GetDevices().at(i);
+        if (device.GetAgentId() == msg->AgentId &&
+            DeviceStats[i].DeviceStatus <= EDeviceStatus::Unavailable)
+        {
+            DeviceStats[i].DeviceStatus = EDeviceStatus::Ok;
+            DeviceStats[i].FirstTimeoutTs = {};
+        }
+    }
 }
 
 void TNonreplicatedPartitionActor::ReplyAndDie(const NActors::TActorContext& ctx)
@@ -560,10 +677,11 @@ STFUNC(TNonreplicatedPartitionActor::StateWork)
         HFunc(TEvVolume::TEvGetScanDiskStatusRequest, HandleGetScanDiskStatus);
         HFunc(TEvService::TEvCheckRangeRequest, HandleCheckRange);
 
-        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvVolumePrivate::TEvDeviceTimeoutedResponse, HandleDeviceTimeoutedResponse);
+        HFunc(TEvNonreplPartitionPrivate::TEvAgentIsUnavailable, HandleAgentIsUnavailable);
+        HFunc(TEvNonreplPartitionPrivate::TEvAgentIsBackOnline, HandleAgentIsBackOnline);
 
-        IgnoreFunc(TEvNonreplPartitionPrivate::TEvAgentIsUnavailable);
-        IgnoreFunc(TEvNonreplPartitionPrivate::TEvAgentIsBackOnline);
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
 
@@ -609,6 +727,7 @@ STFUNC(TNonreplicatedPartitionActor::StateZombie)
         HFunc(TEvVolume::TEvGetScanDiskStatusRequest, RejectGetScanDiskStatus);
 
         IgnoreFunc(TEvents::TEvPoisonPill);
+        IgnoreFunc(TEvVolumePrivate::TEvDeviceTimeoutedResponse);
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
 
         default:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -87,11 +87,11 @@ private:
     };
     TVector<TDeviceStat> DeviceStats;
 
-    struct TRequest
+    struct TRequestData
     {
         TStackVec<int, 2> DeviceIndices;
     };
-    TRequestsInProgress<NActors::TActorId, TRequest> RequestsInProgress{
+    TRequestsInProgress<NActors::TActorId, TRequestData> RequestsInProgress{
         EAllowedRequests::ReadWrite};
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
@@ -153,7 +153,7 @@ private:
         const TBlockRange64& blockRange,
         TVector<TDeviceRequest>* deviceRequests,
         TRequestTimeoutPolicy* timeoutPolicy,
-        TRequest* request);
+        TRequestData* requestData);
 
     void OnRequestCompleted(
         const TEvNonreplPartitionPrivate::TOperationCompleted& operation,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -15,6 +15,7 @@
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
 #include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
+#include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -56,6 +57,7 @@ private:
     enum class EDeviceStatus
     {
         Ok,
+        Unavailable,
         SilentBroken,
         Broken,
     };
@@ -85,7 +87,11 @@ private:
     };
     TVector<TDeviceStat> DeviceStats;
 
-    TRequestsInProgress<NActors::TActorId> RequestsInProgress{
+    struct TRequest
+    {
+        TStackVec<int, 2> DeviceIndices;
+    };
+    TRequestsInProgress<NActors::TActorId, TRequest> RequestsInProgress{
         EAllowedRequests::ReadWrite};
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
@@ -146,7 +152,8 @@ private:
         const TRequestInfo& requestInfo,
         const TBlockRange64& blockRange,
         TVector<TDeviceRequest>* deviceRequests,
-        TRequestTimeoutPolicy* timeoutPolicy);
+        TRequestTimeoutPolicy* timeoutPolicy,
+        TRequest* request);
 
     void OnRequestCompleted(
         const TEvNonreplPartitionPrivate::TOperationCompleted& operation,
@@ -179,6 +186,18 @@ private:
 
     void HandleChecksumBlocksCompleted(
         const TEvNonreplPartitionPrivate::TEvChecksumBlocksCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleDeviceTimeoutedResponse(
+        const TEvVolumePrivate::TEvDeviceTimeoutedResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAgentIsUnavailable(
+        const TEvNonreplPartitionPrivate::TEvAgentIsUnavailable::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleAgentIsBackOnline(
+        const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     bool HandleRequests(STFUNC_SIG);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
@@ -5,11 +5,15 @@
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 
+#include <util/string/join.h>
+
 using namespace NActors;
 
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 namespace NCloud::NBlockStore::NStorage {
+
+using EReason = TEvNonreplPartitionPrivate::TCancelRequest::EReason;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -43,27 +47,23 @@ void TDiskAgentBaseRequestActor::Bootstrap(const TActorContext& ctx)
         RequestInfo->CallContext->RequestId);
 
     StartTime = ctx.Now();
-    ctx.Schedule(TimeoutPolicy.Timeout, new TEvents::TEvWakeup());
+    ctx.Schedule(
+        TimeoutPolicy.Timeout,
+        new TEvNonreplPartitionPrivate::TEvCancelRequest(EReason::Timeouted));
 
     SendRequest(ctx);
 }
 
-bool TDiskAgentBaseRequestActor::HandleError(
+void TDiskAgentBaseRequestActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error,
     bool timedOut)
 {
-    if (FAILED(error.GetCode())) {
-        ProcessError(*TActorContext::ActorSystem(), *PartConfig, error);
-
-        Done(
-            ctx,
-            MakeResponse(std::move(error)),
-            timedOut ? EStatus::Timeout : EStatus::Fail);
-        return true;
-    }
-
-    return false;
+    ProcessError(*TActorContext::ActorSystem(), *PartConfig, error);
+    Done(
+        ctx,
+        MakeResponse(std::move(error)),
+        timedOut ? EStatus::Timeout : EStatus::Fail);
 }
 
 void TDiskAgentBaseRequestActor::Done(
@@ -102,26 +102,64 @@ void TDiskAgentBaseRequestActor::Done(
     Die(ctx);
 }
 
-void TDiskAgentBaseRequestActor::HandleTimeout(
-    const TEvents::TEvWakeup::TPtr& ev,
+void TDiskAgentBaseRequestActor::HandleCancelRequest(
+    const TEvNonreplPartitionPrivate::TEvCancelRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto& device = DeviceRequests[ev->Cookie].Device;
-    LOG_WARN_S(
-        ctx,
-        TBlockStoreComponents::PARTITION_WORKER,
-        RequestName << " request #" << RequestId
-                    << " timed out. Disk id: " << PartConfig->GetName().Quote()
-                    << " Device: " << LogDevice(device));
+    const auto* msg = ev->Get();
 
-    TString message = TStringBuilder() << RequestName << " request timed out";
+    TVector<TString> devices;
+    for (const auto& reuqest: DeviceRequests) {
+        devices.push_back(reuqest.Device.GetDeviceUUID());
+    }
+
+    switch (msg->Reason) {
+        case EReason::Timeouted:
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::PARTITION_WORKER,
+                "[%s] %s request #%lu timed out. Devices: [%s]",
+                PartConfig->GetName().c_str(),
+                RequestName.c_str(),
+                RequestId,
+                JoinSeq(", ", devices).c_str());
+            HandleError(
+                ctx,
+                PartConfig->MakeError(
+                    TimeoutPolicy.ErrorCode,
+                    TimeoutPolicy.OverrideMessage
+                        ? TimeoutPolicy.OverrideMessage
+                        : (TStringBuilder()
+                           << RequestName << " request timed out")),
+                true);
+            return;
+        case EReason::Canceled:
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::PARTITION_WORKER,
+                "[%s] %s request #%lu is canceled from outside. Devices: [%s]",
+                PartConfig->GetName().c_str(),
+                RequestName.c_str(),
+                RequestId,
+                JoinSeq(", ", devices).c_str());
+            HandleError(
+                ctx,
+                PartConfig->MakeError(
+                    E_REJECTED,
+                    TStringBuilder() << RequestName << " request is canceled"),
+                false);
+            return;
+    }
+
+    Y_DEBUG_ABORT_UNLESS(false);
     HandleError(
         ctx,
-        MakeError(
-            TimeoutPolicy.ErrorCode,
-            TimeoutPolicy.OverrideMessage ? TimeoutPolicy.OverrideMessage
-                                          : message),
-        true);
+        PartConfig->MakeError(
+            E_REJECTED,
+            TStringBuilder()
+                << RequestName << " request got an unknown cancel reason: "
+                << static_cast<int>(msg->Reason)),
+        false);
 }
 
 void TDiskAgentBaseRequestActor::StateWork(TAutoPtr<NActors::IEventHandle>& ev)
@@ -133,7 +171,9 @@ void TDiskAgentBaseRequestActor::StateWork(TAutoPtr<NActors::IEventHandle>& ev)
     }
 
     switch (ev->GetTypeRewrite()) {
-        HFunc(TEvents::TEvWakeup, HandleTimeout);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvCancelRequest,
+            HandleCancelRequest);
 
         default:
             HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
@@ -109,8 +109,8 @@ void TDiskAgentBaseRequestActor::HandleCancelRequest(
     const auto* msg = ev->Get();
 
     TVector<TString> devices;
-    for (const auto& reuqest: DeviceRequests) {
-        devices.push_back(reuqest.Device.GetDeviceUUID());
+    for (const auto& request: DeviceRequests) {
+        devices.push_back(request.Device.GetDeviceUUID());
     }
 
     switch (msg->Reason) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.h
@@ -63,7 +63,7 @@ protected:
     virtual NActors::IEventBasePtr MakeResponse(NProto::TError error) = 0;
     virtual TCompletionEventAndBody MakeCompletionResponse(ui32 blocks) = 0;
 
-    bool HandleError(
+    void HandleError(
         const NActors::TActorContext& ctx,
         NProto::TError error,
         bool timedOut);
@@ -76,8 +76,8 @@ protected:
 private:
     void StateWork(TAutoPtr<NActors::IEventHandle>& ev);
 
-    void HandleTimeout(
-        const NActors::TEvents::TEvWakeup::TPtr& ev,
+    void HandleCancelRequest(
+        const TEvNonreplPartitionPrivate::TEvCancelRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.h
@@ -66,7 +66,7 @@ protected:
     void HandleError(
         const NActors::TActorContext& ctx,
         NProto::TError error,
-        bool timedOut);
+        EStatus status);
 
     void Done(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -217,7 +217,7 @@ void TNonreplicatedPartitionActor::HandleChecksumBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
-    TRequest request;
+    TRequestData request;
     bool ok = InitRequests<TEvNonreplPartitionPrivate::TChecksumBlocksMethod>(
         *msg,
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -149,7 +149,7 @@ void TDiskAgentChecksumActor::HandleChecksumDeviceBlocksResponse(
     auto* msg = ev->Get();
 
     if (HasError(msg->GetError())) {
-        HandleError(ctx, msg->GetError(), false);
+        HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -148,7 +148,8 @@ void TDiskAgentChecksumActor::HandleChecksumDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
-    if (HandleError(ctx, msg->GetError(), false)) {
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, msg->GetError(), false);
         return;
     }
 
@@ -216,14 +217,15 @@ void TNonreplicatedPartitionActor::HandleChecksumBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
+    TRequest request;
     bool ok = InitRequests<TEvNonreplPartitionPrivate::TChecksumBlocksMethod>(
         *msg,
         ctx,
         *requestInfo,
         blockRange,
         &deviceRequests,
-        &timeoutPolicy
-    );
+        &timeoutPolicy,
+        &request);
 
     if (!ok) {
         return;
@@ -238,7 +240,7 @@ void TNonreplicatedPartitionActor::HandleChecksumBlocks(
         PartConfig,
         SelfId());
 
-    RequestsInProgress.AddReadRequest(actorId);
+    RequestsInProgress.AddReadRequest(actorId, std::move(request));
 }
 
 void TNonreplicatedPartitionActor::HandleChecksumBlocksCompleted(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -244,7 +244,7 @@ void TNonreplicatedPartitionActor::HandleReadBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
-    TRequest request;
+    TRequestData request;
     bool ok = InitRequests<TEvService::TReadBlocksMethod>(
         *msg,
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -166,7 +166,7 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksResponse(
     auto* msg = ev->Get();
 
     if (HasError(msg->GetError())) {
-        HandleError(ctx, msg->GetError(), false);
+        HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -17,6 +17,8 @@ using namespace NActors;
 
 using namespace NKikimr;
 
+using EReason = TEvNonreplPartitionPrivate::TCancelRequest::EReason;
+
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 namespace {
@@ -150,7 +152,8 @@ void TDiskAgentReadLocalActor::HandleReadDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
-    if (HandleError(ctx, msg->GetError(), false)) {
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, msg->GetError(), false);
         return;
     }
 
@@ -238,13 +241,15 @@ void TNonreplicatedPartitionActor::HandleReadBlocksLocal(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
+    TRequest request;
     bool ok = InitRequests<TEvService::TReadBlocksLocalMethod>(
         *msg,
         ctx,
         *requestInfo,
         blockRange,
         &deviceRequests,
-        &timeoutPolicy);
+        &timeoutPolicy,
+        &request);
 
     if (!ok) {
         return;
@@ -264,7 +269,7 @@ void TNonreplicatedPartitionActor::HandleReadBlocksLocal(
         PartConfig,
         SelfId());
 
-    RequestsInProgress.AddReadRequest(actorId);
+    RequestsInProgress.AddReadRequest(actorId, std::move(request));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -241,7 +241,7 @@ void TNonreplicatedPartitionActor::HandleReadBlocksLocal(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
-    TRequest request;
+    TRequestData request;
     bool ok = InitRequests<TEvService::TReadBlocksLocalMethod>(
         *msg,
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -153,7 +153,7 @@ void TDiskAgentReadLocalActor::HandleReadDeviceBlocksResponse(
     auto* msg = ev->Get();
 
     if (HasError(msg->GetError())) {
-        HandleError(ctx, msg->GetError(), false);
+        HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
 
@@ -165,7 +165,7 @@ void TDiskAgentReadLocalActor::HandleReadDeviceBlocksResponse(
             PartConfig->MakeError(
                 E_CANCELLED,
                 "failed to acquire sglist in DiskAgentReadActor"),
-            false);
+            EStatus::Fail);
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -160,7 +160,7 @@ void TDiskAgentWriteActor::HandleWriteDeviceBlocksResponse(
     auto* msg = ev->Get();
 
     if (HasError(msg->GetError())) {
-        HandleError(ctx, msg->GetError(), false);
+        HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -247,7 +247,7 @@ void TNonreplicatedPartitionActor::HandleWriteBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
-    TRequest request;
+    TRequestData request;
     bool ok = InitRequests<TEvService::TWriteBlocksMethod>(
         *msg,
         ctx,
@@ -333,7 +333,7 @@ void TNonreplicatedPartitionActor::HandleWriteBlocksLocal(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
-    TRequest request;
+    TRequestData request;
     bool ok = InitRequests<TEvService::TWriteBlocksLocalMethod>(
         *msg,
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -159,7 +159,8 @@ void TDiskAgentWriteActor::HandleWriteDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
-    if (HandleError(ctx, msg->GetError(), false)) {
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, msg->GetError(), false);
         return;
     }
 
@@ -246,13 +247,15 @@ void TNonreplicatedPartitionActor::HandleWriteBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
+    TRequest request;
     bool ok = InitRequests<TEvService::TWriteBlocksMethod>(
         *msg,
         ctx,
         *requestInfo,
         blockRange,
         &deviceRequests,
-        &timeoutPolicy);
+        &timeoutPolicy,
+        &request);
 
     if (!ok) {
         return;
@@ -273,7 +276,7 @@ void TNonreplicatedPartitionActor::HandleWriteBlocks(
         assignVolumeRequestId,
         false); // replyLocal
 
-    RequestsInProgress.AddWriteRequest(actorId);
+    RequestsInProgress.AddWriteRequest(actorId, std::move(request));
 }
 
 void TNonreplicatedPartitionActor::HandleWriteBlocksLocal(
@@ -330,13 +333,15 @@ void TNonreplicatedPartitionActor::HandleWriteBlocksLocal(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
+    TRequest request;
     bool ok = InitRequests<TEvService::TWriteBlocksLocalMethod>(
         *msg,
         ctx,
         *requestInfo,
         blockRange,
         &deviceRequests,
-        &timeoutPolicy);
+        &timeoutPolicy,
+        &request);
 
     if (!ok) {
         return;
@@ -387,7 +392,7 @@ void TNonreplicatedPartitionActor::HandleWriteBlocksLocal(
         assignVolumeRequestId,
         true); // replyLocal
 
-    RequestsInProgress.AddWriteRequest(actorId);
+    RequestsInProgress.AddWriteRequest(actorId, std::move(request));
 }
 
 void TNonreplicatedPartitionActor::HandleWriteBlocksCompleted(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -204,7 +204,7 @@ void TNonreplicatedPartitionActor::HandleZeroBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
-    TRequest request;
+    TRequestData request;
     bool ok = InitRequests<TEvService::TZeroBlocksMethod>(
         *msg,
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -148,7 +148,7 @@ void TDiskAgentZeroActor::HandleZeroDeviceBlocksResponse(
     auto* msg = ev->Get();
 
     if (HasError(msg->GetError())) {
-        HandleError(ctx, msg->GetError(), false);
+        HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -147,7 +147,8 @@ void TDiskAgentZeroActor::HandleZeroDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
-    if (HandleError(ctx, msg->GetError(), false)) {
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, msg->GetError(), false);
         return;
     }
 
@@ -203,13 +204,15 @@ void TNonreplicatedPartitionActor::HandleZeroBlocks(
 
     TVector<TDeviceRequest> deviceRequests;
     TRequestTimeoutPolicy timeoutPolicy;
+    TRequest request;
     bool ok = InitRequests<TEvService::TZeroBlocksMethod>(
         *msg,
         ctx,
         *requestInfo,
         blockRange,
         &deviceRequests,
-        &timeoutPolicy);
+        &timeoutPolicy,
+        &request);
 
     if (!ok) {
         return;
@@ -230,7 +233,7 @@ void TNonreplicatedPartitionActor::HandleZeroBlocks(
         PartConfig->GetBlockSize(),
         assignVolumeRequestId);
 
-    RequestsInProgress.AddWriteRequest(actorId);
+    RequestsInProgress.AddWriteRequest(actorId, std::move(request));
 }
 
 void TNonreplicatedPartitionActor::HandleZeroBlocksCompleted(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -53,6 +53,7 @@ struct TTestEnv
         device.SetBlocksCount(blockCount * k);
         device.SetDeviceUUID(name);
         device.SetBlockSize(DefaultDeviceBlockSize);
+        device.SetAgentId("agent-1");
     }
 
     static TDevices DefaultDevices(ui64 nodeId)
@@ -71,6 +72,7 @@ struct TTestEnv
         bool MuteIOErrors = false;
         NProto::EStorageMediaKind MediaKind =
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED;
+        TDuration MaxTimedOutDeviceStateDuration = TDuration::Seconds(20);
 
         TDevices Devices;
     };
@@ -86,6 +88,13 @@ struct TTestEnv
         , StorageStatsServiceState(MakeIntrusive<TStorageStatsServiceState>())
         , DiskAgentState(std::make_shared<TDiskAgentState>())
     {
+        runtime.SetRegistrationObserverFunc(
+            [] (auto& runtime, const auto& parentId, const auto& actorId)
+        {
+            Y_UNUSED(parentId);
+            runtime.EnableScheduleForActor(actorId);
+        });
+
         if (params.Devices.empty()) {
             params.Devices = DefaultDevices(runtime.GetNodeId(0));
         }
@@ -93,7 +102,8 @@ struct TTestEnv
         SetupLogging();
 
         NProto::TStorageServiceConfig storageConfig;
-        storageConfig.SetMaxTimedOutDeviceStateDuration(20'000);
+        storageConfig.SetMaxTimedOutDeviceStateDuration(
+            params.MaxTimedOutDeviceStateDuration.MilliSeconds());
         if (params.MediaKind == NProto::STORAGE_MEDIA_HDD_NONREPLICATED) {
             storageConfig.SetNonReplicatedMinRequestTimeoutSSD(60'000);
             storageConfig.SetNonReplicatedMaxRequestTimeoutSSD(60'000);
@@ -107,6 +117,7 @@ struct TTestEnv
         }
         storageConfig.SetNonReplicatedAgentMaxTimeout(300'000);
         storageConfig.SetAssignIdToWriteAndZeroRequestsEnabled(true);
+        storageConfig.SetLaggingDeviceTimeoutThreshold(3'000);
 
         auto config = std::make_shared<TStorageConfig>(
             std::move(storageConfig),
@@ -137,6 +148,7 @@ struct TTestEnv
         partConfigInitParams.IOMode = params.IOMode;
         partConfigInitParams.MuteIOErrors = params.MuteIOErrors;
         partConfigInitParams.UseSimpleMigrationBandwidthLimiter = false;
+        partConfigInitParams.LaggingDevicesAllowed = true;
         auto partConfig = std::make_shared<TNonreplicatedPartitionConfig>(
             std::move(partConfigInitParams));
 
@@ -629,13 +641,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     {
         TTestBasicRuntime runtime;
 
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
 
         TPartitionClient client(runtime, env.ActorId);
@@ -678,14 +683,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     void DoTestShouldHandleTimedoutIO(NProto::EStorageMediaKind mediaKind)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime, {.MediaKind = mediaKind});
         env.DiskAgentState->ResponseDelay = TDuration::Max();
 
@@ -858,14 +855,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     void DoTestShouldUseResponseTimeHistoryForTimeouts(NProto::EStorageMediaKind mediaKind)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime, {.MediaKind = mediaKind});
         env.DiskAgentState->ResponseDelay = TDuration::MilliSeconds(1'200);
 
@@ -946,14 +935,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     Y_UNIT_TEST(ShouldNotReturnIOErrorUponTimeoutForBackgroundRequests)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
         env.DiskAgentState->ResponseDelay = TDuration::Max();
 
@@ -997,14 +978,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     Y_UNIT_TEST(ShouldRecoverFromShortTimeoutStreak)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
         env.DiskAgentState->ResponseDelay = TDuration::Max();
 
@@ -1423,14 +1396,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     Y_UNIT_TEST(ShouldSendStatsToVolume)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
 
         bool done = false;
@@ -1459,14 +1424,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     Y_UNIT_TEST(ShouldRecoverWithAgentBackFromUnavailable)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
         env.DiskAgentState->ResponseDelay = TDuration::Max();
 
@@ -1540,14 +1497,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         constexpr size_t RequestCount = 10;
 
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
         env.DiskAgentState->ResponseDelay = TDuration::Max();
 
@@ -1593,14 +1542,6 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
     Y_UNIT_TEST(ShouldUpdateStats)
     {
         TTestBasicRuntime runtime;
-
-        runtime.SetRegistrationObserverFunc(
-            [] (auto& runtime, const auto& parentId, const auto& actorId)
-        {
-            Y_UNUSED(parentId);
-            runtime.EnableScheduleForActor(actorId);
-        });
-
         TTestEnv env(runtime);
 
         auto& counters = env.StorageStatsServiceState->Counters.Cumulative;
@@ -2209,6 +2150,306 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         }
 
         UNIT_ASSERT_LT(differentChecksums * 2, totalChecksums);
+    }
+
+    Y_UNIT_TEST(ShouldHandleTimeoutedDevices)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(
+            runtime,
+            {.MediaKind =
+                 NProto::EStorageMediaKind::STORAGE_MEDIA_SSD_MIRROR3});
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        env.KillDiskAgent();
+
+        std::optional<TString> timeoutedDevice;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvVolumePrivate::EvDeviceTimeoutedRequest: {
+                        auto* msg = event->Get<
+                            TEvVolumePrivate::TEvDeviceTimeoutedRequest>();
+                        UNIT_ASSERT(!timeoutedDevice.has_value());
+                        timeoutedDevice = msg->DeviceUUID;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        // Send the first request. Device timeout timer will start from this
+        // moment.
+        {
+            client.SendReadBlocksRequest(TBlockRange64::WithLength(0, 1024));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+
+            auto response = client.RecvReadBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+            UNIT_ASSERT(!timeoutedDevice.has_value());
+        }
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        UNIT_ASSERT(!timeoutedDevice.has_value());
+
+        // After 3 seconds device should be deemed timeouted.
+        {
+            client.SendWriteBlocksRequest(
+                TBlockRange64::WithLength(0, 1024),
+                1);
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+            UNIT_ASSERT(timeoutedDevice.has_value());
+            UNIT_ASSERT_VALUES_EQUAL("vasya", *timeoutedDevice);
+        }
+
+        timeoutedDevice.reset();
+
+        // DeviceTimeouted request should be sent on every timeouted request.
+        {
+            client.SendZeroBlocksRequest(TBlockRange64::WithLength(0, 1024));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            auto response = client.RecvZeroBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+            UNIT_ASSERT(timeoutedDevice.has_value());
+            UNIT_ASSERT_VALUES_EQUAL("vasya", *timeoutedDevice);
+        }
+
+        // Send requests to the second device.
+        {
+            client.SendWriteBlocksRequest(
+                TBlockRange64::WithLength(2048, 1024),
+                1);
+            client.SendZeroBlocksRequest(TBlockRange64::WithLength(3072, 1024));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+
+        // Both devices are now unavailable.
+        {
+            NProto::TLaggingAgent laggingAgent;
+            laggingAgent.SetAgentId("agent-1");
+            auto* laggingDevice = laggingAgent.AddDevices();
+            laggingDevice->SetRowIndex(0);
+            laggingDevice->SetDeviceUUID("vasya");
+
+            laggingDevice = laggingAgent.AddDevices();
+            laggingDevice->SetRowIndex(1);
+            laggingDevice->SetDeviceUUID("petya");
+            auto agentUnavailableRequest = std::make_unique<
+                TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+                std::move(laggingAgent));
+            client.SendRequest(env.ActorId, std::move(agentUnavailableRequest));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+
+        // Requests should be canceled.
+        {
+            auto response = client.RecvZeroBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+            UNIT_ASSERT_C(
+                response->GetErrorReason().Contains("request is canceled"),
+                response->GetErrorReason());
+        }
+        {
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+            UNIT_ASSERT_C(
+                response->GetErrorReason().Contains("request is canceled"),
+                response->GetErrorReason());
+        }
+
+        timeoutedDevice.reset();
+
+        // When devices are unavailable partition should not send
+        // DeviceTimeouted request.
+        {
+            client.SendWriteBlocksRequest(
+                TBlockRange64::WithLength(0, 1024),
+                1);
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            auto response = client.RecvWriteBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+            UNIT_ASSERT(!timeoutedDevice.has_value());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleAgentBackOnline)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(
+            runtime,
+            {.MediaKind = NProto::EStorageMediaKind::STORAGE_MEDIA_SSD_MIRROR3,
+             .MaxTimedOutDeviceStateDuration = TDuration::Minutes(5)});
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        bool dropIoRequests = true;
+        std::optional<TString> lastTimeoutedDevice;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvDiskAgent::EvReadDeviceBlocksRequest:
+                    case TEvDiskAgent::EvWriteDeviceBlocksRequest:
+                    case TEvDiskAgent::EvZeroDeviceBlocksRequest:
+                        return dropIoRequests;
+                    case TEvVolumePrivate::EvDeviceTimeoutedRequest: {
+                        auto* msg = event->Get<
+                            TEvVolumePrivate::TEvDeviceTimeoutedRequest>();
+                        lastTimeoutedDevice = msg->DeviceUUID;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        // There are some connectivity issues.
+        for (int i = 0; i < 2; i++) {
+            client.SendReadBlocksRequest(TBlockRange64::WithLength(1024, 2048));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(5));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+
+            auto response = client.RecvReadBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+        }
+
+        // Requests timeout is 5 seconds.
+        {
+            client.SendReadBlocksRequest(TBlockRange64::WithLength(0, 1024));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(4));
+
+            TAutoPtr<NActors::IEventHandle> handle;
+            try {
+                runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
+                    handle,
+                    TDuration::MilliSeconds(10));
+            } catch (...) {
+                // no-op
+            }
+            UNIT_ASSERT(!handle);
+
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
+                handle,
+                TDuration::MilliSeconds(10));
+            UNIT_ASSERT(handle);
+
+            auto response =
+                handle->Release<TEvService::TEvReadBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+        }
+
+        // Both devices are now unavailable.
+        {
+            NProto::TLaggingAgent laggingAgent;
+            laggingAgent.SetAgentId("agent-1");
+            auto* laggingDevice = laggingAgent.AddDevices();
+            laggingDevice->SetRowIndex(0);
+            laggingDevice->SetDeviceUUID("vasya");
+
+            laggingDevice = laggingAgent.AddDevices();
+            laggingDevice->SetRowIndex(1);
+            laggingDevice->SetDeviceUUID("petya");
+            auto agentUnavailableRequest = std::make_unique<
+                TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+                std::move(laggingAgent));
+            client.SendRequest(env.ActorId, std::move(agentUnavailableRequest));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+
+        // Requests timeout is 1 second.
+        for (int i = 0; i < 5; i++) {
+            client.SendReadBlocksRequest(TBlockRange64::WithLength(0, 1024));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
+            TAutoPtr<NActors::IEventHandle> handle;
+            runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
+                handle,
+                TDuration::MilliSeconds(10));
+            UNIT_ASSERT(handle);
+
+            auto response =
+                handle->Release<TEvService::TEvReadBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+        }
+
+        // Do a successful reading from the second device.
+        dropIoRequests = false;
+        {
+            client.ReadBlocks(TBlockRange64::WithLength(2048, 1024));
+        }
+
+        // Requests timeout has been reset to 1 second.
+        dropIoRequests = true;
+        {
+            client.SendReadBlocksRequest(TBlockRange64::WithLength(2048, 1024));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
+            TAutoPtr<NActors::IEventHandle> handle;
+            runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
+                handle,
+                TDuration::MilliSeconds(10));
+            UNIT_ASSERT(handle);
+
+            auto response =
+                handle->Release<TEvService::TEvReadBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+        }
+
+        // Agent is back online.
+        {
+            auto agentUnavailableRequest = std::make_unique<
+                TEvNonreplPartitionPrivate::TEvAgentIsBackOnline>("agent-1");
+            client.SendRequest(env.ActorId, std::move(agentUnavailableRequest));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+
+        // Requests timeout has been reset to 1 second for the first device.
+        {
+            client.SendReadBlocksRequest(TBlockRange64::WithLength(0, 1024));
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(10));
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
+            TAutoPtr<NActors::IEventHandle> handle;
+            runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
+                handle,
+                TDuration::MilliSeconds(10));
+            UNIT_ASSERT(handle);
+
+            auto response =
+                handle->Release<TEvService::TEvReadBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetStatus());
+            UNIT_ASSERT(
+                response->GetErrorReason().Contains("request timed out"));
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -2338,13 +2338,9 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
             runtime.AdvanceCurrentTime(TDuration::Seconds(4));
 
             TAutoPtr<NActors::IEventHandle> handle;
-            try {
-                runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
-                    handle,
-                    TDuration::MilliSeconds(10));
-            } catch (...) {
-                // no-op
-            }
+            runtime.GrabEdgeEventRethrow<TEvService::TEvReadBlocksResponse>(
+                handle,
+                TDuration::MilliSeconds(10));
             UNIT_ASSERT(!handle);
 
             runtime.AdvanceCurrentTime(TDuration::Seconds(1));


### PR DESCRIPTION
#3
В этом ПРе партишн отслеживает что девайс долго не отвечал и делает запрос в Volume `TEvDeviceTimeoutedRequest`.
Когда Volume ответил что агент недоступен, партишн отменяет все активные запросы. Скорее всего они и так не ответят. А поретраив мы быстрее их завершим об другие реплики.