### PR TITLE
Don't raise ErrorWasSentToTheGuestFor(Non)ReliableDisk when client try to write with read-only mount

### DIFF
--- a/cloud/blockstore/libs/service/aligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/aligned_device_handler.cpp
@@ -482,6 +482,15 @@ void TAlignedDeviceHandler::ReportCriticalError(
         return;
     }
 
+    if (error.GetCode() == E_IO_SILENT &&
+        error.GetMessage().Contains(
+            "Request WriteBlocks is not allowed for client"))
+    {
+        // Don't raise crit event when client try to write with read-only mount.
+        // See cloud/blockstore/libs/storage/volume/model/client_state.cpp
+        return;
+    }
+
     if (IsReliableMediaKind) {
         CriticalErrorReported.store(true);
     } else {

--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -202,6 +202,7 @@ NProto::TError TVolumeClientState::GetWriteError(
         // for legacy clients
         code = E_IO_SILENT;
     }
+    // Keep sync with TAlignedDeviceHandler::ReportCriticalError()
     return MakeError(
         code,
         TStringBuilder()


### PR DESCRIPTION
 Столкнулись с ошибками, когда клиент пытается писать имея монтирование только для чтения. 