### PR TITLE
fix: increase memory limit for two testsuites and configure oom_score_adj

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -174,7 +174,7 @@ runs:
           echo "/home/github/.ya/tools/ not found"
         fi
         date
-        sudo -E -H -u github ./ya make -k -j${{ inputs.build_threads }} --build "${build_type}" --force-build-depends -T --stat  \
+        choom -n 1 -- sudo -E -H -u github ./ya make -k -j${{ inputs.build_threads }} --build "${build_type}" --force-build-depends -T --stat  \
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --dump-graph --dump-graph-to-file "$TMP_DIR/ya_graph.json" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -249,6 +249,7 @@ runs:
         sudo dmesg -T > "$LOG_DIR/dmesg.log" || true
         sudo cp /var/log/atop/atop_* "$LOG_DIR/" || true
         sudo cp /var/log/syslog "$LOG_DIR/syslog.log" || true
+        # shellcheck disable=SC2024
         sudo ps aux > "$LOG_DIR/ps.log" || true
         sudo chown -R github:github "$LOG_DIR/dmesg.log" "$LOG_DIR/atop_*" "$LOG_DIR/syslog.log" "$LOG_DIR/ps.log" || true
         echo "::endgroup::"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -180,7 +180,7 @@ runs:
         echo "::endgroup::"
         date
         echo "::group::ya-make-test"
-        sudo -E -H -u github ./ya test -k --build "${build_type}" \
+        choom -n 1 -- sudo -E -H -u github  ./ya test -k --build "${build_type}" \
           "${test_size[@]/#/--test-size=}" "${test_type[@]/#/--test-type=}" \
           --test-threads "${{ inputs.test_threads }}" --link-threads "${{ inputs.link_threads }}" \
           --cache-size 512G --do-not-output-stderrs -T \

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -149,16 +149,18 @@ jobs:
         echo "vm.swappiness=5" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p
   
-    - name: Create background process that will adjust oom_score_adj for ya-bin processes
+    - name: Create background process that will adjust oom_score_adj for selection of processes
       shell: bash
       run: |
         set -x
-        # set oom_score_adj to 0 for all other processes
         while true; do
-          for pid in $(pgrep -f ya-bin); do
-            echo "-1000" | sudo tee /proc/$pid/oom_score_adj
+          for pid in $(pgrep -f ydbd) $(pgrep -f qemu-system-x86_64); do
+            # check if process is already having oom_score_adj set to 500 if not then set it
+            if [ "$(cat /proc/$pid/oom_score_adj)" != "1000" ]; then
+              echo 1000 | sudo tee /proc/$pid/oom_score_adj
+            fi
           done
-          sleep 60
+          sleep 30
         done &
 
     - name: Build
@@ -169,7 +171,6 @@ jobs:
         build_preset: ${{ inputs.build_preset }}
         cache_update: ${{ inputs.cache_update_build }}
         bazel_remote_uri: ${{ inputs.nebius == 'yes' && vars.NEBIUS_BAZEL_REMOTE_CACHE_URL || vars.REMOTE_CACHE_URL_YA }}
-        bazel_remote_username: ${{ secrets.REMOTE_CACHE_USERNAME }}
         bazel_remote_password: ${{ secrets.REMOTE_CACHE_PASSWORD }}
         build_threads: ${{ inputs.build_threads }}
         link_threads: ${{ inputs.link_threads }}

--- a/cloud/blockstore/tests/loadtest/local-encryption/ya.make
+++ b/cloud/blockstore/tests/loadtest/local-encryption/ya.make
@@ -2,6 +2,11 @@ PY3TEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/loadtest/ya.make.inc)
 
+REQUIREMENTS(
+    cpu:8
+    ram:48
+) 
+
 TEST_SRCS(
     test.py
 )

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/tests/ya.make
@@ -2,6 +2,9 @@ GO_TEST_FOR(cloud/disk_manager/internal/pkg/dataplane/snapshot/storage)
 
 SET_APPEND(RECIPE_ARGS --ydb-only)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/test/recipe/recipe.inc)
+REQUIREMENTS(
+    ram:16
+) 
 
 FORK_SUBTESTS()
 SPLIT_FACTOR(16)


### PR DESCRIPTION
Unintended consequences of setting oom_score_adj for ya-bin is that all child processes also have this score and when shovel comes to shove it kills, for example github agent itself, like it did [here](https://github.com/ydb-platform/nbs/actions/runs/14330059235).

So idea here is, basically to set more correct distribution of scores to ensure that:
1. Runner itself is killed last (with adj 0)
2. ya-bin second to last (adj 1 using choom)
3. ydbd/qemu or other memory intensive processes should be thrown under OOM bus. (adj 500)

Another thing to do is to increase memory request for specific tests to allow ya to schedule them better to prevent OOM in the first place.
