### PR TITLE
[Blockstore] remove hardcoded quota limit of 4GiB

### DIFF
--- a/cloud/blockstore/libs/client/throttling.cpp
+++ b/cloud/blockstore/libs/client/throttling.cpp
@@ -540,16 +540,6 @@ ui64 MinNonzero(ui64 a, ui64 b, Args... args)
     return MinNonzero(a, MinNonzero(b, args...));
 }
 
-template <typename... Args>
-ui64 GetMinLimit(Args... args)
-{
-    auto limit = MinNonzero(args...);
-    if (limit > Max<ui32>()) {
-        limit = Max<ui32>();
-    }
-    return limit;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 bool PrepareMediaKindPerformanceProfile(
@@ -575,7 +565,7 @@ bool PrepareMediaKindPerformanceProfile(
 
         ui64 maxIops = mediaKindConfig.GetMaxReadIops();
 
-        const auto iops = GetMinLimit(
+        const auto iops = MinNonzero(
             cpuUnitCount * iopsPerCpuUnit,
             maxIopsPerGuest,
             maxIops
@@ -591,7 +581,7 @@ bool PrepareMediaKindPerformanceProfile(
 
         ui64 maxIops = mediaKindConfig.GetMaxWriteIops();
 
-        const auto iops = GetMinLimit(
+        const auto iops = MinNonzero(
             cpuUnitCount * iopsPerCpuUnit,
             maxIopsPerGuest,
             maxIops
@@ -607,7 +597,7 @@ bool PrepareMediaKindPerformanceProfile(
 
         ui64 maxBw = mediaKindConfig.GetMaxReadBandwidth() * 1_MB;
 
-        const auto bw = GetMinLimit(
+        const auto bw = MinNonzero(
             cpuUnitCount * bandwidthPerCpuUnit * 1_MB,
             maxBandwidthPerGuest,
             maxBw
@@ -623,7 +613,7 @@ bool PrepareMediaKindPerformanceProfile(
 
         ui64 maxBw = mediaKindConfig.GetMaxWriteBandwidth() * 1_MB;
 
-        const auto bw = GetMinLimit(
+        const auto bw = MinNonzero(
             cpuUnitCount * bandwidthPerCpuUnit * 1_MB,
             maxBandwidthPerGuest,
             maxBw
@@ -675,7 +665,7 @@ bool PreparePerformanceProfile(
         * (tc.GetNetworkThroughputPercentage() / 100.0);
 
     if (!networkBandwidth) {
-        networkBandwidth = Max<ui32>();
+        networkBandwidth = Max<ui64>();
     }
 
     ui64 maxIopsPerGuest = hostFraction * tc.GetMaxIopsPerHost();

--- a/cloud/blockstore/libs/client/throttling_ut.cpp
+++ b/cloud/blockstore/libs/client/throttling_ut.cpp
@@ -486,7 +486,7 @@ Y_UNIT_TEST_SUITE(TThrottlingClientTest)
         NProto::TClientConfig clientConfig;
         NProto::TClientProfile clientProfile;
         ui64 iops = 400;
-        ui64 bw = 1;
+        ui64 bw = 100;
 
         auto& tc = *clientConfig.MutableThrottlingConfig();
         tc.SetIopsPerCpuUnit(iops);
@@ -505,21 +505,15 @@ Y_UNIT_TEST_SUITE(TThrottlingClientTest)
         for (ui32 cpuUnitCount = 1; cpuUnitCount < 100000; ++cpuUnitCount) {
             clientProfile.SetCpuUnitCount(cpuUnitCount);
 
-            auto correctedCpuUnitCount = Max(100u, cpuUnitCount);
-            auto expectedIops = iops * correctedCpuUnitCount;
-            auto expectedBandwidth = bw * correctedCpuUnitCount * 1_MB;
-            auto expectedReadIopsNonreplicated = Min(100'000UL, 2 * expectedIops);
-            auto expectedWriteIopsNonreplicated = Min(200'000UL, 2 * expectedIops);
-            auto expectedReadBandwidthNonreplicated =
+            const auto correctedCpuUnitCount = Max(100u, cpuUnitCount);
+            const auto expectedIops = iops * correctedCpuUnitCount;
+            const auto expectedBandwidth = bw * correctedCpuUnitCount * 1_MB;
+            const auto expectedReadIopsNonreplicated = Min(100'000UL, 2 * expectedIops);
+            const auto expectedWriteIopsNonreplicated = Min(200'000UL, 2 * expectedIops);
+            const auto expectedReadBandwidthNonreplicated =
                 Min(1'000_MB, 2 * expectedBandwidth);
-            auto expectedWriteBandwidthNonreplicated =
+            const auto expectedWriteBandwidthNonreplicated =
                 Min(2'000_MB, 2 * expectedBandwidth);
-            if (expectedIops > Max<ui32>()) {
-                expectedIops = Max<ui32>();
-            }
-            if (expectedBandwidth > Max<ui32>()) {
-                expectedBandwidth = Max<ui32>();
-            }
 
             NProto::TClientPerformanceProfile performanceProfile;
             UNIT_ASSERT(PreparePerformanceProfile(


### PR DESCRIPTION
Removing the artificial volume quota bandwidth limit of 4 GiB/s.