### PR TITLE
Fix clang-18 warning about POD and packing

### DIFF
--- a/cloud/blockstore/libs/rdma/iface/protocol.h
+++ b/cloud/blockstore/libs/rdma/iface/protocol.h
@@ -151,18 +151,20 @@ struct Y_PACKED TBufferDesc
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct Y_PACKED TRequestMessage
+struct Y_PACKED TRequestMessageBody
 {
-    union {
-        struct {
-            TMessageHeader Header;
-            ui32 ReqId : 16;
-            ui32 Unused : 16;
-            TBufferDesc In;
-            TBufferDesc Out;
-        };
-        ui8 Padding[RDMA_REQUEST_SIZE];
-    };
+    TMessageHeader Header;
+    ui32 ReqId : 16;
+    ui32 Unused : 16;
+    TBufferDesc In;
+    TBufferDesc Out;
+};
+
+static_assert(sizeof(TRequestMessageBody) == (4 + 2 + 2 + 16 + 16));
+
+struct Y_PACKED TRequestMessage: TRequestMessageBody
+{
+    ui8 Padding[RDMA_REQUEST_SIZE - sizeof(TRequestMessageBody)] = {};
 };
 
 static_assert(sizeof(TRequestMessage) == RDMA_REQUEST_SIZE);


### PR DESCRIPTION
В Аркадии перевозят транк на clang-18 и он выдает странную ошибку:
```
In file included from $(SOURCE_ROOT)/cloud/blockstore/libs/rdma_test/client_test.cpp:5:
$(SOURCE_ROOT)/cloud/blockstore/libs/rdma/iface/protocol.h:156:5: error: not packing field 'NCloud::NBlockStore::NRdma::TRequestMessage::(anonymous union at $(SOURCE_ROOT)/cloud/blockstore/libs/rdma/iface/protocol.h:156:5)' as it is non-POD for the purposes of layout [-Werror,-Wpacked-non-pod]
  156 |     union {
      |     ^
1 error generated.
```
