### PR TITLE
Wait for in-flight writes before the lagging agent migration

### DIFF
--- a/cloud/blockstore/libs/storage/api/partition.h
+++ b/cloud/blockstore/libs/storage/api/partition.h
@@ -10,9 +10,13 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_PARTITION_REQUESTS(xxx, ...)                                \
-    xxx(WaitReady,              __VA_ARGS__)                                   \
-    xxx(StatPartition,          __VA_ARGS__)                                   \
-    xxx(Drain,                  __VA_ARGS__)                                   \
+    xxx(WaitReady,                                                 __VA_ARGS__)\
+    xxx(StatPartition,                                             __VA_ARGS__)\
+    /* Waits until there are no more in-flight write requests. */              \
+    xxx(Drain,                                                     __VA_ARGS__)\
+    /* Waits for current in-flight writes to finish and does not affect any    \
+     * requests that come after. */                                            \
+    xxx(WaitForInFlightWrites,                                     __VA_ARGS__)\
 // BLOCKSTORE_PARTITION_REQUESTS
 
 // requests forwarded from service to partition
@@ -84,6 +88,18 @@ struct TEvPartition
     };
 
     //
+    // WaitForInFlightWrites
+    //
+
+    struct TWaitForInFlightWritesRequest
+    {
+    };
+
+    struct TWaitForInFlightWritesResponse
+    {
+    };
+
+    //
     // Garbage collector finish report
     //
 
@@ -118,6 +134,9 @@ struct TEvPartition
 
         EvAddLaggingAgentRequest = EvBegin + 9,
         EvRemoveLaggingReplicaRequest = EvBegin + 10,
+
+        EvWaitForInFlightWritesRequest = EvBegin + 11,
+        EvWaitForInFlightWritesResponse = EvBegin + 12,
 
         EvEnd
     };

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -728,6 +728,13 @@ void TPartitionActor::HandleDrain(
     DrainActorCompanion.HandleDrain(ev, ctx);
 }
 
