### PR TITLE
Persist migration progress for linked disks

### DIFF
--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -733,8 +733,11 @@ message TLinkLeaderVolumeToFollowerResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
+    // Uuid of created link.
+    string Uuid = 2;
+
     // Request traces.
-    NCloud.NProto.TTraceInfo Trace = 2;
+    NCloud.NProto.TTraceInfo Trace = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -734,7 +734,7 @@ message TLinkLeaderVolumeToFollowerResponse
     NCloud.NProto.TError Error = 1;
 
     // Uuid of created link.
-    string Uuid = 2;
+    string LinkUUID = 2;
 
     // Request traces.
     NCloud.NProto.TTraceInfo Trace = 3;

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
@@ -1,5 +1,10 @@
 #include "follower_disk.h"
 
+#include <cloud/storage/core/libs/common/format.h>
+
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -7,6 +12,20 @@ namespace NCloud::NBlockStore::NStorage {
 TString TFollowerDiskInfo::GetDiskIdForPrint() const
 {
     return ScaleUnitId ? (ScaleUnitId + "/" + FollowerDiskId) : FollowerDiskId;
+}
+
+TString TFollowerDiskInfo::Describe() const
+{
+    auto builder = TStringBuilder();
+    builder << "{ State:" << ToString(State) << ", MigratedBytes:";
+
+    if (MigratedBytes) {
+        builder << FormatByteSize(*MigratedBytes);
+    } else {
+        builder << "-";
+    }
+    builder << "}";
+    return builder;
 }
 
 bool TFollowerDiskInfo::operator==(

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.h
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.h
@@ -23,9 +23,10 @@ struct TFollowerDiskInfo
     TString FollowerDiskId;
     TString ScaleUnitId;
     EState State = EState::None;
-    std::optional<ui64> MigrationBlockIndex;
+    std::optional<ui64> MigratedBytes;
 
     TString GetDiskIdForPrint() const;
+    TString Describe() const;
     bool operator==(const TFollowerDiskInfo& rhs) const;
 };
 

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.h
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.h
@@ -19,7 +19,7 @@ struct TFollowerDiskInfo
         Error = 3,
     };
 
-    TString Uuid;
+    TString LinkUUID;
     TString FollowerDiskId;
     TString ScaleUnitId;
     EState State = EState::None;

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -591,6 +591,20 @@ TVolumeClient::CreateUnlinkLeaderVolumeFromFollowerRequest(
     return result;
 }
 
+std::unique_ptr<TEvVolumePrivate::TEvUpdateFollowerStateRequest>
+TVolumeClient::CreateUpdateFollowerStateRequest(
+    TString followerUuid,
+    TEvVolumePrivate::TUpdateFollowerStateRequest::EReason reason,
+    std::optional<ui64> migratedBytes)
+{
+    auto result =
+        std::make_unique<TEvVolumePrivate::TEvUpdateFollowerStateRequest>(
+            std::move(followerUuid),
+            reason,
+            migratedBytes);
+    return result;
+}
+
 void TVolumeClient::SendRemoteHttpInfo(
     const TString& params,
     HTTP_METHOD method)

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -476,6 +476,12 @@ public:
         const TString& leaderDiskId,
         const TString& followerDiskId);
 
+    std::unique_ptr<TEvVolumePrivate::TEvUpdateFollowerStateRequest>
+    CreateUpdateFollowerStateRequest(
+        TString followerUuid,
+        TEvVolumePrivate::TUpdateFollowerStateRequest::EReason reason,
+        std::optional<ui64> migratedBytes);
+
     void SendRemoteHttpInfo(
         const TString& params,
         HTTP_METHOD method);

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -994,6 +994,10 @@ STFUNC(TVolumeActor::StateInit)
             HandleUpdateShadowDiskState);
 
         HFunc(
+            TEvVolumePrivate::TEvUpdateFollowerStateRequest,
+            HandleUpdateFollowerState);
+
+        HFunc(
             TEvDiskRegistryProxy::TEvGetDrTabletInfoResponse,
             HandleGetDrTabletInfoResponse);
 
@@ -1113,6 +1117,10 @@ STFUNC(TVolumeActor::StateWork)
             HandleUpdateShadowDiskState);
 
         HFunc(
+            TEvVolumePrivate::TEvUpdateFollowerStateRequest,
+            HandleUpdateFollowerState);
+
+        HFunc(
             TEvDiskRegistryProxy::TEvGetDrTabletInfoResponse,
             HandleGetDrTabletInfoResponse);
 
