### PR TITLE
Teach TGetDeviceForRangeCompaction to disallow every operation; teach TMigrationTimeoutCalculator to work without PartitionConfig provided; add method for FollowerDiskId printing

### DIFF
--- a/cloud/blockstore/libs/storage/core/forward_helpers.h
+++ b/cloud/blockstore/libs/storage/core/forward_helpers.h
@@ -116,7 +116,7 @@ inline TGuardedSgList GetSglist(const NProto::TWriteBlocksLocalRequest& request)
 
 template <typename TEvent>
 void ForwardMessageToActor(
-    TEvent& ev,
+    const TEvent& ev,
     const NActors::TActorContext& ctx,
     NActors::TActorId dstActor)
 {

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.cpp
@@ -21,10 +21,16 @@ TGetDeviceForRangeCompanion::TGetDeviceForRangeCompanion(
         EAllowedOperation allowedOperation,
         TStorageConfigPtr config,
         TNonreplicatedPartitionConfigPtr partConfig)
-    : AllowedOperation(allowedOperation)
-    , Config(std::move(config))
+    : Config(std::move(config))
     , PartConfig(std::move(partConfig))
+    , AllowedOperation(allowedOperation)
 {}
+
+void TGetDeviceForRangeCompanion::SetAllowedOperation(
+    EAllowedOperation allowedOperation)
+{
+    AllowedOperation = allowedOperation;
+}
 
 void TGetDeviceForRangeCompanion::SetDelegate(NActors::TActorId delegate)
 {
@@ -42,6 +48,9 @@ void TGetDeviceForRangeCompanion::HandleGetDeviceForRange(
 
     bool operationAllowed = false;
     switch (AllowedOperation) {
+        case EAllowedOperation::None:
+            operationAllowed = false;
+            break;
         case EAllowedOperation::Read:
             operationAllowed = msg->Purpose == EPurpose::ForReading;
             break;

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
@@ -21,14 +21,16 @@ class TGetDeviceForRangeCompanion
 public:
     enum class EAllowedOperation
     {
+        None,       // Reply with an error to all requests
         Read,       // Reply with an error to requests intended for writing
         ReadWrite   // Requests with any purpose are allowed
     };
 
 private:
-    const EAllowedOperation AllowedOperation;
     const TStorageConfigPtr Config;
     const TNonreplicatedPartitionConfigPtr PartConfig;
+
+    EAllowedOperation AllowedOperation;
     NActors::TActorId Delegate;
 
 public:
@@ -39,6 +41,7 @@ public:
         TStorageConfigPtr config,
         TNonreplicatedPartitionConfigPtr partConfig);
 
+    void SetAllowedOperation(EAllowedOperation allowedOperation);
     void SetDelegate(NActors::TActorId delegate);
 
     void HandleGetDeviceForRange(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator.cpp
@@ -38,7 +38,9 @@ TDuration TMigrationTimeoutCalculator::CalculateTimeout(
     const double migrationFactorPerAgent =
         limitedBandwidthMiBs / ProcessingRangeSizeMiBs;
 
-    if (PartitionConfig->GetUseSimpleMigrationBandwidthLimiter()) {
+    if (!PartitionConfig ||
+        PartitionConfig->GetUseSimpleMigrationBandwidthLimiter())
+    {
         return TDuration::Seconds(1) / migrationFactorPerAgent;
     }
 
@@ -64,6 +66,9 @@ TDuration TMigrationTimeoutCalculator::CalculateTimeout(
 void TMigrationTimeoutCalculator::RegisterTrafficSource(
     const NActors::TActorContext& ctx)
 {
+    if (!PartitionConfig) {
+        return;
+    }
     auto request = std::make_unique<
         TEvStatsServicePrivate::TEvRegisterTrafficSourceRequest>();
     request->SourceId = PartitionConfig->GetName();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_timeout_calculator_ut.cpp
@@ -380,6 +380,27 @@ Y_UNIT_TEST_SUITE(TMigrationCalculatorTest)
             timeoutCalculator.CalculateTimeout(
                 TBlockRange64::WithLength(1024 * 3, 1024)));
     }
+
+    Y_UNIT_TEST(ShouldWorkWithEmptyPartitionConfig)
+    {
+        TMigrationTimeoutCalculator timeoutCalculator(
+            16,
+            100500,
+            nullptr);
+
+        // Calculate timeout with inital bandwidth
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Seconds(1) / 4,
+            timeoutCalculator.CalculateTimeout(
+                TBlockRange64::WithLength(0, 1024)));
+
+        // Calculate timeout with recommended bandwidth
+        timeoutCalculator.SetRecommendedBandwidth(40_MB);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Seconds(1) / 10,
+            timeoutCalculator.CalculateTimeout(
+                TBlockRange64::WithLength(1024 * 0, 1024)));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
@@ -4,6 +4,11 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TString TFollowerDiskInfo::GetDiskIdForPrint() const
+{
+    return ScaleUnitId ? (ScaleUnitId + "/" + FollowerDiskId) : FollowerDiskId;
+}
+
 bool TFollowerDiskInfo::operator==(
     const TFollowerDiskInfo& rhs) const = default;
 

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.h
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.h
@@ -25,6 +25,7 @@ struct TFollowerDiskInfo
     EState State = EState::None;
     std::optional<ui64> MigrationBlockIndex;
 
+    TString GetDiskIdForPrint() const;
     bool operator==(const TFollowerDiskInfo& rhs) const;
 };
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -886,10 +886,7 @@ void TVolumeActor::RenderLinks(IOutputStream& out) const
                             out << follower.Uuid;
                         }
                         TABLED () {
-                            if (follower.ScaleUnitId) {
-                                out << follower.ScaleUnitId << "/";
-                            }
-                            out << follower.FollowerDiskId;
+                            out << follower.GetDiskIdForPrint();
                         }
                         TABLED () {
                             out << ToString(follower.State);


### PR DESCRIPTION
продолжение https://github.com/ydb-platform/nbs/issues/2999
1. добавил пропущенный const
2. TGetDeviceForRangeCompanion теперь умеет на все запросы отвечать ошибкой
3. TMigrationTimeoutCalculator научился работать без конфига, ему достаточно знать разрешенный bandwidth чтобы рассчитывать задержки
4. сделал метод для печати имени диска 