### PR TITLE
fix: typo in github attribute caused build-and-test to not use network cache when workflow build_and_test_on_demand.yaml is executed directly

### DIFF
--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -252,9 +252,9 @@ jobs:
       sleep_after_tests: ${{ inputs.sleep_after_tests }}
       cache_update_build: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('{0}', inputs.cache_update) || format('{0}', inputs.cache_update_build)) }}
       cache_update_tests: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('{0}', inputs.cache_update) || format('{0}', inputs.cache_update_tests)) }}
-      upload_ya_dir: ${{ github.event == 'workflow_dispatch' && 'no' || inputs.upload_ya_dir}}
-      clean_ya_dir: ${{ github.event == 'workflow_dispatch' && 'no' || inputs.clean_ya_dir }}
-      use_network_cache: ${{ github.event == 'workflow_dispatch' && 'yes'|| inputs.use_network_cache }}
+      upload_ya_dir: ${{ github.event_name == 'workflow_dispatch' && 'no' || inputs.upload_ya_dir}}
+      clean_ya_dir: ${{ github.event_name == 'workflow_dispatch' && 'no' || inputs.clean_ya_dir }}
+      use_network_cache: ${{ github.event_name == 'workflow_dispatch' && 'yes'|| inputs.use_network_cache }}
       nebius: ${{ needs.provide-runner.outputs.nebius }}
       truncate_enabled: ${{ contains(github.event.pull_request.labels.*.name, 'disable_truncate') && 'no' || 'yes' }}
     secrets: inherit


### PR DESCRIPTION
Differrence is comically big
https://github.com/librarian-test/nbs/actions/runs/14196590910/job/39773076391 1h23m for build
https://github.com/librarian-test/nbs/actions/runs/14198904719/job/39780755567 4m21s for build with fix

https://github.com/ydb-platform/nbs/actions/runs/14201270002/job/39789160507 with fix
https://github.com/ydb-platform/nbs/actions/runs/14201277706/job/39788606837 without