### PR TITLE
keyring ub-sanitizer fix

### DIFF
--- a/cloud/storage/core/libs/endpoints/keyring/keyring.cpp
+++ b/cloud/storage/core/libs/endpoints/keyring/keyring.cpp
@@ -319,11 +319,13 @@ TVector<TKeyring> TKeyring::GetUserKeys() const
 
     auto data = SysKeyCtlReadValue(KeySerial, size);
 
-    static_assert(sizeof(TKeyring) == sizeof(ui32));
-    auto* ptr = reinterpret_cast<const TKeyring*>(data.data());
+    static_assert(sizeof(TKeyring) == sizeof(ui32), "TKeyring size must match ui32");
     auto count = data.size() / sizeof(ui32);
+    TVector<TKeyring> keyrings;
+    keyrings.resize(count);
+    std::memcpy(keyrings.data(), data.data(), count * sizeof(ui32));
 
-    return {ptr, ptr + count};
+    return keyrings;
 }
 
 void PrintKey(TKeyring key, ui32 level, THashSet<TKeyring>& allKeys)


### PR DESCRIPTION
Ошибка выравнивания под ubsanitizerом
```
<----- TKeyringEndpointsTest
[exec] TKeyringEndpointsTest::ShouldGetStoredEndpointsFromKeyring...
__NR_keyctl failed with error: 126, Required key not available
/place/sandbox-data/tasks/6/3/2938837536/__FUSE/mount_path_8581ac2f-9e9b-4447-9f09-25815c4fddcf/contrib/libs/cxxsupp/libcxx/include/__string/constexpr_c_functions.h:227:33: runtime error: load of misaligned address 0x0000022df609 for type 'const NCloud::TKeyring *', which requires 4 byte alignment
0x0000022df609: note: pointer points here
 00 00 00  18 73 40 61 2a 5a 16 42  0d b5 51 21 29 00 00 00  07 00 00 00 00 00 00 00  30 00 00 00 00
              ^ 
    #0 0xfb5b5e in __constexpr_memmove<NCloud::TKeyring, const NCloud::TKeyring, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__string/constexpr_c_functions.h:227:5
    #1 0xfb5b5e in __copy_trivial_impl<const NCloud::TKeyring, NCloud::TKeyring> /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy_move_common.h:65:3
    #2 0xfb5b5e in operator()<const NCloud::TKeyring, NCloud::TKeyring, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy.h:102:12
    #3 0xfb5b5e in std::__y1::pair<NCloud::TKeyring const*, NCloud::TKeyring*> std::__y1::__copy_move_unwrap_iters[abi:fe190000]<std::__y1::__copy_impl<std::__y1::_ClassicAlgPolicy>, NCloud::TKeyring const*, NCloud::TKeyring const*, NCloud::TKeyring*, 0>(NCloud::TKeyring const*, NCloud::TKeyring const*, NCloud::TKeyring*) /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy_move_common.h:95:19
    #4 0xfb5985 in __copy<std::__y1::_ClassicAlgPolicy, const NCloud::TKeyring *, const NCloud::TKeyring *, NCloud::TKeyring *> /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy.h:109:10
    #5 0xfb5985 in copy<const NCloud::TKeyring *, NCloud::TKeyring *> /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy.h:116:10
    #6 0xfb5985 in __uninitialized_allocator_copy_impl<std::__y1::allocator<NCloud::TKeyring>, const NCloud::TKeyring, NCloud::TKeyring, NCloud::TKeyring, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/uninitialized_algorithms.h:584:12
    #7 0xfb5985 in __uninitialized_allocator_copy<std::__y1::allocator<NCloud::TKeyring>, const NCloud::TKeyring *, const NCloud::TKeyring *, NCloud::TKeyring *> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/uninitialized_algorithms.h:592:28
    #8 0xfb5985 in void std::__y1::vector<NCloud::TKeyring, std::__y1::allocator<NCloud::TKeyring>>::__construct_at_end<NCloud::TKeyring const*, NCloud::TKeyring const*>(NCloud::TKeyring const*, NCloud::TKeyring const*, unsigned long) /-S/contrib/libs/cxxsupp/libcxx/include/vector:1135:17
    #9 0xfb58db in void std::__y1::vector<NCloud::TKeyring, std::__y1::allocator<NCloud::TKeyring>>::__init_with_size[abi:fe190000]<NCloud::TKeyring const*, NCloud::TKeyring const*>(NCloud::TKeyring const*, NCloud::TKeyring const*, unsigned long) /-S/contrib/libs/cxxsupp/libcxx/include/vector:808:7
    #10 0xfb4565 in vector<const NCloud::TKeyring *, 0> /-S/contrib/libs/cxxsupp/libcxx/include/vector:1210:3
    #11 0xfb4565 in TVector<const NCloud::TKeyring *> /-S/util/generic/vector.h:86:11
    #12 0xfb4565 in NCloud::TKeyring::GetUserKeys() const /-S/cloud/storage/core/libs/endpoints/keyring/keyring.cpp:326:12
    #13 0xfb884b in operator() /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints.cpp:127:37
    #14 0xfb884b in SafeExecute<NCloud::TResultOrError<TVector<NCloud::TKeyring, std::__y1::allocator<NCloud::TKeyring> > >, (lambda at /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints.cpp:110:63)> /-S/cloud/storage/core/libs/common/error.h:444:16
    #15 0xfb884b in NCloud::(anonymous namespace)::TKeyringStorage::GetEndpointKeyrings() /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints.cpp:110:16
    #16 0xfb75a2 in NCloud::(anonymous namespace)::TKeyringStorage::GetEndpointIds() /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints.cpp:45:32
    #17 0x5a02b4 in NCloud::NTestSuiteTKeyringEndpointsTest::ShouldGetStoredEndpoints(NCloud::(anonymous namespace)::TStorages const&) /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints_ut.cpp:94:44
    #18 0x59f47c in NCloud::NTestSuiteTKeyringEndpointsTest::TTestCaseShouldGetStoredEndpointsFromKeyring::Execute_(NUnitTest::TTestContext&) /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints_ut.cpp:117:9
    #19 0x5aa09f in NCloud::NTestSuiteTKeyringEndpointsTest::TCurrentTest::Execute()::'lambda'()::operator()() const /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints_ut.cpp:65:1
    #20 0x8eb079 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:374:18
    #21 0x5a83d4 in NCloud::NTestSuiteTKeyringEndpointsTest::TCurrentTest::Execute() /-S/cloud/storage/core/libs/endpoints/keyring/keyring_endpoints_ut.cpp:65:1
    #22 0x8eca45 in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:495:19
    #23 0x90ea0c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:872:44
    #24 0x7fbf01914082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #25 0x58c7c8 in _start (/tmp/2938837536/tmpyp_Fri/build_root/lpal/007133/cloud/storage/core/libs/endpoints/keyring/ut/bin/cloud-storage-core-libs-endpoints-keyring-ut-bin+0x58c7c8) (BuildId: 322e13c6ffebd138e0affdf6c0fc67a695d76e66)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /place/sandbox-data/tasks/6/3/2938837536/__FUSE/mount_path_8581ac2f-9e9b-4447-9f09-25815c4fddcf/contrib/libs/cxxsupp/libcxx/include/__string/constexpr_c_functions.h:227:33 
```