### PR TITLE
Check lagging agent availability by direct requests to disk agent

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.h
@@ -2,8 +2,7 @@
 
 #include "public.h"
 
-#include "part_nonrepl_events_private.h"
-
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -22,19 +21,22 @@ class TAgentAvailabilityMonitoringActor final
 private:
     const TStorageConfigPtr Config;
     const TNonreplicatedPartitionConfigPtr PartConfig;
+    const google::protobuf::RepeatedPtrField<NProto::TDeviceMigration>
+        Migrations;
     const NActors::TActorId NonreplPartitionActorId;
     const NActors::TActorId ParentActorId;
-    const TString AgentId;
+    const NProto::TLaggingAgent LaggingAgent;
 
-    ui64 ReadBlockIndex = 0;
+    ui32 LaggingAgentNodeId = 0;
 
 public:
     TAgentAvailabilityMonitoringActor(
         TStorageConfigPtr config,
         TNonreplicatedPartitionConfigPtr partConfig,
+        google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
         NActors::TActorId nonreplPartitionActorId,
         NActors::TActorId parentActorId,
-        TString agentId);
+        NProto::TLaggingAgent laggingAgent);
 
     ~TAgentAvailabilityMonitoringActor() override;
 
@@ -48,11 +50,11 @@ private:
     STFUNC(StateWork);
 
     void HandleChecksumBlocksUndelivery(
-        const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
+        const TEvDiskAgent::TEvChecksumDeviceBlocksRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleChecksumBlocksResponse(
-        const TEvNonreplPartitionPrivate::TEvChecksumBlocksResponse::TPtr& ev,
+        const TEvDiskAgent::TEvChecksumDeviceBlocksResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleWakeup(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -304,7 +304,7 @@ public:
 
     bool DevicesReadyForReading(
         const TBlockRange64 blockRange,
-        const THashSet<ui32>& excludeIndexes) const
+        const THashSet<TString>& excludeAgentIds) const
     {
         const bool result = VisitDeviceRequests(
             blockRange,
@@ -316,7 +316,7 @@ public:
                 Y_UNUSED(relativeRange);
 
                 return !Devices[i].GetDeviceUUID() ||
-                       excludeIndexes.contains(i) ||
+                       excludeAgentIds.contains(Devices[i].GetAgentId()) ||
                        FreshDeviceIds.contains(Devices[i].GetDeviceUUID()) ||
                        OutdatedDeviceIds.contains(Devices[i].GetDeviceUUID());
             });

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -281,6 +281,7 @@ TLaggingAgentsReplicaProxyActor::TLaggingAgentsReplicaProxyActor(
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TNonreplicatedPartitionConfigPtr partConfig,
+        google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         TString rwClientId,
@@ -289,6 +290,7 @@ TLaggingAgentsReplicaProxyActor::TLaggingAgentsReplicaProxyActor(
     : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , PartConfig(std::move(partConfig))
+    , Migrations(std::move(migrations))
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(blockDigestGenerator))
     , RwClientId(std::move(rwClientId))
@@ -664,9 +666,10 @@ void TLaggingAgentsReplicaProxyActor::HandleAgentIsUnavailable(
         std::make_unique<TAgentAvailabilityMonitoringActor>(
             Config,
             PartConfig,
+            Migrations,
             NonreplPartitionActorId,
             SelfId(),
-            agentId));
+            state.LaggingAgent));
     PoisonPillHelper.TakeOwnership(ctx, state.AvailabilityMonitoringActorId);
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
@@ -39,6 +39,8 @@ private:
     const TStorageConfigPtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const TNonreplicatedPartitionConfigPtr PartConfig;
+    const google::protobuf::RepeatedPtrField<NProto::TDeviceMigration>
+        Migrations;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     TString RwClientId;
@@ -81,6 +83,7 @@ public:
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TNonreplicatedPartitionConfigPtr partConfig,
+        google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         TString rwClientId,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -396,6 +396,7 @@ struct TTestEnv
                     Config,
                     CreateDiagnosticsConfig(),
                     PartConfig->Fork(GetReplicaDevices(replicaIndex)),
+                    Migrations,
                     CreateProfileLogStub(),
                     CreateBlockDigestGeneratorStub(),
                     "",   // rwClientId
@@ -561,13 +562,13 @@ Y_UNIT_TEST_SUITE(TLaggingAgentsReplicaProxyActorTest)
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvNonreplPartitionPrivate::EvChecksumBlocksRequest: {
-                        auto* msg = event->Get<TEvNonreplPartitionPrivate::
-                                                   TEvChecksumBlocksRequest>();
+                    case TEvDiskAgent::EvChecksumDeviceBlocksRequest: {
+                        auto* msg = event->Get<
+                            TEvDiskAgent::TEvChecksumDeviceBlocksRequest>();
                         auto clientId = msg->Record.GetHeaders().GetClientId();
                         if (clientId == CheckHealthClientId) {
                             UNIT_ASSERT_VALUES_EQUAL(
-                                env.ReplicaActors[0],
+                                MakeDiskAgentServiceId(runtime.GetNodeId(1)),
                                 event->Recipient);
                             seenHealthCheck = true;
                         }
@@ -729,13 +730,13 @@ Y_UNIT_TEST_SUITE(TLaggingAgentsReplicaProxyActorTest)
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
-                    case TEvNonreplPartitionPrivate::EvChecksumBlocksRequest: {
-                        auto* msg = event->Get<TEvNonreplPartitionPrivate::
-                                                   TEvChecksumBlocksRequest>();
+                    case TEvDiskAgent::EvChecksumDeviceBlocksRequest: {
+                        auto* msg = event->Get<
+                            TEvDiskAgent::TEvChecksumDeviceBlocksRequest>();
                         auto clientId = msg->Record.GetHeaders().GetClientId();
                         if (clientId == CheckHealthClientId) {
                             UNIT_ASSERT_VALUES_EQUAL(
-                                env.ReplicaActors[0],
+                                MakeDiskAgentServiceId(runtime.GetNodeId(1)),
                                 event->Recipient);
                             seenHealthCheck = true;
                         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -547,12 +547,14 @@ void TMirrorPartitionActor::HandleAddLaggingAgent(
     if (!State.IsLaggingProxySet(replicaIndex)) {
         Y_ABORT_UNLESS(replicaIndex < State.GetReplicaInfos().size());
 
+        const auto& replicaInfo = State.GetReplicaInfos()[replicaIndex];
         auto proxyActorId = NCloud::Register(
             ctx,
             std::make_unique<TLaggingAgentsReplicaProxyActor>(
                 Config,
                 DiagnosticsConfig,
-                State.GetReplicaInfos()[replicaIndex].Config,
+                replicaInfo.Config,
+                replicaInfo.Migrations,
                 ProfileLog,
                 BlockDigestGenerator,
                 State.GetRWClientId(),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
@@ -886,8 +886,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
         env.ReadAndCheckContents(secondRow, 'B');
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            Count(readActors, env.ReplicaActors[0]) +
-                Count(readActors, env.ReplicaActors[1]));
+            Count(readActors, env.ReplicaActors[1]) +
+                Count(readActors, env.ReplicaActors[2]));
         readActors.clear();
 
         env.ReadAndCheckContents(
@@ -904,8 +904,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
             'A');
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            Count(readActors, env.ReplicaActors[0]) +
-                Count(readActors, env.ReplicaActors[1]));
+            Count(readActors, env.ReplicaActors[1]) +
+                Count(readActors, env.ReplicaActors[2]));
         readActors.clear();
 
         // uuid-3 is ok now.
@@ -924,8 +924,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
         env.ReadAndCheckContents(firstAndSecondRows, 'B');
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            Count(readActors, env.ReplicaActors[0]) +
-                Count(readActors, env.ReplicaActors[1]));
+            Count(readActors, env.ReplicaActors[1]) +
+                Count(readActors, env.ReplicaActors[2]));
         readActors.clear();
 
         // Poison pill has killed the proxy actor.


### PR DESCRIPTION
#3
Переделал на проверку живости агента запросами напрямую в диск агента. Это нужно в первую очередь для того чтобы было проще отслеживать живость агента на который мы мигрируем. 
