### PR TITLE
[Blockstore] enable discard/zeroblocks features for vhost device

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -145,7 +145,7 @@ bool CompareRequests(
         && left.GetPersistent() == right.GetPersistent()
         && left.GetNbdDeviceFile() == right.GetNbdDeviceFile()
         && left.GetUseFreeNbdDeviceFile() == right.GetUseFreeNbdDeviceFile()
-        && left.GetVhostEnableDiscard() == right.GetVhostEnableDiscard();
+        && left.GetVhostDiscardEnabled() == right.GetVhostDiscardEnabled();
 }
 
 bool CompareRequests(

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -115,7 +115,7 @@ bool CompareRequests(
     const NProto::TStartEndpointRequest& left,
     const NProto::TStartEndpointRequest& right)
 {
-    Y_DEBUG_ABORT_UNLESS(26 == GetFieldCount<NProto::TStartEndpointRequest>());
+    Y_DEBUG_ABORT_UNLESS(27 == GetFieldCount<NProto::TStartEndpointRequest>());
     return left.GetUnixSocketPath() == right.GetUnixSocketPath()
         && left.GetDiskId() == right.GetDiskId()
         && left.GetInstanceId() == right.GetInstanceId()
@@ -144,7 +144,8 @@ bool CompareRequests(
             right.GetClientCGroups().end())
         && left.GetPersistent() == right.GetPersistent()
         && left.GetNbdDeviceFile() == right.GetNbdDeviceFile()
-        && left.GetUseFreeNbdDeviceFile() == right.GetUseFreeNbdDeviceFile();
+        && left.GetUseFreeNbdDeviceFile() == right.GetUseFreeNbdDeviceFile()
+        && left.GetVhostEnableDiscard() == right.GetVhostEnableDiscard();
 }
 
 bool CompareRequests(

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -46,6 +46,7 @@ public:
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
         options.IsReliableMediaKind =
             IsReliableMediaKind(volume.GetStorageMediaKind());
+        options.EnableDiscard = request.GetVhostEnableDiscard();
 
         return Server->StartEndpoint(
             request.GetUnixSocketPath(),

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -46,7 +46,7 @@ public:
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
         options.IsReliableMediaKind =
             IsReliableMediaKind(volume.GetStorageMediaKind());
-        options.EnableDiscard = request.GetVhostEnableDiscard();
+        options.DiscardEnabled = request.GetVhostDiscardEnabled();
 
         return Server->StartEndpoint(
             request.GetUnixSocketPath(),

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -65,6 +65,23 @@ struct TWriteBlocksLocalMethod
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TZeroBlocksMethod
+{
+    static TFuture<NProto::TZeroBlocksResponse> Execute(
+        IDeviceHandler& deviceHandler,
+        TCallContextPtr ctx,
+        TVhostRequest& vhostRequest)
+    {
+        return deviceHandler.Zero(
+            std::move(ctx),
+            vhostRequest.From,
+            vhostRequest.Length);
+    }
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRequest
     : public TIntrusiveListItem<TRequest>
     , TAtomicRefCount<TRequest>
@@ -245,6 +262,9 @@ public:
                 break;
             case EBlockStoreRequest::ReadBlocks:
                 ProcessRequest<TReadBlocksLocalMethod>(std::move(request));
+                break;
+            case EBlockStoreRequest::ZeroBlocks:
+                ProcessRequest<TZeroBlocksMethod>(std::move(request));
                 break;
             default:
                 Y_ABORT("Unexpected request type: %d",
@@ -441,6 +461,7 @@ public:
             options.BlockSize,
             options.BlocksCount,
             options.VhostQueuesCount,
+            options.EnableDiscard,
             endpoint.get(),
             AppCtx.Callbacks);
         endpoint->SetVhostDevice(std::move(vhostDevice));

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -461,7 +461,7 @@ public:
             options.BlockSize,
             options.BlocksCount,
             options.VhostQueuesCount,
-            options.EnableDiscard,
+            options.DiscardEnabled,
             endpoint.get(),
             AppCtx.Callbacks);
         endpoint->SetVhostDevice(std::move(vhostDevice));

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -28,6 +28,7 @@ struct TStorageOptions
     bool UnalignedRequestsDisabled = false;
     bool CheckBufferModificationDuringWriting = false;
     bool IsReliableMediaKind = false;
+    bool EnableDiscard = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -28,7 +28,7 @@ struct TStorageOptions
     bool UnalignedRequestsDisabled = false;
     bool CheckBufferModificationDuringWriting = false;
     bool IsReliableMediaKind = false;
-    bool EnableDiscard = false;
+    bool DiscardEnabled = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -167,6 +167,28 @@ private:
                 return MakeFuture(NProto::TReadBlocksLocalResponse());
             };
 
+        TestStorage->ZeroBlocksHandler = [&] (TCallContextPtr ctx, std::shared_ptr<NProto::TZeroBlocksRequest> request) {
+            Y_UNUSED(ctx);
+
+            RequestQueue.Enqueue(
+                {EBlockStoreRequest::ZeroBlocks,
+                 request->GetStartIndex(),
+                 request->GetBlocksCount(),
+                {}});
+
+            if (ServiceFrozen.test()) {
+                auto promise = NewPromise<void>();
+                auto future = promise.GetFuture();
+                FrozenPromises.Enqueue(std::move(promise));
+                return future.Apply([=] (const auto& future) {
+                    Y_UNUSED(future);
+                    return NProto::TZeroBlocksResponse();
+                });
+            }
+
+            return MakeFuture(NProto::TZeroBlocksResponse());
+        };
+
         VhostQueueFactory = std::make_shared<TTestVhostQueueFactory>();
 
         TServerConfig serverConfig;
@@ -1019,6 +1041,38 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         server->Stop();
     }
+
+    Y_UNIT_TEST(ShouldHandleVhostZeroBlocksRequests)
+    {
+        const ui32 blockSize = 4096;
+        const ui64 firstSector = 8;
+        const ui64 totalSectors = 32;
+        const ui64 sectorSize = 512;
+
+        UNIT_ASSERT(totalSectors * sectorSize % blockSize == 0);
+
+        auto environment = TTestEnvironment(blockSize);
+        auto device = environment.GetVhostDevice();
+
+        {
+            auto future = device->SendTestRequest(
+                EBlockStoreRequest::ZeroBlocks,
+                firstSector * sectorSize,
+                totalSectors * sectorSize,
+                {});
+            const auto& response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT(response == TVhostRequest::SUCCESS);
+
+            TTestRequest request;
+            bool res = environment.DequeueRequest(request);
+            UNIT_ASSERT(res);
+            UNIT_ASSERT(request.Type == EBlockStoreRequest::ZeroBlocks);
+            UNIT_ASSERT(request.StartIndex * blockSize == firstSector * sectorSize);
+            UNIT_ASSERT(request.BlocksCount * blockSize == totalSectors * sectorSize);
+            UNIT_ASSERT(!environment.DequeueRequest(request));
+        }
+    }
+
 }
 
 }   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/server_ut_stress.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut_stress.cpp
