### PR TITLE
issue-3: added locking ranges for write requests in mirror partition during fresh device migration

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -142,4 +142,10 @@ void TLaggingAgentMigrationActor::OnMigrationError(const TActorContext& ctx)
         AgentId.c_str());
 }
 
+NActors::TActorId
+TLaggingAgentMigrationActor::GetActorToLockAndDrainRange() const
+{
+    return SourceActorId;
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -56,6 +56,7 @@ void TLaggingAgentMigrationActor::OnBootstrap(const TActorContext& ctx)
     InitWork(
         ctx,
         SourceActorId,
+        SourceActorId,
         TargetActorId,
         false,   // takeOwnershipOverActors
         std::make_unique<TMigrationTimeoutCalculator>(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.h
@@ -60,6 +60,7 @@ private:
         ui64 migrationIndex) override;
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
+    NActors::TActorId GetActorToLockAndDrainRange() const override;
 
 private:
     void HandleStartLaggingAgentMigration(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -467,6 +467,11 @@ struct TTestEnv
             });
     }
 
+    // We need to simulate the behavior of a mirror partition with range locks
+    // because in these tests we use some replica as a migration source and not
+    // a mirror partition. A non-replicated partition does not know anything
+    // about range locking and tests will crash if this partition receives a
+    // lock message.
     TTestActorRuntimeBase::EEventAction DefaultObserver(
         TAutoPtr<IEventHandle>& event)
     {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -140,8 +140,8 @@ struct TTestEnv
     {
         SetupLogging();
 
-        Runtime.SetObserverFunc([self = this](auto& event)
-                                { return self->DefaultObserver(event); });
+        Runtime.SetObserverFunc([this](auto& event)
+                                { return DefaultObserver(event); });
 
         Runtime.SetRegistrationObserverFunc(
             [&](TTestActorRuntimeBase& runtime,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -116,17 +116,21 @@ void TMirrorPartitionActor::SetupPartitions(const TActorContext& ctx)
     for (const auto& replicaInfo: State.GetReplicaInfos()) {
         IActorPtr actor;
         if (replicaInfo.Migrations.size()) {
+            auto migrationSrcActorId = State.IsMigrationConfigPreparedForFresh()
+                                           ? SelfId()
+                                           : TActorId();
             actor = CreateNonreplicatedPartitionMigration(
                 Config,
                 DiagnosticsConfig,
                 ProfileLog,
                 BlockDigestGenerator,
-                0,  // initialMigrationIndex
+                0,   // initialMigrationIndex
                 State.GetRWClientId(),
                 replicaInfo.Config,
                 replicaInfo.Migrations,
                 RdmaClient,
-                SelfId());
+                SelfId(),
+                migrationSrcActorId);
         } else {
             actor = CreateNonreplicatedPartition(
                 Config,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_lagging_devices_ut.cpp
@@ -967,8 +967,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
         env.ReadAndCheckContents(secondRow, 'B');
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            Count(readActors, env.ReplicaActors[1]) +
-                Count(readActors, env.ReplicaActors[2]));
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[1]));
         readActors.clear();
 
         env.ReadAndCheckContents(
@@ -985,8 +985,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
             'A');
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            Count(readActors, env.ReplicaActors[1]) +
-                Count(readActors, env.ReplicaActors[2]));
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[1]));
         readActors.clear();
 
         // uuid-3 is ok now.
