### PR TITLE
Resync major replica mismatch block by block

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -48,6 +48,23 @@ enum EVolumePreemptionType
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+enum EResyncPolicy
+{
+    // Fix only minor mismatches by 4MiB range.
+    MINOR_4MB = 0;
+
+    // Fix minor and replace major mismatches by 4MiB range.
+    MINOR_AND_MAJOR_4MB = 1;
+
+    // Fix only minor mismatches with block size range.
+    MINOR_BLOCK_BY_BLOCK = 2;
+
+    // Fix minor and replace major mismatches with block size range.
+    MINOR_AND_MAJOR_BLOCK_BY_BLOCK = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 //
 //  !!!IMPORTANT!!!
 //  Even though StorageServiceConfig is usually stored in textual format, it may
@@ -1154,4 +1171,11 @@ message TStorageServiceConfig
 
     // Use SSL for dynamic node registration.
     optional bool NodeRegistrationUseSsl = 417;
+
+    // Scrubber policy for resync.
+    optional EResyncPolicy ScrubbingResyncPolicy = 418;
+    // Resync policy for auto-resync.
+    optional EResyncPolicy AutoResyncPolicy = 419;
+    // Resync policy for force-resync.
+    optional EResyncPolicy ForceResyncPolicy = 420;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -52,16 +52,16 @@ enum EVolumePreemptionType
 enum EResyncPolicy
 {
     // Fix only minor mismatches by 4MiB range.
-    MINOR_4MB = 0;
+    RESYNC_POLICY_MINOR_4MB = 0;
 
     // Fix minor and replace major mismatches by 4MiB range.
-    MINOR_AND_MAJOR_4MB = 1;
+    RESYNC_POLICY_MINOR_AND_MAJOR_4MB = 1;
 
     // Fix only minor mismatches with block size range.
-    MINOR_BLOCK_BY_BLOCK = 2;
+    RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK = 2;
 
     // Fix minor and replace major mismatches with block size range.
-    MINOR_AND_MAJOR_BLOCK_BY_BLOCK = 3;
+    RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -468,10 +468,10 @@ TDuration MSeconds(ui32 value)
     xxx(ResyncAfterClientInactivityInterval,       TDuration, Minutes(1)      )\
     xxx(AutoResyncPolicy,                                                      \
         NProto::EResyncPolicy,                                                 \
-        NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB                            )\
+        NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB              )\
     xxx(ForceResyncPolicy,                                                     \
         NProto::EResyncPolicy,                                                 \
-        NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB                            )\
+        NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB              )\
     xxx(MirrorReadReplicaCount,                    ui32,      0               )\
                                                                                \
     xxx(PingMetricsHalfDecayInterval,              TDuration, Seconds(15)     )\
@@ -523,7 +523,7 @@ TDuration MSeconds(ui32 value)
     xxx(AutomaticallyEnableBufferCopyingAfterChecksumMismatch, bool, false       )\
     xxx(ScrubbingResyncPolicy,                                                    \
         NProto::EResyncPolicy,                                                    \
-        NProto::EResyncPolicy::MINOR_4MB                                         )\
+        NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB                           )\
                                                                                   \
     xxx(LaggingDevicesForMirror2DisksEnabled,     bool,      false               )\
     xxx(LaggingDevicesForMirror3DisksEnabled,     bool,      false               )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -466,6 +466,12 @@ TDuration MSeconds(ui32 value)
     xxx(ForceMirrorResync,                         bool,      false           )\
     xxx(ResyncIndexCachingInterval,                ui32,      65536           )\
     xxx(ResyncAfterClientInactivityInterval,       TDuration, Minutes(1)      )\
+    xxx(AutoResyncPolicy,                                                      \
+        NProto::EResyncPolicy,                                                 \
+        NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB                            )\
+    xxx(ForceResyncPolicy,                                                     \
+        NProto::EResyncPolicy,                                                 \
+        NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB                            )\
     xxx(MirrorReadReplicaCount,                    ui32,      0               )\
                                                                                \
     xxx(PingMetricsHalfDecayInterval,              TDuration, Seconds(15)     )\
@@ -515,6 +521,9 @@ TDuration MSeconds(ui32 value)
     xxx(MaxScrubbingBandwidth,                          ui64,      50            )\
     xxx(MinScrubbingBandwidth,                          ui64,      5             )\
     xxx(AutomaticallyEnableBufferCopyingAfterChecksumMismatch, bool, false       )\