@@ -153,12 +153,18 @@ void SendRandomRequest(ITestVhostDevice& device)
     thread_local auto eng = CreateRandomEngine();
 
     std::uniform_int_distribution<ui64> dist1(0, 2);
-
-    auto request_type = dist1(eng);
-    EBlockStoreRequest type =
-        request_type == 0   ? EBlockStoreRequest::WriteBlocks
-        : request_type == 1 ? EBlockStoreRequest::ReadBlocks
-                            : EBlockStoreRequest::ZeroBlocks;
+    auto type = EBlockStoreRequest::WriteBlocks;
+    switch (dist1(eng)) {
+        case 0:
+            type = EBlockStoreRequest::WriteBlocks;
+            break;
+        case 1:
+            type = EBlockStoreRequest::ReadBlocks;
+            break;
+        default:
+            type = EBlockStoreRequest::ZeroBlocks;
+            break;
+    }
 
     std::uniform_int_distribution<ui64> dist2(0, 7999);
     ui64 from = dist2(eng) * 512;

--- a/cloud/blockstore/libs/vhost/server_ut_stress.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut_stress.cpp
@@ -152,10 +152,13 @@ void SendRandomRequest(ITestVhostDevice& device)
 {
     thread_local auto eng = CreateRandomEngine();
 
-    std::uniform_int_distribution<ui64> dist1(0, 1);
-    EBlockStoreRequest type = dist1(eng) == 0
-        ? EBlockStoreRequest::WriteBlocks
-        : EBlockStoreRequest::ReadBlocks;
+    std::uniform_int_distribution<ui64> dist1(0, 2);
+
+    auto request_type = dist1(eng);
+    EBlockStoreRequest type =
+        request_type == 0   ? EBlockStoreRequest::WriteBlocks
+        : request_type == 1 ? EBlockStoreRequest::ReadBlocks
+                            : EBlockStoreRequest::ZeroBlocks;
 
     std::uniform_int_distribution<ui64> dist2(0, 7999);
     ui64 from = dist2(eng) * 512;

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -138,7 +138,7 @@ public:
             ui32 blockSize,
             ui64 blocksCount,
             ui32 queuesCount,
-            bool enableDiscard,
+            bool discardEnabled,
             void* cookie,
             const TVhostCallbacks& callbacks)
         : VhdQueue(vhdQueue)
