### PR TITLE
Fix multidevice write when migration running

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
@@ -89,7 +89,8 @@ void TDeviceRequestBuilder::BuildNextRequest(TSgList* sglist)
     ++CurrentDeviceIdx;
 }
 
-TString TDeviceRequestBuilder::TakeBufferAndAdvance() {
+TString TDeviceRequestBuilder::TakeBufferAndAdvance()
+{
     auto& currentBuffer =
         (*Request.MutableBlocks()->MutableBuffers())[CurrentBufferIdx];
 
@@ -101,11 +102,7 @@ TString TDeviceRequestBuilder::TakeBufferAndAdvance() {
         Y_ABORT_UNLESS(
             currentBuffer.size() - CurrentOffsetInBuffer >= BlockSize);
 
-        result.resize(BlockSize);
-        memcpy(
-            result.begin(),
-            currentBuffer.data() + CurrentOffsetInBuffer,
-            BlockSize);
+        result = currentBuffer.substr(CurrentOffsetInBuffer, BlockSize);
         CurrentOffsetInBuffer += BlockSize;
         if (CurrentOffsetInBuffer == currentBuffer.size()) {
             CurrentOffsetInBuffer = 0;
@@ -115,7 +112,8 @@ TString TDeviceRequestBuilder::TakeBufferAndAdvance() {
     return result;
 }
 
-TBlockDataRef TDeviceRequestBuilder::GetBufferAndAdvance() {
+TBlockDataRef TDeviceRequestBuilder::GetBufferAndAdvance()
+{
     auto& currentBuffer =
         (*Request.MutableBlocks()->MutableBuffers())[CurrentBufferIdx];
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
@@ -68,30 +68,70 @@ TDeviceRequestBuilder::TDeviceRequestBuilder(
     : DeviceRequests(deviceRequests)
     , BlockSize(blockSize)
     , Request(request)
-{}
+{
+    const size_t blockCountToSkip =
+        DeviceRequests[0].BlockRange.Start - request.GetStartIndex();
+    for (size_t i = 0; i < blockCountToSkip; ++i) {
+        GetBufferAndAdvance();
+    }
+}
 
 void TDeviceRequestBuilder::BuildNextRequest(TSgList* sglist)
 {
     Y_ABORT_UNLESS(CurrentDeviceIdx < DeviceRequests.size());
 
     const auto& deviceRequest = DeviceRequests[CurrentDeviceIdx];
-    for (ui32 i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
-        const ui32 rem = Buffer().size() - CurrentOffsetInBuffer;
-        Y_ABORT_UNLESS(rem >= BlockSize);
-        sglist->push_back({Buffer().data() + CurrentOffsetInBuffer, BlockSize});
-        CurrentOffsetInBuffer += BlockSize;
-        if (CurrentOffsetInBuffer == Buffer().size()) {
-            CurrentOffsetInBuffer = 0;
-            ++CurrentBufferIdx;
-        }
+    sglist->reserve(sglist->size() + deviceRequest.BlockRange.Size());
+    for (size_t i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
+        sglist->push_back(GetBufferAndAdvance());
     }
 
     ++CurrentDeviceIdx;
 }
 
-TString& TDeviceRequestBuilder::Buffer()
-{
-    return (*Request.MutableBlocks()->MutableBuffers())[CurrentBufferIdx];
+TString TDeviceRequestBuilder::TakeBufferAndAdvance() {
+    auto& currentBuffer =
+        (*Request.MutableBlocks()->MutableBuffers())[CurrentBufferIdx];
+
+    TString result;
+    if (CurrentOffsetInBuffer == 0 && currentBuffer.size() == BlockSize) {
+        currentBuffer.swap(result);
+        ++CurrentBufferIdx;
+    } else {
+        Y_ABORT_UNLESS(
+            currentBuffer.size() - CurrentOffsetInBuffer >= BlockSize);
+
+        result.resize(BlockSize);
+        memcpy(
+            result.begin(),
+            currentBuffer.data() + CurrentOffsetInBuffer,
+            BlockSize);
+        CurrentOffsetInBuffer += BlockSize;
+        if (CurrentOffsetInBuffer == currentBuffer.size()) {
+            CurrentOffsetInBuffer = 0;
+            ++CurrentBufferIdx;
+        }
+    }
+    return result;
+}
+
+TBlockDataRef TDeviceRequestBuilder::GetBufferAndAdvance() {
+    auto& currentBuffer =
+        (*Request.MutableBlocks()->MutableBuffers())[CurrentBufferIdx];
+
+    Y_ABORT_UNLESS(currentBuffer.size() - CurrentOffsetInBuffer >= BlockSize);
+
+    TBlockDataRef result(
+        currentBuffer.data() + CurrentOffsetInBuffer,
+        BlockSize);
+
+    CurrentOffsetInBuffer += BlockSize;
+    if (CurrentOffsetInBuffer == currentBuffer.size()) {
+        CurrentOffsetInBuffer = 0;
+        ++CurrentBufferIdx;
+    }
+
+    return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h
@@ -28,6 +28,17 @@ TString LogDevice(const NProto::TDeviceConfig& device);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Transfers data from a user's TWriteBlocksRequest to subrequests.
+// After construction, the BuildNextRequest method is called as many times as
+// there are elements in DeviceRequests. The subrequests may not cover all the
+// data of the original request, in which case it is necessary to skip and not
+// transfer part of the data to the subrequests.
+// BlockSize in Request and subrequests is the same. Request buffers may vary
+// in size, but they are all multiples of the BlockSize. It is guaranteed that
+// there will be enough data to fill out the subrequests. When building
+// subrequests, all data will be sliced by BlockSize. If possible, the data from
+// the request buffers is moved to the subrequests buffers.
+
 class TDeviceRequestBuilder
 {
 private:
@@ -52,32 +63,17 @@ public:
         Y_ABORT_UNLESS(CurrentDeviceIdx < DeviceRequests.size());
 
         const auto& deviceRequest = DeviceRequests[CurrentDeviceIdx];
-        for (ui32 i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
-            auto& deviceBuffer = *r.MutableBlocks()->AddBuffers();
-            if (CurrentOffsetInBuffer == 0 && Buffer().size() == BlockSize) {
-                deviceBuffer = std::move(Buffer());
-                ++CurrentBufferIdx;
-            } else {
-                const ui32 rem = Buffer().size() - CurrentOffsetInBuffer;
-                Y_ABORT_UNLESS(rem >= BlockSize);
-                deviceBuffer.resize(BlockSize);
-                memcpy(
-                    deviceBuffer.begin(),
-                    Buffer().data() + CurrentOffsetInBuffer,
-                    BlockSize);
-                CurrentOffsetInBuffer += BlockSize;
-                if (CurrentOffsetInBuffer == Buffer().size()) {
-                    CurrentOffsetInBuffer = 0;
-                    ++CurrentBufferIdx;
-                }
-            }
+
+        for (size_t i = 0; i < deviceRequest.BlockRange.Size(); ++i) {
+            r.MutableBlocks()->AddBuffers(TakeBufferAndAdvance());
         }
 
         ++CurrentDeviceIdx;
     }
 
 private:
-    TString& Buffer();
+    TString TakeBufferAndAdvance();
+    TBlockDataRef GetBufferAndAdvance();
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -330,11 +330,13 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
             counters.WriteBlocks.RequestBytes);
     }
 
-    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigrated) {
+    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigrated)
+    {
         DoShouldMirrorRequestsAfterAllDataIsMigrated(false);
     }
 
-    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigratedDirectCopy) {
+    Y_UNIT_TEST(ShouldMirrorRequestsAfterAllDataIsMigratedDirectCopy)
+    {
         DoShouldMirrorRequestsAfterAllDataIsMigrated(true);
     }
 
@@ -516,11 +518,13 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         WaitForMigrations(runtime, 3);
     }
 
-    Y_UNIT_TEST(ShouldDoMigrationViaRdma) {
+    Y_UNIT_TEST(ShouldDoMigrationViaRdma)
+    {
         DoShouldDoMigrationViaRdma(false);
     }
 
-    Y_UNIT_TEST(ShouldDoMigrationViaRdmaDirectCopy) {
+    Y_UNIT_TEST(ShouldDoMigrationViaRdmaDirectCopy)
+    {
         DoShouldDoMigrationViaRdma(true);
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -357,8 +357,8 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         WaitForMigrations(runtime, 3);
 
         const auto blockRange = TBlockRange64::WithLength(2047, 2);
-        const auto buffer_1 = TString(DefaultBlockSize, 'A');
-        const auto buffer_2 = TString(DefaultBlockSize, 'B');
+        const auto buffer1 = TString(DefaultBlockSize, 'A');
+        const auto buffer2 = TString(DefaultBlockSize, 'B');
 
         size_t writeDeviceRequestCount = 0;
         auto checkWriteDeviceRequest =
@@ -377,14 +377,14 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
 
                 if (msg->Record.GetStartIndex() == 2047) {
                     const auto& blocks = msg->Record.GetBlocks().GetBuffers();
-                    TBlockDataRef src{buffer_1.data(), buffer_1.size()};
+                    TBlockDataRef src{buffer1.data(), buffer1.size()};
                     TBlockDataRef dst{blocks[0].data(), DefaultBlockSize};
                     UNIT_ASSERT_VALUES_EQUAL(
                         src.AsStringBuf(),
                         dst.AsStringBuf());
                 } else if (msg->Record.GetStartIndex() == 0) {
                     const auto& blocks = msg->Record.GetBlocks().GetBuffers();
-                    TBlockDataRef src{buffer_2.data(), buffer_2.size()};
+                    TBlockDataRef src{buffer2.data(), buffer2.size()};
                     TBlockDataRef dst{blocks[0].data(), DefaultBlockSize};
                     UNIT_ASSERT_VALUES_EQUAL(
                         src.AsStringBuf(),
@@ -401,19 +401,21 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         auto writeRequest =
             std::make_unique<TEvService::TEvWriteBlocksRequest>();
         writeRequest->Record.SetStartIndex(blockRange.Start);
-        writeRequest->Record.MutableBlocks()->AddBuffers(buffer_1);
-        writeRequest->Record.MutableBlocks()->AddBuffers(buffer_2);
+        writeRequest->Record.MutableBlocks()->AddBuffers(buffer1);
+        writeRequest->Record.MutableBlocks()->AddBuffers(buffer2);
         client.SendRequest(client.GetActorId(), std::move(writeRequest));
         auto response = client.RecvWriteBlocksResponse();
         UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
         UNIT_ASSERT_VALUES_EQUAL(3, writeDeviceRequestCount);
     }
 
-    Y_UNIT_TEST(ShouldMirrorRequestsDuringMigration) {
+    Y_UNIT_TEST(ShouldMirrorRequestsDuringMigration)
+    {
         DoShouldMirrorRequestsDuringMigration(false);
     }
 
-    Y_UNIT_TEST(ShouldMirrorRequestsDuringMigrationDirectCopy) {
+    Y_UNIT_TEST(ShouldMirrorRequestsDuringMigrationDirectCopy)
+    {
         DoShouldMirrorRequestsDuringMigration(true);
     }
 


### PR DESCRIPTION
Исправление бага когда данные писались с не правильным смещением.
1. вольюм должен мигрировать
2. этот девайс должен быть не первым
3. пользователь, пока идет миграция, должен записать запрос, попадающий на границу двух девайсов, так чтобы слева(с адресом меньше) был девайс который НЕ мигрирует, а справа девайс который мигрирует.

Проблема была в том, что не учитывалось что в конфиге миграционного партишена есть только те устройства, на которые идет миграция. Остальных девайсов нет, и нужно пропускать записи на них, а если запись бьется на два девайса, то нужно учитывать это при формировании буфера для запроса TEvWriteDeviceBlocksRequest. Ситуация, когда первого девайса нет, а второй есть - обрабатывалась не правильно.