### PR TITLE
[NBS] add parameter to calculate mixed channel count as percent from merged channel count

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1206,4 +1206,7 @@ message TStorageServiceConfig
     optional bool ResyncAfterLaggingAgentMigration = 422;
 
     optional bool DoNotStopVolumeTabletOnLockLost = 423;
+
+    // Percentage of mixed channels from the merged total
+    optional uint32 MixedChannelsPercentageFromMerged = 424;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -378,6 +378,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(AllocateSeparateMixedChannels,                  bool,   false         )\
     xxx(PoolKindChangeAllowed,                          bool,   false         )\
+    xxx(MixedChannelsPercentageFromMerged,              ui32,   0             )\
                                                                                \
     xxx(BlockDigestsEnabled,                            bool,   false         )\
     xxx(UseTestBlockDigestGenerator,                    bool,   false         )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -275,6 +275,7 @@ public:
     TString GetHybridFreshChannelPoolKind() const;
     bool GetAllocateSeparateMixedChannels() const;
     bool GetPoolKindChangeAllowed() const;
+    [[nodiscard]] ui32 GetMixedChannelsPercentageFromMerged() const;
 
     TString GetFolderId() const;
 

--- a/cloud/blockstore/libs/storage/core/volume_model.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model.cpp
@@ -549,13 +549,8 @@ void SetupChannels(
                 mixedChannelCount = 1;
             }
         } else {
-            const ui32 sumMixedMerged = MaxDataChannelCount - freshChannelCount;
             mixedChannelCount =
                 ceil((mergedChannelCount * mixedPercentage) / 100.f);
-            if ((mixedChannelCount + mergedChannelCount) > sumMixedMerged) {
-                mergedChannelCount = Max((sumMixedMerged * 100) / (100 + mixedPercentage), existingMergedChannelCount);
-                mixedChannelCount = sumMixedMerged - mergedChannelCount;
-            }
         }
     }
 

--- a/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
@@ -150,7 +150,7 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         volumeParams.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
         NKikimrBlockStore::TVolumeConfig volumeConfig;
         ResizeVolume(*config, volumeParams, {}, {}, volumeConfig);
-        UNIT_ASSERT(volumeConfig.ExplicitChannelProfilesSize() == 252);
+        UNIT_ASSERT(volumeConfig.ExplicitChannelProfilesSize() == MaxDataChannelCount);
     }
 
     Y_UNIT_TEST(ShouldSetValuesFromExplicitPerformanceProfile)
@@ -2222,12 +2222,12 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         }
         ResizeVolume(*config, params, {}, {}, volumeConfig);
 
