### PR TITLE
Add ability to adjust actor system thread count according to available CPU cores percentage

### DIFF
--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -58,8 +58,8 @@ void AdjustActorSystemThreadsAccordingToAvailableCpus(
     }
 
     const auto availableCores = TAffinity::Current().GetCores().size();
-    // 3 stands for number of thread pools (System, User, IC)
-    const double scalingFactor = (1.0 * availableCpuCoresPercentage) / 100 / 3;
+    const double scalingFactor =
+        (1.0 * availableCpuCoresPercentage) / (100 * executors.size());
     const auto newThreadCount = std::ceil(availableCores * scalingFactor);
 
     for (auto* executor: executors) {

--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -1,19 +1,78 @@
 #include "config_initializer.h"
 #include "options.h"
 
+#include <cloud/storage/core/libs/common/affinity.h>
+#include <cloud/storage/core/libs/common/proto_helpers.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
 #include <contrib/ydb/core/protos/auth.pb.h>
 #include <contrib/ydb/core/protos/blobstorage.pb.h>
 #include <contrib/ydb/core/protos/feature_flags.pb.h>
 #include <contrib/ydb/core/protos/shared_cache.pb.h>
 
-#include <cloud/storage/core/libs/common/proto_helpers.h>
-#include <cloud/storage/core/libs/diagnostics/logging.h>
-
 namespace NCloud::NStorage {
+
+namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TConfigInitializerYdbBase::ApplyCMSConfigs(NKikimrConfig::TAppConfig cmsConfig)
+void AdjustActorSystemThreadsAccordingToAvailableCpus(
+    NKikimrConfig::TActorSystemConfig& config,
+    ui32 availableCpuCoresPercentage)
+{
+    if (availableCpuCoresPercentage == 0) {
+        // do nothing
+        return;
+    }
+
+    using TExecutor = NKikimrConfig::TActorSystemConfig::TExecutor;
+
+    const auto findPool = [&] (const auto& poolName) -> TExecutor* {
+        for (auto& executor: *config.MutableExecutor()) {
+            if (executor.GetName() == poolName) {
+                return &executor;
+            }
+        }
+
+        return nullptr;
+    };
+
+    const TVector<TExecutor*> executors = {
+        findPool("System"),
+        findPool("User"),
+        findPool("IC")
+    };
+    for (auto* executor: executors) {
+        if (!executor) {
+            // each pool should be set in actor system config
+            return;
+        }
+    }
+
+    const auto threadCount = executors.front()->GetThreads();
+    for (auto* executor: executors) {
+        if (executor->GetThreads() != threadCount) {
+            // each pool should have equal number of threads
+            return;
+        }
+    }
+
+    const auto availableCores = TAffinity::Current().GetCores().size();
+    // 3 stands for number of thread pools (System, User, IC)
+    const double scalingFactor = (1.0 * availableCpuCoresPercentage) / 100 / 3;
+    const auto newThreadCount = std::ceil(availableCores * scalingFactor);
+
+    for (auto* executor: executors) {
+        executor->SetThreads(newThreadCount);
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TConfigInitializerYdbBase::ApplyCMSConfigs(
+    NKikimrConfig::TAppConfig cmsConfig)
 {
     if (cmsConfig.HasBlobStorageConfig()) {
         KikimrConfig->MutableBlobStorageConfig()
@@ -48,6 +107,9 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
     if (Options->SysConfig) {
         ParseProtoTextFromFile(Options->SysConfig, sysConfig);
     }
+    AdjustActorSystemThreadsAccordingToAvailableCpus(
+        sysConfig,
+        Options->ActorSystemAvailableCpuCoresPercentage);
 
     auto& interconnectConfig = *KikimrConfig->MutableInterconnectConfig();
     if (Options->InterconnectConfig) {

--- a/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
@@ -1,0 +1,277 @@
+#include "config_initializer.h"
+#include "options.h"
+
+#include <cloud/storage/core/libs/common/affinity.h>
+
+#include <library/cpp/getopt/small/last_getopt.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/folder/tempdir.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/stream/file.h>
+#include <util/string/printf.h>
+
+#include <iterator>
+
+namespace NCloud::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TOptionsYdb
+    : public TOptionsYdbBase
+{
+    void Parse(int argc, char** argv) override
+    {
+        NLastGetopt::TOptsParseResultException(&Opts, argc, argv);
+    }
+};
+
+TOptionsYdbBasePtr CreateOptions()
+{
+    return std::make_shared<TOptionsYdb>();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TConfigInitializerYdb
+    : public TConfigInitializerYdbBase
+{
+    explicit TConfigInitializerYdb(TOptionsYdbBasePtr options)
+        : TConfigInitializerYdbBase(std::move(options))
+    {}
+
+    void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig&) override
+    {}
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TConfigInitializerTest)
+{
+    Y_UNIT_TEST(ShouldLoadSysConfig)
+    {
+        auto sysConfigStr = R"(
+            Executor {
+                Type: BASIC
+                Threads: 1
+                Name: "System"
+            }
+            Executor {
+                Type: BASIC
+                Threads: 2
+                Name: "User"
+            }
+            Executor {
+                Type: BASIC
+                Threads: 3
+                Name: "Batch"
+            }
+            Executor {
+                Type: IO
+                Threads: 4
+                Name: "IO"
+            }
+            Executor {
+                Type: BASIC
+                Threads: 5
+                Name: "IC"
+            }
+        )";
+
+        TTempDir dir;
+        auto sysConfigPath = dir.Path() / "nbs-sys.txt";
+        TOFStream(sysConfigPath.GetPath()).Write(sysConfigStr);
+
+        auto options = CreateOptions();
+        options->SysConfig = sysConfigPath.GetPath();
+
+        auto ci = TConfigInitializerYdb(std::move(options));
+        ci.InitKikimrConfig();
+
+        const auto& actualConfig = ci.KikimrConfig->GetActorSystemConfig();
+        UNIT_ASSERT_VALUES_EQUAL(5, actualConfig.GetExecutor().size());
+        UNIT_ASSERT_VALUES_EQUAL(1, actualConfig.GetExecutor(0).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(2, actualConfig.GetExecutor(1).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(3, actualConfig.GetExecutor(2).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(4, actualConfig.GetExecutor(3).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(5, actualConfig.GetExecutor(4).GetThreads());
+    }
+
+    void TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+        ui32 systemThreads,
+        ui32 userThreads,
+        ui32 batchThreads,
+        ui32 ioThreads,
+        ui32 icThreads,
+        ui32 expectedSystemThreads,
+        ui32 expectedUserThreads,
+        ui32 expectedBatchThreads,
+        ui32 expectedIoThreads,
+        ui32 expectedIcThreads,
+        ui32 totalCores,
+        ui32 availableCoresPercentage)
+    {
+        auto sysConfigStr = Sprintf(
+            R"(
+                Executor {
+                    Type: BASIC
+                    Threads: %u
+                    Name: "System"
+                }
+                Executor {
+                    Type: BASIC
+                    Threads: %u
+                    Name: "User"
+                }
+                Executor {
+                    Type: BASIC
+                    Threads: %u
+                    Name: "Batch"
+                }
+                Executor {
+                    Type: IO
+                    Threads: %u
+                    Name: "IO"
+                }
+                Executor {
+                    Type: BASIC
+                    Threads: %u
+                    Name: "IC"
+                }
+            )",
+            systemThreads,
+            userThreads,
+            batchThreads,
+            ioThreads,
+            icThreads);
+
+        TTempDir dir;
+        auto sysConfigPath = dir.Path() / "nbs-sys.txt";
+        TOFStream(sysConfigPath.GetPath()).Write(sysConfigStr);
+
+        auto options = CreateOptions();
+        options->SysConfig = sysConfigPath.GetPath();
+
+        char programName[] = "./program";
+        char flagName[] = "--actor-system-available-cpu-cores-percentage";
+        TString availableCpuCoresPercentageStr =
+            TStringBuilder() << availableCoresPercentage;
+        char* argv[] = {
+            programName,
+            flagName,
+            availableCpuCoresPercentageStr.begin(),
+        };
+        options->Parse(3, argv);
+        UNIT_ASSERT_VALUES_EQUAL(
+            availableCoresPercentage,
+            options->ActorSystemAvailableCpuCoresPercentage);
+
+        TVector<ui8> totalCoresVec;
+        for (ui8 i = 0; i < totalCores; i++) {
+            totalCoresVec.push_back(i);
+        }
+        TAffinity affinity(totalCoresVec);
+        TAffinityGuard affinityGuard(affinity);
+
+        auto ci = TConfigInitializerYdb(std::move(options));
+        ci.InitKikimrConfig();
+
+        const auto& actualConfig = ci.KikimrConfig->GetActorSystemConfig();
+        UNIT_ASSERT_VALUES_EQUAL(5, actualConfig.GetExecutor().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedSystemThreads,
+            actualConfig.GetExecutor(0).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedUserThreads,
+            actualConfig.GetExecutor(1).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedBatchThreads,
+            actualConfig.GetExecutor(2).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedIoThreads,
+            actualConfig.GetExecutor(3).GetThreads());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedIcThreads,
+            actualConfig.GetExecutor(4).GetThreads());
+    }
+
+    Y_UNIT_TEST(ShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores)
+    {
+        // should not affect configuration with available cores percentage set
+        // to zero
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            12, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            12, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            36,                // availableCores
+            0                  // availableCoresPercentage
+        );
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            12, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            12, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            36,                // availableCores
+            100                // availableCoresPercentage
+        );
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            12, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            6,   6, 1, 1,  6,  // System, User, Batch, IO, IC
+            36,                // availableCores
+            50                 // availableCoresPercentage
+        );
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            10, 10, 1, 1, 10,  // System, User, Batch, IO, IC
+            10, 10, 1, 1, 10,  // System, User, Batch, IO, IC
+            58,                // availableCores
+            50                 // availableCoresPercentage
+        );
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            10, 10, 1, 1, 10,  // System, User, Batch, IO, IC
+            7,   7, 1, 1,  7,  // System, User, Batch, IO, IC
+            40,                // availableCores
+            50                 // availableCoresPercentage
+        );
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            10, 10, 1, 1, 10,  // System, User, Batch, IO, IC
+            6,   6, 1, 1,  6,  // System, User, Batch, IO, IC
+            32,                // availableCores
+            50                 // availableCoresPercentage
+        );
+        // should not set thread count to zero
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            1, 1, 1, 1, 1,  // System, User, Batch, IO, IC
+            1, 1, 1, 1, 1,  // System, User, Batch, IO, IC
+            1,              // availableCores
+            1               // availableCoresPercentage
+        );
+        // should not affect configuration with non equal-sized
+        // System, User, IC thread pools
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            11, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            11, 12, 1, 1, 12,  // System, User, Batch, IO, IC
+            36,                // availableCores
+            50                 // availableCoresPercentage
+        );
+        // should not affect configuration with non equal-sized
+        // System, User, IC thread pools
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            12, 12, 1, 1, 11,  // System, User, Batch, IO, IC
+            12, 12, 1, 1, 11,  // System, User, Batch, IO, IC
+            36,                // availableCores
+            50                 // availableCoresPercentage
+        );
+        // should not affect configuration with non equal-sized
+        // System, User, IC thread pools
+        TestShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores(
+            12, 11, 1, 1, 11,  // System, User, Batch, IO, IC
+            12, 11, 1, 1, 11,  // System, User, Batch, IO, IC
+            36,                // availableCores
+            50                 // availableCoresPercentage
+        );
+    }
+}
+
+}   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/kikimr/options.cpp
+++ b/cloud/storage/core/libs/kikimr/options.cpp
@@ -91,6 +91,10 @@ TOptionsYdbBase::TOptionsYdbBase()
     Opts.AddLongOption("load-configs-from-cms", "load configs from CMS")
         .NoArgument()
         .StoreTrue(&LoadCmsConfigs);
