### PR TITLE
Execute multi-agent request through nonreplicated partition actor

### DIFF
--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -434,6 +434,9 @@ struct THistogramRequestCounters
         ERequestCounterOption::HasVoidBytes,
         HistCounterOptions};
     THighResCounter WriteBlocks{EPublishingPolicy::All, HistCounterOptions};
+    THighResCounter WriteBlocksMultiAgent{
+        EPublishingPolicy::DiskRegistryBased,
+        HistCounterOptions};
     THighResCounter ZeroBlocks{EPublishingPolicy::All, HistCounterOptions};
     THighResCounter DescribeBlocks{EPublishingPolicy::All, HistCounterOptions};
     THighResCounter ChecksumBlocks{EPublishingPolicy::All, HistCounterOptions};
@@ -444,6 +447,7 @@ struct THistogramRequestCounters
     static constexpr THighResMeta AllHighResCounters[] = {
         MakeMeta<&THistogramRequestCounters::ReadBlocks>(),
         MakeMeta<&THistogramRequestCounters::WriteBlocks>(),
+        MakeMeta<&THistogramRequestCounters::WriteBlocksMultiAgent>(),
         MakeMeta<&THistogramRequestCounters::ZeroBlocks>(),
         MakeMeta<&THistogramRequestCounters::DescribeBlocks>(),
         MakeMeta<&THistogramRequestCounters::ChecksumBlocks>(),
@@ -731,8 +735,10 @@ struct TTransportCounters
 
     TCounter ReadBytes{EPublishingPolicy::All};
     TCounter WriteBytes{EPublishingPolicy::All};
+    TCounter WriteBytesMultiAgent{EPublishingPolicy::DiskRegistryBased};
     TCounter ReadCount{EPublishingPolicy::All};
     TCounter WriteCount{EPublishingPolicy::All};
+    TCounter WriteCountMultiAgent{EPublishingPolicy::DiskRegistryBased};
 
     static constexpr TMeta AllCounters[] = {
         MakeMetaWithTag<&TTransportCounters::ReadBytes>(
@@ -741,13 +747,18 @@ struct TTransportCounters
         MakeMetaWithTag<&TTransportCounters::WriteBytes>(
             "RequestBytes",
             "WriteBlocks"),
+        MakeMetaWithTag<&TTransportCounters::WriteBytesMultiAgent>(
+            "RequestBytesMultiAgent",
+            "WriteBlocks"),
         MakeMetaWithTag<&TTransportCounters::ReadCount>(
             "Count",
             "ReadBlocks"),
         MakeMetaWithTag<&TTransportCounters::WriteCount>(
             "Count",
             "WriteBlocks"),
-
+        MakeMetaWithTag<&TTransportCounters::WriteCountMultiAgent>(
+            "Count",
+            "WriteBlocksMultiAgent"),
     };
 };
 

--- a/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
+++ b/cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h
@@ -9,6 +9,8 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TDeviceStat;
+
 // A companion for processing EvGetDeviceForRangeRequest requests. Finds how
 // many requests needs for processing the range. If only one request is
 // needed, then everything is fine, request can be executed in direct
@@ -29,6 +31,7 @@ public:
 private:
     const TStorageConfigPtr Config;
     const TNonreplicatedPartitionConfigPtr PartConfig;
+    const TVector<TDeviceStat>* const DeviceStats = nullptr;
 
     EAllowedOperation AllowedOperation;
     NActors::TActorId Delegate;
@@ -39,7 +42,8 @@ public:
     TGetDeviceForRangeCompanion(
         EAllowedOperation allowedOperation,
         TStorageConfigPtr config,
-        TNonreplicatedPartitionConfigPtr partConfig);
+        TNonreplicatedPartitionConfigPtr partConfig,
+        const TVector<TDeviceStat>* const deviceStats);
 
     void SetAllowedOperation(EAllowedOperation allowedOperation);
     void SetDelegate(NActors::TActorId delegate);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.cpp
