### PR TITLE
feat: add ability to retry failed tests on checks

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -82,6 +82,7 @@ runs:
         CACHE_UPDATE: ${{ inputs.cache_update }}
       run: |
         function grep_ya_tc() {
+          # shellcheck disable=SC2009
           ps aux | grep "[y]a-tc" || true
         }
 
@@ -161,6 +162,7 @@ runs:
           ya_bin_path=$(find /home/github/.ya/tools/ -type f -name "ya-bin")
           if [ ! -s "$ya_bin_path" ]; then
             echo "ya-bin exists but is empty, lets look for ya-tc process and kill it if it's running somehow."
+            # shellcheck disable=SC2009
             ps auxf | grep -vE "]$"
             ls -lsha "$ya_bin_path"
             du -h -d 1 /home/github/.ya/
@@ -171,14 +173,14 @@ runs:
             start_time=$(date +%s)
 
             while true; do
-              pgrep -x "$process_name" && {
+              if pgrep -x "$process_name"; then
                   echo "$process_name is still running."
                   grep_ya_tc
-              } || {
+              else
                   echo "$process_name is not running."
                   grep_ya_tc
                   break
-              }
+              fi
 
               current_time=$(date +%s)
               elapsed_time=$((current_time - start_time))
@@ -196,6 +198,7 @@ runs:
 
             echo "ya-bin exists but is empty, recovering by removing it."
             ls -lsha "$ya_bin_path"
+            # shellcheck disable=SC2009
             ps auxf | grep -vE "]$"
             rm -rf $ya_bin_path
           fi

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -99,6 +99,9 @@ runs:
           --dump-graph-to-file "$TMP_DIR/ya_graph.json" 
           --cache-size 512G
         )
+        # strip quotes from the string
+        # TODO: remove it when pr.yaml gets updated
+        BUILD_TARGET=${BUILD_TARGET//\"/}
 
         if [ -n "$BUILD_TARGET" ]; then
           readarray -d ',' -t targets < <(printf "%s" "$BUILD_TARGET")

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -38,7 +38,6 @@ inputs:
     default: "yes"
     description: "use network cache"
 
-
 runs:
   using: composite
   steps:
@@ -64,73 +63,101 @@ runs:
         chmod 600 "$BAZEL_REMOTE_PASSWORD_FILE"
         chown github:github "$BAZEL_REMOTE_PASSWORD_FILE"
 
+    - name: Setup cache password file
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        BAZEL_REMOTE_PASSWORD: ${{ inputs.bazel_remote_password }}
+      run: |
+        export BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
+        echo -n "$BAZEL_REMOTE_PASSWORD" > "$BAZEL_REMOTE_PASSWORD_FILE"
+        echo "BAZEL_REMOTE_PASSWORD_FILE=$BAZEL_REMOTE_PASSWORD_FILE" >> "$GITHUB_ENV"
+        chmod 600 "$BAZEL_REMOTE_PASSWORD_FILE"
+        chown github:github "$BAZEL_REMOTE_PASSWORD_FILE"
+
     - name: build
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        NUMBER_OF_RETRIES: ${{ inputs.number_of_retries }}
+        BUILD_PRESET: ${{ inputs.build_preset }}
+        BUILD_TARGET: ${{ inputs.build_target }}
+        BUILD_THREADS: ${{ inputs.build_threads }}
+        LINK_THREADS: ${{ inputs.link_threads }}
+        BAZEL_REMOTE_USERNAME: ${{ inputs.bazel_remote_username }}
+        BAZEL_REMOTE_URI: ${{ inputs.bazel_remote_uri }}
+        USE_NETWORK_CACHE: ${{ inputs.use_network_cache }}
+        CACHE_UPDATE: ${{ inputs.cache_update }}
       run: |
         function grep_ya_tc() {
           ps aux | grep "[y]a-tc" || true
         }
 
-        extra_params=()
+        extra_params=(
+          --keep-going
+          --threads="$BUILD_THREADS"
+          --link-threads "${LINK_THREADS}" 
+          --force-build-depends
+          -T
+          --stat
+          --log-file "$TMP_DIR/ya_log.txt"
+          --evlog-file "$TMP_DIR/ya_evlog.jsonl"
+          --dump-graph
+          --dump-graph-to-file "$TMP_DIR/ya_graph.json" 
+          --cache-size 512G
+        )
 
-        # shellcheck disable=SC2157
-        if [ -n "${{ inputs.build_target }}" ]; then
-          readarray -d ',' -t targets < <(printf "%s" "${{ inputs.build_target }}")
+        if [ -n "$BUILD_TARGET" ]; then
+          readarray -d ',' -t targets < <(printf "%s" "$BUILD_TARGET")
           for target in "${targets[@]}"; do
             extra_params+=(--target="${target}")
           done
         fi
 
-        # shellcheck disable=SC2157,SC2193
-        if [ "${{ inputs.use_network_cache }}" == "yes" ]; then
-          if [ -n "${{ inputs.bazel_remote_uri }}" ]; then
+        if [ "$USE_NETWORK_CACHE" == "yes" ]; then
+          if [ -n "$BAZEL_REMOTE_URI" ]; then
             extra_params+=(--bazel-remote-store)
-            extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
+            extra_params+=(--bazel-remote-base-uri "$BAZEL_REMOTE_URI")
           fi
 
-          # shellcheck disable=SC2157
-          if [ -n "${{ inputs.bazel_remote_username }}" ]; then
-            extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
-            extra_params+=(--bazel-remote-password-file="$BAZEL_REMOTE_PASSWORD_FILE")
+          if [ -n "$BAZEL_REMOTE_USERNAME" ]; then
+            extra_params+=(--bazel-remote-username "$BAZEL_REMOTE_USERNAME")
+            extra_params+=(--bazel-remote-password-file "$BAZEL_PASSWORD_FILE")
             extra_params+=(--add-result .o)
           fi
 
-          # shellcheck disable=SC2193
-          if [ "${{ inputs.cache_update }}" == "true" ]; then
+          if [ "$CACHE_UPDATE" == "true" ]; then
             extra_params+=(--bazel-remote-put)
           fi
         fi
 
-        # shellcheck disable=SC2195
-        case "${{ inputs.build_preset }}" in
+        case "$BUILD_PRESET" in
           debug)
-            build_type=debug
+            extra_params+=(--build "debug")
             ;;
           relwithdebinfo)
-            build_type=relwithdebinfo
+            extra_params+=(--build "relwithdebinfo")
             ;;
           release-asan)
-            build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="address")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             ;;
           release-tsan)
-            build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="thread")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             ;;
           release-msan)
-            build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="memory")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             ;;
           release-ubsan)
-            build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="undefined")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             ;;
           *)
-            echo "Invalid preset: ${{ inputs.build_preset }}"
+            echo "Invalid preset: $BUILD_PRESET"
             exit 1
             ;;
         esac
@@ -182,11 +209,7 @@ runs:
           echo "/home/github/.ya/tools/ not found"
         fi
         date
-        sudo -E -H -u github ./ya make -k -j${{ inputs.build_threads }} --build "${build_type}" --force-build-depends -T --stat  \
-          --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
-          --dump-graph --dump-graph-to-file "$TMP_DIR/ya_graph.json" \
-          --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
-          "${extra_params[@]}"
+        sudo -E -H -u github ./ya make "${extra_params[@]}"
         date
 
     - name: Sync logs to S3

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -44,24 +44,18 @@ runs:
     - name: Init
       id: init
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        CLEAN_YA_DIR: ${{ inputs.clean_ya_dir }}
       run: |
         export TMP_DIR=/home/github/tmp_build
         echo "TMP_DIR=$TMP_DIR" >> $GITHUB_ENV
         rm -rf $TMP_DIR && mkdir $TMP_DIR && chown -R github:github $TMP_DIR $GITHUB_WORKSPACE
 
-        # shellcheck disable=SC2193
-        if [ "${{ inputs.clean_ya_dir }}" == "yes" ] && [ -d /home/github/.ya/ ]; then
+        
+        if [ "$CLEAN_YA_DIR" == "yes" ] && [ -d /home/github/.ya/ ]; then
           echo "Cleaning ya dir"
           rm -rf /home/github/.ya/
         fi
-    - name: Setup cache password file
-      shell: bash
-      run: |
-        export BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
-        echo -n "${{ inputs.bazel_remote_password }}" > "$BAZEL_REMOTE_PASSWORD_FILE"
-        echo "BAZEL_REMOTE_PASSWORD_FILE=$BAZEL_REMOTE_PASSWORD_FILE" >> "$GITHUB_ENV"
-        chmod 600 "$BAZEL_REMOTE_PASSWORD_FILE"
-        chown github:github "$BAZEL_REMOTE_PASSWORD_FILE"
 
     - name: Setup cache password file
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/actions/nebius_cli/action.yaml
+++ b/.github/actions/nebius_cli/action.yaml
@@ -26,9 +26,11 @@ runs:
         curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
     - name: configure nebius cli
       shell: bash
+      with:
+        SA_JSON: ${{ inputs.sa_json }}
       run: |
         cat <<EOF > sa.json
-        ${sa_json}
+        ${SA_JSON}
         EOF
 
         jq -r '."subject-credentials"."private-key"' sa.json > private.pem

--- a/.github/actions/nebius_cli/action.yaml
+++ b/.github/actions/nebius_cli/action.yaml
@@ -54,6 +54,6 @@ runs:
       run: |
         export GITHUB_RUNNER_IPV4=$(nebius compute instance get "${INSTANCE_ID}" --format json | jq -r .network_interfaces[].primary_v4_address.one_to_one_nat.address)
         export GITHUB_RUNNER_IPV4=$(nebius compute instance get --id "${INSTANCE_ID}" --format json | jq -r '.status.network_interfaces[0].public_ip_address.address')
