### PR TITLE
Add parameter WriteMixedBlobThresholdHDD as minimum request size in bytes to write to the mixed channel.

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1219,4 +1219,9 @@ message TStorageServiceConfig
     // The minimum size of the request starting from which the MultiAgentWrite
     // is enabled.
     optional uint32 MultiAgentWriteRequestSizeThreshold = 426;
+
+    // Minimum write request size (in bytes) that lets us write the data directly
+    // to the mixed channel.
+    // It'll be ignored if 0 or more than (equal to) WriteBlobThreshold.
+    optional uint32 WriteMixedBlobThresholdHDD = 427;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -166,6 +166,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \
     xxx(WriteBlobThreshold,            ui32,      1_MB                        )\
     xxx(WriteBlobThresholdSSD,         ui32,      128_KB                      )\
+    xxx(WriteMixedBlobThresholdHDD,    ui32,      0                           )\
     xxx(FlushThreshold,                ui32,      4_MB                        )\
     xxx(FreshBlobCountFlushThreshold,  ui32,      3200                        )\
     xxx(FreshBlobByteCountFlushThreshold,   ui32,      16_MB                  )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -75,6 +75,7 @@ public:
     TString GetSchemeShardDir() const;
     ui32 GetWriteBlobThreshold() const;
     ui32 GetWriteBlobThresholdSSD() const;
+    [[nodiscard]] ui32 GetWriteMixedBlobThresholdHDD() const;
     ui32 GetFlushThreshold() const;
     ui32 GetFreshBlobCountFlushThreshold() const;
     ui32 GetFreshBlobByteCountFlushThreshold() const;

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -322,6 +322,17 @@ ui32 GetWriteBlobThreshold(
     return config.GetWriteBlobThreshold();
 }
 
+ui32 GetWriteMixedBlobThreshold(
+    const TStorageConfig& config,
+    const NCloud::NProto::EStorageMediaKind mediaKind)
+{
+    if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+        return 0;
+    }
+
+    return config.GetWriteMixedBlobThresholdHDD();
+}
+
 bool CompareVolumeConfigs(
     const NKikimrBlockStore::TVolumeConfig& prevConfig,
     const NKikimrBlockStore::TVolumeConfig& newConfig)

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -156,6 +156,10 @@ ui32 GetWriteBlobThreshold(
     const TStorageConfig& config,
     const NCloud::NProto::EStorageMediaKind mediaKind);
 
+ui32 GetWriteMixedBlobThreshold(
+    const TStorageConfig& config,
+    const NCloud::NProto::EStorageMediaKind mediaKind);
+
 inline bool RequiresCheckpointSupport(const NProto::TReadBlocksRequest& request)
 {
     return !request.GetCheckpointId().empty();

--- a/cloud/blockstore/libs/storage/partition/part_actor_writequeue.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writequeue.cpp
@@ -34,8 +34,14 @@ void TPartitionActor::HandleProcessWriteQueue(
     auto& requests = guard.Get();
 
     // building mixed blob requests
-    const auto writeBlobThreshold =
-        GetWriteBlobThreshold(*Config, PartitionConfig.GetStorageMediaKind());
+    const auto mediaKind = PartitionConfig.GetStorageMediaKind();
+    const auto writeMixedBlobThreshold =
+        GetWriteMixedBlobThreshold(*Config, mediaKind);
+    auto writeBlobThreshold = GetWriteBlobThreshold(*Config, mediaKind);
+    if (writeMixedBlobThreshold && writeMixedBlobThreshold < writeBlobThreshold)
+    {
+        writeBlobThreshold = writeMixedBlobThreshold;
+    }
 
     auto g = GroupRequests(
         requests,


### PR DESCRIPTION
A potential issue was discovered during testing. If a user heavily loads multiple HDD drives on a single host for writing, memory overflow can occur because data cannot be moved from the fresh channel fast enough, while not reaching the size threshold for the specific disk’s fresh channel.

To solve this problem, we are introducing a new write threshold for HDD drives and adding the ability to write user data to the mixed channel, bypassing the fresh channel. Thus, HDD drives will have two thresholds: one for writing to merged and another for writing to mixed. All data larger than the merged threshold will be written directly to merged channels, data exceeding the mixed threshold will be written to mixed channels, while the remaining data will be written to fresh channel and processed according to the existing scheme.