+void TPartitionActor::HandleWaitForInFlightWrites(
+    const TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    DrainActorCompanion.HandleWaitForInFlightWrites(ev, ctx);
+}
+
 bool TPartitionActor::HandleRequests(STFUNC_SIG)
 {
     switch (ev->GetTypeRewrite()) {

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -222,9 +222,18 @@ private:
 
     void SendStatsToService(const NActors::TActorContext& ctx);
 
+    // IRequestsInProgress implementation:
     bool WriteRequestInProgress() const override
     {
         return WriteAndZeroRequestsInProgress != 0;
+    }
+
+    void WaitForInFlightWrites() override {
+        Y_ABORT("Unimplemented");
+    }
+
+    bool IsWaitingForInFlightWrites() const override {
+        Y_ABORT("Unimplemented");
     }
 
     template <typename TMethod>

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -228,11 +228,13 @@ private:
         return WriteAndZeroRequestsInProgress != 0;
     }
 
-    void WaitForInFlightWrites() override {
+    void WaitForInFlightWrites() override
+    {
         Y_ABORT("Unimplemented");
     }
 
-    bool IsWaitingForInFlightWrites() const override {
+    bool IsWaitingForInFlightWrites() const override
+    {
         Y_ABORT("Unimplemented");
     }
 

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -703,6 +703,13 @@ void TPartitionActor::HandleDrain(
     DrainActorCompanion.HandleDrain(ev, ctx);
 }
 
+void TPartitionActor::HandleWaitForInFlightWrites(
+    const TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    DrainActorCompanion.HandleWaitForInFlightWrites(ev, ctx);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_HANDLE_UNIMPLEMENTED_REQUEST(name, ns)                      \

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.h
@@ -241,9 +241,18 @@ private:
 
     void SendStatsToService(const NActors::TActorContext& ctx);
 
+    // IRequestsInProgress implementation:
     bool WriteRequestInProgress() const override
     {
         return WriteAndZeroRequestsInProgress != 0;
+    }
+
+    void WaitForInFlightWrites() override {
+        Y_ABORT("Unimplemented");
+    }
+
+    bool IsWaitingForInFlightWrites() const override {
+        Y_ABORT("Unimplemented");
     }
 
     template <typename TMethod>

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.h
@@ -247,11 +247,13 @@ private:
         return WriteAndZeroRequestsInProgress != 0;
     }
 
-    void WaitForInFlightWrites() override {
+    void WaitForInFlightWrites() override
+    {
         Y_ABORT("Unimplemented");
     }
 
-    bool IsWaitingForInFlightWrites() const override {
+    bool IsWaitingForInFlightWrites() const override
+    {
         Y_ABORT("Unimplemented");
     }
 

--- a/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.cpp
@@ -12,6 +12,8 @@
 
 namespace NCloud::NBlockStore::NStorage {
 
+using namespace NActors;
+
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -31,7 +33,7 @@ TDrainActorCompanion::TDrainActorCompanion(
 
 void TDrainActorCompanion::HandleDrain(
     const NPartition::TEvPartition::TEvDrainRequest::TPtr& ev,
-    const NActors::TActorContext& ctx)
+    const TActorContext& ctx)
 {
     auto* msg = ev->Get();
 
@@ -70,7 +72,7 @@ void TDrainActorCompanion::HandleDrain(
 
 void TDrainActorCompanion::HandleWaitForInFlightWrites(
     const NPartition::TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
-    const NActors::TActorContext& ctx)
+    const TActorContext& ctx)
 {
     auto* msg = ev->Get();
 
@@ -103,14 +105,13 @@ void TDrainActorCompanion::HandleWaitForInFlightWrites(
 ////////////////////////////////////////////////////////////////////////////////
 
 void TDrainActorCompanion::ProcessDrainRequests(
-    const NActors::TActorContext& ctx)
+    const TActorContext& ctx)
 {
     DoProcessDrainRequests(ctx);
     DoProcessWaitForInFlightWritesRequests(ctx);
 }
 
-void TDrainActorCompanion::DoProcessDrainRequests(
-    const NActors::TActorContext& ctx)
+void TDrainActorCompanion::DoProcessDrainRequests(const TActorContext& ctx)
 {
     if (DrainRequests.empty() || RequestsInProgress.WriteRequestInProgress()) {
         return;
@@ -139,7 +140,7 @@ void TDrainActorCompanion::DoProcessDrainRequests(
 }
 
 void TDrainActorCompanion::DoProcessWaitForInFlightWritesRequests(
-    const NActors::TActorContext& ctx)
+    const TActorContext& ctx)
 {
     if (!WaitForInFlightWritesRequest ||
         RequestsInProgress.IsWaitingForInFlightWrites())

--- a/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h
@@ -9,7 +9,9 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TDrainActorCompanion
 {
+private:
     TVector<TRequestInfoPtr> DrainRequests;
+    TRequestInfoPtr WaitForInFlightWritesRequest;
     IRequestsInProgress& RequestsInProgress;
     const TString LoggingId;
 
@@ -26,7 +28,15 @@ public:
         const NPartition::TEvPartition::TEvDrainRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleWaitForInFlightWrites(
+        const NPartition::TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void ProcessDrainRequests(const NActors::TActorContext& ctx);
+
+private:
+    void DoProcessDrainRequests(const NActors::TActorContext& ctx);
+    void DoProcessWaitForInFlightWritesRequests(const NActors::TActorContext& ctx);
 };
 
 }  // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/drain_actor_companion_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/drain_actor_companion_ut.cpp
@@ -51,9 +51,25 @@ private:
 public:
     TMyTestEnv()
     {
+        SetupLogging();
         NKikimr::SetupTabletServices(Runtime);
 
         Sender = Runtime.AllocateEdgeActor();
+    }
+
+    void SetupLogging()
+    {
+        Runtime.AppendToLogSettings(
+            TBlockStoreComponents::START,
+            TBlockStoreComponents::END,
+            GetComponentName);
+
+        for (ui32 i = TBlockStoreComponents::START;
+             i < TBlockStoreComponents::END;
+             ++i)
+        {
+            Runtime.SetLogPriority(i, NLog::PRI_TRACE);
+        }
     }
 
     TActorId Register(IActorPtr actor)
@@ -80,6 +96,14 @@ public:
             .GrabEdgeEvent<NPartition::TEvPartition::TEvDrainResponse>(
                 TDuration());
     }
+
+    THolder<NPartition::TEvPartition::TEvWaitForInFlightWritesResponse>
+    GrabWaitForInFlightWritesResponse()
+    {
+        return Runtime.GrabEdgeEvent<
+            NPartition::TEvPartition::TEvWaitForInFlightWritesResponse>(
+            TDuration());
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,6 +113,7 @@ class TActorWithDrain
     , private IRequestsInProgress
 {
     ui32 CurrentWriteRequestInProgress = 0;
+    bool WaitingForInFlightWrites = false;
     TDrainActorCompanion drainCompanion{*this, "LoggingId"};
 
 public:
@@ -100,7 +125,12 @@ public:
     {
         switch (ev->GetTypeRewrite()) {
             HFunc(NPartition::TEvPartition::TEvDrainRequest, HandleDrain);
+            HFunc(
+                NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+                HandleWaitForInFlightWrites);
             HFunc(TEvSetWriteInProgressCount, HandleSetWriteCount);
+            default:
+                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
         }
     }
 
@@ -110,6 +140,14 @@ private:
         return CurrentWriteRequestInProgress != 0;
     }
 
+    void WaitForInFlightWrites() override {
+        WaitingForInFlightWrites = true;
+    }
+
+    bool IsWaitingForInFlightWrites() const override {
+        return WaitingForInFlightWrites && WriteRequestInProgress();
+    }
+
     void HandleDrain(
         const NPartition::TEvPartition::TEvDrainRequest::TPtr& ev,
         const TActorContext& ctx)
@@ -117,11 +155,21 @@ private:
         drainCompanion.HandleDrain(ev, ctx);
     }
 
+    void HandleWaitForInFlightWrites(
+        const NPartition::TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        drainCompanion.HandleWaitForInFlightWrites(ev, ctx);
+    }
+
     void HandleSetWriteCount(
         const TEvSetWriteInProgressCount::TPtr& ev,
         const TActorContext& ctx)
     {
         CurrentWriteRequestInProgress = ev->Get()->WriteCount;
+        if (!WriteRequestInProgress()) {
+            WaitingForInFlightWrites = false;
+        }
         drainCompanion.ProcessDrainRequests(ctx);
     }
 };
@@ -314,6 +362,68 @@ Y_UNIT_TEST_SUITE(TDrainActorCompanionTest)
         {  // Assert no more drain responses
             auto drainResponse = testEnv.GrabDrainResponse();
             UNIT_ASSERT_VALUES_EQUAL(nullptr, drainResponse);
+        }
+    }
+
+    Y_UNIT_TEST(BasicWaitForInFlightWrites)
+    {
+        TMyTestEnv testEnv;
+
+        auto actorId = testEnv.Register(std::make_unique<TActorWithDrain>());
+
+        // Waiting for in-flight writes.
+        testEnv.Send(
+            actorId,
+            std::make_unique<
+                NPartition::TEvPartition::TEvWaitForInFlightWritesRequest>());
+        testEnv.DispatchEvents();
+
+        {   // Get the response
+            auto waitResponse = testEnv.GrabWaitForInFlightWritesResponse();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, waitResponse->GetStatus());
+        }
+    }
+
+    Y_UNIT_TEST(WaitForInFlightWritesWithWriteInProgress)
+    {
+        TMyTestEnv testEnv;
+
+        auto actorId = testEnv.Register(std::make_unique<TActorWithDrain>());
+
+        // Set actor have one write inflight
+        testEnv.Send(actorId, std::make_unique<TEvSetWriteInProgressCount>(1));
+
+        // Waiting for in-flight writes.
+        testEnv.Send(
+            actorId,
+            std::make_unique<
+                NPartition::TEvPartition::TEvWaitForInFlightWritesRequest>());
+        testEnv.DispatchEvents();
+
+        {   // Assert waiting is not finished since the write is in progress
+            auto waitResponse = testEnv.GrabWaitForInFlightWritesResponse();
+            UNIT_ASSERT_VALUES_EQUAL(nullptr, waitResponse);
+        }
+
+        // Sending another wait.
+        testEnv.Send(
+            actorId,
+            std::make_unique<
+                NPartition::TEvPartition::TEvWaitForInFlightWritesRequest>());
+        testEnv.DispatchEvents();
+
+        {   // It should be rejected because the actor is already waiting.
+            auto waitResponse = testEnv.GrabWaitForInFlightWritesResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, waitResponse->GetStatus());
+        }
+
+        // Finish write
+        testEnv.Send(actorId, std::make_unique<TEvSetWriteInProgressCount>(0));
+        testEnv.DispatchEvents();
+
+        {   // Get the response
+            auto waitResponse = testEnv.GrabWaitForInFlightWritesResponse();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, waitResponse->GetStatus());
         }
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -86,7 +86,7 @@ void TLaggingAgentMigrationActor::HandleStartLaggingAgentMigration(
     const NActors::TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    Y_ABORT_UNLESS(!IsMigrationAllowed());
+    Y_ABORT_IF(IsMigrationAllowed());
     StartWork(ctx);
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -59,7 +59,6 @@ void TLaggingAgentMigrationActor::OnBootstrap(const TActorContext& ctx)
             Config->GetMaxMigrationBandwidth(),
             Config->GetExpectedDiskAgentSize(),
             PartConfig));
-    StartWork(ctx);
 }
 
 bool TLaggingAgentMigrationActor::OnMessage(
@@ -67,8 +66,28 @@ bool TLaggingAgentMigrationActor::OnMessage(
     TAutoPtr<IEventHandle>& ev)
 {
     Y_UNUSED(ctx);
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvStartLaggingAgentMigration,
+            HandleStartLaggingAgentMigration);
+
+        default:
+            // Message processing by the base class is required.
+            return false;
+    }
+
+    // We get here if we have processed an incoming message. And its processing
+    // by the base class is not required.
+    return true;
+}
+
+void TLaggingAgentMigrationActor::HandleStartLaggingAgentMigration(
+    const TEvNonreplPartitionPrivate::TEvStartLaggingAgentMigration::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
     Y_UNUSED(ev);
-    return false;
+    Y_ABORT_UNLESS(!IsMigrationAllowed());
+    StartWork(ctx);
 }
 
 void TLaggingAgentMigrationActor::OnMigrationProgress(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.h
@@ -53,6 +53,12 @@ private:
         ui64 migrationIndex) override;
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
+
+private:
+    void HandleStartLaggingAgentMigration(
+        const TEvNonreplPartitionPrivate::TEvStartLaggingAgentMigration::TPtr&
+            ev,
+        const NActors::TActorContext& ctx);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -296,8 +296,7 @@ TLaggingAgentsReplicaProxyActor::TLaggingAgentsReplicaProxyActor(
     , PoisonPillHelper(this)
 {}
 
-TLaggingAgentsReplicaProxyActor::
-    ~TLaggingAgentsReplicaProxyActor() = default;
+TLaggingAgentsReplicaProxyActor::~TLaggingAgentsReplicaProxyActor() = default;
 
 void TLaggingAgentsReplicaProxyActor::Bootstrap(const TActorContext& ctx)
 {
@@ -317,17 +316,6 @@ void TLaggingAgentsReplicaProxyActor::MarkBlocksAsDirty(
     const TString& unavailableAgentId,
     TBlockRange64 range)
 {
-    LOG_TRACE(
-        ctx,
-        TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] Marking block range %s as dirty for agent %s",
-        PartConfig->GetName().c_str(),
-        range.Print().c_str(),
-        unavailableAgentId.Quote().c_str());
-
-    auto& state = AgentState[unavailableAgentId];
-    Y_ABORT_UNLESS(state.CleanBlocksMap);
-
     // We artificially lower the resolution of the "CleanBlocksMap". This is
     // done because the migration actor migrates by ranges of
     // "ProcessingRangeSize" anyway. The full resolution here would lead to
@@ -336,6 +324,21 @@ void TLaggingAgentsReplicaProxyActor::MarkBlocksAsDirty(
         ProcessingRangeSize / PartConfig->GetBlockSize();
     auto alignedStart = AlignDown<ui64>(range.Start, blocksPerRange);
     auto alignedEnd = AlignUp<ui64>(range.End + 1, blocksPerRange);
+
+    LOG_TRACE(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Lower block range resolution %s -> %s and mark blocks as dirty "
+        "for lagging agent %s",
+        PartConfig->GetName().c_str(),
+        range.Print().c_str(),
+        TBlockRange64::MakeClosedInterval(alignedStart, alignedEnd)
+            .Print()
+            .c_str(),
+        unavailableAgentId.Quote().c_str());
+
+    auto& state = AgentState[unavailableAgentId];
+    Y_ABORT_UNLESS(state.CleanBlocksMap);
     state.CleanBlocksMap->Unset(alignedStart, alignedEnd);
 }
 
@@ -520,7 +523,8 @@ TVector<TSplitRequest> TLaggingAgentsReplicaProxyActor::DoSplitRequest(
         result.emplace_back(
             std::move(request),
             forkedCallContext,
-            GetRecipientActorId(deviceRequest.Device.GetAgentId()));
+            GetRecipientActorId(deviceRequest.Device.GetAgentId()),
+            deviceRequest.Device.GetDeviceUUID());
     }
 
     return result;
@@ -598,8 +602,9 @@ NActors::TActorId TLaggingAgentsReplicaProxyActor::GetRecipientActorId(
     switch (agentState->State) {
         case EAgentState::Unavailable:
             return {};
+        case EAgentState::WaitingForDrain:
         case EAgentState::Resyncing:
-            Y_DEBUG_ABORT_UNLESS(agentState->MigrationActorId);
+            Y_ABORT_UNLESS(agentState->MigrationActorId);
             return agentState->MigrationActorId;
     }
     Y_ABORT("Unknown enum value: %u", static_cast<ui8>(agentState->State));
@@ -675,10 +680,22 @@ void TLaggingAgentsReplicaProxyActor::HandleAgentIsBackOnline(
         return;
     }
 
+    auto& state = AgentState[msg->AgentId];
+    switch (state.State) {
+        case EAgentState::Unavailable:
+            break;
+        case EAgentState::WaitingForDrain:
+            return;
+        case EAgentState::Resyncing:
+            Y_DEBUG_ABORT_UNLESS(false);
+            return;
+    }
+    state.State = EAgentState::WaitingForDrain;
+
     LOG_INFO(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] Lagging agent %s is back online. Starting migration actor",
+        "[%s] Lagging agent %s is back online. Draining other partitions",
         PartConfig->GetName().c_str(),
         msg->AgentId.Quote().c_str());
 
@@ -688,14 +705,17 @@ void TLaggingAgentsReplicaProxyActor::HandleAgentIsBackOnline(
         std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsBackOnline>(
             msg->AgentId));
 
-    auto& state = AgentState[msg->AgentId];
-    if (state.State == EAgentState::Resyncing) {
-        return;
-    }
+    DrainRequestCounter++;
+    Y_ABORT_UNLESS(!CurrentDrainingAgents.contains(DrainRequestCounter));
+    CurrentDrainingAgents[DrainRequestCounter] = msg->AgentId;
+    NCloud::Send<NPartition::TEvPartition::TEvWaitForInFlightWritesRequest>(
+        ctx,
+        MirrorPartitionActorId,
+        DrainRequestCounter);
+
     Y_DEBUG_ABORT_UNLESS(!state.MigrationActorId);
     Y_DEBUG_ABORT_UNLESS(state.AvailabilityMonitoringActorId);
 
-    state.State = EAgentState::Resyncing;
     DestroyChildActor(ctx, &state.AvailabilityMonitoringActorId);
 
     TCompressedBitmap cleanBlocksCopy(PartConfig->GetBlockCount());
@@ -704,7 +724,7 @@ void TLaggingAgentsReplicaProxyActor::HandleAgentIsBackOnline(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] Starting lagging agent %s migration. Block count: %lu, dirty "
+        "[%s] Preparing lagging agent %s migration. Block count: %lu, dirty "
         "block count: %lu",
         PartConfig->GetName().c_str(),
         msg->AgentId.Quote().c_str(),
@@ -744,6 +764,9 @@ void TLaggingAgentsReplicaProxyActor::HandleLaggingAgentMigrationFinished(
     switch (state.State) {
         case EAgentState::Unavailable:
             return;
+        case EAgentState::WaitingForDrain:
+            Y_DEBUG_ABORT_UNLESS(false);
+            return;
         case EAgentState::Resyncing:
             break;
     }
@@ -764,6 +787,82 @@ void TLaggingAgentsReplicaProxyActor::HandleLaggingAgentMigrationFinished(
         PartConfig->GetParentActorId(),
         SelfId(),
         ev->ReleaseBase().Release()));
+}
+
+void TLaggingAgentsReplicaProxyActor::HandleWaitForInFlightWrites(
+    const NPartition::TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    ForwardMessageToActor(ev, ctx, NonreplPartitionActorId);
+}
+
+void TLaggingAgentsReplicaProxyActor::HandleWaitForInFlightWritesResponse(
+    const NPartition::TEvPartition::TEvWaitForInFlightWritesResponse::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (!CurrentDrainingAgents.contains(ev->Cookie)) {
+        return;
+    }
+
+    auto it = CurrentDrainingAgents.find(ev->Cookie);
+    TString agentId = std::move(it->second);
+    CurrentDrainingAgents.erase(it);
+
+    const auto* msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::PARTITION_WORKER,
+            "[%s] Failed to drain partitions for lagging agent %s: %s",
+            PartConfig->GetName().c_str(),
+            agentId.Quote().c_str(),
+            FormatError(msg->GetError()).c_str());
+
+        DrainRequestCounter++;
+        Y_ABORT_UNLESS(!CurrentDrainingAgents.contains(DrainRequestCounter));
+        CurrentDrainingAgents[DrainRequestCounter] = agentId;
+
+        ctx.ExecutorThread.Schedule(
+            TDuration::Seconds(1),
+            new IEventHandle(
+                MirrorPartitionActorId,
+                SelfId(),
+                new NPartition::TEvPartition::
+                    TEvWaitForInFlightWritesRequest()));
+        return;
+    }
+
+    Y_DEBUG_ABORT_UNLESS(AgentState.contains(agentId));
+    if (!AgentState.contains(agentId)) {
+        return;
+    }
+
+    auto& state = AgentState[agentId];
+    switch (state.State) {
+        case EAgentState::Unavailable:
+            return;
+        case EAgentState::WaitingForDrain:
+            break;
+        case EAgentState::Resyncing:
+            Y_DEBUG_ABORT_UNLESS(false);
+            return;
+    }
+
+    state.State = EAgentState::Resyncing;
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%s] Starting lagging agent %s migration. Block count: %lu, dirty "
+        "block count: %lu",
+        PartConfig->GetName().c_str(),
+        agentId.Quote().c_str(),
+        PartConfig->GetBlockCount(),
+        PartConfig->GetBlockCount() - state.CleanBlocksMap->Count());
+
+    Y_ABORT_UNLESS(state.MigrationActorId);
+    NCloud::Send<TEvNonreplPartitionPrivate::TEvStartLaggingAgentMigration>(
+        ctx,
+        state.MigrationActorId);
 }
 
 void TLaggingAgentsReplicaProxyActor::HandleWriteBlocks(
@@ -831,8 +930,7 @@ void TLaggingAgentsReplicaProxyActor::HandlePoisonPill(
     AgentState.clear();
 }
 
-void TLaggingAgentsReplicaProxyActor::Die(
-    const NActors::TActorContext& ctx)
+void TLaggingAgentsReplicaProxyActor::Die(const NActors::TActorContext& ctx)
 {
     TBase::Die(ctx);
 }
@@ -857,6 +955,12 @@ STFUNC(TLaggingAgentsReplicaProxyActor::StateWork)
         HFunc(
             TEvVolumePrivate::TEvLaggingAgentMigrationFinished,
             HandleLaggingAgentMigrationFinished);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            HandleWaitForInFlightWrites);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesResponse,