-        UNIT_ASSERT_VALUES_EQUAL(255, volumeConfig.ExplicitChannelProfilesSize());
-        for (ui32 i = 3; i < MaxDataChannelCount - 1; ++i) {
-            CHECK_CHANNEL_HDD(i, "merged", EChannelDataKind::Merged);
+        UNIT_ASSERT_VALUES_EQUAL(MaxChannelCount, volumeConfig.ExplicitChannelProfilesSize());
+        for (ui32 i = 0; i < MaxMergedChannelCount; ++i) {
+            CHECK_CHANNEL_HDD(i + 3, "merged", EChannelDataKind::Merged);
         }
-        for (ui32 i = MaxDataChannelCount - 1; i < MaxChannelCount - 1; ++i) {
-            CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
+        for (ui32 i = MaxMergedChannelCount; i < MaxDataChannelCount - 1; ++i) {
+            CHECK_CHANNEL_HDD(i + 3, "mixed", EChannelDataKind::Mixed);
         }
         CHECK_CHANNEL(
             MaxChannelCount - 1,

--- a/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
@@ -2209,7 +2209,7 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
             CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
         }
         CHECK_CHANNEL(
-            254,
+            MaxChannelCount - 1,
             config->GetHybridFreshChannelPoolKind(),
             EChannelDataKind::Fresh,
             128_MB
@@ -2223,14 +2223,14 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         ResizeVolume(*config, params, {}, {}, volumeConfig);
 
         UNIT_ASSERT_VALUES_EQUAL(255, volumeConfig.ExplicitChannelProfilesSize());
-        for (ui32 i = 3; i < MaxDataChannelCount; ++i) {
+        for (ui32 i = 3; i < MaxDataChannelCount - 1; ++i) {
             CHECK_CHANNEL_HDD(i, "merged", EChannelDataKind::Merged);
         }
-        for (ui32 i = MaxDataChannelCount; i < MaxChannelCount - 1; ++i) {
+        for (ui32 i = MaxDataChannelCount - 1; i < MaxChannelCount - 1; ++i) {
             CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
         }
         CHECK_CHANNEL(
-            254,
+            MaxChannelCount - 1,
             config->GetHybridFreshChannelPoolKind(),
             EChannelDataKind::Fresh,
             128_MB

--- a/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_model_ut.cpp
@@ -1950,9 +1950,6 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         UNIT_ASSERT_VALUES_EQUAL(blocksCount, info.BlocksCountPerPartition);
     }
 
-#undef CHECK_CHANNEL
-#undef CHECK_CHANNEL_HDD
-
     Y_UNIT_TEST(ShouldNotCapWhenEnoughChannels)
     {
         int wantAddMerged = 50;
@@ -2068,6 +2065,297 @@ Y_UNIT_TEST_SUITE(TVolumeModelTest)
         UNIT_ASSERT_VALUES_EQUAL(0, wantAddMixed);
         UNIT_ASSERT_VALUES_EQUAL(1, wantAddFresh);
     }
+
+    Y_UNIT_TEST(ShouldCorrectlyCalculateMixedChannelCountWithMixedPercentage20)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetAllocateSeparateMixedChannels(true);
+        storageServiceConfig.SetHybridMixedChannelPoolKind("mixed");
+        storageServiceConfig.SetHybridMergedChannelPoolKind("merged");
+        storageServiceConfig.SetHybridFreshChannelPoolKind("fresh");
+        storageServiceConfig.SetMinChannelCount(4);
+        storageServiceConfig.SetFreshChannelCount(1);
+        storageServiceConfig.SetAllocationUnitHDD(256);
+        // in case MixedChannelsPercentageFromMerged == 0 we will receive 2 mixed channels
+        storageServiceConfig.SetMixedChannelsPercentageFromMerged(20);
+
+        auto config = std::make_unique<TStorageConfig>(
+            std::move(storageServiceConfig),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig())
+        );
+
+        const auto blocksCount = 16_GB / DefaultBlockSize;
+        TVolumeParams params{
+            .BlockSize = DefaultBlockSize,
+            .BlocksCountPerPartition = blocksCount,
+            .PartitionsCount = 1,
+            .MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID
+        };
+        NKikimrBlockStore::TVolumeConfig volumeConfig;
+        volumeConfig.SetPerformanceProfileMaxWriteIops(300);
+        volumeConfig.SetPerformanceProfileMaxWriteBandwidth(31457280);
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(9, volumeConfig.ExplicitChannelProfilesSize());
+        CHECK_CHANNEL_HDD(3, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(4, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(5, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(6, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(7, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL(
+            8,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+    }
+
+    Y_UNIT_TEST(
+        ShouldCorrectlyCalculateMixedChannelCountForBigDiskWithMixedPercentage20)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetAllocateSeparateMixedChannels(true);
+        storageServiceConfig.SetHybridMixedChannelPoolKind("mixed");
+        storageServiceConfig.SetHybridMergedChannelPoolKind("merged");
+        storageServiceConfig.SetHybridFreshChannelPoolKind("fresh");
+        storageServiceConfig.SetMinChannelCount(4);
+        storageServiceConfig.SetFreshChannelCount(1);
+        storageServiceConfig.SetAllocationUnitHDD(256);
+        storageServiceConfig.SetMixedChannelsPercentageFromMerged(20);
+
+        auto config = std::make_unique<TStorageConfig>(
+            std::move(storageServiceConfig),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig())
+        );
+
+        const auto blocksCount = 100_TB / DefaultBlockSize;
+        TVolumeParams params{
+            .BlockSize = DefaultBlockSize,
+            .BlocksCountPerPartition = blocksCount,
+            .PartitionsCount = 1,
+            .MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID
+        };
+        NKikimrBlockStore::TVolumeConfig volumeConfig;
+        volumeConfig.SetPerformanceProfileMaxWriteIops(300);
+        volumeConfig.SetPerformanceProfileMaxWriteBandwidth(31457280);
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(255, volumeConfig.ExplicitChannelProfilesSize());
+        for (int i = 3; i < 212; ++i) {
+            CHECK_CHANNEL_HDD(i, "merged", EChannelDataKind::Merged);
+        }
+        for (int i = 212; i < 254; ++i) {
+            CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
+        }
+        CHECK_CHANNEL(
+            254,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+    }
+
+    Y_UNIT_TEST(
+        ShouldCorrectlyRecalculateMixedChannelCountForBigDiskWithMixedPercentage20)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetAllocateSeparateMixedChannels(true);
+        storageServiceConfig.SetHybridMixedChannelPoolKind("mixed");
+        storageServiceConfig.SetHybridMergedChannelPoolKind("merged");
+        storageServiceConfig.SetHybridFreshChannelPoolKind("fresh");
+        storageServiceConfig.SetMinChannelCount(4);
+        storageServiceConfig.SetFreshChannelCount(1);
+        storageServiceConfig.SetAllocationUnitHDD(256);
+        storageServiceConfig.SetMixedChannelsPercentageFromMerged(20);
+
+        auto config = std::make_unique<TStorageConfig>(
+            std::move(storageServiceConfig),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig())
+        );
+
+        const auto blocksCount = 100_TB / DefaultBlockSize;
+        TVolumeParams params{
+            .BlockSize = DefaultBlockSize,
+            .BlocksCountPerPartition = blocksCount,
+            .PartitionsCount = 1,
+            .MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID
+        };
+
+        for (int i = 0; i < 100; ++i) {
+            params.DataChannels.emplace_back("merged", EChannelDataKind::Merged);
+        }
+        for (int i = 0; i < 20; ++i) {
+            params.DataChannels.emplace_back("mixed", EChannelDataKind::Mixed);
+        }
+
+        NKikimrBlockStore::TVolumeConfig volumeConfig;
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(MaxChannelCount, volumeConfig.ExplicitChannelProfilesSize());
+        for (int i = 3; i < 103; ++i) {
+            CHECK_CHANNEL_HDD(i, "merged", EChannelDataKind::Merged);
+        }
+        for (ui32 i = 103; i < 123; ++i) {
+            CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
+        }
+
+        for (ui32 i = 123; i < 232; ++i) {
+            CHECK_CHANNEL_HDD(i, "merged", EChannelDataKind::Merged);
+        }
+        for (ui32 i = 232; i < MaxChannelCount - 1; ++i) {
+            CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
+        }
+        CHECK_CHANNEL(
+            254,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+
+        volumeConfig.ClearExplicitChannelProfiles();
+        params.DataChannels.clear();
+        for (ui32 i = 0; i < MaxMergedChannelCount; ++i) {
+            params.DataChannels.emplace_back("merged", EChannelDataKind::Merged);
+        }
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(255, volumeConfig.ExplicitChannelProfilesSize());
+        for (ui32 i = 3; i < MaxDataChannelCount; ++i) {
+            CHECK_CHANNEL_HDD(i, "merged", EChannelDataKind::Merged);
+        }
+        for (ui32 i = MaxDataChannelCount; i < MaxChannelCount - 1; ++i) {
+            CHECK_CHANNEL_HDD(i, "mixed", EChannelDataKind::Mixed);
+        }
+        CHECK_CHANNEL(
+            254,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+    }
+
+    Y_UNIT_TEST(ShouldAddMixedChannelsWithMixedPercentage50)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetAllocateSeparateMixedChannels(true);
+        storageServiceConfig.SetHybridMixedChannelPoolKind("mixed");
+        storageServiceConfig.SetHybridMergedChannelPoolKind("merged");
+        storageServiceConfig.SetHybridFreshChannelPoolKind("fresh");
+        storageServiceConfig.SetMinChannelCount(1);
+        storageServiceConfig.SetFreshChannelCount(1);
+        storageServiceConfig.SetAllocationUnitHDD(1);
+        storageServiceConfig.SetMixedChannelsPercentageFromMerged(50);
+
+        auto config = std::make_unique<TStorageConfig>(
+            std::move(storageServiceConfig),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig())
+        );
+
+        const auto blocksCount = 1_GB / DefaultBlockSize;
+        TVolumeParams params{
+            DefaultBlockSize,
+            blocksCount,
+            1,
+            {
+                {"merged", EChannelDataKind::Merged},
+                {"merged", EChannelDataKind::Merged},
+            },
+            0,
+            0,
+            0,
+            0,
+            NCloud::NProto::STORAGE_MEDIA_HYBRID
+        };
+        NKikimrBlockStore::TVolumeConfig volumeConfig;
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(7, volumeConfig.ExplicitChannelProfilesSize());
+        CHECK_CHANNEL_HDD(3, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(4, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(5, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL(
+            6,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+
+        volumeConfig.ClearExplicitChannelProfiles();
+
+        params.DataChannels = {
+            {"merged", EChannelDataKind::Merged},
+            {"merged", EChannelDataKind::Merged},
+            {"mixed", EChannelDataKind::Mixed},
+        };
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+        UNIT_ASSERT_VALUES_EQUAL(7, volumeConfig.ExplicitChannelProfilesSize());
+        CHECK_CHANNEL_HDD(3, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(4, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(5, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL(
+            6,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+
+        volumeConfig.ClearExplicitChannelProfiles();
+
+        params.DataChannels = {
+            {"merged", EChannelDataKind::Merged},
+            {"merged", EChannelDataKind::Merged},
+            {"merged", EChannelDataKind::Merged},
+            {"mixed", EChannelDataKind::Mixed},
+            {"merged", EChannelDataKind::Merged},
+        };
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+        UNIT_ASSERT_VALUES_EQUAL(10, volumeConfig.ExplicitChannelProfilesSize());
+        CHECK_CHANNEL_HDD(3, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(4, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(5, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(6, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL_HDD(7, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(8, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL(
+            9,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+
+        volumeConfig.ClearExplicitChannelProfiles();
+
+        params.DataChannels = {
+            {"merged", EChannelDataKind::Merged},
+            {"merged", EChannelDataKind::Merged},
+            {"mixed", EChannelDataKind::Mixed},
+        };
+        params.BlocksCountPerPartition = 5 * blocksCount;
+        params.PartitionsCount = 1;
+        ResizeVolume(*config, params, {}, {}, volumeConfig);
+        UNIT_ASSERT_VALUES_EQUAL(12, volumeConfig.ExplicitChannelProfilesSize());
+        CHECK_CHANNEL_HDD(3, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(4, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(5, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL_HDD(6, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(7, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(8, "merged", EChannelDataKind::Merged);
+        CHECK_CHANNEL_HDD(9, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL_HDD(10, "mixed", EChannelDataKind::Mixed);
+        CHECK_CHANNEL(
+            11,
+            config->GetHybridFreshChannelPoolKind(),
+            EChannelDataKind::Fresh,
+            128_MB
+        );
+    }
+
+    #undef CHECK_CHANNEL
+    #undef CHECK_CHANNEL_HDD
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/public.h
+++ b/cloud/blockstore/libs/storage/model/public.h
@@ -15,11 +15,11 @@ constexpr ui32 MaxBlocksCount = 1024;
 constexpr ui64 MaxPartitionBlocksCount = Max<ui32>() - 1;
 constexpr ui64 MaxPartitionBlocksCountForMultipartitionVolume = 1u << 31;
 constexpr ui64 MaxVolumeBlocksCount = 256_TB / DefaultBlockSize;
-// 1 system + 1 log + 1 index + 1 fresh + 251 data channel count
+// 1 system + 1 log + 1 index + 252 data channel count
 constexpr ui32 MaxChannelCount = 255;
 constexpr ui32 MaxMergedChannelCount = 248;
-// max merged + mixed channel count
-constexpr ui32 MaxDataChannelCount = 251;
+// max merged + mixed channel count + fresh channel count
+constexpr ui32 MaxDataChannelCount = 252;
 
 constexpr ui32 InvalidCollectCounter = 0xFFFFFFFFul;
 constexpr ui32 InvalidBlockIndex = 0xFFFFFFFFul;

--- a/cloud/blockstore/libs/storage/model/public.h
+++ b/cloud/blockstore/libs/storage/model/public.h
@@ -15,8 +15,11 @@ constexpr ui32 MaxBlocksCount = 1024;
 constexpr ui64 MaxPartitionBlocksCount = Max<ui32>() - 1;
 constexpr ui64 MaxPartitionBlocksCountForMultipartitionVolume = 1u << 31;
 constexpr ui64 MaxVolumeBlocksCount = 256_TB / DefaultBlockSize;
-// 1 system + 1 log + 1 index + 4 fresh blobs channels
-constexpr ui32 MaxChannelsCount = 248;
+// 1 system + 1 log + 1 index + 1 fresh + 251 data channel count
+constexpr ui32 MaxChannelCount = 255;
+constexpr ui32 MaxMergedChannelCount = 248;
+// max merged + mixed channel count
+constexpr ui32 MaxDataChannelCount = 251;
 
 constexpr ui32 InvalidCollectCounter = 0xFFFFFFFFul;
 constexpr ui32 InvalidBlockIndex = 0xFFFFFFFFul;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -24,7 +24,7 @@ struct TPartitionSchema
         LogChannel,
         IndexChannel,
         FirstDataChannel,
-        MaxDataChannel = FirstDataChannel + MaxChannelsCount - 1,
+        MaxDataChannel = FirstDataChannel + MaxMergedChannelCount - 1,
     };
 
     struct Meta

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -441,7 +441,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 Max(),  // maxIORequestsInFlight
                 0,  // reassignChannelsPercentageThreshold
                 0,  // lastCommitId
-                MaxDataChannelCount + 1,  // channelCount
+                MaxDataChannelCount,  // channelCount
                 0,  // mixedIndexCacheSize
                 10000,  // allocationUnit
                 100,  // maxBlobsPerUnit

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -431,7 +431,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
     {
         for (auto kind: {EChannelDataKind::Mixed, EChannelDataKind::Merged}) {
             TPartitionState state(
-                DefaultConfig(MaxChannelsCount, DefaultBlockCount),
+                DefaultConfig(MaxMergedChannelCount, DefaultBlockCount),
                 0,  // generation
                 BuildDefaultCompactionPolicy(5),
                 0,  // compactionScoreHistorySize
@@ -441,7 +441,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 Max(),  // maxIORequestsInFlight
                 0,  // reassignChannelsPercentageThreshold
                 0,  // lastCommitId
-                MaxChannelsCount + 4,  // channelCount
+                MaxDataChannelCount + 1,  // channelCount
                 0,  // mixedIndexCacheSize
                 10000,  // allocationUnit
                 100,  // maxBlobsPerUnit

--- a/cloud/blockstore/libs/storage/partition2/part2_schema.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_schema.h
@@ -21,7 +21,7 @@ struct TPartitionSchema
         LogChannel,
         IndexChannel,
         FirstDataChannel,
-        MaxDataChannel = FirstDataChannel + MaxChannelsCount - 1,
+        MaxDataChannel = FirstDataChannel + MaxMergedChannelCount - 1,
     };
 
     struct Meta

--- a/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
@@ -1103,14 +1103,14 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
 
     Y_UNIT_TEST(ShouldPickProperNextChannel)
     {
-        auto meta = DefaultConfig(1024, DefaultBlockSize, MaxChannelsCount);
+        auto meta = DefaultConfig(1024, DefaultBlockSize, MaxMergedChannelCount);
 
         for (auto kind: {EChannelDataKind::Mixed, EChannelDataKind::Merged}) {
             TPartitionState state(
                 meta,
                 TestTabletId,
                 0,
-                MaxChannelsCount + 4,
+                MaxDataChannelCount + 1,
                 MaxBlobSize,
                 MaxRangesPerBlob,
                 EOptimizationMode::OptimizeForLongRanges,

--- a/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
@@ -1110,7 +1110,7 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
                 meta,
                 TestTabletId,
                 0,
-                MaxDataChannelCount + 1,
+                MaxDataChannelCount,
                 MaxBlobSize,
                 MaxRangesPerBlob,
                 EOptimizationMode::OptimizeForLongRanges,


### PR DESCRIPTION
Under the current calculation scheme for the number of merged and mixed channels in hybrid drives, we end up with large drives that have a huge number of merged channels and very few mixed channels (for example, 100TB drives have 248 merged channels and only 3 mixed channels). The opposite situation occurs with small drives, which may have an excessive number of mixed channels.

This solution adds a new parameter that sets the percentage of mixed channels relative to the calculated merged channels; it is intended to set it to 15-20%.