### PR TITLE
Report critical event when error replied to guest

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -69,6 +69,8 @@ namespace NCloud::NBlockStore {
     xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
     xxx(DiskRegistryWrongMigratedDeviceOwnership)                              \
     xxx(DiskRegistryInitialAgentRejectionThresholdExceeded)                    \
+    xxx(ErrorWasSentToTheGuestForReliableDisk)                                 \
+    xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_IMPOSSIBLE_EVENTS(xxx)                                      \

--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -55,9 +55,8 @@ public:
         options.CheckBufferModificationDuringWriting =
             ChecksumFlags.GetCheckBufferModificationForMirrorDisk() &&
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
-        options.IsReliableMediaType =
-            !IsDiskRegistryMediaKind(volume.GetStorageMediaKind()) ||
-            IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
+        options.IsReliableMediaKind =
+            IsReliableMediaKind(volume.GetStorageMediaKind());
 
         auto requestFactory = CreateServerHandlerFactory(
             CreateDefaultDeviceHandlerFactory(),

--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -55,6 +55,9 @@ public:
         options.CheckBufferModificationDuringWriting =
             ChecksumFlags.GetCheckBufferModificationForMirrorDisk() &&
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
+        options.IsReliableMediaType =
+            !IsDiskRegistryMediaKind(volume.GetStorageMediaKind()) ||
+            IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
 
         auto requestFactory = CreateServerHandlerFactory(
             CreateDefaultDeviceHandlerFactory(),

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -44,9 +44,8 @@ public:
         options.CheckBufferModificationDuringWriting =
             ChecksumFlags.GetCheckBufferModificationForMirrorDisk() &&
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
-        options.IsReliableMediaType =
-            !IsDiskRegistryMediaKind(volume.GetStorageMediaKind()) ||
-            IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
+        options.IsReliableMediaKind =
+            IsReliableMediaKind(volume.GetStorageMediaKind());
 
         return Server->StartEndpoint(
             request.GetUnixSocketPath(),

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -44,6 +44,9 @@ public:
         options.CheckBufferModificationDuringWriting =
             ChecksumFlags.GetCheckBufferModificationForMirrorDisk() &&
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
+        options.IsReliableMediaType =
+            !IsDiskRegistryMediaKind(volume.GetStorageMediaKind()) ||
+            IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
 
         return Server->StartEndpoint(
             request.GetUnixSocketPath(),

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -955,7 +955,8 @@ IServerHandlerFactoryPtr CreateServerHandlerFactory(
         options.ClientId,
         options.BlockSize,
         options.UnalignedRequestsDisabled,
-        options.CheckBufferModificationDuringWriting);
+        options.CheckBufferModificationDuringWriting,
+        options.IsReliableMediaType);
 
     return std::make_shared<TServerHandlerFactory>(
         std::move(logging),

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -956,7 +956,7 @@ IServerHandlerFactoryPtr CreateServerHandlerFactory(
         options.BlockSize,
         options.UnalignedRequestsDisabled,
         options.CheckBufferModificationDuringWriting,
-        options.IsReliableMediaType);
+        options.IsReliableMediaKind);
 
     return std::make_shared<TServerHandlerFactory>(
         std::move(logging),

--- a/cloud/blockstore/libs/nbd/server_handler.h
+++ b/cloud/blockstore/libs/nbd/server_handler.h
@@ -125,7 +125,7 @@ struct TStorageOptions
     bool UnalignedRequestsDisabled = false;
     bool SendMinBlockSize = false;
     bool CheckBufferModificationDuringWriting = false;
-    bool IsReliableMediaType = false;
+    bool IsReliableMediaKind = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nbd/server_handler.h
+++ b/cloud/blockstore/libs/nbd/server_handler.h
@@ -125,6 +125,7 @@ struct TStorageOptions
     bool UnalignedRequestsDisabled = false;
     bool SendMinBlockSize = false;
     bool CheckBufferModificationDuringWriting = false;
+    bool IsReliableMediaType = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/service/aligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/aligned_device_handler.cpp
@@ -475,6 +475,11 @@ void TAlignedDeviceHandler::ReportCriticalError(
     const TString& operation,
     TBlockRange64 range)
 {
+    if (error.GetCode() == E_CANCELLED) {
+        // Do not raise crit event when client disconnected.
+        // Keep the logic synchronized with blockstore/libs/vhost/server.cpp.
+        return;
+    }
     if (!IsReliableMediaKind && CriticalErrorReported) {
         // For non-reliable disks report crit event only once.
         return;

--- a/cloud/blockstore/libs/service/aligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/aligned_device_handler.cpp
@@ -137,7 +137,7 @@ TAlignedDeviceHandler::TAlignedDeviceHandler(
         ui32 blockSize,
         ui32 maxSubRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaType)
+        bool isReliableMediaKind)
     : Storage(
           checkBufferModificationDuringWriting
               ? CreateChecksumStorageWrapper(std::move(storage), diskId)
@@ -146,7 +146,7 @@ TAlignedDeviceHandler::TAlignedDeviceHandler(
     , ClientId(std::move(clientId))
     , BlockSize(blockSize)
     , MaxBlockCount(maxSubRequestSize / BlockSize)
-    , IsReliableMediaType(isReliableMediaType)
+    , IsReliableMediaKind(isReliableMediaKind)
 {
     Y_ABORT_UNLESS(MaxBlockCount > 0);
 }
@@ -475,14 +475,14 @@ void TAlignedDeviceHandler::ReportCriticalError(
     const TString& operation,
     TBlockRange64 range)
 {
-    if (!IsReliableMediaType && CriticalErrorReported) {
+    if (!IsReliableMediaKind && CriticalErrorReported) {
         // For non-reliable disks report crit event only once.
         return;
     }
     auto message = TStringBuilder()
                    << "disk: " << DiskId.Quote() << ", op: " << operation
                    << ", range: " << range << ", error: " << FormatError(error);
-    if (IsReliableMediaType) {
+    if (IsReliableMediaKind) {
         ReportErrorWasSentToTheGuestForReliableDisk(message);
     } else {
         ReportErrorWasSentToTheGuestForNonReliableDisk(message);

--- a/cloud/blockstore/libs/service/aligned_device_handler.h
+++ b/cloud/blockstore/libs/service/aligned_device_handler.h
@@ -48,9 +48,13 @@ class TAlignedDeviceHandler final
 {
 private:
     const IStoragePtr Storage;
+    const TString DiskId;
     const TString ClientId;
     const ui32 BlockSize;
     const ui32 MaxBlockCount;
+    const bool IsReliableMediaType;
+
+    bool CriticalErrorReported = false;
 
 public:
     TAlignedDeviceHandler(
@@ -59,7 +63,8 @@ public:
         TString clientId,
         ui32 blockSize,
         ui32 maxSubRequestSize,
-        bool checkBufferModificationDuringWriting);
+        bool checkBufferModificationDuringWriting,
+        bool isReliableMediaType);
 
     // implements IDeviceHandler
     NThreading::TFuture<NProto::TReadBlocksLocalResponse> Read(
@@ -85,18 +90,24 @@ public:
         TCallContextPtr ctx,
         TBlocksInfo blocksInfo,
         TGuardedSgList sgList,
-        TString checkpointId) const;
+        TString checkpointId);
 
     // Performs a write. It can only be called for aligned data.
     NThreading::TFuture<NProto::TWriteBlocksResponse> ExecuteWriteRequest(
         TCallContextPtr ctx,
         TBlocksInfo blocksInfo,
-        TGuardedSgList sgList) const;
+        TGuardedSgList sgList);
 
     // Performs a zeroes. It can only be called for aligned data.
     NThreading::TFuture<NProto::TZeroBlocksResponse> ExecuteZeroRequest(
         TCallContextPtr ctx,
-        TBlocksInfo blocksInfo) const;
+        TBlocksInfo blocksInfo);
+
+private:
+    void ReportCriticalError(
+        const NProto::TError& error,
+        const TString& operation,
+        TBlockRange64 range);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/service/aligned_device_handler.h
+++ b/cloud/blockstore/libs/service/aligned_device_handler.h
@@ -52,7 +52,7 @@ private:
     const TString ClientId;
     const ui32 BlockSize;
     const ui32 MaxBlockCount;
-    const bool IsReliableMediaType;
+    const bool IsReliableMediaKind;
 
     bool CriticalErrorReported = false;
 
@@ -64,7 +64,7 @@ public:
         ui32 blockSize,
         ui32 maxSubRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaType);
+        bool isReliableMediaKind);
 
     // implements IDeviceHandler
     NThreading::TFuture<NProto::TReadBlocksLocalResponse> Read(

--- a/cloud/blockstore/libs/service/device_handler.cpp
+++ b/cloud/blockstore/libs/service/device_handler.cpp
@@ -34,7 +34,8 @@ struct TDefaultDeviceHandlerFactory final
         TString clientId,
         ui32 blockSize,
         bool unalignedRequestsDisabled,
-        bool checkBufferModificationDuringWriting) override
+        bool checkBufferModificationDuringWriting,
+        bool isReliableMediaType) override
     {
         if (unalignedRequestsDisabled) {
             return std::make_shared<TAlignedDeviceHandler>(
@@ -43,7 +44,8 @@ struct TDefaultDeviceHandlerFactory final
                 std::move(clientId),
                 blockSize,
                 MaxSubRequestSize,
-                checkBufferModificationDuringWriting);
+                checkBufferModificationDuringWriting,
+                isReliableMediaType);
         }
 
         return std::make_shared<TUnalignedDeviceHandler>(
@@ -53,7 +55,8 @@ struct TDefaultDeviceHandlerFactory final
             blockSize,
             MaxSubRequestSize,
             MaxUnalignedRequestSize,
-            checkBufferModificationDuringWriting);
+            checkBufferModificationDuringWriting,
+            isReliableMediaType);
     }
 };
 

--- a/cloud/blockstore/libs/service/device_handler.cpp
+++ b/cloud/blockstore/libs/service/device_handler.cpp
@@ -35,7 +35,7 @@ struct TDefaultDeviceHandlerFactory final
         ui32 blockSize,
         bool unalignedRequestsDisabled,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaType) override
+        bool isReliableMediaKind) override
     {
         if (unalignedRequestsDisabled) {
             return std::make_shared<TAlignedDeviceHandler>(
@@ -45,7 +45,7 @@ struct TDefaultDeviceHandlerFactory final
                 blockSize,
                 MaxSubRequestSize,
                 checkBufferModificationDuringWriting,
-                isReliableMediaType);
+                isReliableMediaKind);
         }
 
         return std::make_shared<TUnalignedDeviceHandler>(
@@ -56,7 +56,7 @@ struct TDefaultDeviceHandlerFactory final
             MaxSubRequestSize,
             MaxUnalignedRequestSize,
             checkBufferModificationDuringWriting,
-            isReliableMediaType);
+            isReliableMediaKind);
     }
 };
 

