### PR TITLE
issue-1345: reject start\stop\etc endpoint requests before restoring

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -560,7 +560,8 @@ private:
     bool IsEndpointRestoring(const TString& socket)
     {
         switch (AtomicGet(RestoringStage)) {
-            case WaitingForRestoring: return false;
+            case WaitingForRestoring:
+                return true;
             case ReadingStorage: return true;
             case StartingEndpoints: return RestoringEndpoints.contains(socket);
             case Completed: return false;

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -35,6 +35,8 @@ namespace NCloud::NBlockStore::NServer {
 
 using namespace NThreading;
 
+using namespace std::chrono_literals;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -268,6 +270,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             nullptr,    // nbdDeviceFactory
             {}          // options
         );
+        endpointManager->RestoreEndpoints().Wait(5s);
 
         NProto::TStartEndpointRequest request;
         request.SetUnixSocketPath(unixSocket);
@@ -351,6 +354,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             nullptr,    // nbdDeviceFactory
             {}          // options
         );
+        endpointManager->RestoreEndpoints().Wait(5s);
 
         auto endpointService = CreateMultipleEndpointService(
             std::make_shared<TTestService>(),
@@ -762,6 +766,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             nullptr,    // nbdDeviceFactory
             {}          // options
         );
+        endpointManager->RestoreEndpoints().Wait(5s);
 
         auto future = endpointManager->ListKeyrings(
             MakeIntrusive<TCallContext>(),
@@ -921,6 +926,7 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             nullptr,    // nbdDeviceFactory
             {}          // options
         );
+        endpointManager->RestoreEndpoints().Wait(5s);
 
         TTempDir dir;
         TString unixSocket = (dir.Path() / "testSocket").GetPath();


### PR DESCRIPTION
#1345 
Иногда так происходит, что компьют присылает запросы по типу stop endpoint перед тем как мы сделали restore. В коде это учитывается далеко не всегда, что вызывает баги(например один из таких чинился в рамках #2842), плюс фактически мы всегда делаем рестор на старте процесса первым делом, так что легче всего будет просто запретить слать подобные запросы перед началом рестора.