### PR TITLE
Fix non-constant-expression cannot be narrowed from type error

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5592,7 +5592,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                     {"filesystem", "test"}}, 1},
                 {{
                     {"sensor", "TrimBytes.RequestBytes"},
-                    {"filesystem", "test"}}, block + 1_KB},
+                    {"filesystem", "test"}}, static_cast<i64>(block + 1_KB)},
                 {{
                     {"sensor", "TrimBytes.Count"},
                     {"filesystem", "test"}}, 2},


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:5595:46: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 5595 |                     {"filesystem", "test"}}, block + 1_KB},
      |                                              ^~~~~~~~~~~~
```