### PR TITLE
Apply resync policy to all

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -518,12 +518,9 @@ void TMirrorPartitionActor::HandleRangeResynced(
     const auto* msg = ev->Get();
 
     LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Range %s resync finished: mi=%lu mj=%lu/%lu %s",
+        "[%s] Range %s resync finished: %s",
         DiskId.c_str(),
         DescribeRange(msg->Range).c_str(),
-        msg->FixedMinorErrorCount,
-        msg->FixedMajorErrorCount,
-        msg->FoundMajorErrorCount,
         FormatError(msg->GetError()).c_str());
 
     ResyncRangeStarted = false;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync.cpp
@@ -19,7 +19,8 @@ IActorPtr CreateMirrorPartitionResync(
     TVector<TDevices> replicaDevices,
     NRdma::IClientPtr rdmaClient,
     NActors::TActorId statActorId,
-    ui64 initialResyncIndex)
+    ui64 initialResyncIndex,
+    NProto::EResyncPolicy resyncPolicy)
 {
     return std::make_unique<TMirrorPartitionResyncActor>(
         std::move(config),
@@ -32,7 +33,8 @@ IActorPtr CreateMirrorPartitionResync(
         std::move(replicaDevices),
         std::move(rdmaClient),
         statActorId,
-        initialResyncIndex);
+        initialResyncIndex,
+        resyncPolicy);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync.h
@@ -4,6 +4,7 @@
 
 #include "config.h"
 
+#include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
@@ -25,6 +26,7 @@ NActors::IActorPtr CreateMirrorPartitionResync(
     TVector<TDevices> replicaDevices,
     NRdma::IClientPtr rdmaClient,
     NActors::TActorId statActorId,
-    ui64 initialResyncIndex);
+    ui64 initialResyncIndex,
+    NProto::EResyncPolicy resyncPolicy);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
@@ -34,11 +34,13 @@ TMirrorPartitionResyncActor::TMirrorPartitionResyncActor(
         TVector<TDevices> replicaDevices,
         NRdma::IClientPtr rdmaClient,
         NActors::TActorId statActorId,
-        ui64 initialResyncIndex)
+        ui64 initialResyncIndex,
+        NProto::EResyncPolicy resyncPolicy)
     : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(digestGenerator))
+    , ResyncPolicy(resyncPolicy)
     , RWClientId(std::move(rwClientId))
     , PartConfig(std::move(partConfig))
     , Migrations(std::move(migrations))

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
@@ -41,6 +41,8 @@ private:
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
+    const NProto::EResyncPolicy ResyncPolicy;
+
     TString RWClientId;
     TNonreplicatedPartitionConfigPtr PartConfig;
     TMigrations Migrations;
@@ -99,7 +101,8 @@ public:
         TVector<TDevices> replicaDevices,
         NRdma::IClientPtr rdmaClient,
         NActors::TActorId statActorId,
-        ui64 initialResyncIndex);
+        ui64 initialResyncIndex,
+        NProto::EResyncPolicy resyncPolicy);
 
     ~TMirrorPartitionResyncActor();
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -149,12 +149,9 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
     const auto rangeId = BlockRange2RangeId(range, PartConfig->GetBlockSize());
 
     LOG_DEBUG(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Range %s resync finished: mi=%lu mj=%lu/%lu %s",
+        "[%s] Range %s resync finished: %s",
         PartConfig->GetName().c_str(),
         DescribeRange(range).c_str(),
-        msg->FixedMinorErrorCount,
-        msg->FixedMajorErrorCount,
-        msg->FoundMajorErrorCount,
         FormatError(msg->GetError()).c_str());
 
     STORAGE_VERIFY(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
@@ -343,7 +343,10 @@ struct TTestEnv
         // Runtime.SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
     }
 
-    void StartResync(ui64 initialResyncIndex = 0)
+    void StartResync(
+        ui64 initialResyncIndex = 0,
+        NProto::EResyncPolicy resyncPolicy =
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB)
     {
         auto actor = std::make_unique<TMirrorPartitionResyncActor>(
             Config,
@@ -357,7 +360,7 @@ struct TTestEnv
             nullptr,   // rdmaClient
             VolumeActorId,
             initialResyncIndex,
-            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB);
+            resyncPolicy);
 
         actor->SetRequestIdentityKey(RequestIdentityKey);
 