@@ -154,7 +154,7 @@ public:
         VhdBdevInfo.num_queues = queuesCount;
         VhdBdevInfo.map_cb = callbacks.MapMemory;
         VhdBdevInfo.unmap_cb = callbacks.UnmapMemory;
-        if (enableDiscard) {
+        if (discardEnabled) {
             VhdBdevInfo.features |= VHD_BDEV_F_DISCARD | VHD_BDEV_F_WRITE_ZEROES;
         }
     }
@@ -253,7 +253,7 @@ public:
         ui32 blockSize,
         ui64 blocksCount,
         ui32 queuesCount,
-        bool enableDiscard,
+        bool discardEnabled,
         void* cookie,
         const TVhostCallbacks& callbacks) override
     {
@@ -264,7 +264,7 @@ public:
             blockSize,
             blocksCount,
             queuesCount,
-            enableDiscard,
+            discardEnabled,
             cookie,
             callbacks);
     }

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -138,6 +138,7 @@ public:
             ui32 blockSize,
             ui64 blocksCount,
             ui32 queuesCount,
+            bool enableDiscard,
             void* cookie,
             const TVhostCallbacks& callbacks)
         : VhdQueue(vhdQueue)
@@ -153,6 +154,9 @@ public:
         VhdBdevInfo.num_queues = queuesCount;
         VhdBdevInfo.map_cb = callbacks.MapMemory;
         VhdBdevInfo.unmap_cb = callbacks.UnmapMemory;
+        if (enableDiscard) {
+            VhdBdevInfo.features |= VHD_BDEV_F_WRITE_ZEROES;
+        }
     }
 
     ~TVhostDevice()
@@ -249,6 +253,7 @@ public:
         ui32 blockSize,
         ui64 blocksCount,
         ui32 queuesCount,
+        bool enableDiscard,
         void* cookie,
         const TVhostCallbacks& callbacks) override
     {
@@ -259,6 +264,7 @@ public:
             blockSize,
             blocksCount,
             queuesCount,
+            enableDiscard,
             cookie,
             callbacks);
     }
@@ -294,6 +300,9 @@ private:
                 break;
             case VHD_BDEV_WRITE:
                 type = EBlockStoreRequest::WriteBlocks;
