### PR TITLE
[Blockstore] send info about partitions and channels to stats service on partition start; upload this information to ydbstats

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1238,5 +1238,5 @@ message TStorageServiceConfig
     optional uint32 NetworkForwardingTimeout = 430;
 
     // Maximum number of rows to be wtitten to YDB in a single request.
-    optional uint32 StatsUploadRowCount = 431;
+    optional uint32 StatsUploadRowChunkSize = 431;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1236,4 +1236,7 @@ message TStorageServiceConfig
     // Additional time to receive a response from the DiskAgent through which
     // the MultiAgentWrite request was executed.
     optional uint32 NetworkForwardingTimeout = 430;
+
+    // Maximum number of rows to be wtitten to YDB in a single request.
+    optional uint32 StatsUploadRowCount = 431;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1237,6 +1237,6 @@ message TStorageServiceConfig
     // the MultiAgentWrite request was executed.
     optional uint32 NetworkForwardingTimeout = 430;
 
-    // Maximum number of rows to be wtitten to YDB in a single request.
-    optional uint32 StatsUploadRowChunkSize = 431;
+    // Maximum number of rows to be written to YDB in a single request.
+    optional uint32 StatsUploadMaxRowsPerTx = 431;
 }

--- a/cloud/blockstore/libs/storage/api/stats_service.h
+++ b/cloud/blockstore/libs/storage/api/stats_service.h
@@ -80,16 +80,16 @@ struct TEvStatsService
     };
 
     //
-    // PartBootExternal notification
+    // PartitionBootExternalCompleted notification
     //
 
-    struct TPartBootExternal
+    struct TPartitionBootExternalCompleted
     {
         const TString DiskId;
         const ui64 PartitionTabletId;
         TVector<NKikimr::TTabletChannelInfo> ChannelInfos;
 
-        TPartBootExternal(
+        TPartitionBootExternalCompleted(
                 TString diskId,
                 ui64 partitionTabletId,
                 TVector<NKikimr::TTabletChannelInfo> channelInfos)
@@ -207,7 +207,7 @@ struct TEvStatsService
         EvRegisterVolume,
         EvUnregisterVolume,
         EvVolumeConfigUpdated,
-        EvPartBootExternal,
+        EvPartitionBootExternalCompleted,
         EvVolumePartCounters,
         EvVolumeSelfCounters,
         EvGetVolumeStatsRequest,
@@ -236,9 +236,9 @@ struct TEvStatsService
         EvVolumeConfigUpdated
     >;
 
-    using TEvPartBootExternal = TRequestEvent<
-        TPartBootExternal,
-        EvPartBootExternal
+    using TEvPartitionBootExternalCompleted = TRequestEvent<
+        TPartitionBootExternalCompleted,
+        EvPartitionBootExternalCompleted
     >;
 
     using TEvVolumePartCounters = TRequestEvent<

--- a/cloud/blockstore/libs/storage/api/stats_service.h
+++ b/cloud/blockstore/libs/storage/api/stats_service.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "public.h"
-#include "contrib/ydb/core/base/blobstorage.h"
 
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
@@ -10,6 +9,7 @@
 #include <cloud/blockstore/libs/storage/core/metrics.h>
 #include <cloud/blockstore/libs/storage/protos/volume.pb.h>
 
+#include <contrib/ydb/core/base/blobstorage.h>
 #include <contrib/ydb/core/protos/tablet.pb.h>
 #include <contrib/ydb/library/actors/core/actorid.h>
 

--- a/cloud/blockstore/libs/storage/api/stats_service.h
+++ b/cloud/blockstore/libs/storage/api/stats_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "public.h"
+#include "contrib/ydb/core/base/blobstorage.h"
 
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/events.h>
@@ -75,6 +76,26 @@ struct TEvStatsService
                 NProto::TVolume config)
             : DiskId(std::move(diskId))
             , Config(std::move(config))
+        {}
+    };
+
+    //
+    // PartBootExternal notification
+    //
+
+    struct TPartBootExternal
+    {
+        const TString DiskId;
+        const ui64 PartitionTabletId;
+        TVector<NKikimr::TTabletChannelInfo> ChannelInfos;
+
+        TPartBootExternal(
+                TString diskId,
+                ui64 partitionTabletId,
+                TVector<NKikimr::TTabletChannelInfo> channelInfos)
+            : DiskId(std::move(diskId))
+            , PartitionTabletId(partitionTabletId)
+            , ChannelInfos(std::move(channelInfos))
         {}
     };
 
