### PR TITLE
fix: uninitialized bytes warning

### DIFF
--- a/cloud/storage/core/libs/netlink/message.h
+++ b/cloud/storage/core/libs/netlink/message.h
@@ -61,6 +61,9 @@ struct TNetlinkFamilyIdRequest
 
     TNetlinkFamilyIdRequest(const char (&familyName)[FamilyNameLength])
     {
+        // Use memset to resolve the memory sanitizer warning, as this structure
+        //  is transmitted via a socket, and padding may be present depending on
+        //  the length of the family name.
         memset(this, 0, sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>));
         Headers = {
             sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>),

--- a/cloud/storage/core/libs/netlink/message.h
+++ b/cloud/storage/core/libs/netlink/message.h
@@ -61,9 +61,9 @@ struct TNetlinkFamilyIdRequest
 
     TNetlinkFamilyIdRequest(const char (&familyName)[FamilyNameLength])
     {
-        // Use memset to resolve the memory sanitizer warning, as this structure
-        //  is transmitted via a socket, and padding may be present depending on
-        //  the length of the family name.
+        // Use memset to resolve the "uninitialized bytes" memory sanitizer
+        // warning, as this structure is transmitted via a socket, and padding
+        // may be present depending on the length of the family name.
         memset(this, 0, sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>));
         Headers = {
             sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>),

--- a/cloud/storage/core/libs/netlink/message.h
+++ b/cloud/storage/core/libs/netlink/message.h
@@ -55,17 +55,20 @@ union TNetlinkResponse {
 template <size_t FamilyNameLength>
 struct TNetlinkFamilyIdRequest
 {
-    TNetlinkHeader Headers = {
-        sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>),
-        GENL_ID_CTRL,
-        CTRL_CMD_GETFAMILY};
-    ::nlattr FamilyNameAttr = {
-        sizeof(FamilyName) + NLA_HDRLEN,
-        CTRL_ATTR_FAMILY_NAME};
+    TNetlinkHeader Headers;
+    ::nlattr FamilyNameAttr;
     std::array<char, FamilyNameLength> FamilyName;
 
     TNetlinkFamilyIdRequest(const char (&familyName)[FamilyNameLength])
     {
+        memset(this, 0, sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>));
+        Headers = {
+            sizeof(TNetlinkFamilyIdRequest<FamilyNameLength>),
+            GENL_ID_CTRL,
+            CTRL_CMD_GETFAMILY};
+        FamilyNameAttr = {
+            sizeof(FamilyName) + NLA_HDRLEN,
+            CTRL_ATTR_FAMILY_NAME};
         memcpy(&FamilyName[0], familyName, FamilyNameLength);
     }
 };


### PR DESCRIPTION
According to netlink specification we should send raw C structure to the kernel however the structure contains paddings(again it's according to netlink specification) which cause the uninitialized bytes warning from memory sanitizer.

Solution: use memset to initialize all bytes of the structure.