### PR TITLE
[Filestore] fix for code style 

### DIFF
--- a/cloud/filestore/public/sdk/go/client/grpc.go
+++ b/cloud/filestore/public/sdk/go/client/grpc.go
@@ -58,8 +58,8 @@ func (client *grpcClient) setupHeaders(ctx context.Context, req request) {
 	headers.Timestamp = uint64(timestamp)
 
 	if val := ctx.Value(TraceIDHeaderKey); val != nil {
-		if traceId, ok := val.([]byte); ok {
-			headers.TraceId = traceId
+		if traceID, ok := val.([]byte); ok {
+			headers.TraceId = traceID
 		}
 	}
 


### PR DESCRIPTION
Еще ошибки код стайла
```
$S/cloud/filestore/public/sdk/go/client/grpc.go:61:6: "ST1003: var traceId should be traceID"
$S/cloud/filestore/public/sdk/go/client/grpc.go:61:6: "ST1003: if you believe this report is false positive, please silence it with //nolint:st1003 comment"
```