@@ -1162,6 +1170,7 @@ STFUNC(TVolumeActor::StateZombie)
         IgnoreFunc(TEvPartitionCommonPrivate::TEvLongRunningOperation);
 
         IgnoreFunc(TEvVolumePrivate::TEvUpdateShadowDiskStateRequest);
+        IgnoreFunc(TEvVolumePrivate::TEvUpdateFollowerStateRequest);
 
         IgnoreFunc(TEvDiskRegistryProxy::TEvGetDrTabletInfoResponse);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_link_volume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_link_volume.cpp
@@ -15,6 +15,7 @@ bool TVolumeActor::PrepareAddFollower(
     Y_UNUSED(tx);
     Y_UNUSED(args);
 
+    args.Uuid = CreateGuidAsString();
     return true;
 }
 
@@ -36,10 +37,10 @@ void TVolumeActor::ExecuteAddFollower(
     TVolumeDatabase db(tx.DB);
 
     auto newFollower = TFollowerDiskInfo{
-        .Uuid = CreateGuidAsString(),
+        .Uuid = args.Uuid,
         .FollowerDiskId = args.FollowerDiskId,
         .ScaleUnitId = "",
-        .MigrationBlockIndex = std::nullopt};
+        .MigratedBytes = std::nullopt};
 
     db.WriteFollower(newFollower);
     State->AddOrUpdateFollower(std::move(newFollower));
