### PR TITLE
[CSI] fix used bytes stats

### DIFF
--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part1/test.py
@@ -64,7 +64,9 @@ def test_nbs_csi_driver_volume_stat():
             usage = usage_array1[0]
             assert {"unit", "total", "available", "used"} == usage.keys()
             assert 0 != usage["total"]
-            assert usage["total"] == usage["available"] + usage["used"]
+            assert 0 != usage["available"]
+            assert 0 != usage["used"]
+            assert usage["total"] >= usage["available"] + usage["used"]
 
         mount_path = Path("/var/lib/kubelet/pods") / pod_id / "volumes/kubernetes.io~csi" / volume_name / "mount"
         (mount_path / "test1.file").write_bytes(b"\0")
@@ -78,7 +80,9 @@ def test_nbs_csi_driver_volume_stat():
             usage = usage_array2[0]
             assert {"unit", "total", "available", "used"} == usage.keys()
             assert 0 != usage["total"]
-            assert usage["total"] == usage["available"] + usage["used"]
+            assert 0 != usage["available"]
+            assert 0 != usage["used"]
+            assert usage["total"] >= usage["available"] + usage["used"]
 
         bytesUsage1 = usage_array1[0]
         bytesUsage2 = usage_array2[0]

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -1399,7 +1399,7 @@ func (s *nodeService) NodeGetVolumeStats(
 
 	totalBytes := int64(stat.Blocks) * int64(stat.Bsize)
 	availableBytes := int64(stat.Bavail) * int64(stat.Bsize)
-	usedBytes := totalBytes - availableBytes
+	usedBytes := totalBytes - int64(stat.Bfree)*int64(stat.Bsize)
 
 	totalNodes := int64(stat.Files)
 	availableNodes := int64(stat.Ffree)

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -838,7 +838,7 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 	bytesUsage := stat.GetUsage()[0]
 	assert.Equal(t, bytesUsage.Unit, csi.VolumeUsage_BYTES)
 	assert.NotEqual(t, 0, bytesUsage.Total)
-	assert.Equal(t, bytesUsage.Used+bytesUsage.Available, bytesUsage.Total)
+	assert.LessOrEqual(t, bytesUsage.Used+bytesUsage.Available, bytesUsage.Total)
 
 	nodesUsage := stat.GetUsage()[1]
 	assert.Equal(t, nodesUsage.Unit, csi.VolumeUsage_INODES)


### PR DESCRIPTION
statfs returns two fields:

```
f_bfree;   /* Free blocks in filesystem */
f_bavail;  /* Free blocks available to unprivileged user */
```

It's better to use f_bfree to calculate used space and f_bavail to calculate available space. Otherwise nbs used bytes metric for disk can be less than used space reported by kubelet.

However in this case totalBytes!=availableBytes+usedBytes

https://man7.org/linux/man-pages/man2/statfs.2.html