--- a/cloud/blockstore/libs/service/device_handler.h
+++ b/cloud/blockstore/libs/service/device_handler.h
@@ -48,7 +48,7 @@ struct IDeviceHandlerFactory
         ui32 blockSize,
         bool unalignedRequestsDisabled,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaType) = 0;
+        bool isReliableMediaKind) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/service/device_handler.h
+++ b/cloud/blockstore/libs/service/device_handler.h
@@ -47,7 +47,8 @@ struct IDeviceHandlerFactory
         TString clientId,
         ui32 blockSize,
         bool unalignedRequestsDisabled,
-        bool checkBufferModificationDuringWriting) = 0;
+        bool checkBufferModificationDuringWriting,
+        bool isReliableMediaType) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -142,7 +142,7 @@ public:
             BlockSize,
             unalignedRequestsDisabled,   // unalignedRequestsDisabled,
             false,                       // checkBufferModificationDuringWriting
-            false                        // isReliableMediaType
+            false                        // isReliableMediaKind
         );
     }
 
@@ -359,7 +359,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false    // isReliableMediaType
+            false    // isReliableMediaKind
         );
 
         std::array<bool, deviceBlocksCount> zeroBlocks;
@@ -426,7 +426,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             true,    // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false    // isReliableMediaType
+            false    // isReliableMediaKind
         );
 
         ui32 startIndex = 42;
