### PR TITLE
Allow to migrate different range sizes

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set.cpp
@@ -9,14 +9,6 @@ TDisjointRangeSet::~TDisjointRangeSet() = default;
 
 bool TDisjointRangeSet::TryInsert(TBlockRange64 range)
 {
-    if (!BlockSize.has_value()) {
-        BlockSize = range.Size();
-    }
-
-    if (range.Size() != *BlockSize) {
-        return false;
-    }
-
     auto it = EndToStart.lower_bound(range.Start);
     if (it != EndToStart.end()) {
         auto found = TBlockRange64::MakeClosedInterval(it->second, it->first);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set.h
@@ -10,13 +10,11 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Data structure that maintains a collection of non-overlapping intervals of
-// equal length.
+// Data structure that maintains a collection of non-overlapping intervals.
 class TDisjointRangeSet
 {
 private:
     TMap<ui64, ui64> EndToStart;
-    std::optional<ui64> BlockSize;
 
 public:
     TDisjointRangeSet();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/disjoint_range_set_ut.cpp
@@ -15,6 +15,7 @@ Y_UNIT_TEST_SUITE(TDisjointRangeSetTest)
         auto range1 = TBlockRange64::WithLength(0, 4_KB);
         auto range2 = TBlockRange64::WithLength(4_KB, 4_KB);
         auto range3 = TBlockRange64::WithLength(4_KB * 2, 4_KB);
+        auto range4 = TBlockRange64::WithLength(4_KB * 3, 2_KB);
 
         UNIT_ASSERT(set.Empty());
         UNIT_ASSERT(set.TryInsert(range2));
@@ -27,12 +28,13 @@ Y_UNIT_TEST_SUITE(TDisjointRangeSetTest)
         UNIT_ASSERT(set.TryInsert(range3));
         UNIT_ASSERT_VALUES_EQUAL(range1, set.LeftmostRange());
 
+        UNIT_ASSERT(set.TryInsert(range4));
+        UNIT_ASSERT_VALUES_EQUAL(range1, set.LeftmostRange());
+
         // Already inserted.
         UNIT_ASSERT(!set.TryInsert(range1));
         // Intersects.
         UNIT_ASSERT(!set.TryInsert(TBlockRange64::WithLength(2_KB, 4_KB)));
-        // Different length.
-        UNIT_ASSERT(!set.TryInsert(TBlockRange64::WithLength(4_KB * 9, 1)));
 
         UNIT_ASSERT(set.Remove(range1));
         UNIT_ASSERT_VALUES_EQUAL(range2, set.LeftmostRange());
@@ -41,6 +43,9 @@ Y_UNIT_TEST_SUITE(TDisjointRangeSetTest)
         UNIT_ASSERT_VALUES_EQUAL(range3, set.LeftmostRange());
 
         UNIT_ASSERT(set.Remove(range3));
+        UNIT_ASSERT_VALUES_EQUAL(range4, set.LeftmostRange());
+
+        UNIT_ASSERT(set.Remove(range4));
         UNIT_ASSERT(set.Empty());
     }
 


### PR DESCRIPTION
Убираю ограничение на одинаковый размер мигрируемого диапазона. Оказалось, что у нас есть старые диски, которые имеют рамер девайса не кратный 4 MiB