### PR TITLE
issue-3: add lock and drain range request

### DIFF
--- a/cloud/blockstore/libs/rdma/iface/client.h
+++ b/cloud/blockstore/libs/rdma/iface/client.h
@@ -22,9 +22,9 @@ namespace NCloud::NBlockStore::NRdma {
 struct TClientConfig
 {
     ui32 QueueSize = 10;
-    // Keep the value greater then MaxSubRequestSize, ProcessingRangeSize,
+    // Keep the value greater then MaxSubRequestSize, MigrationRangeSize,
     // ResyncRangeSize in cloud/blockstore/libs/service/device_handler.cpp
-    // cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
+    // cloud/blockstore/libs/storage/model/common_constants.h
     // cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_util.h
     // Keep sync with MaxBufferSize in cloud/blockstore/vhost-server/options.h
     // and cloud/blockstore/libs/rdma/iface/server.h

--- a/cloud/blockstore/libs/storage/api/partition.h
+++ b/cloud/blockstore/libs/storage/api/partition.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
 
@@ -17,6 +18,10 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
     /* Waits for current in-flight writes to finish and does not affect any    \
      * requests that come after. */                                            \
     xxx(WaitForInFlightWrites,                                     __VA_ARGS__)\
+    /* Block range for writing requests. Wait for current in-flight writes     \
+     * which overlap that range to finish and reply. Lock can be released by   \
+     * sending a TEvReleaseRange message. */                                   \
+    xxx(LockAndDrainRange,                                        __VA_ARGS__) \
 // BLOCKSTORE_PARTITION_REQUESTS
 
 // requests forwarded from service to partition
@@ -100,6 +105,34 @@ struct TEvPartition
     };
 
     //
+    // LockAndDrainRange
+    //
+
+    struct TLockAndDrainRangeRequest
+    {
+        TBlockRange64 Range;
+        explicit TLockAndDrainRangeRequest(TBlockRange64 range)
+            : Range(range)
+        {}
+    };
+
+    struct TLockAndDrainRangeResponse
+    {
+    };
+
+    //
+    // ReleaseRange
+    //
+
+    struct TReleaseRange
+    {
+        TBlockRange64 Range;
+        explicit TReleaseRange(TBlockRange64 range)
+            : Range(range)
+        {}
+    };
+
+    //
     // Garbage collector finish report
     //
 
@@ -138,6 +171,11 @@ struct TEvPartition
         EvWaitForInFlightWritesRequest = EvBegin + 11,
         EvWaitForInFlightWritesResponse = EvBegin + 12,
 
+        EvLockAndDrainRangeRequest = EvBegin + 13,
+        EvLockAndDrainRangeResponse = EvBegin + 14,
+
+        EvReleaseRange = EvBegin + 15,
+
         EvEnd
     };
 
@@ -145,6 +183,8 @@ struct TEvPartition
         "EvEnd expected to be < TBlockStoreEvents::PARTITION_END");
 
     BLOCKSTORE_PARTITION_REQUESTS(BLOCKSTORE_DECLARE_EVENTS)
+
+    using TEvReleaseRange = TRequestEvent<TReleaseRange, EvReleaseRange>;
 
     using TEvBackpressureReport = TRequestEvent<
         TBackpressureReport,