@@ -1005,8 +1005,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionLaggingDevicesTest)
         env.ReadAndCheckContents(firstAndSecondRows, 'B');
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            Count(readActors, env.ReplicaActors[1]) +
-                Count(readActors, env.ReplicaActors[2]));
+            Count(readActors, env.ReplicaActors[0]) +
+                Count(readActors, env.ReplicaActors[1]));
         readActors.clear();
 
         // Poison pill has killed the proxy actor.

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -78,14 +78,19 @@ NProto::TError TMirrorPartitionState::Validate()
 
 void TMirrorPartitionState::PrepareMigrationConfig()
 {
-    if (MigrationConfigPrepared) {
+    using enum EMigrationConfigState;
+    if (MigrationConfigPrepared != NotPrepared) {
         return;
     }
 
-    if (PrepareMigrationConfigForFreshDevices() ||
-        PrepareMigrationConfigForWarningDevices())
-    {
-        MigrationConfigPrepared = true;
+    if (PrepareMigrationConfigForFreshDevices()) {
+        MigrationConfigPrepared = PreparedForFresh;
+        return;
+    }
+
+    if (PrepareMigrationConfigForWarningDevices()) {
+        MigrationConfigPrepared = PreparedForWarning;
+        return;
     }
 }
 
@@ -179,16 +184,10 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
 
         if (!anotherFreshDevices.contains(uuid)) {
             // we found a good device, lets build our migration config
-            auto targetDevice = devices[deviceIdx];
-            devices[deviceIdx] = anotherDevice;
+            auto& targetDevice = devices[deviceIdx];
             auto& migration = *replicaInfo->Migrations.Add();
-            migration.SetSourceDeviceId(uuid);
-            *migration.MutableTargetDevice() = std::move(targetDevice);
-
-            // we need to replace anotherDevice with a dummy device
-            // since now our migration actor will be responsible for
-            // write request replication to this device
-            anotherDevice.SetDeviceUUID({});
+            migration.ClearSourceDeviceId();
+            *migration.MutableTargetDevice() = targetDevice;
 
             return true;
         }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.h
@@ -16,6 +16,13 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TMirrorPartitionState
 {
+    enum class EMigrationConfigState
+    {
+        NotPrepared,
+        PreparedForFresh,
+        PreparedForWarning,
+    };
+
 private:
     const TStorageConfigPtr Config;
     const TNonreplicatedPartitionConfigPtr PartConfig;
@@ -27,7 +34,8 @@ private:
 
     ui32 ReadReplicaIndex = 0;
 
-    bool MigrationConfigPrepared = false;
+    EMigrationConfigState MigrationConfigPrepared =
+        EMigrationConfigState::NotPrepared;
 
 public:
     TMirrorPartitionState(
@@ -108,6 +116,12 @@ public:
     void PrepareMigrationConfig();
     [[nodiscard]] bool PrepareMigrationConfigForWarningDevices();
     [[nodiscard]] bool PrepareMigrationConfigForFreshDevices();
+
+    [[nodiscard]] bool IsMigrationConfigPreparedForFresh() const
+    {
+        return MigrationConfigPrepared ==
+               EMigrationConfigState::PreparedForFresh;
+    }
 
     [[nodiscard]] NProto::TError NextReadReplica(
         const TBlockRange64 readRange,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
@@ -184,7 +184,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
             1024,
             replica0.Config->GetDevices()[0].GetBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(
-            "4_1",
+            "1_2",
             replica0.Config->GetDevices()[1].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -205,7 +205,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         const auto& migrations0 = replica0.Migrations;
         UNIT_ASSERT_VALUES_EQUAL(1, migrations0.size());
 
-        UNIT_ASSERT_VALUES_EQUAL("4_1", migrations0[0].GetSourceDeviceId());
+        UNIT_ASSERT_VALUES_EQUAL(TString(), migrations0[0].GetSourceDeviceId());
         UNIT_ASSERT_VALUES_EQUAL(
             "1_2",
             migrations0[0].GetTargetDevice().GetDeviceUUID());
@@ -221,7 +221,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
             1024,
             replica1.Config->GetDevices()[0].GetBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(
-            "",
+            "4_1",
             replica1.Config->GetDevices()[1].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -289,7 +289,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica0 = state.GetReplicaInfos()[0];
         UNIT_ASSERT_VALUES_EQUAL(
-            "3_1",
+            "1_1",
             replica0.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -316,7 +316,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         const auto& migrations0 = replica0.Migrations;
         UNIT_ASSERT_VALUES_EQUAL(1, migrations0.size());
 
-        UNIT_ASSERT_VALUES_EQUAL("3_1", migrations0[0].GetSourceDeviceId());
+        UNIT_ASSERT_VALUES_EQUAL(TString(), migrations0[0].GetSourceDeviceId());
         UNIT_ASSERT_VALUES_EQUAL(
             "1_1",
             migrations0[0].GetTargetDevice().GetDeviceUUID());
@@ -326,7 +326,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica1 = state.GetReplicaInfos()[1];
         UNIT_ASSERT_VALUES_EQUAL(
-            "",
+            "3_1",
             replica1.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -384,7 +384,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica0 = state.GetReplicaInfos()[0];
         UNIT_ASSERT_VALUES_EQUAL(
-            "3_1",
+            "1_1",
             replica0.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,
@@ -411,7 +411,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
         const auto& migrations0 = replica0.Migrations;
         UNIT_ASSERT_VALUES_EQUAL(1, migrations0.size());
 
-        UNIT_ASSERT_VALUES_EQUAL("3_1", migrations0[0].GetSourceDeviceId());
+        UNIT_ASSERT_VALUES_EQUAL(TString(), migrations0[0].GetSourceDeviceId());
         UNIT_ASSERT_VALUES_EQUAL(
             "1_1",
             migrations0[0].GetTargetDevice().GetDeviceUUID());
@@ -421,7 +421,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionStateTest)
 
         const auto& replica1 = state.GetReplicaInfos()[1];
         UNIT_ASSERT_VALUES_EQUAL(
-            "",
+            "3_1",
             replica1.Config->GetDevices()[0].GetDeviceUUID());
         UNIT_ASSERT_VALUES_EQUAL(
             1024,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -1119,7 +1119,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(2, mr.MigratedRanges);
 
         UNIT_ASSERT_VALUES_EQUAL("test", mr.DiskId);
-        UNIT_ASSERT_VALUES_EQUAL("vasya#2", mr.SourceDeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(TString(), mr.SourceDeviceId);
         UNIT_ASSERT_VALUES_EQUAL("vasya", mr.TargetDeviceId);
 
         mr.TestAgentData("vasya", 'A', 2048);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -30,6 +30,8 @@ using namespace NActors;
 
 using namespace std::chrono_literals;
 
+using namespace NPartition;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -329,6 +331,60 @@ void WaitUntilScrubbingFinishesCurrentCycle(TTestEnv& testEnv)
             break;
         }
         prevScrubbingProgress = counters.Simple.ScrubbingProgress.Value;
+    }
+}
+
+struct TRangeRequestsCounter
+{
+    TMap<TBlockRange64, ui64, TBlockRangeComparator> RangeToCountMap;
+
+    void AddRequest(TBlockRange64 range)
+    {
+        auto [it, inserted] = RangeToCountMap.try_emplace(range, 1);
+        if (!inserted) {
+            it->second += 1;
+        }
+    }
+
+    ui64 GetRequestCountWithRange(TBlockRange64 range)
+    {
+        auto* count = RangeToCountMap.FindPtr(range);
+        return count ? *count : 0;
+    }
+};
+
+void TestAgentData(
+    TTestActorRuntime& runtime,
+    TString deviceId,
+    char c,
+    ui32 startIndex,
+    ui32 blockCount)
+{
+    auto sender = runtime.AllocateEdgeActor();
+
+    auto request = std::make_unique<TEvDiskAgent::TEvReadDeviceBlocksRequest>();
+
+    request->Record.SetStartIndex(startIndex);
+    request->Record.SetBlockSize(4_KB);
+    request->Record.SetDeviceUUID(deviceId);
+    request->Record.SetBlocksCount(blockCount);
+
+    auto diskAgentActorId = MakeDiskAgentServiceId(runtime.GetNodeId(0));
+    runtime.Send(new IEventHandle(diskAgentActorId, sender, request.release()));
+
+    TAutoPtr<IEventHandle> handle;
+    using TResponse = TEvDiskAgent::TEvReadDeviceBlocksResponse;
+    runtime.GrabEdgeEventRethrow<TResponse>(handle, WaitTimeout);
+
+    UNIT_ASSERT(handle);
+    auto response = handle->Release<TResponse>();
+
+    const auto& buffers = response->Record.GetBlocks().GetBuffers();
+    UNIT_ASSERT_VALUES_EQUAL(blockCount, buffers.size());
+
+    for (const auto& block: buffers)
+    {
+        UNIT_ASSERT_VALUES_EQUAL(TString(4_KB, c), block);
     }
 }
 
@@ -850,7 +906,6 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
     void DoShouldTryToSplitReadRequest(const THashSet<TString>& freshDeviceIds)
     {
-        using namespace std::chrono_literals;
         TTestRuntime runtime;
 
         TTestEnv env(
@@ -1056,35 +1111,13 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
 
         void TestAgentData(TString deviceId, char c, ui32 blockCount)
         {
-            auto sender = Runtime.AllocateEdgeActor();
-
-            auto request =
-                std::make_unique<TEvDiskAgent::TEvReadDeviceBlocksRequest>();
-
-            request->Record.SetStartIndex(0);
-            request->Record.SetBlockSize(4_KB);
-            request->Record.SetDeviceUUID(deviceId);
-            request->Record.SetBlocksCount(blockCount);
-
-            auto diskAgentActorId = MakeDiskAgentServiceId(Runtime.GetNodeId(0));
-            Runtime.Send(new IEventHandle(
-                diskAgentActorId,
-                sender,
-                request.release()));
-
-            TAutoPtr<IEventHandle> handle;
-            using TResponse = TEvDiskAgent::TEvReadDeviceBlocksResponse;
-            Runtime.GrabEdgeEventRethrow<TResponse>(handle, WaitTimeout);
-
-            UNIT_ASSERT(handle);
-            auto response = handle->Release<TResponse>();
-
-            const auto& buffers = response->Record.GetBlocks().GetBuffers();
-            UNIT_ASSERT_VALUES_EQUAL(blockCount, buffers.size());
-
-            UNIT_ASSERT_VALUES_EQUAL(TString(4_KB, c), buffers[0]);
-            UNIT_ASSERT_VALUES_EQUAL(TString(4_KB, c), buffers[blockCount - 1]);
-        };
+            ::NCloud::NBlockStore::NStorage::TestAgentData(
+                Runtime,
+                deviceId,
+                c,
+                0,
+                blockCount);
+        }
     };
 
     Y_UNIT_TEST(ShouldCopyDataToFreshDevices)
@@ -2642,6 +2675,154 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(E_CANCELLED, resp->GetError().GetCode());
     }
 
+    Y_UNIT_TEST(ShouldLockRangeDuringFreshDeviceMigrations)
+    {
+        TTestRuntime runtime;
+
+        const THashSet<TString> freshDeviceIds{"vasya"};
+        TTestEnv env(
+            runtime,
+            TTestEnv::DefaultDevices(runtime.GetNodeId(0)),
+            TVector<TDevices>{
+                TTestEnv::DefaultReplica(runtime.GetNodeId(0), 1),
+                TTestEnv::DefaultReplica(runtime.GetNodeId(0), 2),
+            },
+            {},   // migrations
+            freshDeviceIds);
+
+        TPartitionClient client(runtime, env.ActorId);
+        TVector<std::unique_ptr<IEventHandle>> stollenEvents;
+        THashSet<TString> uuidsToStoleWriteEvents{"vasya#1", "vasya#2"};
+
+        TRangeRequestsCounter lockRanges;
+        TRangeRequestsCounter releaseRanges;
+        TRangeRequestsCounter migrationReadRanges;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
+                        auto* ev = static_cast<
+                            TEvDiskAgent::TEvWriteDeviceBlocksRequest*>(
+                            event->GetBase());
+                        const auto& uuid = ev->Record.GetDeviceUUID();
+                        if (uuidsToStoleWriteEvents.contains(uuid)) {
+                            stollenEvents.emplace_back(
+                                std::unique_ptr<IEventHandle>(event.Release()));
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                    case TEvService::EvReadBlocksRequest: {
+                        auto* ev =
+                            static_cast<TEvService::TEvReadBlocksRequest*>(
+                                event->GetBase());
+                        if (ev->Record.GetHeaders().GetIsBackgroundRequest()) {
+                            migrationReadRanges.AddRequest(
+                                TBlockRange64::WithLength(
+                                    ev->Record.GetStartIndex(),
+                                    ev->Record.GetBlocksCount()));
+                        }
+                        break;
+                    }
+                    case TEvPartition::EvLockAndDrainRangeRequest: {
+                        auto* ev = static_cast<
+                            TEvPartition::TEvLockAndDrainRangeRequest*>(
+                            event->GetBase());
+                        lockRanges.AddRequest(ev->Range);
+                        break;
+                    }
+                    case TEvPartition::EvReleaseRange: {
+                        auto* ev = static_cast<TEvPartition::TEvReleaseRange*>(
+                            event->GetBase());
+                        releaseRanges.AddRequest(ev->Range);
+
+                        UNIT_ASSERT(
+                            lockRanges.GetRequestCountWithRange(ev->Range) ==
+                            releaseRanges.GetRequestCountWithRange(ev->Range));
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        TString dataToWrite = TString(DefaultBlockSize, 'A');
+
+        const auto secondMigrationRange = TBlockRange64::WithLength(1024, 1024);
+        client.SendWriteBlocksLocalRequest(secondMigrationRange, dataToWrite);
+
+        {
+            runtime.AdvanceCurrentTime(40ms);
+            NActors::TDispatchOptions options;
+            options.FinalEvents = {
+                NActors::TDispatchOptions::TFinalEventCondition(
+                    TEvNonreplPartitionPrivate::EvRangeMigrated)};
+
+            runtime.DispatchEvents(options);
+            runtime.AdvanceCurrentTime(40ms);
+            runtime.DispatchEvents({}, 10ms);
+        }
+
+        auto firstMigrationRange = TBlockRange64::WithLength(0, 1024);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            0,
+            lockRanges.GetRequestCountWithRange(firstMigrationRange));
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            0,
+            releaseRanges.GetRequestCountWithRange(firstMigrationRange));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            releaseRanges.GetRequestCountWithRange(secondMigrationRange) + 1,
+            lockRanges.GetRequestCountWithRange(secondMigrationRange));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            migrationReadRanges.GetRequestCountWithRange(secondMigrationRange));
+
+        // Write requeests should work in migrated range.
+        client.ZeroBlocks(firstMigrationRange);
+
+        client.SendZeroBlocksRequest(secondMigrationRange);
+        auto resp = client.RecvZeroBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, resp->GetError().GetCode());
+
+        uuidsToStoleWriteEvents.clear();
+
+        client.SendWriteBlocksLocalRequest(
+            firstMigrationRange,
+            TString(DefaultBlockSize, 'B'));
+
+        for (auto& ev: stollenEvents) {
+            runtime.Send(ev.release());
+        }
+
+        {
+            NActors::TDispatchOptions options;
+            options.FinalEvents = {
+                NActors::TDispatchOptions::TFinalEventCondition(
+                    TEvNonreplPartitionPrivate::EvRangeMigrated)};
+
+            runtime.DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            0,
+            lockRanges.GetRequestCountWithRange(secondMigrationRange));
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            0,
+            releaseRanges.GetRequestCountWithRange(secondMigrationRange));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            releaseRanges.GetRequestCountWithRange(secondMigrationRange),
+            lockRanges.GetRequestCountWithRange(secondMigrationRange));
+
+        TestAgentData(runtime, "vasya", 'A', 1024, 1024);
+        TestAgentData(runtime, "vasya#1", 'A', 1024, 1024);
+        TestAgentData(runtime, "vasya#2", 'A', 1024, 1024);
+    }
+
     Y_UNIT_TEST(ShouldExecuteMultiWriteRequests)
     {
         TTestRuntime runtime;
@@ -2678,13 +2859,6 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                             DefaultBlockSize,
                             record.GetBlockSize());
                         multiWriteRequests.insert(record.GetDeviceUUID());
-                    }
-                    break;
-                }
-                case TEvNonreplPartitionPrivate::EvGetDeviceForRangeRequest: {
-                    ++describeRequestCount;
-                }
-            }
 
             return false;
         };