@@ -636,7 +639,9 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionResyncTest)
             counters.RequestCounters.ReadBlocks.RequestBytes);
     }
 
-    void DoTestShouldResyncWholeDisk(ui32 blockSize)
+    void DoTestShouldResyncWholeDisk(
+        ui32 blockSize,
+        NProto::EResyncPolicy resyncPolicy)
     {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, blockSize);
@@ -647,7 +652,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionResyncTest)
         env.WriteReplica(1, range, 'B');
         env.WriteReplica(2, range, 'B');
 
-        env.StartResync();
+        env.StartResync(0, resyncPolicy);
         env.ResyncController.WaitForResyncedRangeCount(5);
         UNIT_ASSERT(env.ResyncController.ResyncFinished);
 
@@ -678,14 +683,171 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionResyncTest)
         UNIT_ASSERT_VALUES_EQUAL(5, env.ResyncController.ResyncedRanges.size());
     }
 
-    Y_UNIT_TEST(ShouldResyncWholeDisk)
+    Y_UNIT_TEST(ShouldResyncWholeDisk_MINOR_4MB)
     {
-        DoTestShouldResyncWholeDisk(4_KB);
+        DoTestShouldResyncWholeDisk(4_KB, NProto::RESYNC_POLICY_MINOR_4MB);
+        DoTestShouldResyncWholeDisk(128_KB, NProto::RESYNC_POLICY_MINOR_4MB);
     }
 
