### PR TITLE
[Blockstore] ignore TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted in StateZombie

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -915,6 +915,7 @@ STFUNC(TPartitionActor::StateZombie)
 
         IgnoreFunc(TEvPartitionCommonPrivate::TEvReadBlobCompleted);
         IgnoreFunc(TEvPartitionCommonPrivate::TEvLongRunningOperation);
+        IgnoreFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvWriteBlobCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvReadBlocksCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvWriteBlocksCompleted);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/storage/core/unimplemented.h>
+#include <cloud/blockstore/libs/storage/partition_common/events_private.h>
 
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/common/verify.h>
@@ -883,6 +884,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvSendBackpressureReport);
         IgnoreFunc(TEvPartitionPrivate::TEvProcessWriteQueue);
 
+        IgnoreFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvReadBlobCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvWriteBlobCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvReadBlocksCompleted);


### PR DESCRIPTION
```
VERIFY failed (2025-03-20T00:37:43.804917Z): [BLOCKSTORE_PARTITION] Unexpected event: (0x106207EB) NCloud::NBlockStore::TResponseEvent<NCloud::NBlockStore::NStorage::TEvPartitionCommonPrivate::TOperationCompleted, 274860011u>
  cloud/storage/core/libs/actors/helpers.cpp:53
  HandleUnexpectedEvent(): requirement false failed
2025-03-20T00:37:43.805066Z :BLOCKSTORE_BOOTSTRAPPER ERROR: [72075186224037888] Tablet failed: ReasonPill (gen: 4, attempts: 1, threshold: 1)
2025-03-20T00:37:43.805075Z :BLOCKSTORE_BOOTSTRAPPER INFO: [72075186224037888] Exiting tablet (reason: ReasonPill)
2025-03-20T00:37:43.809315Z :BS_PROXY_PUT NOTICE: [5766328155169d5f] SendReply putResult# TEvPutResult {Id# [72075186224037888:4:6:6:0:4096000:0] Status# BLOCKED StatusFlags# { } ErrorReason# "Got VPutResult status# BLOCKED from VDiskId# [82000003:1:0:0:0]" ApproximateFreeSpaceShare# 0} ResponsesSent# 0 PutImpl.Blobs.size# 1 Last# true Marker# BPP21
2025-03-20T00:37:43.809402Z :BLOCKSTORE_PARTITION ERROR: [72075186224037888] TEvBlobStorage::TEvPut failed: Got VPutResult status# BLOCKED from VDiskId# [82000003:1:0:0:0]
TEvPutResult {Id# [72075186224037888:4:6:6:0:4096000:0] Status# BLOCKED StatusFlags# { } ErrorReason# "Got VPutResult status# BLOCKED from VDiskId# [82000003:1:0:0:0]" ApproximateFreeSpaceShare# 0}
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+663 (0x105809E7)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+284 (0x10576C7C)
NCloud::HandleUnexpectedEvent(TAutoPtr<NActors::IEventHandle, TDelete>&, int)+158 (0x209EE4AE)
NCloud::NBlockStore::NStorage::NPartition2::TPartitionActor::StateZombie(TAutoPtr<NActors::IEventHandle, TDelete>&)+290 (0x20B36E42)
NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TReadAsFilledMailbox>(NActors::TMailboxTable::TReadAsFilledMailbox*, unsigned int, bool)+2003 (0x11068853)
??+0 (0x1105E1F7)
NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)+424 (0x1105DBC8)
NActors::TExecutorThread::ThreadProc()+188 (0x1105EA9C)
??+0 (0x10581E5C)
??+0 (0x7FBDE695AAC3)
??+0 (0x7FBDE69EC850)
```

Only one event matches `TResponseEvent<NCloud::NBlockStore::NStorage::TEvPartitionCommonPrivate::TOperationCompleted, 274860011u>` https://github.com/ydb-platform/nbs/blob/ff80ea02554d3cdd2e79f680c6878d07e5d5467d/cloud/blockstore/libs/storage/partition_common/events_private.h#L208

https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/13958464801/1/nebius-x86-64/test_data/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-overflow/test-results/py3test/chunk2/testing_out_stuff/test.py__test_load[version2]/stderr_mt9m6axy