### PR TITLE
[Disk Manager] Allow completion generation without configs present

### DIFF
--- a/cloud/disk_manager/pkg/admin/run.go
+++ b/cloud/disk_manager/pkg/admin/run.go
@@ -27,7 +27,12 @@ func Run(
 		Use:   use,
 		Short: "Admin console for Disk Manager service",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Name() == "__complete" || cmd.Name() == "__completeNoDesc" {
+			helperCommands := map[string]struct{}{
+				"__complete":       {},
+				"__completeNoDesc": {},
+				"completion":       {},
+			}
+			if _, ok := helperCommands[cmd.Name()]; ok {
 				return nil
 			}
 


### PR DESCRIPTION
Requiring config presence to generate completions would be illogical in the first place.