### PR TITLE
[Filestore] reduce service-kikimr-localdb-compaction-test memory footprint size

### DIFF
--- a/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/create-remove.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/create-remove.txt
@@ -5,7 +5,7 @@ Tests {
             FileSystemId: "smoke"
             FolderId: "folder"
             CloudId: "cloud"
-            BlocksCount: 10241024
+            BlocksCount: 5120512
             BlockSize: 4096
         }
         IndexLoadSpec {


### PR DESCRIPTION
Уменьшаю размер теста, что бы он перестал под санитайзерами таймаутиться.

Сейчас под memory sanitizer'ом

```
------ [5/7] chunk ran 1 test (total:791.87s - setup:0.01s recipes:59.95s test:695.36s recipes:25.63s)
Chunk exceeded 600s timeout and was killed
List of the tests involved in the launch:
test.py::test_load[ops3-create-remove] (timeout) duration: 684.25s
Log: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/run_test.log
Logsdir: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk5/testing_out_stuff
Stderr: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk5/testing_out_stuff/stderr
[timeout] test.py::test_load[ops3-create-remove] [default-linux-x86_64-release-msan] (684.25s) Killed by timeout (600 s)
Log: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk5/testing_out_stuff/test.py.test_load.ops3-create-remove.log
Logsdir: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk5/testing_out_stuff
------ [6/7] chunk ran 1 test (total:205.61s - setup:0.01s recipes:9.39s test:191.40s recipes:4.74s)
[good] test.py::test_load[ops3-read-write-validation] [default-linux-x86_64-release-msan] (188.70s)
Log: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk6/testing_out_stuff/test.py.test_load.ops3-read-write-validation.log
Logsdir: http://proxy.sandbox.yandex-team.ru/8288153229/cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test/test-results/py3test/chunk6/testing_out_stuff
------ TIMEOUT: 7 - GOOD, 1 - TIMEOUT cloud/filestore/tests/loadtest/service-kikimr-localdb-compaction-test
```