+    xxx(ScrubbingResyncPolicy,                                                    \
+        NProto::EResyncPolicy,                                                    \
+        NProto::EResyncPolicy::MINOR_4MB                                         )\
                                                                                   \
     xxx(LaggingDevicesForMirror2DisksEnabled,     bool,      false               )\
     xxx(LaggingDevicesForMirror3DisksEnabled,     bool,      false               )\
@@ -676,6 +685,11 @@ IOutputStream& operator <<(
     NProto::EVolumePreemptionType pt)
 {
     return out << EVolumePreemptionType_Name(pt);
+}
+
+IOutputStream& operator<<(IOutputStream& out, NProto::EResyncPolicy pt)
+{
+    return out << NProto::EResyncPolicy_Name(pt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -539,6 +539,8 @@ public:
     bool GetForceMirrorResync() const;
     ui32 GetResyncIndexCachingInterval() const;
     TDuration GetResyncAfterClientInactivityInterval() const;
+    NProto::EResyncPolicy GetAutoResyncPolicy() const;
+    NProto::EResyncPolicy GetForceResyncPolicy() const;
     ui32 GetMirrorReadReplicaCount() const;
 
     TString GetManuallyPreemptedVolumesFile() const;
@@ -605,6 +607,8 @@ public:
     ui64 GetScrubbingBandwidth() const;
     ui64 GetMaxScrubbingBandwidth() const;
     ui64 GetMinScrubbingBandwidth() const;
+    bool GetAutomaticallyEnableBufferCopyingAfterChecksumMismatch() const;
+    NProto::EResyncPolicy GetScrubbingResyncPolicy() const;
 
     bool GetOptimizeVoidBuffersTransferForReadsEnabled() const;
 
@@ -647,7 +651,6 @@ public:
 
     bool GetYdbViewerServiceEnabled() const;
 
-    bool GetAutomaticallyEnableBufferCopyingAfterChecksumMismatch() const;
     [[nodiscard]] bool GetNonReplicatedVolumeDirectAcquireEnabled() const;
     [[nodiscard]] TDuration GetDestroyVolumeTimeout() const;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/checksum_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/checksum_range.cpp
@@ -87,10 +87,11 @@ void TChecksumRangeActorCompanion::HandleChecksumResponse(
     ++CalculatedChecksumsCount;
     auto* msg = ev->Get();
     const auto& error = msg->Record.GetError();
+    auto replicaIndex = ev->Cookie;
     if (HasError(error)) {
         LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
             "[%s] Checksum error %s",
-            Replicas[0].Name.c_str(),
+            Replicas[replicaIndex].ReplicaId.c_str(),
             FormatError(error).c_str());
 
         Error = error;
@@ -98,7 +99,7 @@ void TChecksumRangeActorCompanion::HandleChecksumResponse(
         return;
     }
 
-    Checksums[ev->Cookie] = msg->Record.GetChecksum();
+    Checksums[replicaIndex] = msg->Record.GetChecksum();
     if (CalculatedChecksumsCount == Replicas.size()) {
         ChecksumDuration = ctx.Now() - ChecksumStartTs;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -281,7 +281,7 @@ void TMirrorPartitionActor::StartResyncRange(
     }
 
     // Force usage TResyncRangeActor for minor errors.
-    auto resyncPolicy = isMinor ? NProto::EResyncPolicy::MINOR_4MB
+    auto resyncPolicy = isMinor ? NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB
                                 : Config->GetScrubbingResyncPolicy();
     auto resyncActor = MakeResyncRangeActor(
         std::move(requestInfo),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -122,7 +122,7 @@ private:
     void StartScrubbingRange(
         const NActors::TActorContext& ctx,
         ui64 scrubbingRangeId);
-    void StartResyncRange(const NActors::TActorContext& ctx);
+    void StartResyncRange(const NActors::TActorContext& ctx, bool isMinor);
     void AddTagForBufferCopying(const NActors::TActorContext& ctx);
     ui64 TakeNextRequestIdentifier();
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
@@ -93,7 +93,7 @@ void TMirrorPartitionResyncFastPathActor::CompareChecksums(
                 TBlockStoreComponents::PARTITION,
                 "[%s] Resync range %s: checksum mismatch, %lu (0) != %lu (%d)"
                 ", fast path reading is not available",
-                Replicas[0].Name.c_str(),
+                Replicas[0].ReplicaId.c_str(),
                 DescribeRange(Range).c_str(),
                 firstChecksum,
                 checksum,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.cpp
@@ -25,7 +25,8 @@ TBlockRange64 RangeId2BlockRange(ui32 rangeId, ui32 blockSize)
 
 bool CanFixMismatch(bool isMinor, NProto::EResyncPolicy resyncPolicy)
 {
-    return isMinor || resyncPolicy != NProto::EResyncPolicy::MINOR_4MB;
+    return isMinor ||
+           resyncPolicy != NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB;
 }
 
 std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
@@ -37,8 +38,9 @@ std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     NProto::EResyncPolicy resyncPolicy)
 {
-    if (resyncPolicy == NProto::EResyncPolicy::MINOR_4MB ||
-        resyncPolicy == NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB)
+    if (resyncPolicy == NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB ||
+        resyncPolicy ==
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB)
     {
         return std::make_unique<TResyncRangeActor>(
             std::move(requestInfo),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.cpp
@@ -1,5 +1,8 @@
 #include "part_mirror_resync_util.h"
 
+#include "resync_range.h"
+#include "resync_range_block_by_block.h"
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -17,6 +20,43 @@ TBlockRange64 RangeId2BlockRange(ui32 rangeId, ui32 blockSize)
     const auto resyncRangeBlockCount = ResyncRangeSize / blockSize;
     ui64 start = rangeId * resyncRangeBlockCount;
     return TBlockRange64::WithLength(start, resyncRangeBlockCount);
+}
+
+
+bool CanFixMismatch(bool isMinor, NProto::EResyncPolicy resyncPolicy)
+{
+    return isMinor || resyncPolicy != NProto::EResyncPolicy::MINOR_4MB;
+}
+
+std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
+    TRequestInfoPtr requestInfo,
+    ui32 blockSize,
+    TBlockRange64 range,
+    TVector<TReplicaDescriptor> replicas,
+    TString writerClientId,
+    IBlockDigestGeneratorPtr blockDigestGenerator,
+    NProto::EResyncPolicy resyncPolicy)
+{
+    if (resyncPolicy == NProto::EResyncPolicy::MINOR_4MB ||
+        resyncPolicy == NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB)
+    {
+        return std::make_unique<TResyncRangeActor>(
+            std::move(requestInfo),
+            blockSize,
+            range,
+            std::move(replicas),
+            std::move(writerClientId),
+            blockDigestGenerator);
+    }
+
+    return std::make_unique<TResyncRangeBlockByBlockActor>(
+        std::move(requestInfo),
+        blockSize,
+        range,
+        std::move(replicas),
+        std::move(writerClientId),
+        blockDigestGenerator,
+        resyncPolicy);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
@@ -14,7 +14,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 struct TReplicaDescriptor
 {
-    TString Name;
+    TString ReplicaId;
     ui32 ReplicaIndex = 0;
     NActors::TActorId ActorId;
 };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/blockstore/libs/storage/core/request_info.h>
 
+#include <contrib/ydb/library/actors/core/actor.h>
 #include <contrib/ydb/library/actors/core/actorid.h>
 
 #include <util/generic/size_literals.h>
@@ -30,5 +33,16 @@ constexpr ui64 ResyncRangeSize = 4_MB;
 
 std::pair<ui32, ui32> BlockRange2RangeId(TBlockRange64 range, ui32 blockSize);
 TBlockRange64 RangeId2BlockRange(ui32 rangeId, ui32 blockSize);
+
+bool CanFixMismatch(bool isMinor, NProto::EResyncPolicy resyncPolicy);
+
+std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
+    TRequestInfoPtr requestInfo,
+    ui32 blockSize,
+    TBlockRange64 range,
+    TVector<TReplicaDescriptor> replicas,
+    TString writerClientId,
+    IBlockDigestGeneratorPtr blockDigestGenerator,
+    NProto::EResyncPolicy resyncPolicy);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/disk_agent/public.h>
+
 #include <cloud/storage/core/libs/common/sglist.h>
 
 namespace NCloud::NBlockStore::NStorage {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.h
@@ -67,9 +67,7 @@ private:
         const NActors::TActorContext& ctx,
         const TVector<ui64>& checksums,
         ui64 majorChecksum);
-    void ResyncMajor(
-        const NActors::TActorContext& ctx,
-        const TVector<ui64>& checksums);
+    void ResyncMajor(const NActors::TActorContext& ctx);
     void PrepareWriteBuffer(const NActors::TActorContext& ctx);
     void ReadBlocks(const NActors::TActorContext& ctx, size_t idx);
     void WriteBlocks(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
@@ -1,0 +1,426 @@
+#include "resync_range_block_by_block.h"
+
+#include "cloud/blockstore/libs/storage/disk_agent/model/public.h"
+
+#include <cloud/blockstore/libs/diagnostics/block_digest.h>
+#include <cloud/blockstore/libs/kikimr/components.h>
+#include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
+
+#include <util/string/join.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct THealStat
+{
+    // How many times a replica has been used as a source for fixing a minor
+    // error.
+    size_t HealCount = 0;
+
+    // How many blocks in a replica with minor errors have been fixed.
+    size_t MinorErrorCount = 0;
+
+    // How many blocks in a replica with major errors have been fixed.
+    size_t MajorErrorCount = 0;
+
+    size_t MajorFoundErrorCount = 0;
+
+    [[nodiscard]] TString Print() const
+    {
+        return TStringBuilder()
+               << "[healer=" << HealCount << ", minor=" << MinorErrorCount
+               << ", major=" << MajorErrorCount << "]";
+    }
+};
+
+struct TBlockVariant
+{
+    THealStat& HealStat;
+    TString& Block;
+};
+using TBlockVariants = TVector<TBlockVariant>;
+
+void HealMinors(const TBlockVariants& blockVariants)
+{
+    using TLess =
+        decltype([](const auto* lhs, const auto* rhs) { return *lhs < *rhs; });
+    TMap<TString*, size_t, TLess> variations;
+
+    for (const auto& blockVariant: blockVariants) {
+        variations[&blockVariant.Block]++;
+    }
+
+    if (variations.size() == 1) {
+        // All replicas match.
+        return;
+    }
+
+    for (auto [data, count]: variations) {
+        if (count > 1) {
+            // We found minor mismatch!
+            for (const auto& blockVariant: blockVariants) {
+                if (blockVariant.Block == *data) {
+                    ++blockVariant.HealStat.HealCount;
+                } else {
+                    // Heal block.
+                    blockVariant.Block = *data;
+                    ++blockVariant.HealStat.MinorErrorCount;
+                }
+            }
+        }
+    }
+}
+
+}   // namespace
+
+TResyncRangeBlockByBlockActor::TResyncRangeBlockByBlockActor(
+        TRequestInfoPtr requestInfo,
+        ui32 blockSize,
+        TBlockRange64 range,
+        TVector<TReplicaDescriptor> replicas,
+        TString writerClientId,
+        IBlockDigestGeneratorPtr blockDigestGenerator,
+        NProto::EResyncPolicy resyncPolicy)
+    : RequestInfo(std::move(requestInfo))
+    , BlockSize(blockSize)
+    , Range(range)
+    , Replicas(std::move(replicas))
+    , WriterClientId(std::move(writerClientId))
+    , BlockDigestGenerator(std::move(blockDigestGenerator))
+    , ResyncPolicy(resyncPolicy)
+{}
+
+void TResyncRangeBlockByBlockActor::Bootstrap(const TActorContext& ctx)
+{
+    TRequestScope timer(*RequestInfo);
+
+    Become(&TThis::StateWork);
+
+    LWTRACK(
+        RequestReceived_PartitionWorker,
+        RequestInfo->CallContext->LWOrbit,
+        "ResyncRangeBlockByBlock",
+        RequestInfo->CallContext->RequestId);
+
+    ReadBuffers.resize(Replicas.size());
+    for (size_t replica = 0; replica < Replicas.size(); replica++) {
+        ActorsToResync.push_back(replica);
+        ReadReplicaBlocks(ctx, replica);
+    }
+}
+
+void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
+    const NActors::TActorContext& ctx)
+{
+    TVector<THealStat> healStat(Replicas.size());
+
+    // Let's try to fix range block by block. At the same time, we will
+    // calculate which replicas were used to fix the rest of the replicas.
+    for (size_t blockIndex = 0; blockIndex < Range.Size(); ++blockIndex) {
+        TBlockVariants blockVariants;
+        blockVariants.reserve(Replicas.size());
+        for (size_t replica = 0; replica < Replicas.size(); ++replica) {
+            blockVariants.push_back(TBlockVariant{
+                .HealStat = healStat[replica],
+                .Block = *ReadBuffers[replica].MutableBuffers(blockIndex)});
+        }
+        HealMinors(blockVariants);
+    }
+
+    // We find the replica that fixed the largest number of blocks and use it as
+    // a sample to fix the rest of the replicas.
+    size_t bestHealer = 0;
+    for (size_t i = 1; i < Replicas.size(); ++i) {
+        if (healStat[bestHealer].HealCount < healStat[i].HealCount) {
+            bestHealer = i;
+        }
+    }
+
+    for (size_t blockIndex = 0; blockIndex < Range.Size(); ++blockIndex) {
+        const auto& donorBlock = ReadBuffers[bestHealer].GetBuffers(blockIndex);
+
+        for (size_t replica = 0; replica < Replicas.size(); ++replica) {
+            if (replica == bestHealer) {
+                continue;
+            }
+
+            auto& replicaBlock =
+                *ReadBuffers[replica].MutableBuffers(blockIndex);
+
+            if (donorBlock == replicaBlock) {
+                continue;
+            }
+
+            if (ResyncPolicy ==
+                NProto::EResyncPolicy::MINOR_AND_MAJOR_BLOCK_BY_BLOCK)
+            {
+                // Replace block.
+                replicaBlock = donorBlock;
+                ++healStat[replica].MajorErrorCount;
+            } else {
+                ++healStat[replica].MajorFoundErrorCount;
+            }
+        }
+    }
+
+    size_t minorFixCount = Accumulate(
+        healStat,
+        size_t{},
+        [](size_t count, const THealStat& h)
+        { return count + h.MinorErrorCount; });
+    size_t majorFixCount = Accumulate(
+        healStat,
+        size_t{},
+        [](size_t count, const THealStat& h)
+        { return count + h.MajorErrorCount; });
+    TString replicaStat = Accumulate(
+        healStat,
+        TString(),
+        [](const TString& acc, const THealStat& h)
+        { return acc.empty() ? h.Print() : acc + " " + h.Print(); });
+
+    LOG_WARN(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Replica %lu elected as best healer. In range %s %lu blocks were "
+        "healed and %lu blocks were overwritten during resync. %s%s",
+        Replicas[bestHealer].ReplicaId.c_str(),
+        bestHealer,
+        Range.Print().c_str(),
+        minorFixCount,
+        majorFixCount,
+        (majorFixCount == 0 ? "All blocks healed as minor! " : ""),
+        replicaStat.c_str());
+
+    // Do writes only to replicas with fixed errors.
+    ActorsToResync.clear();
+    for (size_t i = 0; i < Replicas.size(); ++i) {
+        if (healStat[i].MinorErrorCount || healStat[i].MajorErrorCount) {
+            ActorsToResync.push_back(i);
+        }
+    }
+}
+
+void TResyncRangeBlockByBlockActor::ReadReplicaBlocks(
+    const TActorContext& ctx,
+    size_t replicaIndex)
+{
+    auto request = std::make_unique<TEvService::TEvReadBlocksRequest>();
+    request->Record.SetStartIndex(Range.Start);
+    request->Record.SetBlocksCount(Range.Size());
+
+    auto* headers = request->Record.MutableHeaders();
+    headers->SetIsBackgroundRequest(true);
+    headers->SetClientId(TString(BackgroundOpsClientId));
+
+    auto event = std::make_unique<NActors::IEventHandle>(
+        Replicas[replicaIndex].ActorId,
+        ctx.SelfID,
+        request.release(),
+        IEventHandle::FlagForwardOnNondelivery,
+        replicaIndex,   // cookie
+        &ctx.SelfID     // forwardOnNondelivery
+    );
+
+    ctx.Send(event.release());
+
+    ReadStartTs = ctx.Now();
+}
+
+void TResyncRangeBlockByBlockActor::WriteBlocks(const TActorContext& ctx)
+{
+    for (size_t i = 0; i < ActorsToResync.size(); ++i) {
+        WriteReplicaBlocks(ctx, ActorsToResync[i], std::move(ReadBuffers[i]));
+    }
+
+    WriteStartTs = ctx.Now();
+}
+
+void TResyncRangeBlockByBlockActor::WriteReplicaBlocks(
+    const TActorContext& ctx,
+    size_t replicaIndex,
+    NProto::TIOVector data)
+{
+    auto request = std::make_unique<TEvService::TEvWriteBlocksRequest>();
+    request->Record.SetStartIndex(Range.Start);
+    auto clientId =
+        WriterClientId ? WriterClientId : TString(BackgroundOpsClientId);
+    data.Swap(request->Record.MutableBlocks());
+
+    auto* headers = request->Record.MutableHeaders();
+    headers->SetIsBackgroundRequest(true);
+    headers->SetClientId(std::move(clientId));
+
+    for (size_t i = 0; i < request->Record.GetBlocks().BuffersSize(); ++i) {
+        size_t blockIndex = Range.Start + i;
+        const auto digest = BlockDigestGenerator->ComputeDigest(
+            blockIndex,
+            TBlockDataRef(
+                request->Record.GetBlocks().GetBuffers(i).data(),
+                BlockSize));
+
+        if (digest.Defined()) {
+            AffectedBlockInfos.push_back({blockIndex, *digest});
+        }
+    }
+
+    auto event = std::make_unique<NActors::IEventHandle>(
+        Replicas[replicaIndex].ActorId,
+        ctx.SelfID,
+        request.release(),
+        IEventHandle::FlagForwardOnNondelivery,
+        replicaIndex,          // cookie
+        &ctx.SelfID   // forwardOnNondelivery
+    );
+
+    LOG_WARN(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Replica %lu Overwrite block range %s during resync",
+        Replicas[replicaIndex].ReplicaId.c_str(),
+        Replicas[replicaIndex].ReplicaIndex,
+        DescribeRange(Range).c_str());
+
+    ctx.Send(event.release());
+}
+
+void TResyncRangeBlockByBlockActor::Done(const TActorContext& ctx)
+{
+    auto response =
+        std::make_unique<TEvNonreplPartitionPrivate::TEvRangeResynced>(
+            std::move(Error),
+            Range,
+            TInstant(),    // checksumStartTs
+            TDuration(),   // checksumDuration
+            ReadStartTs,
+            ReadDuration,
+            WriteStartTs,
+            WriteDuration,
+            std::move(AffectedBlockInfos));
+
+    LWTRACK(
+        ResponseSent_PartitionWorker,
+        RequestInfo->CallContext->LWOrbit,
+        "ResyncRangeBlockByBlock",
+        RequestInfo->CallContext->RequestId);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TResyncRangeBlockByBlockActor::HandleReadUndelivery(
+    const TEvService::TEvReadBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ReadDuration = ctx.Now() - ReadStartTs;
+
+    Y_UNUSED(ev);
+
+    Error = MakeError(E_REJECTED, "ReadBlocks request undelivered");
+
+    Done(ctx);
+}
+
+void TResyncRangeBlockByBlockActor::HandleReadResponse(
+    const TEvService::TEvReadBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ReadDuration = ctx.Now() - ReadStartTs;
+
+    auto* msg = ev->Get();
+    auto replicaIdx = ev->Cookie;
+
+    Error = msg->Record.GetError();
+
+    if (HasError(Error)) {
+        Done(ctx);
+        return;
+    }
+
+    msg->Record.MutableBlocks()->Swap(&ReadBuffers[replicaIdx]);
+
+    bool allReadsDone = AllOf(
+        ReadBuffers,
+        [](const NProto::TIOVector& data) { return data.BuffersSize() != 0; });
+    if (!allReadsDone) {
+        return;
+    }
+
+    PrepareWriteBuffers(ctx);
+    WriteBlocks(ctx);
+}
+
+void TResyncRangeBlockByBlockActor::HandleWriteUndelivery(
+    const TEvService::TEvWriteBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    WriteDuration = ctx.Now() - WriteStartTs;
+
+    Y_UNUSED(ev);
+
+    Error = MakeError(E_REJECTED, "WriteBlocks request undelivered");
+
+    Done(ctx);
+}
+
+void TResyncRangeBlockByBlockActor::HandleWriteResponse(
+    const TEvService::TEvWriteBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    WriteDuration = ctx.Now() - WriteStartTs;
+
+    auto* msg = ev->Get();
+
+    Error = msg->Record.GetError();
+
+    if (HasError(Error)) {
+        Done(ctx);
+        return;
+    }
+
+    if (++ResyncedCount == ActorsToResync.size()) {
+        Done(ctx);
+    }
+}
+
+void TResyncRangeBlockByBlockActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    Error = MakeError(E_REJECTED, "Dead");
+    Done(ctx);
+}
+
+STFUNC(TResyncRangeBlockByBlockActor::StateWork)
+{
+    TRequestScope timer(*RequestInfo);
+
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+
+        HFunc(TEvService::TEvReadBlocksRequest, HandleReadUndelivery);
+        HFunc(TEvService::TEvReadBlocksResponse, HandleReadResponse);
+        HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteUndelivery);
+        HFunc(TEvService::TEvWriteBlocksResponse, HandleWriteResponse);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            break;
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
@@ -69,16 +69,17 @@ void HealMinors(const TBlockVariants& blockVariants)
     }
 
     for (auto [data, count]: variations) {
-        if (count > 1) {
-            // We found minor mismatch!
-            for (const auto& blockVariant: blockVariants) {
-                if (blockVariant.Block == *data) {
-                    ++blockVariant.HealStat.HealCount;
-                } else {
-                    // Heal block.
-                    blockVariant.Block = *data;
-                    ++blockVariant.HealStat.FixedMinorErrorCount;
-                }
+        if (count < 2) {
+            continue;
+        }
+        // We found minor mismatch!
+        for (const auto& blockVariant: blockVariants) {
+            if (blockVariant.Block == *data) {
+                ++blockVariant.HealStat.HealCount;
+            } else {
+                // Heal block.
+                blockVariant.Block = *data;
+                ++blockVariant.HealStat.FixedMinorErrorCount;
             }
         }
     }
@@ -102,7 +103,8 @@ void AddBlockToRange(ui64 block, TVector<TBlockRange64>& rangesWithMajorError)
     }
 }
 
-TString PrintRanges(const TVector<TBlockRange64>& ranges) {
+TString PrintRanges(const TVector<TBlockRange64>& ranges)
+{
     TStringBuilder builder;
     bool first = true;
     builder << "[";
@@ -123,6 +125,8 @@ TString PrintRanges(const TVector<TBlockRange64>& ranges) {
 }
 
 }   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
 
 TResyncRangeBlockByBlockActor::TResyncRangeBlockByBlockActor(
         TRequestInfoPtr requestInfo,
@@ -210,7 +214,7 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
             ++healStat[replica].FoundMajorErrorCount;
             AddBlockToRange(Range.Start + blockIndex, rangesWithMajorError);
             if (ResyncPolicy ==
-                NProto::EResyncPolicy::MINOR_AND_MAJOR_BLOCK_BY_BLOCK)
+                NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK)
             {
                 // Replace block.
                 replicaBlock = donorBlock;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -351,7 +351,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         {
             auto counters = env.GetReplicaCounters(1);
             UNIT_ASSERT_VALUES_EQUAL(1, counters.RequestCounters.ChecksumBlocks.Count);
-            UNIT_ASSERT_VALUES_EQUAL(0, counters.RequestCounters.ReadBlocks.Count);
+            UNIT_ASSERT_VALUES_EQUAL(1, counters.RequestCounters.ReadBlocks.Count);
             UNIT_ASSERT_VALUES_EQUAL(2, counters.RequestCounters.WriteBlocks.Count);
 
             auto blocks = env.ReadReplica(1, 0, 3071);
@@ -442,7 +442,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         {
             auto counters = env.GetReplicaCounters(1);
             UNIT_ASSERT_VALUES_EQUAL(1, counters.RequestCounters.ChecksumBlocks.Count);
-            UNIT_ASSERT_VALUES_EQUAL(0, counters.RequestCounters.ReadBlocks.Count);
+            UNIT_ASSERT_VALUES_EQUAL(1, counters.RequestCounters.ReadBlocks.Count);
             UNIT_ASSERT_VALUES_EQUAL(2, counters.RequestCounters.WriteBlocks.Count);
 
             auto blocks = env.ReadReplica(1, 0, 3071);
@@ -455,7 +455,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         {
             auto counters = env.GetReplicaCounters(2);
             UNIT_ASSERT_VALUES_EQUAL(1, counters.RequestCounters.ChecksumBlocks.Count);
-            UNIT_ASSERT_VALUES_EQUAL(0, counters.RequestCounters.ReadBlocks.Count);
+            UNIT_ASSERT_VALUES_EQUAL(1, counters.RequestCounters.ReadBlocks.Count);
             UNIT_ASSERT_VALUES_EQUAL(2, counters.RequestCounters.WriteBlocks.Count);
 
             auto blocks = env.ReadReplica(2, 0, 3071);
@@ -537,9 +537,9 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         UNIT_ASSERT_VALUES_EQUAL(2, response->ChecksumDuration.Seconds());
 
         UNIT_ASSERT_VALUES_EQUAL(12, response->ReadStartTs.Seconds());
-        UNIT_ASSERT_VALUES_EQUAL(1, response->ReadDuration.Seconds());
+        UNIT_ASSERT_VALUES_EQUAL(2, response->ReadDuration.Seconds());
 
-        UNIT_ASSERT_VALUES_EQUAL(13, response->WriteStartTs.Seconds());
+        UNIT_ASSERT_VALUES_EQUAL(14, response->WriteStartTs.Seconds());
         UNIT_ASSERT_VALUES_EQUAL(1, response->WriteDuration.Seconds());
 
         UNIT_ASSERT_VALUES_EQUAL(1024, response->AffectedBlockInfos.size());
@@ -572,7 +572,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         }
 
         {
-            env.InjectError<TEvService::TEvReadBlocksLocalResponse>(
+            env.InjectError<TEvService::TEvReadBlocksResponse>(
                 E_REJECTED, "read error");
 
             auto response = env.ResyncRange(0, 3071, {0, 1});
@@ -581,7 +581,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         }
 
         {
-            env.InjectError<TEvService::TEvWriteBlocksLocalResponse>(
+            env.InjectError<TEvService::TEvWriteBlocksResponse>(
                 E_REJECTED, "write error");
 
             auto response = env.ResyncRange(0, 3071, {0, 1});

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -205,7 +205,8 @@ struct TTestEnv
         ui64 start,
         ui64 end,
         TVector<int> idxs,
-        NProto::EResyncPolicy resyncPolicy = NProto::EResyncPolicy::MINOR_AND_MAJOR_4MB)
+        NProto::EResyncPolicy resyncPolicy =
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB)
     {
         auto sender = Runtime.AllocateEdgeActor(0);
 
@@ -609,7 +610,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
             0,
             1023,
             {0, 1, 2},
-            NProto::EResyncPolicy::MINOR_BLOCK_BY_BLOCK);
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
         UNIT_ASSERT(!HasError(response->GetError()));
 
         // Check replica 0
@@ -655,7 +656,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
             0,
             1023,
             {0, 1, 2},
-            NProto::EResyncPolicy::MINOR_BLOCK_BY_BLOCK);
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
         UNIT_ASSERT(!HasError(response->GetError()));
 
         // Check replica 0
@@ -715,7 +716,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
             0,
             1023,
             {0, 1, 2},
-            NProto::EResyncPolicy::MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
         UNIT_ASSERT(!HasError(response->GetError()));
 
         // Check replica 0
@@ -771,7 +772,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
             0,
             1023,
             {0, 1, 2},
-            NProto::EResyncPolicy::MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
         UNIT_ASSERT(!HasError(response->GetError()));
 
         // Check replica 0

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -12,6 +12,7 @@ SRCS(
     migration_timeout_calculator.cpp
     mirror_request_actor.cpp
     replica_info.cpp
+    resync_range_block_by_block.cpp
     resync_range.cpp
 
     part_mirror.cpp


### PR DESCRIPTION
Добавил эвристик при починке мажорного расхождения 4Мб блока. Если раньше просто выбиралась какая то реплика и ее содержимое копировалось всем, то теперь чуть сложнее:
1. Делаем попытку собрать кворум для каждого отдельного блока, может так повезти, что все расхождения починятся. 
2. Считаем сколько раз реплика имела правильные данные при починке минорных расхождений.
3. Выбираем "лучшую" реплику, которая наибольшее количество раз была правильной.
4. Оставшиеся мажорные расхождения чиним содержимым этой "лучшей" реплики.

Новую логику реализует новый актор, по умолчанию он не используется, чтобы он начал работать потребуется включить политику через настройки.