@@ -186,6 +207,7 @@ struct TEvStatsService
         EvRegisterVolume,
         EvUnregisterVolume,
         EvVolumeConfigUpdated,
+        EvPartBootExternal,
         EvVolumePartCounters,
         EvVolumeSelfCounters,
         EvGetVolumeStatsRequest,
@@ -212,6 +234,11 @@ struct TEvStatsService
     using TEvVolumeConfigUpdated = TRequestEvent<
         TVolumeConfigUpdated,
         EvVolumeConfigUpdated
+    >;
+
+    using TEvPartBootExternal = TRequestEvent<
+        TPartBootExternal,
+        EvPartBootExternal
     >;
 
     using TEvVolumePartCounters = TRequestEvent<

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -463,6 +463,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(EnableConversionIntoMixedIndexV2,          bool,      false           )\
                                                                                \
     xxx(StatsUploadDiskCount,                      ui32,      1000            )\
+    xxx(StatsUploadRowCount,                       ui32,      10000           )\
     xxx(StatsUploadRetryTimeout,                   TDuration, Seconds(5)      )\
                                                                                \
     xxx(RemoteMountOnly,                           bool,      false           )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -463,7 +463,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(EnableConversionIntoMixedIndexV2,          bool,      false           )\
                                                                                \
     xxx(StatsUploadDiskCount,                      ui32,      1000            )\
-    xxx(StatsUploadRowCount,                       ui32,      10000           )\
+    xxx(StatsUploadRowChunkSize,                   ui32,      10000           )\
     xxx(StatsUploadRetryTimeout,                   TDuration, Seconds(5)      )\
                                                                                \
     xxx(RemoteMountOnly,                           bool,      false           )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -463,7 +463,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(EnableConversionIntoMixedIndexV2,          bool,      false           )\
                                                                                \
     xxx(StatsUploadDiskCount,                      ui32,      1000            )\
-    xxx(StatsUploadRowChunkSize,                   ui32,      10000           )\
+    xxx(StatsUploadMaxRowsPerTx,                   ui32,      10000           )\
     xxx(StatsUploadRetryTimeout,                   TDuration, Seconds(5)      )\
                                                                                \
     xxx(RemoteMountOnly,                           bool,      false           )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -476,7 +476,7 @@ public:
     bool GetEnableConversionIntoMixedIndexV2() const;
 
     ui32 GetStatsUploadDiskCount() const;
-    ui32 GetStatsUploadRowCount() const;
+    ui32 GetStatsUploadRowChunkSize() const;
     TDuration GetStatsUploadRetryTimeout() const;
 
     bool GetRemoteMountOnly() const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -476,7 +476,7 @@ public:
     bool GetEnableConversionIntoMixedIndexV2() const;
 
     ui32 GetStatsUploadDiskCount() const;
-    ui32 GetStatsUploadRowChunkSize() const;
+    ui32 GetStatsUploadMaxRowsPerTx() const;
     TDuration GetStatsUploadRetryTimeout() const;
 
     bool GetRemoteMountOnly() const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -476,6 +476,7 @@ public:
     bool GetEnableConversionIntoMixedIndexV2() const;
 
     ui32 GetStatsUploadDiskCount() const;
+    ui32 GetStatsUploadRowCount() const;
     TDuration GetStatsUploadRetryTimeout() const;
 
     bool GetRemoteMountOnly() const;

