### PR TITLE
Fix dynamic libs names

### DIFF
--- a/contrib/libs/ibdrv/symbols.cpp
+++ b/contrib/libs/ibdrv/symbols.cpp
@@ -13,32 +13,9 @@
 const TInfinibandSymbols* IBSym() {
     struct TSymbols: TInfinibandSymbols {
         TSymbols() {
-            auto lib = std::make_unique<TDynamicLibrary>();
+            L.Reset(new TDynamicLibrary("libibverbs.so.1"));
 
-            TVector<TString> catchedExceptions;
-            TVector<TString> paths = {"/usr/lib/libibverbs.so", "libibverbs.so", "libibverbs.so.1"};
-
-            for (auto path : paths) {
-                try {
-                    lib->Open(path.c_str());
-                    L.Reset(lib.release());
-                    DOVERBS(LOADSYM)
-                    return;
-                } catch (std::exception& ex) {
-                    catchedExceptions.emplace_back(ex.what());
-                }
-            }
-
-            Y_ABORT_UNLESS(paths.size() == catchedExceptions.size());
-
-            TStringBuilder builder;
-
-            builder << "Cannot open any shared library. Reasons:\n";
-            for (const auto& [reason, path] : Zip(catchedExceptions, paths)) {
-                builder << "Path: " << path << " Reason: " << reason << "\n";
-            }
-
-            ythrow yexception() << builder;
+            DOVERBS(LOADSYM)
         }
 
         THolder<TDynamicLibrary> L;
@@ -50,7 +27,7 @@ const TInfinibandSymbols* IBSym() {
 const TRdmaSymbols* RDSym() {
     struct TSymbols: TRdmaSymbols {
         TSymbols() {
-            L.Reset(new TDynamicLibrary("/usr/lib/librdmacm.so"));
+            L.Reset(new TDynamicLibrary("librdmacm.so.1"));
 
             DORDMA(LOADSYM)
         }
@@ -64,7 +41,7 @@ const TRdmaSymbols* RDSym() {
 const TMlx5Symbols* M5Sym() {
     struct TSymbols: TMlx5Symbols {
         TSymbols() {
-            L.Reset(new TDynamicLibrary("/usr/lib/libmlx5.so"));
+            L.Reset(new TDynamicLibrary("libmlx5.so.1"));
 
             DOMLX5(LOADSYM)
         }


### PR DESCRIPTION
Actual names depend on arch:

/usr/lib/x86_64-linux-gnu/libibverbs.so.1
/usr/lib/x86_64-linux-gnu/librdmacm.so.1
/usr/lib/x86_64-linux-gnu/libmlx5.so.1

/usr/lib/aarch64-linux-gnu/libibverbs.so.1
/usr/lib/aarch64-linux-gnu/librdmacm.so.1
/usr/lib/aarch64-linux-gnu/libmlx5.so.1