-    Y_UNIT_TEST(ShouldResyncWholeDiskWithLargeBlockSize)
+    Y_UNIT_TEST(ShouldResyncWholeDisk_MINOR_AND_MAJOR_4MB)
     {
-        DoTestShouldResyncWholeDisk(128_KB);
+        DoTestShouldResyncWholeDisk(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_4MB);
+        DoTestShouldResyncWholeDisk(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_4MB);
+    }
+
+    Y_UNIT_TEST(ShouldResyncWholeDisk_MINOR_BLOCK_BY_BLOCK)
+    {
+        DoTestShouldResyncWholeDisk(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
+        DoTestShouldResyncWholeDisk(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
+    }
+
+    Y_UNIT_TEST(ShouldResyncWholeDisk_MINOR_AND_MAJOR_BLOCK_BY_BLOCK)
+    {
+        DoTestShouldResyncWholeDisk(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
+        DoTestShouldResyncWholeDisk(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
+    }
+
+    void DoTestShouldResyncWholeDiskWithMajor(
+        ui32 blockSize,
+        NProto::EResyncPolicy resyncPolicy)
+    {
+        using EResyncPolicy = NProto::EResyncPolicy;
+
+        // When fixing a major error, the result will vary depending on the
+        // policy.
+        // 1. RESYNC_POLICY_MINOR_4_MB will not fix 4MB, we get 'AAAA...' in
+        //    first, 'BBBB...' in second and 'CBBB...' in third replica
+        // 2. RESYNC_POLICY_MINOR_AND_MAJOR_4_MB will select the first replica
+        //    for all 4MB and we will get 'AAAA' in all replicas
+        // 3. RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK will fix all blocks with minor
+        //    errors and we will get 'ABBB...' in first replica, 'BBBB...' in
+        //    second and 'CBBBB...' in third
+        // 4. RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK the heuristic
+        //    will work well and we will get 'BBBB...' in all replicas
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, blockSize);
+
+        const auto range = TBlockRange64::WithLength(0, 5120 * 4_KB / blockSize);
+        const auto range4MB = TBlockRange64::WithLength(0, 4_MB / blockSize);
+
+        env.WriteMirror(range, 'A');
+        env.WriteReplica(1, range, 'B');
+        env.WriteReplica(2, range, 'B');
+        env.WriteReplica(2, TBlockRange64::MakeOneBlock(0), 'C');
+
+        env.StartResync(0, resyncPolicy);
+        env.ResyncController.WaitForResyncedRangeCount(5);
+        UNIT_ASSERT(env.ResyncController.ResyncFinished);
+
+        // Check individual replicas
+        auto blocks0 = env.ReadReplica(0, range);
+        auto blocks1 = env.ReadReplica(1, range);
+        auto blocks2 = env.ReadReplica(2, range);
+        for (size_t i = 0; i < blocks0.size(); ++i ) {
+            char expected0 = 'B';
+            char expected1 = 'B';
+            char expected2 = 'B';
+            if (i == 0) {
+                switch (resyncPolicy) {
+                    case EResyncPolicy::RESYNC_POLICY_MINOR_4MB: {
+                        expected0 = 'A';
+                        expected2 = 'C';
+                    } break;
+                    case EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB: {
+                        expected0 = 'A';
+                        expected1 = 'A';
+                        expected2 = 'A';
+                    } break;
+                    case NProto::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK: {
+                        expected0 = 'A';
+                        expected2 = 'C';
+                    } break;
+                    case NProto::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK:
+                        break;
+                }
+            }
+            if (i > 0 && range4MB.Contains(i)) {
+                switch (resyncPolicy) {
+                    case EResyncPolicy::RESYNC_POLICY_MINOR_4MB: {
+                        expected0 = 'A';
+                    } break;
+                    case EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB: {
+                        expected0 = 'A';
+                        expected1 = 'A';
+                        expected2 = 'A';
+                    } break;
+                    case NProto::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK:
+                    case NProto::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK:
+                        break;
+                }
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(TString(blockSize, expected0), blocks0[i]);
+            UNIT_ASSERT_VALUES_EQUAL(TString(blockSize, expected1), blocks1[i]);
+            UNIT_ASSERT_VALUES_EQUAL(TString(blockSize, expected2), blocks2[i]);
+        }
+
+        const ui32 expectedResyncRangeSize = 4_MB;
+        for (const auto& resyncRange: env.ResyncController.ResyncedRanges) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedResyncRangeSize,
+                resyncRange.Size() * blockSize);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(5, env.ResyncController.ResyncedRanges.size());
+    }
+
+    Y_UNIT_TEST(ShouldResyncWholeDiskWithMajor_MINOR_4MB)
+    {
+        DoTestShouldResyncWholeDiskWithMajor(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_4MB);
+        DoTestShouldResyncWholeDiskWithMajor(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_4MB);
+    }
+
+    Y_UNIT_TEST(ShouldResyncWholeDiskWithMajor_MINOR_AND_MAJOR_4MB)
+    {
+        DoTestShouldResyncWholeDiskWithMajor(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_4MB);
+        DoTestShouldResyncWholeDiskWithMajor(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_4MB);
+    }
+
+    Y_UNIT_TEST(ShouldResyncWholeDiskWithMajor_MINOR_BLOCK_BY_BLOCK)
+    {
+        DoTestShouldResyncWholeDiskWithMajor(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
+
+        DoTestShouldResyncWholeDiskWithMajor(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
+    }
+
+    Y_UNIT_TEST(ShouldResyncWholeDiskWithMajor_MINOR_AND_MAJOR_BLOCK_BY_BLOCK)
+    {
+        DoTestShouldResyncWholeDiskWithMajor(
+            4_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
+        DoTestShouldResyncWholeDiskWithMajor(
+            128_KB,
+            NProto::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
     }
 
     Y_UNIT_TEST(ShouldResyncFromStartIndex)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
@@ -350,14 +350,14 @@ struct TTestEnv
             CreateDiagnosticsConfig(),
             CreateProfileLogStub(),
             CreateBlockDigestGeneratorStub(),
-            "", // rwClientId
+            "",   // rwClientId
             PartConfig,
             TMigrations(),
             Replicas,
-            nullptr, // rdmaClient
+            nullptr,   // rdmaClient
             VolumeActorId,
-            initialResyncIndex
-        );
+            initialResyncIndex,
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_4MB);
 
         actor->SetRequestIdentityKey(RequestIdentityKey);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.cpp
@@ -22,7 +22,6 @@ TBlockRange64 RangeId2BlockRange(ui32 rangeId, ui32 blockSize)
     return TBlockRange64::WithLength(start, resyncRangeBlockCount);
 }
 
-
 bool CanFixMismatch(bool isMinor, NProto::EResyncPolicy resyncPolicy)
 {
     return isMinor ||
@@ -36,7 +35,8 @@ std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
     TVector<TReplicaDescriptor> replicas,
     TString writerClientId,
     IBlockDigestGeneratorPtr blockDigestGenerator,
-    NProto::EResyncPolicy resyncPolicy)
+    NProto::EResyncPolicy resyncPolicy,
+    EBlockRangeChecksumStatus checksumStatus)
 {
     if (resyncPolicy == NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB ||
         resyncPolicy ==
@@ -48,7 +48,8 @@ std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
             range,
             std::move(replicas),
             std::move(writerClientId),
-            blockDigestGenerator);
+            std::move(blockDigestGenerator),
+            resyncPolicy);
     }
 
     return std::make_unique<TResyncRangeBlockByBlockActor>(
@@ -57,8 +58,9 @@ std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
         range,
         std::move(replicas),
         std::move(writerClientId),
-        blockDigestGenerator,
-        resyncPolicy);
+        std::move(blockDigestGenerator),
+        resyncPolicy,
+        checksumStatus == EBlockRangeChecksumStatus::Unknown);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
@@ -15,6 +15,14 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class EBlockRangeChecksumStatus
+{
+    Unknown,
+    MinorError,
+    MajorError,
+    Ok
+};
+
 struct TReplicaDescriptor
 {
     TString ReplicaId;
@@ -43,6 +51,7 @@ std::unique_ptr<NActors::IActor> MakeResyncRangeActor(
     TVector<TReplicaDescriptor> replicas,
     TString writerClientId,
     IBlockDigestGeneratorPtr blockDigestGenerator,
-    NProto::EResyncPolicy resyncPolicy);
+    NProto::EResyncPolicy resyncPolicy,
+    EBlockRangeChecksumStatus checksumStatus);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -147,9 +147,6 @@ struct TEvNonreplPartitionPrivate
         TInstant WriteStartTs;
         TDuration WriteDuration;
         TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
-        size_t FixedMinorErrorCount;
-        size_t FixedMajorErrorCount;
-        size_t FoundMajorErrorCount;
 
         TRangeResynced(
                 TBlockRange64 range,
@@ -159,10 +156,7 @@ struct TEvNonreplPartitionPrivate
                 TDuration readDuration,
                 TInstant writeStartTs,
                 TDuration writeDuration,
-                TVector<IProfileLog::TBlockInfo> affectedBlockInfos,
-                size_t fixedMinorErrorCount,
-                size_t fixedMajorErrorCount,
-                size_t foundMajorErrorCount)
+                TVector<IProfileLog::TBlockInfo> affectedBlockInfos)
             : Range(range)
             , ChecksumStartTs(checksumStartTs)
             , ChecksumDuration(checksumDuration)
