### PR TITLE
Fix use-after-free

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -710,21 +710,22 @@ void TVolumeDatabase::WriteFollower(const TFollowerDiskInfo& follower)
 {
     using TTable = TVolumeSchema::FollowerDisks;
 
-    auto& operation =
-        Table<TTable>()
-            .Key(follower.Uuid)
-            .Update(
-                NIceDb::TUpdate<TTable::FollowerDiskId>(
-                    follower.FollowerDiskId),
-                NIceDb::TUpdate<TTable::ScaleUnitId>(follower.ScaleUnitId),
-                NIceDb::TUpdate<TTable::State>(
-                    static_cast<ui32>(follower.State)));
+    Table<TTable>()
+        .Key(follower.Uuid)
+        .Update(
+            NIceDb::TUpdate<TTable::FollowerDiskId>(follower.FollowerDiskId),
+            NIceDb::TUpdate<TTable::ScaleUnitId>(follower.ScaleUnitId),
+            NIceDb::TUpdate<TTable::State>(static_cast<ui32>(follower.State)));
 
     if (follower.MigrationBlockIndex) {
-        operation.Update(NIceDb::TUpdate<TTable::MigratedBlockCount>(
-            *follower.MigrationBlockIndex));
+        Table<TTable>()
+            .Key(follower.Uuid)
+            .Update(NIceDb::TUpdate<TTable::MigratedBlockCount>(
+                *follower.MigrationBlockIndex));
     } else {
-        operation.UpdateToNull<TTable::MigratedBlockCount>();
+        Table<TTable>()
+            .Key(follower.Uuid)
+            .UpdateToNull<TTable::MigratedBlockCount>();
     }
 }
 


