### PR TITLE
[Disk Manager] add checkpointID to image meta, set checkpointID to snapshot/image meta on created

### DIFF
--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -516,34 +516,31 @@ func (s *storageYDB) imageCreated(
 	state := states[0]
 
 	if state.status == imageStatusReady {
-		if state.checkpointID != checkpointID {
+		if state.checkpointID != checkpointID ||
+			state.size != imageSize ||
+			state.storageSize != imageStorageSize {
+
+			makeParamsString := func(
+				checkpointID string,
+				size uint64,
+				storageSize uint64,
+			) string {
+
+				return fmt.Sprintf(
+					"checkpoint id: %v, size: %v, storage size: %v",
+					checkpointID,
+					size,
+					storageSize,
+				)
+			}
+
 			return errors.NewNonRetriableErrorf(
-				"image with id %v and checkpoint id %v can't be created, "+
-					"because image with the same id and another "+
-					"checkpoint id %v already exists",
+				"image with id %v and parameters (%v) can't be created, "+
+					"because image with the same id and different parameters (%v) "+
+					"already exists",
 				imageID,
-				checkpointID,
-				state.checkpointID,
-			)
-		}
-		if state.size != imageSize {
-			return errors.NewNonRetriableErrorf(
-				"image with id %v and size %v can't be created, "+
-					"because image with the same id and another "+
-					"size %v already exists",
-				imageID,
-				imageSize,
-				state.size,
-			)
-		}
-		if state.storageSize != imageStorageSize {
-			return errors.NewNonRetriableErrorf(
-				"image with id %v and storage size %v can't be created, "+
-					"because image with the same id and another "+
-					"storage size %v already exists",
-				imageID,
-				imageStorageSize,
-				state.storageSize,
+				makeParamsString(checkpointID, imageSize, imageStorageSize),
+				makeParamsString(state.checkpointID, state.size, state.storageSize),
 			)
 		}
 

--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -516,31 +516,14 @@ func (s *storageYDB) imageCreated(
 	state := states[0]
 
 	if state.status == imageStatusReady {
-		if state.checkpointID != checkpointID ||
-			state.size != imageSize ||
-			state.storageSize != imageStorageSize {
-
-			makeParamsString := func(
-				checkpointID string,
-				size uint64,
-				storageSize uint64,
-			) string {
-
-				return fmt.Sprintf(
-					"checkpoint id: %v, size: %v, storage size: %v",
-					checkpointID,
-					size,
-					storageSize,
-				)
-			}
-
+		if state.checkpointID != checkpointID {
 			return errors.NewNonRetriableErrorf(
-				"image with id %v and parameters (%v) can't be created, "+
-					"because image with the same id and different parameters (%v) "+
-					"already exists",
+				"image with id %v and checkpoint id %v can't be created, "+
+					"because image with the same id and another "+
+					"checkpoint id %v already exists",
 				imageID,
-				makeParamsString(checkpointID, imageSize, imageStorageSize),
-				makeParamsString(state.checkpointID, state.size, state.storageSize),
+				checkpointID,
+				state.checkpointID,
 			)
 		}
 

--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -53,6 +53,7 @@ type imageState struct {
 	id                string
 	folderID          string
 	srcDiskID         string
+	checkpointID      string
 	srcImageID        string
 	srcSnapshotID     string
 	createRequest     []byte
@@ -79,6 +80,7 @@ func (s *imageState) toImageMeta() *ImageMeta {
 		ID:                s.id,
 		FolderID:          s.folderID,
 		SrcDiskID:         s.srcDiskID,
+		CheckpointID:      s.checkpointID,
 		SrcImageID:        s.srcImageID,
 		SrcSnapshotID:     s.srcSnapshotID,
 		CreateTaskID:      s.createTaskID,
@@ -103,6 +105,7 @@ func (s *imageState) structValue() persistence.Value {
 		persistence.StructFieldValue("id", persistence.UTF8Value(s.id)),
 		persistence.StructFieldValue("folder_id", persistence.UTF8Value(s.folderID)),
 		persistence.StructFieldValue("src_disk_id", persistence.UTF8Value(s.srcDiskID)),
+		persistence.StructFieldValue("checkpoint_id", persistence.UTF8Value(s.checkpointID)),
 		persistence.StructFieldValue("src_image_id", persistence.UTF8Value(s.srcImageID)),
 		persistence.StructFieldValue("src_snapshot_id", persistence.UTF8Value(s.srcSnapshotID)),
 		persistence.StructFieldValue("create_request", persistence.StringValue(s.createRequest)),
@@ -127,6 +130,7 @@ func scanImageState(res persistence.Result) (state imageState, err error) {
 		persistence.OptionalWithDefault("id", &state.id),
 		persistence.OptionalWithDefault("folder_id", &state.folderID),
 		persistence.OptionalWithDefault("src_disk_id", &state.srcDiskID),
+		persistence.OptionalWithDefault("checkpoint_id", &state.checkpointID),
 		persistence.OptionalWithDefault("src_image_id", &state.srcImageID),
 		persistence.OptionalWithDefault("src_snapshot_id", &state.srcSnapshotID),
 		persistence.OptionalWithDefault("create_request", &state.createRequest),
@@ -172,6 +176,7 @@ func imageStateStructTypeString() string {
 		id: Utf8,
 		folder_id: Utf8,
 		src_disk_id: Utf8,
+		checkpoint_id: Utf8,
 		src_image_id: Utf8,
 		src_snapshot_id: Utf8,
 		create_request: String,
@@ -195,6 +200,7 @@ func imageStateTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("folder_id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("src_disk_id", persistence.Optional(persistence.TypeUTF8)),
+		persistence.WithColumn("checkpoint_id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("src_image_id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("src_snapshot_id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("create_request", persistence.Optional(persistence.TypeString)),
@@ -460,6 +466,7 @@ func (s *storageYDB) imageCreated(
 	ctx context.Context,
 	session *persistence.Session,
 	imageID string,
+	checkpointID string,
 	createdAt time.Time,
 	imageSize uint64,
 	imageStorageSize uint64,
@@ -527,6 +534,7 @@ func (s *storageYDB) imageCreated(
 	}
 
 	state.status = imageStatusReady
+	state.checkpointID = checkpointID
 	state.createdAt = createdAt
 	state.size = imageSize
 	state.storageSize = imageStorageSize
@@ -853,6 +861,7 @@ func (s *storageYDB) CreateImage(
 func (s *storageYDB) ImageCreated(
 	ctx context.Context,
 	imageID string,
+	checkpointID string,
 	createdAt time.Time,
 	imageSize uint64,
 	imageStorageSize uint64,
@@ -865,6 +874,7 @@ func (s *storageYDB) ImageCreated(
 				ctx,
 				session,
 				imageID,
+				checkpointID,
 				createdAt,
 				imageSize,
 				imageStorageSize,

--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -516,6 +516,37 @@ func (s *storageYDB) imageCreated(
 	state := states[0]
 
 	if state.status == imageStatusReady {
+		if state.checkpointID != checkpointID {
+			return errors.NewNonRetriableErrorf(
+				"image with id %v and checkpoint id %v can't be created, "+
+					"because image with the same id and another "+
+					"checkpoint id %v already exists",
+				imageID,
+				checkpointID,
+				state.checkpointID,
+			)
+		}
+		if state.size != imageSize {
+			return errors.NewNonRetriableErrorf(
+				"image with id %v and size %v can't be created, "+
+					"because image with the same id and another "+
+					"size %v already exists",
+				imageID,
+				imageSize,
+				state.size,
+			)
+		}
+		if state.storageSize != imageStorageSize {
+			return errors.NewNonRetriableErrorf(
+				"image with id %v and storage size %v can't be created, "+
+					"because image with the same id and another "+
+					"storage size %v already exists",
+				imageID,
+				imageStorageSize,
+				state.storageSize,
+			)
+		}
+
 		// Nothing to do.
 		return tx.Commit(ctx)
 	}

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -379,6 +379,7 @@ func TestImagesGetImage(t *testing.T) {
 	require.NotNil(t, actualImage)
 	requireImagesAreEqual(t, expectedImage, *actualImage)
 
+	// Checkpoint id differs.
 	err = storage.ImageCreated(
 		ctx,
 		imageID,
@@ -389,6 +390,8 @@ func TestImagesGetImage(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
+
+	// Image size differs.
 	err = storage.ImageCreated(
 		ctx,
 		imageID,
@@ -399,6 +402,8 @@ func TestImagesGetImage(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
+
+	// Image storage size differs.
 	err = storage.ImageCreated(
 		ctx,
 		imageID,

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -18,6 +18,7 @@ func requireImagesAreEqual(t *testing.T, expected ImageMeta, actual ImageMeta) {
 	require.Equal(t, expected.ID, actual.ID)
 	require.Equal(t, expected.FolderID, actual.FolderID)
 	require.True(t, proto.Equal(expected.CreateRequest, actual.CreateRequest))
+	require.Equal(t, expected.CheckpointID, actual.CheckpointID)
 	require.Equal(t, expected.CreateTaskID, actual.CreateTaskID)
 	if !expected.CreatingAt.IsZero() {
 		require.WithinDuration(t, expected.CreatingAt, actual.CreatingAt, time.Microsecond)
@@ -62,11 +63,11 @@ func TestImagesCreateImage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, image.ID, created.ID)
 
-	err = storage.ImageCreated(ctx, image.ID, time.Now(), 0, 0)
+	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)
 	require.NoError(t, err)
 
 	// Check idempotency.
-	err = storage.ImageCreated(ctx, image.ID, time.Now(), 0, 0)
+	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)
 	require.NoError(t, err)
 
 	// Check idempotency.
@@ -115,7 +116,7 @@ func TestImagesDeleteImage(t *testing.T) {
 	require.NoError(t, err)
 	requireImagesAreEqual(t, expected, *actual)
 
-	err = storage.ImageCreated(ctx, image.ID, time.Now(), 0, 0)
+	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
 
@@ -140,7 +141,7 @@ func TestImagesDeleteImage(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
 
-	err = storage.ImageCreated(ctx, image.ID, time.Now(), 0, 0)
+	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
 }
@@ -163,7 +164,7 @@ func TestImagesDeleteNonexistentImage(t *testing.T) {
 	err = storage.ImageDeleted(ctx, image.ID, time.Now())
 	require.NoError(t, err)
 
-	err = storage.ImageCreated(ctx, image.ID, time.Now(), 0, 0)
+	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
 
@@ -311,10 +312,11 @@ func TestImagesGetImage(t *testing.T) {
 	imageID := t.Name()
 	imageSize := uint64(2 * 1024 * 1024)
 	imageStorageSize := uint64(3 * 1024 * 1024)
+	checkpointID := "checkpoint"
 
-	i, err := storage.GetImageMeta(ctx, imageID)
+	actualImage, err := storage.GetImageMeta(ctx, imageID)
 	require.NoError(t, err)
-	require.Nil(t, i)
+	require.Nil(t, actualImage)
 
 	image := ImageMeta{
 		ID:       imageID,
@@ -333,22 +335,46 @@ func TestImagesGetImage(t *testing.T) {
 
 	image.CreateRequest = nil
 
-	i, err = storage.GetImageMeta(ctx, imageID)
+	actualImage, err = storage.GetImageMeta(ctx, imageID)
 	require.NoError(t, err)
-	require.NotNil(t, i)
-	requireImagesAreEqual(t, image, *i)
-	require.Equal(t, imageID, i.ID)
-	require.Equal(t, "folder", i.FolderID)
+	require.NotNil(t, actualImage)
+	requireImagesAreEqual(t, image, *actualImage)
+	require.Equal(t, imageID, actualImage.ID)
+	require.Equal(t, "folder", actualImage.FolderID)
 
-	err = storage.ImageCreated(ctx, imageID, time.Now(), imageSize, imageStorageSize)
+	err = storage.ImageCreated(
+		ctx,
+		imageID,
+		checkpointID,
+		time.Now(),
+		imageSize,
+		imageStorageSize,
+	)
 	require.NoError(t, err)
 
 	image.Size = imageSize
 	image.StorageSize = imageStorageSize
+	image.CheckpointID = checkpointID
 	image.Ready = true
 
-	i, err = storage.GetImageMeta(ctx, imageID)
+	actualImage, err = storage.GetImageMeta(ctx, imageID)
 	require.NoError(t, err)
-	require.NotNil(t, i)
-	requireImagesAreEqual(t, image, *i)
+	require.NotNil(t, actualImage)
+	requireImagesAreEqual(t, image, *actualImage)
+
+	// Check idempotency.
+	err = storage.ImageCreated(
+		ctx,
+		imageID,
+		"foo", // checkpointID
+		time.Now(),
+		42,  // imageSize
+		713, // imageStorageSize
+	)
+	require.NoError(t, err)
+
+	actualImage, err = storage.GetImageMeta(ctx, imageID)
+	require.NoError(t, err)
+	require.NotNil(t, actualImage)
+	requireImagesAreEqual(t, image, *actualImage)
 }

--- a/cloud/disk_manager/internal/pkg/resources/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/resources/mocks/storage_mock.go
@@ -97,12 +97,20 @@ func (s *StorageMock) CreateImage(
 func (s *StorageMock) ImageCreated(
 	ctx context.Context,
 	imageID string,
+	checkpointID string,
 	createdAt time.Time,
 	imageSize uint64,
 	imageStorageSize uint64,
 ) error {
 
-	args := s.Called(ctx, imageID, createdAt, imageSize, imageStorageSize)
+	args := s.Called(
+		ctx,
+		imageID,
+		checkpointID,
+		createdAt,
+		imageSize,
+		imageStorageSize,
+	)
 	return args.Error(0)
 }
 
@@ -170,12 +178,20 @@ func (s *StorageMock) CreateSnapshot(
 func (s *StorageMock) SnapshotCreated(
 	ctx context.Context,
 	snapshotID string,
+	checkpointID string,
 	createdAt time.Time,
 	snapshotSize uint64,
 	snapshotStorageSize uint64,
 ) error {
 
-	args := s.Called(ctx, snapshotID, createdAt, snapshotSize, snapshotStorageSize)
+	args := s.Called(
+		ctx,
+		snapshotID,
+		checkpointID,
+		createdAt,
+		snapshotSize,
+		snapshotStorageSize,
+	)
 	return args.Error(0)
 }
 

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -492,31 +492,14 @@ func (s *storageYDB) snapshotCreated(
 	state := states[0]
 
 	if state.status == snapshotStatusReady {
-		if state.checkpointID != checkpointID ||
-			state.size != snapshotSize ||
-			state.storageSize != snapshotStorageSize {
-
-			makeParamsString := func(
-				checkpointID string,
-				size uint64,
-				storageSize uint64,
-			) string {
-
-				return fmt.Sprintf(
-					"checkpoint id: %v, size: %v, storage size: %v",
-					checkpointID,
-					size,
-					storageSize,
-				)
-			}
-
+		if state.checkpointID != checkpointID {
 			return errors.NewNonRetriableErrorf(
-				"snapshot with id %v and parameters (%v) can't be created, "+
-					"because snapshot with the same id and different parameters (%v) "+
-					"already exists",
+				"snapshot with id %v and checkpoint id %v can't be created, "+
+					"because snapshot with the same id and another "+
+					"checkpoint id %v already exists",
 				snapshotID,
-				makeParamsString(checkpointID, snapshotSize, snapshotStorageSize),
-				makeParamsString(state.checkpointID, state.size, state.storageSize),
+				checkpointID,
+				state.checkpointID,
 			)
 		}
 

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -492,34 +492,31 @@ func (s *storageYDB) snapshotCreated(
 	state := states[0]
 
 	if state.status == snapshotStatusReady {
-		if state.checkpointID != checkpointID {
+		if state.checkpointID != checkpointID ||
+			state.size != snapshotSize ||
+			state.storageSize != snapshotStorageSize {
+
+			makeParamsString := func(
+				checkpointID string,
+				size uint64,
+				storageSize uint64,
+			) string {
+
+				return fmt.Sprintf(
+					"checkpoint id: %v, size: %v, storage size: %v",
+					checkpointID,
+					size,
+					storageSize,
+				)
+			}
+
 			return errors.NewNonRetriableErrorf(
-				"snapshot with id %v and checkpoint id %v can't be created, "+
-					"because snapshot with the same id and another "+
-					"checkpoint id %v already exists",
+				"snapshot with id %v and parameters (%v) can't be created, "+
+					"because snapshot with the same id and different parameters (%v) "+
+					"already exists",
 				snapshotID,
-				checkpointID,
-				state.checkpointID,
-			)
-		}
-		if state.size != snapshotSize {
-			return errors.NewNonRetriableErrorf(
-				"snapshot with id %v and size %v can't be created, "+
-					"because snapshot with the same id and another "+
-					"size %v already exists",
-				snapshotID,
-				snapshotSize,
-				state.size,
-			)
-		}
-		if state.storageSize != snapshotStorageSize {
-			return errors.NewNonRetriableErrorf(
-				"snapshot with id %v and storage size %v can't be created, "+
-					"because snapshot with the same id and another "+
-					"storage size %v already exists",
-				snapshotID,
-				snapshotStorageSize,
-				state.storageSize,
+				makeParamsString(checkpointID, snapshotSize, snapshotStorageSize),
+				makeParamsString(state.checkpointID, state.size, state.storageSize),
 			)
 		}
 

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -389,7 +389,6 @@ func (s *storageYDB) createSnapshot(
 		folderID:          snapshot.FolderID,
 		zoneID:            snapshot.Disk.ZoneId,
 		diskID:            snapshot.Disk.DiskId,
-		checkpointID:      snapshot.CheckpointID,
 		createRequest:     createRequest,
 		createTaskID:      snapshot.CreateTaskID,
 		creatingAt:        snapshot.CreatingAt,
@@ -445,6 +444,7 @@ func (s *storageYDB) snapshotCreated(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
+	checkpointID string,
 	createdAt time.Time,
 	snapshotSize uint64,
 	snapshotStorageSize uint64,
@@ -505,6 +505,7 @@ func (s *storageYDB) snapshotCreated(
 	}
 
 	state.status = snapshotStatusReady
+	state.checkpointID = checkpointID
 	state.createdAt = createdAt
 	state.size = snapshotSize
 	state.storageSize = snapshotStorageSize
@@ -829,6 +830,7 @@ func (s *storageYDB) CreateSnapshot(
 func (s *storageYDB) SnapshotCreated(
 	ctx context.Context,
 	snapshotID string,
+	checkpointID string,
 	createdAt time.Time,
 	snapshotSize uint64,
 	snapshotStorageSize uint64,
@@ -841,6 +843,7 @@ func (s *storageYDB) SnapshotCreated(
 				ctx,
 				session,
 				snapshotID,
+				checkpointID,
 				createdAt,
 				snapshotSize,
 				snapshotStorageSize,

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -492,6 +492,37 @@ func (s *storageYDB) snapshotCreated(
 	state := states[0]
 
 	if state.status == snapshotStatusReady {
+		if state.checkpointID != checkpointID {
+			return errors.NewNonRetriableErrorf(
+				"snapshot with id %v and checkpoint id %v can't be created, "+
+					"because snapshot with the same id and another "+
+					"checkpoint id %v already exists",
+				snapshotID,
+				checkpointID,
+				state.checkpointID,
+			)
+		}
+		if state.size != snapshotSize {
+			return errors.NewNonRetriableErrorf(
+				"snapshot with id %v and size %v can't be created, "+
+					"because snapshot with the same id and another "+
+					"size %v already exists",
+				snapshotID,
+				snapshotSize,
+				state.size,
+			)
+		}
+		if state.storageSize != snapshotStorageSize {
+			return errors.NewNonRetriableErrorf(
+				"snapshot with id %v and storage size %v can't be created, "+
+					"because snapshot with the same id and another "+
+					"storage size %v already exists",
+				snapshotID,
+				snapshotStorageSize,
+				state.storageSize,
+			)
+		}
+
 		// Nothing to do.
 		return tx.Commit(ctx)
 	}

--- a/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
@@ -384,6 +384,7 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 	require.NotNil(t, actualSnapshot)
 	requireSnapshotsAreEqual(t, expectedSnapshot, *actualSnapshot)
 
+	// Checkpoint id differs.
 	err = storage.SnapshotCreated(
 		ctx,
 		snapshotID,
@@ -394,6 +395,8 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
+
+	// Snapshot size differs.
 	err = storage.SnapshotCreated(
 		ctx,
 		snapshotID,
@@ -404,6 +407,8 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
+
+	// Snapshot storage size differs.
 	err = storage.SnapshotCreated(
 		ctx,
 		snapshotID,

--- a/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
@@ -343,10 +343,13 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 	expectedSnapshot := snapshot
 	expectedSnapshot.CreateRequest = nil
 
-	actualSnapshot, err = storage.GetSnapshotMeta(ctx, snapshotID)
-	require.NoError(t, err)
-	require.NotNil(t, actualSnapshot)
-	requireSnapshotsAreEqual(t, expectedSnapshot, *actualSnapshot)
+	checkSnapshot := func() {
+		actualSnapshot, err := storage.GetSnapshotMeta(ctx, snapshotID)
+		require.NoError(t, err)
+		require.NotNil(t, actualSnapshot)
+		requireSnapshotsAreEqual(t, expectedSnapshot, *actualSnapshot)
+	}
+	checkSnapshot()
 
 	err = storage.SnapshotCreated(
 		ctx,
@@ -362,11 +365,7 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 	expectedSnapshot.StorageSize = snapshotStorageSize
 	expectedSnapshot.CheckpointID = checkpointID
 	expectedSnapshot.Ready = true
-
-	actualSnapshot, err = storage.GetSnapshotMeta(ctx, snapshotID)
-	require.NoError(t, err)
-	require.NotNil(t, actualSnapshot)
-	requireSnapshotsAreEqual(t, expectedSnapshot, *actualSnapshot)
+	checkSnapshot()
 
 	// Check idempotency.
 	err = storage.SnapshotCreated(
@@ -378,11 +377,7 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 		snapshotStorageSize,
 	)
 	require.NoError(t, err)
-
-	actualSnapshot, err = storage.GetSnapshotMeta(ctx, snapshotID)
-	require.NoError(t, err)
-	require.NotNil(t, actualSnapshot)
-	requireSnapshotsAreEqual(t, expectedSnapshot, *actualSnapshot)
+	checkSnapshot()
 
 	// Checkpoint id differs.
 	err = storage.SnapshotCreated(
@@ -395,6 +390,7 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
+	checkSnapshot()
 
 	// Snapshot size differs.
 	err = storage.SnapshotCreated(
@@ -405,8 +401,8 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 		42, // snapshotSize
 		snapshotStorageSize,
 	)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
+	require.NoError(t, err)
+	checkSnapshot()
 
 	// Snapshot storage size differs.
 	err = storage.SnapshotCreated(
@@ -417,11 +413,6 @@ func TestSnapshotsGetSnapshot(t *testing.T) {
 		snapshotSize,
 		713, // snapshotStorageSize
 	)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, errors.NewEmptyNonRetriableError()))
-
-	actualSnapshot, err = storage.GetSnapshotMeta(ctx, snapshotID)
 	require.NoError(t, err)
-	require.NotNil(t, actualSnapshot)
-	requireSnapshotsAreEqual(t, expectedSnapshot, *actualSnapshot)
+	checkSnapshot()
 }

--- a/cloud/disk_manager/internal/pkg/resources/storage.go
+++ b/cloud/disk_manager/internal/pkg/resources/storage.go
@@ -41,6 +41,7 @@ type ImageMeta struct {
 	ID                string                `json:"id"`
 	FolderID          string                `json:"folder_id"`
 	SrcDiskID         string                `json:"src_disk_id"`
+	CheckpointID      string                `json:"checkpoint_id"`
 	SrcImageID        string                `json:"src_image_id"`
 	SrcSnapshotID     string                `json:"src_snapshot_id"`
 	CreateRequest     proto.Message         `json:"create_request"`
@@ -135,6 +136,7 @@ type Storage interface {
 	ImageCreated(
 		ctx context.Context,
 		imageID string,
+		checkpointID string,
 		createdAt time.Time,
 		imageSize uint64,
 		imageStorageSize uint64,
@@ -168,6 +170,7 @@ type Storage interface {
 	SnapshotCreated(
 		ctx context.Context,
 		snapshotID string,
+		checkpointID string,
 		createdAt time.Time,
 		snapshotSize uint64,
 		snapshotStorageSize uint64,

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_disk_task.go
@@ -146,6 +146,7 @@ func (t *createImageFromDiskTask) run(
 	return t.storage.ImageCreated(
 		ctx,
 		t.request.DstImageId,
+		checkpointID,
 		time.Now(),
 		uint64(t.state.ImageSize),
 		uint64(t.state.ImageStorageSize),

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_image_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_image_task.go
@@ -160,6 +160,7 @@ func (t *createImageFromImageTask) Run(
 	err = t.storage.ImageCreated(
 		ctx,
 		t.request.DstImageId,
+		"", // checkpointID
 		time.Now(),
 		uint64(t.state.ImageSize),
 		uint64(t.state.ImageStorageSize),

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_snapshot_task.go
@@ -160,6 +160,7 @@ func (t *createImageFromSnapshotTask) Run(
 	err = t.storage.ImageCreated(
 		ctx,
 		t.request.DstImageId,
+		"", // checkpointID
 		time.Now(),
 		uint64(t.state.ImageSize),
 		uint64(t.state.ImageStorageSize),

--- a/cloud/disk_manager/internal/pkg/services/images/create_image_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/services/images/create_image_from_url_task.go
@@ -121,6 +121,7 @@ func (t *createImageFromURLTask) Run(
 	err = t.storage.ImageCreated(
 		ctx,
 		t.request.DstImageId,
+		"", // checkpointID
 		time.Now(),
 		uint64(t.state.ImageSize),
 		uint64(t.state.ImageStorageSize),

--- a/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/create_snapshot_from_disk_task.go
@@ -144,6 +144,7 @@ func (t *createSnapshotFromDiskTask) run(
 	return t.storage.SnapshotCreated(
 		ctx,
 		t.request.DstSnapshotId,
+		checkpointID,
 		time.Now(),
 		uint64(t.state.SnapshotSize),
 		uint64(t.state.SnapshotStorageSize),


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1950

Now CheckpointID field in image/snapshot meta works similar to *Size and *StorageSize fields. In is not set on CreateImage/CreateSnapshot. Instead, it is set on ImageCreated/SnapshotCreated.

Needed for retries of checkpoint creation for failed shadow disks, since we don't know checkpoint id untill snapshot/image is created.