-        echo "GITHUB_RUNNER_IPV4=${GITHUB_RUNNER_IPV4}" >> $GITHUB_ENV
+        echo "GITHUB_RUNNER_IPV4=${GITHUB_RUNNER_IPV4}" | tee -a $GITHUB_ENV
         echo "runner_ipv4=${GITHUB_RUNNER_IPV4}" >> $GITHUB_OUTPUT
         echo "ssh github@${GITHUB_RUNNER_IPV4}" | tee -a $GITHUB_SUMMARY

--- a/.github/actions/nebius_cli/action.yaml
+++ b/.github/actions/nebius_cli/action.yaml
@@ -47,9 +47,11 @@ runs:
     - id: result
       name: print ipv4 address of the vm
       shell: bash
+      env:
+        INSTANCE_ID: ${{ inputs.instance_id }}
       run: |
-        export GITHUB_RUNNER_IPV4=$(nebius compute instance get ${{ inputs.instance_id }} --format json | jq -r .network_interfaces[].primary_v4_address.one_to_one_nat.address)
-        export GITHUB_RUNNER_IPV4=$(nebius compute instance get --id ${{ inputs.instance_id }} --format json | jq -r '.status.network_interfaces[0].public_ip_address.address')
+        export GITHUB_RUNNER_IPV4=$(nebius compute instance get "${INSTANCE_ID}" --format json | jq -r .network_interfaces[].primary_v4_address.one_to_one_nat.address)
+        export GITHUB_RUNNER_IPV4=$(nebius compute instance get --id "${INSTANCE_ID}" --format json | jq -r '.status.network_interfaces[0].public_ip_address.address')
         echo "GITHUB_RUNNER_IPV4=${GITHUB_RUNNER_IPV4}" >> $GITHUB_ENV
         echo "runner_ipv4=${GITHUB_RUNNER_IPV4}" >> $GITHUB_OUTPUT
         echo "ssh github@${GITHUB_RUNNER_IPV4}" | tee -a $GITHUB_SUMMARY

--- a/.github/actions/nebius_runner_create/action.yaml
+++ b/.github/actions/nebius_runner_create/action.yaml
@@ -91,9 +91,9 @@ runs:
       run: |
         export SERVICE_ACCOUNT_KEY=$(mktemp)
         echo "SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY}" >> $GITHUB_ENV
-        echo "${key_contents}" > $SERVICE_ACCOUNT_KEY
+        echo "${KEY_CONTENTS}" > $SERVICE_ACCOUNT_KEY
       env:
-        key_contents: ${{ inputs.service_account_key }}
+        KEY_CONTENTS: ${{ inputs.service_account_key }}
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/actions/nebius_runner_remove/action.yaml
+++ b/.github/actions/nebius_runner_remove/action.yaml
@@ -28,9 +28,9 @@ runs:
       run: |
         export SERVICE_ACCOUNT_KEY=$(mktemp)
         echo "SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY}" >> $GITHUB_ENV
-        echo "${key_contents}" > $SERVICE_ACCOUNT_KEY
+        echo "${KEY_CONTENTS}" > $SERVICE_ACCOUNT_KEY
       env:
-        key_contents: ${{ inputs.service_account_key }}
+        KEY_CONTENTS: ${{ inputs.service_account_key }}
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/actions/nebius_threads_calculator/action.yaml
+++ b/.github/actions/nebius_threads_calculator/action.yaml
@@ -27,12 +27,12 @@ runs:
       id: calculate-threads
       shell: bash
       run: |
-        echo "vm_preset: ${vm_preset}"
-        echo "tests_size: ${tests_size}"
+        echo "vm_preset: ${VM_PRESET}"
+        echo "tests_size: ${TESTS_SIZE}"
         echo "checking size of the tests could be small, medium, large and combination of them"
         test_threads=0
-        if [[ $tests_size == *"large"* ]]; then
-          case "$vm_preset" in
+        if [[ $TESTS_SIZE == *"large"* ]]; then
+          case "$VM_PRESET" in
             # for large tests we need 6 vcpu per thread
             "256vcpu-1024gb")
                 test_threads=42
@@ -91,12 +91,12 @@ runs:
                 build_threads=2
             ;;
             *)
-              echo "Unknown vm_preset: $vm_preset"
+              echo "Unknown vm_preset: $VM_PRESET"
               exit 1
             ;;
           esac
         else
-          case "$vm_preset" in
+          case "$VM_PRESET" in
             "256vcpu-1024gb")
                 test_threads=64
                 build_threads=256
@@ -154,7 +154,7 @@ runs:
                 build_threads=2
             ;;
             *)
-              echo "Unknown vm_preset: $vm_preset"
+              echo "Unknown vm_preset: $VM_PRESET"
               exit 1
             ;;
           esac
@@ -167,5 +167,5 @@ runs:
         } | tee -a $GITHUB_OUTPUT
         
       env:
-        vm_preset: ${{ inputs.vm_preset || '80vcpu-320gb' }}
-        tests_size: ${{ inputs.tests_size || 'small,medium,large' }}
+        VM_PRESET: ${{ inputs.vm_preset || '80vcpu-320gb' }}
+        TESTS_SIZE: ${{ inputs.tests_size || 'small,medium,large' }}

--- a/.github/actions/s3cmd/action.yaml
+++ b/.github/actions/s3cmd/action.yaml
@@ -27,7 +27,7 @@ inputs:
     description: "github user"
   install:
     required: false
-    default: true
+    default: "true"
     description: "install s3cmd and awscli"
 
 runs:
@@ -49,32 +49,40 @@ runs:
         }
     - name: configure s3cmd and awscli
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        S3_ENDPOINT: ${{ inputs.s3_endpoint }}
+        S3_BUCKET: ${{ inputs.s3_bucket }}
+        S3_WEBSITE_SUFFIX: ${{ inputs.s3_website_suffix }}
+        S3_FOLDER_PREFIX: ${{ inputs.folder_prefix }}
+        S3_KEY_ID: ${{ inputs.s3_key_id }}
+        S3_SECRET_ACCESS_KEY: ${{ inputs.s3_key_secret }}
+        BUILD_PRESET: ${{ inputs.build_preset }}
+        USER: ${{ inputs.user || 'github'}}
       run: |
-        export S3CMD_CONFIG=$(sudo -E -H -u $user mktemp -p /home/$user)
-        sudo chown $user: $S3CMD_CONFIG
+        export S3CMD_CONFIG=$(sudo -E -H -u $USER mktemp -p /home/$USER)
+        sudo chown $USER: $S3CMD_CONFIG
         echo "S3CMD_CONFIG=$S3CMD_CONFIG" >> $GITHUB_ENV
         export GITHUB_WORKFLOW_NO_SPACES=${GITHUB_WORKFLOW// /-}
-        export S3_ENDPOINT="${{ inputs.s3_endpoint }}"
         export S3_ENDPOINT_NO_PROTOCOL=$(echo $S3_ENDPOINT | sed 's/https\?:\/\///')
-        cat <<EOF | sudo -E -H -u $user tee $S3CMD_CONFIG
+        cat <<EOF | sudo -E -H -u $USER tee $S3CMD_CONFIG
         [default]
-        access_key = ${s3_key_id}
-        secret_key = ${s3_secret_access_key}
+        access_key = ${S3_KEY_ID}
+        secret_key = ${S3_SECRET_ACCESS_KEY}
         bucket_location = eu-north1
         host_base = ${S3_ENDPOINT_NO_PROTOCOL}
         host_bucket = %(bucket)s.${S3_ENDPOINT_NO_PROTOCOL}
         EOF
 
-        sudo -E -H -u $user mkdir -p /home/$user/.aws/
-        cat <<EOF | sudo -E -H -u $user tee /home/$user/.aws/credentials
+        sudo -E -H -u $USER mkdir -p /home/$USER/.aws/
+        cat <<EOF | sudo -E -H -u $USER tee /home/$USER/.aws/credentials
         [default]
-        aws_access_key_id = ${s3_key_id}
-        aws_secret_access_key = ${s3_secret_access_key}
+        aws_access_key_id = ${S3_KEY_ID}
+        aws_secret_access_key = ${S3_SECRET_ACCESS_KEY}
         EOF
-        cat <<EOF | sudo -E -H -u $user tee /home/$user/.aws/config
+        cat <<EOF | sudo -E -H -u $USER tee /home/$USER/.aws/config
         [default]
         region = eu-north1
-        endpoint_url=${{ inputs.s3_endpoint }}
+        endpoint_url=$S3_ENDPOINT
         s3 =
           max_concurrent_requests = 32
           multipart_chunksize = 32MB
@@ -84,13 +92,13 @@ runs:
         sudo mkdir -p /root/.aws/
         cat <<EOF | sudo tee /root/.aws/credentials
         [default]
-        aws_access_key_id = ${s3_key_id}
-        aws_secret_access_key = ${s3_secret_access_key}
+        aws_access_key_id = ${S3_KEY_ID}
+        aws_secret_access_key = ${S3_SECRET_ACCESS_KEY}
         EOF
         cat <<EOF | sudo tee /root/.aws/config
         [default]
         region = eu-north1
-        endpoint_url=${{ inputs.s3_endpoint }}
+        endpoint_url=$S3_ENDPOINT
         s3 =
           max_concurrent_requests = 32
           multipart_chunksize = 32MB
@@ -100,7 +108,7 @@ runs:
         folder="${{ runner.arch == 'X64' && 'x86-64' || runner.arch == 'ARM64' && 'arm64' || 'unknown' }}"
 
         # shellcheck disable=SC2195
-        case "${{ inputs.build_preset }}" in
+        case "$BUILD_PRESET" in
           relwithdebinfo|release)
             ;;
           debug)
@@ -119,21 +127,18 @@ runs:
             folder+="-ubsan"
             ;;
           *)
-            echo "Invalid preset: ${{ inputs.build_preset }}"
+            echo "Invalid preset: $BUILD_PRESET"
             exit 1
             ;;
         esac
         # shellcheck disable=SC2129