@@ -2700,7 +2874,6 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         {
             client.WriteBlocks(TBlockRange64::WithLength(10, 5), 1);
 
-            UNIT_ASSERT_VALUES_EQUAL(3, describeRequestCount);
             UNIT_ASSERT_VALUES_EQUAL(3, device2WriteRange.size());
             UNIT_ASSERT_VALUES_EQUAL(1, multiWriteRequests.size());
 
@@ -2948,142 +3121,6 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         runtime.SetEventFilter(failWrite);
 
         NProto::TStorageServiceConfig config;
-        config.SetMultiAgentWriteEnabled(true);
-        TTestEnv env(runtime, std::move(config));
-
-        TPartitionClient client(runtime, env.ActorId);
-
-        client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
-        auto response = client.RecvWriteBlocksResponse();
-        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
-        UNIT_ASSERT(undeliverySent);
-    }
-
-    Y_UNIT_TEST(ShouldHandleTimeoutForMultiWriteRequests)
-    {
-        TTestRuntime runtime;
-
-        bool requestDropped = false;
-        auto failWrite =
-            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
-        {
-            Y_UNUSED(runtime);
-            switch (event->GetTypeRewrite()) {
-                case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
-                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksRequest;
-
-                    bool isReplicatedRequest =
-                        event->Get<TRequest>()
-                            ->Record.GetReplicationTargets()
-                            .empty();
-
-                    if (!requestDropped && isReplicatedRequest) {
-                        requestDropped = true;
-                        return true;
-                    }
-                    break;
-                }
-                case TEvNonreplPartitionPrivate::EvGetDeviceForRangeResponse: {
-                    using TResponse = TEvNonreplPartitionPrivate::
-                        TEvGetDeviceForRangeResponse;
-
-                    event->Get<TResponse>()->RequestTimeout =
-                        TDuration::Seconds(5);
-                    break;
-                }
-            }
-
-            return false;
-        };
-
-        runtime.SetEventFilter(failWrite);
-
-        NProto::TStorageServiceConfig config;
-        config.SetMultiAgentWriteEnabled(true);
-        TTestEnv env(runtime, std::move(config));
-
-        TPartitionClient client(runtime, env.ActorId);
-
-        client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
-        runtime.AdvanceCurrentTime(TDuration::Seconds(5));
-        auto response = client.RecvWriteBlocksResponse();
-        UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetError().GetCode());
-        UNIT_ASSERT(requestDropped);
-    }
-
-    Y_UNIT_TEST(ShouldHandleInconsistentDiskAgentResponse)
-    {
-        using namespace NMonitoring;
-
-        TTestRuntime runtime;
-
-        bool inconsistentDiskAgentSeen = false;
-
-        size_t multiAgentRequestCount = 0;
-        auto failWrite =
-            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
-        {
-            Y_UNUSED(runtime);
-
-            switch (event->GetTypeRewrite()) {
-                case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
-                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksRequest;
-
-                    const auto& record = event->Get<TRequest>()->Record;
-                    if (!record.GetReplicationTargets().empty()) {
-                        ++multiAgentRequestCount;
-                    }
-
-                    break;
-                }
-
-                case TEvDiskAgent::EvWriteDeviceBlocksResponse: {
-                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksResponse;
-
-                    auto& record = event->Get<TRequest>()->Record;
-                    if (record.GetReplicationResponses().size()) {
-                        // Make response inconsistent.
-                        record.MutableReplicationResponses(0)->SetCode(
-                            E_REJECTED);
-                    }
-
-                    break;
-                }
-
-                case TEvNonreplPartitionPrivate::EvInconsistentDiskAgent: {
-                    inconsistentDiskAgentSeen = true;
-                    break;
-                }
-            }
-
-            return false;
-        };
-
-        runtime.SetEventFilter(failWrite);
-
-        NProto::TStorageServiceConfig config;
-        config.SetMultiAgentWriteEnabled(true);
-        TTestEnv env(runtime, std::move(config));
-
-        TPartitionClient client(runtime, env.ActorId);
-
-        TDynamicCountersPtr critEventsCounters = new TDynamicCounters();
-        InitCriticalEventsCounter(critEventsCounters);
-        auto inconsistentCritEvent =
-            critEventsCounters->GetCounter(
-                "AppCriticalEvents/DiskAgentInconsistentMultiWriteResponse",
-                true);
-
-        // Send the first request and simulate an inconsistent response from the disk-agent.
-        client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
-        auto response = client.RecvWriteBlocksResponse();
-        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
-        UNIT_ASSERT(inconsistentDiskAgentSeen);
-        UNIT_ASSERT_VALUES_EQUAL(1, multiAgentRequestCount);
-        UNIT_ASSERT_VALUES_EQUAL(1, inconsistentCritEvent->Val());
-
-        // Send the second request and expect mirror-partition turn multi-agent feature off.
-        multiAgentRequestCount = 0;
         client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
         response = client.RecvWriteBlocksResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetError().GetCode());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -342,16 +342,12 @@ private:
 public:
     void AddRequest(TBlockRange64 range)
     {
-        auto [it, inserted] = RangeToCountMap.try_emplace(range, 1);
-        if (!inserted) {
-            it->second += 1;
-        }
+        RangeToCountMap[range] += 1;
     }
 
     [[nodiscard]] ui64 GetRequestCountWithRange(TBlockRange64 range) const
     {
-        const auto* count = RangeToCountMap.FindPtr(range);
-        return count ? *count : 0;
+        return RangeToCountMap.Value(range, 0);
     }
 };
 