--- a/cloud/blockstore/libs/storage/model/common_constants.h
+++ b/cloud/blockstore/libs/storage/model/common_constants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+///////////////////////////////////////////////////////////////////////////////
+
+// We process 4 MB of data at a time.
+// Keep the value less than MaxBufferSize in
+// cloud/blockstore/libs/rdma/iface/client.h
+constexpr ui64 MigrationRangeSize = 4_MB;
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/request_bounds_tracker.cpp
+++ b/cloud/blockstore/libs/storage/model/request_bounds_tracker.cpp
@@ -1,0 +1,56 @@
+#include "request_bounds_tracker.h"
+
+#include "common_constants.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+///////////////////////////////////////////////////////////////////////////////
+
+TRequestBoundsTracker::TRequestBoundsTracker(ui64 blockSize)
+    : BlockCountPerRange(MigrationRangeSize / blockSize)
+{}
+
+void TRequestBoundsTracker::AddRequest(TBlockRange64 range)
+{
+    auto startRange = range.Start / BlockCountPerRange;
+    auto endRange = range.End / BlockCountPerRange;
+    for (size_t i = startRange; i <= endRange; ++i) {
+        auto& rangeInfo = RangesWithRequests[i];
+        rangeInfo.RequestCount += 1;
+    }
+}
+
+void TRequestBoundsTracker::RemoveRequest(TBlockRange64 range)
+{
+    auto startRange = range.Start / BlockCountPerRange;
+    auto endRange = range.End / BlockCountPerRange;
+    for (size_t i = startRange; i <= endRange; ++i) {
+        auto it = RangesWithRequests.find(i);
+
+        Y_DEBUG_ABORT_UNLESS(it != RangesWithRequests.end());
+        if (it == RangesWithRequests.end()) {
+            continue;
+        }
+
+        auto& rangeInfo = it->second;
+        rangeInfo.RequestCount -= 1;
+        if (rangeInfo.RequestCount == 0) {
+            RangesWithRequests.erase(it);
+        }
+    }
+}
+
+bool TRequestBoundsTracker::OverlapsWithRequest(TBlockRange64 range) const
+{
+    auto startRange = range.Start / BlockCountPerRange;
+    auto endRange = range.End / BlockCountPerRange;
+    for (size_t i = startRange; i <= endRange; ++i) {
+        if (RangesWithRequests.contains(i)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/request_bounds_tracker.h
+++ b/cloud/blockstore/libs/storage/model/request_bounds_tracker.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "requests_in_progress.h"
+
+#include <cloud/blockstore/libs/common/block_range.h>
+
+#include <util/generic/hash.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+///////////////////////////////////////////////////////////////////////////////
+
+class TRequestBoundsTracker
+{
+    struct TRangeInfo
+    {
+        ui64 RequestCount = 0;
+    };
+
+    THashMap<ui64, TRangeInfo> RangesWithRequests;
+    const ui64 BlockCountPerRange;
+
+public:
+    explicit TRequestBoundsTracker(ui64 blockSize);
+
+    void AddRequest(TBlockRange64 r);
+
+    void RemoveRequest(TBlockRange64 r);
+
+    [[nodiscard]] bool OverlapsWithRequest(TBlockRange64 r) const;
+};
+
+template <typename TValue>
+struct TIsWriteBlockRangeValueWrapper
+{
+    TValue Value;
+    bool IsWrite = false;
+    TBlockRange64 BlockRange;
+};
+
+template <EAllowedRequests TKind, typename TKey, typename TValue = TEmptyType>
+class TRequestsInProgressWithBlockRangeTracking
+    : public IRequestsInProgress
+    , TRequestsInProgressImpl<TKey, TIsWriteBlockRangeValueWrapper<TValue>>
+{
+    using TImpl =
+        TRequestsInProgressImpl<TKey, TIsWriteBlockRangeValueWrapper<TValue>>;
+    using TRangeRequest = TIsWriteBlockRangeValueWrapper<TValue>;
+
+private:
+    TRequestBoundsTracker WriteRequestBoundsTracker;
+
+public:
+    explicit TRequestsInProgressWithBlockRangeTracking(size_t blockSize)
+        : WriteRequestBoundsTracker(blockSize)
+    {}
+
+    using TImpl::AllRequests;
+    using TImpl::Empty;
+    using TImpl::GenerateRequestId;
+    using TImpl::GetRequestCount;
+    using TImpl::SetRequestIdentityKey;
+
+    void AddReadRequest(const TKey& key, TBlockRange64 range, TValue value = {})
+        requires(IsReadAllowed<TKind>)
+    {
+        TImpl::AddRequest(key, TRangeRequest{std::move(value), false, range});
+    }
+
+    TKey AddReadRequest(TBlockRange64 range, TValue value = {})
+        requires(IsReadAllowed<TKind>)
+    {
+        return TImpl::AddRequest(TRangeRequest{std::move(value), false, range});
+    }
+
+    void
+    AddWriteRequest(const TKey& key, TBlockRange64 range, TValue value = {})
+        requires(IsWriteAllowed<TKind>)
+    {
+        WriteRequestBoundsTracker.AddRequest(range);
+
+        TImpl::AddRequest(
+            std::move(key),
+            TRangeRequest{std::move(value), true, range});
+    }
+
+    TKey AddWriteRequest(TBlockRange64 range, TValue value = {})
+        requires(IsWriteAllowed<TKind>)
+    {
+        TKey key = GenerateRequestId();
+        AddWriteRequest(key, range, std::move(value));
+        return key;
+    }
+
+    TValue GetRequest(const TKey& key) const
+    {
+        return TImpl::GetRequest(key).Value;
+    }
+
+    bool RemoveRequest(const TKey& key)
+    {
+        return ExtractRequest(key).has_value();
+    }
+
+    std::optional<std::pair<TBlockRange64, TValue>> ExtractRequest(
+        const TKey& key)
+    {
+        auto maybeValue = TImpl::ExtractRequest(key);
+        if (!maybeValue) {
+            return std::nullopt;
+        }
+
+        if (maybeValue->IsWrite) {
+            WriteRequestBoundsTracker.RemoveRequest(maybeValue->BlockRange);
+        }
+
+        return std::make_pair(
+            maybeValue->BlockRange,
+            std::move(maybeValue->Value));
+    }
+
+    const TRequestBoundsTracker& GetRequestBoundsTracker()
+    {
+        return WriteRequestBoundsTracker;
+    }
+
+    // IRequestsInProgress
+
+    [[nodiscard]] bool WriteRequestInProgress() const override
+    {
+        return TImpl::WriteRequestInProgress();
+    }
+
+    void WaitForInFlightWrites() override
+    {
+        TImpl::WaitForInFlightWrites();
+    }
+
+    [[nodiscard]] bool IsWaitingForInFlightWrites() const override
+    {
+        return TImpl::IsWaitingForInFlightWrites();
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/request_bounds_tracker.h
+++ b/cloud/blockstore/libs/storage/model/request_bounds_tracker.h
@@ -12,12 +12,12 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TRequestBoundsTracker
 {
-private:
     struct TRangeInfo
     {
         ui64 RequestCount = 0;
     };
 
+private:
     THashMap<ui64, TRangeInfo> RangesWithRequests;
     const ui64 BlockCountPerRange;
 

--- a/cloud/blockstore/libs/storage/model/request_bounds_tracker.h
+++ b/cloud/blockstore/libs/storage/model/request_bounds_tracker.h
@@ -12,6 +12,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TRequestBoundsTracker
 {
+private:
     struct TRangeInfo
     {
         ui64 RequestCount = 0;
@@ -43,15 +44,14 @@ class TRequestsInProgressWithBlockRangeTracking
     : public IRequestsInProgress
     , TRequestsInProgressImpl<TKey, TRequestInProgressWithBlockRange<TValue>>
 {
-public:
-    using TRequest = TRequestInProgressWithBlockRange<TValue>;
-
-private:
     using TImpl =
         TRequestsInProgressImpl<TKey, TRequestInProgressWithBlockRange<TValue>>;
 
 private:
     TRequestBoundsTracker WriteRequestBoundsTracker;
+
+public:
+    using TRequest = TRequestInProgressWithBlockRange<TValue>;
 
 public:
     explicit TRequestsInProgressWithBlockRangeTracking(size_t blockSize)

--- a/cloud/blockstore/libs/storage/model/request_bounds_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/request_bounds_tracker_ut.cpp
@@ -1,0 +1,101 @@
+#include "request_bounds_tracker.h"
+
+#include "common_constants.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TRequestBoundsTrackerTest)
+{
+    Y_UNIT_TEST(ShouldTrackRequestsBounds)
+    {
+        auto blockSize = 4_KB;
+        TRequestBoundsTracker requestsInProgress{blockSize};
+
+        auto blocksPerTrackingRange = MigrationRangeSize / 4_KB;
+
+        requestsInProgress.AddRequest(TBlockRange64::WithLength(0, 10));
+
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, 10)));
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(10, 10)));
+        UNIT_ASSERT(
+            !requestsInProgress.OverlapsWithRequest(TBlockRange64::WithLength(
+                blocksPerTrackingRange,
+                blocksPerTrackingRange)));
+
+        requestsInProgress.AddRequest(TBlockRange64::WithLength(10, 10));
+
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+        UNIT_ASSERT(
+            !requestsInProgress.OverlapsWithRequest(TBlockRange64::WithLength(
+                blocksPerTrackingRange,
+                blocksPerTrackingRange)));
+
+        requestsInProgress.RemoveRequest(TBlockRange64::WithLength(0, 10));
+
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, 10)));
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(10, 10)));
+        UNIT_ASSERT(
+            !requestsInProgress.OverlapsWithRequest(TBlockRange64::WithLength(
+                blocksPerTrackingRange,
+                blocksPerTrackingRange)));
+
+        requestsInProgress.RemoveRequest(TBlockRange64::WithLength(10, 10));
+
+        UNIT_ASSERT(!requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+    }
+
+    Y_UNIT_TEST(ShouldMarkSeveralTrackingRangesForBorderRequests)
+    {
+        auto blockSize = 4_KB;
+        TRequestBoundsTracker requestsInProgress{blockSize};
+
+        auto blocksPerTrackingRange = MigrationRangeSize / 4_KB;
+
+        auto firstTrackingRange =
+            TBlockRange64::WithLength(0, blocksPerTrackingRange);
+        auto secondTrackingRange = TBlockRange64::WithLength(
+            blocksPerTrackingRange,
+            blocksPerTrackingRange);
+
+        requestsInProgress.AddRequest(
+            TBlockRange64::WithLength(blocksPerTrackingRange - 1, 2));
+
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(firstTrackingRange));
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, 10)));
+
+        UNIT_ASSERT(
+            requestsInProgress.OverlapsWithRequest(secondTrackingRange));
+        UNIT_ASSERT(requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(blocksPerTrackingRange + 10, 10)));
+
+        requestsInProgress.RemoveRequest(
+            TBlockRange64::WithLength(blocksPerTrackingRange - 1, 2));
+
+        UNIT_ASSERT(
+            !requestsInProgress.OverlapsWithRequest(firstTrackingRange));
+        UNIT_ASSERT(!requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, 10)));
+
+        UNIT_ASSERT(
+            !requestsInProgress.OverlapsWithRequest(secondTrackingRange));
+        UNIT_ASSERT(!requestsInProgress.OverlapsWithRequest(
+            TBlockRange64::WithLength(blocksPerTrackingRange + 10, 10)));
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/model/request_bounds_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/request_bounds_tracker_ut.cpp
@@ -96,6 +96,99 @@ Y_UNIT_TEST_SUITE(TRequestBoundsTrackerTest)
         UNIT_ASSERT(!requestsInProgress.OverlapsWithRequest(
             TBlockRange64::WithLength(blocksPerTrackingRange + 10, 10)));
     }