@@ -1,0 +1,39 @@
+#include "device_stats.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+///////////////////////////////////////////////////////////////////////////////
+
+TDuration TDeviceStat::WorstRequestTime() const
+{
+    TDuration result;
+    for (ui32 i = ResponseTimes.FirstIndex(); i < ResponseTimes.TotalSize();
+         ++i)
+    {
+        result = Max(result, ResponseTimes[i]);
+    }
+    return result;
+}
+
+TDuration TDeviceStat::GetTimedOutStateDuration(TInstant now) const
+{
+    return FirstTimedOutRequestStartTs ? (now - FirstTimedOutRequestStartTs)
+                                       : TDuration();
+}
+
+bool TDeviceStat::CooldownPassed(TInstant now, TDuration cooldownTimeout) const
+{
+    switch (DeviceStatus) {
+        case EDeviceStatus::Ok:
+        case EDeviceStatus::Unavailable:
+            return false;
+        case EDeviceStatus::SilentBroken:
+            return BrokenTransitionTs + cooldownTimeout < now;
+        case EDeviceStatus::Broken:
+            return true;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "util/datetime/base.h"
+
+#include <library/cpp/containers/ring_buffer/ring_buffer.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TDeviceStat
+{
+    enum class EDeviceStatus
+    {
+        Ok,
+        Unavailable,
+        SilentBroken,
+        Broken,
+    };
+
+    // The start time of the first timed out request.
+    TInstant FirstTimedOutRequestStartTs;
+
+    // The start time of the last successful request.
+    TInstant LastSuccessfulRequestStartTs;
+
+    // Execution times of the last 10 requests.
+    TSimpleRingBuffer<TDuration> ResponseTimes{10};
+
+    // The current status of the device.
+    EDeviceStatus DeviceStatus = EDeviceStatus::Ok;
+
+    // When the device was considered broken.
+    TInstant BrokenTransitionTs;
+
+    // Returns the maximum request execution time among the latest.
+    [[nodiscard]] TDuration WorstRequestTime() const;
+
+    [[nodiscard]] TDuration GetTimedOutStateDuration(TInstant now) const;
+
+    [[nodiscard]] bool CooldownPassed(
+        TInstant now,
+        TDuration cooldownTimeout) const;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/deny_ydb_dependency.inc)
 
 SRCS(
     changed_ranges_map.cpp
+    device_stats.cpp
     disjoint_range_set.cpp
     processing_blocks.cpp
     replica_actors.cpp

--- a/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
@@ -6,8 +6,6 @@
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/service/context.h>
-#include <cloud/blockstore/libs/service/request_helpers.h>
-#include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
@@ -28,6 +26,8 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 // disk. It should process all errors from replicas into E_REJECTED. Because
 // sooner or later the disk agent will return to work, or the replica will be
 // replaced. All replicas are equivalent and are placed in the Replicas.
+// The replica for executing the request is selected by the round robin and
+// TEvMultiAgentWriteRequest send to it.
 
 template <typename TMethod>
 class TMultiAgentWriteActor final
@@ -44,10 +44,11 @@ private:
     const TString DiskId;
     const NActors::TActorId ParentActorId;
     const ui64 NonreplicatedRequestCounter;
-    const bool AssignVolumeRequestId = true;
+    const size_t RoundRobinSeed;
 
     TVector<TEvNonreplPartitionPrivate::TGetDeviceForRangeResponse>
         DevicesAndRanges;
+    size_t DiscoveryResponseCount = 0;
 
 public:
     TMultiAgentWriteActor(
@@ -58,7 +59,7 @@ public:
         TString diskId,
         NActors::TActorId parentActorId,
         ui64 nonreplicatedRequestCounter,
-        const bool assignVolumeRequestId);
+        size_t roundRobinSeed);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
@@ -76,16 +77,8 @@ private:
             ev,
         const NActors::TActorContext& ctx);
 
-    void HandleWriteDeviceBlocksResponse(
-        const TEvDiskAgent::TEvWriteDeviceBlocksResponse::TPtr& ev,
-        const NActors::TActorContext& ctx);
-
-    void HandleUndelivery(
-        const TEvDiskAgent::TEvWriteDeviceBlocksRequest::TPtr& ev,
-        const NActors::TActorContext& ctx);
-
-    void HandleWriteTimeout(
-        const NActors::TEvents::TEvWakeup::TPtr& ev,
+    void HandleMultiAgentWriteDeviceBlocksResponse(
+        const TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandlePoisonPill(
@@ -104,7 +97,7 @@ TMultiAgentWriteActor<TMethod>::TMultiAgentWriteActor(
         TString diskId,
         NActors::TActorId parentActorId,
         ui64 nonreplicatedRequestCounter,
-        const bool assignVolumeRequestId)
+        size_t roundRobinSeed)
     : RequestInfo(std::move(requestInfo))
     , Replicas(std::move(replicas))
     , Request(std::move(request))
@@ -112,9 +105,10 @@ TMultiAgentWriteActor<TMethod>::TMultiAgentWriteActor(
     , DiskId(std::move(diskId))
     , ParentActorId(parentActorId)
     , NonreplicatedRequestCounter(nonreplicatedRequestCounter)
-    , AssignVolumeRequestId(assignVolumeRequestId)
+    , RoundRobinSeed(roundRobinSeed)
 {
     Y_DEBUG_ABORT_UNLESS(!Replicas.empty());
+    DevicesAndRanges.resize(Replicas.size());
 }
 
 template <typename TMethod>
@@ -158,15 +152,24 @@ template <typename TMethod>
 void TMultiAgentWriteActor<TMethod>::SendWriteRequest(
     const NActors::TActorContext& ctx)
 {
-    // Randomizing the selection of the disk-agent that will do the job.
-    Shuffle(DevicesAndRanges.begin(), DevicesAndRanges.end());
+    // Select disk-agent that will do the job.
+    const size_t executeOnReplica = RoundRobinSeed % Replicas.size();
+    Rotate(
+        DevicesAndRanges.begin(),
+        DevicesAndRanges.begin() + executeOnReplica,
+        DevicesAndRanges.end());
 
-    auto request =
-        std::make_unique<TEvDiskAgent::TEvWriteDeviceBlocksRequest>();
+    auto request = std::make_unique<
+        TEvNonreplPartitionPrivate::TEvMultiAgentWriteRequest>();
+    request->CallContext = RequestInfo->CallContext;
+
     auto& rec = request->Record;
 
     *rec.MutableHeaders() = Request.GetHeaders();
-    rec.SetBlockSize(DevicesAndRanges[0].PartConfig->GetBlockSize());
+    rec.BlockSize = DevicesAndRanges[0].PartConfig->GetBlockSize();
+    rec.Range = Range;
+    rec.DevicesAndRanges = DevicesAndRanges;
+
     if constexpr (IsLocalMethod<TMethod>) {
         auto guard = Request.Sglist.Acquire();
         if (!guard) {
@@ -179,48 +182,25 @@ void TMultiAgentWriteActor<TMethod>::SendWriteRequest(
         }
         SgListCopy(
             guard.Get(),
-            ResizeIOVector(
-                *rec.MutableBlocks(),
-                Range.Size(),
-                rec.GetBlockSize()));
+            ResizeIOVector(*rec.MutableBlocks(), Range.Size(), rec.BlockSize));
 
     } else {
         rec.MutableBlocks()->Swap(Request.MutableBlocks());
     }
 
-    TDuration maxRequestTimeout;
-    for (const auto& deviceInfo: DevicesAndRanges) {
-        maxRequestTimeout =
-            std::max(maxRequestTimeout, deviceInfo.RequestTimeout);
-
-        auto* replicationTarget = rec.AddReplicationTargets();
-        replicationTarget->SetNodeId(deviceInfo.Device.GetNodeId());
-        replicationTarget->SetDeviceUUID(deviceInfo.Device.GetDeviceUUID());
-        replicationTarget->SetStartIndex(deviceInfo.DeviceBlockRange.Start);
-    }
-
-    if (AssignVolumeRequestId) {
-        rec.SetVolumeRequestId(Request.GetHeaders().GetVolumeRequestId());
-        rec.SetMultideviceRequest(false);
-    }
-
-    auto event = std::make_unique<NActors::IEventHandle>(
-        MakeDiskAgentServiceId(DevicesAndRanges[0].Device.GetNodeId()),
-        ctx.SelfID,
-        request.release(),
-        NActors::IEventHandle::FlagForwardOnNondelivery,
-        0,            // cookie
-        &ctx.SelfID   // forwardOnNondelivery
-    );
-
-    ctx.Send(event.release());
-
-    ctx.Schedule(maxRequestTimeout, new NActors::TEvents::TEvWakeup());
+    NCloud::Send(ctx, Replicas[executeOnReplica], std::move(request));
 }
 
 template <typename TMethod>
 void TMultiAgentWriteActor<TMethod>::Fallback(const NActors::TActorContext& ctx)
 {
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "Fallback to TMirrorRequestActor diskId: %s Range: %s",
+        DiskId.Quote().c_str(),
+        Range.Print().c_str());
+
     // Delegate all work to original actor.
     NCloud::Register<TMirrorRequestActor<TMethod>>(
         ctx,
@@ -268,7 +248,10 @@ void TMultiAgentWriteActor<TMethod>::HandleGetDeviceRangeResponse(
     const NActors::TActorContext& ctx)
 {
     const auto* msg = ev->Get();
-    DevicesAndRanges.push_back(*msg);
+    const size_t replicaIdx = ev->Cookie;
+
+    DevicesAndRanges[replicaIdx] = *msg;
+    ++DiscoveryResponseCount;
 
     if (HasError(msg->GetError())) {
         // For partition we can't perform direct disk-agent write.
@@ -277,32 +260,27 @@ void TMultiAgentWriteActor<TMethod>::HandleGetDeviceRangeResponse(
         return;
     }
 
-    if (DevicesAndRanges.size() == Replicas.size()) {
+    if (DiscoveryResponseCount == Replicas.size()) {
         SendWriteRequest(ctx);
     }
 }
 
 template <typename TMethod>
-void TMultiAgentWriteActor<TMethod>::HandleWriteDeviceBlocksResponse(
-    const TEvDiskAgent::TEvWriteDeviceBlocksResponse::TPtr& ev,
+void TMultiAgentWriteActor<TMethod>::HandleMultiAgentWriteDeviceBlocksResponse(
+    const TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
     const auto* msg = ev->Get();
     NProto::TError error = msg->GetError();
 
-    ProcessError(
-        *NActors::TActorContext::ActorSystem(),
-        *DevicesAndRanges[0].PartConfig,
-        error);
+    if (error.GetCode() == E_ARGUMENT) {
+        Fallback(ctx);
+        return;
+    }
+
     ProcessMirrorActorError(error);
 
-    bool subResponsesOk = msg->Record.GetReplicationResponses().size() ==
-                              static_cast<int>(Replicas.size()) &&
-                          AllOf(
-                              msg->Record.GetReplicationResponses(),
-                              [](const NProto::TError& subResponseError)
-                              { return subResponseError.GetCode() == S_OK; });
-    if (error.GetCode() == S_OK && !subResponsesOk) {
+    if (msg->Record.InconsistentResponse) {
         // The disk agent returned a response that does not contain a subrequest
         // responses, which means that the disk agent cannot process multi-agent
         // requests. In this case, we need to turn off the feature and repeat
@@ -316,36 +294,6 @@ void TMultiAgentWriteActor<TMethod>::HandleWriteDeviceBlocksResponse(
                 DevicesAndRanges[0].PartConfig->GetName()));
     }
 
-    Done(ctx, std::move(error));
-}
-
-template <typename TMethod>
-void TMultiAgentWriteActor<TMethod>::HandleUndelivery(
-    const TEvDiskAgent::TEvWriteDeviceBlocksRequest::TPtr& ev,
-    const NActors::TActorContext& ctx)
-{
-    Y_UNUSED(ev);
-
-    LOG_WARN(
-        ctx,
-        TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] MultiAgentWrite. Request undelivered",
-        DiskId.c_str());
-
-    Done(ctx, MakeError(E_REJECTED, "MultiAgentWrite. Request undelivered"));
-}
-
-template <typename TMethod>
-void TMultiAgentWriteActor<TMethod>::HandleWriteTimeout(
-    const NActors::TEvents::TEvWakeup::TPtr& ev,
-    const NActors::TActorContext& ctx)
-{
-    Y_UNUSED(ev);
-
-    auto error = MakeError(
-        E_TIMEOUT,
-        TStringBuilder() << "Range " << DescribeRange(Range)
-                         << " write timeout");
     Done(ctx, std::move(error));
 }
 
@@ -368,10 +316,8 @@ STFUNC(TMultiAgentWriteActor<TMethod>::StateWork)
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeResponse,
             HandleGetDeviceRangeResponse);
         HFunc(
-            TEvDiskAgent::TEvWriteDeviceBlocksResponse,
-            HandleWriteDeviceBlocksResponse);
-        HFunc(TEvDiskAgent::TEvWriteDeviceBlocksRequest, HandleUndelivery);
-        HFunc(NActors::TEvents::TEvWakeup, HandleWriteTimeout);
+            TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse,
+            HandleMultiAgentWriteDeviceBlocksResponse);
         HFunc(NActors::TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:

--- a/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "part_nonrepl_events_private.h"
-#include "util/random/shuffle.h"
 
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/kikimr/components.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -106,7 +106,7 @@ private:
 
     bool MultiAgentWriteEnabled = true;
     const size_t MultiAgentWriteRequestSizeThreshold = 0;
-    size_t RoundRobinSeed = 0;
+    size_t MultiAgentWriteRoundRobinSeed = 0;
 
 public:
     TMirrorPartitionActor(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -106,6 +106,7 @@ private:
 
     bool MultiAgentWriteEnabled = true;
     const size_t MultiAgentWriteRequestSizeThreshold = 0;
+    size_t RoundRobinSeed = 0;
 
 public:
     TMirrorPartitionActor(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -154,7 +154,7 @@ void TMirrorPartitionActor::MirrorRequest(
                 State.GetReplicaInfos()[0].Config->GetName(),   // diskId
                 SelfId(),                                       // parentActorId
                 requestIdentityKey,
-                Config->GetAssignIdToWriteAndZeroRequestsEnabled());
+                RoundRobinSeed++);
             return;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -154,7 +154,7 @@ void TMirrorPartitionActor::MirrorRequest(
                 State.GetReplicaInfos()[0].Config->GetName(),   // diskId
                 SelfId(),                                       // parentActorId
                 requestIdentityKey,
-                RoundRobinSeed++);
+                MultiAgentWriteRoundRobinSeed++);
             return;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -3002,6 +3002,25 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                 DescribeRange(TBlockRange64::WithLength(20, 5)),
                 DescribeRange(device2WriteRange["vasya#2"]));
         }
+
+        const ui64 bytesWritten = DefaultBlockSize * 5 * 2;
+
+        runtime.AdvanceCurrentTime(UpdateCountersInterval);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+        runtime.AdvanceCurrentTime(UpdateCountersInterval);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+        auto& counters = env.StorageStatsServiceState->Counters.RequestCounters;
+        UNIT_ASSERT_VALUES_EQUAL(2, counters.WriteBlocksMultiAgent.Count);
+        UNIT_ASSERT_VALUES_EQUAL(
+            bytesWritten,
+            counters.WriteBlocksMultiAgent.RequestBytes);
+
+        auto& interconnect =
+            env.StorageStatsServiceState->Counters.Interconnect;
+        UNIT_ASSERT_VALUES_EQUAL(
+            bytesWritten,
+            interconnect.WriteBytesMultiAgent.Value);
+        UNIT_ASSERT_VALUES_EQUAL(2, interconnect.WriteCountMultiAgent.Value);
     }
 
     Y_UNIT_TEST(ShouldFallbackFromMultiWriteRequestsWhenDiscoveryFailed)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -1281,7 +1281,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
     Y_UNIT_TEST(ShouldTransformAnyErrorToRetriable_E_NOT_FOUND)
     {
         DoShouldTransformAnyErrorToRetriable(
-            MakeError(E_TIMEOUT, "E_TIMEOUT error"));
+            MakeError(E_NOT_FOUND, "E_NOT_FOUND error"));
     }
 
     Y_UNIT_TEST(ShouldTransformAnyErrorToRetriable_E_TIMEOUT)
@@ -3272,8 +3272,109 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         client.SendWriteBlocksRequest(TBlockRange64::WithLength(10, 5), 1);
         runtime.AdvanceCurrentTime(TDuration::Seconds(5));
         auto response = client.RecvWriteBlocksResponse();
-        UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
         UNIT_ASSERT(requestDropped);
+    }
+
+    Y_UNIT_TEST(ShouldFallbackFromMultiWriteRequestsWhenTimeoutsAreRepeated)
+    {
+        TTestRuntime runtime;
+
+        size_t multiAgentWriteDeviceBlocksRequestCount = 0;
+        auto dropDiskAgentRequest =
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
+                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksRequest;
+
+                    const auto& record = event->Get<TRequest>()->Record;
+                    if (!record.GetReplicationTargets().empty()) {
+                        ++multiAgentWriteDeviceBlocksRequestCount;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        NProto::TStorageServiceConfig config;
+        config.SetMultiAgentWriteEnabled(true);
+        TTestEnv env(runtime, std::move(config));
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        size_t multiAgentRequestCount = 0;
+        size_t fallbackRequestCount = 0;
+        runtime.SetEventFilter(dropDiskAgentRequest);
+        for (size_t i = 0; i < 100; ++i) {
+            multiAgentWriteDeviceBlocksRequestCount = 0;
+
+            client.SendWriteBlocksRequest(TBlockRange64::MakeOneBlock(0), 1);
+            runtime.AdvanceCurrentTime(TDuration::Seconds(10));
+            auto response = client.RecvWriteBlocksResponse();
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_REJECTED,
+                response->GetError().GetCode());
+            if (multiAgentWriteDeviceBlocksRequestCount == 0) {
+                // The partition accumulated statistics and began to prohibit
+                // the use of multi-agent requests.
+                ++fallbackRequestCount;
+                break;
+            }
+            ++multiAgentRequestCount;
+        }
+        UNIT_ASSERT_VALUES_UNEQUAL(0, multiAgentRequestCount);
+        UNIT_ASSERT_VALUES_UNEQUAL(0, fallbackRequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldSelectReplicaByRoundRobinForMultiWriteRequests)
+    {
+        TTestRuntime runtime;
+
+        TMap<TString, size_t> deviceAndCount;
+        auto countRequest =
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvDiskAgent::EvWriteDeviceBlocksRequest: {
+                    using TRequest = TEvDiskAgent::TEvWriteDeviceBlocksRequest;
+
+                    const auto& record = event->Get<TRequest>()->Record;
+                    if (!record.GetReplicationTargets().empty()) {
+                        const auto& device =
+                            record.GetReplicationTargets()[0].GetDeviceUUID();
+                        ++deviceAndCount[device];
+                    }
+                }
+            }
+
+            return false;
+        };
+
+        NProto::TStorageServiceConfig config;
+        config.SetMultiAgentWriteEnabled(true);
+        TTestEnv env(runtime, std::move(config));
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        runtime.SetEventFilter(countRequest);
+
+        for (size_t i = 0; i < 6; ++i) {
+            client.WriteBlocks(TBlockRange64::MakeOneBlock(0), 1);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(3, deviceAndCount.size());
+        for (const auto& [device, count]: deviceAndCount) {
+            UNIT_ASSERT_VALUES_EQUAL(2, count);
+        }
     }
 
     Y_UNIT_TEST(ShouldHandleInconsistentDiskAgentResponse)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -161,6 +161,18 @@ private:
         TRequestTimeoutPolicy* timeoutPolicy,
         TRequestData* requestData);
 