@@ -2825,6 +2821,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         TestAgentData(runtime, "vasya#2", 'A', 1024, 1024);
     }
 
+
     Y_UNIT_TEST(ShouldExecuteMultiWriteRequests)
     {
         TTestRuntime runtime;
@@ -2861,6 +2858,13 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                             DefaultBlockSize,
                             record.GetBlockSize());
                         multiWriteRequests.insert(record.GetDeviceUUID());
+                    }
+                    break;
+                }
+                case TEvNonreplPartitionPrivate::EvGetDeviceForRangeRequest: {
+                    ++describeRequestCount;
+                }
+            }
 
             return false;
         };
@@ -2876,6 +2880,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         {
             client.WriteBlocks(TBlockRange64::WithLength(10, 5), 1);
 
+            UNIT_ASSERT_VALUES_EQUAL(3, describeRequestCount);
             UNIT_ASSERT_VALUES_EQUAL(3, device2WriteRange.size());
             UNIT_ASSERT_VALUES_EQUAL(1, multiWriteRequests.size());
 
@@ -3123,6 +3128,142 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         runtime.SetEventFilter(failWrite);
 
         NProto::TStorageServiceConfig config;
+        config.SetMultiAgentWriteEnabled(true);
+        TTestEnv env(runtime, std::move(config));
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
+        auto response = client.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+        UNIT_ASSERT(undeliverySent);
+    }
+
+    Y_UNIT_TEST(ShouldHandleTimeoutForMultiWriteRequests)
+    {
+        TTestRuntime runtime;
+
+        bool requestDropped = false;
+        auto failWrite =
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+            switch (event->GetTypeRewrite()) {
+                case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
+                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksRequest;
+
+                    bool isReplicatedRequest =
+                        event->Get<TRequest>()
+                            ->Record.GetReplicationTargets()
+                            .empty();
+
+                    if (!requestDropped && isReplicatedRequest) {
+                        requestDropped = true;
+                        return true;
+                    }
+                    break;
+                }
+                case TEvNonreplPartitionPrivate::EvGetDeviceForRangeResponse: {
+                    using TResponse = TEvNonreplPartitionPrivate::
+                        TEvGetDeviceForRangeResponse;
+
+                    event->Get<TResponse>()->RequestTimeout =
+                        TDuration::Seconds(5);
+                    break;
+                }
+            }
+
+            return false;
+        };
+
+        runtime.SetEventFilter(failWrite);
+
+        NProto::TStorageServiceConfig config;
+        config.SetMultiAgentWriteEnabled(true);
+        TTestEnv env(runtime, std::move(config));
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
+        runtime.AdvanceCurrentTime(TDuration::Seconds(5));
+        auto response = client.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetError().GetCode());
+        UNIT_ASSERT(requestDropped);
+    }
+
+    Y_UNIT_TEST(ShouldHandleInconsistentDiskAgentResponse)
+    {
+        using namespace NMonitoring;
+
+        TTestRuntime runtime;
+
+        bool inconsistentDiskAgentSeen = false;
+
+        size_t multiAgentRequestCount = 0;
+        auto failWrite =
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
+                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksRequest;
+
+                    const auto& record = event->Get<TRequest>()->Record;
+                    if (!record.GetReplicationTargets().empty()) {
+                        ++multiAgentRequestCount;
+                    }
+
+                    break;
+                }
+
+                case TEvDiskAgent::EvWriteDeviceBlocksResponse: {
+                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksResponse;
+
+                    auto& record = event->Get<TRequest>()->Record;
+                    if (record.GetReplicationResponses().size()) {
+                        // Make response inconsistent.
+                        record.MutableReplicationResponses(0)->SetCode(
+                            E_REJECTED);
+                    }
+
+                    break;
+                }
+
+                case TEvNonreplPartitionPrivate::EvInconsistentDiskAgent: {
+                    inconsistentDiskAgentSeen = true;
+                    break;
+                }
+            }
+
+            return false;
+        };
+
+        runtime.SetEventFilter(failWrite);
+
+        NProto::TStorageServiceConfig config;
+        config.SetMultiAgentWriteEnabled(true);
+        TTestEnv env(runtime, std::move(config));
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        TDynamicCountersPtr critEventsCounters = new TDynamicCounters();
+        InitCriticalEventsCounter(critEventsCounters);
+        auto inconsistentCritEvent =
+            critEventsCounters->GetCounter(
+                "AppCriticalEvents/DiskAgentInconsistentMultiWriteResponse",
+                true);
+
+        // Send the first request and simulate an inconsistent response from the disk-agent.
+        client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
+        auto response = client.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+        UNIT_ASSERT(inconsistentDiskAgentSeen);
+        UNIT_ASSERT_VALUES_EQUAL(1, multiAgentRequestCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, inconsistentCritEvent->Val());
+
+        // Send the second request and expect mirror-partition turn multi-agent feature off.
+        multiAgentRequestCount = 0;
         client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
         response = client.RecvWriteBlocksResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetError().GetCode());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -334,10 +334,12 @@ void WaitUntilScrubbingFinishesCurrentCycle(TTestEnv& testEnv)
     }
 }
 