-        echo "S3_BUCKET_PATH=s3://${{ inputs.s3_bucket }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
-        echo "S3_URL_PREFIX=${{ inputs.s3_endpoint }}/${{ inputs.s3_bucket }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
-        echo "S3_WEBSITE_PREFIX=https://${{ inputs.s3_bucket }}.${{ inputs.s3_website_suffix }}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
-        echo "S3_WEBSITE_SUFFIX=${{ inputs.s3_website_suffix }}" >> $GITHUB_ENV
-      env:
-        s3_key_id: ${{ inputs.s3_key_id }}
-        s3_secret_access_key: ${{ inputs.s3_key_secret }}
-        user: ${{ inputs.user || 'github'}}
+        echo "S3_BUCKET_PATH=s3://${S3_BUCKET}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}" >> $GITHUB_ENV
+        echo "S3_URL_PREFIX=${S3_ENDPOINT}/${S3_BUCKET}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}" >> $GITHUB_ENV
+        echo "S3_WEBSITE_PREFIX=https://${S3_BUCKET}.${S3_WEBSITE_SUFFIX}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}" >> $GITHUB_ENV
+        echo "S3_WEBSITE_SUFFIX=${S3_WEBSITE_SUFFIX}" >> $GITHUB_ENV
+        
     - name: test s3cmd
       shell: bash
-      run: sudo -E -H -u $user s3cmd ls
+      run: sudo -E -H -u $USER s3cmd ls
       env:
-        user: ${{ inputs.user || 'github'}}
+        USER: ${{ inputs.user || 'github'}}

--- a/.github/actions/ssh_keys/action.yaml
+++ b/.github/actions/ssh_keys/action.yaml
@@ -23,49 +23,49 @@ runs:
       shell: bash
       if: ${{ github.repository == 'ydb-platform/nbs'}}
       run: |
-        echo "https://api.github.com/orgs/${org}/teams/${team}/members?per_page=100&page=1"
+        echo "https://api.github.com/orgs/${ORG}/teams/${TEAM}/members?per_page=100&page=1"
         curl -s -L -H "Accept: application/vnd.github+json" \
-             -H "Authorization: Bearer $token" \
+             -H "Authorization: Bearer $TOKEN" \
              -H "X-GitHub-Api-Version: 2022-11-28" \
-             "https://api.github.com/orgs/${org}/teams/${team}/members?per_page=100&page=1"
+             "https://api.github.com/orgs/${ORG}/teams/${TEAM}/members?per_page=100&page=1"
         curl -s -L -H "Accept: application/vnd.github+json" \
-             -H "Authorization: Bearer $token" \
+             -H "Authorization: Bearer $TOKEN" \
              -H "X-GitHub-Api-Version: 2022-11-28" \
-             "https://api.github.com/orgs/${org}/teams/${team}/members?per_page=100&page=1" | jq -r .[].login | tee -a $LOGINS_FILE
+             "https://api.github.com/orgs/${ORG}/teams/${TEAM}/members?per_page=100&page=1" | jq -r .[].login | tee -a $LOGINS_FILE
       env:
-        org: ${{ inputs.org }}
-        team: ${{ inputs.team }}
-        token: ${{ inputs.token }}
+        ORG: ${{ inputs.org }}
+        TEAM: ${{ inputs.team }}
+        TOKEN: ${{ inputs.token }}
     - name: collect members
       shell: bash
       if: ${{ github.repository != 'ydb-platform/nbs' }}
       run: |
-        echo "https://api.github.com/orgs/${org}/members?per_page=100&page=1"
+        echo "https://api.github.com/orgs/${ORG}/members?per_page=100&page=1"
         curl -s -L -H "Accept: application/vnd.github+json" \
-             -H "Authorization: Bearer $token" \
+             -H "Authorization: Bearer $TOKEN" \
              -H "X-GitHub-Api-Version: 2022-11-28" \
-             "https://api.github.com/orgs/${org}/members?per_page=100&page=1"
+             "https://api.github.com/orgs/${ORG}/members?per_page=100&page=1"
         curl -s -L -H "Accept: application/vnd.github+json" \
-             -H "Authorization: Bearer $token" \
+             -H "Authorization: Bearer $TOKEN" \
              -H "X-GitHub-Api-Version: 2022-11-28" \
-             "https://api.github.com/orgs/${org}/members?per_page=100&page=1" | jq -r .[].login | tee -a $LOGINS_FILE
+             "https://api.github.com/orgs/${ORG}/members?per_page=100&page=1" | jq -r .[].login | tee -a $LOGINS_FILE
       env:
-        org: ${{ inputs.org }}
-        team: ${{ inputs.team }}
-        token: ${{ inputs.token }}
+        ORG: ${{ inputs.org }}
+        TEAM: ${{ inputs.team }}
+        TOKEN: ${{ inputs.token }}
     - name: collect members public ssh keys
       shell: bash
       run: |
         cat $LOGINS_FILE | while read -r login; do
           curl  -s -L -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer $token" \
+                -H "Authorization: Bearer $TOKEN" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 https://api.github.com/users/${login}/keys | jq -r .[].key | while read -r key; do
                   echo $key $login;
                 done;
         done | tee -a $KEYS_FILE
       env:
-        token: ${{ inputs.token }}
+        TOKEN: ${{ inputs.token }}
     - name: add ssh keys to user authorized_keys file
       shell: bash
       run: |

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -68,6 +68,7 @@ runs:
         {
           echo "TMP_DIR=$TMP_DIR"
           echo "LOG_DIR=$TMP_DIR/logs"
+          echo "YA_MAKE_OUTPUT=$TMP_DIR/logs/ya_make_output"
           echo "OUT_DIR=$TMP_DIR/out"
           echo "ARTIFACTS_DIR=$TMP_DIR/artifacts"
           echo "TESTS_DATA_DIR=$TMP_DIR/test_data"
@@ -75,7 +76,7 @@ runs:
           echo "JUNIT_REPORT_XML=$TMP_DIR/junit.xml"
           echo "JUNIT_REPORT_PARTS=$TMP_DIR/junit-split"
           echo "SUMMARY_LINKS=$(mktemp -p /home/github)"
-        } >> $GITHUB_ENV
+        } | tee -a $GITHUB_ENV
 
     - name: prepare
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -94,7 +95,7 @@ runs:
         cat /etc/hosts
 
     - name: Setup cache password file
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         export BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
         echo -n "${{ inputs.bazel_remote_password }}" > "$BAZEL_REMOTE_PASSWORD_FILE"
@@ -104,37 +105,62 @@ runs:
 
     - name: ya test
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        NUMBER_OF_RETRIES: ${{ github.event_name == 'pull_request_target' && 3 || 1 }}
       run: |
-        set -x
-        extra_params=()
+        extra_params=(
+          --run-all-tests
+          --keep-going
+          --retest
+          --test-threads "${{ inputs.test_threads }}"
+          --link-threads "${{ inputs.link_threads }}"
+          --cache-size 512G
+          --do-not-output-stderrs
+          -T
+          --nice 0
+          --stat
+          --output "$OUT_DIR"
+        )
 
         # shellcheck disable=SC2195
         case "${{ inputs.build_preset }}" in
           debug)
             build_type=debug
+            extra_params+=(--build "debug")
+            RETRY_COUNT=${NUMBER_OF_RETRIES}
             ;;
           relwithdebinfo)
             build_type=relwithdebinfo
+            extra_params+=(--build "relwithdebinfo")
+            RETRY_COUNT=${NUMBER_OF_RETRIES}
             ;;
           release-asan)
             build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="address")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
+            RETRY_COUNT=1
             ;;
           release-tsan)
             build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="thread")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
+            RETRY_COUNT=1
             ;;
           release-msan)
             build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="memory")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
+            RETRY_COUNT=1
             ;;
           release-ubsan)
             build_type=release
+            extra_params+=(--build "release")
             extra_params+=(--sanitize="undefined")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
+            RETRY_COUNT=1
             ;;
           *)
             echo "Invalid preset: ${{ inputs.build_preset }}"
@@ -185,30 +211,72 @@ runs:
         echo "::endgroup::"
         date
         ./ya --version
-        echo "::group::ya-make-test"
-        sudo -E -H -u github ./ya test -k --build "${build_type}" \
-          "${test_size[@]/#/--test-size=}" "${test_type[@]/#/--test-type=}" \
-          --test-threads "${{ inputs.test_threads }}" --link-threads "${{ inputs.link_threads }}" \
-          --cache-size 512G --do-not-output-stderrs -T \
-          --stat --log-file "$LOG_DIR/ya_log.txt" --evlog-file "$LOG_DIR/ya_evlog.jsonl" \
-          --junit "$JUNIT_REPORT_XML" --output "$OUT_DIR" "${extra_params[@]}" --nice 0 || (
-            RC=$?
-            if [ $RC -ne 0 ]; then
-              echo "ya test returned $RC, check existence $JUNIT_REPORT_XML"
-              if [ -s "$JUNIT_REPORT_XML" ]; then
-                echo "$JUNIT_REPORT_XML exists"
-                ls -la "$JUNIT_REPORT_XML"
-                echo "::endgroup::"
-                date
+        RETRIES=$RETRY_COUNT
+        echo "RETRIES=${RETRIES}" | tee -a "$GITHUB_ENV"
+        RETRY_FLAG=""
+        for i in $(seq 1 $RETRIES); do
+          echo "::group::ya-make-test-${i}"
+          set +e
+          (
+            sudo -E -H -u github ./ya make "${test_size[@]/#/--test-size=}" \
+                "${test_type[@]/#/--test-type=}" \
+                "${extra_params[@]}" \
+                --junit "${JUNIT_REPORT_XML}.${i}" \
+                --log-file "$LOG_DIR/ya_log.$i.txt" \
+                --evlog-file "$LOG_DIR/ya_evlog.$i.jsonl" \
+                "$RETRY_FLAG";
+            echo $? > exit_code
+          ) |& tee "${YA_MAKE_OUTPUT}.${i}.txt"
+          set -e
+          RC=$(< exit_code)
+          DO_RETRY=0
+          case $RC in
+            0)
+              echo "ya test successfully finished, no errors"
+              ls -la "${JUNIT_REPORT_XML}.${i}" || true
+              date
+              if [ -s "${JUNIT_REPORT_XML}.${i}" ]; then
+                echo "${JUNIT_REPORT_XML}.${i} exists"
               else