### PR DESCRIPTION
Баг в  https://github.com/ydb-platform/nbs/pull/3147
```
=================================================================
==217357==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f6a2a7e8740 at pc 0x000025757d75 bp 0x7ffce022e490 sp 0x7ffce022e488
READ of size 8 at 0x7f6a2a7e8740 thread T0
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0xa80 has a premature terminator entry at offset 0xa90
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x13c0 has a premature terminator entry at offset 0x13d0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x14e0 has a premature terminator entry at offset 0x14f0
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x15a0 has a premature terminator entry at offset 0x15b0
    #0 0x25757d74 in NKikimr::NIceDb::Schema::Table<11U>::KeyOperations<NCloud::NBlockStore::NStorage::TVolumeSchema::FollowerDisks, std::__y1::tuple<TBasicString<char, std::__y1::char_traits<char> > > >::Update<NKikimr::NIceDb::TNull<NCloud::NBlockStore::NStorage::TVolumeSchema::FollowerDisks::MigratedBlockCount> > /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_cxx_database.h:1961:17
    #1 0x25757d74 in NKikimr::NIceDb::Schema::Table<11U>::KeyOperations<NCloud::NBlockStore::NStorage::TVolumeSchema::FollowerDisks, std::__y1::tuple<TBasicString<char, std::__y1::char_traits<char> > > >::UpdateToNull<NCloud::NBlockStore::NStorage::TVolumeSchema::FollowerDisks::MigratedBlockCount> /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_cxx_database.h:1955:24
    #2 0x25757d74 in NCloud::NBlockStore::NStorage::TVolumeDatabase::WriteFollower(NCloud::NBlockStore::NStorage::TFollowerDiskInfo const&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database.cpp:727:19
    #3 0xeebbd9b in NCloud::NBlockStore::NStorage::NTestSuiteTVolumeDatabaseTest::TTestCaseShouldStoreFollowers::Execute_(NUnitTest::TTestContext &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:1304:20
    #4 0xeebbd9b in NCloud::NBlockStore::NStorage::TTestExecutor::WriteTx<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:1301:13)> /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/testlib/test_executor.h:32:9
    #5 0xeebbd9b in NCloud::NBlockStore::NStorage::NTestSuiteTVolumeDatabaseTest::TTestCaseShouldStoreFollowers::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:1300:18
    #6 0xeecd038 in NCloud::NBlockStore::NStorage::NTestSuiteTVolumeDatabaseTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:109:1
    #7 0xeecd038 in std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:109:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #8 0xeecd038 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:109:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #9 0xeecd038 in std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:109:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:109:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #10 0xeecd038 in std::__y1::__function::__func<NCloud::NBlockStore::NStorage::NTestSuiteTVolumeDatabaseTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NStorage::NTestSuiteTVolumeDatabaseTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12
    #11 0x101c2f1a in std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16
    #12 0x101c2f1a in std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12
    #13 0x101c2f1a in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20
    #14 0x101925f5 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18
    #15 0xeecb8e3 in NCloud::NBlockStore::NStorage::NTestSuiteTVolumeDatabaseTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp:109:1
    #16 0x101943b9 in NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19
    #17 0x101bb3cc in NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44
    #18 0x7f6a2c4d5d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #19 0x7f6a2c4d5e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #20 0xcc89028 in _start (/home/github/.ya/build/build_root/zz12/001585/cloud/blockstore/libs/storage/volume/ut/cloud-blockstore-libs-storage-volume-ut+0xcc89028) (BuildId: 95fa0c409e7cb5bc683ce8da889b9f0524d9335c)
Address 0x7f6a2a7e8740 is located in stack of thread T0 at offset 832 in frame
    #0 0x2575680f in NCloud::NBlockStore::NStorage::TVolumeDatabase::WriteFollower(NCloud::NBlockStore::NStorage::TFollowerDiskInfo const&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/storage/volume/volume_database.cpp:710
  This frame has 15 object(s):
    [32, 72) 'update_ops.i.i'
    [112, 176) 'ref.tmp.i.i'
    [208, 224) 'agg.tmp2.i.i'
    [240, 256) 'agg.tmp3.i.i'
    [272, 312) 'update_ops.i70'
    [352, 416) 'ref.tmp.i71'
    [448, 464) 'agg.tmp2.i'
    [480, 496) 'agg.tmp3.i'
    [512, 632) 'update_ops.i'
    [672, 736) 'ref.tmp.i'
    [768, 784) 'agg.tmp7.i'
    [800, 816) 'agg.tmp8.i'
    [832, 848) 'ref.tmp' (line 714) <== Memory access at offset 832 is inside this variable
    [864, 872) 'agg.tmp'
    [896, 900) 'ref.tmp10' (line 714)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope /actions-runner/_work/nbs/nbs/contrib/ydb/core/tablet_flat/flat_cxx_database.h:1961:17 in NKikimr::NIceDb::Schema::Table<11U>::KeyOperations<NCloud::NBlockStore::NStorage::TVolumeSchema::FollowerDisks, std::__y1::tuple<TBasicString<char, std::__y1::char_traits<char> > > >::Update<NKikimr::NIceDb::TNull<NCloud::NBlockStore::NStorage::TVolumeSchema::FollowerDisks::MigratedBlockCount> >
Shadow bytes around the buggy address:
  0x7f6a2a7e8480: f8 f8 f8 f8 f8 f8 f2 f2 f2 f2 00 00 f2 f2 00 00
  0x7f6a2a7e8500: f2 f2 f8 f8 f8 f8 f8 f2 f2 f2 f2 f2 f8 f8 f8 f8
  0x7f6a2a7e8580: f8 f8 f8 f8 f2 f2 f2 f2 f8 f8 f2 f2 f8 f8 f2 f2
  0x7f6a2a7e8600: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f2
  0x7f6a2a7e8680: f2 f2 f2 f2 f8 f8 f8 f8 f8 f8 f8 f8 f2 f2 f2 f2
=>0x7f6a2a7e8700: f8 f8 f2 f2 f8 f8 f2 f2[f8]f8 f2 f2 00 f2 f2 f2
  0x7f6a2a7e8780: f8 f3 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f6a2a7e8800: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7f6a2a7e8880: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7f6a2a7e8900: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7f6a2a7e8980: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==217357==ABORTING
```