### PR TITLE
Users/vladstepanyuk/issue 3/1

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
@@ -188,10 +188,14 @@ void TDirectCopyRangeActor::Done(const TActorContext& ctx, NProto::TError error)
     using EExecutionSide =
         TEvNonreplPartitionPrivate::TEvRangeMigrated::EExecutionSide;
 
-    ProcessError(
-        *NActors::TActorContext::ActorSystem(),
-        *TargetInfo->PartConfig,
-        error);
+    if (TargetInfo) {
+        // If target info is nullptr, it means that we failed before reading
+        // stage and there is no need to process error.
+        ProcessError(
+            *NActors::TActorContext::ActorSystem(),
+            *TargetInfo->PartConfig,
+            error);
+    }
 
     const auto writeTs = StartTs + ReadDuration;
     auto response =

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -2882,17 +2882,17 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
 
-        const auto migrationRange = TBlockRange64::WithLength(0, 1024);
         runtime.AdvanceCurrentTime(40ms);
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            0,
-            migrationReadRanges.GetRequestCountWithRange(migrationRange));
         NActors::TDispatchOptions options;
         options.FinalEvents = {NActors::TDispatchOptions::TFinalEventCondition(
             TEvNonreplPartitionPrivate::EvRangeMigrated)};
 
         runtime.DispatchEvents(options);
+
+        const auto migrationRange = TBlockRange64::WithLength(0, 1024);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            migrationReadRanges.GetRequestCountWithRange(migrationRange));
     }
 
     Y_UNIT_TEST(ShouldExecuteMultiWriteRequests)


### PR DESCRIPTION
#3 

Если мы не смогли залочить рейндж, то мы вызываем Done, в котором пытаемся обратится к полю TargetInfo, которое еще пустое. В этом пре просто унес ProcessError под иф
```
#0  std::__y1::shared_ptr<NCloud::NBlockStore::NStorage::TNonreplicatedPartitionConfig>::operator*[abi:v180000]() const (this=0xc0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +905
#1  NCloud::NBlockStore::NStorage::TDirectCopyRangeActor::Done (this=0x465bf1e1070, ctx=..., error=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp +193
#2  NCloud::NBlockStore::NStorage::TDirectCopyRangeActor::HandleLockAndDrainRangeResponse (this=0x465bf1e1070, ev=..., ctx=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp +242
```