+
+    Opts.AddLongOption("actor-system-available-cpu-cores-percentage")
+        .OptionalArgument("NUM")
+        .StoreResult(&ActorSystemAvailableCpuCoresPercentage);
 }
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/kikimr/options.h
+++ b/cloud/storage/core/libs/kikimr/options.h
@@ -40,6 +40,8 @@ struct TOptionsYdbBase
 
     bool LoadCmsConfigs = false;
 
+    ui32 ActorSystemAvailableCpuCoresPercentage = 0;
+
     TOptionsYdbBase();
     virtual ~TOptionsYdbBase() = default;
 };

--- a/cloud/storage/core/libs/kikimr/ut/ya.make
+++ b/cloud/storage/core/libs/kikimr/ut/ya.make
@@ -2,6 +2,7 @@ UNITTEST_FOR(cloud/storage/core/libs/kikimr)
 
 SRCS(
     config_dispatcher_helpers_ut.cpp
+    config_initializer_ut.cpp
     node_registration_helpers_ut.cpp
 )
 

--- a/cloud/storage/core/libs/kikimr/ya.make
+++ b/cloud/storage/core/libs/kikimr/ya.make
@@ -20,6 +20,7 @@ SRCS(
 PEERDIR(
     cloud/storage/core/libs/actors
     cloud/storage/core/libs/common
+    cloud/storage/core/libs/daemon
     cloud/storage/core/libs/diagnostics
     cloud/storage/core/protos
 


### PR DESCRIPTION
Introducing `--actor-system-available-cpu-cores-percentage` cmd-line flag which adjusts `System`, `User`, `IC` thread pool sizes (if those sizes are equal) according to available CPU cores percentage