-                echo "$JUNIT_REPORT_XML doesn't exist or has zero size"
-                ls -la "$JUNIT_REPORT_XML" || true
-                echo "::endgroup::"
-                date
-                exit $RC
+                echo "${JUNIT_REPORT_XML}.${i} doesn't exist or has zero size"
               fi
-            fi
-        )
+              ;;
+            137)
+              echo "ya test returned $RC it was killed by OOM killer"
+              DO_RETRY=1
+              if [ "$i" -eq "$RETRY_COUNT" ];
+              then
+                DO_RETRY=0
+              fi
+              ;;
+            *)
+              echo "ya test returned $RC"
+              ls -la "${JUNIT_REPORT_XML}.${i}" || true
+              date
+              if [ -s "${JUNIT_REPORT_XML}.${i}" ]; then
+                echo "${JUNIT_REPORT_XML}.${i} exists"
+              else
+                echo "${JUNIT_REPORT_XML}.${i} doesn't exist or has zero size"
+              fi
+              # disabling retries here for now until we will be able to 
+              # process junit with retried runs
+              DO_RETRY=1
+              RETRY_FLAG="-X"
+              if [ "$i" -eq "$RETRY_COUNT" ];
+              then
+                DO_RETRY=0
+              fi
+              ;;
+          esac
+          if [ $DO_RETRY -eq 1 ]; then
+            echo "Retrying..."
+            echo "::endgroup::"
+            continue
+          else
+            echo "::endgroup::"
+            break
+          fi
+        done
 
     - name: copying system files
       if: ${{ !cancelled() }}
@@ -221,7 +289,14 @@ runs:
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         # shellcheck disable=SC2024
-        sudo -E -H -u github gzip -c $JUNIT_REPORT_XML > $REPORTS_ARTIFACTS_DIR/orig_junit.xml.gz
+        for i in $(seq 1 $RETRIES); do
+          # shellcheck disable=SC2024
+          if [ -f "${JUNIT_REPORT_XML}.${i}" ];
+          then
+            # shellcheck disable=SC2024
+            sudo -E -H -u github gzip -c "${JUNIT_REPORT_XML}.${i}" > "$REPORTS_ARTIFACTS_DIR/orig_junit.${i}.xml.gz"
+          fi
+        done
 
     - name: postprocess junit report
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -230,17 +305,25 @@ runs:
         cat .github/config/muted_ya.txt
         MUTED_CONFIG=".github/config/muted_ya.txt"
         echo "::endgroup::"
-        echo "::group::postprocess-junit"
-        sudo -E -H -u github .github/scripts/tests/transform-ya-junit.py -i \
-          -m "${MUTED_CONFIG}" \
-          --ya-out "$OUT_DIR" \
-          --log-url-prefix "$S3_WEBSITE_PREFIX/logs/" \
-          --data-url-prefix "$S3_WEBSITE_PREFIX/test_data$GITHUB_WORKSPACE" \
-          --log-out-dir "$ARTIFACTS_DIR/logs/" \
-          "$JUNIT_REPORT_XML"
+        # shellcheck disable=SC2024
+        for i in $(seq 1 $RETRIES); do
+          # shellcheck disable=SC2024
+          if [ -f "${JUNIT_REPORT_XML}.${i}" ];
+          then
+            # shellcheck disable=SC2024
+            echo "::group::postprocess-junit-${i}"
+            sudo -E -H -u github .github/scripts/tests/transform-ya-junit.py -i \
+              -m "${MUTED_CONFIG}" \
+              --ya-out "$OUT_DIR" \
+              --log-url-prefix "$S3_WEBSITE_PREFIX/logs/" \
+              --data-url-prefix "$S3_WEBSITE_PREFIX/test_data$GITHUB_WORKSPACE" \
+              --log-out-dir "$ARTIFACTS_DIR/logs/" \
+              "${JUNIT_REPORT_XML}.${i}"
 
-        sudo -E -H -u github .github/scripts/tests/split-junit.py -o "$JUNIT_REPORT_PARTS" "$JUNIT_REPORT_XML"
-        echo "::endgroup::"
+            sudo -E -H -u github .github/scripts/tests/split-junit.py -o "$JUNIT_REPORT_PARTS/${i}" "${JUNIT_REPORT_XML}.${i}"
+            echo "::endgroup::"
+          fi
+        done
 
     - name: dump VM artifacts
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -257,46 +340,67 @@ runs:
     - name: archive unitest reports (transformed)
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        sudo -E -H -u github tar -C $JUNIT_REPORT_PARTS/.. -czf $REPORTS_ARTIFACTS_DIR/junit_parts.xml.tar.gz "$(basename $JUNIT_REPORT_PARTS)" $JUNIT_REPORT_XML
+
+        sudo -E -H -u github tar -C $JUNIT_REPORT_PARTS/.. -czf $REPORTS_ARTIFACTS_DIR/junit_parts.xml.tar.gz "$(basename $JUNIT_REPORT_PARTS)" ${JUNIT_REPORT_XML}*
 
     - name: write tests summary
       shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        echo "::group::write-summary"
-        sudo -E -H -u github mkdir $ARTIFACTS_DIR/summary/
+        # shellcheck disable=SC2024
+        for i in $(seq 1 $RETRIES); do
+          # shellcheck disable=SC2024
+          if [ -f "${JUNIT_REPORT_XML}.${i}" ];
+          then
+            echo "::group::write-summary-${i}"
+            sudo -E -H -u github mkdir -p $ARTIFACTS_DIR/summary/${i}
 
-        cat $SUMMARY_LINKS | python3 -c 'import sys; print(" | ".join([v for _, v in sorted([l.strip().split(" ", 1) for l in sys.stdin], key=lambda a: (int(a[0]), a))]))' >> $GITHUB_STEP_SUMMARY
+            cat $SUMMARY_LINKS | python3 -c 'import sys; print(" | ".join([v for _, v in sorted([l.strip().split(" ", 1) for l in sys.stdin], key=lambda a: (int(a[0]), a))]))' >> $GITHUB_STEP_SUMMARY
 
-        platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
+            platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
 
-        export SUMMARY_OUT_ENV_PATH=$(mktemp -p /home/github)
-        chown github:github $SUMMARY_OUT_ENV_PATH
-        sudo -E -H -u github .github/scripts/tests/generate-summary.py \
-          --summary-out-path "$ARTIFACTS_DIR/summary/" \
-          --summary-out-env-path "$SUMMARY_OUT_ENV_PATH" \
-          --summary-url-prefix "$S3_WEBSITE_PREFIX/summary/" \
-          --build-preset "${platform_name}-${{ inputs.build_preset }}" \
-          "Tests" ya-test.html "$JUNIT_REPORT_XML"
+            export SUMMARY_OUT_ENV_PATH=$(mktemp -p /home/github)
+            chown github:github $SUMMARY_OUT_ENV_PATH
+            sudo -E -H -u github .github/scripts/tests/generate-summary.py \
+              --summary-out-path "$ARTIFACTS_DIR/summary/${i}/" \
+              --summary-out-env-path "$SUMMARY_OUT_ENV_PATH" \
+              --summary-url-prefix "$S3_WEBSITE_PREFIX/summary/${i}/" \
+              --build-preset "${platform_name}-${{ inputs.build_preset }}" \
+              "Tests" ya-test.html "${JUNIT_REPORT_XML}.${i}"
 
-        cat $SUMMARY_OUT_ENV_PATH | tee -a $GITHUB_STEP_SUMMARY
-        echo "::endgroup::"
+            cat $SUMMARY_OUT_ENV_PATH | tee -a $GITHUB_STEP_SUMMARY
+            echo "::endgroup::"
+          fi
+        done
 
     - name: check test results
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        sudo -E -H -u github .github/scripts/tests/fail-checker.py "$JUNIT_REPORT_XML" || {
-          RC=$?
-
-          echo "::group::Copy-failed-tests-data"
-          sudo -E -H -u github .github/scripts/tests/fail-checker.py "$JUNIT_REPORT_XML" --paths-only
-          sudo -E -H -u github .github/scripts/tests/fail-checker.py "$JUNIT_REPORT_XML" --paths-only | while read -r path; do
-            echo $path
-            find "${GITHUB_WORKSPACE}/${path}" -print0 | xargs -0 xargs -0 cp -L -r --parents -t "$TESTS_DATA_DIR"
-          done
+        NEED_COPYING=0
+        # shellcheck disable=SC2024
+        for i in $(seq 1 $RETRIES); do
+          # shellcheck disable=SC2024
+          if [ -f "${JUNIT_REPORT_XML}.${i}" ];
+          then
+            set +e
+            (sudo -E -H -u github .github/scripts/tests/fail-checker.py "${JUNIT_REPORT_XML}.${i}"; echo $? > exit_code) |& tee fail-checker-output.log
+            set -e
+            RC=$(< exit_code)
+            if [ "$RC" -ne 0 ]; then
+              NEED_COPYING=1
+              echo "::group::Copy-failed-tests-data"
+              sudo -E -H -u github .github/scripts/tests/fail-checker.py "${JUNIT_REPORT_XML}.${i}" --paths-only | while read -r path; do
+                echo $path
+                find "${GITHUB_WORKSPACE}/${path}" -print0 | xargs -0 xargs -0 cp -L -r --parents -t "$TESTS_DATA_DIR"
+              done
+              echo "::endgroup::"
+            fi
+          fi
+        done
+        if [ "$NEED_COPYING" -ne "0" ];
+        then 
           chown -R github:github "$TESTS_DATA_DIR"
-          echo "::endgroup::"
           echo "::group::remove-binaries-from-tests-data-dir"
           find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}'
           find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
