### PR TITLE
issue-3: removed unused struct TMirrorPartitionActor::TRequestCtx

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -45,12 +45,6 @@ TDuration CalculateScrubbingInterval(
 class TMirrorPartitionActor final
     : public NActors::TActorBootstrapped<TMirrorPartitionActor>
 {
-    struct TRequestCtx
-    {
-        TBlockRange64 BlockRange;
-        ui64 VolumeRequestId = 0;
-    };
-
 private:
     const TStorageConfigPtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;


### PR DESCRIPTION
#3 в пре #3292 убрал использование структуры TRequestCtx и забыл убрать ее из кода