### PR TITLE
[Disk Manager] increase wait timeout in TestTasksInflightLimit, add taskID to logs

### DIFF
--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -511,10 +511,13 @@ func (s *scheduler) WaitTaskSync(
 	wait := func() error {
 		select {
 		case <-ctx.Done():
-			logging.Info(ctx, "waiting cancelled: %v", ctx.Err())
+			logging.Info(ctx, "waiting cancelled, taskID %v: %v", taskID, ctx.Err())
 			return ctx.Err()
 		case <-timeoutChannel:
-			return errors.NewNonRetriableErrorf("scheduler.WaitTaskSync timed out")
+			return errors.NewNonRetriableErrorf(
+				"scheduler.WaitTaskSync timed out, taskID %v",
+				taskID,
+			)
 		case <-time.After(s.pollForTaskUpdatesPeriod):
 		}
 

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -813,7 +813,7 @@ func TestTasksInflightLimit(t *testing.T) {
 				ctx,
 				s.scheduler,
 				id,
-				2*time.Second,
+				5*time.Second,
 			)
 			doublerTaskErrs <- err
 		}(id)

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -809,6 +809,9 @@ func TestTasksInflightLimit(t *testing.T) {
 	doublerTaskErrs := make(chan error)
 	for _, id := range doublerTaskIDs {
 		go func(id string) {
+			// Doubler tasks must finish fast enough: long tasks must not
+			// exhaust the whole limit on inflight tasks due to the limit on
+			// infilght long tasks.
 			_, err := waitTaskWithTimeout(
 				ctx,
 				s.scheduler,


### PR DESCRIPTION
Fix for TestTasksInflightLimit faulure:

```
    tasks_test.go:837: 
        	Error Trace:	/-S/cloud/tasks/tasks_tests/tasks_test.go:837
        	Error:      	Received unexpected error:
        	            	Non retriable error, Silent=false: scheduler.WaitTaskSync timed out
        	            	goroutine 793 [running]:
        	            	runtime/debug.Stack()
        	            		/-S/contrib/go/_std_1.21/src/runtime/debug/stack.go:24 +0x5e
        	            	github.com/ydb-platform/nbs/cloud/tasks/errors.newNonRetriableError(...)
        	            		/-S/cloud/tasks/errors/errors.go:123
        	            	github.com/ydb-platform/nbs/cloud/tasks/errors.NewNonRetriableErrorf({0x49e08a?, 0xc000651dbc?}, {0x0?, 0x0?, 0x0?})
        	            		/-S/cloud/tasks/errors/errors.go:104 +0x34
        	            	github.com/ydb-platform/nbs/cloud/tasks.(*scheduler).WaitTaskSync.func1()
        	            		/-S/cloud/tasks/scheduler_impl.go:517 +0x22b
        	            	github.com/ydb-platform/nbs/cloud/tasks.(*scheduler).WaitTaskSync(0xc000b2a840, {0x8294b0?, 0xc0008075e0?}, {0xc0004f8540, 0x24}, 0xc0014863f0?)
        	            		/-S/cloud/tasks/scheduler_impl.go:549 +0x162
        	            	github.com/ydb-platform/nbs/cloud/tasks/tasks_tests_test.waitTaskWithTimeout({0x8294b0?, 0xc0008075e0?}, {0x830bf0?, 0xc000b2a840?}, {0xc0004f8540?, 0xc00078a678?}, 0xc00078a668?)
        	            		/-S/cloud/tasks/tasks_tests/tasks_test.go:678 +0x43
        	            	github.com/ydb-platform/nbs/cloud/tasks/tasks_tests_test.TestTasksInflightLimit.func4({0xc0004f8540?, 0xc00078a730?})
        	            		/-S/cloud/tasks/tasks_tests/tasks_test.go:812 +0x47
        	            	created by github.com/ydb-platform/nbs/cloud/tasks/tasks_tests_test.TestTasksInflightLimit in goroutine 122
        	            		/-S/cloud/tasks/tasks_tests/tasks_test.go:811 +0xbe5
        	Test:       	TestTasksInflightLimit
```

The test failed because some of doubler tasks failed to finish before the timeout. In this pr we increate this timeout.

It will not impact the correctness of the tests, because long tasks are executed [for 10 seconds](https://github.com/ydb-platform/nbs/blob/main/cloud/tasks/tasks_tests/tasks_test.go#L317), 10 >> 5 (see the added comment in the code).

I suppose that 2 second timeout was not enough due to `Transaction locks invalidated` errors from YDB. But I'm not sure about that. Adding TaskId to logs for better diagnostics.

```
2025-03-26T03:21:26.736Z	ERROR	persistence/ydb_logger.go:76	attempt failed	{"SYSLOG_IDENTIFIER": "disk-manager", "COMPONENT": "YDB", "YDB_LOG_NAME": "ydb.retry", "error": "Retriable error, IgnoreRetryLimit=false: failed to commit transaction: connError{node_id:1,address:'computeinstance-e00ky4x84gapc4fg7g:22005'}: operation/ABORTED (code = 400040, address = computeinstance-e00ky4x84gapc4fg7g:22005, issues = [{#2001 'Transaction locks invalidated. Table: local/tasks/tasks_ydb_test/TestTasksSendEvent/tasks'}]) at `github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).Invoke(conn.go:364)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer.(*Balancer).wrapCall(balancer.go:351)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/table.(*transaction).CommitTx(transaction.go:174)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/table.do.func1(retry.go:53)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/table.do.retryBackoff.func2(retry.go:83)`", "label": "", "latency": "63.289034ms", "retryable": true, "code": 400040, "deleteSession": false, "version": "3.54.3"}
```