### PR TITLE
[Blockstore] Shutdown volume after locklost on volume deletion during mounting

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1205,5 +1205,7 @@ message TStorageServiceConfig
     // events for any mismatch it finds.
     optional bool ResyncAfterLaggingAgentMigration = 422;
 
+    // Hive sends notifications when locks are lost. If the flag is set, then
+    // the volume will not be stopped.
     optional bool DoNotStopVolumeTabletOnLockLost = 423;
 }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -99,6 +99,8 @@ private:
     void LockTablet(const TActorContext& ctx);
     void UnlockTablet(const TActorContext& ctx);
 
+    void DescribeVolume(const TActorContext& ctx);
+
     void ScheduleReboot(const TActorContext& ctx, bool delay = true);
 
     void BootExternal(const TActorContext& ctx);
@@ -156,6 +158,10 @@ private:
 
     void HandleTabletDead(
         const TEvTablet::TEvTabletDead::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleDescribeVolumeResponse(
+        const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
         const TActorContext& ctx);
 
     void HandleWaitReadyResponse(
@@ -290,6 +296,61 @@ void TStartVolumeActor::HandleTabletLockLost(
 
         auto error = MakeError(E_REJECTED, "Tablet lock has been lost");
         StartShutdown(ctx, error);
+        return;
+    }
+
+    // Check if volume is not destroyed.
+    DescribeVolume(ctx);
+}
+
+void TStartVolumeActor::DescribeVolume(const TActorContext& ctx)
+{
+    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+        "Sending describe request for volume: %s",
+        DiskId.Quote().data());
+
+    NCloud::Send(
+        ctx,
+        MakeSSProxyServiceId(),
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId));
+}
+
+void TStartVolumeActor::HandleDescribeVolumeResponse(
+    const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    if (msg->GetStatus() ==
+        MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
+    {
+        LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+            "[%lu] Volume %s is destroyed",
+            VolumeTabletId,
+            DiskId.Quote().data());
+
+        StartShutdown(ctx);
+        return;
+    } else if (msg->GetStatus() == NKikimrScheme::StatusSuccess) {
+        auto volumeTabletId = msg->
+            PathDescription.
+            GetBlockStoreVolumeDescription().
+            GetVolumeTabletId();
+
+        if (volumeTabletId != VolumeTabletId) {
+            LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+                "Volume %s tablet was changed",
+                DiskId.Quote().data());
+
+
+            StartShutdown(ctx);
+            return;
+        }
+    }
+
+    if (Stopping) {
+        ContinueShutdown(ctx);
+        return;
     }
 }
 
@@ -886,6 +947,8 @@ STFUNC(TStartVolumeActor::StateWork)
         HFunc(TEvHiveProxy::TEvBootExternalResponse, HandleBootExternalResponse);
         HFunc(TEvHiveProxy::TEvTabletLockLost, HandleTabletLockLost);
         HFunc(TEvHiveProxy::TEvUnlockTabletResponse, HandleUnlockTabletResponse);
+
+        HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeVolumeResponse);
 
         HFunc(TEvTablet::TEvRestored, HandleTabletRestored);
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -140,6 +140,10 @@ private:
         const TEvHiveProxy::TEvLockTabletResponse::TPtr& ev,
         const TActorContext& ctx);
 
+    void HandleDescribeVolumeResponse(
+        const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
     void HandleUnlockTabletResponse(
         const TEvHiveProxy::TEvUnlockTabletResponse::TPtr& ev,
         const TActorContext& ctx);
@@ -158,10 +162,6 @@ private:
 
     void HandleTabletDead(
         const TEvTablet::TEvTabletDead::TPtr& ev,
-        const TActorContext& ctx);
-
-    void HandleDescribeVolumeResponse(
-        const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
         const TActorContext& ctx);
 
     void HandleWaitReadyResponse(
@@ -324,7 +324,7 @@ void TStartVolumeActor::HandleDescribeVolumeResponse(
     if (msg->GetStatus() ==
         MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
     {
-        LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+        LOG_WARN(ctx, TBlockStoreComponents::SERVICE,
             "[%lu] Volume %s is destroyed",
             VolumeTabletId,
             DiskId.Quote().data());
@@ -338,10 +338,9 @@ void TStartVolumeActor::HandleDescribeVolumeResponse(
             GetVolumeTabletId();
 
         if (volumeTabletId != VolumeTabletId) {
-            LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+            LOG_WARN(ctx, TBlockStoreComponents::SERVICE,
                 "Volume %s tablet was changed",
                 DiskId.Quote().data());
-
 
             StartShutdown(ctx);
             return;

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -338,7 +338,7 @@ void TStartVolumeActor::HandleDescribeVolumeResponse(
             GetVolumeTabletId();
 
         if (volumeTabletId != VolumeTabletId) {
-            LOG_WARN(ctx, TBlockStoreComponents::SERVICE,
+            LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
                 "Volume %s tablet was changed",
                 DiskId.Quote().data());
 


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/3252

падал тест ДМа на миграцию 

потому что волум удалялся после WaitReady и волум уходил в бесконечное ожидание партишнов, которые уже не могли подняться, тк диск был удален

при этом hive триггерил lockLost и раньше мы ребутали таблетку и поэтому все было ок 

делаю фикс этого сценария