-struct TRangeRequestsCounter
+class TRangeRequestsCounter
 {
+private:
     TMap<TBlockRange64, ui64, TBlockRangeComparator> RangeToCountMap;
 
+public:
     void AddRequest(TBlockRange64 range)
     {
         auto [it, inserted] = RangeToCountMap.try_emplace(range, 1);
@@ -346,9 +348,9 @@ struct TRangeRequestsCounter
         }
     }
 
-    ui64 GetRequestCountWithRange(TBlockRange64 range)
+    [[nodiscard]] ui64 GetRequestCountWithRange(TBlockRange64 range) const
     {
-        auto* count = RangeToCountMap.FindPtr(range);
+        const auto* count = RangeToCountMap.FindPtr(range);
         return count ? *count : 0;
     }
 };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.cpp
@@ -18,7 +18,8 @@ IActorPtr CreateNonreplicatedPartitionMigration(
     TNonreplicatedPartitionConfigPtr partConfig,
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
     NRdma::IClientPtr rdmaClient,
-    NActors::TActorId statActorId)
+    NActors::TActorId statActorId,
+    NActors::TActorId migrationSrcActorId)
 {
     return std::make_unique<TNonreplicatedPartitionMigrationActor>(
         std::move(config),
@@ -30,7 +31,8 @@ IActorPtr CreateNonreplicatedPartitionMigration(
         std::move(partConfig),
         std::move(migrations),
         std::move(rdmaClient),
-        statActorId);
+        statActorId,
+        migrationSrcActorId);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.h
@@ -24,6 +24,7 @@ NActors::IActorPtr CreateNonreplicatedPartitionMigration(
     TNonreplicatedPartitionConfigPtr partConfig,
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
     NRdma::IClientPtr rdmaClient,
-    NActors::TActorId statActorId);
+    NActors::TActorId statActorId,
+    NActors::TActorId migrationSrcActorId = NActors::TActorId());
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -130,6 +130,12 @@ void TNonreplicatedPartitionMigrationActor::OnMigrationProgress(
     UpdatingMigrationState = true;
 }
 
