### PR TITLE
[Filestore] fixed code-style in filestore-public-sdk-go-client

### DIFF
--- a/cloud/filestore/public/sdk/go/client/grpc.go
+++ b/cloud/filestore/public/sdk/go/client/grpc.go
@@ -38,7 +38,7 @@ func (client *grpcClient) setupHeaders(ctx context.Context, req request) {
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
 		if idempotenceID, ok := val.([]byte); ok {
-			headers.IdempotenceId = idempotenceId
+			headers.IdempotenceId = idempotenceID
 		}
 	}
 
@@ -315,7 +315,7 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
 		if idempotenceID, ok := val.([]byte); ok {
-			headers.IdempotenceId = idempotenceId
+			headers.IdempotenceId = idempotenceID
 		}
 	}
 
@@ -336,7 +336,7 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 
 	if val := ctx.Value(TraceIDHeaderKey); val != nil {
 		if traceID, ok := val.([]byte); ok {
-			headers.TraceId = traceId
+			headers.TraceId = traceID
 		}
 	}
 

--- a/cloud/filestore/public/sdk/go/client/grpc.go
+++ b/cloud/filestore/public/sdk/go/client/grpc.go
@@ -37,7 +37,7 @@ func (client *grpcClient) setupHeaders(ctx context.Context, req request) {
 	headers.ClientId = []byte(client.clientID)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
-		if idempotenceId, ok := val.([]byte); ok {
+		if idempotenceId, ok := val.([]byte); ok { //nolint:st1003
 			headers.IdempotenceId = idempotenceId
 		}
 	}
@@ -314,7 +314,7 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 	headers.ClientId = []byte(client.clientID)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
-		if idempotenceId, ok := val.([]byte); ok {
+		if idempotenceId, ok := val.([]byte); ok { //nolint:ST1003
 			headers.IdempotenceId = idempotenceId
 		}
 	}
@@ -335,7 +335,7 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 	headers.Timestamp = uint64(timestamp)
 
 	if val := ctx.Value(TraceIDHeaderKey); val != nil {
-		if traceId, ok := val.([]byte); ok {
+		if traceId, ok := val.([]byte); ok { //nolint:ST1003
 			headers.TraceId = traceId
 		}
 	}

--- a/cloud/filestore/public/sdk/go/client/grpc.go
+++ b/cloud/filestore/public/sdk/go/client/grpc.go
@@ -37,7 +37,7 @@ func (client *grpcClient) setupHeaders(ctx context.Context, req request) {
 	headers.ClientId = []byte(client.clientID)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
-		if idempotenceId, ok := val.([]byte); ok { //nolint:st1003
+		if idempotenceID, ok := val.([]byte); ok {
 			headers.IdempotenceId = idempotenceId
 		}
 	}
@@ -314,7 +314,7 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 	headers.ClientId = []byte(client.clientID)
 
 	if val := ctx.Value(IdempotenceIDHeaderKey); val != nil {
-		if idempotenceId, ok := val.([]byte); ok { //nolint:ST1003
+		if idempotenceID, ok := val.([]byte); ok {
 			headers.IdempotenceId = idempotenceId
 		}
 	}
@@ -335,7 +335,7 @@ func (client *grpcEndpointClient) setupHeaders(ctx context.Context, req request)
 	headers.Timestamp = uint64(timestamp)
 
 	if val := ctx.Value(TraceIDHeaderKey); val != nil {
-		if traceId, ok := val.([]byte); ok { //nolint:ST1003
+		if traceID, ok := val.([]byte); ok {
 			headers.TraceId = traceId
 		}
 	}


### PR DESCRIPTION
cloud/filestore/public/sdk/go/client/ut <govet>
```
------ sole chunk ran 1 test (total:0.73s - test:0.71s)
[fail] filestore-public-sdk-go-client.vet.txt::govet [default-linux-x86_64-relwithdebinfo] (0.32s)
$S/cloud/filestore/public/sdk/go/client/grpc.go:40:6: "ST1003: var idempotenceId should be idempotenceID"
$S/cloud/filestore/public/sdk/go/client/grpc.go:40:6: "ST1003: if you believe this report is false positive, please silence it with //nolint:st1003 comment"
$S/cloud/filestore/public/sdk/go/client/grpc.go:61:6: "ST1003: var traceId should be traceID"
$S/cloud/filestore/public/sdk/go/client/grpc.go:61:6: "ST1003: if you believe this report is false positive, please silence it with //nolint:st1003 comment"
$S/cloud/filestore/public/sdk/go/client/grpc.go:317:6: "ST1003: var idempotenceId should be idempotenceID"
$S/cloud/filestore/public/sdk/go/client/grpc.go:317:6: "ST1003: if you believe this report is false positive, please silence it with //nolint:st1003 comment"
$S/cloud/filestore/public/sdk/go/client/grpc.go:338:6: "ST1003: var traceId should be traceID"
$S/cloud/filestore/public/sdk/go/client/grpc.go:338:6: "ST1003: if you believe this report is false positive, please silence it with //nolint:st1003 comment"
```