### PR TITLE
Eliminate possibility of a race condition in adding lagging agent to the volume DB

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/helpers.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/helpers.cpp
@@ -211,8 +211,8 @@ TVector<NProto::TLaggingDevice> CollectLaggingDevices(
     return result;
 }
 
-bool HaveCommonRows(
-    const TVector<NProto::TLaggingDevice>& laggingCandidates,
+bool GetHaveCommonRows(
+    const RepeatedPtrField<NProto::TLaggingDevice>& laggingCandidates,
     const RepeatedPtrField<NProto::TLaggingDevice>& alreadyLagging)
 {
     TLaggingDeviceIndexCmp cmp;
@@ -222,7 +222,7 @@ bool HaveCommonRows(
     Y_ABORT_UNLESS(IsSorted(alreadyLagging.begin(), alreadyLagging.end(), cmp));
 
     for (int i = 0, j = 0;
-         i < laggingCandidates.ysize() && j < alreadyLagging.size();)
+         i < laggingCandidates.size() && j < alreadyLagging.size();)
     {
         if (cmp(laggingCandidates[i], alreadyLagging[j])) {
             i++;

--- a/cloud/blockstore/libs/storage/volume/model/helpers.h
+++ b/cloud/blockstore/libs/storage/volume/model/helpers.h
@@ -25,8 +25,9 @@ namespace NCloud::NBlockStore::NStorage {
     ui32 rowIndex,
     ui32 timedOutDeviceReplicaIndex);
 
-[[nodiscard]] bool HaveCommonRows(
-    const TVector<NProto::TLaggingDevice>& laggingCandidates,
+[[nodiscard]] bool GetHaveCommonRows(
+    const google::protobuf::RepeatedPtrField<NProto::TLaggingDevice>&
+        laggingCandidates,
     const google::protobuf::RepeatedPtrField<NProto::TLaggingDevice>&
         alreadyLagging);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
 #include <cloud/blockstore/libs/storage/volume/model/helpers.h>
+
 #include <cloud/storage/core/libs/common/media.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
@@ -178,94 +179,13 @@ void TVolumeActor::HandleDeviceTimedOut(
             timedOutDeviceConfig->GetAgentId());
     Y_DEBUG_ABORT_UNLESS(!timedOutAgentDevices.empty());
 
-    for (const auto& laggingAgent: meta.GetLaggingAgentsInfo().GetAgents()) {
-        // Whether the agent is lagging already.
-        if (laggingAgent.GetAgentId() == timedOutDeviceConfig->GetAgentId()) {
-            LOG_WARN(
-                ctx,
-                TBlockStoreComponents::VOLUME,
-                "[%lu] Agent %s is already lagging",
-                TabletID(),
-                laggingAgent.GetAgentId().c_str());
-
-            STORAGE_CHECK_PRECONDITION(
-                laggingAgent.DevicesSize() == timedOutAgentDevices.size());
-            NCloud::Send(
-                ctx,
-                State->GetDiskRegistryBasedPartitionActor(),
-                std::make_unique<
-                    TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest>(
-                    laggingAgent));
-
-            auto response =
-                std::make_unique<TEvVolumePrivate::TEvDeviceTimedOutResponse>(
-                    MakeError(S_ALREADY, "Device is already lagging"));
-            NCloud::Reply(ctx, *ev, std::move(response));
-            return;
-        }
-
-        // Intersect row indexes of known lagging devices and a new one. We only
-        // allow one lagging device per row.
-        const bool intersects =
-            HaveCommonRows(timedOutAgentDevices, laggingAgent.GetDevices());
-        if (intersects) {
-            // TODO(komarevtsev-d): Allow source and target of the migration to
-            // lag at the same time. "TLaggingAgentsReplicaProxyActor" does not
-            // support this yet.
-            LOG_WARN(
-                ctx,
-                TBlockStoreComponents::VOLUME,
-                "[%lu] Will not add a lagging agent %s. Agent's "
-                "devices intersect with already lagging %s",
-                TabletID(),
-                timedOutDeviceConfig->GetAgentId().c_str(),
-                laggingAgent.GetAgentId().c_str());
-
-            auto response =
-                std::make_unique<TEvVolumePrivate::TEvDeviceTimedOutResponse>(
-                    MakeError(
-                        E_INVALID_STATE,
-                        TStringBuilder()
-                            << "There are other lagging devices on agent "
-                            << laggingAgent.GetAgentId()));
-            NCloud::Reply(ctx, *ev, std::move(response));
-            return;
-        }
-    }
-
-    // Check for fresh devices in the same row.
-    for (const auto& laggingDevice: timedOutAgentDevices) {
-        const bool rowHasFreshDevice = RowHasFreshDevices(
-            meta,
-            laggingDevice.GetRowIndex(),
-            *timedOutDeviceReplicaIndex);
-        if (rowHasFreshDevice) {
-            LOG_WARN(
-                ctx,
-                TBlockStoreComponents::VOLUME,
-                "[%lu] There are other fresh devices on the same row with "
-                "device %s",
-                TabletID(),
-                laggingDevice.GetDeviceUUID().c_str());
-
-            auto response =
-                std::make_unique<TEvVolumePrivate::TEvDeviceTimedOutResponse>(
-                    MakeError(
-                        E_INVALID_STATE,
-                        TStringBuilder() << "There are other fresh devices on "
-                                            "the same row with device "
-                                         << laggingDevice.GetDeviceUUID()));
-            NCloud::Reply(ctx, *ev, std::move(response));
-            return;
-        }
-    }
-
     NProto::TLaggingAgent unavailableAgent;
     unavailableAgent.SetAgentId(timedOutDeviceConfig->GetAgentId());
     unavailableAgent.SetReplicaIndex(*timedOutDeviceReplicaIndex);
     unavailableAgent.MutableDevices()->Assign(
         std::make_move_iterator(timedOutAgentDevices.begin()),
         std::make_move_iterator(timedOutAgentDevices.end()));
+
     auto requestInfo =
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
     AddTransaction(*requestInfo);
@@ -351,12 +271,79 @@ void TVolumeActor::ExecuteAddLaggingAgent(
     TTxVolume::TAddLaggingAgent& args)
 {
     Y_DEBUG_ABORT_UNLESS(!args.Agent.GetDevices().empty());
+    const auto& meta = State->GetMeta();
+    for (const auto& laggingAgent: meta.GetLaggingAgentsInfo().GetAgents()) {
+        // Whether the agent is lagging already.
+        if (laggingAgent.GetAgentId() == args.Agent.GetAgentId()) {
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::VOLUME,
+                "[%lu] Agent %s is already lagging",
+                TabletID(),
+                laggingAgent.GetAgentId().c_str());
+
+            STORAGE_CHECK_PRECONDITION(
+                laggingAgent.DevicesSize() == args.Agent.DevicesSize());
+            args.Error = MakeError(S_ALREADY, "Device is already lagging");
+            return;
+        }
+
+        // Intersect row indexes of known lagging devices and a new one. We only
+        // allow one lagging device per row.
+        const bool intersects = GetHaveCommonRows(
+            args.Agent.GetDevices(),
+            laggingAgent.GetDevices());
+        if (intersects) {
+            // TODO(komarevtsev-d): Allow source and target of the migration to
+            // lag at the same time. "TLaggingAgentsReplicaProxyActor" does not
+            // support this yet.
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::VOLUME,
+                "[%lu] Will not add a lagging agent %s. Agent's "
+                "devices intersect with already lagging %s",
+                TabletID(),
+                args.Agent.GetAgentId().Quote().c_str(),
+                laggingAgent.GetAgentId().Quote().c_str());
+
+            args.Error = MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "There are other lagging devices on agent "
+                                 << laggingAgent.GetAgentId());
+            return;
+        }
+    }
+
+    // Check for fresh devices in the same row.
+    for (const auto& laggingDevice: args.Agent.GetDevices()) {
+        const bool rowHasFreshDevice = RowHasFreshDevices(
+            meta,
+            laggingDevice.GetRowIndex(),
+            args.Agent.GetReplicaIndex());
+        if (rowHasFreshDevice) {
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::VOLUME,
+                "[%lu] There are other fresh devices on the same row with "
+                "device %s",
+                TabletID(),
+                laggingDevice.GetDeviceUUID().c_str());
+
+            args.Error = MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "There are other fresh devices on "
+                                    "the same row with device "
+                                 << laggingDevice.GetDeviceUUID());
+            return;
+        }
+    }
+
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
         "[%lu] Add lagging agent: %s, replicaIndex: %u, devices: ( %s )",
         TabletID(),
-        args.Agent.GetAgentId().c_str(),
+        args.Agent.GetAgentId().Quote().c_str(),
         args.Agent.GetReplicaIndex(),
         [&laggingDevices = args.Agent.GetDevices()]()
         {
@@ -370,8 +357,8 @@ void TVolumeActor::ExecuteAddLaggingAgent(
         }()
             .c_str());
 
-    TVolumeDatabase db(tx.DB);
     State->AddLaggingAgent(args.Agent);
+    TVolumeDatabase db(tx.DB);
     db.WriteMeta(State->GetMeta());
 }
 
