### PR TITLE
[Blockstore] return E_FAIL error code instead of E_REJECTED on GetChangedBlocks if shadow disk is broken

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -1216,9 +1216,16 @@ void TShadowDiskActor::HandleGetChangedBlocks(
 
         auto response =
             std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
-        *response->Record.MutableError() = MakeError(
-            E_REJECTED,
-            "Can't GetChangedBlocks when shadow disk is not ready.");
+
+        if (State == EActorState::Error) {
+            *response->Record.MutableError() = MakeError(
+                E_FAIL,
+                "Can't GetChangedBlocks when shadow disk is broken.");
+        } else {
+            *response->Record.MutableError() = MakeError(
+                E_REJECTED,
+                "Can't GetChangedBlocks when shadow disk is not ready.");
+        }
 
         NCloud::Reply(ctx, *ev, std::move(response));
         return;


### PR DESCRIPTION
E_FAIL is nonretrialble, while E_REJECTED is retriable.
If shadow disk actor is in error state, we should no retry GetChangedBlocks request.

Needed for the fix of the test https://github.com/ydb-platform/nbs/pull/3468