### PR TITLE
[Filestore] data race in vfs_fuse tests fixed for tsan

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -291,6 +291,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT_VALUES_EQUAL(handle.GetValue(WaitTimeout), handleId);
@@ -350,6 +353,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto req = std::make_shared<TCreateHandleRequest>("/file1", RootNodeId);
         req->In->Body.flags |= O_WRONLY;
@@ -415,6 +421,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT_VALUES_EQUAL(handle.GetValue(WaitTimeout), handleId);
@@ -468,6 +477,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future1 = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT(!future1.HasValue());
@@ -511,6 +523,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         });
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         failSession = true;
         auto future = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
@@ -557,12 +572,13 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
         UNIT_ASSERT_VALUES_EQUAL(future.GetValue(WaitTimeout), handle);
-
-        bootstrap.Stop();
     }
 
     Y_UNIT_TEST(ShouldPingSession)
@@ -590,6 +606,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         scheduler->RunAllScheduledTasks();
 
@@ -629,6 +648,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         const ui64 nodeId = 123;
 
@@ -667,6 +689,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         const ui64 nodeId = 123;
 
@@ -706,6 +731,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         const ui64 nodeId = 123;
 
@@ -744,6 +772,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         TBootstrap bootstrap;
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         const ui64 nodeId = 123;
         const ui64 refCount = 10;