+    template <typename TRequest, typename TResponse>
+    bool InitRequests(
+        const char* methodName,
+        const bool isWriteMethod,
+        const TRequest& msg,
+        const NActors::TActorContext& ctx,
+        const TRequestInfo& requestInfo,
+        const TBlockRange64& blockRange,
+        TVector<TDeviceRequest>* deviceRequests,
+        TRequestTimeoutPolicy* timeoutPolicy,
+        TRequestData* requestData);
+
     void OnRequestCompleted(
         const TEvNonreplPartitionPrivate::TOperationCompleted& operation,
         TInstant now);
@@ -185,6 +197,11 @@ private:
         const TEvNonreplPartitionPrivate::TEvWriteBlocksCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleMultiAgentWriteBlocksCompleted(
+        const TEvNonreplPartitionPrivate::TEvMultiAgentWriteBlocksCompleted::
+            TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleZeroBlocksCompleted(
         const TEvNonreplPartitionPrivate::TEvZeroBlocksCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
@@ -205,6 +222,10 @@ private:
         const TEvNonreplPartitionPrivate::TEvAgentIsBackOnline::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleGetDeviceForRange(
+        const TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx) const;
+
     bool HandleRequests(STFUNC_SIG);
 
     BLOCKSTORE_IMPLEMENT_REQUEST(ReadBlocks, TEvService);
@@ -214,6 +235,7 @@ private:
     BLOCKSTORE_IMPLEMENT_REQUEST(ZeroBlocks, TEvService);
     BLOCKSTORE_IMPLEMENT_REQUEST(DescribeBlocks, TEvVolume);
     BLOCKSTORE_IMPLEMENT_REQUEST(ChecksumBlocks, TEvNonreplPartitionPrivate);
+    BLOCKSTORE_IMPLEMENT_REQUEST(MultiAgentWrite, TEvNonreplPartitionPrivate);
     BLOCKSTORE_IMPLEMENT_REQUEST(Drain, NPartition::TEvPartition);
     BLOCKSTORE_IMPLEMENT_REQUEST(
         WaitForInFlightWrites,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -1,0 +1,324 @@
+#include "part_nonrepl_actor.h"
+
+#include "part_nonrepl_actor_base_request.h"
+#include "part_nonrepl_common.h"
+
+#include <cloud/blockstore/libs/common/iovector.h>
+#include <cloud/blockstore/libs/service/request_helpers.h>
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/core/block_handler.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDuration GetMaxTimeout(const NProto::TMultiAgentWriteRequest& request)
+{
+    TDuration maxRequestTimeout;
+    for (const auto& deviceInfo: request.DevicesAndRanges) {
+        maxRequestTimeout = Max(maxRequestTimeout, deviceInfo.RequestTimeout);
+    }
+    return maxRequestTimeout;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDiskAgentMultiWriteActor final: public TDiskAgentBaseRequestActor
+{
+private:
+    const bool AssignVolumeRequestId;
+
+    NProto::TMultiAgentWriteRequest Request;
+
+public:
+    TDiskAgentMultiWriteActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TMultiAgentWriteRequest request,
+        TRequestTimeoutPolicy timeoutPolicy,
+        TVector<TDeviceRequest> deviceRequests,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        const TActorId& part,
+        bool assignVolumeRequestId);
+
+protected:
+    void SendRequest(const NActors::TActorContext& ctx) override;
+    NActors::IEventBasePtr MakeResponse(NProto::TError error) override;
+    TCompletionEventAndBody MakeCompletionResponse(ui32 blocks) override;
+    bool OnMessage(TAutoPtr<NActors::IEventHandle>& ev) override;
+
+private:
+    void HandleWriteDeviceBlocksResponse(
+        const TEvDiskAgent::TEvWriteDeviceBlocksResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleWriteDeviceBlocksUndelivery(
+        const TEvDiskAgent::TEvWriteDeviceBlocksRequest::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDiskAgentMultiWriteActor::TDiskAgentMultiWriteActor(
+        TRequestInfoPtr requestInfo,
+        NProto::TMultiAgentWriteRequest request,
+        TRequestTimeoutPolicy timeoutPolicy,
+        TVector<TDeviceRequest> deviceRequests,
+        TNonreplicatedPartitionConfigPtr partConfig,
+        const TActorId& part,
+        bool assignVolumeRequestId)
+    : TDiskAgentBaseRequestActor(
+          std::move(requestInfo),
+          GetRequestId(request),
+          "MultiAgentWriteBlocks",
+          std::move(timeoutPolicy),
+          std::move(deviceRequests),
+          std::move(partConfig),
+          part)
+    , AssignVolumeRequestId(assignVolumeRequestId)
+    , Request(std::move(request))
+{}
+
+void TDiskAgentMultiWriteActor::SendRequest(const TActorContext& ctx)
+{
+    auto request =
+        std::make_unique<TEvDiskAgent::TEvWriteDeviceBlocksRequest>();
+
+    *request->Record.MutableHeaders() = Request.GetHeaders();
+    request->Record.SetBlockSize(Request.BlockSize);
+    request->Record.MutableBlocks()->Swap(Request.MutableBlocks());
+
+    for (const auto& deviceInfo: Request.DevicesAndRanges) {
+        auto* replicationTarget = request->Record.AddReplicationTargets();
+        replicationTarget->SetNodeId(deviceInfo.Device.GetNodeId());
+        replicationTarget->SetDeviceUUID(deviceInfo.Device.GetDeviceUUID());
+        replicationTarget->SetStartIndex(deviceInfo.DeviceBlockRange.Start);
+    }
+
+    if (AssignVolumeRequestId) {
+        request->Record.SetVolumeRequestId(
+            Request.GetHeaders().GetVolumeRequestId());
+        request->Record.SetMultideviceRequest(false);
+    }
+
+    auto event = std::make_unique<NActors::IEventHandle>(
+        MakeDiskAgentServiceId(Request.DevicesAndRanges[0].Device.GetNodeId()),
+        ctx.SelfID,
+        request.release(),
+        NActors::IEventHandle::FlagForwardOnNondelivery,
+        0,            // cookie
+        &ctx.SelfID   // forwardOnNondelivery
+    );
+
+    ctx.Send(event.release());
+}
+
+NActors::IEventBasePtr TDiskAgentMultiWriteActor::MakeResponse(
+    NProto::TError error)
+{
+    return std::make_unique<
+        TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
+        std::move(error));
+}
+
+TDiskAgentBaseRequestActor::TCompletionEventAndBody
+TDiskAgentMultiWriteActor::MakeCompletionResponse(ui32 blocks)
+{
+    auto completion = std::make_unique<
+        TEvNonreplPartitionPrivate::TEvMultiAgentWriteBlocksCompleted>();
+
+    completion->Stats.MutableUserWriteCounters()->SetBlocksCount(blocks);
+
+    return TCompletionEventAndBody(std::move(completion));
+}
+
+void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksUndelivery(
+    const TEvDiskAgent::TEvWriteDeviceBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    LOG_WARN_S(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "MultiAgentWriteBlocks request #"
+            << GetRequestId(Request)
+            << " undelivered. Disk id: " << PartConfig->GetName()
+            << " Device: " << LogDevice(Request.DevicesAndRanges[0].Device));
+
+    // Ignore undelivered event. Wait for TEvWakeup.
+}
+
+void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksResponse(
+    const TEvDiskAgent::TEvWriteDeviceBlocksResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    auto error = msg->GetError();
+    if (HasError(error)) {
+        HandleError(ctx, error, EStatus::Fail);
+        return;
+    }
+
+    bool subResponsesOk =
+        msg->Record.GetReplicationResponses().size() ==
+            static_cast<int>(Request.DevicesAndRanges.size()) &&
+        AllOf(
+            msg->Record.GetReplicationResponses(),
+            [](const NProto::TError& subResponseError)
+            { return subResponseError.GetCode() == S_OK; });
+
+    if (error.GetCode() == S_OK && !subResponsesOk) {
+        auto response = std::make_unique<
+            TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
+            MakeError(E_REJECTED));
+        response->Record.InconsistentResponse = true;
+
+        Done(ctx, std::move(response), EStatus::Fail);
+        return;
+    }
+
+    Done(ctx, MakeResponse(std::move(error)), EStatus::Success);
+}
+
+bool TDiskAgentMultiWriteActor::OnMessage(TAutoPtr<NActors::IEventHandle>& ev)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvDiskAgent::TEvWriteDeviceBlocksRequest,
+            HandleWriteDeviceBlocksUndelivery);
+        HFunc(
+            TEvDiskAgent::TEvWriteDeviceBlocksResponse,
+            HandleWriteDeviceBlocksResponse);
+        default:
+            return false;
+    }
+    return true;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TNonreplicatedPartitionActor::HandleMultiAgentWrite(
+    const TEvNonreplPartitionPrivate::TEvMultiAgentWriteRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto requestInfo = CreateRequestInfoWithResponse<
+        TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+
+    TRequestScope timer(*requestInfo);
+
+    LWTRACK(
+        RequestReceived_Partition,
+        requestInfo->CallContext->LWOrbit,
+        "MultiAgentWriteBlocks",
+        requestInfo->CallContext->RequestId);
+
+    auto replyError = [&](ui32 errorCode, TString errorReason)
+    {
+        auto response = std::make_unique<
+            TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
+            PartConfig->MakeError(errorCode, std::move(errorReason)));
+
+        LWTRACK(
+            ResponseSent_Partition,
+            requestInfo->CallContext->LWOrbit,
+            "MultiAgentWriteBlocks",
+            requestInfo->CallContext->RequestId);
+
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+    };
+
+    TVector<TDeviceRequest> deviceRequests;
+    TRequestTimeoutPolicy timeoutPolicy;
+    TRequestData request;
+    bool ok = InitRequests<
+        TEvNonreplPartitionPrivate::TEvMultiAgentWriteRequest,
+        TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
+        "MultiAgentWriteBlocks",
+        true,
+        *msg,
+        ctx,
+        *requestInfo,
+        msg->Record.Range,
+        &deviceRequests,
+        &timeoutPolicy,
+        &request);
+
+    if (!ok) {
+        return;
+    }
+
+    if (deviceRequests.size() != 1) {
+        replyError(
+            E_ARGUMENT,
+            "Can't execute MultiAgentWriteBlocks request cross device borders");
+        return;
+    }
+
+    timeoutPolicy.Timeout =
+        Max(timeoutPolicy.Timeout, GetMaxTimeout(msg->Record));
+
+    auto actorId = NCloud::Register<TDiskAgentMultiWriteActor>(
+        ctx,
+        requestInfo,
+        std::move(msg->Record),
+        std::move(timeoutPolicy),
+        std::move(deviceRequests),
+        PartConfig,
+        SelfId(),
+        Config->GetAssignIdToWriteAndZeroRequestsEnabled());
+
+    RequestsInProgress.AddWriteRequest(actorId, std::move(request));
+}
+
+void TNonreplicatedPartitionActor::HandleMultiAgentWriteBlocksCompleted(
+    const TEvNonreplPartitionPrivate::TEvMultiAgentWriteBlocksCompleted::TPtr&
+        ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    LOG_TRACE(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "[%s] Complete multi agent write blocks",
+        SelfId().ToString().c_str());
+
+    UpdateStats(msg->Stats);
+
+    const auto requestBytes =
+        msg->Stats.GetUserWriteCounters().GetBlocksCount() *
+        PartConfig->GetBlockSize();
+    const auto time = CyclesToDurationSafe(msg->TotalCycles).MicroSeconds();
+    PartCounters->RequestCounters.WriteBlocks.AddRequest(time, requestBytes);
+    PartCounters->Interconnect.WriteBytes.Increment(requestBytes);
+    PartCounters->Interconnect.WriteCount.Increment(1);
+
+    NetworkBytes += requestBytes;
+    CpuUsage += CyclesToDurationSafe(msg->ExecCycles);
+
+    RequestsInProgress.RemoveRequest(ev->Sender);
+    OnRequestCompleted(*msg, ctx.Now());
+
+    DrainActorCompanion.ProcessDrainRequests(ctx);
+
+    if (RequestsInProgress.Empty() && Poisoner) {
+        ReplyAndDie(ctx);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -150,7 +150,7 @@ void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksUndelivery(
         TBlockStoreComponents::PARTITION_WORKER,
         "MultiAgentWriteBlocks request #"
             << GetRequestId(Request)
-            << " undelivered. Disk id: " << PartConfig->GetName()
+            << " undelivered. Disk id: " << PartConfig->GetName().Quote()
             << " Device: " << LogDevice(Request.DevicesAndRanges[0].Device));
 
     // Ignore undelivered event. Wait for TEvWakeup.
@@ -185,6 +185,7 @@ void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksResponse(
         return;
     }
 
+    Y_DEBUG_ABORT_UNLESS(error.GetCode() == S_OK);
     Done(ctx, MakeResponse(std::move(error)), EStatus::Success);
 }
 
@@ -304,9 +305,9 @@ void TNonreplicatedPartitionActor::HandleMultiAgentWriteBlocksCompleted(
         msg->Stats.GetUserWriteCounters().GetBlocksCount() *
         PartConfig->GetBlockSize();
     const auto time = CyclesToDurationSafe(msg->TotalCycles).MicroSeconds();
-    PartCounters->RequestCounters.WriteBlocks.AddRequest(time, requestBytes);
-    PartCounters->Interconnect.WriteBytes.Increment(requestBytes);
-    PartCounters->Interconnect.WriteCount.Increment(1);
+    PartCounters->RequestCounters.WriteBlocksMultiAgent.AddRequest(time, requestBytes);
+    PartCounters->Interconnect.WriteBytesMultiAgent.Increment(requestBytes);
+    PartCounters->Interconnect.WriteCountMultiAgent.Increment(1);
 
     NetworkBytes += requestBytes;
     CpuUsage += CyclesToDurationSafe(msg->ExecCycles);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -16,8 +16,12 @@
 
 namespace NCloud::NBlockStore::NProto {
 
-    using TChecksumBlocksRequest = NProto::TChecksumDeviceBlocksRequest;
-    using TChecksumBlocksResponse = NProto::TChecksumDeviceBlocksResponse;
+using TChecksumBlocksRequest = NProto::TChecksumDeviceBlocksRequest;
+using TChecksumBlocksResponse = NProto::TChecksumDeviceBlocksResponse;
+
+struct TMultiAgentWriteRequest;
+struct TMultiAgentWriteResponse;
+
 }   // namespace NCloud::NBlockStore::NProto
 
 namespace NCloud::NBlockStore::NStorage {
@@ -26,6 +30,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 #define BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE(xxx, ...)             \
     xxx(ChecksumBlocks, __VA_ARGS__)                                        \
+    xxx(MultiAgentWrite, __VA_ARGS__)                                       \
 // BLOCKSTORE_PARTITION_NONREPL_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -377,6 +382,7 @@ struct TEvNonreplPartitionPrivate
         EvScrubbingNextRange,
         EvReadBlocksCompleted,
         EvWriteBlocksCompleted,
+        EvMultiAgentWriteBlocksCompleted,
         EvZeroBlocksCompleted,
         EvRangeMigrated,
         EvMigrateNextRange,
@@ -410,6 +416,7 @@ struct TEvNonreplPartitionPrivate
     using TEvScrubbingNextRange = TResponseEvent<TEmpty, EvScrubbingNextRange>;
     using TEvReadBlocksCompleted = TResponseEvent<TOperationCompleted, EvReadBlocksCompleted>;
     using TEvWriteBlocksCompleted = TResponseEvent<TOperationCompleted, EvWriteBlocksCompleted>;
+    using TEvMultiAgentWriteBlocksCompleted = TResponseEvent<TOperationCompleted, EvMultiAgentWriteBlocksCompleted>;
     using TEvZeroBlocksCompleted = TResponseEvent<TOperationCompleted, EvZeroBlocksCompleted>;
     using TEvChecksumBlocksCompleted = TResponseEvent<TOperationCompleted, EvChecksumBlocksCompleted>;
 
@@ -502,3 +509,22 @@ struct TEvNonreplPartitionPrivate
 };
 
 }   // namespace NCloud::NBlockStore::NStorage
+
+namespace NCloud::NBlockStore::NProto {
+
+struct TMultiAgentWriteRequest: public NProto::TWriteBlocksRequest
+{
+    using TGetDeviceForRangeResponse = NCloud::NBlockStore::NStorage::
+        TEvNonreplPartitionPrivate::TGetDeviceForRangeResponse;
+
+    ui32 BlockSize = 0;
+    TBlockRange64 Range;
+    TVector<TGetDeviceForRangeResponse> DevicesAndRanges;
+};
+
+struct TMultiAgentWriteResponse: public NProto::TWriteBlocksResponse
+{
+    bool InconsistentResponse = false;
+};
+
+}   // namespace NCloud::NBlockStore::NProto

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -63,7 +63,8 @@ private:
     TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
         TGetDeviceForRangeCompanion::EAllowedOperation::ReadWrite,
         Config,
-        PartConfig};
+        PartConfig,
+        nullptr};
 
     bool UpdateCountersScheduled = false;
     TPartitionDiskCountersPtr PartCounters;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ya.make