+            HandleWaitForInFlightWritesResponse);
         HFunc(TEvVolume::TEvRWClientIdChanged, HandleRWClientIdChanged);
 
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
@@ -883,7 +987,11 @@ STFUNC(TLaggingAgentsReplicaProxyActor::StateZombie)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
         HFunc(TEvService::TEvReadBlocksRequest, RejectReadBlocks);
         HFunc(TEvService::TEvReadBlocksLocalRequest, RejectReadBlocksLocal);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            RejectWaitForInFlightWrites);
 
+        IgnoreFunc(NPartition::TEvPartition::TEvWaitForInFlightWritesResponse);
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
         IgnoreFunc(TEvents::TEvPoisonPill);
         HFunc(TEvents::TEvPoisonTaken, PoisonPillHelper.HandlePoisonTaken);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
@@ -62,6 +62,8 @@ private:
     THashMap<TString, TAgentState> AgentState;
 
     ui64 DrainRequestCounter = 0;
+    // To determine which agent has drained in-flight writes by cookie in the
+    // response.
     THashMap<ui64, TString> CurrentDrainingAgents;
 
     TPoisonPillHelper PoisonPillHelper;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
@@ -7,6 +7,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
@@ -47,6 +48,7 @@ private:
     enum class EAgentState : ui8
     {
         Unavailable,
+        WaitingForDrain,
         Resyncing
     };
     struct TAgentState