@@ -171,9 +165,6 @@ struct TEvNonreplPartitionPrivate
             , WriteStartTs(writeStartTs)
             , WriteDuration(writeDuration)
             , AffectedBlockInfos(std::move(affectedBlockInfos))
-            , FixedMinorErrorCount(fixedMinorErrorCount)
-            , FixedMajorErrorCount(fixedMajorErrorCount)
-            , FoundMajorErrorCount(foundMajorErrorCount)
         {
         }
     };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -147,6 +147,9 @@ struct TEvNonreplPartitionPrivate
         TInstant WriteStartTs;
         TDuration WriteDuration;
         TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
+        size_t FixedMinorErrorCount;
+        size_t FixedMajorErrorCount;
+        size_t FoundMajorErrorCount;
 
         TRangeResynced(
                 TBlockRange64 range,
@@ -156,7 +159,10 @@ struct TEvNonreplPartitionPrivate
                 TDuration readDuration,
                 TInstant writeStartTs,
                 TDuration writeDuration,
-                TVector<IProfileLog::TBlockInfo> affectedBlockInfos)
+                TVector<IProfileLog::TBlockInfo> affectedBlockInfos,
+                size_t fixedMinorErrorCount,
+                size_t fixedMajorErrorCount,
+                size_t foundMajorErrorCount)
             : Range(range)
             , ChecksumStartTs(checksumStartTs)
             , ChecksumDuration(checksumDuration)
