### PR TITLE
Unset ShouldStartResync in TRemoveLaggingAgent::Clear

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -754,6 +754,7 @@ struct TTxVolume
         void Clear()
         {
             RemovedLaggingAgent.Clear();
+            ShouldStartResync = false;
         }
     };
 


### PR DESCRIPTION
Поправил для конвенции. Сам Clear() тут никогда не вызывается