### PR TITLE
issue-3: reject requests if agent has become unavailable

### DIFF
--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -14,6 +14,8 @@
 
 namespace NCloud::NBlockStore::NStorage {
 
+using namespace NThreading;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -56,7 +58,13 @@ struct TRdmaClientTest::TRdmaEndpointImpl
     TMessageObserver MessageObserver;
     TForceReconnectObserver ForceReconnectObserver;
 
-    TRdmaEndpointImpl() = default;
+    ui64 NextRequestId = 0;
+    THashMap<ui64, NRdma::TClientRequestPtr> Requests;
+
+    TFuture<void> FutureToWaitBeforeRequestProcessing;
+
+    TRdmaEndpointImpl() : FutureToWaitBeforeRequestProcessing(MakeFuture())
+    {}
 
     TResultOrError<NRdma::TClientRequestPtr> AllocateRequest(
         NRdma::IClientHandlerPtr handler,
@@ -83,6 +91,30 @@ struct TRdmaClientTest::TRdmaEndpointImpl
     {
         Y_UNUSED(callContext);
 
+        auto reqId = ++NextRequestId;
+
+        Requests[reqId] = std::move(req);
+
+        FutureToWaitBeforeRequestProcessing.Subscribe(
+            [self = this, reqId](const auto&)
+            {
+                auto it = self->Requests.find(reqId);
+
+                if (it == self->Requests.end()) {
+                    return;
+                }
+
+                auto req = std::move(it->second);
+                self->Requests.erase(it);
+
+                self->ContinueRequestSending(std::move(req));
+            });
+
+        return reqId;
+    }
+
+    void ContinueRequestSending(NRdma::TClientRequestPtr req)
+    {
         auto* serializer = TBlockStoreProtocol::Serializer();
         auto [result, err] = serializer->Parse(req->RequestBuffer);
         Y_ENSURE_EX(!HasError(err), yexception() << err.GetMessage());
@@ -103,7 +135,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
                 NRdma::RDMA_PROTO_FAIL,
                 len);
 
-            return 0;
+            return;
         }
 
         size_t responseBytes = 0;
@@ -248,17 +280,30 @@ struct TRdmaClientTest::TRdmaEndpointImpl
             std::move(req),
             NRdma::RDMA_PROTO_OK,
             responseBytes);
-        return 0;
     }
 
     void CancelRequest(ui64 reqId) override
     {
-        Y_UNUSED(reqId);
+        auto it = Requests.find(reqId);
+        if (it == Requests.end()) {
+            return;
+        }
+
+        auto req = std::move(it->second);
+        Requests.erase(it);
+
+        auto len = NRdma::SerializeError(
+            E_CANCELLED,
+            "cancelled",
+            req->ResponseBuffer);
+
+        auto* handler = req->Handler.get();
+        handler->HandleResponse(std::move(req), NRdma::RDMA_PROTO_FAIL, len);
     }
 
-    NThreading::TFuture<void> Stop() override
+    TFuture<void> Stop() override
     {
-        return NThreading::MakeFuture();
+        return MakeFuture();
     }
 
     void TryForceReconnect() override