@@ -40,13 +40,14 @@ SRCS(
 
     part_nonrepl.cpp
     part_nonrepl_actor.cpp
-    part_nonrepl_actor_checkrange.cpp
     part_nonrepl_actor_base_request.cpp
+    part_nonrepl_actor_checkrange.cpp
     part_nonrepl_actor_checksumblocks.cpp
     part_nonrepl_actor_readblocks.cpp
     part_nonrepl_actor_readblocks_local.cpp
     part_nonrepl_actor_stats.cpp
     part_nonrepl_actor_writeblocks.cpp
+    part_nonrepl_actor_writeblocks_multi_agent.cpp
     part_nonrepl_actor_zeroblocks.cpp
     part_nonrepl_common.cpp
 

--- a/example/0-setup.sh
+++ b/example/0-setup.sh
@@ -148,6 +148,7 @@ setup_nonrepl_disk_registry() {
     setup_remote_disk_agent 1
     setup_remote_disk_agent 2
     setup_remote_disk_agent 3
+    setup_remote_disk_agent 4
 
     cat > "$BIN_DIR"/nbs/nbs-disk-registry.txt <<EOF
 KnownAgents {
@@ -169,6 +170,13 @@ KnownAgents {
     Devices: "remote3-1024-1"
     Devices: "remote3-1024-2"
     Devices: "remote3-1024-3"
+}
+
+KnownAgents {
+    AgentId: "remote4.cloud-example.net"
+    Devices: "remote4-1024-1"
+    Devices: "remote4-1024-2"
+    Devices: "remote4-1024-3"
 }
 
 KnownAgents {

--- a/example/4-start_disk_agent.sh
+++ b/example/4-start_disk_agent.sh
@@ -52,6 +52,10 @@ start_nbs_agent 3
 pid3=$!
 echo "Agent 3 started with pid $pid3"
 
+start_nbs_agent 4
+pid4=$!
+echo "Agent 4 started with pid $pid4"
+
 # trap ctrl-c and call ctrl_c()
 trap ctrl_c INT
 
@@ -60,6 +64,7 @@ function ctrl_c() {
     kill $pid1
     kill $pid2
     kill $pid3
+    kill $pid4
     exit 0
 }
 

--- a/example/nbs/nbs-diag.txt
+++ b/example/nbs/nbs-diag.txt
@@ -1,2 +1,2 @@
 UseAsyncLogger: true
-
+SamplingRate: 1000


### PR DESCRIPTION
продолжение https://github.com/ydb-platform/nbs/issues/1720
1. Запросы теперь проходят через TNonreplicatedPartitionActor, что позволяет обновлять service и service_volume статистику и учитывать время последних запросов для вычисления таймаута
2. если одна из реплик таймаутит или сломана, то откатываемся на старый режим выполнения запросов. 
3. Реплики для записи теперь выбираются поочередно. 