@@ -165,6 +171,9 @@ struct TEvNonreplPartitionPrivate
             , WriteStartTs(writeStartTs)
             , WriteDuration(writeDuration)
             , AffectedBlockInfos(std::move(affectedBlockInfos))
+            , FixedMinorErrorCount(fixedMinorErrorCount)
+            , FixedMajorErrorCount(fixedMajorErrorCount)
+            , FoundMajorErrorCount(foundMajorErrorCount)
         {
         }
     };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.h
@@ -41,9 +41,6 @@ private:
     TInstant WriteStartTs;
     TDuration WriteDuration;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
-    size_t FixedMinorErrorCount = 0;
-    size_t FixedMajorErrorCount = 0;
-    size_t FoundMajorErrorCount = 0;
 
     TChecksumRangeActorCompanion ChecksumRangeActorCompanion{Replicas};
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.h
@@ -28,6 +28,7 @@ private:
     const TVector<TReplicaDescriptor> Replicas;
     const TString WriterClientId;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
+    const NProto::EResyncPolicy ResyncPolicy;
 
     TVector<int> ActorsToResync;
     ui32 ResyncedCount = 0;
@@ -40,6 +41,9 @@ private:
     TInstant WriteStartTs;
     TDuration WriteDuration;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
+    size_t FixedMinorErrorCount = 0;
+    size_t FixedMajorErrorCount = 0;
+    size_t FoundMajorErrorCount = 0;
 
     TChecksumRangeActorCompanion ChecksumRangeActorCompanion{Replicas};
 
@@ -50,7 +54,8 @@ public:
         TBlockRange64 range,
         TVector<TReplicaDescriptor> replicas,
         TString writerClientId,
-        IBlockDigestGeneratorPtr blockDigestGenerator);
+        IBlockDigestGeneratorPtr blockDigestGenerator,
+        NProto::EResyncPolicy resyncPolicy);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
@@ -248,17 +248,17 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
         }
     }
 
