### PR TITLE
Fix build for arm

### DIFF
--- a/contrib/ydb/library/yql/minikql/comp_nodes/ut/ya.make.inc
+++ b/contrib/ydb/library/yql/minikql/comp_nodes/ut/ya.make.inc
@@ -78,9 +78,11 @@ PEERDIR(
     contrib/ydb/library/yql/sql/pg_dummy
 )
 
-CFLAGS(
-    -mprfchw
-)
+IF(ARCH_X86_64)
+    CFLAGS(
+        -mprfchw
+    )
+ENDIF()
 
 YQL_LAST_ABI_VERSION()
 

--- a/contrib/ydb/library/yql/minikql/comp_nodes/ya.make.inc
+++ b/contrib/ydb/library/yql/minikql/comp_nodes/ya.make.inc
@@ -157,9 +157,11 @@ PEERDIR(
     contrib/ydb/library/yql/public/issue/protos
 )
 
-CFLAGS(
-    -mprfchw
-)
+IF(ARCH_X86_64)
+    CFLAGS(
+        -mprfchw
+    )
+ENDIF()
 
 YQL_LAST_ABI_VERSION()
 

--- a/contrib/ydb/library/yql/minikql/perf/mprefetch/ya.make
+++ b/contrib/ydb/library/yql/minikql/perf/mprefetch/ya.make
@@ -8,9 +8,11 @@ SRCS(
     mprefetch.cpp
 )
 
-CFLAGS(
-    -mprfchw
-)
+IF(ARCH_X86_64)
+    CFLAGS(
+        -mprfchw
+    )
+ENDIF()
 
 YQL_LAST_ABI_VERSION()
 


### PR DESCRIPTION
-mprfchw makes unused compiled param warning -> error when building for arm