### PR TITLE
[Blockstore] diagnostics: introduce new ydb tables in ydbstats database for information about partition tablets and bs groups

### DIFF
--- a/cloud/blockstore/config/ydbstats.proto
+++ b/cloud/blockstore/config/ydbstats.proto
@@ -43,4 +43,10 @@ message TYdbStatsConfig
 
     // Archive stats table ttl.
     optional uint32 ArchiveStatsTableTtl = 12;
+
+    // Table to report correspondence between blob storage groups and partition tablets.
+    optional string GroupsTableName = 13;
+
+    // Table to report correspondence between partition tablets and volume tablets.
+    optional string PartitionsTableName = 14;
 }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -524,7 +524,9 @@ void TBootstrapYdb::InitKikimrService()
                 NYdbStats::CreateStatsTableScheme(statsConfig->GetStatsTableTtl()),
                 NYdbStats::CreateHistoryTableScheme(),
                 NYdbStats::CreateArchiveStatsTableScheme(statsConfig->GetArchiveStatsTableTtl()),
-                NYdbStats::CreateBlobLoadMetricsTableScheme()));
+                NYdbStats::CreateBlobLoadMetricsTableScheme(),
+                NYdbStats::CreateGroupsTableScheme(),
+                NYdbStats::CreatePartitionsTableScheme()));
     } else {
         StatsUploader = NYdbStats::CreateVolumesStatsUploaderStub();
     }

--- a/cloud/blockstore/libs/ydbstats/config.cpp
+++ b/cloud/blockstore/libs/ydbstats/config.cpp
@@ -25,6 +25,8 @@ TDuration Seconds(ui32 value)
     xxx(StatsTableRotationAfterDays,      ui32,             1                 )\
     xxx(ArchiveStatsTableName,            TString,          ""                )\
     xxx(BlobLoadMetricsTableName,         TString,          ""                )\
+    xxx(GroupsTableName,                  TString,          ""                )\
+    xxx(PartitionsTableName,              TString,          ""                )\
     xxx(UseSsl,                           bool,             false             )\
     xxx(StatsTableTtl,                    TDuration,        Seconds(0)        )\
     xxx(ArchiveStatsTableTtl,             TDuration,        Seconds(0)        )\

--- a/cloud/blockstore/libs/ydbstats/config.h
+++ b/cloud/blockstore/libs/ydbstats/config.h
@@ -26,6 +26,8 @@ public:
     TString GetArchiveStatsTableName() const;
     TString GetBlobLoadMetricsTableName() const;
     TString GetHistoryTablePrefix() const;
+    TString GetGroupsTableName() const;
+    TString GetPartitionsTableName() const;
     TString GetDatabaseName() const;
     TString GetTokenFile() const;
     TString GetServerAddress() const;

--- a/cloud/blockstore/libs/ydbstats/ydbrow.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.cpp
@@ -102,5 +102,33 @@ TStringBuf TYdbBlobLoadMetricRow::GetYdbRowDefinition()
     return TStringBuf(RowDefinition.data());
 }
 
+TValue TYdbGroupsRow::GetYdbValues() const
+{
+    NYdb::TValueBuilder value;
+    value.BeginStruct();
+
+    value.AddMember(PartitionTabletIdName.data()).Uint64(PartitionTabletId);
+    value.AddMember(ChannelName.data()).Uint32(Channel);
+    value.AddMember(GroupIdName.data()).Uint32(GroupId);
+    value.AddMember(GenerationName.data()).Uint32(Generation);
+    value.AddMember(TimestampName.data()).Uint64(Timestamp.Seconds());
+
+    value.EndStruct();
+    return value.Build();
+}
+
+TValue TYdbPartitionsRow::GetYdbValues() const
+{
+    NYdb::TValueBuilder value;
+    value.BeginStruct();
+
+    value.AddMember(DiskIdName.data()).String(DiskId);
+    value.AddMember(VolumeTabletIdName.data()).Uint64(VolumeTabletId);
+    value.AddMember(PartitionTabletIdName.data()).Uint64(PartitionTabletId);
+    value.AddMember(TimestampName.data()).Uint64(Timestamp.Seconds());
+
+    value.EndStruct();
+    return value.Build();
+}
 
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/ydbrow.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.cpp
@@ -107,7 +107,7 @@ TValue TYdbGroupsRow::GetYdbValues() const
     NYdb::TValueBuilder value;
     value.BeginStruct();
 