-    FixedMinorErrorCount = Accumulate(
+    size_t fixedMinorErrorCount = Accumulate(
         healStat,
         size_t{},
         [](size_t count, const THealStat& h)
         { return count + h.FixedMinorErrorCount; });
-    FixedMajorErrorCount = Accumulate(
+    size_t fixedMajorErrorCount = Accumulate(
         healStat,
         size_t{},
         [](size_t count, const THealStat& h)
         { return count + h.FixedMajorErrorCount; });
-    FoundMajorErrorCount = Accumulate(
+    size_t foundMajorErrorCount = Accumulate(
         healStat,
         size_t{},
         [](size_t count, const THealStat& h)
@@ -283,10 +283,10 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
         Replicas[bestHealer].ReplicaId.c_str(),
         bestHealer,
         Range.Print().c_str(),
-        FixedMinorErrorCount,
-        FixedMajorErrorCount,
-        FoundMajorErrorCount,
-        (FoundMajorErrorCount == 0 ? "All blocks healed as minor! " : ""),
+        fixedMinorErrorCount,
+        fixedMajorErrorCount,
+        foundMajorErrorCount,
+        (foundMajorErrorCount == 0 ? "All blocks healed as minor! " : ""),
         replicaStat.c_str(),
         blocksWithMajorErrors.c_str());
 
@@ -408,10 +408,7 @@ void TResyncRangeBlockByBlockActor::Done(const TActorContext& ctx)
             ReadDuration,
             WriteStartTs,
             WriteDuration,
-            std::move(AffectedBlockInfos),
-            FixedMinorErrorCount,
-            FixedMajorErrorCount,
-            FoundMajorErrorCount);
+            std::move(AffectedBlockInfos));
 
     LWTRACK(
         ResponseSent_PartitionWorker,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
@@ -135,7 +135,8 @@ TResyncRangeBlockByBlockActor::TResyncRangeBlockByBlockActor(
         TVector<TReplicaDescriptor> replicas,
         TString writerClientId,
         IBlockDigestGeneratorPtr blockDigestGenerator,
-        NProto::EResyncPolicy resyncPolicy)
+        NProto::EResyncPolicy resyncPolicy,
+        bool performChecksumPreliminaryCheck)
     : RequestInfo(std::move(requestInfo))
     , BlockSize(blockSize)
     , Range(range)
@@ -143,7 +144,14 @@ TResyncRangeBlockByBlockActor::TResyncRangeBlockByBlockActor(
     , WriterClientId(std::move(writerClientId))
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , ResyncPolicy(resyncPolicy)
-{}
+    , PerformChecksumPreliminaryCheck(performChecksumPreliminaryCheck)
+{
+    using EResyncPolicy = NProto::EResyncPolicy;
+    Y_DEBUG_ABORT_UNLESS(
+        ResyncPolicy == EResyncPolicy::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK ||
+        ResyncPolicy ==
+            EResyncPolicy::RESYNC_POLICY_MINOR_AND_MAJOR_BLOCK_BY_BLOCK);
+}
 
 void TResyncRangeBlockByBlockActor::Bootstrap(const TActorContext& ctx)
 {
@@ -157,11 +165,28 @@ void TResyncRangeBlockByBlockActor::Bootstrap(const TActorContext& ctx)
         "ResyncRangeBlockByBlock",
         RequestInfo->CallContext->RequestId);
 
-    ReadBuffers.resize(Replicas.size());
-    for (size_t replica = 0; replica < Replicas.size(); replica++) {
-        ActorsToResync.push_back(replica);
-        ReadReplicaBlocks(ctx, replica);
+    if (PerformChecksumPreliminaryCheck) {
+        ChecksumRangeActorCompanion.CalculateChecksums(ctx, Range);
+    } else {
+        ReadBlocks(ctx);
     }
+}
+
+void TResyncRangeBlockByBlockActor::CompareChecksums(const TActorContext& ctx)
+{
+    const auto& checksums = ChecksumRangeActorCompanion.GetChecksums();
+    THashMap<ui64, ui32> checksumCount;
+    for (auto checksum : checksums) {
+        ++checksumCount[checksum];
+    }
+
+    if (checksumCount.size() == 1) {
+        // all checksums match
+        Done(ctx);
+        return;
+    }
+
+    ReadBlocks(ctx);
 }
 
 void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
@@ -223,17 +248,17 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
         }
     }
 
