### PR TITLE
Rename RestartDiskRegistryBasedPartition method

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -1065,7 +1065,10 @@ private:
         NActors::TActorId nonreplicatedActorId,
         std::shared_ptr<TNonreplicatedPartitionConfig> srcConfig);
 
-    void RestartDiskRegistryBasedPartition(
+    // Restart partitions. If these were partition of DiskRegistry-based disk,
+    // then the onPartitionStopped callback will be called after the partition
+    // is stopped.
+    void RestartPartition(
         const NActors::TActorContext& ctx,
         TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped);
     void StartPartitionsImpl(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1436,7 +1436,7 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                 std::make_unique<TEvVolumePrivate::TEvExternalDrainDone>();
             NCloud::Send(ctx, actorId, std::move(event));
         };
-        RestartDiskRegistryBasedPartition(ctx, std::move(onPartitionStopped));
+        RestartPartition(ctx, std::move(onPartitionStopped));
     }
 }
 
@@ -1576,7 +1576,7 @@ void TVolumeActor::CompleteUpdateCheckpointRequest(
         !State->GetCheckpointStore().HasShadowActor(request.CheckpointId);
 
     if (needToCreateShadowActor) {
-        RestartDiskRegistryBasedPartition(ctx, {});
+        RestartPartition(ctx, {});
     }
 
     if (request.Type == ECheckpointType::Light) {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_resync.cpp
@@ -167,7 +167,7 @@ void TVolumeActor::CompleteToggleResync(
     Y_UNUSED(args);
 
     if (args.ResyncWasNeeded != State->IsMirrorResyncNeeded()) {
-        RestartDiskRegistryBasedPartition(ctx, {});
+        RestartPartition(ctx, {});
     } else {
         State->SetReadWriteError({});
     }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -307,7 +307,7 @@ NActors::TActorId TVolumeActor::WrapNonreplActorIfNeeded(
     return nonreplicatedActorId;
 }
 
-void TVolumeActor::RestartDiskRegistryBasedPartition(
+void TVolumeActor::RestartPartition(
     const TActorContext& ctx,
     TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped)
 {


### PR DESCRIPTION
Название вводило в заблуждение, потому что метод рестартовал партишены любого типа.