+
+    Y_UNIT_TEST(ShouldTrackRequestsWithBlockRange)
+    {
+        auto blockSize = 4_KB;
+
+        TRequestsInProgressWithBlockRangeTracking<
+            EAllowedRequests::ReadWrite,
+            ui32>
+            requestsInProgress{blockSize};
+
+        const auto& boundsTracker =
+            requestsInProgress.GetRequestBoundsTracker();
+
+        auto blocksPerTrackingRange = MigrationRangeSize / 4_KB;
+
+        {
+            auto id1 = requestsInProgress.GenerateRequestId();
+
+            requestsInProgress.AddWriteRequest(
+                id1,
+                TBlockRange64::WithLength(0, 10));
+
+            UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+            auto id2 = requestsInProgress.GenerateRequestId();
+            requestsInProgress.AddWriteRequest(
+                id2,
+                TBlockRange64::WithLength(10, 10));
+            requestsInProgress.ExtractRequest(id1);
+
+            UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+            requestsInProgress.ExtractRequest(id2);
+            UNIT_ASSERT(!boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+        }
+
+        // should mark several tracking ranges if it lays at the border;
+        {
+            auto id1 = requestsInProgress.GenerateRequestId();
+
+            requestsInProgress.AddWriteRequest(
+                id1,
+                TBlockRange64::WithLength(blocksPerTrackingRange - 1, 2));
+
+            UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+            UNIT_ASSERT(
+                boundsTracker.OverlapsWithRequest(TBlockRange64::WithLength(
+                    blocksPerTrackingRange,
+                    2 * blocksPerTrackingRange)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldTrackAllWriteRequests)
+    {
+        auto blockSize = 4_KB;
+
+        TRequestsInProgressWithBlockRangeTracking<
+            EAllowedRequests::ReadWrite,
+            ui32>
+            requestsInProgress{blockSize};
+
+        const auto& boundsTracker =
+            requestsInProgress.GetRequestBoundsTracker();
+
+        auto blocksPerTrackingRange = MigrationRangeSize / 4_KB;
+
+        auto id1 = requestsInProgress.GenerateRequestId();
+        requestsInProgress.AddWriteRequest(
+            id1,
+            TBlockRange64::WithLength(0, blocksPerTrackingRange));
+
+        UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+        requestsInProgress.RemoveRequest(id1);
+
+        UNIT_ASSERT(!boundsTracker.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+        auto id2 = requestsInProgress.AddWriteRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange));
+        UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+        requestsInProgress.RemoveRequest(id2);
+
+        UNIT_ASSERT(!boundsTracker.OverlapsWithRequest(
+            TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/model/request_in_progress_impl.h
+++ b/cloud/blockstore/libs/storage/model/request_in_progress_impl.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <util/generic/hash.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+///////////////////////////////////////////////////////////////////////////////
+
+enum class EAllowedRequests
+{
+    ReadOnly,
+    WriteOnly,
+    ReadWrite,
+};
+
+template <EAllowedRequests TKind>
+constexpr bool IsWriteAllowed = TKind == EAllowedRequests::ReadWrite ||
+                                TKind == EAllowedRequests::WriteOnly;
+
+template <EAllowedRequests TKind>
+constexpr bool IsReadAllowed =
+    TKind == EAllowedRequests::ReadOnly || TKind == EAllowedRequests::ReadWrite;
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename TKey, typename TRequest>
+    requires requires(TRequest t) {
+        {
+            t.IsWrite
+        } -> std::convertible_to<bool>;
+    }
+class TRequestsInProgressImpl
+{
+    using TRequests = THashMap<TKey, TRequest>;
+
+private:
+    TRequests RequestsInProgress;
+    size_t WriteRequestCount = 0;
+    TKey RequestIdentityKeyCounter = {};
+
+    THashSet<TKey> WaitingForWriteRequests;
+
+public:
+    ~TRequestsInProgressImpl() = default;
+
+    TKey GenerateRequestId()
+    {
+        return RequestIdentityKeyCounter++;
+    }
+
+    void SetRequestIdentityKey(TKey value)
+    {
+        RequestIdentityKeyCounter = value;
+    }
+
+    void AddRequest(const TKey& key, TRequest request)
+    {
+        Y_DEBUG_ABORT_UNLESS(!RequestsInProgress.contains(key));
+
+        RequestsInProgress.emplace(key, std::move(request));
+        WriteRequestCount += !!request.IsWrite;
+    }
+
+    TKey AddRequest(TRequest request)
+    {
+        auto key = GenerateRequestId();
+        AddRequest(key, std::move(request));
+        return key;
+    }
+
+    TRequest GetRequest(const TKey& key) const
+    {
+        if (auto* requestInfo = RequestsInProgress.FindPtr(key)) {
+            return *requestInfo;
+        }
+        Y_DEBUG_ABORT_UNLESS(0);
+
+        return {};
+    }
+
+    std::optional<TRequest> ExtractRequest(const TKey& key)
+    {
+        auto it = RequestsInProgress.find(key);
+
+        if (it == RequestsInProgress.end()) {
+            Y_DEBUG_ABORT_UNLESS(0);
+            return std::nullopt;
+        }
+
+        if (it->second.IsWrite) {
+            WaitingForWriteRequests.erase(key);
+            --WriteRequestCount;
+        }
+        TRequest res = std::move(it->second);
+        RequestsInProgress.erase(it);
+        return res;
+    }
+
+    const TRequests& AllRequests() const
+    {
+        return RequestsInProgress;
+    }
+
+    [[nodiscard]] size_t GetRequestCount() const
+    {
+        return RequestsInProgress.size();
+    }
+
+    [[nodiscard]] bool Empty() const
+    {
+        return GetRequestCount() == 0;
+    }
+
+    [[nodiscard]] bool WriteRequestInProgress() const
+    {
+        return WriteRequestCount != 0;
+    }
+
+    void WaitForInFlightWrites()
+    {
+        for (const auto& [key, value]: RequestsInProgress) {
+            if (value.IsWrite) {
+                WaitingForWriteRequests.insert(key);
+            }
+        }
+    }
+
+    [[nodiscard]] bool IsWaitingForInFlightWrites() const
+    {
+        return !WaitingForWriteRequests.empty();
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/requests_in_progress_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/requests_in_progress_ut.cpp
@@ -1,4 +1,5 @@
-#include "requests_in_progress.h"
+#include "common_constants.h"
+#include "request_bounds_tracker.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -10,8 +11,8 @@ Y_UNIT_TEST_SUITE(TRequestsInProgressTest)
 {
     Y_UNIT_TEST(Basic)
     {
-        TRequestsInProgress<ui32, TString> requestsInProgress{
-            EAllowedRequests::ReadWrite};
+        TRequestsInProgress<EAllowedRequests::ReadWrite, ui32, TString>
+            requestsInProgress;
         IRequestsInProgress* interface = &requestsInProgress;
 
         UNIT_ASSERT(requestsInProgress.Empty());
@@ -47,8 +48,8 @@ Y_UNIT_TEST_SUITE(TRequestsInProgressTest)
 
     Y_UNIT_TEST(CustomId)
     {
-        TRequestsInProgress<ui32, TString> requestsInProgress{
-            EAllowedRequests::ReadWrite};
+        TRequestsInProgress<EAllowedRequests::ReadWrite, ui32, TString>
+            requestsInProgress;
         IRequestsInProgress* interface = &requestsInProgress;
 
         requestsInProgress.AddReadRequest(100, "Read Request 1");
@@ -68,8 +69,8 @@ Y_UNIT_TEST_SUITE(TRequestsInProgressTest)
 
     Y_UNIT_TEST(ResetIdentityKey)
     {
-        TRequestsInProgress<ui32, TString> requestsInProgress{
-            EAllowedRequests::ReadWrite};
+        TRequestsInProgress<EAllowedRequests::ReadWrite, ui32, TString>
+            requestsInProgress;
 
         requestsInProgress.SetRequestIdentityKey(1000);
         auto id1 = requestsInProgress.AddReadRequest("Read Request 1");
@@ -81,8 +82,8 @@ Y_UNIT_TEST_SUITE(TRequestsInProgressTest)
 
     Y_UNIT_TEST(GenerateIdentityKey)
     {
-        TRequestsInProgress<ui32, TString> requestsInProgress{
-            EAllowedRequests::ReadWrite};
+        TRequestsInProgress<EAllowedRequests::ReadWrite, ui32, TString>
+            requestsInProgress;
 
         auto id1 = requestsInProgress.GenerateRequestId();
         auto id2 = requestsInProgress.GenerateRequestId();
@@ -91,59 +92,65 @@ Y_UNIT_TEST_SUITE(TRequestsInProgressTest)
 
     Y_UNIT_TEST(AllRequests)
     {
-        using TRequests = TRequestsInProgress<ui32, TString>;
+        using TRequests =
+            TRequestsInProgress<EAllowedRequests::ReadWrite, ui32, TString>;
 
         TMap<ui32, TRequests::TRequest> testData{
-            {0, {"Read Request 1", false}},
-            {1, {"Write Request 1", true}},
-            {10, {"Read Request 2", false}},
-            {20, {"Write Request 2", true}},
+            {0, {.Value = "Read Request 1", .IsWrite = false}},
+            {1, {.Value = "Write Request 1", .IsWrite = true}},
+            {10, {.Value = "Read Request 2", .IsWrite = false}},
+            {20, {.Value = "Write Request 2", .IsWrite = true}},
         };
 
-        TRequests requestsInProgress{EAllowedRequests::ReadWrite};
-        for (const auto& item : testData) {
-            if (item.second.Write) {
+        TRequests requestsInProgress;
+        for (const auto& item: testData) {
+            if (item.second.IsWrite) {
                 requestsInProgress.AddWriteRequest(
-                    item.first, TString(item.second.Value));
+                    item.first,
+                    TString(item.second.Value));
             } else {
                 requestsInProgress.AddReadRequest(
-                    item.first, TString(item.second.Value));
+                    item.first,
+                    TString(item.second.Value));
             }
         }
 
-        for (const auto& request : requestsInProgress.AllRequests()) {
+        for (const auto& request: requestsInProgress.AllRequests()) {
             ui32 id = request.first;
             const TRequests::TRequest& item = request.second;
             const auto& testItem = testData[id];
-            UNIT_ASSERT_EQUAL(testItem.Write, item.Write);
+            UNIT_ASSERT_EQUAL(testItem.IsWrite, item.IsWrite);
             UNIT_ASSERT_EQUAL(testItem.Value, item.Value);
         }
     }
 
     Y_UNIT_TEST(ShouldWaitForInFlightWrites)
     {
-        using TRequests = TRequestsInProgress<ui32, TString>;
+        using TRequests =
+            TRequestsInProgress<EAllowedRequests::ReadWrite, ui32, TString>;
 
         TMap<ui32, TRequests::TRequest> testData{
-            {0, {"Read Request 1", false}},
-            {1, {"Write Request 1", true}},
-            {10, {"Read Request 2", false}},
-            {20, {"Write Request 2", true}},
+            {0, {.Value = "Read Request 1", .IsWrite = false}},
+            {1, {.Value = "Write Request 1", .IsWrite = true}},
+            {10, {.Value = "Read Request 2", .IsWrite = false}},
+            {20, {.Value = "Write Request 2", .IsWrite = true}},
         };
 
         // When there is no in-flight requests waiting does nothing.
-        TRequests requestsInProgress{EAllowedRequests::ReadWrite};
+        TRequests requestsInProgress;
         UNIT_ASSERT(!requestsInProgress.IsWaitingForInFlightWrites());
         requestsInProgress.WaitForInFlightWrites();
         UNIT_ASSERT(!requestsInProgress.IsWaitingForInFlightWrites());
 
-        for (const auto& item : testData) {
-            if (item.second.Write) {
+        for (const auto& item: testData) {
+            if (item.second.IsWrite) {
                 requestsInProgress.AddWriteRequest(
-                    item.first, TString(item.second.Value));
+                    item.first,
+                    TString(item.second.Value));
             } else {
                 requestsInProgress.AddReadRequest(
-                    item.first, TString(item.second.Value));
+                    item.first,
+                    TString(item.second.Value));
             }
         }
 
@@ -156,6 +163,61 @@ Y_UNIT_TEST_SUITE(TRequestsInProgressTest)
         requestsInProgress.RemoveRequest(20);
         UNIT_ASSERT(!requestsInProgress.IsWaitingForInFlightWrites());
     }
+
+    Y_UNIT_TEST(ShouldTrackRequestsWithBlockRange)
+    {
+        auto blockSize = 4_KB;
+
+        TRequestsInProgressWithBlockRangeTracking<
+            EAllowedRequests::ReadWrite,
+            ui32>
+            requestsInProgress{blockSize};
+
+        const auto& boundsTracker =
+            requestsInProgress.GetRequestBoundsTracker();
+
+        auto blocksPerTrackingRange = MigrationRangeSize / 4_KB;
+
+        {
+            auto id1 = requestsInProgress.GenerateRequestId();
+
+            requestsInProgress.AddWriteRequest(
+                id1,
+                TBlockRange64::WithLength(0, 10));
+
+            UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+            auto id2 = requestsInProgress.GenerateRequestId();
+            requestsInProgress.AddWriteRequest(
+                id2,
+                TBlockRange64::WithLength(10, 10));
+            requestsInProgress.ExtractRequest(id1);
+
+            UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+
+            requestsInProgress.ExtractRequest(id2);
+            UNIT_ASSERT(!boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+        }
+
+        // should mark several tracking ranges if it lays at the border;
+        {
+            auto id1 = requestsInProgress.GenerateRequestId();
+
+            requestsInProgress.AddWriteRequest(
+                id1,
+                TBlockRange64::WithLength(blocksPerTrackingRange - 1, 2));
+
+            UNIT_ASSERT(boundsTracker.OverlapsWithRequest(
+                TBlockRange64::WithLength(0, blocksPerTrackingRange)));
+            UNIT_ASSERT(
+                boundsTracker.OverlapsWithRequest(TBlockRange64::WithLength(
+                    blocksPerTrackingRange,
+                    2 * blocksPerTrackingRange)));
+        }
+    }
 }
 
-}  // namespace NCloud::NBlockStore::NStorage::NPartition
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/model/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 SRCS(
     composite_id_ut.cpp
     composite_task_waiter_ut.cpp
+    request_bounds_tracker_ut.cpp
     requests_in_progress_ut.cpp
 )
 

--- a/cloud/blockstore/libs/storage/model/ya.make
+++ b/cloud/blockstore/libs/storage/model/ya.make
@@ -14,6 +14,7 @@ SRCS(
     channel_data_kind.cpp
     channel_permissions.cpp
     composite_task_waiter.cpp
+    request_bounds_tracker.cpp
     requests_in_progress.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -735,6 +735,15 @@ void TPartitionActor::HandleWaitForInFlightWrites(
     DrainActorCompanion.HandleWaitForInFlightWrites(ev, ctx);
 }
 
+void TPartitionActor::HandleLockAndDrainRange(
+    const TEvPartition::TEvLockAndDrainRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    Y_UNUSED(ctx);
+    Y_DEBUG_ABORT_UNLESS(0);
+}
+
 bool TPartitionActor::HandleRequests(STFUNC_SIG)
 {
     switch (ev->GetTypeRewrite()) {

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -710,6 +710,15 @@ void TPartitionActor::HandleWaitForInFlightWrites(
     DrainActorCompanion.HandleWaitForInFlightWrites(ev, ctx);
 }
 
+void TPartitionActor::HandleLockAndDrainRange(
+    const TEvPartition::TEvLockAndDrainRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    Y_UNUSED(ctx);
+    Y_ABORT("Unimplemented");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_HANDLE_UNIMPLEMENTED_REQUEST(name, ns)                      \

--- a/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.cpp
@@ -10,6 +10,8 @@
 #include <util/generic/string.h>
 #include <util/string/builder.h>
 
+#include <ranges>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -20,15 +22,21 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 TDrainActorCompanion::TDrainActorCompanion(
         IRequestsInProgress& requestsInProgress,
-        TString loggingId)
+        TString loggingId,
+        const TRequestBoundsTracker* requestBoundsTracker)
     : RequestsInProgress(requestsInProgress)
+    , RequestBoundsTracker(requestBoundsTracker)
     , LoggingId(std::move(loggingId))
 {}
 
 TDrainActorCompanion::TDrainActorCompanion(
         IRequestsInProgress& requestsInProgress,
-        ui64 tabletID)
-    : TDrainActorCompanion(requestsInProgress, ToString(tabletID))
+        ui64 tabletID,
+        const TRequestBoundsTracker* requestBoundsTracker)
+    : TDrainActorCompanion(
+          requestsInProgress,
+          ToString(tabletID),
+          requestBoundsTracker)
 {}
 
 void TDrainActorCompanion::HandleDrain(
@@ -102,13 +110,25 @@ void TDrainActorCompanion::HandleWaitForInFlightWrites(
     DoProcessWaitForInFlightWritesRequests(ctx);
 }
 
+void TDrainActorCompanion::AddDrainRangeRequest(
+    const TActorContext& ctx,
+    TRequestInfoPtr reqInfo,
+    TBlockRange64 range)
+{
+    Y_DEBUG_ABORT_UNLESS(RequestBoundsTracker);
+    DrainRangeRequests.emplace_back(std::move(reqInfo), range);
+    DoProcessDrainRangeRequests(ctx);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-void TDrainActorCompanion::ProcessDrainRequests(
-    const TActorContext& ctx)
+void TDrainActorCompanion::ProcessDrainRequests(const TActorContext& ctx)
 {
     DoProcessDrainRequests(ctx);
     DoProcessWaitForInFlightWritesRequests(ctx);
+    if (RequestBoundsTracker) {
+        DoProcessDrainRangeRequests(ctx);
+    }
 }
 
 void TDrainActorCompanion::DoProcessDrainRequests(const TActorContext& ctx)
@@ -158,6 +178,58 @@ void TDrainActorCompanion::DoProcessWaitForInFlightWritesRequests(
         NPartition::TEvPartition::TEvWaitForInFlightWritesResponse>();
     NCloud::Reply(ctx, *WaitForInFlightWritesRequest, std::move(response));
     WaitForInFlightWritesRequest.Reset();
+}
+
+void TDrainActorCompanion::RemoveDrainRangeRequest(
+    const TActorContext& ctx,
+    TBlockRange64 range)
+{
+    Y_DEBUG_ABORT_UNLESS(RequestBoundsTracker);
+
+    auto cancelRemovedRequest = [&](const TDrainRangeInfo& drainRequest)
+    {
+        if (drainRequest.RangeToDrain != range) {
+            return false;
+        }
+
+        NCloud::Reply(
+            ctx,
+            *drainRequest.RequestInfo,
+            std::make_unique<
+                NPartition::TEvPartition::TEvLockAndDrainRangeResponse>(
+                MakeError(E_CANCELLED)));
+        return true;
+    };
+
+    EraseIf(DrainRangeRequests, cancelRemovedRequest);
+}
+
+void TDrainActorCompanion::DoProcessDrainRangeRequests(const TActorContext& ctx)
+{
+    Y_DEBUG_ABORT_UNLESS(RequestBoundsTracker);
+    if (!RequestBoundsTracker) {
+        return;
+    }
+
+    TVector<ui64> reqsToErase;
+
+    auto checkNoRequestsInRange = [&](const TDrainRangeInfo& drainRequest)
+    {
+        if (RequestBoundsTracker->OverlapsWithRequest(
+                drainRequest.RangeToDrain))
+        {
+            return false;
+        }
+
+        NCloud::Reply(
+            ctx,
+            *drainRequest.RequestInfo,
+            std::make_unique<
+                NPartition::TEvPartition::TEvLockAndDrainRangeResponse>());
+        return true;
+    };
+
+    EraseIf(DrainRangeRequests, checkNoRequestsInRange);
 }
 
 }  // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h
@@ -2,7 +2,7 @@
 
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
-#include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
+#include <cloud/blockstore/libs/storage/model/request_bounds_tracker.h>
 #include <cloud/storage/core/libs/actors/public.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -10,33 +10,53 @@ namespace NCloud::NBlockStore::NStorage {
 class TDrainActorCompanion
 {
 private:
+    struct TDrainRangeInfo
+    {
+        TRequestInfoPtr RequestInfo;
+        TBlockRange64 RangeToDrain;
+    };
+    TVector<TDrainRangeInfo> DrainRangeRequests;
     TVector<TRequestInfoPtr> DrainRequests;
     TRequestInfoPtr WaitForInFlightWritesRequest;
     IRequestsInProgress& RequestsInProgress;
+    const TRequestBoundsTracker* RequestBoundsTracker;
     const TString LoggingId;
 
 public:
     TDrainActorCompanion(
         IRequestsInProgress& requestsInProgress,
-        TString loggingId);
+        TString loggingId,
+        const TRequestBoundsTracker* requestBoundsTracker = nullptr);
 
     TDrainActorCompanion(
         IRequestsInProgress& requestsInProgress,
-        ui64 tabletID);
+        ui64 tabletID,
+        const TRequestBoundsTracker* requestBoundsTracker = nullptr);
 
     void HandleDrain(
         const NPartition::TEvPartition::TEvDrainRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleWaitForInFlightWrites(
-        const NPartition::TEvPartition::TEvWaitForInFlightWritesRequest::TPtr& ev,
+        const NPartition::TEvPartition::TEvWaitForInFlightWritesRequest::TPtr&
+            ev,
         const NActors::TActorContext& ctx);
 
     void ProcessDrainRequests(const NActors::TActorContext& ctx);
 
+    void AddDrainRangeRequest(
+        const NActors::TActorContext& ctx,
+        TRequestInfoPtr reqInfo,
+        TBlockRange64 range);
+
+    void RemoveDrainRangeRequest(
+        const NActors::TActorContext& ctx,
+        TBlockRange64 range);
+
 private:
     void DoProcessDrainRequests(const NActors::TActorContext& ctx);
     void DoProcessWaitForInFlightWritesRequests(const NActors::TActorContext& ctx);
+    void DoProcessDrainRangeRequests(const NActors::TActorContext& ctx);
 };
 
 }  // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h
@@ -2,14 +2,15 @@
 
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 
-#include <contrib/ydb/library/actors/core/actorid.h>
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/actorid.h>
 #include <contrib/ydb/library/actors/core/events.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -29,6 +30,7 @@ private:
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     const NActors::TActorId VolumeActorId;
     const bool AssignVolumeRequestId;
+    const NActors::TActorId ActorToLockAndDrainRange;
 
     ui64 VolumeRequestId = 0;
     TInstant ReadStartTs;
@@ -37,6 +39,7 @@ private:
     TDuration WriteDuration;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
     bool AllZeroes = false;
+    bool NeedToReleaseRange = false;
 
 public:
     TCopyRangeActor(
@@ -48,12 +51,14 @@ public:
         TString writerClientId,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         NActors::TActorId volumeActorId,
-        bool assignVolumeRequestId);
+        bool assignVolumeRequestId,
+        NActors::TActorId actorToLockAndDrainRange);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
 private:
     void GetVolumeRequestId(const NActors::TActorContext& ctx);
+    void LockAndDrainRange(const NActors::TActorContext& ctx);
     void ReadBlocks(const NActors::TActorContext& ctx);
     void WriteBlocks(
         const NActors::TActorContext& ctx,
@@ -66,6 +71,9 @@ private:
 
     void HandleVolumeRequestId(
         const TEvVolumePrivate::TEvTakeVolumeRequestIdResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+    void HandleLockAndDrainRangeResponse(
+        const NPartition::TEvPartition::TEvLockAndDrainRangeResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleReadResponse(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -321,10 +321,9 @@ void TLaggingAgentsReplicaProxyActor::MarkBlocksAsDirty(
 {
     // We artificially lower the resolution of the "CleanBlocksMap". This is
     // done because the migration actor migrates by ranges of
-    // "ProcessingRangeSize" anyway. The full resolution here would lead to
+    // "MigrationRangeSize" anyway. The full resolution here would lead to
     // migrating not aligned ranges which is not ideal.
-    const ui64 blocksPerRange =
-        ProcessingRangeSize / PartConfig->GetBlockSize();
+    const ui64 blocksPerRange = MigrationRangeSize / PartConfig->GetBlockSize();
     auto alignedStart = AlignDown<ui64>(range.Start, blocksPerRange);
     auto alignedEnd = AlignUp<ui64>(range.End + 1, blocksPerRange);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -585,11 +585,11 @@ Y_UNIT_TEST_SUITE(TLaggingAgentsReplicaProxyActorTest)
                         auto clientId = msg->Record.GetHeaders().GetClientId();
                         if (clientId == BackgroundOpsClientId) {
                             UNIT_ASSERT_VALUES_EQUAL(
-                                ProcessingRangeSize,
+                                MigrationRangeSize,
                                 msg->Record.GetBlocksCount() *
                                     DefaultBlockSize);
                             const ui64 rangeSize =
-                                ProcessingRangeSize / DefaultBlockSize;
+                                MigrationRangeSize / DefaultBlockSize;
                             UNIT_ASSERT_VALUES_EQUAL(
                                 0,
                                 msg->Record.GetStartIndex() % rangeSize);
@@ -612,10 +612,10 @@ Y_UNIT_TEST_SUITE(TLaggingAgentsReplicaProxyActorTest)
                             const auto range =
                                 BuildRequestBlockRange(*msg, DefaultBlockSize);
                             UNIT_ASSERT_VALUES_EQUAL(
-                                ProcessingRangeSize,
+                                MigrationRangeSize,
                                 range.Size() * DefaultBlockSize);
                             const ui64 rangeSize =
-                                ProcessingRangeSize / DefaultBlockSize;
+                                MigrationRangeSize / DefaultBlockSize;
                             UNIT_ASSERT_VALUES_EQUAL(
                                 0,
                                 range.Start % rangeSize);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.cpp
@@ -25,18 +25,18 @@ TDuration TMigrationTimeoutCalculator::CalculateTimeout(
 {
     if (RecommendedBandwidth) {
         auto rangesPerSecond =
-            static_cast<double>(RecommendedBandwidth) / ProcessingRangeSize;
+            static_cast<double>(RecommendedBandwidth) / MigrationRangeSize;
         return TDuration::Seconds(1) / Max(rangesPerSecond, 1.0);
     }
 
     // migration range is 4_MB
-    constexpr double ProcessingRangeSizeMiBs =
-        static_cast<double>(ProcessingRangeSize) / 1_MB;
+    constexpr double MigrationRangeSizeMiBs =
+        static_cast<double>(MigrationRangeSize) / 1_MB;
 
     const ui32 limitedBandwidthMiBs =
         Min(MaxMigrationBandwidthMiBs, LimitedBandwidthMiBs);
     const double migrationFactorPerAgent =
-        limitedBandwidthMiBs / ProcessingRangeSizeMiBs;
+        limitedBandwidthMiBs / MigrationRangeSizeMiBs;
 
     if (!PartitionConfig ||
         PartitionConfig->GetUseSimpleMigrationBandwidthLimiter())

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
@@ -128,7 +128,7 @@ ui64 TProcessingBlocks::CalculateNextProcessingIndex() const
 {
     return Min(
         BlockCount,
-        CurrentProcessingIndex + ProcessingRangeSize / BlockSize);
+        CurrentProcessingIndex + MigrationRangeSize / BlockSize);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
@@ -1,18 +1,13 @@
 #pragma once
 
 #include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/blockstore/libs/storage/model/common_constants.h>
+
 #include <cloud/storage/core/libs/common/compressed_bitmap.h>
 
 #include <optional>
 
 namespace NCloud::NBlockStore::NStorage {
-
-////////////////////////////////////////////////////////////////////////////////
-
-// We process 4 MB of data at a time.
-// Keep the value less than MaxBufferSize in
-// cloud/blockstore/libs/rdma/iface/client.h
-constexpr ui64 ProcessingRangeSize = 4_MB;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -22,6 +22,8 @@ using namespace NActors;
 
 using namespace NKikimr;
 
+using namespace NPartition;
+
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -425,10 +427,10 @@ void TMirrorPartitionActor::HandleScrubbingNextRange(
     auto scrubbingRange = GetScrubbingRange();
 
     for (const auto& [key, requestInfo]: RequestsInProgress.AllRequests()) {
-        if (!requestInfo.Write) {
+        if (!requestInfo.IsWrite) {
             continue;
         }
-        const auto& requestRange = requestInfo.Value.BlockRange;
+        const auto& requestRange = requestInfo.BlockRange;
         if (scrubbingRange.Overlaps(requestRange)) {
             LOG_DEBUG(
                 ctx,
@@ -660,6 +662,58 @@ void TMirrorPartitionActor::HandleAddTagsResponse(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TMirrorPartitionActor::HandleLockAndDrainRange(
+    const TEvPartition::TEvLockAndDrainRangeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (BlockRangeRequests.OverlapsWithRequest(msg->Range)) {
+        auto response =
+            std::make_unique<TEvPartition::TEvLockAndDrainRangeResponse>(
+                MakeError(
+                    E_REJECTED,
+                    "request overlaps with other block range request"));
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return;
+    }
+    BlockRangeRequests.AddRequest(msg->Range);
+
+    auto reqInfo = CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+
+    DrainActorCompanion.AddDrainRangeRequest(
+        ctx,
+        std::move(reqInfo),
+        msg->Range);
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Range %s is blocked for writing requests",
+        DiskId.c_str(),
+        DescribeRange(msg->Range).c_str());
+}
+
+void TMirrorPartitionActor::HandleReleaseRange(
+    const TEvPartition::TEvReleaseRange::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ctx);
+    auto* msg = ev->Get();
+
+    BlockRangeRequests.RemoveRequest(msg->Range);
+
+    DrainActorCompanion.RemoveDrainRangeRequest(ctx, msg->Range);
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Releasing range %s for writing requests",
+        DiskId.c_str(),
+        DescribeRange(msg->Range).c_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 #define BLOCKSTORE_HANDLE_UNIMPLEMENTED_REQUEST(name, ns)                      \
     void TMirrorPartitionActor::Handle##name(                                  \
         const ns::TEv##name##Request::TPtr& ev,                                \
@@ -711,9 +765,9 @@ STFUNC(TMirrorPartitionActor::StateWork)
 
         HFunc(TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest, HandleAddLaggingAgent);
         HFunc(TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest, HandleRemoveLaggingAgent);
-        HFunc(NPartition::TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
+        HFunc(TEvPartition::TEvDrainRequest, DrainActorCompanion.HandleDrain);
         HFunc(
-            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            TEvPartition::TEvWaitForInFlightWritesRequest,
             DrainActorCompanion.HandleWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
@@ -748,6 +802,12 @@ STFUNC(TMirrorPartitionActor::StateWork)
             TEvService::TEvAddTagsResponse,
             HandleAddTagsResponse);
 
+        HFunc(
+            TEvPartition::TEvLockAndDrainRangeRequest,
+            HandleLockAndDrainRange);
+
+        HFunc(TEvPartition::TEvReleaseRange, HandleReleaseRange);
+
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
         IgnoreFunc(TEvents::TEvPoisonTaken);
 
@@ -773,9 +833,9 @@ STFUNC(TMirrorPartitionActor::StateZombie)
         HFunc(TEvService::TEvReadBlocksLocalRequest, RejectReadBlocksLocal);
         HFunc(TEvService::TEvWriteBlocksLocalRequest, RejectWriteBlocksLocal);
 
-        HFunc(NPartition::TEvPartition::TEvDrainRequest, RejectDrain);
+        HFunc(TEvPartition::TEvDrainRequest, RejectDrain);
         HFunc(
-            NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
+            TEvPartition::TEvWaitForInFlightWritesRequest,
             RejectWaitForInFlightWrites);
         HFunc(TEvService::TEvGetChangedBlocksRequest, DeclineGetChangedBlocks);
         HFunc(
@@ -797,6 +857,10 @@ STFUNC(TMirrorPartitionActor::StateZombie)
         IgnoreFunc(TEvVolume::TEvDiskRegistryBasedPartitionCounters);
 
         IgnoreFunc(TEvService::TEvAddTagsResponse);
+
+        IgnoreFunc(TEvPartition::TEvLockAndDrainRangeRequest);
+
+        IgnoreFunc(TEvPartition::TEvReleaseRange);
 
         IgnoreFunc(TEvents::TEvPoisonPill);
         HFunc(TEvents::TEvPoisonTaken, HandlePoisonTaken);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -16,6 +16,7 @@
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/model/request_bounds_tracker.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
 #include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
@@ -68,11 +69,15 @@ private:
     TDuration CpuUsage;
 
     THashSet<ui64> DirtyReadRequestIds;
-    TRequestsInProgress<ui64, TRequestCtx> RequestsInProgress{
-        EAllowedRequests::ReadWrite};
+    TRequestsInProgressWithBlockRangeTracking<
+        EAllowedRequests::ReadWrite,
+        ui64,
+        ui64>
+        RequestsInProgress{State.GetBlockSize()};
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
-        DiskId};
+        DiskId,
+        &RequestsInProgress.GetRequestBoundsTracker()};
     TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
         TGetDeviceForRangeCompanion::EAllowedOperation::Read};
 
@@ -96,6 +101,8 @@ private:
     TBlockRangeSet64 Majors;
     TBlockRangeSet64 Fixed;
     TBlockRangeSet64 FixedPartial;
+
+    TRequestBoundsTracker BlockRangeRequests{State.GetBlockSize()};
 
 public:
     TMirrorPartitionActor(
@@ -186,6 +193,14 @@ private:
     void HandleRemoveLaggingAgent(
         const TEvNonreplPartitionPrivate::TEvRemoveLaggingAgentRequest::TPtr&
             ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleLockAndDrainRange(
+        const NPartition::TEvPartition::TEvLockAndDrainRangeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleReleaseRange(
+        const NPartition::TEvPartition::TEvReleaseRange::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandlePoisonPill(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -71,8 +71,8 @@ private:
     THashSet<ui64> DirtyReadRequestIds;
     TRequestsInProgressWithBlockRangeTracking<
         EAllowedRequests::ReadWrite,
-        ui64,
-        ui64>
+        ui64,   // key
+        ui64>   // volume request id
         RequestsInProgress{State.GetBlockSize()};
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -28,7 +28,7 @@ void TMirrorPartitionActor::HandleWriteOrZeroCompleted(
         return;
     }
     DrainActorCompanion.ProcessDrainRequests(ctx);
-    auto [range, volumeRequestId] = completeRequest.value();
+    auto [volumeRequestId, _, range] = completeRequest.value();
     for (const auto& [id, request]: RequestsInProgress.AllRequests()) {
         if (range.Overlaps(request.BlockRange)) {
             DirtyReadRequestIds.insert(id);
@@ -69,7 +69,7 @@ void TMirrorPartitionActor::HandleMirroredReadCompleted(
             ReportMirroredDiskChecksumMismatchUponRead(
                 TStringBuilder()
                 << " disk: " << DiskId.Quote() << ", range: "
-                << (requestCtx ? requestCtx->first.Print() : ""));
+                << (requestCtx ? requestCtx->BlockRange.Print() : ""));
         }
     } else {
         DirtyReadRequestIds.erase(it);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -578,7 +578,8 @@ void TMirrorPartitionActor::ReadBlocks(
     const auto requestIdentityKey = TakeNextRequestIdentifier();
     RequestsInProgress.AddReadRequest(
         requestIdentityKey,
-        {blockRange, record.GetHeaders().GetVolumeRequestId()});
+        blockRange,
+        record.GetHeaders().GetVolumeRequestId());
 
     auto requestInfo =
         CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext);
@@ -630,7 +631,8 @@ NProto::TError TMirrorPartitionActor::SplitReadBlocks(
     const auto requestIdentityKey = TakeNextRequestIdentifier();
     RequestsInProgress.AddReadRequest(
         requestIdentityKey,
-        {blockRange, record.GetHeaders().GetVolumeRequestId()});
+        blockRange,
+        record.GetHeaders().GetVolumeRequestId());
 
     LOG_DEBUG(
         ctx,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.h
@@ -62,8 +62,8 @@ private:
 
     bool ResyncFinished = false;
 
-    TRequestsInProgress<ui64, TBlockRange64> WriteAndZeroRequestsInProgress{
-        EAllowedRequests::WriteOnly};
+    TRequestsInProgress<EAllowedRequests::WriteOnly, ui64, TBlockRange64>
+        WriteAndZeroRequestsInProgress;
     TDrainActorCompanion DrainActorCompanion{
         WriteAndZeroRequestsInProgress,
         PartConfig->GetName()};

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -94,8 +94,11 @@ private:
     {
         TStackVec<int, 2> DeviceIndices;
     };
-    TRequestsInProgress<NActors::TActorId, TRequestData> RequestsInProgress{
-        EAllowedRequests::ReadWrite};
+    TRequestsInProgress<
+        EAllowedRequests::ReadWrite,
+        NActors::TActorId,
+        TRequestData>
+        RequestsInProgress;
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -43,7 +43,7 @@ TNonreplicatedPartitionMigrationCommonActor::
     , VolumeActorId(volumeActorId)
     , RWClientId(std::move(rwClientId))
     , ProcessingBlocks(blockCount, blockSize, initialMigrationIndex)
-    , NonZeroRangesMap(blockCount, blockSize, ProcessingRangeSize)
+    , NonZeroRangesMap(blockCount, blockSize, MigrationRangeSize)
     , StatActorId(statActorId)
     , PoisonPillHelper(this)
 {
@@ -76,7 +76,7 @@ TNonreplicatedPartitionMigrationCommonActor::
     , VolumeActorId(volumeActorId)
     , RWClientId(std::move(rwClientId))
     , ProcessingBlocks(blockCount, blockSize, std::move(migrationBlockMap))
-    , NonZeroRangesMap(blockCount, blockSize, ProcessingRangeSize)
+    , NonZeroRangesMap(blockCount, blockSize, MigrationRangeSize)
     , StatActorId(statActorId)
     , PoisonPillHelper(this)
 {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -116,7 +116,8 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
             RWClientId,
             BlockDigestGenerator,
             VolumeActorId,
-            Config->GetAssignIdToWriteAndZeroRequestsEnabled());
+            Config->GetAssignIdToWriteAndZeroRequestsEnabled(),
+            MigrationOwner->GetActorToLockAndDrainRange());
     } else {
         NCloud::Register<TCopyRangeActor>(
             ctx,
@@ -131,7 +132,8 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
             RWClientId,
             BlockDigestGenerator,
             VolumeActorId,
-            Config->GetAssignIdToWriteAndZeroRequestsEnabled());
+            Config->GetAssignIdToWriteAndZeroRequestsEnabled(),
+            MigrationOwner->GetActorToLockAndDrainRange());
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -33,7 +33,7 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 // The block count migrated at a time.
-constexpr ui64 ProcessingBlockCount = ProcessingRangeSize / DefaultBlockSize;
+constexpr ui64 ProcessingBlockCount = MigrationRangeSize / DefaultBlockSize;
 
 auto MakeLeaderFollowerFilter(
     TActorId* leaderPartition,
@@ -336,7 +336,7 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionMigrationTest)
         const size_t migrationCopyBlocks = useDirectCopy ? 3 : 0;
         UNIT_ASSERT_VALUES_EQUAL(migrationCopyBlocks, counters.CopyBlocks.Count);
         UNIT_ASSERT_VALUES_EQUAL(
-            migrationCopyBlocks * ProcessingRangeSize,
+            migrationCopyBlocks * MigrationRangeSize,
             counters.CopyBlocks.RequestBytes);
 
         runtime.AdvanceCurrentTime(UpdateCountersInterval);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -47,7 +47,7 @@ private:
 
     // TODO implement DeviceStats and similar stuff
 
-    TRequestsInProgress<ui64> RequestsInProgress{EAllowedRequests::ReadWrite};
+    TRequestsInProgress<EAllowedRequests::ReadWrite, ui64> RequestsInProgress;
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -5,6 +5,7 @@
 
 #include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -463,6 +464,19 @@ public:
         return request;
     }
 
+    std::unique_ptr<NPartition::TEvPartition::TEvLockAndDrainRangeRequest>
+    CreateLockAndDrainRangeRequest(TBlockRange64 range)
+    {
+        return std::make_unique<
+            NPartition::TEvPartition::TEvLockAndDrainRangeRequest>(range);
+    }
+
+    void SendReleaseRange(TBlockRange64 range)
+    {
+        auto req =
+            std::make_unique<NPartition::TEvPartition::TEvReleaseRange>(range);
+        SendRequest(ActorId, std::move(req), ++RequestId);
+    }
 
 #define BLOCKSTORE_DECLARE_METHOD(name, ns)                                    \
     template <typename... Args>                                                \
@@ -498,6 +512,7 @@ public:
     BLOCKSTORE_DECLARE_METHOD(ZeroBlocks, TEvService);
     BLOCKSTORE_DECLARE_METHOD(CheckRange, TEvVolume);
     BLOCKSTORE_DECLARE_METHOD(ChecksumBlocks, TEvNonreplPartitionPrivate);
+    BLOCKSTORE_DECLARE_METHOD(LockAndDrainRange, NPartition::TEvPartition);
 
 #undef BLOCKSTORE_DECLARE_METHOD
 };

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1104,7 +1104,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         const ui64 totalBlockCount = 3 * blocksPerDevice;
         // We are migrating the first and third devices.
         const ui64 totalRangesToMigrate =
-            2 * blocksPerDevice * DefaultBlockSize / ProcessingRangeSize;
+            2 * blocksPerDevice * DefaultBlockSize / MigrationRangeSize;
 
         // creating a nonreplicated disk
         volume.UpdateVolumeConfig(
@@ -1620,7 +1620,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         constexpr auto VolumeBlockCount = BlocksPerDevice * 2.5;
         // We will migrate only the first and third devices.
         constexpr auto MigrationRangesPerDevice =
-            BlocksPerDevice * DefaultBlockSize / ProcessingRangeSize;
+            BlocksPerDevice * DefaultBlockSize / MigrationRangeSize;
         constexpr auto RangesToMigrateCount = MigrationRangesPerDevice * 2;
         constexpr auto TotalRangesInVolume = MigrationRangesPerDevice * 3;
         auto getDeviceBlocks = [&](ui32 deviceIndex) -> TBlockRange64
@@ -1630,7 +1630,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
                 BlocksPerDevice);
         };
         auto getMigrationRangeIndexByBlockStart = [&](ui64 start) -> ui32 {
-            return start * DefaultBlockSize / ProcessingRangeSize;
+            return start * DefaultBlockSize / MigrationRangeSize;
         };
 
         // creating a nonreplicated disk
@@ -1740,7 +1740,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         const auto volumeBlockCount = blocksPerDevice * 2.5;
         // We will migrate only the first and third devices.
         const auto migrationRangesPerDevice =
-            blocksPerDevice * DefaultBlockSize / ProcessingRangeSize;
+            blocksPerDevice * DefaultBlockSize / MigrationRangeSize;
         const auto totalRangesInVolume = migrationRangesPerDevice * 3;
         auto getDeviceBlocks = [&](ui32 deviceIndex) -> TBlockRange64
         {
@@ -1749,7 +1749,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
                 blocksPerDevice);
         };
         auto getMigrationRangeIndexByBlockStart = [&](ui64 start) -> ui32 {
-            return start * DefaultBlockSize / ProcessingRangeSize;
+            return start * DefaultBlockSize / MigrationRangeSize;
         };
 
         // creating a nonreplicated disk
@@ -1845,10 +1845,10 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         const auto blocksPerDevice =
             DefaultDeviceBlockCount * DefaultDeviceBlockSize / DefaultBlockSize;
         const auto migrationRangesPerDevice =
-            blocksPerDevice * DefaultBlockSize / ProcessingRangeSize;
+            blocksPerDevice * DefaultBlockSize / MigrationRangeSize;
         const auto totalRangesToMigrateCount = migrationRangesPerDevice * 2;
         const ui64 blockPerMigratedRange =
-            ProcessingRangeSize / DefaultBlockSize;
+            MigrationRangeSize / DefaultBlockSize;
 
         // creating a nonreplicated disk
         volume.UpdateVolumeConfig(

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -4960,7 +4960,7 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
             DefaultDeviceBlockSize * DefaultDeviceBlockCount / DefaultBlockSize;
 
         const ui64 blocksInProcessingRange =
-            ProcessingRangeSize / DefaultBlockSize;
+            MigrationRangeSize / DefaultBlockSize;
 
         TVolumeClient volume(*runtime);
         volume.UpdateVolumeConfig(


### PR DESCRIPTION
#3 пр для починки #3273
В этом пре добавил сообщения BlockRangeAndDrain и ReleaseRange в миррор партишен.

При получении сообщения BlockRangeAndDrain миррор ппартишен блокирует запись в определенный рейндж(реджектит запросы, приходящие в него) и делает дрейн для запросов из этого рейнджа. Как только пишущих запросов в рейндже не осталось, посылает ответ.

Сообщение ReleaseRange разблокирует рейндж для записи.

Предполагавется, что при миграции фреш девайса мы сперва будем посылать BlockRangeAndDrain, дожидаться ответа на это сообющение, затем выполнять копирование, и посылать ReleaseRange разблокируя рейндж для записи.

Для этого были реализованы классы TRequestBoundsTracker и TCopyRangeActorCommon. TRequestBoundsTracker - это мапа, в которой мы помечаем, что в диапозоне присутствует реквест, чтобы было меньше оверхеда это делается с точностью 4MB(размер миграционного рейнджа), таким образом на каждую IO операцию будет делаться максимум 2 лукапа\вставки в хэшмапу, что должно быть весьма быстро. TCopyRangeActorCommon - актор от которого наследуются TCopyRangeActor и TDirectCopyRangeActor, нужен чтобы выполнять общие действия: при поднятии лочить рейндж и дожидать дрейна,  при смерти освобождать заблокированный рейндж. Похож на коммон актор для миграций.

Также был добавлен класс TRequestsInProgressWithBlockRangeTracking, который является композицией классов TRequestInProgress и TRequestBoundsTracker. При добавлении запроса на запись, он добавляет его в TRequestBoundsTracker и в TRequestInProgress, при удалении так же удаляет запрос из TRequestBoundsTracker(если это был запрос на запись). Соответственно в миррор партишене заменил TRequestInProgress на TRequestsInProgressWithBlockRangeTracking.