@@ -325,14 +429,15 @@ runs:
             sudo -E -H -u github s3cmd sync --follow-symlinks --acl-private --no-progress --stats --no-check-md5 "$TESTS_DATA_DIR/" "$S3_BUCKET_PATH/test_data/"
           fi
           echo "::endgroup::"
-          exit $RC
-        }
+        fi
+        echo "Exiting with $RC"
+        exit $RC
       env:
         SYNC_TO_S3: ${{ inputs.sync_to_s3 || 'false' }}
 
     - name: Sync test results to S3
       if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         echo "::group::s3-sync"
         sudo -E -H -u github s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$ARTIFACTS_DIR/" "$S3_BUCKET_PATH/"
@@ -340,14 +445,7 @@ runs:
 
     - name: Sync logs results to S3
       if: always()
-      shell: bash
-      run: |
-        echo "::group::s3-sync"
-        sudo -E -H -u github s3cmd sync --follow-symlinks --acl-private --no-progress --stats --no-check-md5 "$LOG_DIR/" "$S3_BUCKET_PATH/test_logs/"
-        echo "::endgroup::"
-    - name: Sync reports to S3
-      if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         echo "::group::s3-sync"
         sudo -E -H -u github s3cmd sync --follow-symlinks --acl-private --no-progress --stats --no-check-md5 "$LOG_DIR/" "$S3_BUCKET_PATH/test_logs/"
@@ -355,7 +453,7 @@ runs:
 
     - name: Display links to s3 summary
       if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         echo "::group::s3-report-links"
         echo ${S3_URL_PREFIX}/summary/ya-test.html
@@ -440,12 +538,12 @@ runs:
         path: /home/github/ya_s3_url.txt
     - name: Create directory listing on s3
       if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         echo "::group::generate-listing"
         sudo -E -H -u github python3 .github/scripts/index.py "$S3_BUCKET_PATH" --generate-indexes --apply
         echo "::endgroup::"
     - name: show free space
       if: always()
-      shell: bash
+      shell: bash --noprofile --norc -eo pipefail -x {0}
       run: df -h

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -201,16 +201,6 @@ runs:
         # shellcheck disable=SC2153
         readarray -d ',' -t test_type < <(printf "%s" "$TEST_TYPE")
 
-        echo "::group::empty-files"
-        [ -d  /home/github/.ya/tools/ ] && {
-          find /home/github/.ya/tools/ -type f -exec file {} \; | grep empty;
-          ya_bin_path=$(find /home/github/.ya/tools/ -type f -name "ya-bin")
-          if [ ! -s "$ya_bin_path" ]; then
-            echo "ya-bin exists but is empty, recovering by removing ya-bin"
-            rm -rf $ya_bin_path
-          fi
-        }
-        echo "::endgroup::"
         date
         ./ya --version
         RETRIES="${NUMBER_OF_RETRIES}"
@@ -219,8 +209,8 @@ runs:
         RETRY_FLAG=""
         i=0
         while [ "$RETRIES" -gt 0 ]; do
-          ((RETRIES--))
-          ((i++))
+          RETRIES=$((RETRIES - 1))
+          i=$((i + 1))
           echo "::group::ya-make-test-${i}"
           set +e
           (
@@ -254,7 +244,9 @@ runs:
               else
                 DO_RETRY=1
                 OOM_CAN_BE_RETRIED=0
-                echo "Retrying once because OOM killer killed ya-bin"
+                RETRIES=$((RETRIES + 1 ))
+                echo "RETRIES=$((RETRIES + 1 ))" | tee -a "$GITHUB_ENV"
+                echo "Retrying once because OOM killer killed ya-bin, increasing retry count by 1"
               fi
               ;;
             *)
@@ -503,7 +495,7 @@ runs:
 
             sleep 5
         done
-        
+
         # shellcheck disable=SC2009
         ps aux | grep ya
         # checking if files are not corrupted

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -290,7 +290,7 @@ runs:
       if: ${{ !cancelled() }}
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        sudo cp /var/log/kern.log "$LOG_DIR/kern.log" &&
+        sudo cp /var/log/kern.log "$LOG_DIR/kern.log" || true
         sudo chown -R github:github "$LOG_DIR/kern.log" || true
 
     - name: archive unitest reports (orig)
@@ -473,6 +473,7 @@ runs:
       if: success() && inputs.upload_ya_dir == 'yes'
       run: |
         function grep_ya_tc() {
+          # shellcheck disable=SC2009
           ps aux | grep "[y]a-tc" || true
         }
         process_name="ya-tc"
@@ -480,14 +481,14 @@ runs:
         timeout=360
         start_time=$(date +%s)
         while true; do
-            pgrep -x "$process_name" && {
+            if pgrep -x "$process_name"; then
                 echo "$process_name is still running."
                 grep_ya_tc
-            } || {
+            else
                 echo "$process_name is not running."
                 grep_ya_tc
                 break
-            }
+            fi
 
             current_time=$(date +%s)
             elapsed_time=$((current_time - start_time))
@@ -502,7 +503,8 @@ runs:
 
             sleep 5
         done
-
+        
+        # shellcheck disable=SC2009
         ps aux | grep ya
         # checking if files are not corrupted
         echo "::group::ya-files-empty"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -38,24 +38,28 @@ inputs:
     description: "Use cache for tests"
   sync_to_s3:
     required: false
-    default: 'false'
-    description: 'Sync failed tests folders to s3'
+    default: "false"
+    description: "Sync failed tests folders to s3"
   upload_ya_dir:
     required: false
-    default: 'no'
-    description: 'Upload ya dir to s3'
+    default: "no"
+    description: "Upload ya dir to s3"
   clean_ya_dir:
     required: false
-    default: 'no'
-    description: 'Clean ya dir'
+    default: "no"
+    description: "Clean ya dir"
   use_network_cache:
     required: false
-    default: 'yes'
-    description: 'Use network cache'
+    default: "yes"
+    description: "Use network cache"
   truncate_enabled:
     required: false
-    default: 'yes'
-    description: 'Truncate err files'
+    default: "yes"
+    description: "Truncate err files"
+  number_of_retries:
+    required: false
+    default: "1"
+    description: "Number of retries for ya make"
 
 runs:
   using: composite
@@ -80,6 +84,8 @@ runs:
 
     - name: prepare
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        CLEAN_YA_DIR: ${{ inputs.clean_ya_dir }}
       run: |
         rm -rf $TMP_DIR $JUNIT_REPORT_XML $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR $TESTS_DATA_DIR
         mkdir -p $TMP_DIR $OUT_DIR $ARTIFACTS_DIR $LOG_DIR $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR $TESTS_DATA_DIR
@@ -87,7 +93,7 @@ runs:
                                $REPORTS_ARTIFACTS_DIR $SUMMARY_LINKS $GITHUB_WORKSPACE \
                                $GITHUB_STEP_SUMMARY $TESTS_DATA_DIR
         # shellcheck disable=SC2193
-        if [ "${{ inputs.clean_ya_dir }}" == "yes" ] && [ -d /home/github/.ya/ ]; then
+        if [ "$CLEAN_YA_DIR" == "yes" ] && [ -d /home/github/.ya/ ]; then
           echo "Cleaning ya dir"
           rm -rf /home/github/.ya/
         fi
@@ -96,9 +102,11 @@ runs:
 
     - name: Setup cache password file
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        BAZEL_REMOTE_PASSWORD: ${{ inputs.bazel_remote_password }}
       run: |
         export BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
-        echo -n "${{ inputs.bazel_remote_password }}" > "$BAZEL_REMOTE_PASSWORD_FILE"
+        echo -n "$BAZEL_REMOTE_PASSWORD" > "$BAZEL_REMOTE_PASSWORD_FILE"
         echo "BAZEL_REMOTE_PASSWORD_FILE=$BAZEL_REMOTE_PASSWORD_FILE" >> "$GITHUB_ENV"
         chmod 600 "$BAZEL_REMOTE_PASSWORD_FILE"
         chown github:github "$BAZEL_REMOTE_PASSWORD_FILE"
@@ -106,14 +114,24 @@ runs:
     - name: ya test
       shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
-        NUMBER_OF_RETRIES: ${{ github.event_name == 'pull_request_target' && 3 || 1 }}
+        NUMBER_OF_RETRIES: ${{ inputs.number_of_retries }}
+        BUILD_PRESET: ${{ inputs.build_preset }}
+        TEST_TARGET: ${{ inputs.test_target }}
+        TEST_SIZE: ${{ inputs.test_size }}
+        TEST_TYPE: ${{ inputs.test_type }}
+        TEST_THREADS: ${{ inputs.test_threads }}
+        LINK_THREADS: ${{ inputs.link_threads }}
+        BAZEL_REMOTE_USERNAME: ${{ inputs.bazel_remote_username }}
+        BAZEL_REMOTE_URI: ${{ inputs.bazel_remote_uri }}
+        USE_NETWORK_CACHE: ${{ inputs.use_network_cache }}
+        CACHE_UPDATE: ${{ inputs.cache_update }}
       run: |
         extra_params=(
           --run-all-tests
           --keep-going
           --retest
-          --test-threads "${{ inputs.test_threads }}"
-          --link-threads "${{ inputs.link_threads }}"
+          --test-threads "$TEST_THREADS"
+          --link-threads "$LINK_THREADS"
           --cache-size 512G
           --do-not-output-stderrs
           -T
@@ -122,8 +140,7 @@ runs:
           --output "$OUT_DIR"
         )
 
