### PR TITLE
[Disk Manager] fix error check in disk service test

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -671,14 +671,15 @@ func testCreateDiskFromImage(
 			diskContentInfo,
 			encryption,
 		)
+		require.NoError(t, err)
 	} else {
 		err = nbsClient.ValidateCrc32(
 			ctx,
 			diskID,
 			diskContentInfo,
 		)
+		require.NoError(t, err)
 	}
-	require.NoError(t, err)
 
 	diskParams, err := nbsClient.Describe(ctx, diskID)
 	require.NoError(t, err)


### PR DESCRIPTION
In line 665, we create another 'err' variable because of ':='. So the value of err from line 668 was never checked.