### PR TITLE
Proto flag for instant retries

### DIFF
--- a/cloud/blockstore/libs/client/durable.cpp
+++ b/cloud/blockstore/libs/client/durable.cpp
@@ -490,21 +490,21 @@ public:
             return spec;
         }
 
-        const auto newRetryTimeout =
-            state.Retries > 0
-                ? (state.RetryTimeout + Config->GetRetryTimeoutIncrement())
-                : InitialRetryTimeout;
         spec.ShouldRetry = true;
-
         if (HasProtoFlag(error.GetFlags(), NProto::EF_INSTANT_RETRIABLE) &&
             !state.DoneInstantRetry)
         {
             spec.Backoff = TDuration::Zero();
             state.DoneInstantRetry = true;
-        } else {
-            spec.Backoff = newRetryTimeout;
+            return spec;
         }
 
+        const auto newRetryTimeout =
+            state.Retries > 0
+                ? (state.RetryTimeout + Config->GetRetryTimeoutIncrement())
+                : InitialRetryTimeout;
+
+        spec.Backoff = newRetryTimeout;
         if (IsConnectionError(error) &&
             spec.Backoff > Config->GetConnectionErrorMaxRetryTimeout())
         {

--- a/cloud/blockstore/libs/client/durable.h
+++ b/cloud/blockstore/libs/client/durable.h
@@ -19,6 +19,7 @@ struct TRetryState
 
     TDuration RetryTimeout;
     ui32 Retries = 0;
+    bool DoneInstantRetry = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/client/durable_ut.cpp
+++ b/cloud/blockstore/libs/client/durable_ut.cpp
@@ -8,8 +8,8 @@
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/service_test.h>
-
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/scheduler_test.h>
 #include <cloud/storage/core/libs/common/sglist_test.h>
@@ -954,6 +954,86 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             spec = policy->ShouldRetry(state, MakeError(E_REJECTED));
             UNIT_ASSERT(spec.ShouldRetry);
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), spec.Backoff);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCalculateCorrectTimeoutForInstantRetryFlag)
+    {
+        NProto::TClientAppConfig configProto;
+        auto& clientConfigProto = *configProto.MutableClientConfig();
+        clientConfigProto.SetRetryTimeoutIncrement(3'000);
+        clientConfigProto.SetConnectionErrorMaxRetryTimeout(7'000);
+        // Should not be used in this test.
+        clientConfigProto.SetDiskRegistryBasedDiskInitialRetryTimeout(500);
+        clientConfigProto.SetYDBBasedDiskInitialRetryTimeout(500);
+        auto config = std::make_shared<TClientAppConfig>(configProto);
+
+        auto policy = CreateRetryPolicy(config, std::nullopt);
+        ui32 flags = 0;
+        SetProtoFlag(flags, NProto::EF_INSTANT_RETRIABLE);
+
+        {
+            TRetryState state;
+
+            auto spec = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(3), spec.Backoff);
+            UNIT_ASSERT(!state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), spec.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), spec.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), spec.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+        }
+
+        {
+            TRetryState state;
+
+            auto spec = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(3), spec.Backoff);
+            UNIT_ASSERT(!state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(6), spec.Backoff);
+            UNIT_ASSERT(!state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(
+                state,
+                MakeError(E_GRPC_UNAVAILABLE, "", flags));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), spec.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(
+                state,
+                MakeError(E_GRPC_UNAVAILABLE, "", flags));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(7), spec.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            spec = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            UNIT_ASSERT(spec.ShouldRetry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), spec.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
         }
     }
 

--- a/cloud/blockstore/libs/client/durable_ut.cpp
+++ b/cloud/blockstore/libs/client/durable_ut.cpp
@@ -989,13 +989,13 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             state.Retries++;
             spec = policy->ShouldRetry(state, MakeError(E_REJECTED));
             UNIT_ASSERT(spec.ShouldRetry);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), spec.Backoff);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(6), spec.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
 
             state.Retries++;
             spec = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
             UNIT_ASSERT(spec.ShouldRetry);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), spec.Backoff);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), spec.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
         }
 