@@ -379,17 +366,22 @@ void TVolumeActor::CompleteAddLaggingAgent(
     const TActorContext& ctx,
     TTxVolume::TAddLaggingAgent& args)
 {
-    const auto& partActorId = State->GetDiskRegistryBasedPartitionActor();
-    Y_DEBUG_ABORT_UNLESS(partActorId);
-    NCloud::Send(
-        ctx,
-        partActorId,
-        std::make_unique<TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest>(
-            args.Agent));
-
     RemoveTransaction(*args.RequestInfo);
+
+    if (!HasError(args.Error)) {
+        const auto& partActorId = State->GetDiskRegistryBasedPartitionActor();
+        Y_DEBUG_ABORT_UNLESS(partActorId);
+        NCloud::Send(
+            ctx,
+            partActorId,
+            std::make_unique<
+                TEvNonreplPartitionPrivate::TEvAddLaggingAgentRequest>(
+                args.Agent));
+    }
+
     auto response =
-        std::make_unique<TEvVolumePrivate::TEvDeviceTimedOutResponse>();
+        std::make_unique<TEvVolumePrivate::TEvDeviceTimedOutResponse>(
+            std::move(args.Error));
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -723,6 +723,8 @@ struct TTxVolume
         const TRequestInfoPtr RequestInfo;
         const NProto::TLaggingAgent Agent;
 
+        NProto::TError Error;
+
         TAddLaggingAgent(
                 TRequestInfoPtr requestInfo,
                 NProto::TLaggingAgent agent)
@@ -731,7 +733,9 @@ struct TTxVolume
         {}
 
         void Clear()
-        {}
+        {
+            Error.Clear();
+        }
     };
 
     //


### PR DESCRIPTION
#3
Исправляю гонку, в которой чтение поля `LaggingAgentsInfo` (и решение о записи) происходило в одном месте, а запись в него в другом. 
По смыслу в коде особо ничего не поменялось, просто унёс код внутрь транзакции волума.