+                break;
+            case VHD_BDEV_WRITE_ZEROES:
+                type = EBlockStoreRequest::ZeroBlocks;
                 break;
             default:
                 STORAGE_ERROR("Unexpected vhost request type: " <<

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -155,7 +155,7 @@ public:
         VhdBdevInfo.map_cb = callbacks.MapMemory;
         VhdBdevInfo.unmap_cb = callbacks.UnmapMemory;
         if (enableDiscard) {
-            VhdBdevInfo.features |= VHD_BDEV_F_WRITE_ZEROES;
+            VhdBdevInfo.features |= VHD_BDEV_F_DISCARD | VHD_BDEV_F_WRITE_ZEROES;
         }
     }
 
@@ -301,6 +301,7 @@ private:
             case VHD_BDEV_WRITE:
                 type = EBlockStoreRequest::WriteBlocks;
                 break;
+            case VHD_BDEV_DISCARD:
             case VHD_BDEV_WRITE_ZEROES:
                 type = EBlockStoreRequest::ZeroBlocks;
                 break;

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -61,7 +61,7 @@ struct IVhostQueue
         ui32 blockSize,
         ui64 blocksCount,
         ui32 queuesCount,
-        bool enableDiscard,
+        bool discardEnabled,
         void* cookie,
         const TVhostCallbacks& callbacks) = 0;
 

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -61,6 +61,7 @@ struct IVhostQueue
         ui32 blockSize,
         ui64 blocksCount,
         ui32 queuesCount,
+        bool enableDiscard,
         void* cookie,
         const TVhostCallbacks& callbacks) = 0;
 

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -205,7 +205,7 @@ public:
         ui32 blockSize,
         ui64 blocksCount,
         ui32 queuesCount,
-        bool enableDiscard,
+        bool discardEnabled,
         void* cookie,
         const TVhostCallbacks& callbacks) override
     {
@@ -213,7 +213,7 @@ public:
         Y_UNUSED(blockSize);
         Y_UNUSED(blocksCount);
         Y_UNUSED(queuesCount);
-        Y_UNUSED(enableDiscard);
+        Y_UNUSED(discardEnabled);
         Y_UNUSED(callbacks);
 
         auto vhostDevice = std::make_shared<TTestVhostDevice>(

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -205,6 +205,7 @@ public:
         ui32 blockSize,
         ui64 blocksCount,
         ui32 queuesCount,
+        bool enableDiscard,
         void* cookie,
         const TVhostCallbacks& callbacks) override
     {
@@ -212,6 +213,7 @@ public:
         Y_UNUSED(blockSize);
         Y_UNUSED(blocksCount);
         Y_UNUSED(queuesCount);
+        Y_UNUSED(enableDiscard);
         Y_UNUSED(callbacks);
 
         auto vhostDevice = std::make_shared<TTestVhostDevice>(

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -95,6 +95,9 @@ message TStartEndpointRequest
         // Use any free nbd device file which nbd-client will connect to.
         bool UseFreeNbdDeviceFile = 26;
     }
+
+    // enable support of ZeroBlocks reuqests in libvhost
+    bool VhostEnableDiscard = 27;
 }
 
 message TStartEndpointResponse

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -96,8 +96,8 @@ message TStartEndpointRequest
         bool UseFreeNbdDeviceFile = 26;
     }
 
-    // enable Discard/ZeroBlocks features for vhost device
-    bool VhostEnableDiscard = 27;
+    // Enable Discard/ZeroBlocks features for vhost device
+    bool VhostDiscardEnabled = 27;
 }
 
 message TStartEndpointResponse

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -96,7 +96,7 @@ message TStartEndpointRequest
         bool UseFreeNbdDeviceFile = 26;
     }
 
-    // enable support of ZeroBlocks reuqests in libvhost
+    // enable Discard/ZeroBlocks features for vhost device
     bool VhostEnableDiscard = 27;
 }
 


### PR DESCRIPTION
issue: #3371

 enable discard/zeroblocks features for vhost device when StartEndpoint request contains "Discard Enabled" flag.