-        # shellcheck disable=SC2195
-        case "${{ inputs.build_preset }}" in
+        case "$BUILD_PRESET" in
           debug)
             extra_params+=(--build "debug")
             RETRY_COUNT=${NUMBER_OF_RETRIES}
@@ -157,41 +174,38 @@ runs:
             RETRY_COUNT=1
             ;;
           *)
-            echo "Invalid preset: ${{ inputs.build_preset }}"
+            echo "Invalid preset: $BUILD_PRESET"
             exit 1
             ;;
         esac
 
-        # shellcheck disable=SC2157
-        if [ -n "${{ inputs.test_target }}" ]; then
-          readarray -d ',' -t targets < <(printf "%s" "${{ inputs.test_target }}")
+        if [ -n "$TEST_TARGET" ]; then
+          readarray -d ',' -t targets < <(printf "%s" "$TEST_TARGET")
           for target in "${targets[@]}"; do
             extra_params+=(--target="${target}")
           done
         fi
 
-        # shellcheck disable=SC2157,SC2193
-        if [ "${{ inputs.use_network_cache }}" == "yes" ]; then
-          # shellcheck disable=SC2157
-          if [ -n "${{ inputs.bazel_remote_uri }}" ]; then
+        if [ "$USE_NETWORK_CACHE" == "yes" ]; then
+          if [ -n "$BAZEL_REMOTE_URI" ]; then
             extra_params+=(--bazel-remote-store)
-            extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
+            extra_params+=(--bazel-remote-base-uri "$BAZEL_REMOTE_URI")
           fi
 
-          # shellcheck disable=SC2157
-          if [ -n "${{ inputs.bazel_remote_username }}" ]; then
-            extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
-            extra_params+=(--bazel-remote-password-file="$BAZEL_REMOTE_PASSWORD_FILE")
+          if [ -n "$BAZEL_REMOTE_USERNAME" ]; then
+            extra_params+=(--bazel-remote-username "$BAZEL_REMOTE_USERNAME")
+            extra_params+=(--bazel-remote-password-file "$BAZEL_REMOTE_PASSWORD_FILE")
           fi
 
-          # shellcheck disable=SC2193
-          if [ "${{ inputs.cache_update }}" == "true" ]; then
+          if [ "$CACHE_UPDATE" = "true" ]; then
             extra_params+=(--bazel-remote-put)
           fi
         fi
 
-        readarray -d ',' -t test_size < <(printf "%s" "${{ inputs.test_size }}")
-        readarray -d ',' -t test_type < <(printf "%s" "${{ inputs.test_type }}")
+        # shellcheck disable=SC2153
+        readarray -d ',' -t test_size < <(printf "%s" "$TEST_SIZE")
+        # shellcheck disable=SC2153
+        readarray -d ',' -t test_type < <(printf "%s" "$TEST_TYPE")
 
         echo "::group::empty-files"
         [ -d  /home/github/.ya/tools/ ] && {
@@ -299,12 +313,9 @@ runs:
         cat .github/config/muted_ya.txt
         MUTED_CONFIG=".github/config/muted_ya.txt"
         echo "::endgroup::"
-        # shellcheck disable=SC2024
         for i in $(seq 1 $RETRIES); do
-          # shellcheck disable=SC2024
           if [ -f "${JUNIT_REPORT_XML}.${i}" ];
           then
-            # shellcheck disable=SC2024
             echo "::group::postprocess-junit-${i}"
             sudo -E -H -u github .github/scripts/tests/transform-ya-junit.py -i \
               -m "${MUTED_CONFIG}" \
@@ -341,6 +352,7 @@ runs:
       shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        BUILD_PRESET: ${{ inputs.build_preset }}
       run: |
         # shellcheck disable=SC2024
         for i in $(seq 1 $RETRIES); do
@@ -360,7 +372,7 @@ runs:
               --summary-out-path "$ARTIFACTS_DIR/summary/${i}/" \
               --summary-out-env-path "$SUMMARY_OUT_ENV_PATH" \
               --summary-url-prefix "$S3_WEBSITE_PREFIX/summary/${i}/" \
-              --build-preset "${platform_name}-${{ inputs.build_preset }}" \
+              --build-preset "${platform_name}-${BUILD_PRESET}" \
               "Tests" ya-test.html "${JUNIT_REPORT_XML}.${i}"
 
             cat $SUMMARY_OUT_ENV_PATH | tee -a $GITHUB_STEP_SUMMARY
@@ -370,6 +382,9 @@ runs:
 
     - name: check test results
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        TRUNCATE_ENABLED: ${{ inputs.truncate_enabled }}
+        SYNC_TO_S3: ${{ inputs.sync_to_s3 || 'false' }}
       run: |
         NEED_COPYING=0
         # shellcheck disable=SC2024
@@ -408,7 +423,7 @@ runs:
               orig_size=$(du -h "$file" | cut -f1)
               echo "$file - $orig_size"
               # shellcheck disable=SC2193
-              if [ "${{ inputs.truncate_enabled }}" == "yes" ]; then
+              if [ "$TRUNCATE_ENABLED" == "yes" ]; then
                 truncate -s 1G "$file"
                 echo "... truncated (original size was $orig_size) ..." >> "$file"
               else
@@ -426,8 +441,6 @@ runs:
         fi
         echo "Exiting with $RC"
         exit $RC
-      env:
-        SYNC_TO_S3: ${{ inputs.sync_to_s3 || 'false' }}
 
     - name: Sync test results to S3
       if: always()

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -143,35 +143,29 @@ runs:
         case "$BUILD_PRESET" in
           debug)
             extra_params+=(--build "debug")
-            RETRY_COUNT=${NUMBER_OF_RETRIES}
             ;;
           relwithdebinfo)
             extra_params+=(--build "relwithdebinfo")
-            RETRY_COUNT=${NUMBER_OF_RETRIES}
             ;;
           release-asan)
             extra_params+=(--build "release")
             extra_params+=(--sanitize="address")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
-            RETRY_COUNT=1
             ;;
           release-tsan)
             extra_params+=(--build "release")
             extra_params+=(--sanitize="thread")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
-            RETRY_COUNT=1
             ;;
           release-msan)
             extra_params+=(--build "release")
             extra_params+=(--sanitize="memory")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
-            RETRY_COUNT=1
             ;;
           release-ubsan)
             extra_params+=(--build "release")
             extra_params+=(--sanitize="undefined")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
-            RETRY_COUNT=1
             ;;
           *)
             echo "Invalid preset: $BUILD_PRESET"
@@ -219,7 +213,7 @@ runs:
         echo "::endgroup::"
         date
         ./ya --version
-        RETRIES=$RETRY_COUNT
+        RETRIES="${NUMBER_OF_RETRIES}"
         echo "RETRIES=${RETRIES}" | tee -a "$GITHUB_ENV"
         RETRY_FLAG=""
         for i in $(seq 1 $RETRIES); do

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -214,9 +214,13 @@ runs:
         date
         ./ya --version
         RETRIES="${NUMBER_OF_RETRIES}"
+        OOM_CAN_BE_RETRIED=1
         echo "RETRIES=${RETRIES}" | tee -a "$GITHUB_ENV"
         RETRY_FLAG=""
-        for i in $(seq 1 $RETRIES); do
+        i=0
+        while [ "$RETRIES" -gt 0 ]; do
+          ((RETRIES--))
+          ((i++))
           echo "::group::ya-make-test-${i}"
           set +e
           (
@@ -245,10 +249,12 @@ runs:
               ;;
             137)
               echo "ya test returned $RC it was killed by OOM killer"
-              DO_RETRY=1
-              if [ "$i" -eq "$RETRY_COUNT" ];
-              then
+              if [ $OOM_CAN_BE_RETRIED -eq 0 ]; then
                 DO_RETRY=0
+              else
+                DO_RETRY=1
+                OOM_CAN_BE_RETRIED=0
+                echo "Retrying once because OOM killer killed ya-bin"
               fi
               ;;
             *)

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -125,38 +125,32 @@ runs:
         # shellcheck disable=SC2195
         case "${{ inputs.build_preset }}" in
           debug)
-            build_type=debug
             extra_params+=(--build "debug")
             RETRY_COUNT=${NUMBER_OF_RETRIES}
             ;;
           relwithdebinfo)
-            build_type=relwithdebinfo
             extra_params+=(--build "relwithdebinfo")
             RETRY_COUNT=${NUMBER_OF_RETRIES}
             ;;
           release-asan)
-            build_type=release
             extra_params+=(--build "release")
             extra_params+=(--sanitize="address")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             RETRY_COUNT=1
             ;;
           release-tsan)
-            build_type=release
             extra_params+=(--build "release")
             extra_params+=(--sanitize="thread")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             RETRY_COUNT=1
             ;;
           release-msan)
-            build_type=release
             extra_params+=(--build "release")
             extra_params+=(--sanitize="memory")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)
             RETRY_COUNT=1
             ;;
           release-ubsan)
-            build_type=release
             extra_params+=(--build "release")
             extra_params+=(--sanitize="undefined")
             extra_params+=(-DSKIP_JUNK -DUSE_EAT_MY_DATA -DDEBUGINFO_LINES_ONLY)

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -173,6 +173,10 @@ runs:
             ;;
         esac
 
+        # strip quotes from the string
+        # TODO: remove it when pr.yaml gets updated
+        TEST_TARGET=${TEST_TARGET//\"/}
+
         if [ -n "$TEST_TARGET" ]; then
           readarray -d ',' -t targets < <(printf "%s" "$TEST_TARGET")
           for target in "${targets[@]}"; do

--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -51,6 +51,10 @@ on:
         type: string
         default: "0"
         description: "Amount of seconds to sleep after tests"
+      number_of_retries:
+        type: string
+        default: "1"
+        description: "Number of retries for tests"
   workflow_call:
     inputs:
       build_target:
@@ -105,6 +109,10 @@ on:
         type: string
         default: "no"
         description: "Allow downgrade of VM"
+      number_of_retries:
+        type: string
+        default: "1"
+        description: "Number of retries for tests"
 
 env:
   allow_downgrade: ${{ vars.GLOBAL_ALLOW_DOWNGRADE == 'yes' || ((github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'allow-downgrade')) || inputs.allow_downgrade == 'yes') }}
