### PR TITLE
[Disk Manager] remove redundant check in test

### DIFF
--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -343,9 +343,6 @@ func TestImagesGetImage(t *testing.T) {
 		requireImagesAreEqual(t, expectedImage, *actualImage)
 	}
 	checkImage()
-	actualImage, err = storage.GetImageMeta(ctx, imageID)
-	require.Equal(t, imageID, actualImage.ID)
-	require.Equal(t, "folder", actualImage.FolderID)
 
 	err = storage.ImageCreated(
 		ctx,


### PR DESCRIPTION
```
$S/cloud/disk_manager/internal/pkg/resources/images_test.go:346:2: "SA4006: this value of err is never used"
$S/cloud/disk_manager/internal/pkg/resources/images_test.go:346:2: "SA4006: if you believe this report is false positive, please silence it with //nolint:sa4006 comment"
```

This check was redundant: id and folder id are already checked in requireImagesAreEqual.