@@ -52,7 +53,10 @@ void TVolumeActor::CompleteAddFollower(
     auto response =
         std::make_unique<TEvVolume::TEvLinkLeaderVolumeToFollowerResponse>(
             MakeError(S_OK));
+    response->Record.SetUuid(args.Uuid);
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+
+    RestartPartition(ctx, {});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,9 +78,9 @@ void TVolumeActor::ExecuteRemoveFollower(
     ITransactionBase::TTransactionContext& tx,
     TTxVolume::TRemoveFollower& args)
 {
-    Y_DEBUG_ABORT_UNLESS(!args.Id.empty());
+    Y_DEBUG_ABORT_UNLESS(!args.Uuid.empty());
 
-    auto follower = State->FindFollowerByUuid(args.Id);
+    auto follower = State->FindFollowerByUuid(args.Uuid);
     Y_DEBUG_ABORT_UNLESS(follower);
 
     LOG_INFO(
@@ -88,7 +92,7 @@ void TVolumeActor::ExecuteRemoveFollower(
         follower->FollowerDiskId.c_str());
 
     TVolumeDatabase db(tx.DB);
-    State->RemoveFollower(args.Id);
+    State->RemoveFollower(args.Uuid);
     db.DeleteFollower(*follower);
 }
 
@@ -100,6 +104,59 @@ void TVolumeActor::CompleteRemoveFollower(
         std::make_unique<TEvVolume::TEvUnlinkLeaderVolumeFromFollowerResponse>(
             MakeError(S_OK));
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+
+    RestartPartition(ctx, {});
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TVolumeActor::PrepareUpdateFollower(
+    const TActorContext& ctx,
+    ITransactionBase::TTransactionContext& tx,
+    TTxVolume::TUpdateFollower& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TVolumeActor::ExecuteUpdateFollower(
+    const TActorContext& ctx,
+    ITransactionBase::TTransactionContext& tx,
+    TTxVolume::TUpdateFollower& args)
+{
+    auto current = State->FindFollowerByUuid(args.FollowerInfo.Uuid);
+    if (!current) {
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "[%lu] Update follower %s <- %s: %s -> %s",
+        TabletID(),
+        State->GetDiskId().Quote().c_str(),
+        args.FollowerInfo.GetDiskIdForPrint().Quote().c_str(),
+        current->Describe().c_str(),
+        args.FollowerInfo.Describe().c_str());
+
+    TVolumeDatabase db(tx.DB);
+    State->AddOrUpdateFollower(args.FollowerInfo);
+    db.WriteFollower(args.FollowerInfo);
+}
+
+void TVolumeActor::CompleteUpdateFollower(
+    const TActorContext& ctx,
+    TTxVolume::TUpdateFollower& args)
+{
+    auto response =
+        std::make_unique<TEvVolumePrivate::TEvUpdateFollowerStateResponse>(
+            MakeError(S_OK));
+    response->NewState = args.FollowerInfo.State;
+    response->MigratedBytes = args.FollowerInfo.MigratedBytes;
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,6 +166,7 @@ void TVolumeActor::HandleLinkLeaderVolumeToFollower(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
+
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
@@ -137,6 +195,7 @@ void TVolumeActor::HandleUnlinkLeaderVolumeFromFollower(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
+
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
@@ -161,6 +220,68 @@ void TVolumeActor::HandleUnlinkLeaderVolumeFromFollower(
         ctx,
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
         follower->Uuid);
+}
+
+void TVolumeActor::HandleUpdateFollowerState(
+    const TEvVolumePrivate::TEvUpdateFollowerStateRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    using EReason = TEvVolumePrivate::TUpdateFollowerStateRequest::EReason;
+    using EState = TFollowerDiskInfo::EState;
+
+    auto* msg = ev->Get();
+
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+
+    auto followerInfo = State->FindFollowerByUuid(msg->FollowerUuid);
+
+    auto reply = [&](EState newState)
+    {
+        auto response = std::make_unique<
+            TEvVolumePrivate::TEvUpdateFollowerStateResponse>(
+            newState,
+            msg->MigratedBytes);
+        NCloud::Reply(ctx, *ev, std::move(response));
+    };
+
+    if (!followerInfo) {
+        reply(EState::Error);
+        return;
+    }
+
+    auto currentState = followerInfo->State;
+    if (currentState == EState::Error) {
+        reply(EState::Error);
+        return;
+    }
+
+    EState newState = EState::None;
+
+    switch (msg->Reason) {
+        case EReason::FillProgressUpdate: {
+            if (currentState == EState::Ready) {
+                reply(EState::Ready);
+                return;
+            }
+            newState = EState::Preparing;
+        } break;
+        case EReason::FillCompleted: {
+            newState = EState::Ready;
+        } break;
+        case EReason::FillError: {
+            newState = EState::Error;
+        } break;
+    }
+    Y_DEBUG_ABORT_UNLESS(newState != EState::None);
+
+    followerInfo->State = newState;
+    followerInfo->MigratedBytes = msg->MigratedBytes;
+
+    ExecuteTx<TUpdateFollower>(
+        ctx,
+        std::move(requestInfo),
+        std::move(*followerInfo));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -892,8 +892,8 @@ void TVolumeActor::RenderLinks(IOutputStream& out) const
                             out << ToString(follower.State);
                         }
                         TABLED () {
-                            if (follower.MigrationBlockIndex) {
-                                out << *follower.MigrationBlockIndex;
+                            if (follower.MigratedBytes) {
+                                out << FormatByteSize(*follower.MigratedBytes);
                             }
                         }
                     }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -883,7 +883,7 @@ void TVolumeActor::RenderLinks(IOutputStream& out) const
                 for (const auto& follower: State->GetAllFollowers()) {
                     TABLER () {
                         TABLED () {
-                            out << follower.Uuid;
+                            out << follower.LinkUUID;
                         }
                         TABLED () {
                             out << follower.GetDiskIdForPrint();

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -717,15 +717,15 @@ void TVolumeDatabase::WriteFollower(const TFollowerDiskInfo& follower)
             NIceDb::TUpdate<TTable::ScaleUnitId>(follower.ScaleUnitId),
             NIceDb::TUpdate<TTable::State>(static_cast<ui32>(follower.State)));
 
-    if (follower.MigrationBlockIndex) {
+    if (follower.MigratedBytes) {
         Table<TTable>()
             .Key(follower.Uuid)
-            .Update(NIceDb::TUpdate<TTable::MigratedBlockCount>(
-                *follower.MigrationBlockIndex));
+            .Update(NIceDb::TUpdate<TTable::MigratedBytes>(
+                *follower.MigratedBytes));
     } else {
         Table<TTable>()
             .Key(follower.Uuid)
-            .UpdateToNull<TTable::MigratedBlockCount>();
+            .UpdateToNull<TTable::MigratedBytes>();
     }
 }
 
@@ -756,10 +756,9 @@ bool TVolumeDatabase::ReadFollowers(
             .ScaleUnitId = it.GetValue<TTable::ScaleUnitId>(),
             .State = static_cast<TFollowerDiskInfo::EState>(
                 it.GetValue<TTable::State>()),
-            .MigrationBlockIndex =
-                it.HaveValue<TTable::MigratedBlockCount>()
-                    ? it.GetValue<TTable::MigratedBlockCount>()
-                    : std::optional<ui64>()});
+            .MigratedBytes = it.HaveValue<TTable::MigratedBytes>()
+                                 ? it.GetValue<TTable::MigratedBytes>()
+                                 : std::optional<ui64>()});
         if (!it.Next()) {
             return false;   // not ready
         }

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -711,7 +711,7 @@ void TVolumeDatabase::WriteFollower(const TFollowerDiskInfo& follower)
     using TTable = TVolumeSchema::FollowerDisks;
 
     Table<TTable>()
-        .Key(follower.Uuid)
+        .Key(follower.LinkUUID)
         .Update(
             NIceDb::TUpdate<TTable::FollowerDiskId>(follower.FollowerDiskId),
             NIceDb::TUpdate<TTable::ScaleUnitId>(follower.ScaleUnitId),
@@ -719,12 +719,12 @@ void TVolumeDatabase::WriteFollower(const TFollowerDiskInfo& follower)
 
     if (follower.MigratedBytes) {
         Table<TTable>()
-            .Key(follower.Uuid)
+            .Key(follower.LinkUUID)
             .Update(NIceDb::TUpdate<TTable::MigratedBytes>(
                 *follower.MigratedBytes));
     } else {
         Table<TTable>()
-            .Key(follower.Uuid)
+            .Key(follower.LinkUUID)
             .UpdateToNull<TTable::MigratedBytes>();
     }
 }
@@ -733,7 +733,7 @@ void TVolumeDatabase::DeleteFollower(const TFollowerDiskInfo& follower)
 {
     using TTable = TVolumeSchema::FollowerDisks;
 
-    Table<TTable>().Key(follower.Uuid).Delete();
+    Table<TTable>().Key(follower.LinkUUID).Delete();
 }
 
 bool TVolumeDatabase::ReadFollowers(
@@ -751,7 +751,7 @@ bool TVolumeDatabase::ReadFollowers(
 
     while (it.IsValid()) {
         followers.push_back(TFollowerDiskInfo{
-            .Uuid = it.GetValue<TTable::Uuid>(),
+            .LinkUUID = it.GetValue<TTable::Uuid>(),
             .FollowerDiskId = it.GetValue<TTable::FollowerDiskId>(),
             .ScaleUnitId = it.GetValue<TTable::ScaleUnitId>(),
             .State = static_cast<TFollowerDiskInfo::EState>(

--- a/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
@@ -1287,12 +1287,12 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
         TTestExecutor executor;
 
         TFollowerDiskInfo follower1{
-            .Uuid = "xxxxx",
+            .LinkUUID = "xxxxx",
             .FollowerDiskId = "volume_1",
             .ScaleUnitId = "SU_1"};
 
         TFollowerDiskInfo follower2{
-            .Uuid = "yyyyy",
+            .LinkUUID = "yyyyy",
             .FollowerDiskId = "volume_2",
             .State = TFollowerDiskInfo::EState::Preparing,
             .MigratedBytes = 1_MB};

--- a/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
@@ -1295,7 +1295,7 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
             .Uuid = "yyyyy",
             .FollowerDiskId = "volume_2",
             .State = TFollowerDiskInfo::EState::Preparing,
-            .MigrationBlockIndex = 100};
+            .MigratedBytes = 1_MB};
 
         executor.WriteTx(
             [&](TVolumeDatabase db)
@@ -1315,7 +1315,7 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 UNIT_ASSERT_EQUAL(follower2, readFollowers[1]);
             });
 
-        follower1.MigrationBlockIndex = 200;
+        follower1.MigratedBytes = 2_MB;
         follower1.State = TFollowerDiskInfo::EState::Ready;
 
         executor.WriteTx(
@@ -1350,7 +1350,7 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
                 UNIT_ASSERT_VALUES_EQUAL(1, readFollowers.size());
                 UNIT_ASSERT_EQUAL(follower2, readFollowers[0]);
             });
-        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -26,6 +26,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(UpdateShadowDiskState,              __VA_ARGS__)                       \
     xxx(ReadMetaHistory,                    __VA_ARGS__)                       \
     xxx(DeviceTimedOut,                     __VA_ARGS__)                       \
+    xxx(UpdateFollowerState,                __VA_ARGS__)                       \
 // BLOCKSTORE_VOLUME_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -384,6 +385,48 @@ struct TEvVolumePrivate
 
     struct TDevicesReleaseFinished
     {
+    };
+
+    //
+    //  UpdateFollowerStateRequest
+    //
+
+    struct TUpdateFollowerStateRequest
+    {
+        enum class EReason
+        {
+            FillProgressUpdate,
+            FillCompleted,
+            FillError,
+        };
+
+        TString FollowerUuid;
+        EReason Reason = EReason::FillError;
+        std::optional<ui64> MigratedBytes;
+
+        TUpdateFollowerStateRequest(
+                TString followerUuid,
+                EReason reason,
+                std::optional<ui64> migratedBytes)
+            : FollowerUuid(std::move(followerUuid))
+            , Reason(reason)
+            , MigratedBytes(migratedBytes)
+        {}
+    };
+
+    struct TUpdateFollowerStateResponse
+    {
+        TFollowerDiskInfo::EState NewState = TFollowerDiskInfo::EState::None;
+        std::optional<ui64> MigratedBytes;
+
+        TUpdateFollowerStateResponse() = default;
+
+        TUpdateFollowerStateResponse(
+                TFollowerDiskInfo::EState newState,
+                std::optional<ui64> migratedBytes)
+            : NewState(newState)
+            , MigratedBytes(migratedBytes)
+        {}
     };
 
     //

--- a/cloud/blockstore/libs/storage/volume/volume_schema.h
+++ b/cloud/blockstore/libs/storage/volume/volume_schema.h
@@ -292,7 +292,7 @@ struct TVolumeSchema
         {
         };
 
-        struct MigratedBlockCount
+        struct MigratedBytes
             : public Column<5, NKikimr::NScheme::NTypeIds::Uint64>
         {
         };
@@ -303,7 +303,7 @@ struct TVolumeSchema
             FollowerDiskId,
             ScaleUnitId,
             State,
-            MigratedBlockCount>;
+            MigratedBytes>;
     };
 
     using TTables = SchemaTables<

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -950,7 +950,7 @@ TVolumeState::GetAllDevicesForAcquireRelease() const
 void TVolumeState::AddOrUpdateFollower(TFollowerDiskInfo follower)
 {
     for (auto& followerInfo: FollowerDisks) {
-        if (followerInfo.Uuid == follower.Uuid) {
+        if (followerInfo.LinkUUID == follower.LinkUUID) {
             followerInfo = std::move(follower);
             return;
         }
@@ -958,19 +958,19 @@ void TVolumeState::AddOrUpdateFollower(TFollowerDiskInfo follower)
     FollowerDisks.push_back(std::move(follower));
 }
 
-void TVolumeState::RemoveFollower(const TString& uuid)
+void TVolumeState::RemoveFollower(const TString& linkUUID)
 {
     EraseIf(
         FollowerDisks,
         [&](const TFollowerDiskInfo& follower)
-        { return follower.Uuid == uuid; });
+        { return follower.LinkUUID == linkUUID; });
 }
 
 std::optional<TFollowerDiskInfo> TVolumeState::FindFollowerByUuid(
-    const TString& uuid) const
+    const TString& linkUUID) const
 {
     for (const auto& follower: FollowerDisks) {
-        if (follower.Uuid == uuid) {
+        if (follower.LinkUUID == linkUUID) {
             return follower;
         }
     }

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -380,6 +380,10 @@ public:
 
     void FillDeviceInfo(NProto::TVolume& volume) const;
 
+    NProto::EStorageMediaKind GetStorageMediaKind() const
+    {
+        return Config->GetStorageMediaKind();
+    }
     bool IsDiskRegistryMediaKind() const;
 
     bool HasPerformanceProfileModifications(const TStorageConfig& config) const;

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -768,9 +768,9 @@ public:
     //
 
     void AddOrUpdateFollower(TFollowerDiskInfo follower);
-    void RemoveFollower(const TString& uuid);
+    void RemoveFollower(const TString& linkUUID);
     std::optional<TFollowerDiskInfo> FindFollowerByUuid(
-        const TString& uuid) const;
+        const TString& linkUUID) const;
     std::optional<TFollowerDiskInfo> FindFollowerByDiskId(
         const TString& diskId) const;
     const TFollowerDisks& GetAllFollowers() const

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -1986,11 +1986,11 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
         auto volumeState = CreateVolumeState();
 
         volumeState.AddOrUpdateFollower(
-            TFollowerDiskInfo{.Uuid = "x", .FollowerDiskId = "vol1"});
+            TFollowerDiskInfo{.LinkUUID = "x", .FollowerDiskId = "vol1"});
 
         const auto& followers = volumeState.GetAllFollowers();
         UNIT_ASSERT_VALUES_EQUAL(1, followers.size());
-        UNIT_ASSERT_VALUES_EQUAL("x", followers[0].Uuid);
+        UNIT_ASSERT_VALUES_EQUAL("x", followers[0].LinkUUID);
         UNIT_ASSERT_VALUES_EQUAL("vol1", followers[0].FollowerDiskId);
         UNIT_ASSERT_EQUAL(TFollowerDiskInfo::EState::None, followers[0].State);
         UNIT_ASSERT_EQUAL(
@@ -1998,7 +1998,7 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
             followers[0].MigratedBytes);
 
         volumeState.AddOrUpdateFollower(TFollowerDiskInfo{
-            .Uuid = "x",
+            .LinkUUID = "x",
             .FollowerDiskId = "vol1",
             .State = TFollowerDiskInfo::EState::Preparing,
             .MigratedBytes = 100});
@@ -2009,15 +2009,15 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
         UNIT_ASSERT_VALUES_EQUAL(100, *followers[0].MigratedBytes);
 
         volumeState.AddOrUpdateFollower(TFollowerDiskInfo{
-            .Uuid = "y",
+            .LinkUUID = "y",
             .FollowerDiskId = "vol2"});
         UNIT_ASSERT_VALUES_EQUAL(2, followers.size());
-        UNIT_ASSERT_VALUES_EQUAL("y", followers[1].Uuid);
+        UNIT_ASSERT_VALUES_EQUAL("y", followers[1].LinkUUID);
         UNIT_ASSERT_VALUES_EQUAL("vol2", followers[1].FollowerDiskId);
 
         volumeState.RemoveFollower("x");
         UNIT_ASSERT_VALUES_EQUAL(1, followers.size());
-        UNIT_ASSERT_VALUES_EQUAL("y", followers[0].Uuid);
+        UNIT_ASSERT_VALUES_EQUAL("y", followers[0].LinkUUID);
         UNIT_ASSERT_VALUES_EQUAL("vol2", followers[0].FollowerDiskId);
 
         volumeState.RemoveFollower("y");

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -1995,18 +1995,18 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
         UNIT_ASSERT_EQUAL(TFollowerDiskInfo::EState::None, followers[0].State);
         UNIT_ASSERT_EQUAL(
             std::nullopt,
-            followers[0].MigrationBlockIndex);
+            followers[0].MigratedBytes);
 
         volumeState.AddOrUpdateFollower(TFollowerDiskInfo{
             .Uuid = "x",
             .FollowerDiskId = "vol1",
             .State = TFollowerDiskInfo::EState::Preparing,
-            .MigrationBlockIndex = 100});
+            .MigratedBytes = 100});
         UNIT_ASSERT_VALUES_EQUAL(1, followers.size());
         UNIT_ASSERT_EQUAL(
             TFollowerDiskInfo::EState::Preparing,
             followers[0].State);
-        UNIT_ASSERT_VALUES_EQUAL(100, *followers[0].MigrationBlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(100, *followers[0].MigratedBytes);
 
         volumeState.AddOrUpdateFollower(TFollowerDiskInfo{
             .Uuid = "y",

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -45,6 +45,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(RemoveLaggingAgent,             __VA_ARGS__)                           \
     xxx(AddFollower,                    __VA_ARGS__)                           \
     xxx(RemoveFollower,                 __VA_ARGS__)                           \
+    xxx(UpdateFollower,                 __VA_ARGS__)                           \
 // BLOCKSTORE_VOLUME_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -758,6 +759,7 @@ struct TTxVolume
     {
         const TRequestInfoPtr RequestInfo;
         const TString FollowerDiskId;
+        TString Uuid;
 
         TAddFollower(
                 TRequestInfoPtr requestInfo,
@@ -779,13 +781,13 @@ struct TTxVolume
     struct TRemoveFollower
     {
         const TRequestInfoPtr RequestInfo;
-        const TString Id;
+        const TString Uuid;
 
         TRemoveFollower(
                 TRequestInfoPtr requestInfo,
-                TString id)
+                TString uuid)
             : RequestInfo(std::move(requestInfo))
-            , Id(std::move(id))
+            , Uuid(std::move(uuid))
         {}
 
         void Clear()
@@ -794,6 +796,28 @@ struct TTxVolume
         }
     };
 
+
+    //
+    // UpdateFollower
+    //
+
+    struct TUpdateFollower
+    {
+        const TRequestInfoPtr RequestInfo;
+        const TFollowerDiskInfo FollowerInfo;
+
+        TUpdateFollower(
+                TRequestInfoPtr requestInfo,
+                TFollowerDiskInfo followerInfo)
+            : RequestInfo(std::move(requestInfo))
+            , FollowerInfo(std::move(followerInfo))
+        {}
+
+        void Clear()
+        {
+            // nothing to do
+        }
+    };
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -759,7 +759,7 @@ struct TTxVolume
     {
         const TRequestInfoPtr RequestInfo;
         const TString FollowerDiskId;
-        TString Uuid;
+        TString LinkUUID;
 
         TAddFollower(
                 TRequestInfoPtr requestInfo,
@@ -781,13 +781,13 @@ struct TTxVolume
     struct TRemoveFollower
     {
         const TRequestInfoPtr RequestInfo;
-        const TString Uuid;
+        const TString LinkUUID;
 
         TRemoveFollower(
                 TRequestInfoPtr requestInfo,
-                TString uuid)
+                TString linkUUID)
             : RequestInfo(std::move(requestInfo))
-            , Uuid(std::move(uuid))
+            , LinkUUID(std::move(linkUUID))
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9614,7 +9614,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         {
             // Create link
             auto response = volume1.LinkLeaderVolumeToFollower("vol1", "vol2");
-            linkUuid = response->Record.GetUuid();
+            linkUuid = response->Record.GetLinkUUID();
 
             // Reboot tablet
             volume1.RebootTablet();

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9610,9 +9610,11 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             7 * 1024,   // block count per partition
             "vol2");
 
+        TString linkUuid;
         {
             // Create link
-            volume1.LinkLeaderVolumeToFollower("vol1", "vol2");
+            auto response = volume1.LinkLeaderVolumeToFollower("vol1", "vol2");
+            linkUuid = response->Record.GetUuid();
 
             // Reboot tablet
             volume1.RebootTablet();
@@ -9621,8 +9623,46 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             // Should get S_ALREADY since link persisted in local volume
             // database.
             volume1.SendLinkLeaderVolumeToFollowerRequest("vol1", "vol2");
-            auto response = volume1.RecvLinkLeaderVolumeToFollowerResponse();
+            response = volume1.RecvLinkLeaderVolumeToFollowerResponse();
             UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, response->GetStatus());
+        }
+
+        {   // Update link state
+            using EReason =
+                TEvVolumePrivate::TUpdateFollowerStateRequest::EReason;
+            using EState = TFollowerDiskInfo::EState;
+
+            auto response = volume1.UpdateFollowerState(
+                linkUuid,
+                EReason::FillProgressUpdate,
+                1_MB);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(EState::Preparing, response->NewState);
+            UNIT_ASSERT_VALUES_EQUAL(1_MB, response->MigratedBytes);
+
+            response = volume1.UpdateFollowerState(
+                linkUuid,
+                EReason::FillProgressUpdate,
+                2_MB);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(EState::Preparing, response->NewState);
+            UNIT_ASSERT_VALUES_EQUAL(2_MB, response->MigratedBytes);
+
+            response = volume1.UpdateFollowerState(
+                linkUuid,
+                EReason::FillCompleted,
+                2_MB);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(EState::Ready, response->NewState);
+            UNIT_ASSERT_VALUES_EQUAL(2_MB, response->MigratedBytes);
+
+            response = volume1.UpdateFollowerState(
+                linkUuid,
+                EReason::FillError,
+                2_MB);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(EState::Error, response->NewState);
+            UNIT_ASSERT_VALUES_EQUAL(2_MB, response->MigratedBytes);
         }
 
         {


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999
Сделано сохранение в БД прогресса наливки связанного диска.