### PR TITLE
Send DeviceTimedOut on request allocation failure in the RDMA partition

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -616,7 +616,7 @@ void TNonreplicatedPartitionRdmaActor::HandleDeviceTimedOutResponse(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Attempted to deem device %s as lagging. Result: %s",
+        "[%s] Attempted to mark device %s as lagging. Result: %s",
         PartConfig->GetName().c_str(),
         PartConfig->GetDevices()[ev->Cookie].GetDeviceUUID().c_str(),
         FormatError(msg->GetError()).c_str());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -169,6 +169,10 @@ private:
         const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleDeviceTimedOutResponse(
+        const TEvVolumePrivate::TEvDeviceTimedOutResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     bool HandleRequests(STFUNC_SIG);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -261,6 +261,8 @@ void TNonreplicatedPartitionRdmaActor::HandleChecksumBlocks(
                 ", error: %s",
                 FormatError(err).c_str());
 
+            NotifyDeviceTimedOutIfNeeded(ctx, r.Device.GetDeviceUUID());
+
             NCloud::Reply(
                 ctx,
                 *requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -284,6 +284,8 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocks(
                 " error: %s",
                 FormatError(err).c_str());
 
+            NotifyDeviceTimedOutIfNeeded(ctx, r.Device.GetDeviceUUID());
+
             using TResponse = TEvService::TEvWriteBlocksResponse;
             NCloud::Reply(
                 ctx,
@@ -433,6 +435,8 @@ void TNonreplicatedPartitionRdmaActor::HandleWriteBlocksLocal(
                 "Failed to allocate rdma memory for WriteDeviceBlocksRequest"
                 ", error: %s",
                 FormatError(err).c_str());
+
+            NotifyDeviceTimedOutIfNeeded(ctx, r.Device.GetDeviceUUID());
 
             using TResponse = TEvService::TEvWriteBlocksLocalResponse;
             NCloud::Reply(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -230,6 +230,8 @@ void TNonreplicatedPartitionRdmaActor::HandleZeroBlocks(
                 ", error: %s",
                 FormatError(err).c_str());
 
+            NotifyDeviceTimedOutIfNeeded(ctx, r.Device.GetDeviceUUID());
+
             NCloud::Reply(
                 ctx,
                 *requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_ut.cpp
@@ -40,6 +40,7 @@ enum class EIOType {
     Zero = 2,
     Checksum = 3
 };
+
 struct TTestEnv
 {
     TTestActorRuntime& Runtime;


### PR DESCRIPTION
#3
Когда диск агент недоступен, то скорее всего RDMA партишн даже не попытается отправить запрос, т.к. аллокация памяти сфейлится. Здесь я добавляю учёт этой ошибки, чтобы `DeviceTimedOut` сообщение отправлялось стабильнее. Оно ялвяется триггером к лаганию