### PR TITLE
Test fix: fix use of uninitialize values in ydbstats

### DIFF
--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -222,10 +222,10 @@ struct TYdbGroupRow
     static constexpr TStringBuf TimestampName = "Timestamp";
     static constexpr TDuration TtlDuration = TDuration::Days(7);
 
-    ui64 TabletId;
-    ui32 Channel;
-    ui32 GroupId;
-    ui32 Generation;
+    ui64 TabletId = 0;
+    ui32 Channel = 0;
+    ui32 GroupId = 0;
+    ui32 Generation = 0;
     TInstant Timestamp;
 
     NYdb::TValue GetYdbValues() const;
@@ -239,8 +239,8 @@ struct TYdbPartitionRow
     static constexpr TStringBuf TimestampName = "Timestamp";
     static constexpr TDuration TtlDuration = TDuration::Days(7);
 
-    ui64 PartitionTabletId;
-    ui64 VolumeTabletId;
+    ui64 PartitionTabletId = 0;
+    ui64 VolumeTabletId = 0;
     TString DiskId;
     TInstant Timestamp;
 


### PR DESCRIPTION
```
Test crashed (return code: 100)
==995313==WARNING: MemorySanitizer: use-of-uninitialized-value
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0x180 has a premature terminator entry at offset 0x190
warning: address range table at offset 0x1b0 has a premature terminator entry at offset 0x1c0
warning: address range table at offset 0x1e0 has a premature terminator entry at offset 0x1f0
warning: address range table at offset 0x790 has a premature terminator entry at offset 0x7a0
warning: address range table at offset 0x7c0 has a premature terminator entry at offset 0x7d0
warning: address range table at offset 0x7f0 has a premature terminator entry at offset 0x800
warning: address range table at offset 0x820 has a premature terminator entry at offset 0x830
warning: address range table at offset 0x850 has a premature terminator entry at offset 0x860
warning: address range table at offset 0x880 has a premature terminator entry at offset 0x890
warning: address range table at offset 0x8b0 has a premature terminator entry at offset 0x8c0
warning: address range table at offset 0x8e0 has a premature terminator entry at offset 0x8f0
warning: address range table at offset 0x910 has a premature terminator entry at offset 0x920
warning: address range table at offset 0x940 has a premature terminator entry at offset 0x950
warning: address range table at offset 0x970 has a premature terminator entry at offset 0x980
warning: address range table at offset 0x9a0 has a premature terminator entry at offset 0x9b0
warning: address range table at offset 0x9d0 has a premature terminator entry at offset 0x9e0
warning: address range table at offset 0xa00 has a premature terminator entry at offset 0xa10
warning: address range table at offset 0xa30 has a premature terminator entry at offset 0xa40
warning: address range table at offset 0xb50 has a premature terminator entry at offset 0xb60
warning: address range table at offset 0xb80 has a premature terminator entry at offset 0xb90
warning: address range table at offset 0xbe0 has a premature terminator entry at offset 0xbf0
warning: address range table at offset 0xc40 has a premature terminator entry at offset 0xc50
warning: address range table at offset 0xc70 has a premature terminator entry at offset 0xc80
warning: address range table at offset 0xca0 has a premature terminator entry at offset 0xcb0
warning: address range table at offset 0xcd0 has a premature terminator entry at offset 0xce0
warning: address range table at offset 0xd00 has a premature terminator entry at offset 0xd10
warning: address range table at offset 0xd30 has a premature terminator entry at offset 0xd40
warning: address range table at offset 0xd60 has a premature terminator entry at offset 0xd70
    #0 0x200472d2 in NCloud::NBlockStore::NYdbStats::TYdbGroupRow::GetYdbValues() const /-S/cloud/blockstore/libs/ydbstats/ydbrow.cpp:111:41
    #1 0x20026fa1 in NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TYdbStatsUploader::DoUploadStats(const NCloud::NBlockStore::NYdbStats::TYdbRowData &, const NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TSetupTablesResult &)::(anonymous class)::operator() /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:443:41
    #2 0x20026fa1 in std::__y1::__invoke<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:440:26) &, NYdb::TValueBuilder &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25
    #3 0x20026fa1 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:440:26) &, NYdb::TValueBuilder &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5
    #4 0x20026fa1 in std::__y1::__function::__alloc_func<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:440:26), std::__y1::allocator<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:440:26)>, void (NYdb::TValueBuilder &)>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16
    #5 0x20026fa1 in std::__y1::__function::__func<NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TYdbStatsUploader::DoUploadStats(NCloud::NBlockStore::NYdbStats::TYdbRowData const&, NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TSetupTablesResult const&)::$_3, std::__y1::allocator<NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TYdbStatsUploader::DoUploadStats(NCloud::NBlockStore::NYdbStats::TYdbRowData const&, NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TSetupTablesResult const&)::$_3>, void (NYdb::TValueBuilder&)>::operator()(NYdb::TValueBuilder&) /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12
    #6 0x1ffe3afe in std::__y1::__function::__value_func<void (NYdb::TValueBuilder &)>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16
    #7 0x1ffe3afe in std::__y1::function<void (NYdb::TValueBuilder &)>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12
    #8 0x1ffe3afe in NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TYdbStatsUploader::DoUploadStats(const NCloud::NBlockStore::NYdbStats::TYdbRowData &, const NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TSetupTablesResult &)::(anonymous class)::operator() /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:457:9
    #9 0x1ffe3afe in NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TYdbStatsUploader::DoUploadStats(NCloud::NBlockStore::NYdbStats::TYdbRowData const&, NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TSetupTablesResult const&) /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:496:13
    #10 0x1ffe0c9b in NCloud::NBlockStore::NYdbStats::(anonymous namespace)::TYdbStatsUploader::UploadStats(NCloud::NBlockStore::NYdbStats::TYdbRowData const&) /-S/cloud/blockstore/libs/ydbstats/ydbstats.cpp:410:16
    #11 0xacb2179 in NCloud::NBlockStore::NYdbStats::NTestSuiteTYdbStatsUploadTest::TTestCaseShouldReportNotFoundInCaseOfSchemeErrors::Execute_(NUnitTest::TTestContext&) /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:732:35
    #12 0xacd91f6 in NCloud::NBlockStore::NYdbStats::NTestSuiteTYdbStatsUploadTest::TCurrentTest::Execute()::(anonymous class)::operator() /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:525:1
    #13 0xacd91f6 in std::__y1::__invoke<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:525:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25
    #14 0xacd91f6 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:525:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5
    #15 0xacd91f6 in std::__y1::__function::__alloc_func<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:525:1), std::__y1::allocator<(lambda at /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:525:1)>, void ()>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16
    #16 0xacd91f6 in std::__y1::__function::__func<NCloud::NBlockStore::NYdbStats::NTestSuiteTYdbStatsUploadTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NYdbStats::NTestSuiteTYdbStatsUploadTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12
    #17 0xb1d3e6b in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:374:18
    #18 0xacd7bdd in NCloud::NBlockStore::NYdbStats::NTestSuiteTYdbStatsUploadTest::TCurrentTest::Execute() /-S/cloud/blockstore/libs/ydbstats/ydbstats_ut.cpp:525:1
    #19 0xb1d577f in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:495:19
    #20 0xb200074 in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:872:44
    #21 0x7f6fa3255082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/../csu/libc-start.c:308:16
    #22 0x9014028 in _start (build-release/cloud/blockstore/libs/ydbstats/ut/cloud-blockstore-libs-ydbstats-ut+0x9014028) (BuildId: e2c2836a3a1eb2d83beff2d784032a57204f06e7)
SUMMARY: MemorySanitizer: use-of-uninitialized-value /-S/cloud/blockstore/libs/ydbstats/ydbrow.cpp:111:41 in NCloud::NBlockStore::NYdbStats::TYdbGroupRow::GetYdbValues() const
Exiting
```