@@ -771,6 +802,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         UNIT_ASSERT_VALUES_EQUAL(resets.load(), 1);
         with_lock(stateMutex) {
@@ -818,6 +852,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT_VALUES_EQUAL(handle.GetValue(WaitTimeout), handleId);
@@ -827,6 +864,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<ui32> called = 0;
         bootstrap.Service->SetHandlerAcquireLock([&] (auto callContext, auto request) {
@@ -851,6 +891,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<ui32> called = 0;
         bootstrap.Service->SetHandlerAcquireLock([&] (auto callContext, auto request) {
@@ -961,6 +1004,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         const ui64 nodeId = 123;
 
@@ -999,6 +1045,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         const ui64 nodeId = 123;
 
@@ -1029,6 +1078,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         bootstrap.Service->SetHandlerGetNodeAttr([&] (auto callContext, auto request) {
             Y_UNUSED(request);
@@ -1050,6 +1102,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<int> callCount = 0;
         bootstrap.Service->SetHandlerGetNodeXAttr([&] (auto callContext, auto request) {
@@ -1080,6 +1135,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         int callCount = 0;
         bootstrap.Service->SetHandlerGetNodeXAttr([&] (auto callContext, auto request) {
@@ -1116,6 +1174,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         std::shared_ptr<TTestTimer> timer = std::make_shared<TTestTimer>();
         TBootstrap bootstrap{timer};
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<int> callCount = 0;
         bootstrap.Service->SetHandlerGetNodeXAttr([&] (auto callContext, auto request) {
@@ -1149,6 +1210,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<int> callCount = 0;
         bootstrap.Service->SetHandlerGetNodeXAttr([&] (auto callContext, auto request) {
@@ -1183,6 +1247,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<int> callCount = 0;
         bootstrap.Service->SetHandlerGetNodeXAttr([&] (auto callContext, auto request) {
@@ -1218,6 +1285,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         std::atomic<bool> sessionDestroyed = false;
         bootstrap.Service->SetHandlerDestroySession([&] (auto, auto) {
@@ -1273,6 +1343,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future = bootstrap.Loop->StopAsync();
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
@@ -1359,6 +1432,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto read = bootstrap.Fuse->SendRequest<TReadRequest>(
             nodeId, handleId, 0, size);
@@ -1387,6 +1463,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
 
@@ -1423,6 +1502,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         bootstrap.Start();
         bootstrap.InterruptNextRequest();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto create = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT_EQUAL(create.GetValueSync(), handleId); // no interrupted
@@ -1559,6 +1641,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             });
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future =
             bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId1, handle1);
@@ -1611,6 +1696,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             });
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future =
             bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId, handle);
@@ -1643,6 +1731,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             });
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto future =
             bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId, handle);
@@ -1696,6 +1787,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             });
 
         bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
 
         auto counters = bootstrap.Counters
             ->FindSubgroup("component", "fs_ut")

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -430,7 +430,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         const TString sessionId = CreateGuidAsString();
 
         std::atomic_bool recovered = false;
-        bootstrap.Service->CreateSessionHandler = [&] (auto callContext, auto request) {
+        bootstrap.Service->CreateSessionHandler = [sessionId, &recovered] (auto callContext, auto request) {
             Y_UNUSED(callContext);
 
             NProto::TCreateSessionResponse result;
@@ -561,6 +561,8 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         auto future = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
         UNIT_ASSERT_VALUES_EQUAL(future.GetValue(WaitTimeout), handle);
+
+        bootstrap.Stop();
     }
 
     Y_UNIT_TEST(ShouldPingSession)

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -439,7 +439,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         const TString sessionId = CreateGuidAsString();
 
         std::atomic_bool recovered = false;
-        bootstrap.Service->CreateSessionHandler = [sessionId, &recovered] (auto callContext, auto request) {
+        bootstrap.Service->CreateSessionHandler =
+            [sessionId, &recovered](auto callContext, auto request)
+        {
             Y_UNUSED(callContext);
 
             NProto::TCreateSessionResponse result;

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -439,9 +439,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         const TString sessionId = CreateGuidAsString();
 
         std::atomic_bool recovered = false;
-        bootstrap.Service->CreateSessionHandler =
-            [sessionId, &recovered](auto callContext, auto request)
-        {
+        bootstrap.Service->CreateSessionHandler = [sessionId, &recovered] (auto callContext, auto request) {
             Y_UNUSED(callContext);
 
             NProto::TCreateSessionResponse result;


### PR DESCRIPTION
Под Fsan  падали тесты из-за data race в коде

Ошибки:

```
Number of suites skipped by tags: 1

cloud/filestore/libs/vfs_fuse/ut <unittest> [size:medium] nchunks:7 [tags: sb:MULTISLOT, sb:cores=8, sb:logs_ttl=3, sb:ssd, sb:ttl=3]
------ [2/7] chunk ran 6 tests (total:3.04s - test:3.02s)
[crashed] TFileSystemTest::ShouldNoFailRequestIfSessionIsAbleToRecover [default-linux-x86_64-release-FORCE_STATIC_LINKING=yes-tsan] (0.64s)
Test crashed (return code: 100)
WARNING: ThreadSanitizer: data race (pid=738793)
  Write of size 8 at 0x7b100000f580 by main thread:
    #0 operator delete(void*) /home/sazonov99/arcadia/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (cloud-filestore-libs-vfs_fuse-ut+0xee948f) (BuildId: 33008ce6d6f4040c11525ef888059e2058db9fc4)
    #1 void std::__y1::__libcpp_operator_delete[abi:v180000]<void*>(void*) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/new:282:3 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264) (BuildId: 33008ce6d6f4040c11525ef888059e2058db9fc4)
    #2 void std::__y1::__do_deallocate_handle_size[abi:v180000]<>(void*, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/new:306:10 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264)
    #3 std::__y1::__libcpp_deallocate[abi:v180000](void*, unsigned long, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/new:322:14 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264)
    #4 std::__y1::allocator<char>::deallocate[abi:v180000](char*, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:130:13 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264)
    #5 std::__y1::allocator_traits<std::__y1::allocator<char>>::deallocate[abi:v180000](std::__y1::allocator<char>&, char*, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:288:13 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264)
    #6 std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char>>::~basic_string() /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/string:1107:7 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264)
    #7 TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char>>>::~TStdString() /home/sazonov99/arcadia/util/generic/string.h:72:8 (cloud-filestore-libs-vfs_fuse-ut+0xd7e264)
    #8 TStdString<std::__y1::basic_string<char, std::__y1::char_
..[snippet truncated]..
p/vhost.socket_10714620661014501825[1]: stopped vring with 0 in-flight requests
2025-04-09T10:27:52.890433Z :NFS_VHOST INFO: : vring_mark_stopped:266: /home/sazonov99/arcadia/r3tmp/vhost.socket_10714620661014501825[0]: stopped vring with 0 in-flight requests
2025-04-09T10:27:52.890676Z :NFS_VHOST INFO: : unregister_complete:299: stopping device /home/sazonov99/arcadia/r3tmp/vhost.socket_10714620661014501825
2025-04-09T10:27:52.890886Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:456: stopped FUSE loop
2025-04-09T10:27:52.890901Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:468: unmounting FUSE session
2025-04-09T10:27:52.890941Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1006: [f:"fs1"][c:""] got destroy request
2025-04-09T10:27:52.890966Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1016: [f:"fs1"][c:""][l:0] resetting session state
2025-04-09T10:27:52.891125Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1036: [f:"fs1"][c:""] session reset completed: S_OK
2025-04-09T10:27:52.891140Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:70: resetting filesystem cache
2025-04-09T10:27:52.891156Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp:218: clear directory cache of size 0
2025-04-09T10:27:52.891174Z :NFS_VHOST INFO: : virtio_session_close:402: destroying device /home/sazonov99/arcadia/r3tmp/vhost.socket_10714620661014501825
2025-04-09T10:27:52.891422Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:92: DestroySession #14087921227774551833 [f:fs1] REQUEST
2025-04-09T10:27:52.891459Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:530: [f:""][c:""][s:"331671b3-bad21a3c-fa99c636-d6ae6ba5"][n:0] destroying session
2025-04-09T10:27:52.891499Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:554: [f:""][c:""][s:"331671b3-bad21a3c-fa99c636-d6ae6ba5"][n:0] session destroyed
2025-04-09T10:27:52.891595Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:131: DestroySession #14087921227774551833 [f:fs1][c:] RESPONSE request completed(total_time: 111us, execution_time: 111us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2025-04-09T10:27:52.893087Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:70: resetting filesystem cache
2025-04-09T10:27:52.893120Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp:218: clear directory cache of size 0
Logsdir: /home/sazonov99/arcadia/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk2/testing_out_stuff
Stderr: /home/sazonov99/arcadia/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk2/testing_out_stuff/TFileSystemTest.ShouldNoFailRequestIfSessionIsAbleToRecover.err
Stdout: /home/sazonov99/arcadia/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk2/testing_out_stuff/TFileSystemTest.ShouldNoFailRequestIfSessionIsAbleToRecover.out
------ [5/7] chunk ran 5 tests (total:3.24s - test:3.22s)
[crashed] TFileSystemTest::ShouldRecoverSession [default-linux-x86_64-release-FORCE_STATIC_LINKING=yes-tsan] (0.76s)
Test crashed (return code: 100)
WARNING: ThreadSanitizer: data race (pid=738788)
  Write of size 8 at 0x7b1000087880 by main thread:
    #0 operator delete(void*) /home/sazonov99/arcadia/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (cloud-filestore-libs-vfs_fuse-ut+0xee948f) (BuildId: 33008ce6d6f4040c11525ef888059e2058db9fc4)
    #1 void std::__y1::__libcpp_operator_delete[abi:v180000]<void*>(void*) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/new:282:3 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a) (BuildId: 33008ce6d6f4040c11525ef888059e2058db9fc4)
    #2 void std::__y1::__do_deallocate_handle_size[abi:v180000]<>(void*, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/new:306:10 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a)
    #3 std::__y1::__libcpp_deallocate[abi:v180000](void*, unsigned long, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/new:322:14 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a)
    #4 std::__y1::allocator<char>::deallocate[abi:v180000](char*, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:130:13 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a)
    #5 std::__y1::allocator_traits<std::__y1::allocator<char>>::deallocate[abi:v180000](std::__y1::allocator<char>&, char*, unsigned long) /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:288:13 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a)
    #6 std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char>>::~basic_string() /home/sazonov99/arcadia/contrib/libs/cxxsupp/libcxx/include/string:1107:7 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a)
    #7 TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char>>>::~TStdString() /home/sazonov99/arcadia/util/generic/string.h:72:8 (cloud-filestore-libs-vfs_fuse-ut+0xd7c62a)
    #8 TStdString<std::__y1::basic_string<char, std::__y1::char_
..[snippet truncated]..
dia/r3tmp/vhost.socket_16665100360326512033[1]: stopped vring with 0 in-flight requests
2025-04-09T10:27:52.802898Z :NFS_VHOST INFO: : vring_mark_stopped:266: /home/sazonov99/arcadia/r3tmp/vhost.socket_16665100360326512033[0]: stopped vring with 0 in-flight requests
2025-04-09T10:27:52.803187Z :NFS_VHOST INFO: : unregister_complete:299: stopping device /home/sazonov99/arcadia/r3tmp/vhost.socket_16665100360326512033
2025-04-09T10:27:52.803472Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:456: stopped FUSE loop
2025-04-09T10:27:52.803502Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:468: unmounting FUSE session
2025-04-09T10:27:52.803577Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1006: [f:"fs1"][c:""] got destroy request
2025-04-09T10:27:52.803617Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1016: [f:"fs1"][c:""][l:0] resetting session state
2025-04-09T10:27:52.803862Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1036: [f:"fs1"][c:""] session reset completed: S_OK
2025-04-09T10:27:52.803886Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:70: resetting filesystem cache
2025-04-09T10:27:52.803906Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp:218: clear directory cache of size 0
2025-04-09T10:27:52.803934Z :NFS_VHOST INFO: : virtio_session_close:402: destroying device /home/sazonov99/arcadia/r3tmp/vhost.socket_16665100360326512033
2025-04-09T10:27:52.804314Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:92: DestroySession #7922107692037226534 [f:fs1] REQUEST
2025-04-09T10:27:52.804370Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:530: [f:""][c:""][s:"4592138-8b2911-4c1ddf80-b9010009"][n:0] destroying session
2025-04-09T10:27:52.804443Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:554: [f:""][c:""][s:"4592138-8b2911-4c1ddf80-b9010009"][n:0] session destroyed
2025-04-09T10:27:52.804590Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:131: DestroySession #7922107692037226534 [f:fs1][c:] RESPONSE request completed(total_time: 177us, execution_time: 177us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2025-04-09T10:27:52.806277Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:70: resetting filesystem cache
2025-04-09T10:27:52.806304Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp:218: clear directory cache of size 0
Logsdir: /home/sazonov99/arcadia/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk5/testing_out_stuff
Stderr: /home/sazonov99/arcadia/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk5/testing_out_stuff/TFileSystemTest.ShouldRecoverSession.err
Stdout: /home/sazonov99/arcadia/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk5/testing_out_stuff/TFileSystemTest.ShouldRecoverSession.out
------ FAIL: 37 - GOOD, 2 - CRASHED cloud/filestore/libs/vfs_fuse/ut
```