### PR TITLE
Suppress performance-enum-size clang-tidy warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks: >
   -llvm-header-guard,
   -llvmlibc-*,
   -modernize-use-trailing-return-type,
+  -performance-enum-size,
   -readability-avoid-const-params-in-decls,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,


### PR DESCRIPTION
Убрал предупреждение clang-tidy что у перечислений слишком большой базовый тип