-    size_t fixedMinorErrorCount = Accumulate(
+    FixedMinorErrorCount = Accumulate(
         healStat,
         size_t{},
         [](size_t count, const THealStat& h)
         { return count + h.FixedMinorErrorCount; });
-    size_t fixedMajorErrorCount = Accumulate(
+    FixedMajorErrorCount = Accumulate(
         healStat,
         size_t{},
         [](size_t count, const THealStat& h)
         { return count + h.FixedMajorErrorCount; });
-    size_t foundMajorErrorCount = Accumulate(
+    FoundMajorErrorCount = Accumulate(
         healStat,
         size_t{},
         [](size_t count, const THealStat& h)
@@ -258,10 +283,10 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
         Replicas[bestHealer].ReplicaId.c_str(),
         bestHealer,
         Range.Print().c_str(),
-        fixedMinorErrorCount,
-        fixedMajorErrorCount,
-        foundMajorErrorCount,
-        (foundMajorErrorCount == 0 ? "All blocks healed as minor! " : ""),
+        FixedMinorErrorCount,
+        FixedMajorErrorCount,
+        FoundMajorErrorCount,
+        (FoundMajorErrorCount == 0 ? "All blocks healed as minor! " : ""),
         replicaStat.c_str(),
         blocksWithMajorErrors.c_str());
 
@@ -271,6 +296,15 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
         if (healStat[i].FixedMinorErrorCount || healStat[i].FixedMajorErrorCount) {
             ActorsToResync.push_back(i);
         }
+    }
+}
+
+void TResyncRangeBlockByBlockActor::ReadBlocks(const TActorContext& ctx)
+{
+    ReadBuffers.resize(Replicas.size());
+    for (size_t replica = 0; replica < Replicas.size(); replica++) {
+        ActorsToResync.push_back(replica);
+        ReadReplicaBlocks(ctx, replica);
     }
 }
 
@@ -374,7 +408,10 @@ void TResyncRangeBlockByBlockActor::Done(const TActorContext& ctx)
             ReadDuration,
             WriteStartTs,
             WriteDuration,
-            std::move(AffectedBlockInfos));
+            std::move(AffectedBlockInfos),
+            FixedMinorErrorCount,
+            FixedMajorErrorCount,
+            FoundMajorErrorCount);
 
     LWTRACK(
         ResponseSent_PartitionWorker,
@@ -388,6 +425,35 @@ void TResyncRangeBlockByBlockActor::Done(const TActorContext& ctx)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TResyncRangeBlockByBlockActor::HandleChecksumUndelivery(
+    const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    ChecksumRangeActorCompanion.HandleChecksumUndelivery(ctx);
+    Error = ChecksumRangeActorCompanion.GetError();
+
+    Done(ctx);
+}
+
+void TResyncRangeBlockByBlockActor::HandleChecksumResponse(
+    const TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    ChecksumRangeActorCompanion.HandleChecksumResponse(ev, ctx);
+
+    Error = ChecksumRangeActorCompanion.GetError();
+    if (HasError(Error)) {
+        Done(ctx);
+        return;
+    }
+
+    if (ChecksumRangeActorCompanion.IsFinished()) {
+        CompareChecksums(ctx);
+    }
+}
 
 void TResyncRangeBlockByBlockActor::HandleReadUndelivery(
     const TEvService::TEvReadBlocksRequest::TPtr& ev,
@@ -481,7 +547,12 @@ STFUNC(TResyncRangeBlockByBlockActor::StateWork)
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
-
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest,
+            HandleChecksumUndelivery);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse,
+            HandleChecksumResponse);
         HFunc(TEvService::TEvReadBlocksRequest, HandleReadUndelivery);
         HFunc(TEvService::TEvReadBlocksResponse, HandleReadResponse);
         HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteUndelivery);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "part_mirror_resync_util.h"
-#include "part_nonrepl_events_private.h"
 
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/checksum_range.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 
@@ -29,6 +29,7 @@ private:
     const TString WriterClientId;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const NProto::EResyncPolicy ResyncPolicy;
+    const bool PerformChecksumPreliminaryCheck;
 
     TVector<size_t> ActorsToResync;
     ui32 ResyncedCount = 0;
@@ -40,6 +41,11 @@ private:
     TInstant WriteStartTs;
     TDuration WriteDuration;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
+    size_t FixedMinorErrorCount = 0;
+    size_t FixedMajorErrorCount = 0;
+    size_t FoundMajorErrorCount = 0;
+
+    TChecksumRangeActorCompanion ChecksumRangeActorCompanion{Replicas};
 
 public:
     TResyncRangeBlockByBlockActor(
@@ -49,12 +55,15 @@ public:
         TVector<TReplicaDescriptor> replicas,
         TString writerClientId,
         IBlockDigestGeneratorPtr blockDigestGenerator,
-        NProto::EResyncPolicy resyncPolicy);
+        NProto::EResyncPolicy resyncPolicy,
+        bool performChecksumPreliminaryCheck);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
 private:
+    void CompareChecksums(const NActors::TActorContext& ctx);
     void PrepareWriteBuffers(const NActors::TActorContext& ctx);
+    void ReadBlocks(const NActors::TActorContext& ctx);
     void ReadReplicaBlocks(
         const NActors::TActorContext& ctx,
         size_t replicaIndex);
@@ -67,6 +76,14 @@ private:
 
 private:
     STFUNC(StateWork);