-    value.AddMember(PartitionTabletIdName.data()).Uint64(PartitionTabletId);
+    value.AddMember(TabletIdName.data()).Uint64(TabletId);
     value.AddMember(ChannelName.data()).Uint32(Channel);
     value.AddMember(GroupIdName.data()).Uint32(GroupId);
     value.AddMember(GenerationName.data()).Uint32(Generation);
@@ -122,9 +122,9 @@ TValue TYdbPartitionsRow::GetYdbValues() const
     NYdb::TValueBuilder value;
     value.BeginStruct();
 
-    value.AddMember(DiskIdName.data()).String(DiskId);
-    value.AddMember(VolumeTabletIdName.data()).Uint64(VolumeTabletId);
     value.AddMember(PartitionTabletIdName.data()).Uint64(PartitionTabletId);
+    value.AddMember(VolumeTabletIdName.data()).Uint64(VolumeTabletId);
+    value.AddMember(DiskIdName.data()).String(DiskId);
     value.AddMember(TimestampName.data()).Uint64(Timestamp.Seconds());
 
     value.EndStruct();

--- a/cloud/blockstore/libs/ydbstats/ydbrow.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.cpp
@@ -102,7 +102,7 @@ TStringBuf TYdbBlobLoadMetricRow::GetYdbRowDefinition()
     return TStringBuf(RowDefinition.data());
 }
 
-TValue TYdbGroupsRow::GetYdbValues() const
+TValue TYdbGroupRow::GetYdbValues() const
 {
     NYdb::TValueBuilder value;
     value.BeginStruct();
@@ -117,7 +117,7 @@ TValue TYdbGroupsRow::GetYdbValues() const
     return value.Build();
 }
 
