### PR TITLE
Reset lagging migration progress on DeviceTimedOut message

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_lagging_agents.cpp
@@ -369,6 +369,8 @@ void TVolumeActor::CompleteAddLaggingAgent(
     RemoveTransaction(*args.RequestInfo);
 
     if (!HasError(args.Error)) {
+        State->ResetLaggingAgentMigrationState(args.Agent.GetAgentId());
+
         const auto& partActorId = State->GetDiskRegistryBasedPartitionActor();
         Y_DEBUG_ABORT_UNLESS(partActorId);
         NCloud::Send(

--- a/cloud/blockstore/libs/storage/volume/volume_lagging_agent_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_lagging_agent_ut.cpp
@@ -763,6 +763,128 @@ Y_UNIT_TEST_SUITE(TLaggingAgentVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(0, laggingMigrationProgress);
     }
 
+    Y_UNIT_TEST(ShouldResetLaggingMigrationProgress)
+    {
+        constexpr ui32 AgentCount = 3;
+        auto diskRegistryState = MakeIntrusive<TDiskRegistryState>();
+        diskRegistryState->Devices = MakeDeviceList(AgentCount, 3);
+        diskRegistryState->AllocateDiskReplicasOnDifferentNodes = true;
+        diskRegistryState->ReplicaCount = 2;
+        TVector<TDiskAgentStatePtr> agentStates;
+        for (ui32 i = 0; i < AgentCount; i++) {
+            agentStates.push_back(TDiskAgentStatePtr{});
+        }
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetLaggingDevicesForMirror3DisksEnabled(true);
+        auto runtime = PrepareTestActorRuntime(
+            std::move(storageServiceConfig),
+            diskRegistryState,
+            {},
+            {},
+            std::move(agentStates));
+
+        // Create mirror-3 volume with a size of 1 device.
+        TVolumeClient volume(*runtime);
+        const ui64 blockCount =
+            DefaultDeviceBlockCount * DefaultDeviceBlockSize / DefaultBlockSize;
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,   // version
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3,
+            blockCount);
+
+        volume.WaitReady();
+
+        bool hasLaggingDevices = false;
+        ui64 laggingDevicesCount = 0;
+        ui64 laggingMigrationProgress = 0;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvNonreplPartitionPrivate::EvAddLaggingAgentRequest:
+                    case TEvNonreplPartitionPrivate::
+                        EvRemoveLaggingAgentRequest:
+                        return true;
+
+                    case TEvStatsService::EvVolumeSelfCounters: {
+                        if (event->Recipient != MakeStorageStatsServiceId()) {
+                            break;
+                        }
+                        const auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumeSelfCounters>();
+                        const auto& counters = msg->VolumeSelfCounters->Simple;
+                        hasLaggingDevices = !!counters.HasLaggingDevices.Value;
+                        laggingDevicesCount =
+                            counters.LaggingDevicesCount.Value;
+                        laggingMigrationProgress =
+                            counters.LaggingMigrationProgress.Value;
+                    }
+                }
+                return false;
+            });
+
+        // Device in the first replica is timed out.
+        volume.DeviceTimedOut("uuid-2.0");
+
+        // Update lagging agent migration progress.
+        volume.SendToPipe(
+            std::make_unique<
+                TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState>(
+                "agent-2",
+                blockCount / 2,
+                blockCount / 2));
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+        runtime->DispatchEvents(
+            {.CustomFinalCondition =
+                 [&]()
+             {
+                 return hasLaggingDevices;
+             }},
+            TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1, laggingDevicesCount);
+        UNIT_ASSERT_VALUES_EQUAL(50, laggingMigrationProgress);
+
+        // Update lagging agent migration progress.
+        volume.SendToPipe(
+            std::make_unique<
+                TEvVolumePrivate::TEvUpdateLaggingAgentMigrationState>(
+                "agent-2",
+                blockCount / 2,
+                blockCount / 2));
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+        runtime->DispatchEvents(
+            {.CustomFinalCondition =
+                 [&]()
+             {
+                 return laggingMigrationProgress > 0;
+             }},
+            TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1, laggingDevicesCount);
+        UNIT_ASSERT_VALUES_EQUAL(50, laggingMigrationProgress);
+
+        // Device has timed out again.
+        volume.DeviceTimedOut("uuid-2.0");
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+        // Lagging migration progress should be reset.
+        runtime->DispatchEvents(
+            {.CustomFinalCondition =
+                 [&]()
+             {
+                 return laggingMigrationProgress == 0;
+             }},
+            TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1, laggingDevicesCount);
+        UNIT_ASSERT(hasLaggingDevices);
+    }
+
     Y_UNIT_TEST(ShouldReturnErrorWhenFeatureIsDisabled)
     {
         constexpr ui32 AgentCount = 3;

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -180,7 +180,8 @@ void TVolumeState::AddLaggingAgent(NProto::TLaggingAgent agent)
 std::optional<NProto::TLaggingAgent> TVolumeState::RemoveLaggingAgent(
     const TString& agentId)
 {
-    CurrentlyMigratingLaggingAgents.erase(agentId);
+    ResetLaggingAgentMigrationState(agentId);
+
     auto agentIdPredicate = [&agentId](const auto& info)
     {
         return info.GetAgentId() == agentId;
@@ -232,6 +233,11 @@ void TVolumeState::UpdateLaggingAgentMigrationState(
         .CleanBlocks = cleanBlocks,
         .DirtyBlocks = dirtyBlocks,
     };
+}
+
+void TVolumeState::ResetLaggingAgentMigrationState(const TString& agentId)
+{
+    CurrentlyMigratingLaggingAgents.erase(agentId);
 }
 
 auto TVolumeState::GetLaggingAgentsMigrationInfo() const

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -349,6 +349,7 @@ public:
         const TString& agentId,
         ui64 cleanBlocks,
         ui64 dirtyBlocks);
+    void ResetLaggingAgentMigrationState(const TString& agentId);
     const THashMap<TString, TLaggingAgentMigrationInfo>&
     GetLaggingAgentsMigrationInfo() const;
 


### PR DESCRIPTION
#3
Сбрасываю прогресс миграции лагающего агента, если в процессе он снова залагал. Влияет только на метрики и отображение на мон страничке