@@ -517,7 +517,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             true,    // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false    // isReliableMediaType
+            false    // isReliableMediaKind
         );
 
         {
@@ -641,7 +641,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             unalignedRequestDisabled,   // unalignedRequestsDisabled,
             false,                      // checkBufferModificationDuringWriting
-            false                       // isReliableMediaType
+            false                       // isReliableMediaKind
         );
 
         storage->ZeroBlocksHandler = [&] (
@@ -761,7 +761,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
                 blockSize,
                 false,   // unalignedRequestsDisabled,
                 false,   // checkBufferModificationDuringWriting
-                false    // isReliableMediaType
+                false    // isReliableMediaKind
             );
 
         storage->WriteBlocksLocalHandler = [&] (
@@ -830,7 +830,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
                 blockSize,
                 false,   // unalignedRequestsDisabled,
                 false,   // checkBufferModificationDuringWriting
-                false    // isReliableMediaType
+                false    // isReliableMediaKind
             );
 
         storage->WriteBlocksLocalHandler = [&] (
@@ -958,7 +958,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            false    // isReliableMediaType
+            false    // isReliableMediaKind
         );
 
         ui32 writeAttempts  = 0;
@@ -1020,7 +1020,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            true     // isReliableMediaType
+            true     // isReliableMediaKind
         );
         auto deviceHandlerForNonReliableDisk = factory->CreateDeviceHandler(
             storage,
@@ -1029,7 +1029,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            false    // isReliableMediaType
+            false    // isReliableMediaKind
         );
 
         auto buffer = TString(DefaultBlockSize, 'g');

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -1069,7 +1069,9 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             "AppCriticalEvents/ErrorWasSentToTheGuestForNonReliableDisk",
             true);
 