-TValue TYdbPartitionsRow::GetYdbValues() const
+TValue TYdbPartitionRow::GetYdbValues() const
 {
     NYdb::TValueBuilder value;
     value.BeginStruct();

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -215,14 +215,14 @@ struct TYdbBlobLoadMetricRow
 
 struct TYdbGroupsRow
 {
-    static constexpr TStringBuf PartitionTabletIdName = "PartitionTabletId";
+    static constexpr TStringBuf TabletIdName = "TabletId";
     static constexpr TStringBuf ChannelName = "Channel";
     static constexpr TStringBuf GroupIdName = "GroupId";
     static constexpr TStringBuf GenerationName = "Generation";
     static constexpr TStringBuf TimestampName = "Timestamp";
     static constexpr TDuration TtlDuration = TDuration::Days(7);
 
-    ui64 PartitionTabletId;
+    ui64 TabletId;
     ui32 Channel;
     ui32 GroupId;
     ui32 Generation;
@@ -233,15 +233,15 @@ struct TYdbGroupsRow
 
 struct TYdbPartitionsRow
 {
-    static constexpr TStringBuf DiskIdName = "DiskId";
-    static constexpr TStringBuf VolumeTabletIdName = "VolumeTabletId";
     static constexpr TStringBuf PartitionTabletIdName = "PartitionTabletId";
+    static constexpr TStringBuf VolumeTabletIdName = "VolumeTabletId";
+    static constexpr TStringBuf DiskIdName = "DiskId";
     static constexpr TStringBuf TimestampName = "Timestamp";
     static constexpr TDuration TtlDuration = TDuration::Days(7);
 
-    TString DiskId;
-    ui64 VolumeTabletId;
     ui64 PartitionTabletId;
+    ui64 VolumeTabletId;
+    TString DiskId;
     TInstant Timestamp;
 
     NYdb::TValue GetYdbValues() const;

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -213,7 +213,7 @@ struct TYdbBlobLoadMetricRow
     static TStringBuf GetYdbRowDefinition();
 };
 
-struct TYdbGroupsRow
+struct TYdbGroupRow
 {
     static constexpr TStringBuf TabletIdName = "TabletId";
     static constexpr TStringBuf ChannelName = "Channel";
@@ -231,7 +231,7 @@ struct TYdbGroupsRow
     NYdb::TValue GetYdbValues() const;
 };
 
-struct TYdbPartitionsRow
+struct TYdbPartitionRow
 {
     static constexpr TStringBuf PartitionTabletIdName = "PartitionTabletId";
     static constexpr TStringBuf VolumeTabletIdName = "VolumeTabletId";
@@ -251,16 +251,16 @@ struct TYdbRowData
 {
     TVector<TYdbStatsRow> Stats;
     TVector<TYdbBlobLoadMetricRow> Metrics;
-    TVector<TYdbGroupsRow> Groups;
-    TVector<TYdbPartitionsRow> Partitions;
+    TVector<TYdbGroupRow> Groups;
+    TVector<TYdbPartitionRow> Partitions;
 
     TYdbRowData() = default;
 
     TYdbRowData(
             TVector<TYdbStatsRow> stats,
             TVector<TYdbBlobLoadMetricRow> metrics,
-            TVector<TYdbGroupsRow> groups,
-            TVector<TYdbPartitionsRow> partitions)
+            TVector<TYdbGroupRow> groups,
+            TVector<TYdbPartitionRow> partitions)
         : Stats(std::move(stats))
         , Metrics(std::move(metrics))
         , Groups(std::move(groups))

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -213,18 +213,58 @@ struct TYdbBlobLoadMetricRow
     static TStringBuf GetYdbRowDefinition();
 };
 
+struct TYdbGroupsRow
+{
+    static constexpr TStringBuf PartitionTabletIdName = "PartitionTabletId";
+    static constexpr TStringBuf ChannelName = "Channel";
+    static constexpr TStringBuf GroupIdName = "GroupId";
+    static constexpr TStringBuf GenerationName = "Generation";
+    static constexpr TStringBuf TimestampName = "Timestamp";
+    static constexpr TDuration TtlDuration = TDuration::Days(7);
+
+    ui64 PartitionTabletId;
+    ui32 Channel;
+    ui32 GroupId;
+    ui32 Generation;
+    TInstant Timestamp;
+
+    NYdb::TValue GetYdbValues() const;
+};
+
+struct TYdbPartitionsRow
+{
+    static constexpr TStringBuf DiskIdName = "DiskId";
+    static constexpr TStringBuf VolumeTabletIdName = "VolumeTabletId";
+    static constexpr TStringBuf PartitionTabletIdName = "PartitionTabletId";
+    static constexpr TStringBuf TimestampName = "Timestamp";
+    static constexpr TDuration TtlDuration = TDuration::Days(7);
+
+    TString DiskId;
+    ui64 VolumeTabletId;
+    ui64 PartitionTabletId;
+    TInstant Timestamp;
+
+    NYdb::TValue GetYdbValues() const;
+};
+
 struct TYdbRowData
 {
     TVector<TYdbStatsRow> Stats;
     TVector<TYdbBlobLoadMetricRow> Metrics;
+    TVector<TYdbGroupsRow> Groups;
+    TVector<TYdbPartitionsRow> Partitions;
 
     TYdbRowData() = default;
 
     TYdbRowData(
             TVector<TYdbStatsRow> stats,
-            TVector<TYdbBlobLoadMetricRow> metrics)
+            TVector<TYdbBlobLoadMetricRow> metrics,
+            TVector<TYdbGroupsRow> groups,
+            TVector<TYdbPartitionsRow> partitions)
         : Stats(std::move(stats))
         , Metrics(std::move(metrics))
+        , Groups(std::move(groups))
+        , Partitions(std::move(partitions))
     {}
 };
 

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
@@ -140,4 +140,73 @@ TStatsTableSchemePtr CreateBlobLoadMetricsTableScheme()
     return out.Finish();
 }
 
