### PR TITLE
[Disk Manager] Fix flappy test

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -176,6 +176,9 @@ func TestSnapshotServiceCancelCreateSnapshotFromDisk(t *testing.T) {
 	require.NotEmpty(t, operation)
 	testcommon.CancelOperation(t, ctx, client, operation.Id)
 
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Cancelled by client")
 	// Should wait here because checkpoint is deleted on operation cancel (and
 	// exact time of this event is unknown).
 	testcommon.WaitForCheckpointDoesNotExist(t, ctx, diskID, snapshotID)


### PR DESCRIPTION
After https://github.com/ydb-platform/nbs/pull/3120 test TestSnapshotServiceDeleteSnapshotWhenCreationIsInFlight became flappy.