-        {   // Two write errors generate same crit events for reliable disk.
+        {
+            // Two write errors generate same critical events count for reliable
+            // disk.
             reliableCritEvent->Set(0);
             nonReliableCritEvent->Set(0);
             {
@@ -1092,8 +1094,9 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             UNIT_ASSERT_VALUES_EQUAL(0, nonReliableCritEvent->Val());
         }
 
-        {   // Two write errors generate only one critEvent for non reliable
-            // disk.
+        {
+            // Two write errors generate only one critical event for non
+            // reliable disk.
             reliableCritEvent->Set(0);
             nonReliableCritEvent->Set(0);
             {
@@ -1116,7 +1119,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             UNIT_ASSERT_VALUES_EQUAL(1, nonReliableCritEvent->Val());
         }
 
-        {   // Check critEvent for reads.
+        {
+            // Check critical event for read.
             reliableCritEvent->Set(0);
             nonReliableCritEvent->Set(0);
 
@@ -1136,7 +1140,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             UNIT_ASSERT_VALUES_EQUAL(0, nonReliableCritEvent->Val());
         }
 
-        {   // Check critEvent for zero.
+        {
+            // Check critical event for zero.
             reliableCritEvent->Set(0);
             nonReliableCritEvent->Set(0);
 

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -141,7 +141,8 @@ public:
             "testClientId",
             BlockSize,
             unalignedRequestsDisabled,   // unalignedRequestsDisabled,
-            false                        // checkBufferModificationDuringWriting
+            false,                       // checkBufferModificationDuringWriting
+            false                        // isReliableMediaType
         );
     }
 
@@ -345,7 +346,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
         const auto diskId = "disk1";
         const auto clientId = "testClientId";
         const ui32 blockSize = DefaultBlockSize;
-        const ui64 deviceBlocksCount = 8*1024;
+        const ui64 deviceBlocksCount = 8 * 1024;
         const ui64 blocksCountLimit = deviceBlocksCount / 4;
 
         auto storage = std::make_shared<TTestStorage>();
@@ -357,7 +358,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             clientId,
             blockSize,
             false,   // unalignedRequestsDisabled,
-            false    // checkBufferModificationDuringWriting
+            false,   // checkBufferModificationDuringWriting
+            false    // isReliableMediaType
         );
 
         std::array<bool, deviceBlocksCount> zeroBlocks;
@@ -422,8 +424,9 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             diskId,
             clientId,
             blockSize,
-            true,   // unalignedRequestsDisabled,
-            false   // checkBufferModificationDuringWriting
+            true,    // unalignedRequestsDisabled,
+            false,   // checkBufferModificationDuringWriting
+            false    // isReliableMediaType
         );
 
         ui32 startIndex = 42;
@@ -512,8 +515,9 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             diskId,
             clientId,
             blockSize,
-            true,   // unalignedRequestsDisabled,
-            false   // checkBufferModificationDuringWriting
+            true,    // unalignedRequestsDisabled,
+            false,   // checkBufferModificationDuringWriting
+            false    // isReliableMediaType
         );
 
         {
@@ -567,6 +571,12 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
         UNIT_ASSERT_VALUES_EQUAL(4, env.GetWriteRequestCount());
 
         env.ReadSectorsAndCheck(0, 24, "aaaaaaaabbbbbbbbZZZZZZZZ");
+        UNIT_ASSERT_VALUES_EQUAL(6, env.GetReadRequestCount());
+
+        env.ResetRequestCounters();
+        env.ZeroSectors(4, 8);
+        UNIT_ASSERT_VALUES_EQUAL(2, env.GetZeroRequestCount());
+        env.ReadSectorsAndCheck(0, 24, "aaaaZZZZZZZZbbbbZZZZZZZZ");
         UNIT_ASSERT_VALUES_EQUAL(6, env.GetReadRequestCount());
     }
 
@@ -630,7 +640,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             clientId,
             blockSize,
             unalignedRequestDisabled,   // unalignedRequestsDisabled,
-            false                       // checkBufferModificationDuringWriting
+            false,                      // checkBufferModificationDuringWriting
+            false                       // isReliableMediaType
         );
 
         storage->ZeroBlocksHandler = [&] (
@@ -749,7 +760,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
                 clientId,
                 blockSize,
                 false,   // unalignedRequestsDisabled,
-                false    // checkBufferModificationDuringWriting
+                false,   // checkBufferModificationDuringWriting
+                false    // isReliableMediaType
             );
 
         storage->WriteBlocksLocalHandler = [&] (
@@ -817,7 +829,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
                 clientId,
                 blockSize,
                 false,   // unalignedRequestsDisabled,
-                false    // checkBufferModificationDuringWriting
+                false,   // checkBufferModificationDuringWriting
+                false    // isReliableMediaType
             );
 
         storage->WriteBlocksLocalHandler = [&] (
@@ -944,7 +957,8 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             clientId,
             blockSize,
             false,   // unalignedRequestsDisabled,
-            true    // checkBufferModificationDuringWriting
+            true,    // checkBufferModificationDuringWriting
+            false    // isReliableMediaType
         );
 
         ui32 writeAttempts  = 0;
@@ -986,6 +1000,155 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
         UNIT_ASSERT(!HasError(response));
         UNIT_ASSERT_VALUES_EQUAL(2, writeAttempts);
         UNIT_ASSERT_VALUES_EQUAL(1, mirroredDiskChecksumMismatchUponWrite->Val());
+    }
+
+    Y_UNIT_TEST(ShouldReportCriticalEventOnError)
+    {
+        const auto diskId = "disk1";
+        const auto clientId = "testClientId";
+        const ui32 blockSize = DefaultBlockSize;
+        const ui64 deviceBlocksCount = 8 * 1024;
+        const ui64 blocksCountLimit = deviceBlocksCount / 4;
+
+        auto storage = std::make_shared<TTestStorage>();
+
+        auto factory = CreateDeviceHandlerFactory(blocksCountLimit * blockSize);
+        auto deviceHandlerForReliableDisk = factory->CreateDeviceHandler(
+            storage,
+            diskId,
+            clientId,
+            blockSize,
+            false,   // unalignedRequestsDisabled,
+            true,    // checkBufferModificationDuringWriting
+            true     // isReliableMediaType
+        );
+        auto deviceHandlerForNonReliableDisk = factory->CreateDeviceHandler(
+            storage,
+            diskId,
+            clientId,
+            blockSize,
+            false,   // unalignedRequestsDisabled,
+            true,    // checkBufferModificationDuringWriting
+            false    // isReliableMediaType
+        );
+
+        auto buffer = TString(DefaultBlockSize, 'g');
+        TSgList sgList{{buffer.data(), buffer.size()}};
+        storage->WriteBlocksLocalHandler =
+            [&](TCallContextPtr ctx,
+                std::shared_ptr<NProto::TWriteBlocksLocalRequest> request)
+        {
+            Y_UNUSED(ctx);
+            Y_UNUSED(request);
+            return MakeFuture<NProto::TWriteBlocksLocalResponse>(
+                TErrorResponse{E_IO});
+        };
+        storage->ReadBlocksLocalHandler =
+            [&](TCallContextPtr ctx,
+                std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
+        {
+            Y_UNUSED(ctx);
+            Y_UNUSED(request);
+            return MakeFuture<NProto::TReadBlocksLocalResponse>(
+                TErrorResponse{E_IO});
+        };
+        storage->ZeroBlocksHandler =
+            [&](TCallContextPtr ctx,
+                std::shared_ptr<NProto::TZeroBlocksRequest> request)
+        {
+            Y_UNUSED(ctx);
+            Y_UNUSED(request);
+            return MakeFuture<NProto::TZeroBlocksResponse>(
+                TErrorResponse{E_IO});
+        };
+        auto counters = SetupCriticalEvents();
+        auto reliableCritEvent = counters->GetCounter(
+            "AppCriticalEvents/ErrorWasSentToTheGuestForReliableDisk",
+            true);
+        auto nonReliableCritEvent = counters->GetCounter(
+            "AppCriticalEvents/ErrorWasSentToTheGuestForNonReliableDisk",
+            true);
+
+        {   // Two write errors generate same crit events for reliable disk.
+            reliableCritEvent->Set(0);
+            nonReliableCritEvent->Set(0);
+            {
+                auto future = deviceHandlerForReliableDisk->Write(
+                    MakeIntrusive<TCallContext>(),
+                    0,
+                    blockSize,
+                    TGuardedSgList(sgList));
+                UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            }
+            {
+                auto future = deviceHandlerForReliableDisk->Write(
+                    MakeIntrusive<TCallContext>(),
+                    0,
+                    blockSize,
+                    TGuardedSgList(sgList));
+                UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            }
+            UNIT_ASSERT_VALUES_EQUAL(2, reliableCritEvent->Val());
+            UNIT_ASSERT_VALUES_EQUAL(0, nonReliableCritEvent->Val());
+        }
+
+        {   // Two write errors generate only one critEvent for non reliable
+            // disk.
+            reliableCritEvent->Set(0);
+            nonReliableCritEvent->Set(0);
+            {
+                auto future = deviceHandlerForNonReliableDisk->Write(
+                    MakeIntrusive<TCallContext>(),
+                    0,
+                    blockSize,
+                    TGuardedSgList(sgList));
+                UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            }
+            {
+                auto future = deviceHandlerForNonReliableDisk->Write(
+                    MakeIntrusive<TCallContext>(),
+                    0,
+                    blockSize,
+                    TGuardedSgList(sgList));
+                UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            }
+            UNIT_ASSERT_VALUES_EQUAL(0, reliableCritEvent->Val());
+            UNIT_ASSERT_VALUES_EQUAL(1, nonReliableCritEvent->Val());
+        }
+
+        {   // Check critEvent for reads.
+            reliableCritEvent->Set(0);
+            nonReliableCritEvent->Set(0);
+
+            auto buffer = TString::Uninitialized(DefaultBlockSize);
+            TSgList sgList{{buffer.data(), buffer.size()}};
+
+            auto future = deviceHandlerForReliableDisk->Read(
+                MakeIntrusive<TCallContext>(),
+                0,
+                DefaultBlockSize,
+                TGuardedSgList(sgList),
+                {});
+            UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            Cout << FormatError(future.GetValue().GetError());
+
+            UNIT_ASSERT_VALUES_EQUAL(1, reliableCritEvent->Val());
+            UNIT_ASSERT_VALUES_EQUAL(0, nonReliableCritEvent->Val());
+        }
+
+        {   // Check critEvent for zero.
+            reliableCritEvent->Set(0);
+            nonReliableCritEvent->Set(0);
+
+            auto future = deviceHandlerForReliableDisk->Zero(
+                MakeIntrusive<TCallContext>(),
+                0,
+                1);
+            UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            UNIT_ASSERT(HasError(future.GetValue(TDuration::Seconds(5))));
+            UNIT_ASSERT_VALUES_EQUAL(1, reliableCritEvent->Val());
+            UNIT_ASSERT_VALUES_EQUAL(0, nonReliableCritEvent->Val());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/service/storage_ut.cpp
+++ b/cloud/blockstore/libs/service/storage_ut.cpp
@@ -292,7 +292,7 @@ Y_UNIT_TEST_SUITE(TStorageTest)
         DoShouldHandleTimedOutRequests(runRequest);
     }
 
-    Y_UNIT_TEST(ShouldHandleTimeedOutZeroRequests)
+    Y_UNIT_TEST(ShouldHandleTimedOutZeroRequests)
     {
         auto runRequest =
             [](std::shared_ptr<TStorageAdapter> adapter, TInstant now)

--- a/cloud/blockstore/libs/service/unaligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/unaligned_device_handler.cpp
@@ -473,14 +473,16 @@ TUnalignedDeviceHandler::TUnalignedDeviceHandler(
         ui32 blockSize,
         ui32 maxSubRequestSize,
         ui32 maxUnalignedRequestSize,
-        bool checkBufferModificationDuringWriting)
+        bool checkBufferModificationDuringWriting,
+        bool isReliableMediaType)
     : Backend(std::make_shared<TAlignedDeviceHandler>(
           std::move(storage),
           std::move(diskId),
           std::move(clientId),
           blockSize,
           maxSubRequestSize,
-          checkBufferModificationDuringWriting))
+          checkBufferModificationDuringWriting,
+          isReliableMediaType))
     , BlockSize(blockSize)
     , MaxUnalignedBlockCount(maxUnalignedRequestSize / BlockSize)
 {}

