### PR TITLE
Add volume tablet id to perf stats

### DIFF
--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -496,6 +496,10 @@ struct TVolumeSelfSimpleCounters
     using TMeta = TMemberMeta<TCounter TVolumeSelfSimpleCounters::*>;
 
     // Common
+    TCounter VolumeTabletId{
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
     TCounter MaxReadBandwidth{
         EPublishingPolicy::All,
         TCumulativeCounter::ECounterType::Generic,
@@ -594,6 +598,7 @@ struct TVolumeSelfSimpleCounters
         ECounterExpirationPolicy::Permanent};
 
     static constexpr TMeta AllCounters[] = {
+        MakeMeta<&TVolumeSelfSimpleCounters::VolumeTabletId>(),
         MakeMeta<&TVolumeSelfSimpleCounters::MaxReadBandwidth>(),
         MakeMeta<&TVolumeSelfSimpleCounters::MaxWriteBandwidth>(),
         MakeMeta<&TVolumeSelfSimpleCounters::MaxReadIops>(),

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -104,6 +104,8 @@ NYdbStats::TYdbRow BuildStatsForUpload(
 #define BLOCKSTORE_SIMPLE_COUNTER(counter)                                     \
         out.counter = disk.VolumeSelfCounters.Simple.counter.Value;            \
 //  BLOCKSTORE_SIMPLE_COUNTER
+
+    BLOCKSTORE_SIMPLE_COUNTER(VolumeTabletId);
     BLOCKSTORE_SIMPLE_COUNTER(MaxReadBandwidth);
     BLOCKSTORE_SIMPLE_COUNTER(MaxWriteBandwidth);
     BLOCKSTORE_SIMPLE_COUNTER(MaxReadIops);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -362,8 +362,12 @@ void TVolumeActor::SendSelfStatsToService(const TActorContext& ctx)
         return;
     }
 
-    const auto& pp = State->GetConfig().GetPerformanceProfile();
     auto& simple = VolumeSelfCounters->Simple;
+
+    simple.VolumeTabletId.Set(TabletID());
+
+    const auto& pp = State->GetConfig().GetPerformanceProfile();
+
     simple.MaxReadBandwidth.Set(pp.GetMaxReadBandwidth());
     simple.MaxWriteBandwidth.Set(pp.GetMaxWriteBandwidth());
     simple.MaxReadIops.Set(pp.GetMaxReadIops());

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -21,6 +21,7 @@ namespace NCloud::NBlockStore::NYdbStats {
     xxx(BlocksCount,                 __VA_ARGS__)                              \
     xxx(BlockSize,                   __VA_ARGS__)                              \
     xxx(StorageMediaKind,            __VA_ARGS__)                              \
+    xxx(VolumeTabletId,              __VA_ARGS__)                              \
     xxx(MixedBytesCount,             __VA_ARGS__)                              \
     xxx(MergedBytesCount,            __VA_ARGS__)                              \
     xxx(FreshBytesCount,             __VA_ARGS__)                              \


### PR DESCRIPTION
Add volume tablet id to perfstats ydb tables. Motivation: it provides easy way go get disk id by tablet id.