### PR TITLE
Ignore TEvVolumePrivate::TAllocateDiskIfNeeded in StateZombie

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1136,6 +1136,7 @@ STFUNC(TVolumeActor::StateZombie)
 
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);
 
+        IgnoreFunc(TEvVolumePrivate::TEvAllocateDiskIfNeeded);
         IgnoreFunc(TEvVolumePrivate::TEvUpdateCounters);
         IgnoreFunc(TEvVolumePrivate::TEvUpdateThrottlerState);
         IgnoreFunc(TEvVolumePrivate::TEvUpdateReadWriteClientInfo);


### PR DESCRIPTION
Fixes `TestAlterPlacementGroupMembershipFailureBecauseDiskIsInAnotherGroup`:
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/PR-check/13977198773/1/nebius-x86-64/summary/ya-test.html#FAIL

```
VERIFY failed (2025-03-20T19:16:47.329823Z): [BLOCKSTORE_VOLUME] Unexpected event: (0x10620142) NCloud::NBlockStore::TRequestEvent<NCloud::NBlockStore::NStorage::TEvVolumePrivate::TAllocateDiskIfNeeded, 274858306u>, void NCloud::NBlockStore::NStorage::TVolumeActor::StateZombie(TAutoPtr< ::NActors::IEventHandle> &)
  cloud/storage/core/libs/actors/helpers.cpp:70
  HandleUnexpectedEvent(): requirement false failed
```