--- a/cloud/blockstore/libs/service/unaligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/unaligned_device_handler.cpp
@@ -474,7 +474,7 @@ TUnalignedDeviceHandler::TUnalignedDeviceHandler(
         ui32 maxSubRequestSize,
         ui32 maxUnalignedRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaType)
+        bool isReliableMediaKind)
     : Backend(std::make_shared<TAlignedDeviceHandler>(
           std::move(storage),
           std::move(diskId),
@@ -482,7 +482,7 @@ TUnalignedDeviceHandler::TUnalignedDeviceHandler(
           blockSize,
           maxSubRequestSize,
           checkBufferModificationDuringWriting,
-          isReliableMediaType))
+          isReliableMediaKind))
     , BlockSize(blockSize)
     , MaxUnalignedBlockCount(maxUnalignedRequestSize / BlockSize)
 {}

--- a/cloud/blockstore/libs/service/unaligned_device_handler.h
+++ b/cloud/blockstore/libs/service/unaligned_device_handler.h
@@ -48,7 +48,8 @@ public:
         ui32 blockSize,
         ui32 maxSubRequestSize,
         ui32 maxUnalignedRequestSize,
-        bool checkBufferModificationDuringWriting);
+        bool checkBufferModificationDuringWriting,
+        bool isReliableMediaType);
 
     ~TUnalignedDeviceHandler() override;
 

