### PR TITLE
[Filestore] fix client not working for single-argument commands

### DIFF
--- a/cloud/filestore/apps/client/lib/app.cpp
+++ b/cloud/filestore/apps/client/lib/app.cpp
@@ -44,8 +44,15 @@ int TApp::Run(
         }
 
         if (argc == 2) {
-            NLastGetopt::TOptsParseResult parsedOpts(&opts, argc, argv);
-            return 0;
+            TStringBuf arg(argv[1]);
+            if (arg == "-h" || arg == "--help") {
+                opts.PrintUsage(GetProgramName());
+                return 0;
+            }
+            if (arg == "-V" || arg == "--svnrevision") {
+                NLastGetopt::PrintVersionAndExit(nullptr);
+                return 0;
+            }
         }
 
         auto name = NormalizeCommand(*std::next(argv));


### PR DESCRIPTION
Reverting this: https://github.com/ydb-platform/nbs/pull/2632#pullrequestreview-2482291564

Allows to use just `filestore-client listfilestores` command without specifying other arguments