+NActors::TActorId
+TNonreplicatedPartitionMigrationActor::GetActorToLockAndDrainRange()
+{
+    return MigrationSrcActorId;
+}
+
 void TNonreplicatedPartitionMigrationActor::FinishMigration(
     const NActors::TActorContext& ctx,
     bool isRetry)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -131,7 +131,7 @@ void TNonreplicatedPartitionMigrationActor::OnMigrationProgress(
 }
 
 NActors::TActorId
-TNonreplicatedPartitionMigrationActor::GetActorToLockAndDrainRange()
+TNonreplicatedPartitionMigrationActor::GetActorToLockAndDrainRange() const
 {
     return MigrationSrcActorId;
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -44,7 +44,7 @@ public:
         ui64 migrationIndex) override;
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
-    NActors::TActorId GetActorToLockAndDrainRange() override;
+    NActors::TActorId GetActorToLockAndDrainRange() const override;
 
 private:
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -44,6 +44,7 @@ public:
         ui64 migrationIndex) override;
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
+    NActors::TActorId GetActorToLockAndDrainRange() override;
 
 private:
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -47,7 +47,6 @@ public:
     NActors::TActorId GetActorToLockAndDrainRange() const override;
 
 private:
-
     bool IsMigrationTarget(const NProto::TDeviceConfig& device) const
     {
         return AnyOf(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.h
@@ -16,6 +16,7 @@ private:
     TNonreplicatedPartitionConfigPtr SrcConfig;
     google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> Migrations;
     NRdma::IClientPtr RdmaClient;
+    NActors::TActorId MigrationSrcActorId;
 
     bool UpdatingMigrationState = false;
     bool MigrationFinished = false;
@@ -31,7 +32,8 @@ public:
         TNonreplicatedPartitionConfigPtr srcConfig,
         google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
         NRdma::IClientPtr rdmaClient,
-        NActors::TActorId statActorId);
+        NActors::TActorId statActorId,
+        NActors::TActorId migrationSrcActorId);
 
     // IMigrationOwner implementation
     void OnBootstrap(const NActors::TActorContext& ctx) override;