--- a/cloud/blockstore/libs/service/unaligned_device_handler.h
+++ b/cloud/blockstore/libs/service/unaligned_device_handler.h
@@ -49,7 +49,7 @@ public:
         ui32 maxSubRequestSize,
         ui32 maxUnalignedRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaType);
+        bool isReliableMediaKind);
 
     ~TUnalignedDeviceHandler() override;
 

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -423,7 +423,8 @@ public:
             options.ClientId,
             options.BlockSize,
             options.UnalignedRequestsDisabled,
-            options.CheckBufferModificationDuringWriting);
+            options.CheckBufferModificationDuringWriting,
+            options.IsReliableMediaType);
 
         auto endpoint = std::make_shared<TEndpoint>(
             AppCtx,

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -424,7 +424,7 @@ public:
             options.BlockSize,
             options.UnalignedRequestsDisabled,
             options.CheckBufferModificationDuringWriting,
-            options.IsReliableMediaType);
+            options.IsReliableMediaKind);
 
         auto endpoint = std::make_shared<TEndpoint>(
             AppCtx,

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -346,6 +346,8 @@ private:
             return TVhostRequest::SUCCESS;
         }
 
+        // Keep the logic the logic synchronized with
+        // TAlignedDeviceHandler::ReportCriticalError().
         bool cancelError =
             error.GetCode() == E_CANCELLED ||
             GetErrorKind(error) == EErrorKind::ErrorRetriable;

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -346,7 +346,7 @@ private:
             return TVhostRequest::SUCCESS;
         }
 
