### PR TITLE
Fix replicas mess when only minors healed in second or third replicas

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
@@ -292,9 +292,11 @@ void TResyncRangeBlockByBlockActor::PrepareWriteBuffers(
 
     // Do writes only to replicas with fixed errors.
     ActorsToResync.clear();
-    for (size_t i = 0; i < Replicas.size(); ++i) {
-        if (healStat[i].FixedMinorErrorCount || healStat[i].FixedMajorErrorCount) {
-            ActorsToResync.push_back(i);
+    for (size_t replica = 0; replica < Replicas.size(); ++replica) {
+        if (healStat[replica].FixedMinorErrorCount ||
+            healStat[replica].FixedMajorErrorCount)
+        {
+            ActorsToResync.push_back(replica);
         }
     }
 }
@@ -341,8 +343,8 @@ void TResyncRangeBlockByBlockActor::WriteBlocks(const TActorContext& ctx)
         return;
     }
 
-    for (size_t i = 0; i < ActorsToResync.size(); ++i) {
-        WriteReplicaBlocks(ctx, ActorsToResync[i], std::move(ReadBuffers[i]));
+    for (auto replica: ActorsToResync) {
+        WriteReplicaBlocks(ctx, replica, std::move(ReadBuffers[replica]));
     }
 
     WriteStartTs = ctx.Now();


### PR DESCRIPTION
Исправлен баг режима RESYNC_POLICY_MINOR_BLOCK_BY_BLOCK
Для воспроизведения нужно:
1.  имелось мажорное расхождение
2. в одной или двух репликах имелись минорные расхождения
3. реплика без минорного расхождения #0 

К чему приводило:
1. в реплику/реплики c минорным расхождением вместе с починкой приезжали мажорные  расхождения чужой реплики. 
2. после этого расхождения превращались в минорные
3. на следующий ресинк эти расхождения чинились