### PR TITLE
[Filestore] vhost bug fix

### DIFF
--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -132,7 +132,7 @@ def start(argv):
     set_env("NFS_MON_PORT", str(filestore_configurator.mon_port))
     set_env("NFS_DOMAIN", str(domain))
     set_env("NFS_CONFIG_DIR", str(filestore_configurator.configs_dir))
-    set_env("NFS_RESTART_INTERVAL", restart_interval)
+    set_env("NFS_RESTART_INTERVAL", str(restart_interval))
     if secure:
         set_env("NFS_SERVER_SECURE_PORT", str(filestore_configurator.secure_port))
 


### PR DESCRIPTION
The tests for _cloud/filestore/tests/auth/new/vhost_, _cloud/filestore/tests/auth/old/vhost_ and _cloud/filestore/tests/endpoints_, as well as other tests, failed because the JSON parser expected a string from the NFS_RESTART_INTERVAL value.

```
RecipeStartUpError: vhost-recipe-3 failed
Stderr tail:estore/tests/recipes/vhost/__main__.py", line 149, in start
    wait_for_filestore_vhost(filestore_vhost, vhost_configurator.port)
  File "contrib/python/retrying/py3/retrying.py", line 56, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "contrib/python/retrying/py3/retrying.py", line 257, in call
    return attempt.get(self._wrap_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "contrib/python/retrying/py3/retrying.py", line 301, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "contrib/python/six/py3/six.py", line 724, in reraise
    raise value
  File "contrib/python/retrying/py3/retrying.py", line 251, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
                      ^^^^^^^^^^^^^^^^^^^
  File "cloud/filestore/tests/python/lib/vhost.py", line 30, in wait_for_filestore_vhost
    raise RuntimeError("vhost server is dead")
RuntimeError: vhost server is dead
```

filestore-vhost.err:

```
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_Z17print_stack_tracev+0x21) [0x12ddd6c1]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_ZNK5NJson10TJsonValue13GetStringSafeEv+0x8b) [0x12de01ab]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_ZNK5NJson10TJsonValue13GetStringSafeERK12TBasicStringIcNSt4__y111char_traitsIcEEE+0x11) [0x12de03d1]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_ZN8NPrivate8TTestEnv12ReInitializeEv+0x1257) [0x1ce632c7]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_ZN8NPrivate8TTestEnvC1Ev+0xbd) [0x1ce61fdd]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_ZN8NPrivate13SingletonBaseINS_8TTestEnvELm65536EJEEEPT_RNSt4__y16atomicIS3_EEDpOT1_+0x27) [0x1ce64c17]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_Z10FromYaTestv+0x1e) [0x1ce61f0e]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost() [0x1ce60556]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(__libc_csu_init+0x4d) [0x24069cad]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x5c) [0x7f14595cce1c]
/home/sazonov99/.ya/build/build_root/g2id/000014/cloud/filestore/apps/vhost/filestore-vhost(_start+0x29) [0x11f40029]
Terminating due to uncaught exception 0x56ecbf601310    what() -> "library/cpp/json/writer/json_value.cpp:477: Not a string"
 of type NJson::TJsonException

```