@@ -58,6 +60,9 @@ private:
         std::unique_ptr<TCompressedBitmap> CleanBlocksMap;
     };
     THashMap<TString, TAgentState> AgentState;
+
+    ui64 DrainRequestCounter = 0;
+    THashMap<ui64, TString> CurrentDrainingAgents;
 
     TPoisonPillHelper PoisonPillHelper;
 
@@ -135,6 +140,11 @@ private:
         const TEvVolumePrivate::TEvLaggingAgentMigrationFinished::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleWaitForInFlightWritesResponse(
+        const NPartition::TEvPartition::TEvWaitForInFlightWritesResponse::TPtr&
+            ev,
+        const NActors::TActorContext& ctx);
+
     void HandleWriteOrZeroCompleted(
         const TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
@@ -170,6 +180,9 @@ private:
     BLOCKSTORE_IMPLEMENT_REQUEST(ZeroBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocksLocal, TEvService);
+    BLOCKSTORE_IMPLEMENT_REQUEST(
+        WaitForInFlightWrites,
+        NPartition::TEvPartition);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -691,6 +691,9 @@ STFUNC(TMirrorPartitionActor::StateWork)
         HFunc(TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest, HandleAddLaggingAgent);
         HFunc(TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest, HandleRemoveLaggingAgent);
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            DrainActorCompanion.HandleWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
@@ -750,6 +753,9 @@ STFUNC(TMirrorPartitionActor::StateZombie)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            RejectWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -175,12 +175,12 @@ private:
         const NActors::TActorContext& ctx);
 
     void HandleAddLaggingAgent(
-        const TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest::
-            TPtr& ev,
+        const TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleRemoveLaggingAgent(
-        const TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest::TPtr& ev,
+        const TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest::TPtr&
+            ev,
         const NActors::TActorContext& ctx);
 
     void HandlePoisonPill(
@@ -219,6 +219,9 @@ private:
     BLOCKSTORE_IMPLEMENT_REQUEST(ZeroBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(CheckRange, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(Drain, NPartition::TEvPartition);
+    BLOCKSTORE_IMPLEMENT_REQUEST(
+        WaitForInFlightWrites,
+        NPartition::TEvPartition);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(DescribeBlocks, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(CompactRange, TEvVolume);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
@@ -261,6 +261,9 @@ STFUNC(TMirrorPartitionResyncActor::StateWork)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            DrainActorCompanion.HandleWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
@@ -315,6 +318,9 @@ STFUNC(TMirrorPartitionResyncActor::StateZombie)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            RejectWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
@@ -223,6 +223,9 @@ private:
     BLOCKSTORE_IMPLEMENT_REQUEST(WriteBlocksLocal, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(ZeroBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(Drain, NPartition::TEvPartition);
+    BLOCKSTORE_IMPLEMENT_REQUEST(
+        WaitForInFlightWrites,
+        NPartition::TEvPartition);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(DescribeBlocks, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(CompactRange, TEvVolume);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -655,6 +655,7 @@ STFUNC(TNonreplicatedPartitionActor::StateWork)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, HandleWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(NPartition::TEvPartition::TEvWaitForInFlightWritesRequest, DrainActorCompanion.HandleWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
@@ -705,6 +706,7 @@ STFUNC(TNonreplicatedPartitionActor::StateZombie)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
+        HFunc(NPartition::TEvPartition::TEvWaitForInFlightWritesRequest, RejectWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -210,6 +210,9 @@ private:
     BLOCKSTORE_IMPLEMENT_REQUEST(DescribeBlocks, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(ChecksumBlocks, TEvNonreplPartitionPrivate);
     BLOCKSTORE_IMPLEMENT_REQUEST(Drain, NPartition::TEvPartition);
+    BLOCKSTORE_IMPLEMENT_REQUEST(
+        WaitForInFlightWrites,
+        NPartition::TEvPartition);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(CompactRange, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(GetCompactionStatus, TEvVolume);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -304,6 +304,10 @@ struct TEvNonreplPartitionPrivate
         {}
     };
 
+    struct TStartLaggingAgentMigration
+    {
+    };
+
     //
     // Events declaration
     //
@@ -332,6 +336,7 @@ struct TEvNonreplPartitionPrivate
         EvRemoveLaggingAgentRequest,
         EvAgentIsUnavailable,
         EvAgentIsBackOnline,
+        EvStartLaggingAgentMigration,
 
         BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(BLOCKSTORE_DECLARE_EVENT_IDS)
 
@@ -412,6 +417,11 @@ struct TEvNonreplPartitionPrivate
     using TEvAgentIsBackOnline = TRequestEvent<
         TAgentIsBackOnline,
         EvAgentIsBackOnline
+    >;
+
+    using TEvStartLaggingAgentMigration = TRequestEvent<
+        TStartLaggingAgentMigration,
+        EvStartLaggingAgentMigration
     >;
 
     BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(BLOCKSTORE_DECLARE_PROTO_EVENTS)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -242,6 +242,9 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateWork)
         HFunc(
             NPartition::TEvPartition::TEvDrainRequest,
             DrainActorCompanion.HandleDrain);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            DrainActorCompanion.HandleWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
@@ -306,6 +309,9 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateZombie)
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
 
         HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
+        HFunc(
+            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            RejectWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -208,6 +208,9 @@ public:
     // processed.
     ui64 GetProcessedBlockCount() const;
 
+    // Called from the inheritor to check if migration is allowed.
+    [[nodiscard]] bool IsMigrationAllowed() const;
+
     // IPoisonPillHelperOwner implementation
     void Die(const NActors::TActorContext& ctx) override
     {
@@ -220,7 +223,6 @@ protected:
     const TDiagnosticsConfigPtr& GetDiagnosticsConfig() const;
 
 private:
-    bool IsMigrationAllowed() const;
     bool IsMigrationFinished() const;
     bool IsIoDepthLimitReached() const;
     bool OverlapsWithInflightWriteAndZero(TBlockRange64 range) const;
@@ -303,6 +305,9 @@ private:
     BLOCKSTORE_IMPLEMENT_REQUEST(ZeroBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(ChecksumBlocks, TEvNonreplPartitionPrivate);
     BLOCKSTORE_IMPLEMENT_REQUEST(Drain, NPartition::TEvPartition);
+    BLOCKSTORE_IMPLEMENT_REQUEST(
+        WaitForInFlightWrites,
+        NPartition::TEvPartition);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(DescribeBlocks, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(CompactRange, TEvVolume);


### PR DESCRIPTION
#3
Добавляю новый тип drain: `WaitForInFlightWrites`. Это запрос, который дожидается завершения всех записей в полёте на момент получения сообщения. Нужно это перед началом миграции лагающего диска. 
Мигрировать сразу мы не можем, т.к. миграционный партишн не знает о текущих записях пользователя и начинает вычитывать из этих диапазонов, что может привести к чтению устареших данных.