### PR TITLE
[NBS] Do not convert E_TRY_AGAIN to E_REJECTED on local disk allocation retries

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
@@ -142,7 +142,7 @@ void TDiskRegistryActor::ExecuteAddDisk(
         // Update createEmptyDiskTask simultaneously if you change it.
         args.Error = MakeError(
             E_TRY_AGAIN,
-            "Can allocate local disk after secure erase.");
+            "Unable to allocate local disk: secure erase has not finished yet");
     }
 
     args.Devices = std::move(result.Devices);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
@@ -138,6 +138,8 @@ void TDiskRegistryActor::ExecuteAddDisk(
             args.PoolName,
             args.BlocksCount * args.BlockSize))
     {
+        // Note: DM uses this specific error message to identify this case.
+        // Update createEmptyDiskTask simultaneously if you change it.
         args.Error = MakeError(
             E_TRY_AGAIN,
             "Can allocate local disk after secure erase.");

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -314,12 +314,6 @@ void TVolumeActor::HandleAllocateDiskError(
         return;
     }
 
-    if (error.GetCode() != E_BS_RESOURCE_EXHAUSTED &&
-        error.GetCode() != E_TRY_AGAIN)
-    {
-        ReportDiskAllocationFailure();
-    }
-
     const auto mediaKind = static_cast<NProto::EStorageMediaKind>(
         GetNewestConfig().GetStorageMediaKind());
     const bool localDiskAllocationRetry =
@@ -327,24 +321,18 @@ void TVolumeActor::HandleAllocateDiskError(
         error.GetCode() == E_TRY_AGAIN &&
         IsDiskRegistryLocalMediaKind(mediaKind);
 
-    if (localDiskAllocationRetry) {
-        LOG_WARN(
-            ctx,
-            TBlockStoreComponents::VOLUME,
-            "[%lu] Local disk allocation failed but can succeed later. "
-            "Converted error code: E_TRY_AGAIN->E_REJECTED. DiskId=%s",
-            TabletID(),
-            GetNewestConfig().GetDiskId().Quote().c_str());
-        error.SetCode(E_REJECTED);
-    } else {
-        LOG_ERROR(
-            ctx,
-            TBlockStoreComponents::VOLUME,
-            "[%lu] Disk allocation failed with error: %s. DiskId=%s",
-            TabletID(),
-            FormatError(error).c_str(),
-            GetNewestConfig().GetDiskId().Quote().c_str());
+    if (error.GetCode() != E_BS_RESOURCE_EXHAUSTED && !localDiskAllocationRetry)
+    {
+        ReportDiskAllocationFailure();
     }
+
+    LOG_ERROR(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "[%lu] Disk allocation failed with error: %s. DiskId=%s",
+        TabletID(),
+        FormatError(error).c_str(),
+        GetNewestConfig().GetDiskId().Quote().c_str());
 
     StorageAllocationResult = std::move(error);
 }

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -949,32 +949,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(0, migratedRanges);
     }
 
-    Y_UNIT_TEST(ShouldConvertTryAgainToRejectedWhenCanAllocateLocalDiskLater)
-    {
-        NProto::TStorageServiceConfig config;
-        config.SetLocalDiskAsyncDeallocationEnabled(true);
-
-        auto state = MakeIntrusive<TDiskRegistryState>();
-        state->CurrentErrorCode = E_TRY_AGAIN;
-        auto runtime = PrepareTestActorRuntime(config, state);
-
-        TVolumeClient volume(*runtime);
-        volume.UpdateVolumeConfig(
-            0,
-            0,
-            0,
-            0,
-            false,
-            1,
-            NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL);
-
-        volume.SendWaitReadyRequest();
-        {
-            auto response = volume.RecvWaitReadyResponse();
-            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
-        }
-    }
-
     void DoShouldEnsureRejectWriteZeroRequestsOverlappingWithMigrating(
         ui32 ioDepth)
     {


### PR DESCRIPTION
#2945

После обсуждения с командой DM было решено не конвертировать `E_TRY_AGAIN` в `E_REJECTED` в ситуации, когда создание локального диска ожидает окончания `SecureErase` на неком числе девайсов, чтобы отличать эту сиуацию от других ситуаций вида `E_REJECTED`

Помимо этого, было решено полагаться на сообщение об ошибке для определения этой специфической ситуации в DM'е (соответствующий [PR](https://github.com/ydb-platform/nbs/pull/3285)), поэтому здесь же добавил комментарий о том, что менять это сообщение об ошибке стоит аккуратно