### PR TITLE
[Disk Manager] use logger in s3 sdk

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_test.go
@@ -97,7 +97,7 @@ func setupEnvironment(
 	)
 	require.NoError(t, err)
 
-	s3, err := test.NewS3Client()
+	s3, err := test.NewS3Client(ctx)
 	require.NoError(t, err)
 
 	storageFolder := fmt.Sprintf("snapshot_chunk_storage_test/%v", t.Name())

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go
@@ -346,7 +346,7 @@ func createFixture(t *testing.T) *fixture {
 	db, err := newYDB(ctx)
 	require.NoError(t, err)
 
-	s3, err := test.NewS3Client()
+	s3, err := test.NewS3Client(ctx)
 	require.NoError(t, err)
 
 	storageFolder := fmt.Sprintf("storage_ydb_test/%v", t.Name())

--- a/cloud/disk_manager/internal/pkg/dataplane/test/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/test/common.go
@@ -18,11 +18,12 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func NewS3Client() (*persistence.S3Client, error) {
+func NewS3Client(ctx context.Context) (*persistence.S3Client, error) {
 	endpoint := fmt.Sprintf("http://localhost:%s", os.Getenv("DISK_MANAGER_RECIPE_S3_PORT"))
 	credentials := persistence.NewS3Credentials("test", "test")
 	callTimeout := 600 * time.Second
 	return persistence.NewS3Client(
+		ctx,
 		endpoint,
 		"test",
 		credentials,

--- a/cloud/disk_manager/internal/pkg/dataplane/transfer_tests/transfer_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/transfer_tests/transfer_test.go
@@ -280,7 +280,7 @@ func newStorage(
 		ChunkBlobsS3KeyPrefix:     &chunkBlobsS3KeyPrefix,
 	}
 
-	s3, err := test.NewS3Client()
+	s3, err := test.NewS3Client(ctx)
 	require.NoError(t, err)
 
 	err = schema.Create(ctx, config, db, s3, false /* dropUnusedColumns */)

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -208,7 +208,7 @@ func run(
 			registry := mon.NewRegistry("s3_client")
 
 			var err error
-			s3, err = persistence.NewS3ClientFromConfig(s3Config, registry)
+			s3, err = persistence.NewS3ClientFromConfig(ctx, s3Config, registry)
 			if err != nil {
 				return err
 			}
@@ -233,7 +233,11 @@ func run(
 			migrationDstS3Config := migrationDstSnapshotConfig.GetPersistenceConfig().GetS3Config()
 			if migrationDstS3Config != nil {
 				registry := mon.NewRegistry("migration_s3_client")
-				migrationDstS3, err = persistence.NewS3ClientFromConfig(migrationDstS3Config, registry)
+				migrationDstS3, err = persistence.NewS3ClientFromConfig(
+					ctx,
+					migrationDstS3Config,
+					registry,
+				)
 				if err != nil {
 					return err
 				}

--- a/cloud/disk_manager/pkg/schema/dataplane.go
+++ b/cloud/disk_manager/pkg/schema/dataplane.go
@@ -48,7 +48,11 @@ func initDataplane(
 	var s3 *persistence.S3Client
 	// TODO: remove when s3 will always be initialized.
 	if s3Config != nil {
-		s3, err = persistence.NewS3ClientFromConfig(s3Config, metrics.NewEmptyRegistry())
+		s3, err = persistence.NewS3ClientFromConfig(
+			ctx,
+			s3Config,
+			metrics.NewEmptyRegistry(),
+		)
 		if err != nil {
 			return err
 		}
@@ -78,7 +82,11 @@ func initDataplane(
 	migrationDstS3Config := migrationDstPersistenceConfig.GetS3Config()
 	var migrationDstS3 *persistence.S3Client
 	if migrationDstS3Config != nil {
-		migrationDstS3, err = persistence.NewS3ClientFromConfig(migrationDstS3Config, metrics.NewEmptyRegistry())
+		migrationDstS3, err = persistence.NewS3ClientFromConfig(
+			ctx,
+			migrationDstS3Config,
+			metrics.NewEmptyRegistry(),
+		)
 		if err != nil {
 			return err
 		}

--- a/cloud/tasks/persistence/s3_test.go
+++ b/cloud/tasks/persistence/s3_test.go
@@ -17,12 +17,14 @@ const maxRetriableErrorCount = 3
 ////////////////////////////////////////////////////////////////////////////////
 
 func newS3Client(
+	ctx context.Context,
 	metricsRegistry *mocks.RegistryMock,
 	callTimeout time.Duration,
 ) (*S3Client, error) {
 
 	credentials := NewS3Credentials("test", "test")
 	return NewS3Client(
+		ctx,
 		"endpoint",
 		"region",
 		credentials,
@@ -39,7 +41,11 @@ func TestS3ShouldSendErrorCanceledMetric(t *testing.T) {
 
 	metricsRegistry := mocks.NewRegistryMock()
 
-	s3, err := newS3Client(metricsRegistry, 10*time.Second /* callTimeout */)
+	s3, err := newS3Client(
+		ctx,
+		metricsRegistry,
+		10*time.Second, // callTimeout
+	)
 	require.NoError(t, err)
 
 	cancel()
@@ -66,7 +72,7 @@ func TestS3ShouldSendErrorTimeoutMetric(t *testing.T) {
 
 	metricsRegistry := mocks.NewRegistryMock()
 
-	s3, err := newS3Client(metricsRegistry, 0 /* callTimeout */)
+	s3, err := newS3Client(ctx, metricsRegistry, 0 /* callTimeout */)
 	require.NoError(t, err)
 
 	metricsRegistry.GetCounter(
@@ -96,7 +102,11 @@ func TestS3ShouldRetryRequests(t *testing.T) {
 
 	metricsRegistry := mocks.NewRegistryMock()
 
-	s3, err := newS3Client(metricsRegistry, 10*time.Second /* callTimeout */)
+	s3, err := newS3Client(
+		ctx,
+		metricsRegistry,
+		10*time.Second, // callTimeout
+	)
 	require.NoError(t, err)
 
 	metricsRegistry.GetCounter(


### PR DESCRIPTION
Log messages from S3 go SDK. These logs contain information about all http requests to S3 (for GetObject, PutObject, etc)  and responses from S3.

For example:
```
2025-03-14T08:54:21.758Z        INFO    persistence/s3.go:38    S3 SDK: DEBUG: Request s3/PutObject Details:
---[ REQUEST POST-SIGN ]-----------------------------
PUT /snapshot/healthCheckKey HTTP/1.1
Host: localhost:1756
User-Agent: aws-sdk-go/1.44.263 (go1.21.3; linux; amd64)
Content-Length: 1
Authorization: AWS4-HMAC-SHA256 Credential=test/20250314/test/s3/aws4_request, SignedHeaders=content-encoding;content-length;content-md5;host;x-amz-content-sha256;x-amz-date, Signature=fc39562adfde8681acccd79e9238a81fdad9111d123e63a206449b0e75904ac7
Content-Encoding: application/octet-stream
Content-Md5: AFlP1PQrpD/BygQnoFdilQ==
X-Amz-Content-Sha256: a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89
X-Amz-Date: 20250314T085421Z
Accept-Encoding: gzip


-----------------------------------------------------
        {"SYSLOG_IDENTIFIER": "disk-manager"}
```

```
2025-03-14T08:54:21.758Z        INFO    persistence/s3.go:38    S3 SDK: DEBUG: Send Request s3/PutObject failed, attempt 1/3, error RequestErr
or: send request failed
caused by: Put "http://localhost:1756/snapshot/healthCheckKey": dial tcp [::1]:1756: connect: connection refused
        {"SYSLOG_IDENTIFIER": "disk-manager"}
```

```
2025-03-14T09:08:39.128Z        INFO    persistence/s3.go:38    S3 SDK: DEBUG: Response s3/GetObject Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.0 200 OK
Connection: close
Content-Length: 1
Access-Control-Allow-Origin: *
Content-Encoding: application/octet-stream
Content-Md5: AFlP1PQrpD/BygQnoFdilQ==
Content-Type: binary/octet-stream
Date: Fri, 14 Mar 2025 09:08:39 GMT
Etag: "00594fd4f42ba43fc1ca0427a0576295"
Last-Modified: Fri, 14 Mar 2025 09:08:39 GMT
Server: Werkzeug/2.0.3 Python/3.11.7
X-Amz-Version-Id: null
X-Amzn-Requestid: 9BDUTTVY6Y10E4JIITFMIKU2D0YKVDLWXO796BYF7S4EW43UKD0Z


-----------------------------------------------------
        {"SYSLOG_IDENTIFIER": "disk-manager"}

```

Note the `X-Amzn-Requestid` header in response. It can be useful: if something is wrong with the request, S3 will be able to debug the request on their side using with id.