### PR TITLE
Don't write obsolete used blocks map for DiskRegistry-based encrypted disks

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -273,17 +273,7 @@ bool TVolumeState::ShouldTrackUsedBlocks() const
     }
 
     const bool overlay = !GetBaseDiskId().empty();
-    if (overlay) {
-        return true;
-    }
-
-    // TODO(drbasic)
-    // For encrypted disk-registry based disks, we will continue to
-    // write a map of encrypted blocks for a while.
-    const auto mode = Meta.GetVolumeConfig().GetEncryptionDesc().GetMode();
-
-    return mode != NProto::NO_ENCRYPTION &&
-           mode != NProto::ENCRYPTION_AT_REST;
+    return overlay;
 }
 
 void TVolumeState::Reset()

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -1935,7 +1935,7 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
                 NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
                 NProto::ENCRYPTION_AES_XTS);
 
-            UNIT_ASSERT(state.GetTrackUsedBlocks());
+            UNIT_ASSERT(!state.GetTrackUsedBlocks());
         }
 
         {


### PR DESCRIPTION
Пришло время избавится от записи карты блоков для зашифрованных дисков. Эта карта не используется при чтении. 
после https://github.com/ydb-platform/nbs/pull/1771