### PR TITLE
make multiple_errors test large under tsan

### DIFF
--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -140,7 +140,7 @@ def test_multiple_errors():
     request_timeout = 2
     runtime = request_timeout * 2
     nbs_downtime = request_timeout + 1
-    numjobs = 256
+    iodepth = 1024
 
     env, run = init(
         with_netlink=True,
@@ -178,7 +178,7 @@ def test_multiple_errors():
             [
                 "fio",
                 "--name=fio",
-                "--ioengine=sync",
+                "--ioengine=libaio",
                 "--direct=1",
                 "--time_based=1",
                 "--rw=randrw",
@@ -186,7 +186,7 @@ def test_multiple_errors():
                 "--filename=" + nbd_device,
                 "--runtime=" + str(runtime),
                 "--blocksize=" + str(block_size),
-                "--numjobs=" + str(numjobs),
+                "--iodepth=" + str(iodepth),
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
@@ -196,7 +196,6 @@ def test_multiple_errors():
         os.kill(env.nbs.pid, signal.SIGCONT)
 
         proc.communicate(timeout=60)
-        assert proc.returncode == 0
 
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)

--- a/cloud/blockstore/tests/e2e-tests/ya.make
+++ b/cloud/blockstore/tests/e2e-tests/ya.make
@@ -1,6 +1,11 @@
 PY3TEST()
 
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+IF (SANITIZER_TYPE)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ENDIF()
+
 SPLIT_FACTOR(1)
 
 TEST_SRCS(


### PR DESCRIPTION
Мы здесь делаем 2 вещи:
1.  Под tsan-ом меняем тест на large, чтобы у него было больше времени (с возвратом параллельности)
2. Убираем проверку статуса, про это ниже

В ядре, которое используется в нашем образе для тестов, не поддержаны ретраи при таймаутах запросов – https://elixir.bootlin.com/linux/v5.4/source/drivers/block/nbd.c#L398. Для сравнения, более новое ядро – https://elixir.bootlin.com/linux/v5.15.130/source/drivers/block/nbd.c#L419

То есть in-flight запросы завершались ошибкой, а новые запросы ждали переподключения – https://elixir.bootlin.com/linux/v5.4/source/drivers/block/nbd.c#L903 + из-за особенностей обработки ошибок fio, если numjobs > 1, весь процесс мог завершиться без ошибок

Сценарий, который мы пытаемся воспроизвести, приводит к зависанию процесса в D-state, поэтому нам вообще говоря не сильно важно, чтобы fio завершился без ошибок – проще всего будет убрать проверку