### PR TITLE
Save partition actors and wrappers in stack

### DIFF
--- a/cloud/blockstore/libs/storage/volume/multi_partition_requests.cpp
+++ b/cloud/blockstore/libs/storage/volume/multi_partition_requests.cpp
@@ -32,7 +32,7 @@ ui32 InitPartitionRequest(
     );
     const auto& partition = partitions[stripeInfo.PartitionId];
 
-    request.ActorId = partition.Owner,
+    request.ActorId = partition.GetTopActorId(),
     request.TabletId = partition.TabletId;
     request.PartitionId = stripeInfo.PartitionId;
     request.BlockRange = stripeInfo.BlockRange;
@@ -84,7 +84,7 @@ bool ToPartitionRequestsSimple(
     requests->resize(partitions.size());
 
     for (ui32 i = 0; i < partitions.size(); ++i) {
-        (*requests)[i].ActorId = partitions[i].Owner;
+        (*requests)[i].ActorId = partitions[i].GetTopActorId();
         (*requests)[i].TabletId = partitions[i].TabletId;
         (*requests)[i].PartitionId = i;
         (*requests)[i].Event = std::make_unique<typename TMethod::TRequest>();
@@ -457,7 +457,7 @@ bool ToPartitionRequests<TEvVolume::TGetPartitionInfoMethod>(
 
     const auto partitionId = ev->Get()->Record.GetPartitionId();
     const auto& partition = partitions[partitionId];
-    (*requests)[0].ActorId = partition.Owner;
+    (*requests)[0].ActorId = partition.GetTopActorId();
     (*requests)[0].TabletId = partition.TabletId;
     (*requests)[0].PartitionId = partitionId;
     (*requests)[0].Event = std::make_unique<TEvVolume::TEvGetPartitionInfoRequest>();

--- a/cloud/blockstore/libs/storage/volume/partition_info.cpp
+++ b/cloud/blockstore/libs/storage/volume/partition_info.cpp
@@ -1,1 +1,119 @@
 #include "partition_info.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TActorsStack::Push(NActors::TActorId actorId)
+{
+    if (!actorId || IsKnown(actorId)) {
+        return;
+    }
+
+    Actors.push_front(actorId);
+}
+
+void TActorsStack::Clear()
+{
+    Actors.clear();
+}
+
+bool TActorsStack::IsKnown(NActors::TActorId actorId) const
+{
+    return AnyOf(
+        Actors,
+        [actorId](const NActors::TActorId& actor) { return actor == actorId; });
+}
+
+NActors::TActorId TActorsStack::GetTop() const
+{
+    return Actors.empty() ? NActors::TActorId() : Actors.front();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TPartitionInfo::TPartitionInfo(
+        ui64 tabletId,
+        NProto::TPartitionConfig partitionConfig,
+        TDuration timeoutIncrement,
+        TDuration timeoutMax)
+    : TabletId(tabletId)
+    , PartitionConfig(std::move(partitionConfig))
+    , RetryPolicy(timeoutIncrement, timeoutMax)
+{}
+
+void TPartitionInfo::Init(const NActors::TActorId& bootstrapper)
+{
+    Bootstrapper = bootstrapper;
+    State = UNKNOWN;
+    Message = {};
+}
+
+void TPartitionInfo::SetStarted(TActorsStack actors)
+{
+    RelatedActors = std::move(actors);
+    State = STARTED;
+    Message = {};
+}
+
+void TPartitionInfo::SetReady()
+{
+    Y_ABORT_UNLESS(State == STARTED);
+    State = READY;
+}
+
+void TPartitionInfo::SetStopped()
+{
+    RelatedActors.Clear();
+    State = STOPPED;
+    Message = {};
+}
+
+void TPartitionInfo::SetFailed(TString message)
+{
+    RelatedActors.Clear();
+    State = FAILED;
+    Message = std::move(message);
+}
+
+NActors::TActorId TPartitionInfo::GetTopActorId() const
+{
+    return RelatedActors.GetTop();
+}
+
+bool TPartitionInfo::IsKnownActorId(const NActors::TActorId actorId) const
+{
+    return RelatedActors.IsKnown(actorId);
+}
+
+TString TPartitionInfo::GetStatus() const
+{
+    TStringStream out;
+
+    switch (State) {
+        default:
+        case UNKNOWN:
+            out << "UNKNOWN";
+            break;
+        case STOPPED:
+            out << "STOPPED";
+            break;
+        case STARTED:
+            out << "STARTED";
+            break;
+        case FAILED:
+            out << "FAILED";
+            break;
+        case READY:
+            out << "READY";
+            break;
+    }
+
+    if (Message) {
+        out << ": " << Message;
+    }
+
+    return out.Str();
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -351,17 +351,21 @@ private:
 
     NBlobMetrics::TBlobLoadMetrics PrevMetrics;
 
-    THashSet<NActors::TActorId> StoppedPartitions;
+    using TPoisonCallback =
+        std::function<void(const NActors::TActorContext&, NProto::TError)>;
 
-    using TPoisonCallback = std::function<
-        void (const NActors::TActorContext&, NProto::TError)
-    >;
+    struct TPartitionDestroyCallback
+    {
+        const ui64 VolumeRequestId = 0;
+        const NActors::TActorId PartitionActorId;
+        TPoisonCallback PoisonCallback;
+        bool Destroyed = false;
+    };
 
-    TDeque<std::pair<NActors::TActorId, TPoisonCallback>> WaitForPartitions;
-
-    using TDiskRegistryBasedPartitionStoppedCallback =
-        std::function<void(const NActors::TActorContext&)>;
-    THashMap<ui64, TDiskRegistryBasedPartitionStoppedCallback> OnPartitionStopped;
+    // Stores callbacks that need to be called when receiving a PoisonTaken
+    // message from destroyed partition. Callbacks are called in FIFO order,
+    // even if the partitions are deleted in a different order.
+    TDeque<TPartitionDestroyCallback> WaitForPartitionDestroy;
 
     TVector<ui64> GCCompletedPartitions;
 
@@ -480,7 +484,15 @@ private:
     void StartPartitionsForGc(const NActors::TActorContext& ctx);
     void StopPartitions(
         const NActors::TActorContext& ctx,
-        TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped);
+        TPoisonCallback onPartitionStopped);
+    void StopDiskRegistryBasedPartition(
+        const NActors::TActorContext& ctx,
+        TPoisonCallback onPartitionStopped);
+    void OnDiskRegistryBasedPartitionStopped(
+        const NActors::TActorContext& ctx,
+        NActors::TActorId sender,
+        ui64 volumeRequestId,
+        NProto::TError error);
 
     void SetupDiskRegistryBasedPartitions(const NActors::TActorContext& ctx);
 
@@ -1060,7 +1072,7 @@ private:
         const TEvPartitionCommonPrivate::TEvLongRunningOperation::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    NActors::TActorId WrapNonreplActorIfNeeded(
+    TActorsStack WrapNonreplActorIfNeeded(
         const NActors::TActorContext& ctx,
         NActors::TActorId nonreplicatedActorId,
         std::shared_ptr<TNonreplicatedPartitionConfig> srcConfig);
@@ -1070,7 +1082,7 @@ private:
     // is stopped.
     void RestartPartition(
         const NActors::TActorContext& ctx,
-        TDiskRegistryBasedPartitionStoppedCallback onPartitionStopped);
+        TPoisonCallback onPartitionStopped);
     void StartPartitionsImpl(const NActors::TActorContext& ctx);
 
     BLOCKSTORE_VOLUME_REQUESTS(BLOCKSTORE_IMPLEMENT_REQUEST, TEvVolume)

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -366,6 +366,7 @@ private:
     // message from destroyed partition. Callbacks are called in FIFO order,
     // even if the partitions are deleted in a different order.
     TDeque<TPartitionDestroyCallback> WaitForPartitionDestroy;
+    ui64 PartitionRestartCounter = 0;
 
     TVector<ui64> GCCompletedPartitions;
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -605,32 +605,27 @@ void TVolumeActor::CompleteUpdateDevices(
         State->GetDiskId().c_str(),
         args.LiteReallocation);
 
-    if (auto actorId = State->GetDiskRegistryBasedPartitionActor()) {
-        if (!args.RequestInfo) {
-            WaitForPartitions.emplace_back(actorId, nullptr);
-        } else {
-            auto reply =
-                [requestInfo = args.RequestInfo](const auto& ctx, auto error)
-            {
-                using TResponse = TEvVolumePrivate::TEvUpdateDevicesResponse;
-
-                NCloud::Reply(
-                    ctx,
-                    *requestInfo,
-                    std::make_unique<TResponse>(std::move(error)));
-            };
-
-            WaitForPartitions.emplace_back(actorId, std::move(reply));
-        }
-    }
-
     // Hacky way to avoid race condition with "TTxVolume::TUpdateMigrationState"
     // TODO(komarevtsev-d): Remove after proper fix in #3162.
     if (!args.LiteReallocation) {
         State->UpdateMigrationIndexInMeta(0);
     }
 
-    StopPartitions(ctx, {});
+    TPoisonCallback onPartitionDestroy =
+        [requestInfo =
+             args.RequestInfo](const TActorContext& ctx, NProto::TError error)
+    {
+        if (!requestInfo) {
+            return;
+        }
+        NCloud::Reply(
+            ctx,
+            *requestInfo,
+            std::make_unique<TEvVolumePrivate::TEvUpdateDevicesResponse>(
+                std::move(error)));
+    };
+
+    StopPartitions(ctx, onPartitionDestroy);
     SendVolumeConfigUpdated(ctx);
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -106,7 +106,7 @@ bool TVolumeActor::HandleMultipartitionVolumeRequest(
     ui64 traceTs)
 {
     static_assert(!IsCheckpointMethod<TMethod>);
-    Y_ABORT_UNLESS(!State->GetDiskRegistryBasedPartitionActor());
+    Y_ABORT_UNLESS(!State->IsDiskRegistryMediaKind());
     Y_ABORT_UNLESS(State->GetPartitions().size() > 1);
 
     const auto blocksPerStripe =
@@ -246,14 +246,14 @@ void TVolumeActor::SendRequestToPartition(
     ui64 traceTime)
 {
     STORAGE_VERIFY_C(
-        State->GetDiskRegistryBasedPartitionActor() || State->GetPartitions(),
+        State->IsDiskRegistryMediaKind() || State->GetPartitions(),
         TWellKnownEntityTypes::TABLET,
         TabletID(),
         "Empty partition list");
 
-    auto partActorId = State->GetDiskRegistryBasedPartitionActor()
+    auto partActorId = State->IsDiskRegistryMediaKind()
         ? State->GetDiskRegistryBasedPartitionActor()
-        : State->GetPartitions()[partitionId].Owner;
+        : State->GetPartitions()[partitionId].GetTopActorId();
 
     if (State->GetPartitions()) {
         LOG_TRACE(ctx, TBlockStoreComponents::VOLUME,
@@ -715,7 +715,7 @@ void TVolumeActor::ForwardRequest(
                 E_REJECTED,
                 TStringBuilder() // NBS-4447. Do not change message.
                     << "Checkpoint reject request. " << TMethod::Name << " is not allowed "
-                    << (State->GetDiskRegistryBasedPartitionActor()
+                    << (State->IsDiskRegistryMediaKind()
                             ? "if a checkpoint exists"
                             : "during checkpoint creation")));
             return;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -467,7 +467,7 @@ void TVolumeActor::StopDiskRegistryBasedPartition(
     const NActors::TActorContext& ctx,
     TPoisonCallback onPartitionStopped)
 {
-    const ui64 requestId = VolumeRequestIdGenerator->AdvanceUnsafe();
+    const ui64 requestId = ++PartitionRestartCounter;
     const auto actorId = State->GetDiskRegistryBasedPartitionActor();
 
     WaitForPartitionDestroy.push_back(TPartitionDestroyCallback{

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -475,9 +475,7 @@ void TVolumeActor::HandleLongRunningBlobOperation(
 
     const auto& msg = *ev->Get();
 
-    if (ev->Get()->Reason ==
-        TEvLongRunningOperation::EReason::LongRunningDetected)
-    {
+    if (msg.Reason == TEvLongRunningOperation::EReason::LongRunningDetected) {
         if (msg.FirstNotify) {
             LongRunningActors.Insert(ev->Sender);
             LongRunningActors.MarkLongRunning(ev->Sender, msg.Operation);
@@ -504,7 +502,7 @@ void TVolumeActor::HandleLongRunningBlobOperation(
             "[%lu] For volume %s %s %s (actor %s, group %u) detected after %s",
             TabletID(),
             State->GetDiskId().Quote().c_str(),
-            ToString(ev->Get()->Reason).c_str(),
+            ToString(msg.Reason).c_str(),
             ToString(msg.Operation).c_str(),
             ev->Sender.ToString().c_str(),
             msg.GroupId,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
@@ -313,7 +313,7 @@ void TVolumeActor::HandleStatVolume(
     if (!noPartition && State->GetPartitions()) {
         TVector<TActorId> partActorIds;
         for (const auto& partition: State->GetPartitions()) {
-            partActorIds.push_back(partition.Owner);
+            partActorIds.push_back(partition.GetTopActorId());
         }
 
         NCloud::Register<TStatPartitionActor>(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -322,12 +322,6 @@ void TVolumeActor::CompleteUpdateConfig(
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 
-    if (State) {
-        if (auto actorId = State->GetDiskRegistryBasedPartitionActor()) {
-            WaitForPartitions.emplace_back(actorId, nullptr);
-        }
-    }
-
     // stop partitions that might have been using old configuration
     StopPartitions(ctx, {});
 

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -22,38 +22,6 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TString TPartitionInfo::GetStatus() const
-{
-    TStringStream out;
-
-    switch (State) {
-        default:
-        case UNKNOWN:
-            out << "UNKNOWN";
-            break;
-        case STOPPED:
-            out << "STOPPED";
-            break;
-        case STARTED:
-            out << "STARTED";
-            break;
-        case FAILED:
-            out << "FAILED";
-            break;
-        case READY:
-            out << "READY";
-            break;
-    }
-
-    if (Message) {
-        out << ": " << Message;
-    }
-
-    return out.Str();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 bool THistoryLogKey::operator == (const THistoryLogKey& rhs) const
 {
     return std::tie(Timestamp, SeqNo) == std::tie(rhs.Timestamp, rhs.SeqNo);
@@ -499,22 +467,22 @@ TPartitionInfo* TVolumeState::GetPartition(ui64 tabletId)
     return nullptr;
 }
 
-std::optional<ui32>
-TVolumeState::FindPartitionIndex(NActors::TActorId owner) const
+std::optional<ui32> TVolumeState::FindPartitionIndex(
+    NActors::TActorId partitionActorId) const
 {
     for (ui32 i = 0; i < Partitions.size(); ++i) {
-        if (Partitions[i].Owner == owner) {
+        if (Partitions[i].IsKnownActorId(partitionActorId)) {
             return i;
         }
     }
     return std::nullopt;
 }
 
-std::optional<ui64>
-TVolumeState::FindPartitionTabletId(NActors::TActorId owner) const
+std::optional<ui64> TVolumeState::FindPartitionTabletId(
+    NActors::TActorId partitionActorId) const
 {
     for (const auto& partition: Partitions) {
-        if (partition.Owner == owner) {
+        if (partition.IsKnownActorId(partitionActorId)) {
             return partition.TabletId;
         }
     }
@@ -538,7 +506,8 @@ TPartitionInfo::EState TVolumeState::UpdatePartitionsState()
 
         const bool allocated =
             bytes >= Config->GetBlockSize() * Config->GetBlocksCount();
-        const bool actorStarted = !!DiskRegistryBasedPartitionActor;
+        const bool actorStarted =
+            DiskRegistryBasedPartitionActor.GetTop() != TActorId();
         if (allocated && actorStarted) {
             PartitionsState = TPartitionInfo::READY;
         } else {
@@ -601,10 +570,10 @@ TString TVolumeState::GetPartitionsError() const
 }
 
 void TVolumeState::SetDiskRegistryBasedPartitionActor(
-    const NActors::TActorId& actor,
+    TActorsStack actors,
     TNonreplicatedPartitionConfigPtr config)
 {
-    DiskRegistryBasedPartitionActor = actor;
+    DiskRegistryBasedPartitionActor = std::move(actors);
     NonreplicatedPartitionConfig = std::move(config);
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -196,7 +196,7 @@ private:
 
     TPartitionInfoList Partitions;
     TPartitionInfo::EState PartitionsState = TPartitionInfo::UNKNOWN;
-    NActors::TActorId DiskRegistryBasedPartitionActor;
+    TActorsStack DiskRegistryBasedPartitionActor;
     TNonreplicatedPartitionConfigPtr NonreplicatedPartitionConfig;
 
     TVector<TPartitionStatInfo> PartitionStatInfos;
@@ -401,8 +401,10 @@ public:
     }
 
     TPartitionInfo* GetPartition(ui64 tabletId);
-    std::optional<ui32> FindPartitionIndex(NActors::TActorId owner) const;
-    std::optional<ui64> FindPartitionTabletId(NActors::TActorId owner) const;
+    std::optional<ui32> FindPartitionIndex(
+        NActors::TActorId partitionActorId) const;
+    std::optional<ui64> FindPartitionTabletId(
+        NActors::TActorId partitionActorId) const;
 
     //
     // State
@@ -434,12 +436,12 @@ public:
     TString GetPartitionsError() const;
 
     void SetDiskRegistryBasedPartitionActor(
-        const NActors::TActorId& actor,
+        TActorsStack actors,
         TNonreplicatedPartitionConfigPtr config);
 
-    const NActors::TActorId& GetDiskRegistryBasedPartitionActor() const
+    NActors::TActorId GetDiskRegistryBasedPartitionActor() const
     {
-        return DiskRegistryBasedPartitionActor;
+        return DiskRegistryBasedPartitionActor.GetTop();
     }
 
     const TNonreplicatedPartitionConfigPtr& GetNonreplicatedPartitionConfig() const


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999
1. так как актор партишена может быть скрыт внутри оберток, то удобнее при получении сообщения в вольюм, проверить что это партишен или его обертки, чем пропускать все сообщения через цепочку оберток, гарантируя что сообщения будут всегда приходить из верхней обертки.
2. упростил вызов колбэков на умирание акторов партишенов. Колбэки вызываются в порядке вызовов StopPartition.
3. иногда тип диска определялся через GetDiskRegistryBasedPartitionActor() - заменил на IsDiskRegistryMediaKind()
4. добавил в счетчик запросов вольюма небольшой запас, чтобы когда он исчерпался для обычных запросов была возможность им еще немного пользоваться для сервисных нужд, не усложняя код.