+TStatsTableSchemePtr CreateGroupsTableScheme()
+{
+    using namespace NYdb;
+
+    TStatsTableSchemeBuilder out;
+
+    static const TVector<std::pair<TString, EPrimitiveType>> columns = {
+        {TYdbGroupsRow::PartitionTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbGroupsRow::ChannelName.data(), EPrimitiveType::Uint32},
+        {TYdbGroupsRow::GroupIdName.data(), EPrimitiveType::Uint32},
+        {TYdbGroupsRow::GenerationName.data(), EPrimitiveType::Uint32},
+        {TYdbGroupsRow::TimestampName.data(), EPrimitiveType::Uint64}};
+
+    STORAGE_VERIFY_C(
+        out.AddColumns(columns),
+        TWellKnownEntityTypes::YDB_TABLE,
+        "groups table",
+        "unable to setup fields");
+
+    STORAGE_VERIFY_C(
+        out.SetKeyColumns({
+            TYdbGroupsRow::PartitionTabletIdName.data(),
+            TYdbGroupsRow::ChannelName.data(),
+            TYdbGroupsRow::GroupIdName.data(),
+            TYdbGroupsRow::GenerationName.data()}),
+        TWellKnownEntityTypes::YDB_TABLE,
+        "groups table",
+        "unable to setup key fields");
+
+    out.SetTtl(NTable::TTtlSettings{
+        TYdbGroupsRow::TimestampName.data(),
+        NTable::TTtlSettings::EUnit::Seconds,
+        TYdbGroupsRow::TtlDuration});
+
+    return out.Finish();
+}
+
+TStatsTableSchemePtr CreatePartitionsTableScheme()
+{
+    using namespace NYdb;
+
+    TStatsTableSchemeBuilder out;
+
+    static const TVector<std::pair<TString, EPrimitiveType>> columns = {
+        {TYdbPartitionsRow::DiskIdName.data(), EPrimitiveType::String},
+        {TYdbPartitionsRow::VolumeTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbPartitionsRow::PartitionTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbPartitionsRow::TimestampName.data(), EPrimitiveType::Uint64}};
+
+    STORAGE_VERIFY_C(
+        out.AddColumns(columns),
+        TWellKnownEntityTypes::YDB_TABLE,
+        "partitions table",
+        "unable to setup fields");
+
+    STORAGE_VERIFY_C(
+        out.SetKeyColumns({TYdbPartitionsRow::PartitionTabletIdName.data()}),
+        TWellKnownEntityTypes::YDB_TABLE,
+        "partitions table",
+        "unable to setup key fields");
+
+    out.SetTtl(NTable::TTtlSettings{
+        TYdbPartitionsRow::TimestampName.data(),
+        NTable::TTtlSettings::EUnit::Seconds,
+        TYdbPartitionsRow::TtlDuration});
+
+    return out.Finish();
+}
+
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
@@ -147,11 +147,11 @@ TStatsTableSchemePtr CreateGroupsTableScheme()
     TStatsTableSchemeBuilder out;
 
     static const TVector<std::pair<TString, EPrimitiveType>> columns = {
-        {TYdbGroupsRow::TabletIdName.data(), EPrimitiveType::Uint64},
-        {TYdbGroupsRow::ChannelName.data(), EPrimitiveType::Uint32},
-        {TYdbGroupsRow::GroupIdName.data(), EPrimitiveType::Uint32},
-        {TYdbGroupsRow::GenerationName.data(), EPrimitiveType::Uint32},
-        {TYdbGroupsRow::TimestampName.data(), EPrimitiveType::Uint64}};
+        {TYdbGroupRow::TabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbGroupRow::ChannelName.data(), EPrimitiveType::Uint32},
+        {TYdbGroupRow::GroupIdName.data(), EPrimitiveType::Uint32},
+        {TYdbGroupRow::GenerationName.data(), EPrimitiveType::Uint32},
+        {TYdbGroupRow::TimestampName.data(), EPrimitiveType::Uint64}};
 
     STORAGE_VERIFY_C(
         out.AddColumns(columns),
@@ -161,18 +161,18 @@ TStatsTableSchemePtr CreateGroupsTableScheme()
 
     STORAGE_VERIFY_C(
         out.SetKeyColumns({
-            TYdbGroupsRow::TabletIdName.data(),
-            TYdbGroupsRow::ChannelName.data(),
-            TYdbGroupsRow::GroupIdName.data(),
-            TYdbGroupsRow::GenerationName.data()}),
+            TYdbGroupRow::TabletIdName.data(),
+            TYdbGroupRow::ChannelName.data(),
+            TYdbGroupRow::GroupIdName.data(),
+            TYdbGroupRow::GenerationName.data()}),
         TWellKnownEntityTypes::YDB_TABLE,
         "groups table",
         "unable to setup key fields");
 
     out.SetTtl(NTable::TTtlSettings{
-        TYdbGroupsRow::TimestampName.data(),
+        TYdbGroupRow::TimestampName.data(),
         NTable::TTtlSettings::EUnit::Seconds,
-        TYdbGroupsRow::TtlDuration});
+        TYdbGroupRow::TtlDuration});
 
     return out.Finish();
 }