@@ -204,6 +212,7 @@ jobs:
       clean_ya_dir: ${{ github.event_name == 'workflow_dispatch' && 'no' || inputs.clean_ya_dir }}
       use_network_cache: ${{ github.event_name == 'workflow_dispatch' && 'yes'|| inputs.use_network_cache }}
       truncate_enabled: ${{ contains(github.event.pull_request.labels.*.name, 'disable_truncate') && 'no' || 'yes' }}
+      number_of_retries: ${{ github.event_name == 'pull_request_target' && '1' || inputs.number_of_retries }}
     secrets: inherit
 
   sleep-if-needed:

--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -212,7 +212,7 @@ jobs:
       clean_ya_dir: ${{ github.event_name == 'workflow_dispatch' && 'no' || inputs.clean_ya_dir }}
       use_network_cache: ${{ github.event_name == 'workflow_dispatch' && 'yes'|| inputs.use_network_cache }}
       truncate_enabled: ${{ contains(github.event.pull_request.labels.*.name, 'disable_truncate') && 'no' || 'yes' }}
-      number_of_retries: ${{ github.event_name == 'pull_request_target' && '1' || inputs.number_of_retries }}
+      number_of_retries: ${{ inputs.number_of_retries }}
     secrets: inherit
 
   sleep-if-needed:

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -144,6 +144,23 @@ jobs:
         echo "ALGO=lz4" | sudo tee -a /etc/default/zramswap
         sudo systemctl restart zramswap
 
+    - name: Create background process that will adjust oom_score_adj for selection of processes
+      shell: bash
+      run: |
+        set -x
+        while true; do
+          echo "$(date) done sleeping" | tee -a /tmp/oom_score_adj.log
+          for pid in $(pgrep -f ydbd) $(pgrep -f qemu-system-x86_64); do
+            # check if process is already having oom_score_adj set to 500 if not then set it
+            if [ "$(cat /proc/$pid/oom_score_adj)" != "1000" ]; then
+              echo 1000 | sudo tee /proc/$pid/oom_score_adj
+              echo "set oom_score_adj=1000 for pid: $pid" | tee -a /tmp/oom_score_adj.log
+            fi
+          done
+          echo "$(date) sleeping for 30s" | tee -a /tmp/oom_score_adj.log
+          sleep 30
+        done &
+
     - name: Build
       uses: ./.github/actions/build
       if: inputs.run_build

--- a/.github/workflows/build_and_test_ya.yaml
+++ b/.github/workflows/build_and_test_ya.yaml
@@ -86,6 +86,10 @@ on:
         type: string
         default: "yes"
         description: "Truncate enabled"
+      number_of_retries:
+        type: string
+        default: "1"
+        description: "Number of retries for tests"
     outputs:
       sleep_after_tests:
         description: "sleep_after_tests"
@@ -194,6 +198,7 @@ jobs:
         upload_ya_dir: ${{ inputs.upload_ya_dir }}
         clean_ya_dir: ${{ inputs.run_build && 'no' || inputs.clean_ya_dir }}
         use_network_cache: ${{ inputs.use_network_cache }}
+        number_of_retries: ${{ inputs.number_of_retries }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
     - id: failure
       name: set sleep_after_tests in case of failure

--- a/.github/workflows/create_and_delete_vm.yaml
+++ b/.github/workflows/create_and_delete_vm.yaml
@@ -28,6 +28,10 @@ on:
         options:
           - "yes"
           - "no"
+      number_of_retries:
+        type: number
+        default: 1
+        description: "Number of retries for the tests"
   workflow_call:
     inputs:
       vm_name_suffix:
@@ -50,6 +54,10 @@ on:
         type: string
         default: "no"
         description: "Launch large tests"
+      number_of_retries:
+        type: number
+        default: 1
+        description: "Number of retries for the tests"
 
 env:
   allow_downgrade: ${{ vars.GLOBAL_ALLOW_DOWNGRADE == 'yes' || ((github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'allow-downgrade')) || inputs.allow_downgrade == 'yes') }}
@@ -151,6 +159,7 @@ jobs:
       upload_ya_dir: "no"
       clean_ya_dir: "no"
       use_network_cache: "yes"
+      number_of_retries: ${{ inputs.number_of_retries }}
       truncate_enabled: ${{ contains(github.event.pull_request.labels.*.name, 'disable_truncate') && 'no' || 'yes' }}
     secrets: inherit
 

--- a/.github/workflows/github_actions_scripts.yaml
+++ b/.github/workflows/github_actions_scripts.yaml
@@ -18,7 +18,7 @@ jobs:
         export GITHUB_REPOSITORY="ydb-platform/nbs"
 
         mkdir -p $GITHUB_WORKSPACE/.github/scripts/tests/test-data/
-        cd $GITHUB_WORKSPACE/.github/scripts/tests/test-data/
+        cd $GITHUB_WORKSPACE/.github/scripts/tests/test-data/ || exit
         wget "https://storage.eu-north1.nebius.cloud/github-actions-test-data/cloud-v${ACTIONS_TEST_DATA_VERSION}.tar.gz" -O cloud.tar.gz
         tar zxvf cloud.tar.gz
 
@@ -88,7 +88,7 @@ jobs:
       run: |
         set -x
         mkdir -p $GITHUB_WORKSPACE/.github/scripts/tests/test-data/
-        cd $GITHUB_WORKSPACE/.github/scripts/tests/test-data/
+        cd $GITHUB_WORKSPACE/.github/scripts/tests/test-data/ || exit
         wget "https://storage.eu-north1.nebius.cloud/github-actions-test-data/cloud-v${ACTIONS_TEST_DATA_VERSION}.tar.gz" -O cloud.tar.gz
         tar zxvf cloud.tar.gz
       env:
@@ -139,14 +139,14 @@ jobs:
         echo "::group::check-md5"
         # find . -type f -exec md5sum {} + > ../test-data/MD5SUMS
         cp .github/scripts/tests/test-data/MD5SUMS $TMP_DIR/MD5SUMS
-        cd $TMP_DIR
+        cd $TMP_DIR || exit
         md5sum -c MD5SUMS | tee -a RESULT
         echo "::endgroup::"
     - name: additional info in case of failure
       if: failure()
       shell: bash
       run: |
-        cd $TMP_DIR
+        cd $TMP_DIR || exit
         grep FAILED RESULT | awk -F: '{print $1}' | while read -r f;
         do
           echo "=========="

--- a/.github/workflows/nightly-asan.yaml
+++ b/.github/workflows/nightly-asan.yaml
@@ -22,3 +22,4 @@ jobs:
       cache_update_build: true
       cache_update_tests: false
       sleep_after_tests: 1
+      number_of_retries: 1

--- a/.github/workflows/nightly-msan.yaml
+++ b/.github/workflows/nightly-msan.yaml
@@ -22,3 +22,4 @@ jobs:
       cache_update_build: true
       cache_update_tests: false
       sleep_after_tests: 1
+      number_of_retries: 1

--- a/.github/workflows/nightly-tsan.yaml
+++ b/.github/workflows/nightly-tsan.yaml
@@ -22,3 +22,4 @@ jobs:
       cache_update_build: true
       cache_update_tests: false
       sleep_after_tests: 1
+      number_of_retries: 1

--- a/.github/workflows/nightly-ubsan.yaml
+++ b/.github/workflows/nightly-ubsan.yaml
@@ -22,3 +22,4 @@ jobs:
       cache_update_build: true
       cache_update_tests: false
       sleep_after_tests: 1
+      number_of_retries: 1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,6 +46,7 @@ jobs:
       cache_update_build: true
       cache_update_tests: false
       sleep_after_tests: 1
+      number_of_retries: 1
   build_schedule:
     name: Build/test x86_64 using YA (relwithdebinfo) (schedule)
     if: github.event_name == 'schedule'
@@ -58,3 +59,4 @@ jobs:
       cache_update_build: true
       cache_update_tests: false
       sleep_after_tests: 1
+      number_of_retries: 1

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -51,7 +51,7 @@ jobs:
       run: |
         curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
         cat <<EOF > sa.json
-        ${sa_json}
+        ${SA_JSON}
         EOF
 
         jq -r '."subject-credentials"."private-key"'  sa.json > private.pem
@@ -67,7 +67,7 @@ jobs:
                               --private-key-file private.pem \
                               --service-account-id "${service_account_id}"
       env:
-        sa_json: ${{ secrets.NEW_NEBIUS_SA_JSON_CREDENTIALS }}
+        SA_JSON: ${{ secrets.NEW_NEBIUS_SA_JSON_CREDENTIALS }}
 
     - name: Get latest image ID from Nebius
       id: get-image-id

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -212,13 +212,13 @@ jobs:
         with:
           scandir: .github
         env:
-          SHELLCHECK_OPTS: "-e SC2155,SC2086,SC2154,SC2164,SC2009,SC2015"
+          SHELLCHECK_OPTS: "-e SC2155,SC2086,SC2164,SC2009,SC2015"
 
 
       - name: shellcheck for github actions shell scripts in .temporary dir
         uses: ludeeus/action-shellcheck@master
         env:
-          SHELLCHECK_OPTS: "-e SC2155,SC2086,SC2154,SC2164,SC2009,SC2015"
+          SHELLCHECK_OPTS: "-e SC2155,SC2086,SC2164,SC2009,SC2015"
         with:
           scandir: .temporary
 

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -329,4 +329,5 @@ jobs:
     with:
       allow_downgrade: ${{ needs.set-env.outputs.allow_downgrade }}
       large_tests: ${{ needs.set-env.outputs.large_tests }}