@@ -42,6 +44,19 @@ public:
         ui64 migrationIndex) override;
     void OnMigrationFinished(const NActors::TActorContext& ctx) override;
     void OnMigrationError(const NActors::TActorContext& ctx) override;
+
+private:
+
+    bool IsMigrationTarget(const NProto::TDeviceConfig& device) const
+    {
+        return AnyOf(
+            Migrations,
+            [&](const NProto::TDeviceMigration& m)
+            {
+                return m.GetTargetDevice().GetDeviceUUID() ==
+                       device.GetDeviceUUID();
+            });
+    }
 
 private:
     void PrepareForMigration(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -115,6 +115,7 @@ private:
     const NActors::TActorId VolumeActorId;
     TString RWClientId;
 
+    NActors::TActorId MigrationSrcActorId;
     NActors::TActorId SrcActorId;
     NActors::TActorId DstActorId;
     bool ActorOwner = false;
@@ -213,6 +214,7 @@ public:
     // Called from the inheritor to initialize migration.
     void InitWork(
         const NActors::TActorContext& ctx,
+        NActors::TActorId migrationSrcActorId,
         NActors::TActorId srcActorId,
         NActors::TActorId dstActorId,
         bool takeOwnershipOverActors,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -73,7 +73,7 @@ public:
     // response before copying the range during migration. After copying, we
     // should send ReleaseRange to the same actor. If the ActorId is invalid,
     // there is no need to send either of these messages.
-    virtual NActors::TActorId GetActorToLockAndDrainRange()
+    [[nodiscard]] virtual NActors::TActorId GetActorToLockAndDrainRange() const
     {
         return {};
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_checksumblocks.cpp
@@ -12,10 +12,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleChecksumBlocks(
     const TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    ForwardRequestWithNondeliveryTracking(
-        ctx,
-        SrcActorId,
-        *ev);
+    ForwardRequestWithNondeliveryTracking(ctx, SrcActorId, *ev);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -23,11 +23,13 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 void TNonreplicatedPartitionMigrationCommonActor::InitWork(
     const NActors::TActorContext& ctx,
+    NActors::TActorId migrationSrcActorId,
     NActors::TActorId srcActorId,
     NActors::TActorId dstActorId,
     bool takeOwnershipOverActors,
     std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator)
 {
+    MigrationSrcActorId = migrationSrcActorId;
     SrcActorId = srcActorId;
     DstActorId = dstActorId;
     TimeoutCalculator = std::move(timeoutCalculator);
@@ -111,7 +113,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
                 MakeIntrusive<TCallContext>()),
             BlockSize,
             range,
-            SrcActorId,
+            MigrationSrcActorId,
             DstActorId,
             RWClientId,
             BlockDigestGenerator,
@@ -127,7 +129,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
                 MakeIntrusive<TCallContext>()),
             BlockSize,
             range,
-            SrcActorId,
+            MigrationSrcActorId,
             DstActorId,
             RWClientId,
             BlockDigestGenerator,
@@ -141,7 +143,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MigrateRange(
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationAllowed() const
 {
-    return SrcActorId && DstActorId && MigrationEnabled;
+    return MigrationSrcActorId && DstActorId && MigrationEnabled;
 }
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationFinished() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_readblocks.cpp
@@ -12,10 +12,7 @@ void TNonreplicatedPartitionMigrationCommonActor::HandleReadBlocks(
     const TEvService::TEvReadBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    ForwardRequestWithNondeliveryTracking(
-        ctx,
-        SrcActorId,
-        *ev);
+    ForwardRequestWithNondeliveryTracking(ctx, SrcActorId, *ev);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_ut.cpp
@@ -1,3 +1,4 @@
+#include "part_nonrepl_migration.h"
 #include "part_nonrepl_migration_actor.h"
 #include "ut_env.h"
 
@@ -216,7 +217,7 @@ struct TTestEnv
         auto partConfig =
             std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 
-        auto part = std::make_unique<TNonreplicatedPartitionMigrationActor>(
+        auto part = CreateNonreplicatedPartitionMigration(
             std::move(config),
             CreateDiagnosticsConfig(),
             CreateProfileLogStub(),

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -851,6 +851,7 @@ void TShadowDiskActor::CreateShadowDiskPartitionActor(
         InitWork(
             ctx,
             SrcActorId,
+            SrcActorId,
             DstActorId,
             true,   // takeOwnershipOverActors
             std::make_unique<TMigrationTimeoutCalculator>(

--- a/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-fresh-device-migration.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-fresh-device-migration.txt
@@ -40,10 +40,10 @@ Vertices {
                 End: 524287
                 WriteRate: 100
                 ReadRate: 100
-                ZeroRate: 100
+                ZeroRate: 10
                 LoadType: LOAD_TYPE_RANDOM
-                IoDepth: 1024
-                MaxRequestSize: 100
+                IoDepth: 32
+                MaxRequestSize: 1024
             }
         }
         TestDuration: 60

--- a/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-fresh-device-migration.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-fresh-device-migration.txt
@@ -1,0 +1,66 @@
+Vertices {
+    ControlPlaneAction {
+        Name: "create_volume"
+
+        CreateVolumeRequest {
+            DiskId: "vol0"
+            BlocksCount: 524288
+            BlockSize: 4096
+            StorageMediaKind: STORAGE_MEDIA_SSD_MIRROR2
+        }
+    }
+}
+
+Vertices {
+    ControlPlaneAction {
+        Name: "make_devices_fresh"
+
+        ReplaceDevicesRequest {
+            DiskId: "vol0"
+            DevicesToReplace {
+                ReplicaIndex: 0
+                DeviceIndex: 0
+            }
+            DevicesToReplace {
+                ReplicaIndex: 1
+                DeviceIndex: 1
+            }
+        }
+    }
+}
+
+Vertices {
+    Test {
+        Name: "shoot_vol0"
+        VolumeName: "vol0"
+
+        ArtificialLoadSpec {
+            Ranges {
+                Start: 0
+                End: 524287
+                WriteRate: 100
+                ReadRate: 100
+                ZeroRate: 100
+                LoadType: LOAD_TYPE_RANDOM
+                IoDepth: 1024
+                MaxRequestSize: 100
+            }
+        }
+        TestDuration: 60
+        Verify: true
+    }
+}
+
+Dependencies {
+    key: "make_devices_fresh",
+    value {
+        Names: "create_volume"
+    }
+}
+
+Dependencies {
+    key: "shoot_vol0",
+    value {
+        Names: "make_devices_fresh"
+    }
+}

--- a/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-column.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-column.txt
@@ -40,7 +40,7 @@ Vertices {
                 End: 262644
                 WriteRate: 100
                 ReadRate: 100
-                ZeroRate: 100
+                ZeroRate: 10
                 LoadType: LOAD_TYPE_RANDOM
                 IoDepth: 20
                 MaxRequestSize: 100

--- a/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-cross.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-split-read-cross.txt
@@ -40,7 +40,7 @@ Vertices {
                 End: 262644
                 WriteRate: 100
                 ReadRate: 100
-                ZeroRate: 100
+                ZeroRate: 10
                 LoadType: LOAD_TYPE_RANDOM
                 IoDepth: 20
                 MaxRequestSize: 100

--- a/cloud/blockstore/tests/loadtest/local-mirror/test.py
+++ b/cloud/blockstore/tests/loadtest/local-mirror/test.py
@@ -101,6 +101,12 @@ TESTS = [
         dump_block_digests=True,
         max_migration_bandwidth=1
     ),
+    TestCase(
+        "mirror2-fresh-device-migration",
+        "cloud/blockstore/tests/loadtest/local-mirror/local-mirror2-fresh-device-migration.txt",
+        agent_count=6,
+        dump_block_digests=True,
+    ),
 ]
 
 


### PR DESCRIPTION
#3 продолжение #3292 для починки бага из #3273
В этом пре я собираюсь вернуть обратно изменения, которые привели к появлению бага (чтение при миграции из MigrationSrcActorId, который в случае фреш миграций будет являться миррор партишеном) и прикрутить отправку LockAndDrainRange сообщений к миграциям (добавить нормальную перегрузку функции IMigrationOwner::GetActorToLockAndDrainRange, которая возвращает миррор партишен, а не пустой актор айди)