@@ -282,14 +327,14 @@ struct TRdmaClientTest::TRdmaEndpointImpl
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NThreading::TFuture<NRdma::IClientEndpointPtr> TRdmaClientTest::StartEndpoint(
+TFuture<NRdma::IClientEndpointPtr> TRdmaClientTest::StartEndpoint(
     TString host,
     ui32 port)
 {
     auto& ep = Endpoints[MakeKey(host, port)];
     if (!ep.Endpoint) {
         ep.Endpoint = std::make_shared<TRdmaEndpointImpl>();
-        ep.Promise = NThreading::NewPromise<NRdma::IClientEndpointPtr>();
+        ep.Promise = NewPromise<NRdma::IClientEndpointPtr>();
     }
     return ep.Promise;
 }
@@ -338,6 +383,15 @@ void TRdmaClientTest::SetForceReconnectObserver(
 {
     for (auto& [_, endpointInfo]: Endpoints) {
         endpointInfo.Endpoint->ForceReconnectObserver = forceReconnectObserver;
+    }
+}
+
+void TRdmaClientTest::InjectFutureToWaitBeforeRequestProcessing(
+    const TFuture<void>& future)
+{
+    for (auto& x: Endpoints) {
+        auto& ep = static_cast<TRdmaEndpointImpl&>(*x.second.Endpoint);
+        ep.FutureToWaitBeforeRequestProcessing = future;
     }
 }
 

--- a/cloud/blockstore/libs/rdma_test/client_test.h
+++ b/cloud/blockstore/libs/rdma_test/client_test.h
@@ -61,6 +61,8 @@ struct TRdmaClientTest: NRdma::IClient
     void SetMessageObserver(const TMessageObserver& messageObserver);
     void SetForceReconnectObserver(
         const TForceReconnectObserver& forceReconnectObserver);
+    void InjectFutureToWaitBeforeRequestProcessing(
+        const NThreading::TFuture<void>& future);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -28,12 +28,12 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TDeviceRequestContext: public NRdma::TNullContext
+struct TDeviceRequestRdmaContext: public NRdma::TNullContext
 {
     ui32 DeviceIdx = 0;
 };
 
-struct TDeviceReadRequestContext: public TDeviceRequestContext
+struct TDeviceReadRequestContext: public TDeviceRequestRdmaContext
 {
     ui64 StartIndexOffset = 0;
     ui64 BlockCount = 0;
@@ -42,11 +42,21 @@ struct TDeviceReadRequestContext: public TDeviceRequestContext
 
 bool NeedToNotifyAboutDeviceRequestError(const NProto::TError& err);
 
+void ConvertRdmaErrorIfNeeded(ui32 rdmaStatus, NProto::TError& err);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TNonreplicatedPartitionRdmaActor final
     : public NActors::TActorBootstrapped<TNonreplicatedPartitionRdmaActor>
 {
+    struct TDeviceRequestContext
+    {
+        ui64 DeviceIndex = 0;
+        ui64 SentRequestId = 0;
+    };
+
+    using TRequestContext = TStackVec<TDeviceRequestContext, 2>;
+
 private:
     const TStorageConfigPtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
@@ -56,7 +66,8 @@ private:
 
     // TODO implement DeviceStats and similar stuff
 
-    TRequestsInProgress<EAllowedRequests::ReadWrite, ui64> RequestsInProgress;
+    TRequestsInProgress<EAllowedRequests::ReadWrite, ui64, TRequestContext>
+        RequestsInProgress;
     TDrainActorCompanion DrainActorCompanion{
         RequestsInProgress,
         PartConfig->GetName()};
@@ -126,7 +137,7 @@ private:
         const TBlockRange64& blockRange,
         TVector<TDeviceRequest>* deviceRequests);
 
-    NProto::TError SendReadRequests(
+    TResultOrError<TRequestContext> SendReadRequests(
         const NActors::TActorContext& ctx,
         TCallContextPtr callContext,
         const NProto::THeaders& headers,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -23,7 +23,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TDeviceChecksumRequestContext: public TDeviceRequestContext
+struct TDeviceChecksumRequestContext: public TDeviceRequestRdmaContext
 {
     ui64 RangeStartIndex = 0;
     ui32 RangeSize = 0;
@@ -124,6 +124,7 @@ public:
             HandleResult(*reqCtx, buffer);
         } else {
             Error = NRdma::ParseError(buffer);
+            ConvertRdmaErrorIfNeeded(status, Error);
             if (NeedToNotifyAboutDeviceRequestError(Error)) {
                 ErrorDeviceIndices.emplace_back(reqCtx->DeviceIdx);
             }
@@ -233,6 +234,7 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
     };
 
     TVector<TDeviceRequestInfo> requests;
+    TRequestContext sentRequestCtx;
 
     for (auto& r: deviceRequests) {
         auto ep = AgentId2Endpoint[r.Device.GetAgentId()];
@@ -241,6 +243,8 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
         dc->RangeStartIndex = r.BlockRange.Start;
         dc->RangeSize = r.DeviceBlockRange.Size() * PartConfig->GetBlockSize();
         dc->DeviceIdx = r.DeviceIdx;
+
+        sentRequestCtx.emplace_back(r.DeviceIdx);
 
         NProto::TChecksumDeviceBlocksRequest deviceRequest;
         deviceRequest.MutableHeaders()->CopyFrom(msg->Record.GetHeaders());
@@ -280,13 +284,14 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
         requests.push_back({std::move(ep), std::move(req)});
     }
 
-    for (auto& request: requests) {
-        request.Endpoint->SendRequest(
+    for (size_t i = 0; i < requests.size(); ++i) {
+        auto& request = requests[i];
+        sentRequestCtx[i].SentRequestId = request.Endpoint->SendRequest(
             std::move(request.ClientRequest),
             requestInfo->CallContext);
     }
 
-    RequestsInProgress.AddReadRequest(requestId);
+    RequestsInProgress.AddReadRequest(requestId, sentRequestCtx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
@@ -142,6 +142,7 @@ public:
             HandleResult(*reqCtx, buffer);
         } else {
             Error = NRdma::ParseError(buffer);
+            ConvertRdmaErrorIfNeeded(status, Error);
             if (NeedToNotifyAboutDeviceRequestError(Error)) {
                 ErrorDeviceIndices.emplace_back(reqCtx->DeviceIdx);
             }
@@ -248,7 +249,7 @@ void TNonreplicatedPartitionRdmaActor::HandleReadBlocks(
         requestId,
         Config->GetOptimizeVoidBuffersTransferForReadsEnabled());
 
-    auto error = SendReadRequests(
+    auto [sentRequestCtx, error] = SendReadRequests(
         ctx,
         requestInfo->CallContext,
         msg->Record.GetHeaders(),
@@ -265,7 +266,7 @@ void TNonreplicatedPartitionRdmaActor::HandleReadBlocks(
         return;
     }
 
-    RequestsInProgress.AddReadRequest(requestId);
+    RequestsInProgress.AddReadRequest(requestId, sentRequestCtx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
@@ -145,6 +145,7 @@ public:
             HandleResult(*reqCtx, buffer);
         } else {
             Error = NRdma::ParseError(buffer);
+            ConvertRdmaErrorIfNeeded(status, Error);
             if (NeedToNotifyAboutDeviceRequestError(Error)) {
                 ErrorDeviceIndices.emplace_back(reqCtx->DeviceIdx);
             }
@@ -248,7 +249,7 @@ void TNonreplicatedPartitionRdmaActor::HandleReadBlocksLocal(
         requestId,
         Config->GetOptimizeVoidBuffersTransferForReadsEnabled());
 
-    auto error = SendReadRequests(
+    auto [sentRequestCtx, error] = SendReadRequests(
         ctx,
         requestInfo->CallContext,
         msg->Record.GetHeaders(),
@@ -265,7 +266,7 @@ void TNonreplicatedPartitionRdmaActor::HandleReadBlocksLocal(
         return;
     }
 
-    RequestsInProgress.AddReadRequest(requestId);
+    RequestsInProgress.AddReadRequest(requestId, sentRequestCtx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -89,7 +89,7 @@ public:
         auto guard = Guard(Lock);
 
         auto buffer = req->ResponseBuffer.Head(responseBytes);
-        auto* reqCtx = static_cast<TDeviceRequestContext*>(req->Context.get());
+        auto* reqCtx = static_cast<TDeviceRequestRdmaContext*>(req->Context.get());
 
         DeviceIndices.emplace_back(reqCtx->DeviceIdx);
 
@@ -97,6 +97,7 @@ public:
             HandleResult(buffer);
         } else {
             Error = NRdma::ParseError(buffer);
+            ConvertRdmaErrorIfNeeded(status, Error);
             if (NeedToNotifyAboutDeviceRequestError(Error)) {
                 ErrorDeviceIndices.emplace_back(reqCtx->DeviceIdx);
             }
@@ -198,10 +199,13 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
     };
 
     TVector<TDeviceRequestInfo> requests;
+    TRequestContext sentRequestCtx;
 
     for (auto& r: deviceRequests) {
         auto ep = AgentId2Endpoint[r.Device.GetAgentId()];
         Y_ABORT_UNLESS(ep);
+
+        sentRequestCtx.emplace_back(r.DeviceIdx);
 
         NProto::TZeroDeviceBlocksRequest deviceRequest;
         deviceRequest.MutableHeaders()->CopyFrom(msg->Record.GetHeaders());
@@ -215,7 +219,7 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
             deviceRequest.SetMultideviceRequest(deviceRequests.size() > 1);
         }
 
-        auto context = std::make_unique<TDeviceRequestContext>();
+        auto context = std::make_unique<TDeviceRequestRdmaContext>();
         context->DeviceIdx = r.DeviceIdx;
 
         auto [req, err] = ep->AllocateRequest(
@@ -249,13 +253,14 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
         requests.push_back({std::move(ep), std::move(req)});
     }
 
-    for (auto& request: requests) {
-        request.Endpoint->SendRequest(
+    for (size_t i = 0; i < requests.size(); ++i) {
+        auto& request = requests[i];
+        sentRequestCtx[i].SentRequestId = request.Endpoint->SendRequest(
             std::move(request.ClientRequest),
             requestInfo->CallContext);
     }
 
-    RequestsInProgress.AddWriteRequest(requestId);
+    RequestsInProgress.AddWriteRequest(requestId, sentRequestCtx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -481,6 +481,17 @@ public:
         SendRequest(ActorId, std::move(req), ++RequestId);
     }
 
+    void SendAgentIsUnavailable(TString agentId)
+    {
+        NProto::TLaggingAgent laggingAgent;
+        laggingAgent.SetAgentId(std::move(agentId));
+        auto msg =
+            std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+                std::move(laggingAgent));
+
+        SendRequest(ActorId, std::move(msg), ++RequestId);
+    }
+
 #define BLOCKSTORE_DECLARE_METHOD(name, ns)                                    \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \


### PR DESCRIPTION
#3 продолжение #3187 Добавил отмену запросов при получении сообщения, что агент стал недоступен. При отправке запросов запоминаем индексы девайсов и рдма реквест айди отправленных сообщений.  При обработке сообщения TEvNonreplPartitionPrivate::TEvAgentIsUnavailable прохожусь по всем In flight запросам и если он попадает в лагающего агента отменяю его. При отмене конвертирую ошибку E_CANCELLED в  E_REJECTED, т.к. необходимо чтобы запрос поретраился и попал в другую реплику, а не завершился с ошибкой.