### PR TITLE
[blockstore] upload volume tablet id to ydb-stats

### DIFF
--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -221,6 +221,7 @@ void TStatsServiceActor::HandleRegisterVolume(
     const auto* msg = ev->Get();
 
     auto volume = State.GetOrAddVolume(msg->DiskId, msg->Config);
+    volume->VolumeTabletId = msg->TabletId;
 
     if (volume->IsDiskRegistryBased()) {
         volume->PerfCounters = TDiskPerfData(

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -74,6 +74,7 @@ NYdbStats::TYdbRow BuildStatsForUpload(
     out.StorageMediaKind =
         static_cast<ui64>(volume.VolumeInfo.GetStorageMediaKind());
     out.HostName = FQDNHostName();
+    out.VolumeTabletId = volume.VolumeTabletId;
 
     const auto& disk = volume.PerfCounters;
 
@@ -104,6 +105,7 @@ NYdbStats::TYdbRow BuildStatsForUpload(
 #define BLOCKSTORE_SIMPLE_COUNTER(counter)                                     \
         out.counter = disk.VolumeSelfCounters.Simple.counter.Value;            \
 //  BLOCKSTORE_SIMPLE_COUNTER
+
     BLOCKSTORE_SIMPLE_COUNTER(MaxReadBandwidth);
     BLOCKSTORE_SIMPLE_COUNTER(MaxWriteBandwidth);
     BLOCKSTORE_SIMPLE_COUNTER(MaxReadIops);

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -127,6 +127,7 @@ public:
 struct TVolumeStatsInfo
 {
     NProto::TVolume VolumeInfo;
+    ui64 VolumeTabletId = 0;
 
     TDiskPerfData PerfCounters;
     NBlobMetrics::TBlobLoadMetrics OffsetBlobMetrics;

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -17,6 +17,7 @@ namespace NCloud::NBlockStore::NYdbStats {
 // YDB_SIMPLE_STRING_COUNTERS
 
 #define YDB_SIMPLE_UINT64_COUNTERS(xxx, ...)                                   \
+    xxx(VolumeTabletId,              __VA_ARGS__)                              \
     xxx(Timestamp,                   __VA_ARGS__)                              \
     xxx(BlocksCount,                 __VA_ARGS__)                              \
     xxx(BlockSize,                   __VA_ARGS__)                              \


### PR DESCRIPTION
Add volume tablet id to ydb perfstats tables. This provides convenient way go resolve volume tablet id into disk id.