--- a/cloud/blockstore/libs/storage/service/service_ut.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut.cpp
@@ -56,7 +56,7 @@ ui32 SetupTestEnvWithYdbStats(
 
     NProto::TStorageServiceConfig storageServiceConfig;
     storageServiceConfig.SetStatsUploadDiskCount(diskCnt);
-    storageServiceConfig.SetStatsUploadRowChunkSize(rowCnt);
+    storageServiceConfig.SetStatsUploadMaxRowsPerTx(rowCnt);
     storageServiceConfig.SetStatsUploadInterval(statsUploadInterval.MilliSeconds());
     storageServiceConfig.SetStatsUploadRetryTimeout(statsUploadRetryTimeout.MilliSeconds());
 

--- a/cloud/blockstore/libs/storage/service/service_ut.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut.cpp
@@ -56,7 +56,7 @@ ui32 SetupTestEnvWithYdbStats(
 
     NProto::TStorageServiceConfig storageServiceConfig;
     storageServiceConfig.SetStatsUploadDiskCount(diskCnt);
-    storageServiceConfig.SetStatsUploadRowCount(rowCnt);
+    storageServiceConfig.SetStatsUploadRowChunkSize(rowCnt);
     storageServiceConfig.SetStatsUploadInterval(statsUploadInterval.MilliSeconds());
     storageServiceConfig.SetStatsUploadRetryTimeout(statsUploadRetryTimeout.MilliSeconds());
 

--- a/cloud/blockstore/libs/storage/service/service_ut.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut.cpp
@@ -47,6 +47,7 @@ ui32 SetupTestEnv(
 ui32 SetupTestEnvWithYdbStats(
     TTestEnv& env,
     ui32 diskCnt,
+    ui32 rowCnt,
     TDuration statsUploadInterval,
     TDuration statsUploadRetryTimeout,
     NYdbStats::IYdbVolumesStatsUploaderPtr ydbStatsUploader)
@@ -55,6 +56,7 @@ ui32 SetupTestEnvWithYdbStats(
 
     NProto::TStorageServiceConfig storageServiceConfig;
     storageServiceConfig.SetStatsUploadDiskCount(diskCnt);
+    storageServiceConfig.SetStatsUploadRowCount(rowCnt);
     storageServiceConfig.SetStatsUploadInterval(statsUploadInterval.MilliSeconds());
     storageServiceConfig.SetStatsUploadRetryTimeout(statsUploadRetryTimeout.MilliSeconds());
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.cpp
@@ -122,6 +122,7 @@ STFUNC(TStatsServiceActor::StateWork)
         HFunc(TEvStatsService::TEvRegisterVolume, HandleRegisterVolume);
         HFunc(TEvStatsService::TEvUnregisterVolume, HandleUnregisterVolume);
         HFunc(TEvStatsService::TEvVolumeConfigUpdated, HandleVolumeConfigUpdated);
+        HFunc(TEvStatsService::TEvPartBootExternal, HandlePartBootExternal);
         HFunc(TEvStatsService::TEvVolumePartCounters, HandleVolumePartCounters);
         HFunc(TEvStatsService::TEvVolumeSelfCounters, HandleVolumeSelfCounters);
         HFunc(TEvStatsService::TEvGetVolumeStatsRequest, HandleGetVolumeStats);

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.cpp
@@ -122,7 +122,9 @@ STFUNC(TStatsServiceActor::StateWork)
         HFunc(TEvStatsService::TEvRegisterVolume, HandleRegisterVolume);
         HFunc(TEvStatsService::TEvUnregisterVolume, HandleUnregisterVolume);
         HFunc(TEvStatsService::TEvVolumeConfigUpdated, HandleVolumeConfigUpdated);
-        HFunc(TEvStatsService::TEvPartBootExternal, HandlePartBootExternal);
+        HFunc(
+            TEvStatsService::TEvPartitionBootExternalCompleted,
+            HandlePartitionBootExternalCompleted);
         HFunc(TEvStatsService::TEvVolumePartCounters, HandleVolumePartCounters);
         HFunc(TEvStatsService::TEvVolumeSelfCounters, HandleVolumeSelfCounters);
         HFunc(TEvStatsService::TEvGetVolumeStatsRequest, HandleGetVolumeStats);

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -110,7 +110,7 @@ private:
 
     void PushYdbStats(const NActors::TActorContext& ctx);
 
-    void SplitRowsIntoRequests(
+    TVector<TStatsUploadRequest> SplitRowsIntoRequests(
         NYdbStats::TYdbRowData rows,
         const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -137,8 +137,8 @@ private:
         const TEvStatsService::TEvUnregisterVolume::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    void HandlePartBootExternal(
-        const TEvStatsService::TEvPartBootExternal::TPtr& ev,
+    void HandlePartitionBootExternalCompleted(
+        const TEvStatsService::TEvPartitionBootExternalCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleVolumePartCounters(

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -137,6 +137,10 @@ private:
         const TEvStatsService::TEvUnregisterVolume::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandlePartBootExternal(
+        const TEvStatsService::TEvPartBootExternal::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleVolumePartCounters(
         const TEvStatsService::TEvVolumePartCounters::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -110,6 +110,10 @@ private:
 
     void PushYdbStats(const NActors::TActorContext& ctx);
 
+    void SplitRowsIntoRequests(
+        NYdbStats::TYdbRowData rows,
+        const NActors::TActorContext& ctx);
+
     [[nodiscard]] ui32 CalcBandwidthLimit(const TString& sourceId) const;
     void ScheduleCleanupBackgroundSources(
         const NActors::TActorContext& ctx) const;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -299,7 +299,9 @@ void TStatsServiceActor::HandlePartitionBootExternalCompleted(
 
     auto volume = State.GetVolume(msg->DiskId);
     if (!volume) {
-        LOG_WARN(ctx, TBlockStoreComponents::STATS_SERVICE,
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::STATS_SERVICE,
             "Volume %s not found",
             msg->DiskId.Quote().data());
         return;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -291,8 +291,8 @@ void TStatsServiceActor::HandleUnregisterVolume(
     }
 }
 
-void TStatsServiceActor::HandlePartBootExternal(
-    const TEvStatsService::TEvPartBootExternal::TPtr& ev,
+void TStatsServiceActor::HandlePartitionBootExternalCompleted(
+    const TEvStatsService::TEvPartitionBootExternalCompleted::TPtr& ev,
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -291,6 +291,24 @@ void TStatsServiceActor::HandleUnregisterVolume(
     }
 }
 
+void TStatsServiceActor::HandlePartBootExternal(
+    const TEvStatsService::TEvPartBootExternal::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    auto volume = State.GetVolume(msg->DiskId);
+    if (!volume) {
+        LOG_WARN(ctx, TBlockStoreComponents::STATS_SERVICE,
+            "Volume %s not found",
+            msg->DiskId.Quote().data());
+        return;
+    }
+
+    volume->ChannelInfos[msg->PartitionTabletId] =
+        std::move(msg->ChannelInfos);
+}
+
 void TStatsServiceActor::HandleVolumePartCounters(
     const TEvStatsService::TEvVolumePartCounters::TPtr& ev,
     const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -434,13 +434,13 @@ void TStatsServiceActor::SplitRowsIntoRequests(
     }
 
     for (ui32 from = 0; from < rows.Groups.size();
-         from += Config->GetStatsUploadRowChunkSize())
+         from += Config->GetStatsUploadMaxRowsPerTx())
     {
         TStatsUploadRequest request;
         request.second = timestamp;
 
         ui32 to = std::min(
-            from + Config->GetStatsUploadRowChunkSize(),
+            from + Config->GetStatsUploadMaxRowsPerTx(),
             static_cast<ui32>(rows.Groups.size()));
         request.first.Groups.reserve(to - from);
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -434,13 +434,13 @@ void TStatsServiceActor::SplitRowsIntoRequests(
     }
 
     for (ui32 from = 0; from < rows.Groups.size();
-         from += Config->GetStatsUploadRowCount())
+         from += Config->GetStatsUploadRowChunkSize())
     {
         TStatsUploadRequest request;
         request.second = timestamp;
 
         ui32 to = std::min(
-            from + Config->GetStatsUploadRowCount(),
+            from + Config->GetStatsUploadRowChunkSize(),
             static_cast<ui32>(rows.Groups.size()));
         request.first.Groups.reserve(to - from);
 
@@ -512,7 +512,7 @@ void TStatsServiceActor::HandleUploadDisksStats(
         ));
     }
 
-    SplitRowsIntoRequests(rows, ctx);
+    SplitRowsIntoRequests(std::move(rows), ctx);
     PushYdbStats(ctx);
 
     ScheduleStatsUpload(ctx);

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "contrib/ydb/core/base/blobstorage.h"
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
@@ -133,6 +134,8 @@ struct TVolumeStatsInfo
     NBlobMetrics::TBlobLoadMetrics OffsetBlobMetrics;
     TInstant ApproximateStartTs;
     TDuration ApproximateBootstrapTime;
+
+    THashMap<ui64, TVector<NKikimr::TTabletChannelInfo>> ChannelInfos;
 
     TVolumeStatsInfo(
             NProto::TVolume config,

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "contrib/ydb/core/base/blobstorage.h"
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
@@ -9,6 +8,7 @@
 
 #include <cloud/storage/core/libs/common/media.h>
 
+#include <contrib/ydb/core/base/blobstorage.h>
 #include <contrib/ydb/library/actors/core/actorid.h>
 
 #include <util/datetime/base.h>

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -1209,7 +1209,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
 
         NProto::TStorageServiceConfig storageServiceConfig;
         storageServiceConfig.SetStatsUploadDiskCount(1);
-        storageServiceConfig.SetStatsUploadRowChunkSize(3);
+        storageServiceConfig.SetStatsUploadMaxRowsPerTx(3);
         storageServiceConfig.SetStatsUploadInterval(
             TDuration::Seconds(300).MilliSeconds());
         storageServiceConfig.SetStatsUploadRetryTimeout(

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -1209,7 +1209,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
 
         NProto::TStorageServiceConfig storageServiceConfig;
         storageServiceConfig.SetStatsUploadDiskCount(1);
-        storageServiceConfig.SetStatsUploadRowCount(3);
+        storageServiceConfig.SetStatsUploadRowChunkSize(3);
         storageServiceConfig.SetStatsUploadInterval(
             TDuration::Seconds(300).MilliSeconds());
         storageServiceConfig.SetStatsUploadRetryTimeout(

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -170,14 +170,14 @@ void RegisterVolume(
     RegisterVolume(runtime, diskId, 0);
 }
 
-void PartBootExternal(
+void PartitionBootExternalCompleted(
     TTestActorRuntime& runtime,
     const TString& diskId,
     const ui64 partitionTabletId,
     TVector<NKikimr::TTabletChannelInfo> channels)
 {
-    auto partBootExternalResponseMsg =
-        std::make_unique<TEvStatsService::TEvPartBootExternal>(
+    auto partitionBootExternalCompletedMsg =
+        std::make_unique<TEvStatsService::TEvPartitionBootExternalCompleted>(
             diskId,
             partitionTabletId,
             std::move(channels));
@@ -185,7 +185,7 @@ void PartBootExternal(
         new IEventHandle(
             MakeStorageStatsServiceId(),
             MakeStorageStatsServiceId(),
-            partBootExternalResponseMsg.release(),
+            partitionBootExternalCompletedMsg.release(),
             0, // flags
             0),
             0);
@@ -1132,22 +1132,22 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
                 {0 /* fromGeneration */, 3 /* groupId*/},
                 {2 /* fromGeneration */, 2 /* groupId*/}};
 
-            PartBootExternal(
+            PartitionBootExternalCompleted(
                 runtime,
                 "vol1",
                 9, // partitionTabletId
                 std::move(channels9));
-            PartBootExternal(
+            PartitionBootExternalCompleted(
                 runtime,
                 "vol2",
                 18, // partitionTabletId
                 std::move(channels18));
-            PartBootExternal(
+            PartitionBootExternalCompleted(
                 runtime,
                 "vol2",
                 19, // partitionTabletId
                 std::move(channels19));
-            PartBootExternal(
+            PartitionBootExternalCompleted(
                 runtime,
                 "vol3",
                 29, // partitionTabletId

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -186,9 +186,9 @@ void PartitionBootExternalCompleted(
             MakeStorageStatsServiceId(),
             MakeStorageStatsServiceId(),
             partitionBootExternalCompletedMsg.release(),
-            0, // flags
+            0,   // flags
             0),
-            0);
+        0);
 }
 
 void SendDiskStats(

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -476,6 +476,10 @@ private:
     bool SendBootExternalRequest(
         const NActors::TActorContext& ctx,
         TPartitionInfo& partition);
+    void SendPartBootExternalToStatsService(
+        const NActors::TActorContext& ctx,
+        ui64 partTabletId,
+        const TVector<NKikimr::TTabletChannelInfo>& channels);
 
     void ScheduleRetryStartPartition(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -476,10 +476,6 @@ private:
     bool SendBootExternalRequest(
         const NActors::TActorContext& ctx,
         TPartitionInfo& partition);
-    void SendPartBootExternalToStatsService(
-        const NActors::TActorContext& ctx,
-        ui64 partTabletId,
-        const TVector<NKikimr::TTabletChannelInfo>& channels);
 
     void ScheduleRetryStartPartition(
         const NActors::TActorContext& ctx,


### PR DESCRIPTION
- Send info about channels and groups of the partition tablet to stats service actor. We do this on partition start (namely, in In TVolumeActor::HandleBootExternalResponse).
- In stats volume actor, we send the corresponding information to ydb tables that were introdiced here https://github.com/ydb-platform/nbs/pull/3433.