### PR TITLE
[Filestore] Change type from string to bytes in Protobuf messages

### DIFF
--- a/cloud/filestore/public/api/protos/data.proto
+++ b/cloud/filestore/public/api/protos/data.proto
@@ -42,7 +42,7 @@ message TCreateHandleRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Parent node.
     uint64 NodeId = 3;
@@ -63,7 +63,7 @@ message TCreateHandleRequest
     uint64 Gid = 11;
 
     // If set, the node will be created or looked up in the shard FS.
-    string ShardFileSystemId = 12;
+    bytes ShardFileSystemId = 12;
 }
 
 message TCreateHandleResponse
@@ -78,9 +78,9 @@ message TCreateHandleResponse
     TNodeAttr NodeAttr = 3;
 
     // Shard FS id - if the request should be redirected to a shard.
-    string ShardFileSystemId = 4;
+    bytes ShardFileSystemId = 4;
     // Node name in the shard FS (under RootNode).
-    string ShardNodeName = 5;
+    bytes ShardNodeName = 5;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -95,7 +95,7 @@ message TDestroyHandleRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;
@@ -122,7 +122,7 @@ message TReadDataRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;
@@ -161,7 +161,7 @@ message TWriteDataRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;
@@ -208,7 +208,7 @@ message TAllocateDataRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;
@@ -245,7 +245,7 @@ message TTruncateDataRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;
@@ -275,7 +275,7 @@ message TFsyncRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;
@@ -305,7 +305,7 @@ message TFsyncDirRequest
     THeaders Headers = 1;
 
     // FileSystem identifier.
-    string FileSystemId = 2;
+    bytes FileSystemId = 2;
 
     // Node.
     uint64 NodeId = 3;

--- a/cloud/filestore/public/api/protos/headers.proto
+++ b/cloud/filestore/public/api/protos/headers.proto
@@ -15,16 +15,16 @@ option go_package = "github.com/ydb-platform/nbs/cloud/filestore/public/api/prot
 message THeaders
 {
     // Trace identifier for logging.
-    string TraceId = 1;
+    bytes TraceId = 1;
 
     // Idempotence identifier for retries.
-    string IdempotenceId = 2;
+    bytes IdempotenceId = 2;
 
     // Client identifier for client detection.
-    string ClientId = 3;
+    bytes ClientId = 3;
 
     // Session identifier.
-    string SessionId = 4;
+    bytes SessionId = 4;
 
     // Request timestamp.
     uint64 Timestamp = 5;
@@ -45,14 +45,14 @@ message THeaders
         NCloud.NProto.ERequestSource RequestSource = 2;
 
         // IAM auth token.
-        string AuthToken = 3;
+        bytes AuthToken = 3;
     }
 
     // Internal header, should not be used outside.
     TInternal Internal = 9;
 
     // FQDN of the host, where the request originated.
-    string OriginFqdn = 10;
+    bytes OriginFqdn = 10;
 
     // Explicitly disables multitablet forwarding.
     bool DisableMultiTabletForwarding = 11;

--- a/cloud/filestore/public/sdk/go/client/grpc.go
+++ b/cloud/filestore/public/sdk/go/client/grpc.go
@@ -34,11 +34,11 @@ type grpcClient struct {
 
 func (client *grpcClient) setupHeaders(ctx context.Context, req request) {
 	headers := req.GetHeaders()
-	headers.ClientId = client.clientID
+	headers.ClientId = []byte(client.clientID)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
-		if str, ok := val.(string); ok {
-			headers.IdempotenceId = str
+		if idempotenceId, ok := val.([]byte); ok {
+			headers.IdempotenceId = idempotenceId
 		}
 	}
 
@@ -58,8 +58,8 @@ func (client *grpcClient) setupHeaders(ctx context.Context, req request) {
 	headers.Timestamp = uint64(timestamp)
 
 	if val := ctx.Value(TraceIDHeaderKey); val != nil {
-		if str, ok := val.(string); ok {
-			headers.TraceId = str
+		if traceId, ok := val.([]byte); ok {
+			headers.TraceId = traceId
 		}
 	}
 
@@ -311,11 +311,11 @@ type grpcEndpointClient struct {
 
 func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request) {
 	headers := req.GetHeaders()
-	headers.ClientId = client.clientID
+	headers.ClientId = []byte(client.clientID)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
-		if str, ok := val.(string); ok {
-			headers.IdempotenceId = str
+		if idempotenceId, ok := val.([]byte); ok {
+			headers.IdempotenceId = idempotenceId
 		}
 	}
 
@@ -335,8 +335,8 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 	headers.Timestamp = uint64(timestamp)
 
 	if val := ctx.Value(TraceIDHeaderKey); val != nil {
-		if str, ok := val.(string); ok {
-			headers.TraceId = str
+		if traceId, ok := val.([]byte); ok {
+			headers.TraceId = traceId
 		}
 	}
 

--- a/cloud/filestore/public/sdk/python/client/base_client.py
+++ b/cloud/filestore/public/sdk/python/client/base_client.py
@@ -105,7 +105,7 @@ class _Base(object):
     def __init__(self, endpoint, timeout):
 
         self.__endpoint = endpoint
-        self.__client_id = str(uuid.uuid4())
+        self.__client_id = uuid.uuid4().bytes
 
         self.__timeout = DEFAULT_REQUEST_TIMEOUT
         if timeout is not None:


### PR DESCRIPTION
# Overview

These changes are done to get rid of `UTF8` validation function calls and increase performance.

# Performance measurements

The measurements were done using the command:
```sh
fio --name test --size 16M --bs 4k --time_based --ioengine=libaio --rw=read --runtime 60s
```

The command was used 5 times before the changes and 5 times after the changes. The latency results were min-ed, max-ed and avg-ed across the 5 runs.

Before:
 - min = 921 `ns`
 - avg = 12.193 `us`
 - max = 17.289 `ms`

After:
 - min = 921 `ns`
 - avg = 11.820 `us`
 - max = 8.365 `ms`

It can be seen that the `max` latency was lowered significantly, and the average latency was lowered by `~370ns` or by `~3%`.

FlameGraph before:
![out_before_0011](https://github.com/user-attachments/assets/88942412-f808-46a0-bf7b-6632af56f096)

FlameGraph after:
![out_after_0011](https://github.com/user-attachments/assets/920ab48c-8c85-42d8-841c-b3df3e95b6db)

