### PR TITLE
Fix duplicate symbol error for YdbDefaultPDiskSequence

### DIFF
--- a/cloud/blockstore/apps/disk_agent/ya.make
+++ b/cloud/blockstore/apps/disk_agent/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     cloud/storage/core/libs/daemon
 
     contrib/ydb/core/security
+    contrib/ydb/library/keys
 
     library/cpp/getopt
 )

--- a/cloud/blockstore/apps/server/ya.make
+++ b/cloud/blockstore/apps/server/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
     cloud/storage/core/libs/iam/iface
 
     contrib/ydb/core/security
+    contrib/ydb/library/keys
 
     library/cpp/getopt
 )

--- a/cloud/filestore/apps/server/ya.make
+++ b/cloud/filestore/apps/server/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     cloud/storage/core/libs/daemon
 
     contrib/ydb/core/security
+    contrib/ydb/library/keys
 )
 
 YQL_LAST_ABI_VERSION()

--- a/cloud/filestore/apps/vhost/ya.make
+++ b/cloud/filestore/apps/vhost/ya.make
@@ -21,6 +21,7 @@ PEERDIR(
     cloud/storage/core/libs/daemon
 
     contrib/ydb/core/security
+    contrib/ydb/library/keys
 )
 
 YQL_LAST_ABI_VERSION()

--- a/cloud/storage/core/libs/kikimr/ya.make
+++ b/cloud/storage/core/libs/kikimr/ya.make
@@ -30,7 +30,6 @@ PEERDIR(
     contrib/ydb/library/actors/util
     contrib/ydb/library/actors/protos
     contrib/ydb/library/actors/wilson
-    contrib/ydb/library/keys
 
     contrib/ydb/core/base
     contrib/ydb/core/config/init


### PR DESCRIPTION
Кажется разобрался почему у нас не линковался тест.
1. есть символ https://github.com/ydb-platform/nbs/blob/main/contrib/ydb/core/blobstorage/crypto/default.h#L8 который объявлен extern
2. есть определение, которое должно попадать в релизный бинарь https://github.com/ydb-platform/nbs/blob/main/contrib/ydb/library/keys/default_keys.cpp#L6
3. есть определение, которое должно попадать в тестовые бинари https://github.com/ydb-platform/nbs/blob/main/contrib/ydb/core/testlib/basics/services.cpp#L40
4. кроме этого много где в тестах символ переопределен прям в cpp например https://github.com/ydb-platform/nbs/blob/main/contrib/ydb/core/blobstorage/ut_vdisk/vdisk_test.cpp#L21
5. мы добавляли зависимость от contrib/ydb/library/keys в промежуточной либе cloud/storage/core/libs/kikimr которая использовалась как для сборки релизного бинаря 
6. Все тесты зависят как от этой cloud/storage/core/libs/kikimr так и тестовой contrib/ydb/core/testlib/basics. Вот тут у нас уже есть проблема, но она пока не стреляет
7. добавляется тест вывод через << optional<ui64>, для этого типа где-то определена такая функция, все работает.
8. а вот тут моя гипотеза: в аркадии при поиске этого символа из-за изменившегося порядка линковщик обходит большее количество объектников и натыкается что оказывается символ то определен 2 раза и падает с ошибкой, которая вообще никак не связана с operator<<(optional<ui64>)
```
ld.lld: error: duplicate symbol: __odr_asan_gen__ZN7NKikimr6NPDisk23YdbDefaultPDiskSequenceE
>>> defined at default_keys.cpp
>>>            default_keys.cpp.pic.o:(__odr_asan_gen__ZN7NKikimr6NPDisk23YdbDefaultPDiskSequenceE) in archive contrib/ydb/library/keys/libydb-library-keys.a
>>> defined at services.cpp
>>>            services.cpp.pic.o:(.bss.__odr_asan_gen__ZN7NKikimr6NPDisk23YdbDefaultPDiskSequenceE+0x0) in archive contrib/ydb/core/testlib/basics/libcore-testlib-basics.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
9. после удаления вызова << (https://github.com/ydb-platform/nbs/pull/3270) ему не надо перебирать кучу объектников, и он не находит ошибки и собирает бинарь.
10. YDB зависят от определения один раз и только в бинаре. https://github.com/ydb-platform/nbs/blob/main/contrib/ydb/apps/ydbd/ya.make#L45 я сделал также