@@ -1032,7 +1032,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             state.Retries++;
             spec = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
             UNIT_ASSERT(spec.ShouldRetry);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), spec.Backoff);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), spec.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
         }
     }

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -6,8 +6,8 @@
 #include <cloud/filestore/libs/service/endpoint.h>
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/service/request.h>
-
 #include <cloud/storage/core/libs/common/format.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -307,27 +307,39 @@ struct TRetryPolicy final
 {
     TClientConfigPtr Config;
 
-    TRetryPolicy(TClientConfigPtr config)
+    explicit TRetryPolicy(TClientConfigPtr config)
         : Config(std::move(config))
     {}
 
     bool ShouldRetry(TRetryState& state, const NProto::TError& error) override
     {
         bool isRetriable = IsRetriableError(error);
-        if (isRetriable && TInstant::Now() - state.Started < Config->GetRetryTimeout()) {
-            auto timeout = state.RetryTimeout + Config->GetRetryTimeoutIncrement();
+        if (!isRetriable ||
+            TInstant::Now() - state.Started >= Config->GetRetryTimeout())
+        {
+            return false;
+        }
 
+        auto timeout = state.RetryTimeout + Config->GetRetryTimeoutIncrement();
+
+        if (HasProtoFlag(error.GetFlags(), NProto::EF_INSTANT_RETRIABLE) &&
+            !state.DoneInstantRetry)
+        {
+            state.Backoff = TDuration::Zero();
+            state.DoneInstantRetry = true;
+        } else {
             state.Backoff = timeout;
-            if (IsConnectionError(error) && state.Backoff > Config->GetConnectionErrorMaxRetryTimeout()) {
-                state.Backoff = Config->GetConnectionErrorMaxRetryTimeout();
-            } else {
-                state.RetryTimeout = timeout;
-            }
+        }
 
+        if (IsConnectionError(error) &&
+            state.Backoff > Config->GetConnectionErrorMaxRetryTimeout())
+        {
+            state.Backoff = Config->GetConnectionErrorMaxRetryTimeout();
             return true;
         }
 
-        return false;
+        state.RetryTimeout = timeout;
+        return true;
     }
 };
 

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -328,8 +328,9 @@ struct TRetryPolicy final
             return true;
         }
 
-        auto timeout = state.RetryTimeout + Config->GetRetryTimeoutIncrement();
-        state.Backoff = timeout;
+        const auto newRetryTimeout =
+            state.RetryTimeout + Config->GetRetryTimeoutIncrement();
+        state.Backoff = newRetryTimeout;
         if (IsConnectionError(error) &&
             state.Backoff > Config->GetConnectionErrorMaxRetryTimeout())
         {
@@ -337,7 +338,7 @@ struct TRetryPolicy final
             return true;
         }
 
-        state.RetryTimeout = timeout;
+        state.RetryTimeout = newRetryTimeout;
         return true;
     }
 };

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -320,17 +320,16 @@ struct TRetryPolicy final
             return false;
         }
 
-        auto timeout = state.RetryTimeout + Config->GetRetryTimeoutIncrement();
-
         if (HasProtoFlag(error.GetFlags(), NProto::EF_INSTANT_RETRIABLE) &&
             !state.DoneInstantRetry)
         {
             state.Backoff = TDuration::Zero();
             state.DoneInstantRetry = true;
-        } else {
-            state.Backoff = timeout;
+            return true;
         }
 
+        auto timeout = state.RetryTimeout + Config->GetRetryTimeoutIncrement();
+        state.Backoff = timeout;
         if (IsConnectionError(error) &&
             state.Backoff > Config->GetConnectionErrorMaxRetryTimeout())
         {

--- a/cloud/filestore/libs/client/durable.h
+++ b/cloud/filestore/libs/client/durable.h
@@ -21,6 +21,7 @@ struct TRetryState
     TDuration RetryTimeout;
     TDuration Backoff;
     ui32 Retries = 0;
+    bool DoneInstantRetry = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/client/durable_ut.cpp
+++ b/cloud/filestore/libs/client/durable_ut.cpp
@@ -289,7 +289,8 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(3), state.Backoff);
             UNIT_ASSERT(!state.DoneInstantRetry);
 
