### PR TITLE
Refactoring: move TYdbRowData from service_stats to ydbstats, deduplicate some code in ydbstats, rename TYdbRow into TYdbStatsRow

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -520,10 +520,11 @@ void TBootstrapYdb::InitKikimrService()
             statsConfig,
             logging,
             YdbStorage,
-            NYdbStats::CreateStatsTableScheme(statsConfig->GetStatsTableTtl()),
-            NYdbStats::CreateHistoryTableScheme(),
-            NYdbStats::CreateArchiveStatsTableScheme(statsConfig->GetArchiveStatsTableTtl()),
-            NYdbStats::CreateBlobLoadMetricsTableScheme());
+            NYdbStats::TYDBTableSchemes(
+                NYdbStats::CreateStatsTableScheme(statsConfig->GetStatsTableTtl()),
+                NYdbStats::CreateHistoryTableScheme(),
+                NYdbStats::CreateArchiveStatsTableScheme(statsConfig->GetArchiveStatsTableTtl()),
+                NYdbStats::CreateBlobLoadMetricsTableScheme()));
     } else {
         StatsUploader = NYdbStats::CreateVolumesStatsUploaderStub();
     }

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -35,13 +35,6 @@ class TStatsServiceActor final
 {
     struct TActorSystemHolder;
 
-    // TODO:_ ok?
-    // struct TYdbRowData
-    // {
-    //     TVector<NYdbStats::TYdbRow>               Stats;
-    //     TVector<NYdbStats::TYdbBlobLoadMetricRow> Metrics;
-    // };
-
     using TStatsUploadRequest = std::pair<NYdbStats::TYdbRowData, TInstant>;
 
     struct TBackgroundBandwidthInfo

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -16,6 +16,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/core/tablet_counters.h>
 #include <cloud/blockstore/libs/ydbstats/ydbstats.h>
+#include <cloud/blockstore/libs/ydbstats/ydbrow.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -34,13 +35,14 @@ class TStatsServiceActor final
 {
     struct TActorSystemHolder;
 
-    struct TYdbRowData
-    {
-        TVector<NYdbStats::TYdbRow>               Stats;
-        TVector<NYdbStats::TYdbBlobLoadMetricRow> Metrics;
-    };
+    // TODO:_ ok?
+    // struct TYdbRowData
+    // {
+    //     TVector<NYdbStats::TYdbRow>               Stats;
+    //     TVector<NYdbStats::TYdbBlobLoadMetricRow> Metrics;
+    // };
 
-    using TStatsUploadRequest = std::pair<TYdbRowData, TInstant>;
+    using TStatsUploadRequest = std::pair<NYdbStats::TYdbRowData, TInstant>;
 
     struct TBackgroundBandwidthInfo
     {

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -347,9 +347,7 @@ void TStatsServiceActor::PushYdbStats(const NActors::TActorContext& ctx)
 
         YdbStatsRequestSentTs = ctx.Now();
 
-        StatsUploader->UploadStats(
-            YdbStatsRequests.front().first.Stats,
-            YdbStatsRequests.front().first.Metrics).Subscribe(
+        StatsUploader->UploadStats(YdbStatsRequests.front().first).Subscribe(
             [=] (const auto& future) {
                 if (auto p = weak.lock()) {
                     NProto::TError result;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -57,13 +57,13 @@ NYdbStats::TPercentileCounterField CreatePercentileCounterField(const TVector<do
     return out;
 }
 
-NYdbStats::TYdbRow BuildStatsForUpload(
+NYdbStats::TYdbStatsRow BuildStatsForUpload(
     const TActorContext& ctx,
     const TVolumeStatsInfo& volume,
     TDuration updateInterval,
     TDuration uploadInterval)
 {
-    TYdbRow out;
+    TYdbStatsRow out;
 
     out.DiskId = volume.VolumeInfo.GetDiskId();
     out.Timestamp = ctx.Now().Seconds();

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -59,10 +59,9 @@ public:
     virtual ~TYdbStatsMock() = default;
 
     NThreading::TFuture<NProto::TError> UploadStats(
-        const TVector<TYdbRow>& stats,
-        const TVector<TYdbBlobLoadMetricRow>&) override
+        const TYdbRowData& rows) override
     {
-        return Callback(stats);
+        return Callback(rows.Stats);
     }
 
     void Start() override

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -43,7 +43,7 @@ static const TString DefaultFolderId = "test_folder";
 ////////////////////////////////////////////////////////////////////////////////
 
 using TYdbStatsCallback =
-    std::function<NThreading::TFuture<NProto::TError>(const TVector<TYdbRow>& stats)>;
+    std::function<NThreading::TFuture<NProto::TError>(const TVector<TYdbStatsRow>& stats)>;
 
 class TYdbStatsMock:
     public IYdbVolumesStatsUploader
@@ -898,7 +898,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
 
     Y_UNIT_TEST(ShouldReportYdbStatsInBatches)
     {
-        auto callback = [] (const TVector<TYdbRow>& stats)
+        auto callback = [] (const TVector<TYdbStatsRow>& stats)
         {
             Y_UNUSED(stats);
             return NThreading::MakeFuture(MakeError(S_OK));
@@ -922,7 +922,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
     Y_UNIT_TEST(ShouldRetryStatsUploadInCaseOfFailure)
     {
         ui32 attemptCount = 0;
-        auto callback = [&] (const TVector<TYdbRow>& stats)
+        auto callback = [&] (const TVector<TYdbStatsRow>& stats)
         {
             UNIT_ASSERT_VALUES_EQUAL(1, stats.size());
 
@@ -954,7 +954,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
         bool failUpload = true;
         ui32 callCnt = 0;
 
-        auto callback = [&] (const TVector<TYdbRow>& stats)
+        auto callback = [&] (const TVector<TYdbStatsRow>& stats)
         {
             UNIT_ASSERT_VALUES_EQUAL(1, stats.size());
 
@@ -998,7 +998,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
     Y_UNIT_TEST(ShouldCorrectlyPrepareYdbStatsRequests)
     {
         TVector<TVector<TString>> batches;
-        auto callback = [&] (const TVector<TYdbRow>& stats)
+        auto callback = [&] (const TVector<TYdbStatsRow>& stats)
         {
             TVector<TString> batch;
             for (const auto& x: stats) {
@@ -1050,7 +1050,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
     {
         TVector<TVector<TString>> batches;
         bool uploadSeen = false;
-        auto callback = [&] (const TVector<TYdbRow>& stats)
+        auto callback = [&] (const TVector<TYdbStatsRow>& stats)
         {
             Y_UNUSED(stats);
             uploadSeen = true;

--- a/cloud/blockstore/libs/ydbstats/ydbrow.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.cpp
@@ -8,7 +8,7 @@ using namespace NYdb;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TValue TYdbRow::GetYdbValues() const
+TValue TYdbStatsRow::GetYdbValues() const
 {
     NYdb::TValueBuilder value;
     value.BeginStruct();
@@ -44,7 +44,7 @@ TValue TYdbRow::GetYdbValues() const
     return value.Build();
 }
 
-TStringBuf TYdbRow::GetYdbRowDefinition()
+TStringBuf TYdbStatsRow::GetYdbRowDefinition()
 {
     static TStringBuf RowDefinition =
 #define YDB_SIMPLE_STRING_FIELD(name , ...)                                    \

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -162,7 +162,7 @@ struct TPercentileCounterField
     double P100 = 0;
 };
 
-struct TYdbRow
+struct TYdbStatsRow
 {
 #define YDB_SIMPLE_STRING_FIELD(name, ...)                                     \
     TString name;                                                              \
@@ -215,13 +215,13 @@ struct TYdbBlobLoadMetricRow
 
 struct TYdbRowData
 {
-    TVector<TYdbRow> Stats;
+    TVector<TYdbStatsRow> Stats;
     TVector<TYdbBlobLoadMetricRow> Metrics;
 
     TYdbRowData() = default;
 
     TYdbRowData(
-            TVector<TYdbRow> stats,
+            TVector<TYdbStatsRow> stats,
             TVector<TYdbBlobLoadMetricRow> metrics)
         : Stats(std::move(stats))
         , Metrics(std::move(metrics))

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -4,6 +4,7 @@
 
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 
 namespace NCloud::NBlockStore::NYdbStats {
 
@@ -212,8 +213,21 @@ struct TYdbBlobLoadMetricRow
     static TStringBuf GetYdbRowDefinition();
 };
 
+struct TYdbRowData
+{
+    TVector<TYdbRow> Stats;
+    TVector<TYdbBlobLoadMetricRow> Metrics;
+
+    TYdbRowData() = default;
+
+    TYdbRowData(
+            TVector<TYdbRow> stats,
+            TVector<TYdbBlobLoadMetricRow> metrics)
+        : Stats(std::move(stats))
+        , Metrics(std::move(metrics))
+    {}
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 }   // namespace NCloud::NBlockStore::NYdbStats
-
-

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.h
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.h
@@ -112,4 +112,23 @@ TStatsTableSchemePtr CreateHistoryTableScheme();
 TStatsTableSchemePtr CreateArchiveStatsTableScheme(TDuration ttl);
 TStatsTableSchemePtr CreateBlobLoadMetricsTableScheme();
 
+struct TYDBTableSchemes
+{
+    TStatsTableSchemePtr Stats;
+    TStatsTableSchemePtr History;
+    TStatsTableSchemePtr Archive;
+    TStatsTableSchemePtr Metrics;
+
+    TYDBTableSchemes(
+            TStatsTableSchemePtr stats,
+            TStatsTableSchemePtr history,
+            TStatsTableSchemePtr archive,
+            TStatsTableSchemePtr metrics)
+        : Stats(std::move(stats))
+        , History(std::move(history))
+        , Archive(std::move(archive))
+        , Metrics(std::move(metrics))
+    {}
+};
+
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/ydbstats.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.h
@@ -23,8 +23,7 @@ struct IYdbVolumesStatsUploader
     virtual ~IYdbVolumesStatsUploader() = default;
 
     virtual NThreading::TFuture<NProto::TError> UploadStats(
-        const TVector<TYdbRow>& stats,
-        const TVector<TYdbBlobLoadMetricRow>& metrics) = 0;
+        const TYdbRowData& rows) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/ydbstats/ydbstats.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 #include "ydbrow.h"
+#include "ydbscheme.h"
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/storage/core/libs/common/error.h>
@@ -32,11 +33,20 @@ IYdbVolumesStatsUploaderPtr CreateYdbVolumesStatsUploader(
     TYdbStatsConfigPtr config,
     ILoggingServicePtr logging,
     IYdbStoragePtr dbStorage,
-    TStatsTableSchemePtr statsTableScheme,
-    TStatsTableSchemePtr historyTableScheme,
-    TStatsTableSchemePtr archiveStatsTableScheme,
-    TStatsTableSchemePtr metricsTableScheme);
+    TYDBTableSchemes tableSchemes);
 
 IYdbVolumesStatsUploaderPtr CreateVolumesStatsUploaderStub();
 
 }   // namespace NCloud::NBlockStore::NYdbStats
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TYDBTableNames
+{
+    TString Stats;
+    TString History;
+    TString Archive;
+    TString Metrics;
+
+    TYDBTableNames() = default;
+};

--- a/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
@@ -231,9 +231,9 @@ TYDBTableSchemes CreateBadTestSchemes()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NYdbStats::TYdbRow BuildTestStats()
+NYdbStats::TYdbStatsRow BuildTestStats()
 {
-    TYdbRow out;
+    TYdbStatsRow out;
     out.DiskId = "vol0";
     out.Timestamp = TInstant::Now().Seconds();
     out.BlocksCount = 100;

--- a/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
@@ -230,6 +230,11 @@ NYdbStats::TYdbBlobLoadMetricRow BuildTestMetrics()
     return out;
 }
 
+NYdbStats::TYdbRowData BuildTestYdbRowData()
+{
+    return {{BuildTestStats()}, {BuildTestMetrics()}};
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TYdbTestStorage final
@@ -449,9 +454,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             metricsScheme);
         uploader->Start();
 
-        auto response = uploader->UploadStats(
-             { BuildTestStats() },
-             { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.GetCode());
         UNIT_ASSERT_VALUES_EQUAL(3, ydbTestStorage->CreateTableCalls);
@@ -485,9 +488,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             directory,
             true);
 
-        auto response = uploader->UploadStats(
-            { BuildTestStats() },
-            { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
         UNIT_ASSERT(
             response.GetCode() == S_OK &&
             ydbTestStorage->CreateTableCalls == 0);
@@ -520,9 +521,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             directory,
             true);
 
-        auto response = uploader->UploadStats(
-            { BuildTestStats() },
-            { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
         UNIT_ASSERT(
             response.GetCode() == S_OK &&
             ydbTestStorage->CreateTableCalls == 1);
@@ -557,9 +556,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             directory,
             true);
 
-        auto response = uploader->UploadStats(
-            { BuildTestStats() },
-            { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
         UNIT_ASSERT(
             response.GetCode() == S_OK &&
             ydbTestStorage->AlterTableCalls == 2);
@@ -594,9 +591,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             directory,
             true);
 
-        auto response = uploader->UploadStats(
-            { BuildTestStats() },
-            { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
         UNIT_ASSERT(
             response.GetCode() == E_ARGUMENT &&
             ydbTestStorage->AlterTableCalls == 0);
@@ -629,9 +624,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             directory,
             true);
 
-        auto response = uploader->UploadStats(
-            { BuildTestStats() },
-            { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
         UNIT_ASSERT(
             response.GetCode() == S_OK &&
             ydbTestStorage->DropTableCalls == 1);
@@ -667,9 +660,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             return MakeFuture(MakeError(S_OK));
         };
 
-        auto response = uploader->UploadStats(
-             { BuildTestStats() },
-             { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.GetCode());
         UNIT_ASSERT_VALUES_EQUAL(4, ydbTestStorage->UpsertCalls);
@@ -713,9 +704,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             return MakeFuture(MakeError(E_FAIL));
         };
 
-        auto response = uploader->UploadStats(
-             { BuildTestStats() },
-             { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, response.GetCode());
         UNIT_ASSERT_VALUES_EQUAL(4, ydbTestStorage->UpsertCalls);
@@ -743,9 +732,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             metricsScheme);
         uploader->Start();
 
-        auto response = uploader->UploadStats(
-             { BuildTestStats() },
-             { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.GetCode());
         UNIT_ASSERT_VALUES_EQUAL(4, ydbTestStorage->CreateTableCalls);
@@ -816,9 +803,7 @@ Y_UNIT_TEST_SUITE(TYdbStatsUploadTest)
             true);
         ydbTestStorage->AddTable("arctest", archiveScheme);
 
-        auto response = uploader->UploadStats(
-            { BuildTestStats() },
-            { BuildTestMetrics() }).GetValueSync();
+        auto response = uploader->UploadStats(BuildTestYdbRowData()).GetValueSync();
         UNIT_ASSERT(
             response.GetCode() == S_OK &&
             ydbTestStorage->AlterTableCalls == 1);


### PR DESCRIPTION
Refactored code in ydbstats. Motivation: we are going to add more tables to ydbstats (in order to resolve partition tablet id or blob storage group id into volume id). If we add these tables without refactoing, there will be too much boilerplate and duplicate code.
