### PR TITLE
Remove DiskRegistryCleanupAgentConfigError crit event

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -65,7 +65,6 @@ namespace NCloud::NBlockStore {
     xxx(DiskRegistryResumeDeviceFailed)                                        \
     xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
     xxx(DiskRegistryPurgeHostError)                                            \
-    xxx(DiskRegistryCleanupAgentConfigError)                                   \
     xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
     xxx(DiskRegistryWrongMigratedDeviceOwnership)                              \
     xxx(DiskRegistryInitialAgentRejectionThresholdExceeded)                    \

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5649,16 +5649,11 @@ void TDiskRegistryState::CleanupAgentConfig(
     const NProto::TAgentConfig& agent)
 {
     auto error = TryToRemoveAgentDevices(db, agent.GetAgentId());
+    // Do not return the error from "TryToRemoveAgentDevices()" since
+    // it's internal and shouldn't block node removal.
     if (!HasError(error) || error.GetCode() == E_NOT_FOUND) {
         return;
     }
-
-    // Do not return the error from "TryToRemoveAgentDevices()" since
-    // it's internal and shouldn't block node removal.
-    ReportDiskRegistryCleanupAgentConfigError(
-        TStringBuilder() << "Could not remove device from agent "
-                         << agent.GetAgentId().Quote() << ": "
-                         << FormatError(error));
 
     SuspendLocalDevices(db, agent);
 }


### PR DESCRIPTION
Изначально этот крит эвент добавлялся с целью удостовериться, что PurgeHost вызывается инфрой в тот момент, когда мы уже можем удалить все девайсы (т.е. все диски смигрировали).
Стало понятно, что он имеет право срабатывать, например, в ситуации когда агент ушёл в unavailable, а инфра дергает PurgeHost или RemoveHost.

