### PR TITLE
Minor fix of migration test: throw correct exception if disk is not found

### DIFF
--- a/cloud/blockstore/tools/ci/migration_test/lib/main.py
+++ b/cloud/blockstore/tools/ci/migration_test/lib/main.py
@@ -96,6 +96,10 @@ class TestRunner:
                     self.instance = ycp.get_instance(disk.instance_ids[0])
                     break
 
+            if self.disk_id is None:
+                description = f'id={args.disk_id}' if args.disk_id else f'name={args.disk_name}'
+                raise Error(f"Can't find disk with {description}")
+
             if args.use_auth:
                 if args.service_account_id:
                     token = ycp.create_iam_token_for_service_account(args.service_account_id)
@@ -105,10 +109,6 @@ class TestRunner:
 
             host = args.nbs_host if args.nbs_host else self.instance.compute_node
             self.endpoint = '{}:{}'.format(host, self.port)
-
-            if self.disk_id is None:
-                description = f'id={args.disk_id}' if args.disk_id else f'name={args.disk_name}'
-                raise Error(f"Can't find disk with {description}")
 
         try:
             self.client = make_client(


### PR DESCRIPTION
If disk is not found, the test doesn't reach the corresponding check. Instead, if fails earlier with a misleading error:
```
File "cloud/blockstore/tools/ci/migration_test/lib/main.py", line 106, in __init__
[09:03:20 ](https://teamcity.aw.cloud.yandex.net/buildConfiguration/NBS_NbsTests_Nbs_MigrationTests_HwNbsStableLab_MigrationTestRdma/20423531?buildTab=log&focusLine=227&logView=flowAware&linesState=227)      host = args.nbs_host if args.nbs_host else self.instance.compute_node
[09:03:20 ](https://teamcity.aw.cloud.yandex.net/buildConfiguration/NBS_NbsTests_Nbs_MigrationTests_HwNbsStableLab_MigrationTestRdma/20423531?buildTab=log&focusLine=228&logView=flowAware&linesState=228)                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
[09:03:20 ](https://teamcity.aw.cloud.yandex.net/buildConfiguration/NBS_NbsTests_Nbs_MigrationTests_HwNbsStableLab_MigrationTestRdma/20423531?buildTab=log&focusLine=229&logView=flowAware&linesState=229)  AttributeError: 'NoneType' object has no attribute 'compute_node'
```

We fix this problem.