### PR TITLE
[Disk Manager] testcommon: use predicate when await for checkpoints, add WaitForNoCheckpointsExist function

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -370,7 +370,7 @@ func waitUntilCheckpointsMeetRequirements(
 	t *testing.T,
 	ctx context.Context,
 	diskID string,
-	doCheckpointsMeetRequirements func([]string) bool,
+	checkRequirements func([]string) bool,
 ) {
 
 	nbsClient := NewNbsTestingClient(t, ctx, "zone-a")
@@ -381,7 +381,7 @@ func waitUntilCheckpointsMeetRequirements(
 		checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
 		require.NoError(t, err)
 
-		if doCheckpointsMeetRequirements(checkpoints) {
+		if checkRequirements(checkpoints) {
 			return
 		}
 

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -370,7 +370,7 @@ func waitUntilCheckpointsMeetRequirements(
 	t *testing.T,
 	ctx context.Context,
 	diskID string,
-	predicate func([]string) bool,
+	doCheckpointsMeetRequirements func([]string) bool,
 ) {
 
 	nbsClient := NewNbsTestingClient(t, ctx, "zone-a")
@@ -381,7 +381,7 @@ func waitUntilCheckpointsMeetRequirements(
 		checkpoints, err := nbsClient.GetCheckpoints(ctx, diskID)
 		require.NoError(t, err)
 
-		if predicate(checkpoints) {
+		if doCheckpointsMeetRequirements(checkpoints) {
 			return
 		}
 

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -366,7 +366,7 @@ func RequireCheckpointsDoNotExist(
 	require.Empty(t, checkpoints)
 }
 
-func waitForCheckpointsWithPredicate(
+func waitUntilCheckpointsMeetRequirements(
 	t *testing.T,
 	ctx context.Context,
 	diskID string,
@@ -387,7 +387,7 @@ func waitForCheckpointsWithPredicate(
 
 		logging.Debug(
 			ctx,
-			"waitForCheckpointsWithPredicate proceeding to next iteration",
+			"waitUntilCheckpointsMeetRequirements proceeding to next iteration",
 		)
 	}
 }
@@ -399,7 +399,7 @@ func WaitForCheckpointDoesNotExist(
 	checkpointID string,
 ) {
 
-	waitForCheckpointsWithPredicate(
+	waitUntilCheckpointsMeetRequirements(
 		t,
 		ctx,
 		diskID,
@@ -415,7 +415,7 @@ func WaitForNoCheckpointsExist(
 	diskID string,
 ) {
 
-	waitForCheckpointsWithPredicate(
+	waitUntilCheckpointsMeetRequirements(
 		t,
 		ctx,
 		diskID,


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1950

WaitForNoCheckpointsExist is needed for tests with [failing shadow disks](https://github.com/ydb-platform/nbs/pull/3004), since can't get concrete checkpoint from inside the code of the test.

In order to deduplicate the code of existing WaitForCheckpointDoesNotExist function and added WaitForNoCheckpointsExist function, we use waitForCheckpointsWithPredicate function.