### PR TITLE
[CSI] enable discard in vm mode for ydb-based disks

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -505,7 +504,6 @@ func (s *nodeService) nodePublishDiskAsVhostSocket(
 		deviceName = diskId
 	}
 
-	vhostDiscardEnabled := slices.Contains(volumeCapabilities.MountFlags, "discard")
 	hostType := nbsapi.EHostType_HOST_TYPE_DEFAULT
 	_, err := s.nbsClient.StartEndpoint(ctx, &nbsapi.TStartEndpointRequest{
 		UnixSocketPath:   filepath.Join(endpointDir, nbsSocketName),
@@ -524,7 +522,7 @@ func (s *nodeService) nodePublishDiskAsVhostSocket(
 		ClientProfile: &nbsapi.TClientProfile{
 			HostType: &hostType,
 		},
-		VhostDiscardEnabled: vhostDiscardEnabled,
+		VhostDiscardEnabled: s.IsDiscardEnabled(ctx, diskId),
 	})
 
 	if err != nil {
@@ -603,7 +601,6 @@ func (s *nodeService) nodeStageDiskAsVhostSocket(
 		deviceName = diskId
 	}
 
-	vhostDiscardEnabled := slices.Contains(volumeCapabilities.MountFlags, "discard")
 	hostType := nbsapi.EHostType_HOST_TYPE_DEFAULT
 	_, err := s.nbsClient.StartEndpoint(ctx, &nbsapi.TStartEndpointRequest{
 		UnixSocketPath:   filepath.Join(endpointDir, nbsSocketName),
@@ -622,7 +619,7 @@ func (s *nodeService) nodeStageDiskAsVhostSocket(
 		ClientProfile: &nbsapi.TClientProfile{
 			HostType: &hostType,
 		},
-		VhostDiscardEnabled: vhostDiscardEnabled,
+		VhostDiscardEnabled: s.IsDiscardEnabled(ctx, diskId),
 	})
 
 	if err != nil {
@@ -1668,3 +1665,21 @@ func (s *nodeService) NodeExpandVolume(
 }
 
 func ignoreError(_ error) {}
+
+func (s *nodeService) IsDiscardEnabled(ctx context.Context, diskId string) bool {
+	if !s.useDiscardForYDBBasedDisks {
+		return false
+	}
+
+	resp, err := s.nbsClient.DescribeVolume(
+		ctx, &nbsapi.TDescribeVolumeRequest{
+			DiskId: diskId,
+		},
+	)
+
+	if err != nil {
+		return false
+	}
+
+	return !isDiskRegistryMediaKind(resp.Volume.StorageMediaKind)
+}


### PR DESCRIPTION
issue: #3371

1. Enable discard for ydb-based disks
2. Use DescribeVolume to determine disk type as we can't rely on disk type information from the storage class