-            retry = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            retry =
+                policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
             UNIT_ASSERT(retry);
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), state.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
@@ -297,13 +298,14 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             state.Retries++;
             retry = policy->ShouldRetry(state, MakeError(E_REJECTED));
             UNIT_ASSERT(retry);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), state.Backoff);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(6), state.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
 
             state.Retries++;
-            retry = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            retry =
+                policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
             UNIT_ASSERT(retry);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), state.Backoff);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), state.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
         }
 
@@ -341,7 +343,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             retry =
                 policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
             UNIT_ASSERT(retry);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), state.Backoff);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), state.Backoff);
             UNIT_ASSERT(state.DoneInstantRetry);
         }
     }

--- a/cloud/filestore/libs/client/durable_ut.cpp
+++ b/cloud/filestore/libs/client/durable_ut.cpp
@@ -4,8 +4,8 @@
 
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/service/filestore_test.h>
-
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/scheduler_test.h>
 #include <cloud/storage/core/libs/common/timer.h>
@@ -266,6 +266,83 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             retry = policy->ShouldRetry(state, MakeError(E_GRPC_UNAVAILABLE));
             UNIT_ASSERT(retry);
             UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(3), state.Backoff);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCalculateCorrectTimeoutForInstantRetryFlag)
+    {
+        NProto::TClientConfig proto;
+        proto.SetRetryTimeoutIncrement(3'000);
+        proto.SetConnectionErrorMaxRetryTimeout(7'000);
+
+        auto config = std::make_shared<TClientConfig>(proto);
+        auto policy = CreateRetryPolicy(config);
+
+        ui32 flags = 0;
+        SetProtoFlag(flags, NProto::EF_INSTANT_RETRIABLE);
+
+        {
+            TRetryState state;
+
+            bool retry = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(3), state.Backoff);
+            UNIT_ASSERT(!state.DoneInstantRetry);
+
+            retry = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), state.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            retry = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(9), state.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            retry = policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), state.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+        }
+
+        {
+            TRetryState state;
+
+            bool retry = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(3), state.Backoff);
+            UNIT_ASSERT(!state.DoneInstantRetry);
+
+            state.Retries++;
+            retry = policy->ShouldRetry(state, MakeError(E_REJECTED));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(6), state.Backoff);
+            UNIT_ASSERT(!state.DoneInstantRetry);
+
+            state.Retries++;
+            retry = policy->ShouldRetry(
+                state,
+                MakeError(E_GRPC_UNAVAILABLE, "", flags));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(0), state.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            retry = policy->ShouldRetry(
+                state,
+                MakeError(E_GRPC_UNAVAILABLE, "", flags));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(7), state.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
+
+            state.Retries++;
+            retry =
+                policy->ShouldRetry(state, MakeError(E_REJECTED, "", flags));
+            UNIT_ASSERT(retry);
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Seconds(12), state.Backoff);
+            UNIT_ASSERT(state.DoneInstantRetry);
         }
     }
 

--- a/cloud/storage/core/protos/error.proto
+++ b/cloud/storage/core/protos/error.proto
@@ -22,6 +22,11 @@ enum EErrorFlag
     // Currently set if a problem with nonreplicated disk/agent was detected.
     EF_HW_PROBLEMS_DETECTED = 2;
 
+    // A flag for retriable errors that indicates which requests can be retried
+    // without any delay. It works only once per request to prevent the
+    // possibility of a retry storm.
+    EF_INSTANT_RETRIABLE = 3;
+
     // TODO: EF_RETRIABLE, EF_CLIENT
 }
 


### PR DESCRIPTION
Добавил флаг, который поможет мне в реализации #3. Там есть два места в которых можно будет использовать этот флаг:
1) если девайс был признан лагающим, то мы можем отклонить запросы касающиеся этих девайсов, т.к. они наверняка затаймаутятся. А ретрай перевыполнит их на здоровых репликах. 
2) Когда девайс ожил после лагания, мы не можем сразу начинать миграцию, т.к. есть запросы на запись в полёте. Возникает гонка из-за которой мы можем прочитать то что было на диске до записи. Здесь этот флаг бы тоже помог чтобы отклонить все такие запросы. (Этот пункт под вопросом, можно решить иначе проблему)

В filestore добавил чтобы было симметрично.
