### PR TITLE
[Disk Manager] tests: check GetChangedBlocks error in tests with broken checkpoints

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_test/with_broken_checkpoints_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_test/with_broken_checkpoints_test.go
@@ -247,7 +247,8 @@ func testCreateSnapshotOrImageFromDiskWithFailedShadowDisk(
 			return
 		}
 
-		if strings.Contains(err.Error(), "Device disabled") {
+		if strings.Contains(err.Error(), "Device disabled") ||
+			strings.Contains(err.Error(), "Can't GetChangedBlocks when shadow disk is broken") {
 			// Dataplane task failed with 'Device disabled' error, but shadow
 			// disk was filled successfully.
 			// TODO: improve this test after https://github.com/ydb-platform/nbs/issues/1950#issuecomment-2541530203


### PR DESCRIPTION
Together with https://github.com/ydb-platform/nbs/pull/3467 it will fix the test.

The test timeouted with the repeated error:

```
2025-05-06T01:34:42.312537Z :BLOCKSTORE_VOLUME ERROR: Shadow disk: "TestImageServiceCreateImageFromDiskWithFailedShadowDisk1-TestImageServiceCreateImageFromDiskWithFailedShadowDisk_0" Can't GetChangedBlocks when shadow disk is not ready.
```

- We make this error non-retriable in case of broken shadow disk (see https://github.com/ydb-platform/nbs/pull/3467)
- We handle this error in the test