### PR TITLE
feat: add checking for run status for future merge requirement

### DIFF
--- a/.github/actions/final_check/action.yaml
+++ b/.github/actions/final_check/action.yaml
@@ -1,0 +1,27 @@
+name: Check job statuses
+description: Fails if any non-excluded jobs in a workflow run have failed
+
+inputs:
+  token:
+    required: true
+    description: "GitHub token"
+  excluded:
+    required: false
+    description: "Comma-separated list of job names to exclude from failure check"
+    default: ""
+  self:
+    required: true
+    description: "Name of the job running this check (to be excluded automatically)"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check failed jobs
+      shell: bash
+      run: bash ${GITHUB_ACTION_PATH}/check.sh
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        REPO: ${{ github.repository }}
+        EXCLUDED_JOBS: ${{ inputs.excluded }}
+        SELF_JOB_NAME: ${{ inputs.self }}

--- a/.github/actions/final_check/check.sh
+++ b/.github/actions/final_check/check.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 echo "🔍 Checking failed jobs in workflow run: $GITHUB_RUN_ID"
 
-IFS=',' read -ra EXCLUDED <<<"$EXCLUDED_JOBS"
+IFS=',' read -ra EXCLUDED <<< "$EXCLUDED_JOBS"
 EXCLUDED+=("$SELF_JOB_NAME")
 
 for ex in "${EXCLUDED[@]}"; do

--- a/.github/actions/final_check/check.sh
+++ b/.github/actions/final_check/check.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🔍 Checking failed jobs in workflow run: $GITHUB_RUN_ID"
+
+IFS=',' read -ra EXCLUDED <<<"$EXCLUDED_JOBS"
+EXCLUDED+=("$SELF_JOB_NAME")
+
+for ex in "${EXCLUDED[@]}"; do
+    echo "🚫 Excluded job: $ex"
+done
+
+# Get job list from GitHub API
+response=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs")
+
+# Parse failed jobs
+FAILED=()
+JOB_COUNT=$(echo "$response" | jq '.jobs | length')
+echo "📦 Found $JOB_COUNT jobs in this workflow run."
+
+for row in $(echo "$response" | jq -r '.jobs[] | @base64'); do
+    _jq() {
+        echo "$row" | base64 --decode | jq -r "$1"
+    }
+
+    name=$(_jq '.name')
+    conclusion=$(_jq '.conclusion')
+
+    if [[ "$conclusion" == "failure" ]]; then
+        skip=false
+        for ex in "${EXCLUDED[@]}"; do
+            if [[ "$name" == "$ex" ]]; then
+                echo "⚠️  Excluding failed job: $name"
+                skip=true
+                break
+            fi
+        done
+        if [[ "$skip" == false ]]; then
+            echo "❌ Failed job: $name"
+            FAILED+=("$name")
+        fi
+    fi
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo ""
+    echo "❗ The following jobs failed and are not excluded:"
+    for job in "${FAILED[@]}"; do
+        echo " - $job"
+    done
+    exit 1
+else
+    echo "✅ All required jobs passed."
+fi

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -1,11 +1,6 @@
 name: Check github workflow
 
 on:
-  push:
-    paths:
-      - ".github/**"
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -338,3 +333,27 @@ jobs:
       allow_downgrade: ${{ needs.set-env.outputs.allow_downgrade }}
       large_tests: ${{ needs.set-env.outputs.large_tests }}
     secrets: inherit
+  final-check:
+    name: Check run status
+    needs:
+      - create-and-delete-vm
+      - nbs-github-actions
+      - workflows
+      - python
+      - shell
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github'
+      - name: Run final check
+        uses: ./.github/actions/final_check
+        with:
+          token: ${{ github.token }}
+          excluded: "Check for correct approvals"
+          self: "Check run status"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -364,3 +364,23 @@ jobs:
       cache_update_tests: false
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
+  final-check:
+    name: Check run status
+    needs:
+      - build_and_test
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github'
+      - name: Run final check
+        uses: ./.github/actions/final_check
+        with:
+          token: ${{ github.token }}
+          excluded: "Check for correct approvals"
+          self: "Check run status"


### PR DESCRIPTION
Proposed change after this commit is that we 

Example of how it works:

https://github.com/librarian-test/nbs/pull/100
![afbeelding](https://github.com/user-attachments/assets/8c3d8dbe-95e4-49e6-a976-5f98380a6ea2)

We **MUST** have two conditions met:
1. At least two approvals per PR
2. Two checks are required to finish: 
![afbeelding](https://github.com/user-attachments/assets/4f4cb63e-bc39-4ead-bc89-dfc204f107d1)

"Check for correct approvals" is this one https://github.com/ydb-platform/nbs/blob/main/.github/workflows/approvals.yaml which checks that both right and left teams approved this change. With exception of superuser approval from two superusers.
"Check run status" is the new one where we query API for all checks within PR check run (excluding two)

Some improvements for the future:
* separate list of users whose comment will explicitly make "Check run status" as successful. Or, alternatively, add those people to "Bypass list" in settings. Which need some research in what this thing actually does
* add support for regexes to exclude "service" jobs that might fail for some external reason, like releasing of runner.
* add separate mute file for PR checks that will be ignored during nightly builds