+      number_of_retries: 3
     secrets: inherit

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -212,13 +212,13 @@ jobs:
         with:
           scandir: .github
         env:
-          SHELLCHECK_OPTS: "-e SC2155,SC2086,SC2164,SC2009,SC2015"
+          SHELLCHECK_OPTS: "-e SC2155,SC2086"
 
 
       - name: shellcheck for github actions shell scripts in .temporary dir
         uses: ludeeus/action-shellcheck@master
         env:
-          SHELLCHECK_OPTS: "-e SC2155,SC2086,SC2164,SC2009,SC2015"
+          SHELLCHECK_OPTS: "-e SC2155,SC2086"
         with:
           scandir: .temporary
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -194,19 +194,19 @@ jobs:
               if [ "$contains" = "true" ]; then
                   build_target_components="${build_target_components}${build_component},"
                   test_target_components="${test_target_components}${test_component},"
-                  if [ "$should_asan" = "true" ] && [ "$has_asan_label" = "true" ]; then
+                  if [ "$should_asan" = "true" ] && [ "$HAS_ASAN_LABEL" = "true" ]; then
                       build_target_asan="${build_target_asan}${build_component},"
                       test_target_asan="${test_target_asan}${test_component},"
                   fi
-                  if [ "$should_tsan" = "true" ] && [ "$has_tsan_label" = "true" ]; then
+                  if [ "$should_tsan" = "true" ] && [ "$HAS_TSAN_LABEL" = "true" ]; then
                       build_target_tsan="${build_target_tsan}${build_component},"
                       test_target_tsan="${test_target_tsan}${test_component},"
                   fi
-                  if [ "$should_msan" = "true" ] && [ "$has_msan_label" = "true" ]; then
+                  if [ "$should_msan" = "true" ] && [ "$HAS_MSAN_LABEL" = "true" ]; then
                       build_target_msan="${build_target_msan}${build_component},"
                       test_target_msan="${test_target_msan}${test_component},"
                   fi
-                  if [ "$should_ubsan" = "true" ] && [ "$has_ubsan_label" = "true" ]; then
+                  if [ "$should_ubsan" = "true" ] && [ "$HAS_UBSAN_LABEL" = "true" ]; then
                       build_target_ubsan="${build_target_ubsan}${build_component},"
                       test_target_ubsan="${test_target_ubsan}${test_component},"
                   fi
@@ -217,11 +217,11 @@ jobs:
           }
 
           # Add components based on conditions
-          add_components "blockstore" "$contains_blockstore" "cloud/blockstore/apps/" "cloud/blockstore/"
-          add_components "filestore" "$contains_filestore" "cloud/filestore/apps/" "cloud/filestore/"
-          add_components "disk_manager" "$contains_disk_manager" "cloud/disk_manager/" "cloud/disk_manager/"
-          add_components "tasks" "$contains_tasks" "cloud/tasks/" "cloud/tasks/"
-          add_components "storage" "$contains_storage" "cloud/storage/" "cloud/storage/"
+          add_components "blockstore" "$CONTAINS_BLOCKSTORE" "cloud/blockstore/apps/" "cloud/blockstore/"
+          add_components "filestore" "$CONTAINS_FILESTORE" "cloud/filestore/apps/" "cloud/filestore/"
+          add_components "disk_manager" "$CONTAINS_DISK_MANAGER" "cloud/disk_manager/" "cloud/disk_manager/"
+          add_components "tasks" "$CONTAINS_TASKS" "cloud/tasks/" "cloud/tasks/"
+          add_components "storage" "$CONTAINS_STORAGE" "cloud/storage/" "cloud/storage/"
 
           # Remove trailing commas
           build_target_components=${build_target_components%,}
@@ -261,15 +261,15 @@ jobs:
           } >> $GITHUB_OUTPUT
 
         env:
-          contains_blockstore: ${{ contains(github.event.pull_request.labels.*.name, 'blockstore') && 'true' || 'false' }}
-          contains_filestore: ${{ contains(github.event.pull_request.labels.*.name, 'filestore') && 'true' || 'false' }}
-          contains_disk_manager: ${{ contains(github.event.pull_request.labels.*.name, 'disk_manager') && 'true' || 'false' }}
-          contains_tasks: ${{ contains(github.event.pull_request.labels.*.name, 'tasks') && 'true' || 'false' }}
-          contains_storage: ${{ contains(github.event.pull_request.labels.*.name, 'storage') && 'true' || 'false' }}
-          has_asan_label: ${{ contains(github.event.pull_request.labels.*.name, 'asan') && 'true' || 'false' }}
-          has_tsan_label: ${{ contains(github.event.pull_request.labels.*.name, 'tsan') && 'true' || 'false' }}
-          has_msan_label: ${{ contains(github.event.pull_request.labels.*.name, 'msan') && 'true' || 'false' }}
-          has_ubsan_label: ${{ contains(github.event.pull_request.labels.*.name, 'ubsan') && 'true' || 'false' }}
+          CONTAINS_BLOCKSTORE: ${{ contains(github.event.pull_request.labels.*.name, 'blockstore') && 'true' || 'false' }}
+          CONTAINS_FILESTORE: ${{ contains(github.event.pull_request.labels.*.name, 'filestore') && 'true' || 'false' }}
+          CONTAINS_DISK_MANAGER: ${{ contains(github.event.pull_request.labels.*.name, 'disk_manager') && 'true' || 'false' }}
+          CONTAINS_TASKS: ${{ contains(github.event.pull_request.labels.*.name, 'tasks') && 'true' || 'false' }}
+          CONTAINS_STORAGE: ${{ contains(github.event.pull_request.labels.*.name, 'storage') && 'true' || 'false' }}
+          HAS_ASAN_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'asan') && 'true' || 'false' }}
+          HAS_TSAN_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'tsan') && 'true' || 'false' }}
+          HAS_MSAN_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'msan') && 'true' || 'false' }}
+          HAS_UBSAN_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ubsan') && 'true' || 'false' }}
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -285,6 +285,7 @@ jobs:
       test_type: "unittest,clang_tidy,gtest,py3test,py2test,pytest,flake8,black,py2_flake8,go_test,gofmt"
       cache_update_build: false
       cache_update_tests: false
+      number_of_retries: 3
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
   build_and_test_asan:
@@ -303,6 +304,7 @@ jobs:
       test_type: "unittest,clang_tidy,gtest,py3test,py2test,pytest,flake8,black,py2_flake8,gofmt"
       cache_update_build: false
       cache_update_tests: false
+      number_of_retries: 1
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
   build_and_test_tsan:
@@ -321,6 +323,7 @@ jobs:
       test_type: "unittest,clang_tidy,gtest,py3test,py2test,pytest,flake8,black,py2_flake8,gofmt"
       cache_update_build: false
       cache_update_tests: false
+      number_of_retries: 1
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
   build_and_test_msan:
@@ -339,6 +342,7 @@ jobs:
       test_type: "unittest,clang_tidy,gtest,py3test,py2test,pytest,flake8,black,py2_flake8,gofmt"
       cache_update_build: false
       cache_update_tests: false
+      number_of_retries: 1
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
   build_and_test_ubsan:
@@ -357,5 +361,6 @@ jobs:
       test_type: "unittest,clang_tidy,gtest,py3test,py2test,pytest,flake8,black,py2_flake8,gofmt"
       cache_update_build: false
       cache_update_tests: false
+      number_of_retries: 1
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -163,6 +163,7 @@ jobs:
 
         shell: bash
         run: |
+          set -x
           # Initialize variables
           build_target_components=""
           test_target_components=""
@@ -247,18 +248,18 @@ jobs:
 
           # Output to GitHub environment file
           {
-            echo "build_target=\"$build_target\""
-            echo "build_target_asan=\"$build_target_asan\""
-            echo "build_target_tsan=\"$build_target_tsan\""
-            echo "build_target_msan=\"$build_target_msan\""
-            echo "build_target_ubsan=\"$build_target_ubsan\""
+            echo "build_target=$build_target"
+            echo "build_target_asan=$build_target_asan"
+            echo "build_target_tsan=$build_target_tsan"
+            echo "build_target_msan=$build_target_msan"
+            echo "build_target_ubsan=$build_target_ubsan"
 
-            echo "test_target=\"$test_target\""
-            echo "test_target_asan=\"$test_target_asan\""
-            echo "test_target_tsan=\"$test_target_tsan\""
-            echo "test_target_msan=\"$test_target_msan\""
-            echo "test_target_ubsan=\"$test_target_ubsan\""
-          } >> $GITHUB_OUTPUT
+            echo "test_target=$test_target"
+            echo "test_target_asan=$test_target_asan"
+            echo "test_target_tsan=$test_target_tsan"
+            echo "test_target_msan=$test_target_msan"
+            echo "test_target_ubsan=$test_target_ubsan"
+          } | tee -a "$GITHUB_OUTPUT"
 
         env:
           CONTAINS_BLOCKSTORE: ${{ contains(github.event.pull_request.labels.*.name, 'blockstore') && 'true' || 'false' }}


### PR DESCRIPTION
For PR checks there will be 3 retries and for nightly builds - there will be no retries
Also there will be retries if ya make will fail with exit code 137 (oom)

This does not mean that if the test was ultimately successful, then there is no need to look at why the test might have failed

Examples how it will look:
Success: https://github.com/librarian-test/nbs/pull/104
All failed: https://github.com/librarian-test/nbs/pull/103
Two failed and success in the end: https://github.com/librarian-test/nbs/pull/102

Additionally there was refactoring:
1. How we assemble list of arguments for ya make
2. Replaced in-place github variables for shell env vars. It is useful for shellcheck/shfmt because otherwise we need to add automatically shellcheck disable directives for almost half of the already difficult to debug scripts.
3. Removed, with appropriate fixes, shellcheck's disable SC2164,SC2009,SC2015 directives
4. Removed quotes from "Set build and test targets" script that was interfering with point 2 of this list.
