### PR TITLE
Delete copy and move constructors of TDiskRegistryState

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -420,6 +420,8 @@ TDiskRegistryState::TDiskRegistryState(
     }
 }
 
+TDiskRegistryState::~TDiskRegistryState() = default;
+
 void TDiskRegistryState::AllowNotifications(
     const TDiskId& diskId,
     const TDiskState& disk)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -359,6 +359,11 @@ public:
         TDeque<TAutomaticallyReplacedDeviceInfo> automaticallyReplacedDevices,
         THashMap<TString, NProto::TDiskRegistryAgentParams> diskRegistryAgentListParams);
 
+    ~TDiskRegistryState();
+
+    TDiskRegistryState(const TDiskRegistryState&) = delete;
+    TDiskRegistryState& operator=(const TDiskRegistryState&) = delete;
+
     struct TAgentRegistrationResult
     {
         TVector<TDiskId> AffectedDisks;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -44,7 +44,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-2", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { complete });
@@ -77,7 +78,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-2", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { config1 });
@@ -110,7 +112,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-2", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { config1 });
@@ -147,7 +150,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-3", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { config1 });
@@ -223,7 +227,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { config1 });
@@ -300,13 +305,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-2.3", "rack-2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2a })
             .WithDisks({
                 Disk("disk-1", {"uuid-1.1", "uuid-2.1"}),
                 Disk("disk-2", {"uuid-1.2", "uuid-2.2"})
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TString> affectedDisks;
@@ -352,12 +358,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         device.SetPhysicalOffset(222);
         const auto agent1d = AgentConfig(1, {device});
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1a })
             .WithDisks({
                 Disk("disk-1", {"uuid-1"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             auto [r, error] = state.RegisterAgent(db, agent1b, Now());
@@ -427,9 +434,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-1.3", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithConfig(1, { agent1a })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TString> affectedDisks;
@@ -490,9 +498,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.UpdateAgent(agent2);
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TString> affectedDisks;
@@ -532,9 +541,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         const auto config1 = AgentConfig(42, {device});
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TDeviceConfig> devices;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -556,9 +566,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -589,9 +600,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         const auto config1 = AgentConfig(42, {device});
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TDeviceConfig> devices;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -638,9 +650,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-9", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1, config2, config3 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TDeviceConfig> expected;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -692,9 +705,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-3", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -813,9 +827,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TDeviceConfig> devices;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -838,9 +853,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -896,9 +912,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-4", "rack-2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1, config2 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -964,7 +981,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-2", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { stage1 });
@@ -1143,10 +1161,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
     {
         const auto config1 = AgentConfig(1, { Device("dev-1", "uuid-1", "rack-1")});
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ config1 })
             .WithDisks({ Disk("disk-1", {"uuid-1"}) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         {
             TDiskInfo diskInfo;
@@ -1191,13 +1210,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
     Y_UNIT_TEST(ShouldGetDiskIds)
     {
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithDisks({
                 Disk("disk-1", {}),
                 Disk("disk-2", {}),
                 Disk("disk-3", {})
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto ids = state.GetDiskIds();
 
@@ -1227,13 +1247,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-7", "rack-1")
         });
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents({agent1, agent2})
                 .WithDisks({Disk("disk-1", {"uuid-1"})})
                 .WithDirtyDevices(
                     {TDirtyDevice{"uuid-4", {}}, TDirtyDevice{"uuid-7", {}}})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -1292,10 +1313,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-3", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1 })
             .WithDisks({ Disk("disk-1", {"uuid-1", "uuid-2"}) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.MarkDiskForCleanup(db, "disk-1"));
@@ -1344,9 +1366,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         const auto agent1 = AgentConfig(1, { Device("dev-1", "uuid-1", "rack-1") });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT(state.MarkDeviceAsDirty(db, "uuid-1"));
@@ -1398,12 +1421,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(CreateStorageConfig(proto))
             .With(diskRegistryGroup)
             .WithKnownAgents(agents)
             .AddDevicePoolConfig("local-ssd", 10_GB, NProto::DEVICE_POOL_KIND_LOCAL)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TDiskRegistrySelfCounters::TDevicePoolCounters defaultPool;
         TDiskRegistrySelfCounters::TDevicePoolCounters localPool;
@@ -1864,10 +1888,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(diskRegistryGroup)
             .WithConfig({ config1, config2 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         config2 = AgentConfig(1001, {
             Device("dev-1", "uuid-2.1"),
@@ -1984,7 +2009,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto config2 = config1;
         config2.SetNodeId(1400);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { config1 });
@@ -2033,8 +2059,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { agentConfig });
@@ -2087,7 +2114,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-12", "uuid-12", "rack-4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({
                 agentConfig1,
                 agentConfig2,
@@ -2095,6 +2122,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agentConfig4
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -2399,7 +2427,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-12", "uuid-12", "rack-4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({
                 agentConfig1,
                 agentConfig2,
@@ -2407,6 +2435,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agentConfig4
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -2698,13 +2727,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-9", "uuid-9", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({
                 agentConfig1,
                 agentConfig2,
                 agentConfig3
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -2888,13 +2918,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-9", "uuid-9", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({
                 agentConfig1,
                 agentConfig2,
                 agentConfig3
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -3116,7 +3147,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-4", "uuid-4", "rack-4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({
                 agentConfig1,
                 agentConfig2,
@@ -3124,6 +3155,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agentConfig4
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -3334,9 +3366,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agentConfig1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -3408,9 +3441,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-2", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agentConfig1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -3496,9 +3530,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agentConfig1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Make two groups with different placement strategy.
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -3601,9 +3636,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agentConfig1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Make group with partitions.
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -3676,10 +3712,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({config})
             .WithSpreadPlacementGroups({"group-1"})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -3731,7 +3768,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         ui64 lastSeqNo = 0;
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2, agent3 })
             .WithDisks({
                 Disk("disk-1", {"uuid-1"}),
@@ -3740,6 +3777,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
             .With(lastSeqNo)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // #1 : online -> warning
         // disk-1 : online -> migration
@@ -4008,7 +4046,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-7", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2, agent3 })
             .WithDisks({
                 Disk("disk-1", {"uuid-1"}),
@@ -4016,6 +4054,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-3", {"uuid-2", "uuid-4"})
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // uuid-1 : online -> warning
         // disk-1 : online -> migration
@@ -4227,9 +4266,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-3", "uuid-5", "rack-2")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // #2 : online -> warning
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -4351,7 +4391,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .WithDisks({
                 Disk("disk-1", {"uuid-1.1"}),
@@ -4360,6 +4400,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-4", {"uuid-1.3", "uuid-2.3"})
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // #2 : online -> warning
         // disk-2 : online -> migration
@@ -4509,7 +4550,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1a, agent2a, agent3a, agent4a })
             .WithDisks({
                 Disk("disk-1", {"uuid-1.1"}),
@@ -4518,6 +4559,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-4", {"uuid-1.3", "uuid-2.3"})
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             // drop uuid-1.1
@@ -4759,9 +4801,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1a })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // check initial configuration
         {
@@ -4825,9 +4868,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TString> affectedDisks;
@@ -4911,9 +4955,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2, agent3 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -5009,10 +5054,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .WithDisks({ Disk("disk-1", { "uuid-1.1", "uuid-2.1" }) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TString affectedDisk;
@@ -5106,9 +5152,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -5234,12 +5281,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .WithDisks({
                 Disk("disk-1", { "uuid-1.1", "uuid-1.2", "uuid-1.3" })
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TString affectedDisk;
@@ -5296,12 +5344,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .WithDisks({
                 Disk("disk-1", { "uuid-1.1", "uuid-1.2", "uuid-1.3" })
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             bool updated = false;
@@ -5355,7 +5404,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { agent1 });
@@ -5460,7 +5510,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { agent1 });
@@ -5516,7 +5567,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, { agent1 });
@@ -5709,12 +5761,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2a })
             .WithDisks({
                 Disk("disk-1", { "uuid-1.1", "uuid-2.1" })
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TString affectedDisk;
@@ -5802,7 +5855,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             TDuration::Hours(1).MilliSeconds());
         auto storageConfig = CreateStorageConfig(proto);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(storageConfig)
             .WithKnownAgents({ agent1 })
             .WithDisks({
@@ -5811,6 +5864,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
             .With(lastSeqNo)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto ts = Now();
         TDuration cmsTimeout;
@@ -6093,7 +6147,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         ui64 lastSeqNo = 0;
         auto storageConfig = CreateStorageConfig();
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(storageConfig)
             .WithKnownAgents({ agent1 })
             .WithDisks({
@@ -6102,6 +6156,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
             .With(lastSeqNo)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto ts = Now();
 
@@ -6221,11 +6276,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .AddDevicePoolConfig("", 100_GB, NProto::DEVICE_POOL_KIND_DEFAULT)
             .AddDevicePoolConfig("rot", 100_GB, NProto::DEVICE_POOL_KIND_GLOBAL)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TTestExecutor executor;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -6302,13 +6358,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .AddDevicePoolConfig("rot", 100_GB, NProto::DEVICE_POOL_KIND_GLOBAL)
             .WithDisks({
                 Disk("disk-1", {"uuid-1.1"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TTestExecutor executor;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -6368,12 +6425,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto disksInWarningState = diskRegistryGroup->GetCounter("DisksInWarningState");
         auto maxWarningTime = diskRegistryGroup->GetCounter("MaxWarningTime");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(diskRegistryGroup)
             .With(storageConfig)
             .WithKnownAgents(agents)
             .AddDevicePoolConfig("rot", 100_GB, NProto::DEVICE_POOL_KIND_GLOBAL)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TTestExecutor executor;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -6741,11 +6799,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         proto.SetNonReplicatedInfraTimeout(TDuration::Days(1).MilliSeconds());
         auto storageConfig = CreateStorageConfig(proto);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(storageConfig)
             .WithKnownAgents(agents)
             .AddDevicePoolConfig("rot", 100_GB, NProto::DEVICE_POOL_KIND_GLOBAL)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TTestExecutor executor;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -7007,7 +7066,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-5", "uuid-10", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .WithDisks({
                 Disk("disk-1", {"uuid-1", "uuid-2"}),
@@ -7015,6 +7074,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-3", {"uuid-5"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TString> diskIds;
         auto error =
@@ -7070,10 +7130,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             });
         disks.push_back(Disk("disk-1", {"uuid-2.3", "uuid-3.3"}));
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2, agent3 })
             .WithDisks(disks)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TString> agentsIds = {
             agent1.GetAgentId(),
@@ -7119,7 +7180,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         const auto agent2 =
             AgentConfig(2, {Device("dev-2", "uuid-2", "rack-1")});
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents({agent1, agent2})
                 .WithDisks({
@@ -7127,6 +7188,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     ShadowDisk("disk-1", "cp-1", {"uuid-2"}),
                 })
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TString> diskIds;
         auto error =
@@ -7152,9 +7214,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         {
             auto agents = state.GetAgents();
@@ -7277,9 +7340,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1a })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -7324,8 +7388,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TString> affectedDisks;
@@ -7419,11 +7484,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         ui64 lastSeqNo = 0;
         auto storageConfig = CreateStorageConfig();
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(storageConfig)
             .WithKnownAgents({ agent1 })
             .With(lastSeqNo)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto ts = Now();
 
@@ -7473,11 +7539,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         ui64 lastSeqNo = 0;
         auto storageConfig = CreateStorageConfig();
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(storageConfig)
             .WithKnownAgents({ agent1 })
             .With(lastSeqNo)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto updateDevice = [&] (auto db, auto desiredState) {
             return state.UpdateCmsDeviceState(
@@ -7564,11 +7631,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         ui64 lastSeqNo = 0;
         auto storageConfig = CreateStorageConfig();
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(storageConfig)
             .WithKnownAgents({ agent1 })
             .With(lastSeqNo)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto ts = Now();
 
@@ -7622,8 +7690,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-2", "rack-2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, {agent1, agent2});
@@ -7709,7 +7778,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({
                 AgentConfig(1, {
                     Device("dev-1", "uuid-1.1", "rack-1"),
@@ -7737,6 +7806,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 })
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TVector<TDeviceConfig>> diskDevices(5);
 
@@ -7829,10 +7899,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithDisks({Disk("disk-1", {"uuid-2.1", "uuid-1.1"})})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -7997,7 +8068,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agentA })
             .WithStorageConfig([] {
                 auto config = CreateDefaultStorageConfigProto();
@@ -8016,6 +8087,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 } ()
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             auto [r, error] = state.RegisterAgent(db, agentB, Now());
@@ -8079,7 +8151,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto maxWarningTime = diskRegistryGroup->GetCounter("MaxWarningTime");
         auto maxMigrationTime = diskRegistryGroup->GetCounter("MaxMigrationTime");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(diskRegistryGroup)
             .WithKnownAgents(agents)
             .WithDisks({
@@ -8091,6 +8163,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-6", {"uuid-1.6"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto kickDevice = [&] (
             int i,
@@ -8283,7 +8356,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             }),
         };
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents(agents)
                 .WithDisks({
@@ -8306,6 +8379,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     10_GB,
                     NProto::DEVICE_POOL_KIND_GLOBAL)
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         const auto poolNames = state.GetPoolNames();
         ASSERT_VECTORS_EQUAL(
@@ -8441,7 +8515,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .With(diskRegistryGroup)
             .WithStorageConfig([] {
@@ -8466,6 +8540,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 SpreadPlacementGroup("group-3", {"disk-7", "disk-8", "disk-9"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TTestExecutor executor;
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -8585,7 +8660,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .With(diskRegistryGroup)
             .WithStorageConfig([] {
@@ -8614,6 +8689,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 }),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
 
         TTestExecutor executor;
@@ -8738,11 +8814,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ->GetSubgroup("component", "disk_registry");
         auto freeBytes = diskRegistryGroup->GetCounter("FreeBytes");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .With(diskRegistryGroup)
             .WithDisks({ Disk("disk-1", {"uuid-1.1"}) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         state.PublishCounters(TInstant::Zero());
 
@@ -8804,9 +8881,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-1.2", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({agent1a})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(RegisterAgent(state, db, agent1b));
@@ -8848,10 +8926,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithConfig(agents)
             .WithAgents({agents[0]})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -8962,7 +9041,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithDisks({
                 Disk("disk-1", {"uuid-1.1", "uuid-3.1"}, NProto::DISK_STATE_WARNING),
@@ -8970,6 +9049,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-3", {"uuid-2.1", "uuid-3.2"}, NProto::DISK_STATE_WARNING),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto migrations = state.BuildMigrationList();
         UNIT_ASSERT_VALUES_EQUAL(4, migrations.size());
@@ -9009,11 +9089,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithConfig(agents)
             .WithAgents({ agents[0], agents[1] })
             .WithDisks({ Disk("disk-1", {"uuid-1.1", "uuid-1.2"}) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
@@ -9143,9 +9224,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto config = CreateDefaultStorageConfigProto();
         config.SetAllocationUnitNonReplicatedSSD(10);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithStorageConfig(config)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, {agent1b});
@@ -9305,10 +9387,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto config = CreateDefaultStorageConfigProto();
         config.SetAllocationUnitNonReplicatedSSD(referenceDeviceSize / 1_GB);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithStorageConfig(config)
             .WithDisks({Disk("disk-1", {"uuid-1.1", "uuid-1.2"})})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, agents);
@@ -9472,10 +9555,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         deviceOverrides.back().SetDevice("uuid-1.1");
         deviceOverrides.back().SetBlocksCount(referenceDeviceSize / blockSize);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithStorageConfig(config)
             .WithDisks({Disk("disk-1", {"uuid-1.1", "uuid-1.2"})})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UpdateConfig(state, db, agents, deviceOverrides);
@@ -9623,9 +9707,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
     {
         const TVector<TString> expected {"group1", "group2", "group3"};
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithSpreadPlacementGroups(expected)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<TPlacementGroupInfo> groups;
 
@@ -9661,7 +9746,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithDisksToReallocate({ "disk-1" })
             .WithDisks({
@@ -9669,6 +9754,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-2", {"uuid-1.2", "uuid-2.2"})
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(1, state.GetDisksToReallocate().size());
         UNIT_ASSERT_GT(state.GetDisksToReallocate().at("disk-1"), 0);
@@ -9734,12 +9820,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto config = CreateDefaultStorageConfigProto();
         config.SetAllocationUnitNonReplicatedSSD(10);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithStorageConfig(config)
             .WithKnownAgents(agents)
             .WithDisksToReallocate({ "disk-1" })
             .WithDisks({ Disk("disk-1", { "uuid-1.1" }) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         {
             TVector<NProto::TDeviceConfig> devices;
@@ -10002,9 +10089,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1a })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto CheckDevices = [&] () {
             const auto dev1 = state.GetDevice("uuid-1.1");
@@ -10055,11 +10143,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             AgentConfig(1, { Device("dev-1", "uuid-1.1") })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithDisksToReallocate({ "disk-1" })
             .WithDisks({ Disk("disk-1", { "uuid-1.1" }) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         {
             TDiskInfo info;
@@ -10094,9 +10183,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agentConfig1 })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(state.CreatePlacementGroup(
@@ -10210,12 +10300,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-2", "uuid-2", "rack-1")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({agent1})
             .WithDisks({
                 Disk("disk-1", {"uuid-1", "uuid-2"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocateDisk = [&] (auto& db, auto& diskId, auto totalSize) {
             TDiskRegistryState::TAllocateDiskResult result {};
@@ -10316,12 +10407,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-2", "rack-2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({agent1, agent2})
             .WithDisks({
                 Disk("disk-1", {"uuid-1", "uuid-2"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto updateAgentState = [&] (auto db, const auto& agent, auto desiredState) {
             TVector<TString> affectedDisks;
@@ -10393,12 +10485,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithDisks({
                 Disk("disk-1", {"uuid-1.1", "uuid-1.2"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
         UNIT_ASSERT(state.IsMigrationListEmpty());
@@ -10541,7 +10634,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithStorageConfig([] {
                 auto config = CreateDefaultStorageConfigProto();
@@ -10552,6 +10645,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 Disk("disk-1", {"uuid-1.1", "uuid-1.2"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         for (TString uuid: { "uuid-1.1", "uuid-1.2" }) {
             auto device = state.GetDevice(uuid);
@@ -10599,7 +10693,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.WriteDiskRegistryConfig(MakeConfig(agents));
         });
 
-        std::optional<TDiskRegistryState> state = TDiskRegistryStateBuilder()
+        auto state = TDiskRegistryStateBuilder()
             .WithConfig(agents)
             .WithStorageConfig([] {
                 auto config = CreateDefaultStorageConfigProto();
@@ -10891,13 +10985,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 diskRegistryAgentListParams));
             UNIT_ASSERT_VALUES_EQUAL(0, diskRegistryAgentListParams.size());
 
-            state.emplace(TDiskRegistryState {
+            state = std::make_unique<TDiskRegistryState>(
                 CreateLoggingService("console"),
-                CreateStorageConfig([] {
-                    auto proto = CreateDefaultStorageConfigProto();
-                    proto.SetAllocationUnitNonReplicatedSSD(93);
-                    return proto;
-                }()),
+                CreateStorageConfig(
+                    []
+                    {
+                        auto proto = CreateDefaultStorageConfigProto();
+                        proto.SetAllocationUnitNonReplicatedSSD(93);
+                        return proto;
+                    }()),
                 rootGroup,
                 std::move(config),
                 std::move(agents),
@@ -10914,8 +11010,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 std::move(outdatedVolumeConfigs),
                 std::move(suspendedDevices),
                 std::move(automaticallyReplacedDevices),
-                std::move(diskRegistryAgentListParams)
-            });
+                std::move(diskRegistryAgentListParams));
         });
 
         UNIT_ASSERT_VALUES_EQUAL(0, criticalEvents->Val());
@@ -11007,7 +11102,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents(agents)
             .WithDisks([] {
                 TVector disks {
@@ -11034,6 +11129,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 return disks;
             }())
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         {
             TDiskInfo info;
@@ -11082,10 +11178,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         auto agentCounters = diskRegistryGroup
             ->GetSubgroup("agent", agent.GetAgentId());
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(diskRegistryGroup)
             .WithKnownAgents({agent})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto changeAgentState = [&] (const auto& newState, const auto& ts) {
             executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -11221,9 +11318,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
     Y_UNIT_TEST(ShouldPullInLegacyDiskErrorUserNotifications)
     {
-        auto state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithErrorNotifications({"disk0", "disk1", "disk2"})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(3, state.GetUserNotifications().Count);
 
@@ -11267,10 +11365,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({ agent1, agent2 })
             .WithDisks({ Disk("disk-1", { "uuid-1.1", "uuid-2.1" }) })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto moveDeviceToErrorState = [&] (auto deviceId, auto seqNum) {
             executor.WriteTx([&](TDiskRegistryDatabase db) mutable {
@@ -11426,13 +11525,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents({agent1, agent2})
                 .WithDisks(
                     {Disk("disk-1", {"uuid-1.1", "uuid-1.2"}),
                      Disk("disk-2", {"uuid-2.1", "uuid-2.2"})})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto moveDeviceToState =
             [&](TString deviceId, NProto::EDeviceState deviceState)
@@ -11604,13 +11704,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents({agent1, agent2})
                 .WithDisks(
                     {Disk("disk-1", {"uuid-1.1", "uuid-1.2"}),
                      Disk("disk-2", {"uuid-2.1", "uuid-2.2"})})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto moveDeviceToState =
             [&](TString deviceId, NProto::EDeviceState deviceState)
@@ -11786,9 +11887,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("dev-1", "uuid-1", "rack-1")
         });
 
-        auto state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithConfig({agentConfig})
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Register new agent with one device.
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -11850,7 +11952,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             2,
             {Device("dev-2", "uuid-2", "rack-1")});
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents({agent1, agent2})
                 .WithDisks({Disk("disk-1", {"uuid-1", "uuid-2"})})
@@ -11858,6 +11960,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     {TDirtyDevice{"uuid-1", "disk-1"},
                      TDirtyDevice{"uuid-2", "disk-1"}})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_EQUAL(state.GetDirtyDevices().size(), 2);
 
@@ -11888,7 +11991,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             2,
             {Device("dev-2", "uuid-2", "rack-1")});
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents({agent1, agent2})
                 .WithDisks(
@@ -11897,6 +12000,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     {TDirtyDevice{"uuid-1", "disk-1"},
                      TDirtyDevice{"uuid-2", "disk-2"}})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_EQUAL(state.GetDirtyDevices().size(), 2);
 
@@ -11938,10 +12042,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .With(counters)
             .WithKnownAgents(agents)
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         TDiskRegistrySelfCounters::TDevicePoolCounters defaultPool;
         defaultPool.Init(counters->GetSubgroup("pool", "default"));
@@ -12116,12 +12221,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             Device("NVMENBS02", "uuid-1.2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
             .WithKnownAgents({agentConfig})
             .WithDisks({
                 Disk("disk-1", {"uuid-1.2"}),
             })
             .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
@@ -12240,7 +12346,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)
             {
-                auto state = TDiskRegistryStateBuilder::LoadState(db).Build();
+                auto statePtr =
+                    TDiskRegistryStateBuilder::LoadState(db).Build();
+                TDiskRegistryState& state = *statePtr;
 
                 auto orphanDevices = state.FindOrphanDevices();
                 UNIT_ASSERT_EQUAL(static_cast<size_t>(3), orphanDevices.size());
@@ -12349,7 +12457,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             agentConfig,
         };
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -12376,6 +12484,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     TDirtyDevice{"uuid-2", {}},
                 })
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocate = [&](auto db, ui32 deviceCount)
         {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
@@ -43,7 +43,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                  Device("dev-3", "uuid-2.3"),
                  Device("dev-4", "uuid-2.4")})};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -59,6 +59,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                     }())
                 .WithAgents(agents)
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto agentsInfo = state.QueryAgentsInfo();
         UNIT_ASSERT_VALUES_EQUAL(2, agentsInfo.size());
@@ -95,7 +96,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
             1,
             {Device("dev-1", "uuid-1.1"), Device("dev-2", "uuid-1.2")})};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -112,6 +113,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                 .WithAgents(agents)
                 .WithDirtyDevices({TDirtyDevice{"uuid-1.1", {}}})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto agentsInfo = state.QueryAgentsInfo();
         UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
@@ -139,7 +141,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
             1,
             {Device("dev-1", "uuid-1.1"), Device("dev-2", "uuid-1.2")})};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -156,6 +158,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                 .WithAgents(agents)
                 .WithSuspendedDevices({"uuid-1.1"})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto agentsInfo = state.QueryAgentsInfo();
         UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
@@ -183,7 +186,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
             1,
             {Device("dev-1", "uuid-1.1"), Device("dev-2", "uuid-1.2")})};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -199,6 +202,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                     }())
                 .WithAgents(agents)
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocate = [&](auto db,
                             TString agentId,
@@ -268,7 +272,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                     "uuid-2.2",
                     NProto::EDeviceState::DEVICE_STATE_ERROR)})};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -283,6 +287,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                     }())
                 .WithAgents(agents)
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         const auto agentsInfo = state.QueryAgentsInfo();
         UNIT_ASSERT_VALUES_EQUAL(2, agentsInfo.size());
@@ -341,7 +346,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                     "uuid-2.2",
                     NProto::EDeviceState::DEVICE_STATE_WARNING)})};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     [&]
@@ -356,6 +361,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
                     }())
                 .WithAgents(agents)
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         const auto agentsInfo = state.QueryAgentsInfo();
         UNIT_ASSERT_VALUES_EQUAL(2, agentsInfo.size());

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_checkpoint.cpp
@@ -27,7 +27,7 @@ namespace {
 constexpr ui32 AvailableBlockSizes[] =
     {4_KB, 8_KB, 16_KB, 32_KB, 64_KB, 128_KB};
 
-TDiskRegistryState MakeDiskRegistryState()
+std::unique_ptr<TDiskRegistryState> MakeDiskRegistryState()
 {
     auto agentConfig1 = AgentConfig(
         1,
@@ -91,7 +91,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx([&](TDiskRegistryDatabase db)
@@ -227,7 +228,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -283,7 +285,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -344,7 +347,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -443,7 +447,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -515,7 +520,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -634,7 +640,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -704,7 +711,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
-        TDiskRegistryState state = MakeDiskRegistryState();
+        auto statePtr = MakeDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(
@@ -771,8 +779,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCheckpointTest)
                 Device("dev-2", "uuid-2", "rack-1"),
             });
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder().WithKnownAgents({agentConfig}).Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Create source disk
         executor.WriteTx(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -37,7 +37,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             Device("NVMENBS04", "uuid-1.4", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder().Build();
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_VALUES_EQUAL(0, state.GetConfig().KnownAgentsSize());
@@ -110,9 +111,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             Device("NVMENBS04", "uuid-1.4", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig({agentConfig})
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder().WithConfig({agentConfig}).Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_VALUES_EQUAL(0, state.GetConfigVersion());
@@ -184,9 +185,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             Device("NVMENBS04", "uuid-1.4", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig({agentConfig})
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder().WithConfig({agentConfig}).Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_VALUES_EQUAL(0, state.GetConfigVersion());
@@ -300,9 +301,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             Device("NVMENBS04", "uuid-1.4", "rack-1"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-                                       .WithKnownAgents({lostAgentConfig})
-                                       .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({lostAgentConfig})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // prepare agent-1
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -486,10 +488,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                         NProto::DEVICE_STATE_ERROR),
                 })};
 
-        TDiskRegistryState state =
-            TDiskRegistryStateBuilder()
-                .WithConfig(agents)
-                .Build();
+        auto statePtr = TDiskRegistryStateBuilder().WithConfig(agents).Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Register agents.
         executor.WriteTx(
@@ -736,8 +736,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
 
         // Init state.
         {
-            TDiskRegistryState state =
+            auto statePtr =
                 TDiskRegistryStateBuilder().WithConfig({agent}).Build();
+            TDiskRegistryState& state = *statePtr;
 
             // Register agent.
             executor.WriteTx(
@@ -771,9 +772,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             [&](TDiskRegistryDatabase db)
             {
                 // Load state from db.
-                auto state = TDiskRegistryStateBuilder::LoadState(db)
-                                 .WithConfig({agent})
-                                 .Build();
+                auto statePtr = TDiskRegistryStateBuilder::LoadState(db)
+                                    .WithConfig({agent})
+                                    .Build();
+                TDiskRegistryState& state = *statePtr;
 
                 // Remove agent.
                 TVector<TString> affectedDisks;
@@ -847,7 +849,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     WithPool("local-ssd", NProto::DEVICE_POOL_KIND_LOCAL),
             })};
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithConfig(
                     MakeConfig(0, agents) | WithPoolConfig(
@@ -855,6 +857,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                                                 NProto::DEVICE_POOL_KIND_LOCAL,
                                                 DefaultDeviceSize))
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Register agents.
         executor.WriteTx(
@@ -964,10 +967,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     Device("NVMENBS04", "uuid-2.4", "rack-2"),
                 })};
 
-        TDiskRegistryState state =
-            TDiskRegistryStateBuilder()
-                .WithConfig(agents)
-                .Build();
+        auto statePtr = TDiskRegistryStateBuilder().WithConfig(agents).Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Register agents.
         executor.WriteTx(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_config.cpp
@@ -34,9 +34,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateConfigTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .With(counters)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder().With(counters).Build();
+        TDiskRegistryState& state = *statePtr;
 
         const TString uuid = "uuid-1.1";
         const auto agentConfig = AgentConfig(1, { Device("dev-1", uuid) });
@@ -102,9 +101,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateConfigTest)
             }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig(agents)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder().WithConfig(agents).Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
@@ -66,7 +66,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
             })
         };
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithAgents(agents)
                 .WithConfig(
@@ -84,6 +84,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
                 .WithDisks({Disk("disk-1", {"uuid-1.1"})})
                 .WithDirtyDevices({TDirtyDevice{"uuid-2.1", {}}})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto deviceByName = [] (auto agentId, auto name) {
             NProto::TDeviceConfig config;
@@ -381,10 +382,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .With(diskRegistryGroup)
-            .WithKnownAgents(agents)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(diskRegistryGroup)
+                            .WithKnownAgents(agents)
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         state.PublishCounters(TInstant::Zero());
 
@@ -427,18 +429,22 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
             deviceConfig("dev-4", "uuid-1.4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, {agent});
-                auto* pool = config.AddDevicePoolConfigs();
-                pool->SetName(poolName);
-                pool->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                pool->SetAllocationUnit(logicalDeviceSize);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, {agent});
+                        auto* pool = config.AddDevicePoolConfigs();
+                        pool->SetName(poolName);
+                        pool->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        pool->SetAllocationUnit(logicalDeviceSize);
 
-                return config;
-            }())
-            .WithAgents({agent})
-            .Build();
+                        return config;
+                    }())
+                .WithAgents({agent})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         {
             auto [infos, error] = state.QueryAvailableStorage(
@@ -514,9 +520,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
                 testDeviceSizeInBytes)
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithStorageConfig({})
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder().WithStorageConfig({}).Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
@@ -14,7 +14,7 @@ using namespace NDiskRegistryStateTest;
 
 namespace {
 
-TDiskRegistryState CreateDiskRegistryState()
+std::unique_ptr<TDiskRegistryState> CreateDiskRegistryState()
 {
     auto agentConfig1 = AgentConfig(
         1,
@@ -120,7 +120,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateLaggingAgentsTest)
     {
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
-        auto state = CreateDiskRegistryState();
+        auto statePtr = CreateDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
         CreateMirror3Disk(executor, state);
 
         // Request with wrong disk id should return an error.
@@ -321,7 +322,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateLaggingAgentsTest)
     {
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
-        auto state = CreateDiskRegistryState();
+        auto statePtr = CreateDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
         CreateMirror3Disk(executor, state);
 
         // Migrate devices from the first agent.
@@ -467,7 +469,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateLaggingAgentsTest)
     {
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
-        auto state = CreateDiskRegistryState();
+        auto statePtr = CreateDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
         CreateMirror3Disk(executor, state);
 
         // Migrate devices from the first agent.
@@ -588,7 +591,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateLaggingAgentsTest)
     {
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
-        auto state = CreateDiskRegistryState();
+        auto statePtr = CreateDiskRegistryState();
+        TDiskRegistryState& state = *statePtr;
         CreateMirror3Disk(executor, state);
 
         // Migrate devices from the second replica.
@@ -773,9 +777,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateLaggingAgentsTest)
                         Sprintf("rack-%u", i + 1)),
                 }));
         }
-        auto state = TDiskRegistryStateBuilder()
+        auto statePtr = TDiskRegistryStateBuilder()
                          .WithKnownAgents(std::move(agents))
                          .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx(
             [&](TDiskRegistryDatabase db)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -78,7 +78,8 @@ TVector<NProto::TAgentConfig> CreateSeveralAgents()
             })};
 }
 
-TDiskRegistryState CreateTestState(const TVector<NProto::TAgentConfig>& agents)
+std::unique_ptr<TDiskRegistryState> CreateTestState(
+    const TVector<NProto::TAgentConfig>& agents)
 {
     return TDiskRegistryStateBuilder()
         .WithKnownAgents(agents)
@@ -115,7 +116,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             })
         };
 
-        TDiskRegistryState state =
+        auto statePtr =
             TDiskRegistryStateBuilder()
                 .WithKnownAgents(agents)
                 .WithDisks({
@@ -127,6 +128,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                      TDirtyDevice{"uuid-4.2", {}},
                      TDirtyDevice{"uuid-4.3", {}}})
                 .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT(state.IsMigrationListEmpty());
 
@@ -300,10 +302,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             AgentConfig(3, { Device("dev-1", "uuid-3.1", "rack-1") }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({ Disk("foo", { "uuid-1.1" }) })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents(agents)
+                            .WithDisks({Disk("foo", {"uuid-1.1"})})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             auto affectedDisks = ChangeAgentState(
@@ -413,13 +416,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             }),
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({
-                Disk("foo", { "uuid-1.1" }),
-                Disk("bar", { "uuid-1.2", "uuid-1.3" })
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents(agents)
+                            .WithDisks(
+                                {Disk("foo", {"uuid-1.1"}),
+                                 Disk("bar", {"uuid-1.2", "uuid-1.3"})})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             TVector<TString> affectedDisks;
@@ -499,10 +502,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .With(diskRegistryGroup)
-            .WithKnownAgents(agents)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(diskRegistryGroup)
+                            .WithKnownAgents(agents)
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto minusCounter =
             diskRegistryGroup->GetCounter("Mirror3DisksMinus1");
@@ -999,17 +1003,19 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             Device("dev-2", "uuid-1.2")
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({agent})
-            .WithDisks({
-                Disk("foo", {"uuid-1.1"}),
-                [] {
-                    auto config = Disk("bar", {"uuid-1.2"});
-                    config.SetStorageMediaKind(NProto::STORAGE_MEDIA_SSD_LOCAL);
-                    return config;
-                }()
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({agent})
+                            .WithDisks(
+                                {Disk("foo", {"uuid-1.1"}),
+                                 []
+                                 {
+                                     auto config = Disk("bar", {"uuid-1.2"});
+                                     config.SetStorageMediaKind(
+                                         NProto::STORAGE_MEDIA_SSD_LOCAL);
+                                     return config;
+                                 }()})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT(state.IsMigrationListEmpty());
 
@@ -1055,14 +1061,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({
-                Disk("disk-1", {"uuid-1.1", "uuid-1.2"}),
-                Disk("disk-2", {"uuid-2.1"}),
-            })
-            .WithStorageConfig(std::move(config))
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents(agents)
+                            .WithDisks({
+                                Disk("disk-1", {"uuid-1.1", "uuid-1.2"}),
+                                Disk("disk-2", {"uuid-2.1"}),
+                            })
+                            .WithStorageConfig(std::move(config))
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
 
@@ -1185,7 +1192,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
 
         const TVector agents = CreateSeveralAgents();
 
-        TDiskRegistryState state = CreateTestState(agents);
+        auto statePtr = CreateTestState(agents);
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
         UNIT_ASSERT(state.IsMigrationListEmpty());
@@ -1325,7 +1333,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
 
         const TVector agents = CreateSeveralAgents();
 
-        TDiskRegistryState state = CreateTestState(agents);
+        auto statePtr = CreateTestState(agents);
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
         UNIT_ASSERT(state.IsMigrationListEmpty());
@@ -1445,7 +1454,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
 
         const TVector agents = CreateSeveralAgents();
 
-        TDiskRegistryState state = CreateTestState(agents);
+        auto statePtr = CreateTestState(agents);
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
         UNIT_ASSERT(state.IsMigrationListEmpty());
@@ -1568,7 +1578,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
 
         const TVector agents = CreateSeveralAgents();
 
-        TDiskRegistryState state = CreateTestState(agents);
+        auto statePtr = CreateTestState(agents);
+        TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.BuildMigrationList().size());
         UNIT_ASSERT(state.IsMigrationListEmpty());

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -55,14 +55,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-12", "uuid-12", "rack-4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-                agentConfig4,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -184,12 +185,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-6", "uuid-6", "rack-2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -353,14 +355,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-15", "uuid-15", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-                agentConfig4,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -437,35 +440,46 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                AgentConfig(1, {
-                    Device("dev-1", "uuid-1", "rack-1"),
-                    Device("dev-2", "uuid-2", "rack-1"),
-                    Device("dev-3", "uuid-3", "rack-1"),
-                }),
-                AgentConfig(2, {
-                    Device("dev-4", "uuid-4", "rack-2"),
-                    Device("dev-5", "uuid-5", "rack-2"),
-                    Device("dev-6", "uuid-6", "rack-2"),
-                }),
-                AgentConfig(3, {
-                    Device("dev-7", "uuid-7", "rack-3"),
-                    Device("dev-8", "uuid-8", "rack-3"),
-                    Device("dev-9", "uuid-9", "rack-3"),
-                }),
-                AgentConfig(4, {
-                    Device("dev-10", "uuid-10", "rack-4"),
-                    Device("dev-11", "uuid-11", "rack-4"),
-                    Device("dev-12", "uuid-12", "rack-4"),
-                }),
-                AgentConfig(5, {
-                    Device("dev-13", "uuid-13", "rack-5"),
-                    Device("dev-14", "uuid-14", "rack-5"),
-                    Device("dev-15", "uuid-15", "rack-5"),
-                }),
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                AgentConfig(
+                                    1,
+                                    {
+                                        Device("dev-1", "uuid-1", "rack-1"),
+                                        Device("dev-2", "uuid-2", "rack-1"),
+                                        Device("dev-3", "uuid-3", "rack-1"),
+                                    }),
+                                AgentConfig(
+                                    2,
+                                    {
+                                        Device("dev-4", "uuid-4", "rack-2"),
+                                        Device("dev-5", "uuid-5", "rack-2"),
+                                        Device("dev-6", "uuid-6", "rack-2"),
+                                    }),
+                                AgentConfig(
+                                    3,
+                                    {
+                                        Device("dev-7", "uuid-7", "rack-3"),
+                                        Device("dev-8", "uuid-8", "rack-3"),
+                                        Device("dev-9", "uuid-9", "rack-3"),
+                                    }),
+                                AgentConfig(
+                                    4,
+                                    {
+                                        Device("dev-10", "uuid-10", "rack-4"),
+                                        Device("dev-11", "uuid-11", "rack-4"),
+                                        Device("dev-12", "uuid-12", "rack-4"),
+                                    }),
+                                AgentConfig(
+                                    5,
+                                    {
+                                        Device("dev-13", "uuid-13", "rack-5"),
+                                        Device("dev-14", "uuid-14", "rack-5"),
+                                        Device("dev-15", "uuid-15", "rack-5"),
+                                    }),
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> d;
@@ -557,35 +571,46 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                AgentConfig(1, {
-                    Device("dev-1", "uuid-1", "rack-1"),
-                    Device("dev-2", "uuid-2", "rack-1"),
-                    Device("dev-3", "uuid-3", "rack-1"),
-                }),
-                AgentConfig(2, {
-                    Device("dev-4", "uuid-4", "rack-2"),
-                    Device("dev-5", "uuid-5", "rack-2"),
-                    Device("dev-6", "uuid-6", "rack-2"),
-                }),
-                AgentConfig(3, {
-                    Device("dev-7", "uuid-7", "rack-3"),
-                    Device("dev-8", "uuid-8", "rack-3"),
-                    Device("dev-9", "uuid-9", "rack-3"),
-                }),
-                AgentConfig(4, {
-                    Device("dev-10", "uuid-10", "rack-4"),
-                    Device("dev-11", "uuid-11", "rack-4"),
-                    Device("dev-12", "uuid-12", "rack-4"),
-                }),
-                AgentConfig(5, {
-                    Device("dev-13", "uuid-13", "rack-5"),
-                    Device("dev-14", "uuid-14", "rack-5"),
-                    Device("dev-15", "uuid-15", "rack-5"),
-                }),
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                AgentConfig(
+                                    1,
+                                    {
+                                        Device("dev-1", "uuid-1", "rack-1"),
+                                        Device("dev-2", "uuid-2", "rack-1"),
+                                        Device("dev-3", "uuid-3", "rack-1"),
+                                    }),
+                                AgentConfig(
+                                    2,
+                                    {
+                                        Device("dev-4", "uuid-4", "rack-2"),
+                                        Device("dev-5", "uuid-5", "rack-2"),
+                                        Device("dev-6", "uuid-6", "rack-2"),
+                                    }),
+                                AgentConfig(
+                                    3,
+                                    {
+                                        Device("dev-7", "uuid-7", "rack-3"),
+                                        Device("dev-8", "uuid-8", "rack-3"),
+                                        Device("dev-9", "uuid-9", "rack-3"),
+                                    }),
+                                AgentConfig(
+                                    4,
+                                    {
+                                        Device("dev-10", "uuid-10", "rack-4"),
+                                        Device("dev-11", "uuid-11", "rack-4"),
+                                        Device("dev-12", "uuid-12", "rack-4"),
+                                    }),
+                                AgentConfig(
+                                    5,
+                                    {
+                                        Device("dev-13", "uuid-13", "rack-5"),
+                                        Device("dev-14", "uuid-14", "rack-5"),
+                                        Device("dev-15", "uuid-15", "rack-5"),
+                                    }),
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> d;
@@ -657,35 +682,46 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                AgentConfig(1, {
-                    Device("dev-1", "uuid-1", "rack-1"),
-                    Device("dev-2", "uuid-2", "rack-1"),
-                    Device("dev-3", "uuid-3", "rack-1"),
-                }),
-                AgentConfig(2, {
-                    Device("dev-4", "uuid-4", "rack-2"),
-                    Device("dev-5", "uuid-5", "rack-2"),
-                    Device("dev-6", "uuid-6", "rack-2"),
-                }),
-                AgentConfig(3, {
-                    Device("dev-7", "uuid-7", "rack-3"),
-                    Device("dev-8", "uuid-8", "rack-3"),
-                    Device("dev-9", "uuid-9", "rack-3"),
-                }),
-                AgentConfig(4, {
-                    Device("dev-10", "uuid-10", "rack-4"),
-                    Device("dev-11", "uuid-11", "rack-4"),
-                    Device("dev-12", "uuid-12", "rack-4"),
-                }),
-                AgentConfig(5, {
-                    Device("dev-13", "uuid-13", "rack-5"),
-                    Device("dev-14", "uuid-14", "rack-5"),
-                    Device("dev-15", "uuid-15", "rack-5"),
-                }),
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                AgentConfig(
+                                    1,
+                                    {
+                                        Device("dev-1", "uuid-1", "rack-1"),
+                                        Device("dev-2", "uuid-2", "rack-1"),
+                                        Device("dev-3", "uuid-3", "rack-1"),
+                                    }),
+                                AgentConfig(
+                                    2,
+                                    {
+                                        Device("dev-4", "uuid-4", "rack-2"),
+                                        Device("dev-5", "uuid-5", "rack-2"),
+                                        Device("dev-6", "uuid-6", "rack-2"),
+                                    }),
+                                AgentConfig(
+                                    3,
+                                    {
+                                        Device("dev-7", "uuid-7", "rack-3"),
+                                        Device("dev-8", "uuid-8", "rack-3"),
+                                        Device("dev-9", "uuid-9", "rack-3"),
+                                    }),
+                                AgentConfig(
+                                    4,
+                                    {
+                                        Device("dev-10", "uuid-10", "rack-4"),
+                                        Device("dev-11", "uuid-11", "rack-4"),
+                                        Device("dev-12", "uuid-12", "rack-4"),
+                                    }),
+                                AgentConfig(
+                                    5,
+                                    {
+                                        Device("dev-13", "uuid-13", "rack-5"),
+                                        Device("dev-14", "uuid-14", "rack-5"),
+                                        Device("dev-15", "uuid-15", "rack-5"),
+                                    }),
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TDiskInfo diskInfo;
@@ -796,14 +832,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-12", "uuid-12", "rack-4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-                agentConfig4
-            })
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents(
+                    {agentConfig1, agentConfig2, agentConfig3, agentConfig4})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -1130,12 +1164,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-6", "uuid-6", "rack-2"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -1436,15 +1471,16 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-15", "uuid-15", "rack-5"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-                agentConfig4,
-                agentConfig5,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                                agentConfig5,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -1606,13 +1642,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-9", "uuid-9", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -1788,14 +1825,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         *disks.back().AddDeviceReplacementUUIDs() = "uuid-1";
         *disks.back().AddDeviceReplacementUUIDs() = "uuid-6";
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-            })
-            .WithDisks(disks)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                            })
+                            .WithDisks(disks)
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         const auto rt = GetReplicaTableRepr(state, "disk-1");
 
@@ -1827,13 +1865,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-1", "uuid-5", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3
-            })
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents({agentConfig1, agentConfig2, agentConfig3})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Create a mirror-2 disk
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -1965,15 +2001,16 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "disk_registry");
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .With(diskRegistryGroup)
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-                agentConfig4,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(diskRegistryGroup)
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -2228,14 +2265,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-12", "uuid-12", "rack-4"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-                agentConfig4
-            })
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents(
+                    {agentConfig1, agentConfig2, agentConfig3, agentConfig4})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -2474,13 +2509,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
 
         // intentionally setting agent count to 3 to get E_DISK_ALLOCATION_FAILED
         // upon ReplaceDevice call
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;
@@ -2638,13 +2674,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             Device("dev-1", "uuid-3", "rack-3"),
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-                agentConfig3,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Creating a mirror-3 (one device per replica)
 
@@ -2755,10 +2792,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         proto.SetAllocationUnitNonReplicatedSSD(10);
         auto storageConfig = CreateStorageConfig(proto);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .With(storageConfig)
-            .WithKnownAgents(agents)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(storageConfig)
+                            .WithKnownAgents(agents)
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         /*
          *  Creating a small mirror-2 disk that will use 2 agents.
@@ -2926,13 +2964,14 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         storageConfig.SetAllocationUnitNonReplicatedSSD(10);
         storageConfig.SetMaxAutomaticDeviceReplacementsPerHour(1);
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .With(CreateStorageConfig(storageConfig))
-            .WithKnownAgents({
-                agentConfig1,
-                agentConfig2,
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(CreateStorageConfig(storageConfig))
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                            })
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto monitoring = CreateMonitoringServiceStub();
         auto rootGroup = monitoring->GetCounters()
@@ -3059,9 +3098,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder().WithKnownAgents(agents).Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             TVector<TDeviceConfig> devices;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pending_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pending_cleanup.cpp
@@ -44,9 +44,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePendingCleanupTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithAgents(agents)
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder().WithAgents(agents).Build();
+        TDiskRegistryState& state = *statePtr;
 
         TVector<NProto::TDeviceConfig> devices;
 
@@ -156,12 +155,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePendingCleanupTest)
              Device("dev-3", "uuid-1.3"),
              Device("dev-4", "uuid-1.4")})};
 
-        TDiskRegistryState state =
-            TDiskRegistryStateBuilder()
-                .WithAgents(agents)
-                .WithSuspendedDevices({"uuid-1.1"})
-                .WithDirtyDevices({TDirtyDevice{"uuid-1.1", ""}})
-                .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithAgents(agents)
+                            .WithSuspendedDevices({"uuid-1.1"})
+                            .WithDirtyDevices({TDirtyDevice{"uuid-1.1", ""}})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // Create a disk.
         executor.WriteTx(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
@@ -121,19 +121,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, agents);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
 
-                auto* local = config.AddDevicePoolConfigs();
-                local->SetName("local-ssd");
-                local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                local->SetAllocationUnit(DefaultDeviceSize);
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
 
-                return config;
-             }())
-            .WithAgents(agents)
-            .Build();
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocate = [&] (auto db, ui32 deviceCount, TString agentId) {
             TDiskRegistryState::TAllocateDiskResult result;
@@ -200,19 +204,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, agents);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
 
-                auto* local = config.AddDevicePoolConfigs();
-                local->SetName("local-ssd");
-                local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                local->SetAllocationUnit(DefaultDeviceSize);
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
 
-                return config;
-             }())
-            .WithAgents(agents)
-            .Build();
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocate = [&] (auto db, ui32 deviceCount, TString agentId) {
             TDiskRegistryState::TAllocateDiskResult result;
@@ -275,19 +283,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, agents);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
 
-                auto* local = config.AddDevicePoolConfigs();
-                local->SetName("pool");
-                local->SetAllocationUnit(DefaultDeviceSize);
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("pool");
+                        local->SetAllocationUnit(DefaultDeviceSize);
 
-                return config;
-             }())
-            .WithAgents(agents)
-            .WithDisks({ Disk("disk-1", { "uuid-1.1", "uuid-1.2" }) })
-            .Build();
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .WithDisks({Disk("disk-1", {"uuid-1.1", "uuid-1.2"})})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             bool updated = false;
@@ -350,20 +362,24 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, agents);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
 
-                auto* local = config.AddDevicePoolConfigs();
-                local->SetName("local-ssd");
-                local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                local->SetAllocationUnit(DefaultDeviceSize);
+                        auto* local = config.AddDevicePoolConfigs();
+                        local->SetName("local-ssd");
+                        local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        local->SetAllocationUnit(DefaultDeviceSize);
 
-                return config;
-             }())
-            .WithAgents(agents)
-            .WithDisks({ Disk("disk-1", { "uuid-1.1", "uuid-1.2" }) })
-            .Build();
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .WithDisks({Disk("disk-1", {"uuid-1.1", "uuid-1.2"})})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             bool updated = false;
@@ -425,30 +441,34 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             {"global2", 2500_MB}
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, {agent});
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, {agent});
 
-                auto* nonrepl = config.AddDevicePoolConfigs();
-                nonrepl->SetAllocationUnit(pools[""]);
+                        auto* nonrepl = config.AddDevicePoolConfigs();
+                        nonrepl->SetAllocationUnit(pools[""]);
 
-                for (auto* name: {"local1", "local2"}) {
-                    auto* local = config.AddDevicePoolConfigs();
-                    local->SetName(name);
-                    local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                    local->SetAllocationUnit(pools[name]);
-                }
+                        for (auto* name: {"local1", "local2"}) {
+                            auto* local = config.AddDevicePoolConfigs();
+                            local->SetName(name);
+                            local->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                            local->SetAllocationUnit(pools[name]);
+                        }
 
-                for (auto* name: {"global1", "global2"}) {
-                    auto* local = config.AddDevicePoolConfigs();
-                    local->SetName(name);
-                    local->SetKind(NProto::DEVICE_POOL_KIND_GLOBAL);
-                    local->SetAllocationUnit(pools[name]);
-                }
+                        for (auto* name: {"global1", "global2"}) {
+                            auto* local = config.AddDevicePoolConfigs();
+                            local->SetName(name);
+                            local->SetKind(NProto::DEVICE_POOL_KIND_GLOBAL);
+                            local->SetAllocationUnit(pools[name]);
+                        }
 
-                return config;
-             }())
-            .Build();
+                        return config;
+                    }())
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(RegisterAgent(state, db, agent));
@@ -597,19 +617,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig([&] {
-                auto config = MakeConfig(0, agents);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
 
-                auto* pool = config.AddDevicePoolConfigs();
-                pool->SetName("local-ssd");
-                pool->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                pool->SetAllocationUnit(localDeviceSize);
+                        auto* pool = config.AddDevicePoolConfigs();
+                        pool->SetName("local-ssd");
+                        pool->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        pool->SetAllocationUnit(localDeviceSize);
 
-                return config;
-             }())
-            .WithAgents(agents)
-            .Build();
+                        return config;
+                    }())
+                .WithAgents(agents)
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocate = [&] (auto db, ui32 deviceCount, TVector<TString> agentIds) {
             TDiskRegistryState::TAllocateDiskResult result;
@@ -682,28 +706,34 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
                 | WithTotalSize(bigPoolUnitSize, DefaultLogicalBlockSize)
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithStorageConfig([]{
-                auto config = CreateDefaultStorageConfigProto();
-                config.SetAllocationUnitNonReplicatedSSD(93);
-                return config;
-            }())
-            .WithConfig([&] {
-                auto config = MakeConfig(0, {agentConfig});
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithStorageConfig(
+                    []
+                    {
+                        auto config = CreateDefaultStorageConfigProto();
+                        config.SetAllocationUnitNonReplicatedSSD(93);
+                        return config;
+                    }())
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, {agentConfig});
 
-                auto* small = config.AddDevicePoolConfigs();
-                small->SetName("small");
-                small->SetKind(NProto::DEVICE_POOL_KIND_GLOBAL);
-                small->SetAllocationUnit(smallPoolUnitSize);
+                        auto* small = config.AddDevicePoolConfigs();
+                        small->SetName("small");
+                        small->SetKind(NProto::DEVICE_POOL_KIND_GLOBAL);
+                        small->SetAllocationUnit(smallPoolUnitSize);
 
-                auto* big = config.AddDevicePoolConfigs();
-                big->SetName("big");
-                big->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
-                big->SetAllocationUnit(bigPoolUnitSize);
+                        auto* big = config.AddDevicePoolConfigs();
+                        big->SetName("big");
+                        big->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        big->SetAllocationUnit(bigPoolUnitSize);
 
-                return config;
-             }())
-            .Build();
+                        return config;
+                    }())
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             UNIT_ASSERT_SUCCESS(RegisterAgent(state, db, agentConfig));
@@ -869,25 +899,30 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             })
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithStorageConfig([] {
-                auto config = CreateDefaultStorageConfigProto();
-                config.SetAllocationUnitNonReplicatedSSD(
-                    static_cast<ui32>(allocationUnitSize / 1_GB));
-                return config;
-            }())
-            .WithKnownAgents(agents)
-            .WithDisks({[] {
-                NProto::TDiskConfig disk;
-                disk.SetDiskId("vol0");
-                disk.AddDeviceUUIDs("uuid-4.1");
-                disk.SetBlockSize(4_KB);
-                disk.SetStorageMediaKind(
-                    NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithStorageConfig(
+                    []
+                    {
+                        auto config = CreateDefaultStorageConfigProto();
+                        config.SetAllocationUnitNonReplicatedSSD(
+                            static_cast<ui32>(allocationUnitSize / 1_GB));
+                        return config;
+                    }())
+                .WithKnownAgents(agents)
+                .WithDisks({[]
+                            {
+                                NProto::TDiskConfig disk;
+                                disk.SetDiskId("vol0");
+                                disk.AddDeviceUUIDs("uuid-4.1");
+                                disk.SetBlockSize(4_KB);
+                                disk.SetStorageMediaKind(
+                                    NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
 
-                return disk;
-            }()})
-            .Build();
+                                return disk;
+                            }()})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         // uuid-2.1 was detected as a non-standart size device.
         UNIT_ASSERT_VALUES_EQUAL(1, criticalEvents->Val());

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
@@ -93,10 +93,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                     DefaultDeviceSize);
         };
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig(makeConfig(0, TVector { Agents[0] }))
-            .WithAgents({ Agents[0] })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithConfig(makeConfig(0, TVector{Agents[0]}))
+                            .WithAgents({Agents[0]})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         auto allocateDisk = [&] (auto db, auto* diskId, auto deviceCount, auto kind) {
             TDiskRegistryState::TAllocateDiskResult result;
@@ -249,14 +250,16 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
 
     Y_UNIT_TEST_F(ShouldSuspendDevicesOnCMSRequest, TFixture)
     {
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithConfig(MakeConfig(0, Agents)
-                | WithPoolConfig(
-                    "local-ssd",
-                    NProto::DEVICE_POOL_KIND_LOCAL,
-                    DefaultDeviceSize))
-            .WithAgents(Agents)
-            .Build();
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    MakeConfig(0, Agents) | WithPoolConfig(
+                                                "local-ssd",
+                                                NProto::DEVICE_POOL_KIND_LOCAL,
+                                                DefaultDeviceSize))
+                .WithAgents(Agents)
+                .Build();
+        TDiskRegistryState& state = *statePtr;
 
         for (auto& agent: Agents) {
             for (const auto& d: agent.GetDevices()) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_updates.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_updates.cpp
@@ -57,11 +57,10 @@ struct TChangeNonreplDiskDevice
                 deviceConfig("dev-3", "uuid-1.3"),
             })};
 
-        State = std::make_unique<TDiskRegistryState>(
-            TDiskRegistryStateBuilder()
-                .WithKnownAgents(Agents)
-                .WithDisks({ Disk("disk-1", {"uuid-1.1", "uuid-1.2"}) })
-                .Build());
+        State = TDiskRegistryStateBuilder()
+                    .WithKnownAgents(Agents)
+                    .WithDisks({Disk("disk-1", {"uuid-1.1", "uuid-1.2"})})
+                    .Build();
     }
 };
 
@@ -106,13 +105,12 @@ struct TChangeMirrorDiskDevice
                 deviceConfig("dev-3", "uuid-2.3"),
             })};
 
-        State = std::make_unique<TDiskRegistryState>(
-            TDiskRegistryStateBuilder()
-                .WithKnownAgents(Agents)
-                .WithDisks({ MirrorDisk("disk-1", {
-                    {"uuid-1.1", "uuid-1.2"},
-                    {"uuid-2.1", "uuid-2.2"}}) })
-                .Build());
+        State = TDiskRegistryStateBuilder()
+                    .WithKnownAgents(Agents)
+                    .WithDisks({MirrorDisk(
+                        "disk-1",
+                        {{"uuid-1.1", "uuid-1.2"}, {"uuid-2.1", "uuid-2.2"}})})
+                    .Build();
     }
 };
 
@@ -137,12 +135,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateUpdatesTest)
 
         const auto diskId = "disk-1";
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({
-                Disk(diskId, { "uuid-1.1" })
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents(agents)
+                            .WithDisks({Disk(diskId, {"uuid-1.1"})})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             auto error = state.UpdateDiskBlockSize(Now(), db, "", 1_KB, false);
@@ -193,12 +190,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateUpdatesTest)
             db.InitSchema();
         });
 
-        TDiskRegistryState state = TDiskRegistryStateBuilder()
-            .WithKnownAgents(agents)
-            .WithDisks({
-                Disk(diskId, { deviceId })
-            })
-            .Build();
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents(agents)
+                            .WithDisks({Disk(diskId, {deviceId})})
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
             auto error = state.UpdateDiskBlockSize(Now(), db, diskId, 128_KB, false);

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.cpp
@@ -483,9 +483,9 @@ TDiskRegistryStateBuilder TDiskRegistryStateBuilder::LoadState(
     return builder;
 }
 
-TDiskRegistryState TDiskRegistryStateBuilder::Build()
+std::unique_ptr<TDiskRegistryState> TDiskRegistryStateBuilder::Build()
 {
-    return TDiskRegistryState(
+    return std::make_unique<TDiskRegistryState>(
         std::move(Logging),
         std::move(StorageConfig),
         std::move(Counters),

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h
@@ -256,7 +256,7 @@ struct TDiskRegistryStateBuilder
 
     static TDiskRegistryStateBuilder LoadState(TDiskRegistryDatabase& db);
 
-    TDiskRegistryState Build();
+    std::unique_ptr<TDiskRegistryState> Build();
 
     TDiskRegistryStateBuilder& With(TStorageConfigPtr config);
 


### PR DESCRIPTION
#1155
Сейчас `TDiskRegistryState` - большой монолит. Для распила его на кусочки или добавления нового "модульного" кода мешает тот факт, что этот класс можно копировать и перемещать. Это не позволяет создавать дочерние классы, которые бы хранили raw/weak указатель на `TDiskRegistryState`.