+
+    void HandleChecksumResponse(
+        const TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleChecksumUndelivery(
+        const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
 
     void HandleReadResponse(
         const TEvService::TEvReadBlocksResponse::TPtr& ev,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.h
@@ -41,9 +41,6 @@ private:
     TInstant WriteStartTs;
     TDuration WriteDuration;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
-    size_t FixedMinorErrorCount = 0;
-    size_t FixedMajorErrorCount = 0;
-    size_t FoundMajorErrorCount = 0;
 
     TChecksumRangeActorCompanion ChecksumRangeActorCompanion{Replicas};
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -228,7 +228,8 @@ struct TTestEnv
             std::move(replicas),
             "",   // rwClientId
             BlockDigestGenerator,
-            resyncPolicy);
+            resyncPolicy,
+            EBlockRangeChecksumStatus::Unknown);
 
         Runtime.Register(actor.release(), 0);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_ut.cpp
@@ -639,7 +639,8 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldNotReplaceMajorBlocksMismatchAccordingToPolicy)
+    void DoShouldNotReplaceMajorBlocksMismatchAccordingToPolicy(
+        NProto::EResyncPolicy resyncPolicy)
     {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -653,11 +654,7 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
         env.WriteReplica(0, blockWithMajorError, blockWithMajorError, 'x');
         env.WriteReplica(1, blockWithMajorError, blockWithMajorError, 'y');
 
-        auto response = env.ResyncRange(
-            0,
-            1023,
-            {0, 1, 2},
-            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
+        auto response = env.ResyncRange(0, 1023, {0, 1, 2}, resyncPolicy);
         UNIT_ASSERT(!HasError(response->GetError()));
 
         // Check replica 0
@@ -689,6 +686,18 @@ Y_UNIT_TEST_SUITE(TResyncRangeTest)
                 UNIT_ASSERT_VALUES_EQUAL(TString(DefaultBlockSize, 'A'), block);
             }
         }
+    }
+
+    Y_UNIT_TEST(ShouldNotReplaceMajorBlocksMismatchAccordingToPolicy)
+    {
+        DoShouldNotReplaceMajorBlocksMismatchAccordingToPolicy(
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB);
+    }
+
+    Y_UNIT_TEST(ShouldNotReplaceMajorBlocksMismatchAccordingToPolicyBlockByBlock)
+    {
+        DoShouldNotReplaceMajorBlocksMismatchAccordingToPolicy(
+            NProto::EResyncPolicy::RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK);
     }
 
     Y_UNIT_TEST(ShouldHealMinorErrorsAndSelectBestHealerForMajorSource)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -230,6 +230,9 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
         // XXX naming (nonreplicated)
         if (State->IsMirrorResyncNeeded()) {
             // mirrored disk in resync state
+            auto resyncPolicy = State->IsForceMirrorResync()
+                                    ? Config->GetForceResyncPolicy()
+                                    : Config->GetAutoResyncPolicy();
             nonreplicatedActorId = NCloud::Register(
                 ctx,
                 CreateMirrorPartitionResync(
@@ -243,7 +246,8 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
                     std::move(replicas),
                     GetRdmaClient(),
                     SelfId(),
-                    State->GetMeta().GetResyncIndex()));
+                    State->GetMeta().GetResyncIndex(),
+                    resyncPolicy));
         } else {
             // mirrored disk (may be in migration state)
             nonreplicatedActorId = NCloud::Register(

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -748,6 +748,11 @@ public:
         return Meta.GetResyncNeeded();
     }
 
+    bool IsForceMirrorResync() const
+    {
+        return ForceMirrorResync;
+    }
+
     TVector<NProto::TDeviceConfig> GetAllDevicesForAcquireRelease() const;
 
     //


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/pull/3239
1. Теперь все политики по ресинку применяются и можно гибко настроить как чинить разъехавшиеся блоки.
2. научил старый актор ресинка учитывать политику и не чинить только миноры, если задана такая политика.
3. Новый актор для ресинка научился перед тем как начать работу узнавать чексуммы из всех реплик, и если чексуммы совпадают, то ничего не делать. Это нужно для автоматического или force-ресинка.