@@ -184,10 +184,10 @@ TStatsTableSchemePtr CreatePartitionsTableScheme()
     TStatsTableSchemeBuilder out;
 
     static const TVector<std::pair<TString, EPrimitiveType>> columns = {
-        {TYdbPartitionsRow::PartitionTabletIdName.data(), EPrimitiveType::Uint64},
-        {TYdbPartitionsRow::VolumeTabletIdName.data(), EPrimitiveType::Uint64},
-        {TYdbPartitionsRow::DiskIdName.data(), EPrimitiveType::String},
-        {TYdbPartitionsRow::TimestampName.data(), EPrimitiveType::Uint64}};
+        {TYdbPartitionRow::PartitionTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbPartitionRow::VolumeTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbPartitionRow::DiskIdName.data(), EPrimitiveType::String},
+        {TYdbPartitionRow::TimestampName.data(), EPrimitiveType::Uint64}};
 
     STORAGE_VERIFY_C(
         out.AddColumns(columns),
@@ -196,15 +196,15 @@ TStatsTableSchemePtr CreatePartitionsTableScheme()
         "unable to setup fields");
 
     STORAGE_VERIFY_C(
-        out.SetKeyColumns({TYdbPartitionsRow::PartitionTabletIdName.data()}),
+        out.SetKeyColumns({TYdbPartitionRow::PartitionTabletIdName.data()}),
         TWellKnownEntityTypes::YDB_TABLE,
         "partitions table",
         "unable to setup key fields");
 
     out.SetTtl(NTable::TTtlSettings{
-        TYdbPartitionsRow::TimestampName.data(),
+        TYdbPartitionRow::TimestampName.data(),
         NTable::TTtlSettings::EUnit::Seconds,
-        TYdbPartitionsRow::TtlDuration});
+        TYdbPartitionRow::TtlDuration});
 
     return out.Finish();
 }

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.cpp
@@ -147,7 +147,7 @@ TStatsTableSchemePtr CreateGroupsTableScheme()
     TStatsTableSchemeBuilder out;
 
     static const TVector<std::pair<TString, EPrimitiveType>> columns = {
-        {TYdbGroupsRow::PartitionTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbGroupsRow::TabletIdName.data(), EPrimitiveType::Uint64},
         {TYdbGroupsRow::ChannelName.data(), EPrimitiveType::Uint32},
         {TYdbGroupsRow::GroupIdName.data(), EPrimitiveType::Uint32},
         {TYdbGroupsRow::GenerationName.data(), EPrimitiveType::Uint32},
@@ -161,7 +161,7 @@ TStatsTableSchemePtr CreateGroupsTableScheme()
 
     STORAGE_VERIFY_C(
         out.SetKeyColumns({
-            TYdbGroupsRow::PartitionTabletIdName.data(),
+            TYdbGroupsRow::TabletIdName.data(),
             TYdbGroupsRow::ChannelName.data(),
             TYdbGroupsRow::GroupIdName.data(),
             TYdbGroupsRow::GenerationName.data()}),
@@ -184,9 +184,9 @@ TStatsTableSchemePtr CreatePartitionsTableScheme()
     TStatsTableSchemeBuilder out;
 
     static const TVector<std::pair<TString, EPrimitiveType>> columns = {
-        {TYdbPartitionsRow::DiskIdName.data(), EPrimitiveType::String},
-        {TYdbPartitionsRow::VolumeTabletIdName.data(), EPrimitiveType::Uint64},
         {TYdbPartitionsRow::PartitionTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbPartitionsRow::VolumeTabletIdName.data(), EPrimitiveType::Uint64},
+        {TYdbPartitionsRow::DiskIdName.data(), EPrimitiveType::String},
         {TYdbPartitionsRow::TimestampName.data(), EPrimitiveType::Uint64}};
 
     STORAGE_VERIFY_C(

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.h
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.h
@@ -111,6 +111,8 @@ TStatsTableSchemePtr CreateStatsTableScheme(TDuration ttl);
 TStatsTableSchemePtr CreateHistoryTableScheme();
 TStatsTableSchemePtr CreateArchiveStatsTableScheme(TDuration ttl);
 TStatsTableSchemePtr CreateBlobLoadMetricsTableScheme();
+TStatsTableSchemePtr CreateGroupsTableScheme();
+TStatsTableSchemePtr CreatePartitionsTableScheme();
 
 struct TYDBTableSchemes
 {
@@ -118,16 +120,22 @@ struct TYDBTableSchemes
     TStatsTableSchemePtr History;
     TStatsTableSchemePtr Archive;
     TStatsTableSchemePtr Metrics;
+    TStatsTableSchemePtr Groups;
+    TStatsTableSchemePtr Partitions;
 
     TYDBTableSchemes(
             TStatsTableSchemePtr stats,
             TStatsTableSchemePtr history,
             TStatsTableSchemePtr archive,
-            TStatsTableSchemePtr metrics)
+            TStatsTableSchemePtr metrics,
+            TStatsTableSchemePtr groups,
+            TStatsTableSchemePtr partitions)
         : Stats(std::move(stats))
         , History(std::move(history))
         , Archive(std::move(archive))
         , Metrics(std::move(metrics))
+        , Groups(std::move(groups))
+        , Partitions(std::move(partitions))
     {}
 };
 

--- a/cloud/blockstore/libs/ydbstats/ydbstats.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.h
@@ -47,6 +47,8 @@ struct TYDBTableNames
     TString History;
     TString Archive;
     TString Metrics;
+    TString Groups;
+    TString Partitions;
 
     TYDBTableNames() = default;
 };

--- a/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
@@ -289,18 +289,18 @@ NYdbStats::TYdbBlobLoadMetricRow BuildTestMetrics()
     return out;
 }
 
