### PR TITLE
issue-3462: avoid RPC failure in the filestore/blockstore client when channel is in CONNECTING state

### DIFF
--- a/cloud/blockstore/libs/client/client.cpp
+++ b/cloud/blockstore/libs/client/client.cpp
@@ -335,7 +335,9 @@ public:
         , CallContext(std::move(callContext))
         , Request(std::move(request))
         , Promise(promise)
-    {}
+    {
+        Context.set_wait_for_ready(true);
+    }
 
     static void Start(
         TAppContext& appCtx,

--- a/cloud/filestore/libs/client/client.cpp
+++ b/cloud/filestore/libs/client/client.cpp
@@ -183,7 +183,9 @@ public:
         , CallContext(std::move(callContext))
         , Request(std::move(request))
         , Promise(promise)
-    {}
+    {
+        Context.set_wait_for_ready(true);
+    }
 
     static void Start(
         TAppContext& appCtx,


### PR DESCRIPTION
issue: #3462 

Fixes TServerTest flaps. Test failure is reproducible under the stress. Fixed by setting wait_for_ready on the client side. With this flag RPC doesn't fail fast if channel is in CONNECTING state.
https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md

Also applying the same fix for blockstore client