### PR TITLE
issue-3341: mixed index ranges should be unreferenced upon the DescribeData completion

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -833,6 +833,10 @@ void TIndexTabletActor::CompleteTx_ReadData(
 {
     RemoveTransaction(*args.RequestInfo);
 
+    Y_DEFER {
+        ReleaseMixedBlocks(args.MixedBlocksRanges);
+    };
+
     if (args.DescribeOnly && !HasError(args.Error)) {
         if (args.ReadAheadRange) {
             NProtoPrivate::TDescribeDataResponse record;
@@ -921,7 +925,6 @@ void TIndexTabletActor::CompleteTx_ReadData(
             args.RequestInfo->CallContext,
             ctx);
 
-        ReleaseMixedBlocks(args.MixedBlocksRanges);
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
         return;
     }


### PR DESCRIPTION
References #3341

This leak was introduced by the completion of https://github.com/ydb-platform/nbs/issues/324