-NYdbStats::TYdbGroupsRow BuildTestGroups()
+NYdbStats::TYdbGroupRow BuildTestGroups()
 {
-    TYdbGroupsRow out;
+    TYdbGroupRow out;
     out.TabletId = 713;
     out.GroupId = 42;
     out.Timestamp = TInstant::Now();
     return out;
 }
 
-NYdbStats::TYdbPartitionsRow BuildTestPartitions()
+NYdbStats::TYdbPartitionRow BuildTestPartitions()
 {
-    TYdbPartitionsRow out;
+    TYdbPartitionRow out;
     out.PartitionTabletId = 713;
     out.VolumeTabletId = 712;
     out.DiskId = "vol0";

--- a/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp
@@ -208,11 +208,11 @@ TStatsTableSchemePtr CreateGroupsTestScheme()
 {
     TStatsTableSchemeBuilder out;
     static TVector<std::pair<TString, NYdb::EPrimitiveType>> columns = {
-        {"PartitionTabletId", NYdb::EPrimitiveType::Uint64},
+        {"TabletId", NYdb::EPrimitiveType::Uint64},
         {"GroudId", NYdb::EPrimitiveType::Uint32},
         {"Timestamp", NYdb::EPrimitiveType::Uint64},
     };
-    out.SetKeyColumns({"PartitionTabletId", "GroudId"});
+    out.SetKeyColumns({"TabletId", "GroudId"});
     out.AddColumns(columns);
     return out.Finish();
 }
@@ -221,9 +221,9 @@ TStatsTableSchemePtr CreatePartitionsTestScheme()
 {
     TStatsTableSchemeBuilder out;
     static TVector<std::pair<TString, NYdb::EPrimitiveType>> columns = {
-        {"DiskId", NYdb::EPrimitiveType::String},
-        {"VolumeTabletId", NYdb::EPrimitiveType::Uint64},
         {"PartitionTabletId", NYdb::EPrimitiveType::Uint64},
+        {"VolumeTabletId", NYdb::EPrimitiveType::Uint64},
+        {"DiskId", NYdb::EPrimitiveType::String},
         {"Timestamp", NYdb::EPrimitiveType::Uint64},
     };
     out.SetKeyColumns({"PartitionTabletId"});
@@ -292,7 +292,7 @@ NYdbStats::TYdbBlobLoadMetricRow BuildTestMetrics()
 NYdbStats::TYdbGroupsRow BuildTestGroups()
 {
     TYdbGroupsRow out;
-    out.PartitionTabletId = 713;
+    out.TabletId = 713;
     out.GroupId = 42;
     out.Timestamp = TInstant::Now();
     return out;


### PR DESCRIPTION
В базу данных ydbstats добавляются две таблицы: Partitions и Groups. Записи данных в эти таблицы пока нет, сделаем в отдельном pr.

Таблица Partitions содержит колонки
```
DiskId, VolumeTabletId, PartitionTabletId, Timestamp
```
Первичный ключ -- PartitionTabletId.

Таким образом, с помощью таблицы partitions можно резолвить partition tablet id в disk id и volume tablet id.

Таблица Groups содержит колонки
```
PartitionTabletId, Channel, Generation, GroupId, Timestamp.
```
Здесь Channel -- номер канала, Generation -- поколение канала (растёт при reassing-ах канала).
Первочный ключ состоит сразу из четырёх колонок: PartitionTabletId, Channel, Generation, GroupId.

Таким образом, с помощью таблицы partitions можно резолвить group id в partition tablet id. Наоборот, можно по partition tablet id узнавать group id. Информация есть как для текущих групп, так и для групп в истории каналов.

Планируется, для каждого диска, у которого подняты partition таблетки, все данные по нему будут отгружаться в эти таблицы раз в 5 минут. Одинаковые записи для одного и того же диска не будут дублироваться -- будет лишь обновляться Timestamp у старых записей.

Если диск удалён или преестал поднимать партишены, то Timestamp у записей по этому диску перестанут обновляться. Записи, у которых Timestamp устарел более, чем на неделю, автоматически подчищаются.

Таким образом:
- Если из этих таблиц нужно получить данные только для тех дисков, которые сузествуют сейчас, то можно сделать запрос записей со свежим Timestamp
- Но при этом есть возможность найти и старые данные (т.е. по уже удалённым дискам или дискам, у которых не подняты партишены) -- если по диску отгружалить данные хотя бы раз за поледнюю неделю. 