### PR TITLE
[Disk Manager] Ignore retry limit for local disk creation task on E_TRY_AGAIN

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -139,6 +139,25 @@ func isDiskRegistryBasedDisk(mediaKind core_protos.EStorageMediaKind) bool {
 	return false
 }
 
+func IsLocalDisk(kind types.DiskKind) bool {
+	mediaKind, err := getStorageMediaKind(kind)
+	if err != nil {
+		return false
+	}
+
+	return isLocalDisk(mediaKind)
+}
+
+func isLocalDisk(mediaKind core_protos.EStorageMediaKind) bool {
+	switch mediaKind {
+	case core_protos.EStorageMediaKind_STORAGE_MEDIA_HDD_LOCAL,
+		core_protos.EStorageMediaKind_STORAGE_MEDIA_SSD_LOCAL:
+		return true
+	}
+
+	return false
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func toEncryptionMode(
@@ -383,6 +402,17 @@ func isAbortedError(e error) bool {
 	var clientErr *nbs_client.ClientError
 	if errors.As(e, &clientErr) {
 		if clientErr.Code == nbs_client.E_ABORTED {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsTryAgainError(e error) bool {
+	var clientErr *nbs_client.ClientError
+	if errors.As(e, &clientErr) {
+		if clientErr.Code == nbs_client.E_TRY_AGAIN {
 			return true
 		}
 	}

--- a/cloud/disk_manager/internal/pkg/services/disks/create_empty_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/create_empty_disk_task.go
@@ -91,6 +91,10 @@ func (t *createEmptyDiskTask) Run(
 		EncryptionDesc:          t.params.EncryptionDesc,
 	})
 	if err != nil {
+		if nbs.IsLocalDisk(t.params.Kind) && nbs.IsTryAgainError(err) {
+			return errors.NewRetriableErrorWithIgnoreRetryLimit(err)
+		}
+
 		return err
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/disks/create_empty_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/create_empty_disk_task_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	nbs_client "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
 	nbs_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs/mocks"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/resources"
 	storage_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/resources/mocks"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/disks/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 )
 
 func TestCreateEmptyDiskTask(t *testing.T) {
@@ -189,4 +191,52 @@ func TestCancelCreateEmptyDiskTaskFailure(t *testing.T) {
 	err := task.Cancel(ctx, execCtx)
 	mock.AssertExpectationsForObjects(t, storage, nbsFactory, nbsClient, execCtx)
 	require.Equal(t, err, assert.AnError)
+}
+
+func TestCreateEmptyLocalDiskTaskTryAgainShouldNotIncrementRetriableErrorsCount(t *testing.T) {
+	ctx := context.Background()
+	storage := storage_mocks.NewStorageMock()
+	nbsFactory := nbs_mocks.NewFactoryMock()
+	nbsClient := nbs_mocks.NewClientMock()
+	execCtx := newExecutionContextMock()
+
+	params := &protos.CreateDiskParams{
+		BlocksCount: 123,
+		Disk: &types.Disk{
+			ZoneId: "zone",
+			DiskId: "disk",
+		},
+		BlockSize: 456,
+		Kind:      types.DiskKind_DISK_KIND_SSD_LOCAL,
+		CloudId:   "cloud",
+		FolderId:  "folder",
+	}
+	task := &createEmptyDiskTask{
+		storage:    storage,
+		nbsFactory: nbsFactory,
+		params:     params,
+		state:      &protos.CreateEmptyDiskTaskState{},
+	}
+
+	// TODO: Improve this expectations.
+	storage.On("CreateDisk", ctx, mock.Anything).Return(&resources.DiskMeta{
+		ID: "disk",
+	}, nil)
+
+	nbsFactory.On("GetClient", ctx, "zone").Return(nbsClient, nil)
+	nbsClient.On("Create", ctx, nbs.CreateDiskParams{
+		ID:          "disk",
+		BlocksCount: 123,
+		BlockSize:   456,
+		Kind:        types.DiskKind_DISK_KIND_SSD_LOCAL,
+		CloudID:     "cloud",
+		FolderID:    "folder",
+	}).Return(&nbs_client.ClientError{Code: nbs_client.E_TRY_AGAIN})
+
+	err := task.Run(ctx, execCtx)
+	mock.AssertExpectationsForObjects(t, storage, nbsFactory, nbsClient, execCtx)
+
+	e := errors.NewEmptyRetriableError()
+	require.True(t, errors.As(err, &e))
+	require.True(t, e.IgnoreRetryLimit)
 }


### PR DESCRIPTION
#2945

Modify the Disk Manager code to prevent it from failing disk creation task during prolonged local disk creation attempts due to secure erasing dirty devices. Specifically, we need to ensure that it does not exceed the limit of retriable errors.