### PR TITLE
fix: use port manager to get data port

### DIFF
--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -29,6 +29,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->PingHandler =
@@ -41,10 +42,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -75,6 +78,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->PingHandler =
@@ -94,6 +98,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 "certs/server.crt",
                 "certs/server.crt",
                 "certs/server.key")
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
@@ -101,6 +106,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 port,
                 "certs/server.crt",
                 "test")
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -191,6 +197,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->PingHandler =
@@ -216,6 +223,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
             .AddCert(
                 "certs/server.crt",
                 "certs/server.key")
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
@@ -223,6 +231,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 port,
                 "certs/server.crt",
                 "test")
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -254,6 +263,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         TPortManager portManager;
         ui16 securePort = portManager.GetPort(9001);
         ui16 insecurePort = portManager.GetPort(9002);
+        ui16 dataPort = portManager.GetPort(9003);
 
         auto service = std::make_shared<TTestService>();
         service->PingHandler =
@@ -271,6 +281,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 "certs/server.crt",
                 "certs/server.crt",
                 "certs/server.key")
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto secureClient = testFactory.CreateClientBuilder()
@@ -278,10 +289,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 securePort,
                 "certs/server.crt",
                 "test")
+            .SetDataPort(dataPort)
             .BuildClient();
 
         auto insecureClient = testFactory.CreateClientBuilder()
             .SetPort(insecurePort)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -326,6 +339,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->PingHandler =
@@ -341,10 +355,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -378,6 +394,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
         TString clientId = "testClientId";
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->PingHandler =
@@ -391,10 +408,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .SetClientId(clientId)
             .BuildClient();
 
@@ -474,6 +493,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->WriteBlocksHandler =
@@ -486,6 +506,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         // mismatched Client/DataClient
@@ -522,6 +543,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto writePromise = NewPromise<NProto::TWriteBlocksResponse>();
 
@@ -541,10 +563,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -595,6 +619,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto writePromise = NewPromise<NProto::TWriteBlocksResponse>();
 
@@ -614,10 +639,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -664,6 +691,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -679,10 +707,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -713,6 +743,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -732,6 +763,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 "certs/server.crt",
                 "certs/server.crt",
                 "certs/server.key")
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
@@ -739,6 +771,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 port,
                 "certs/server.crt",
                 "test")
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -817,6 +850,8 @@ Y_UNIT_TEST_SUITE(TServerTest)
     Y_UNIT_TEST(ShouldIdentifyFdControlChannelSource)
     {
         TFsPath unixSocket(CreateGuidAsString() + ".sock");
+        TPortManager portManager;
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -832,10 +867,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetUnixSocketPath(unixSocket.GetPath())
+            .SetDataPort(dataPort)
             .BuildServer(nullptr, service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetUnixSocketPath(unixSocket.GetPath())
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();
@@ -946,6 +983,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -957,11 +995,13 @@ Y_UNIT_TEST_SUITE(TServerTest)
         TTestFactory testFactory;
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .SetUnixSocketPath(unixSocket.GetPath())
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         UNIT_ASSERT_VALUES_EQUAL(0, static_cast<int>(*errorCounter));
@@ -995,6 +1035,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
     {
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
         TString diskId = "testDiskId";
 
         auto service = std::make_shared<TTestService>();
@@ -1017,11 +1058,13 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .SetVolumeStats(serverVolumeStats)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .SetVolumeStats(clientVolumeStats)
             .BuildClient();
 
@@ -1155,6 +1198,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         TPortManager portManager;
         ui16 port = portManager.GetPort(9001);
+        ui16 dataPort = portManager.GetPort(9002);
 
         auto service = std::make_shared<TTestService>();
         service->ReadBlocksHandler =
@@ -1194,10 +1238,12 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         auto server = testFactory.CreateServerBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildServer(service);
 
         auto client = testFactory.CreateClientBuilder()
             .SetPort(port)
+            .SetDataPort(dataPort)
             .BuildClient();
 
         server->Start();


### PR DESCRIPTION
fix flaky server tests:
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(msan)/13962498973/1/nebius-x86-64-msan/summary/ya-test.html#FAIL


`2025-03-20T06:27:16.748689Z :GRPC ERROR: contrib/libs/grpc/src/core/ext/transport/chttp2/server/chttp2_server.cc:1061: UNKNOWN:No address added out of total 2 resolved for 'localhost:9767' {created_time:"2025-03-20T06:27:16.748483632+00:00", children:[UNKNOWN:Unable to configure socket {fd:9, created_time:"2025-03-20T06:27:16.748393906+00:00", children:[UNKNOWN:Address already in use {created_time:"2025-03-20T06:27:16.748354331+00:00", errno:98, os_error:"Address already in use", syscall:"bind"}]}, UNKNOWN:Unable to configure socket {fd:9, created_time:"2025-03-20T06:27:16.748460719+00:00", children:[UNKNOWN:Address already in use {created_time:"2025-03-20T06:27:16.748447824+00:00", errno:98, os_error:"Address already in use", syscall:"bind"}]}]}`

9767 is a default data port