### PR TITLE
Revert "issue-3: read from mirror partition during fresh device migration"

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -51,7 +51,6 @@ void TLaggingAgentMigrationActor::OnBootstrap(const TActorContext& ctx)
     InitWork(
         ctx,
         SourceActorId,
-        SourceActorId,
         TargetActorId,
         false,   // takeOwnershipOverActors
         std::make_unique<TMigrationTimeoutCalculator>(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -110,21 +110,17 @@ void TMirrorPartitionActor::SetupPartitions(const TActorContext& ctx)
     for (const auto& replicaInfo: State.GetReplicaInfos()) {
         IActorPtr actor;
         if (replicaInfo.Migrations.size()) {
-            auto migrationSrcActorId = State.IsMigrationConfigPreparedForFresh()
-                                           ? SelfId()
-                                           : TActorId();
             actor = CreateNonreplicatedPartitionMigration(
                 Config,
                 DiagnosticsConfig,
                 ProfileLog,
                 BlockDigestGenerator,
-                0,   // initialMigrationIndex
+                0,  // initialMigrationIndex
                 State.GetRWClientId(),
                 replicaInfo.Config,
                 replicaInfo.Migrations,
                 RdmaClient,
-                SelfId(),
-                migrationSrcActorId);
+                SelfId());
         } else {
             actor = CreateNonreplicatedPartition(
                 Config,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
@@ -17,13 +17,6 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TMirrorPartitionState
 {
-    enum class EMigrationConfigState
-    {
-        NotPrepared,
-        PreparedForFresh,
-        PreparedForWarning,
-    };
-
 private:
     const TStorageConfigPtr Config;
     const TNonreplicatedPartitionConfigPtr PartConfig;
@@ -35,8 +28,7 @@ private:
 
     ui32 ReadReplicaIndex = 0;
 
-    EMigrationConfigState MigrationConfigPrepared =
-        EMigrationConfigState::NotPrepared;
+    bool MigrationConfigPrepared = false;
 
 public:
     TMirrorPartitionState(
@@ -90,12 +82,6 @@ public:
     void PrepareMigrationConfig();
     [[nodiscard]] bool PrepareMigrationConfigForWarningDevices();
     [[nodiscard]] bool PrepareMigrationConfigForFreshDevices();
-
-    [[nodiscard]] bool IsMigrationConfigPreparedForFresh() const
-    {
-        return MigrationConfigPrepared ==
-               EMigrationConfigState::PreparedForFresh;
-    }
 
     [[nodiscard]] NProto::TError NextReadReplica(
         const TBlockRange64 readRange,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
@@ -184,7 +184,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
             1024,
             replica0.Config->GetDevices()[0].GetBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(
-            "1_2",
+            "4_1",
             replica0.Config->GetDevices()[1].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -205,7 +205,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         const auto& migrations0 = replica0.Migrations;
         UNIT_ASSERT_VALUES_EQUAL(1, migrations0.size());
 
-        UNIT_ASSERT_VALUES_EQUAL(TString(), migrations0[0].GetSourceDeviceId());
+        UNIT_ASSERT_VALUES_EQUAL("4_1", migrations0[0].GetSourceDeviceId());
         UNIT_ASSERT_VALUES_EQUAL(
             "1_2",
             migrations0[0].GetTargetDevice().GetDeviceUUID());
@@ -221,7 +221,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
             1024,
             replica1.Config->GetDevices()[0].GetBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(
-            "4_1",
+            "",
             replica1.Config->GetDevices()[1].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -289,7 +289,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica0 = state.GetReplicaInfos()[0];
         UNIT_ASSERT_VALUES_EQUAL(
-            "1_1",
+            "3_1",
             replica0.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -316,7 +316,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         const auto& migrations0 = replica0.Migrations;
         UNIT_ASSERT_VALUES_EQUAL(1, migrations0.size());
 
-        UNIT_ASSERT_VALUES_EQUAL(TString(), migrations0[0].GetSourceDeviceId());
+        UNIT_ASSERT_VALUES_EQUAL("3_1", migrations0[0].GetSourceDeviceId());
         UNIT_ASSERT_VALUES_EQUAL(
             "1_1",
             migrations0[0].GetTargetDevice().GetDeviceUUID());
@@ -326,7 +326,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica1 = state.GetReplicaInfos()[1];
         UNIT_ASSERT_VALUES_EQUAL(
-            "3_1",
+            "",
             replica1.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -384,7 +384,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica0 = state.GetReplicaInfos()[0];
         UNIT_ASSERT_VALUES_EQUAL(
-            "1_1",
+            "3_1",
             replica0.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -411,7 +411,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         const auto& migrations0 = replica0.Migrations;
         UNIT_ASSERT_VALUES_EQUAL(1, migrations0.size());
 
-        UNIT_ASSERT_VALUES_EQUAL(TString(), migrations0[0].GetSourceDeviceId());
+        UNIT_ASSERT_VALUES_EQUAL("3_1", migrations0[0].GetSourceDeviceId());
         UNIT_ASSERT_VALUES_EQUAL(
             "1_1",
             migrations0[0].GetTargetDevice().GetDeviceUUID());
@@ -421,7 +421,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica1 = state.GetReplicaInfos()[1];
         UNIT_ASSERT_VALUES_EQUAL(
-            "3_1",
+            "",
             replica1.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -1117,7 +1117,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(2, mr.MigratedRanges);
 
         UNIT_ASSERT_VALUES_EQUAL("test", mr.DiskId);
-        UNIT_ASSERT_VALUES_EQUAL(TString(), mr.SourceDeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("vasya#2", mr.SourceDeviceId);
         UNIT_ASSERT_VALUES_EQUAL("vasya", mr.TargetDeviceId);
 
         mr.TestAgentData("vasya", 'A', 2048);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.cpp
@@ -18,8 +18,7 @@ IActorPtr CreateNonreplicatedPartitionMigration(
     TNonreplicatedPartitionConfigPtr partConfig,
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
     NRdma::IClientPtr rdmaClient,
-    NActors::TActorId statActorId,
-    NActors::TActorId migrationSrcActorId)
+    NActors::TActorId statActorId)
 {
     return std::make_unique<TNonreplicatedPartitionMigrationActor>(
         std::move(config),
@@ -31,8 +30,7 @@ IActorPtr CreateNonreplicatedPartitionMigration(
         std::move(partConfig),
         std::move(migrations),
         std::move(rdmaClient),
-        statActorId,
-        migrationSrcActorId);
+        statActorId);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.h
@@ -24,7 +24,6 @@ NActors::IActorPtr CreateNonreplicatedPartitionMigration(
     TNonreplicatedPartitionConfigPtr partConfig,
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
     NRdma::IClientPtr rdmaClient,
-    NActors::TActorId statActorId,
-    NActors::TActorId migrationSrcActorId = NActors::TActorId());
+    NActors::TActorId statActorId);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -16,7 +16,6 @@ private:
     TNonreplicatedPartitionConfigPtr SrcConfig;
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> Migrations;
     NRdma::IClientPtr RdmaClient;
-    NActors::TActorId MigrationSrcActorId;
 
     bool UpdatingMigrationState = false;
     bool MigrationFinished = false;
@@ -32,8 +31,7 @@ public:
         TNonreplicatedPartitionConfigPtr srcConfig,
         google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
         NRdma::IClientPtr rdmaClient,
-        NActors::TActorId statActorId,
-        NActors::TActorId migrationSrcActorId);
+        NActors::TActorId statActorId);
 
     // IMigrationOwner implementation
     void OnBootstrap(const NActors::TActorContext& ctx) override;
@@ -44,19 +42,6 @@ public:
         ui64 migrationIndex) override;
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
-
-private:
-
-    bool IsMigrationTarget(const NProto::TDeviceConfig& device) const
-    {
-        return AnyOf(
-            Migrations,
-            [&](const NProto::TDeviceMigration& m)
-            {
-                return m.GetTargetDevice().GetDeviceUUID() ==
-                       device.GetDeviceUUID();
-            });
-    }
 
 private:
     void PrepareForMigration(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -96,7 +96,6 @@ private:
     const ui32 MaxIoDepth;
     TString RWClientId;
 
-    NActors::TActorId MigrationSrcActorId;
     NActors::TActorId SrcActorId;
     NActors::TActorId DstActorId;
     bool ActorOwner = false;
@@ -189,7 +188,6 @@ public:
     // Called from the inheritor to initialize migration.
     void InitWork(
         const NActors::TActorContext& ctx,
-        NActors::TActorId migrationSrcActorId,
         NActors::TActorId srcActorId,
         NActors::TActorId dstActorId,
         bool takeOwnershipOverActors,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_checksumblocks.cpp
@@ -12,7 +12,10 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleChecksumBlocks(
     const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    ForwardRequestWithNondeliveryTracking(ctx, SrcActorId, *ev);
+    ForwardRequestWithNondeliveryTracking(
+        ctx,
+        SrcActorId,
+        *ev);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -23,13 +23,11 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 void TNonreplicatedPartitionMigrationCommonActor::InitWork(
     const NActors::TActorContext& ctx,
-    NActors::TActorId migrationSrcActorId,
     NActors::TActorId srcActorId,
     NActors::TActorId dstActorId,
     bool takeOwnershipOverActors,
     std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator)
 {
-    MigrationSrcActorId = migrationSrcActorId;
     SrcActorId = srcActorId;
     DstActorId = dstActorId;
     TimeoutCalculator = std::move(timeoutCalculator);
@@ -113,7 +111,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
                 MakeIntrusive<TCallContext>()),
             BlockSize,
             range,
-            MigrationSrcActorId,
+            SrcActorId,
             DstActorId,
             RWClientId,
             BlockDigestGenerator);
@@ -126,7 +124,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
                 MakeIntrusive<TCallContext>()),
             BlockSize,
             range,
-            MigrationSrcActorId,
+            SrcActorId,
             DstActorId,
             RWClientId,
             BlockDigestGenerator);
@@ -137,7 +135,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationAllowed() const
 {
-    return MigrationSrcActorId && DstActorId && MigrationEnabled;
+    return SrcActorId && DstActorId && MigrationEnabled;
 }
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationFinished() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_readblocks.cpp
@@ -12,7 +12,10 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleReadBlocks(
     const TEvService::TEvReadBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    ForwardRequestWithNondeliveryTracking(ctx, SrcActorId, *ev);
+    ForwardRequestWithNondeliveryTracking(
+        ctx,
+        SrcActorId,
+        *ev);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -1,4 +1,3 @@
-#include "part_nonrepl_migration.h"
 #include "part_nonrepl_migration_actor.h"
 #include "ut_env.h"
 
@@ -211,7 +210,7 @@ struct TTestEnv
         auto partConfig =
             std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
-        auto part = CreateNonreplicatedPartitionMigration(
+        auto part = std::make_unique<TNonreplicatedPartitionMigrationActor>(
             std::move(config),
             CreateDiagnosticsConfig(),
             CreateProfileLogStub(),

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -850,7 +850,6 @@ void TShadowDiskActor::CreateShadowDiskPartitionActor(
         InitWork(
             ctx,
             SrcActorId,
-            SrcActorId,
             DstActorId,
             true,   // takeOwnershipOverActors
             std::make_unique<TMigrationTimeoutCalculator>(


### PR DESCRIPTION
Reverts ydb-platform/nbs#3075 and ydb-platform/nbs#3149

В #3075 потеряли гарантию что пользователь не пишет в мигрируемый диапазон. Из-за этого после наливки фреша реплики могут отличаться по данным. 
Сценарий:
1. в миррор партишен пришел запрос на запись в рендж [x, y]
2. в реплике с мигрирующим фрешом запись  в [x, y] блоки прошла во фреш девайc
3. начинаем мигрировать рейндж, который включает в себя рейндж блоков [x, y]
4. читаем из остальных реплик данные, в которые еще не прошла запись из пункта 1 и перетираем в мигрурующей реплике уже записанные пользователем данные.
5. запись из пункта 1 проходит в оставшиеся реплики и получаем расхождения по данным