-        // Keep the logic the logic synchronized with
+        // Keep the logic synchronized with
         // TAlignedDeviceHandler::ReportCriticalError().
         bool cancelError =
             error.GetCode() == E_CANCELLED ||

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -27,6 +27,7 @@ struct TStorageOptions
     ui32 VhostQueuesCount = 0;
     bool UnalignedRequestsDisabled = false;
     bool CheckBufferModificationDuringWriting = false;
+    bool IsReliableMediaType = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -27,7 +27,7 @@ struct TStorageOptions
     ui32 VhostQueuesCount = 0;
     bool UnalignedRequestsDisabled = false;
     bool CheckBufferModificationDuringWriting = false;
-    bool IsReliableMediaType = false;
+    bool IsReliableMediaKind = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/common/media.cpp
+++ b/cloud/storage/core/libs/common/media.cpp
@@ -41,6 +41,12 @@ bool IsDiskRegistryLocalMediaKind(NProto::EStorageMediaKind mediaKind)
     }
 }
 
+bool IsReliableMediaKind(NProto::EStorageMediaKind mediaKind)
+{
+    return !IsDiskRegistryMediaKind(mediaKind) ||
+           IsReliableDiskRegistryMediaKind(mediaKind);
+}
+
 TString MediaKindToString(NProto::EStorageMediaKind mediaKind)
 {
     switch (mediaKind) {

--- a/cloud/storage/core/libs/common/media.h
+++ b/cloud/storage/core/libs/common/media.h
@@ -12,6 +12,7 @@ namespace NCloud {
 bool IsDiskRegistryMediaKind(NProto::EStorageMediaKind mediaKind);
 bool IsReliableDiskRegistryMediaKind(NProto::EStorageMediaKind mediaKind);
 bool IsDiskRegistryLocalMediaKind(NProto::EStorageMediaKind mediaKind);
+bool IsReliableMediaKind(NProto::EStorageMediaKind mediaKind);
 TString MediaKindToString(NProto::EStorageMediaKind mediaKind);
 TString MediaKindToStatsString(NProto::EStorageMediaKind mediaKind);
 TString MediaKindToComputeType(NProto::EStorageMediaKind mediaKind);


### PR DESCRIPTION
Сделал чтобы  зажигались крит-эвенты, если мы все-таки отвечаем гостю ошибкой.
Если диск надежный и не должен ломаться, то зажигаем ErrorWasSentToTheGuestForReliableDisk на все ошибки.
Для нереплицирванных дисков зажигается один раз и ErrorWasSentToTheGuestForNonReliableDisk 