### PR TITLE
Show function in unexpected event message

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -190,7 +190,10 @@ private:
             HFunc(TEvents::TEvWakeup, HandleTimeout);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
@@ -136,7 +136,10 @@ private:
             HFunc(TEvents::TEvWakeup, HandleTimeout);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE_PROXY,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -163,7 +163,10 @@ private:
             HFunc(TEvents::TEvWakeup, HandleTimeout);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE_PROXY,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
@@ -64,7 +64,10 @@ struct TTestServiceActor final
     STFUNC(StateWork)
     {
         if (!HandleRequests(ev)) {
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
         }
     }
 

--- a/cloud/blockstore/libs/storage/bootstrapper/bootstrapper.cpp
+++ b/cloud/blockstore/libs/storage/bootstrapper/bootstrapper.cpp
@@ -360,7 +360,10 @@ STFUNC(TBootstrapperActor::StateInit)
         HFunc(TEvBootstrapper::TEvStop, HandleStop);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::BOOTSTRAPPER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::BOOTSTRAPPER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -376,7 +379,10 @@ STFUNC(TBootstrapperActor::StateBoot)
         HFunc(TEvTablet::TEvReady, IgnoreEvent);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::BOOTSTRAPPER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::BOOTSTRAPPER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -405,7 +411,10 @@ STFUNC(TBootstrapperActor::StateWait)
         HFunc(TEvents::TEvWakeup, HandleWakeUp);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::BOOTSTRAPPER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::BOOTSTRAPPER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_health_check_actor.cpp
@@ -242,7 +242,10 @@ STFUNC(TDeviceHealthCheckActor::StateWork)
             HandleReadDeviceBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/direct_copy_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/direct_copy_actor.cpp
@@ -203,7 +203,10 @@ STFUNC(TDirectCopyActor::StateWork)
             TEvDiskAgent::TEvZeroDeviceBlocksRequest,
             HandleZeroBlocksUndelivery);
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.cpp
@@ -57,7 +57,8 @@ private:
             default:
                 HandleUnexpectedEvent(
                     ev,
-                    TBlockStoreComponents::DISK_AGENT_WORKER);
+                    TBlockStoreComponents::DISK_AGENT_WORKER,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.cpp
@@ -175,7 +175,10 @@ STFUNC(TMultiAgentWriteDeviceBlocksActor::StateWork)
             HandleWriteBlocksUndelivery);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/session_cache_actor.cpp
@@ -96,7 +96,8 @@ private:
             default:
                 HandleUnexpectedEvent(
                     ev,
-                    TBlockStoreComponents::DISK_AGENT_WORKER);
+                    TBlockStoreComponents::DISK_AGENT_WORKER,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -309,7 +309,10 @@ STFUNC(TDiskAgentActor::StateInit)
                     ctx,
                     TBlockStoreComponents::DISK_AGENT,
                     "Unexpected request in Init state");
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_AGENT,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -409,7 +412,10 @@ STFUNC(TDiskAgentActor::StateWork)
                     ctx,
                     TBlockStoreComponents::DISK_AGENT,
                     "Unexpected request in Work state");
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_AGENT,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -433,7 +439,10 @@ STFUNC(TDiskAgentActor::StateIdle)
                     ctx,
                     TBlockStoreComponents::DISK_AGENT,
                     "Unexpected request in Idle state");
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_AGENT,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
@@ -101,7 +101,10 @@ STFUNC(TRegisterActor::StateWork)
         HFunc(TEvDiskRegistry::TEvRegisterAgentResponse, HandleRegisterAgentResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stats.cpp
@@ -218,7 +218,10 @@ STFUNC(TStatsActor::StateWork)
             HandleUpdateAgentStatsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_AGENT_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_AGENT_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.cpp
@@ -58,7 +58,10 @@ STFUNC(TDiskRegistryMock::StateWork)
         HFunc(TEvDiskRegistryProxy::TEvSubscribeRequest, HandleSubscribe);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY,
+                __PRETTY_FUNCTION__);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/actors/restore_validator_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/actors/restore_validator_actor.cpp
@@ -730,7 +730,7 @@ STFUNC(TRestoreValidationActor::StateWork)
             HandleGetVolumeInfoResponse)
 
         default:
-            HandleUnexpectedEvent(ev, Component);
+            HandleUnexpectedEvent(ev, Component, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -636,7 +636,10 @@ STFUNC(TDiskRegistryActor::StateInit)
 
         default:
             if (!RejectRequests(ev) && !HandleDefaultEvents(ev, SelfId())) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -713,7 +716,10 @@ STFUNC(TDiskRegistryActor::StateWork)
 
         default:
             if (!HandleRequests(ev) && !HandleDefaultEvents(ev, SelfId())) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -857,7 +863,10 @@ STFUNC(TDiskRegistryActor::StateZombie)
 
         default:
             if (!RejectRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_acquire.cpp
@@ -381,7 +381,10 @@ STFUNC(TAcquireDiskActor::StateAcquire)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_change_agent_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_change_agent_state.cpp
@@ -162,7 +162,8 @@ STFUNC(TChangeAgentStateActor::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::DISK_REGISTRY_WORKER);
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_change_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_change_device_state.cpp
@@ -163,7 +163,8 @@ STFUNC(TChangeDeviceStateActor::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::DISK_REGISTRY_WORKER);
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cleanup.cpp
@@ -188,7 +188,10 @@ STFUNC(TCleanupActor::StateWork)
         HFunc(TEvDiskRegistry::TEvDeallocateDiskResponse, HandleDeallocateDiskResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cms.cpp
@@ -305,7 +305,10 @@ STFUNC(TCmsRequestActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_destroy.cpp
@@ -169,7 +169,10 @@ STFUNC(TDestroyActor::StateWork)
         HFunc(TEvService::TEvDestroyVolumeResponse, HandleDestroyVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
@@ -141,7 +141,10 @@ STFUNC(TMarkReplacementDevicesActor::StateWork)
         HFunc(TEvDiskRegistry::TEvMarkReplacementDeviceResponse, HandleResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_replace_device.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_replace_device.cpp
@@ -157,7 +157,10 @@ STFUNC(TReplaceActor::StateWork)
             HandleReplaceDeviceResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_volume_realloc.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_volume_realloc.cpp
@@ -145,7 +145,10 @@ STFUNC(THttpVolumeReallocActor::StateWork)
             HandleInitiateDiskReallocationResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
@@ -192,7 +192,10 @@ STFUNC(TNotifyActor::StateWork)
         HFunc(TEvVolume::TEvReallocateDiskResponse, HandleReallocateDiskResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify_users.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify_users.cpp
@@ -215,7 +215,10 @@ STFUNC(TNotifyActor::StateWork)
         );
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_release.cpp
@@ -252,7 +252,10 @@ STFUNC(TReleaseDiskActor::StateWork)
             HandleRemoveDiskSessionResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_replace.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_replace.cpp
@@ -135,7 +135,10 @@ STFUNC(TReplaceActor::StateWork)
             HandleReplaceDiskDeviceResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_resume_device.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_resume_device.cpp
@@ -119,7 +119,8 @@ STFUNC(TResumeDeviceActor::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::DISK_REGISTRY_WORKER);
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -234,7 +234,10 @@ STFUNC(TSecureEraseActor::StateErase)
         HFunc(TEvDiskAgent::TEvSecureEraseDeviceResponse, HandleSecureEraseDeviceResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -251,7 +254,10 @@ STFUNC(TSecureEraseActor::StateCleanup)
         HFunc(TEvDiskRegistryPrivate::TEvCleanupDevicesResponse, HandleCleanupDevicesResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
@@ -196,7 +196,10 @@ STFUNC(TUpdateActor::StateWork)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleModifySchemeResponse);
 
     default:
-        HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_WORKER);
+        HandleUnexpectedEvent(
+            ev,
+            TBlockStoreComponents::DISK_REGISTRY_WORKER,
+            __PRETTY_FUNCTION__);
         break;
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -407,7 +407,10 @@ private:
             HFunc(TEvService::TEvDestroyVolumeRequest, HandleDestroyVolumeRequest);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
         }
     }
 
@@ -437,7 +440,10 @@ private:
             HFunc(TEvVolume::TEvReallocateDiskRequest, HandleReallocateDiskRequest);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
         }
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_actor.cpp
@@ -583,8 +583,10 @@ STFUNC(TDiskRegistryProxyActor::StateError)
 
         default:
             if (!ReplyWithError(ActorContext(), ev)) {
-                HandleUnexpectedEvent(ev,
-                    TBlockStoreComponents::DISK_REGISTRY_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -616,8 +618,10 @@ STFUNC(TDiskRegistryProxyActor::StateLookup)
 
         default:
             if (!ReplyWithError(ActorContext(), ev)) {
-                HandleUnexpectedEvent(ev,
-                    TBlockStoreComponents::DISK_REGISTRY_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -650,8 +654,10 @@ STFUNC(TDiskRegistryProxyActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev,
-                    TBlockStoreComponents::DISK_REGISTRY_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_ut.cpp
@@ -106,7 +106,10 @@ private:
 
             default:
                 if (!HandleDefaultEvents(ev, SelfId())) {
-                    HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_PROXY);
+                    HandleUnexpectedEvent(
+                        ev,
+                        TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                        __PRETTY_FUNCTION__);
                 }
         }
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -858,7 +858,10 @@ STFUNC(TPartitionActor::StateInit)
             if (!RejectRequests(ev) &&
                 !HandleDefaultEvents(ev, SelfId()))
             {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -913,7 +916,10 @@ STFUNC(TPartitionActor::StateWork)
             if (!HandleRequests(ev) &&
                 !HandleDefaultEvents(ev, SelfId()))
             {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -961,7 +967,10 @@ STFUNC(TPartitionActor::StateZombie)
 
         default:
             if (!RejectRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -173,7 +173,10 @@ STFUNC(TAddConfirmedBlobsActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
@@ -246,7 +246,10 @@ STFUNC(TGetChangedBlocksActor::StateWork)
         HFunc(TEvService::TEvGetChangedBlocksResponse, HandleGetChangedBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
@@ -295,7 +295,10 @@ STFUNC(TCollectGarbageActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvDeleteGarbageResponse, HandleDeleteGarbageResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -510,7 +513,10 @@ STFUNC(TCollectGarbageHardActor::StateWork)
         HFunc(TEvBlobStorage::TEvCollectGarbageResult, HandleCollectGarbageResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -979,7 +979,10 @@ STFUNC(TCompactionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compactrange.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compactrange.cpp
@@ -133,7 +133,10 @@ STFUNC(TForcedCompactionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvCompactionResponse, HandleCompactionResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
@@ -171,7 +171,10 @@ STFUNC(TConfirmBlobsActor::StateWork)
         HFunc(TEvBlobStorage::TEvGetResult, HandleGetResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -374,7 +374,10 @@ STFUNC(TFlushActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
@@ -200,7 +200,10 @@ STFUNC(TMetadataRebuildBlockCountActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse, HandleMetadataRebuildResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
@@ -164,7 +164,10 @@ STFUNC(TMetadataRebuildUsedBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvMetadataRebuildUsedBlocksResponse, HandleMetadataRebuildUsedBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_garbage.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_garbage.cpp
@@ -194,7 +194,10 @@ STFUNC(THttpGarbageActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvCollectGarbageRequest, HandleCollectGarbageRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_view.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_view.cpp
@@ -268,7 +268,10 @@ STFUNC(THttpReadBlockActor::StateWork)
         HFunc(TEvService::TEvReadBlocksLocalRequest, HandleReadBlockRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_patchblob.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_patchblob.cpp
@@ -237,7 +237,10 @@ STFUNC(TPatchBlobActor::StateWork)
         HFunc(TEvBlobStorage::TEvPatchResult, HandlePatchResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -661,7 +661,10 @@ STFUNC(TReadBlocksActor::StateWork)
             HandleDescribeBlocksCompleted);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_scan_disk.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_scan_disk.cpp
@@ -225,7 +225,9 @@ STFUNC(TScanDiskActor::StateWork)
 
         default:
             HandleUnexpectedEvent(
-                ev, TBlockStoreComponents::PARTITION_WORKER);
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblob.cpp
@@ -296,7 +296,10 @@ STFUNC(TWriteBlobActor::StateWork)
         HFunc(TEvBlobStorage::TEvPutResult, HandlePutResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -364,7 +364,10 @@ STFUNC(TWriteFreshBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddFreshBlocksResponse, HandleAddFreshBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -474,7 +474,10 @@ STFUNC(TWriteMergedBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddUnconfirmedBlobsResponse, HandleAddUnconfirmedBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
@@ -469,7 +469,10 @@ STFUNC(TWriteMixedBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_zeroblocks.cpp
@@ -213,7 +213,10 @@ STFUNC(TZeroBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -1313,7 +1313,10 @@ STFUNC(TTestVolumeProxyActor::StateWork)
         IgnoreFunc(TEvVolume::TEvClearBaseDiskIdToTabletIdMapping);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -830,7 +830,10 @@ STFUNC(TPartitionActor::StateInit)
 
         default:
             if (!RejectRequests(ev) && !HandleDefaultEvents(ev, SelfId())) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -875,7 +878,10 @@ STFUNC(TPartitionActor::StateWork)
 
         default:
             if (!HandleRequests(ev) && !HandleDefaultEvents(ev, SelfId())) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -919,7 +925,10 @@ STFUNC(TPartitionActor::StateZombie)
 
         default:
             if (!RejectRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_changedblocks.cpp
@@ -248,7 +248,10 @@ STFUNC(TGetChangedBlocksActor::StateWork)
         HFunc(TEvService::TEvGetChangedBlocksResponse, HandleGetChangedBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
@@ -290,7 +290,10 @@ STFUNC(TCollectGarbageActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvDeleteGarbageResponse, HandleDeleteGarbageResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -499,7 +502,10 @@ STFUNC(TCollectGarbageHardActor::StateWork)
         HFunc(TEvBlobStorage::TEvCollectGarbageResult, HandleCollectGarbageResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_compaction.cpp
@@ -563,7 +563,10 @@ STFUNC(TCompactionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_compactrange.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_compactrange.cpp
@@ -120,7 +120,10 @@ STFUNC(TForcedCompactionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvCompactionResponse, HandleCompactionResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_flush.cpp
@@ -295,7 +295,10 @@ STFUNC(TFlushActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
@@ -91,7 +91,10 @@ STFUNC(TInitFreshZonesActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvInitIndexResponse, HandleInitIndexResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_cleanup.cpp
@@ -108,7 +108,10 @@ STFUNC(TForcedCleanupActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvCleanupResponse, HandleCleanupResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_garbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_garbage.cpp
@@ -195,7 +195,10 @@ STFUNC(THttpGarbageActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvCollectGarbageRequest, HandleCollectGarbageRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_view.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_view.cpp
@@ -252,7 +252,10 @@ STFUNC(THttpReadBlockActor::StateWork)
         HFunc(TEvService::TEvReadBlocksLocalResponse, HandleReadBlockResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
@@ -336,7 +336,10 @@ STFUNC(TReadBlobActor::StateWork)
         HFunc(TEvBlobStorage::TEvGetResult, HandleGetResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblocks.cpp
@@ -690,7 +690,10 @@ STFUNC(TReadBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvReadBlobResponse, HandleReadBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
@@ -249,7 +249,10 @@ STFUNC(TWriteBlobActor::StateWork)
         HFunc(TEvBlobStorage::TEvPutResult, HandlePutResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writefreshblocks.cpp
@@ -421,7 +421,10 @@ STFUNC(TWriteFreshBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvInitIndexResponse, HandleInitIndexResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writemergedblocks.cpp
@@ -371,7 +371,10 @@ STFUNC(TWriteMergedBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writemixedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writemixedblocks.cpp
@@ -461,7 +461,10 @@ STFUNC(TWriteMixedBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_zeroblocks.cpp
@@ -201,7 +201,10 @@ STFUNC(TZeroBlocksActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -1143,7 +1143,10 @@ STFUNC(TTestVolumeProxyActor::StateWork)
         HFunc(TEvService::TEvGetChangedBlocksRequest, HandleGetChangedBlocksRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_common/actor_checkrange.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_checkrange.cpp
@@ -71,7 +71,10 @@ STFUNC(TCheckRangeActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
         HFunc(TEvService::TEvReadBlocksResponse, HandleReadBlocksResponse);
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_common/actor_describe_base_disk_blocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_describe_base_disk_blocks.cpp
@@ -238,7 +238,10 @@ STFUNC(TDescribeBaseDiskBlocksActor::StateWork)
         HFunc(TEvVolume::TEvDescribeBlocksResponse, HandleDescribeBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_COMMON);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_COMMON,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_common/actor_loadfreshblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_loadfreshblobs.cpp
@@ -240,7 +240,10 @@ STFUNC(TLoadFreshBlobsActor::StateWork)
         HFunc(TEvBlobStorage::TEvRangeResult, HandleRangeResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_read_blob.cpp
@@ -312,7 +312,10 @@ STFUNC(TReadBlobActor::StateWork)
         HFunc(TEvents::TEvUndelivered, HandleUndelivered);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_COMMON);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_COMMON,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -169,7 +169,10 @@ STFUNC(TTrimFreshLogActor::StateWork)
         HFunc(TEvBlobStorage::TEvCollectGarbageResult, HandleCollectGarbageResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_common/drain_actor_companion_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/drain_actor_companion_ut.cpp
@@ -130,7 +130,10 @@ public:
                 HandleWaitForInFlightWrites);
             HFunc(TEvSetWriteInProgressCount, HandleSetWriteCount);
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
         }
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/agent_availability_monitoring_actor.cpp
@@ -201,7 +201,10 @@ STFUNC(TAgentAvailabilityMonitoringActor::StateWork)
         IgnoreFunc(TEvVolume::TEvRWClientIdChanged);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.cpp
@@ -363,7 +363,8 @@ STFUNC(TCopyRangeActor::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::PARTITION_WORKER);
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
@@ -354,7 +354,10 @@ STFUNC(TDirectCopyRangeActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleRangeMigrationTimeout);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -272,7 +272,10 @@ STFUNC(TSplitRequestSenderActor<TMethod>::StateWork)
         HFunc(TMethod::TRequest, HandleUndelivery);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -1148,7 +1151,10 @@ STFUNC(TLaggingAgentsReplicaProxyActor::StateWork)
         HFunc(TEvents::TEvPoisonTaken, PoisonPillHelper.HandlePoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -1177,7 +1183,10 @@ STFUNC(TLaggingAgentsReplicaProxyActor::StateZombie)
         HFunc(TEvents::TEvPoisonTaken, PoisonPillHelper.HandlePoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
@@ -298,7 +298,8 @@ STFUNC(TMigrationRequestActor<TMethod>::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::PARTITION_WORKER);
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
@@ -45,7 +45,10 @@ public:
             HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteBlocks);
             IgnoreFunc(TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted);
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor.h
@@ -258,7 +258,8 @@ STFUNC(TMirrorRequestActor<TMethod>::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::PARTITION_WORKER);
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/mirror_request_actor_ut.cpp
@@ -41,7 +41,10 @@ public:
             HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteBlocks);
             IgnoreFunc(TEvNonreplPartitionPrivate::TEvWriteOrZeroCompleted);
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
@@ -375,7 +375,10 @@ STFUNC(TMultiAgentWriteActor<TMethod>::StateWork)
         HFunc(NActors::TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -847,7 +847,10 @@ STFUNC(TMirrorPartitionActor::StateWork)
         IgnoreFunc(TEvents::TEvPoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -902,7 +905,10 @@ STFUNC(TMirrorPartitionActor::StateZombie)
         HFunc(TEvents::TEvPoisonTaken, HandlePoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -403,7 +403,8 @@ STFUNC(TRequestActor<TMethod>::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::PARTITION_WORKER);
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor.cpp
@@ -71,7 +71,10 @@ void TMirrorPartitionResyncActor::RejectPostponedRead(TPostponedRead& pr)
         HFunc(TEvService::TEvReadBlocksLocalRequest, RejectReadBlocksLocal);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -84,7 +87,10 @@ void TMirrorPartitionResyncActor::RejectFastPathRecord(TFastPathRecord& fpr)
         HFunc(TEvService::TEvReadBlocksLocalRequest, RejectReadBlocksLocal);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -301,7 +307,10 @@ STFUNC(TMirrorPartitionResyncActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -344,7 +353,10 @@ STFUNC(TMirrorPartitionResyncActor::StateZombie)
         HFunc(TEvents::TEvPoisonTaken, HandlePoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
@@ -248,7 +248,10 @@ STFUNC(TMirrorPartitionResyncFastPathActor::StateWork)
         HFunc(TEvService::TEvReadBlocksLocalResponse, HandleReadResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_read_blocks_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_split_read_blocks_actor.h
@@ -109,7 +109,8 @@ private:
             default:
                 HandleUnexpectedEvent(
                     ev,
-                    TBlockStoreComponents::PARTITION_WORKER);
+                    TBlockStoreComponents::PARTITION_WORKER,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -695,7 +695,10 @@ STFUNC(TNonreplicatedPartitionActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -741,7 +744,10 @@ STFUNC(TNonreplicatedPartitionActor::StateZombie)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.cpp
@@ -186,7 +186,10 @@ void TDiskAgentBaseRequestActor::StateWork(TAutoPtr<NActors::IEventHandle>& ev)
             HandleCancelRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -251,7 +251,10 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_NONREPL);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_NONREPL,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -311,7 +314,10 @@ STFUNC(TNonreplicatedPartitionMigrationCommonActor::StateZombie)
         HFunc(TEvents::TEvPoisonTaken, PoisonPillHelper.HandlePoisonTaken);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_NONREPL);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_NONREPL,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -738,7 +738,10 @@ STFUNC(TNonreplicatedPartitionRdmaActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -787,7 +790,10 @@ STFUNC(TNonreplicatedPartitionRdmaActor::StateZombie)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
@@ -413,7 +413,8 @@ STFUNC(TResyncRangeActor::StateWork)
         default:
             HandleUnexpectedEvent(
                 ev,
-                TBlockStoreComponents::PARTITION_WORKER);
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range_block_by_block.cpp
@@ -607,7 +607,10 @@ STFUNC(TResyncRangeBlockByBlockActor::StateWork)
         HFunc(TEvService::TEvWriteBlocksResponse, HandleWriteResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -314,7 +314,10 @@ STFUNC(TServiceActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_backup_disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_backup_disk_registry_state.cpp
@@ -119,7 +119,10 @@ STFUNC(TBackupDiskRegistryStateActor::StateWork)
             HandleBackupDiskRegistryStateResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_backup_path_descriptions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_backup_path_descriptions.cpp
@@ -99,7 +99,10 @@ STFUNC(TBackupPathDescriptionsActor::StateWork)
             HandleBackupPathDescriptionsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_backup_tablet_boot_infos.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_backup_tablet_boot_infos.cpp
@@ -102,7 +102,10 @@ STFUNC(TBackupTabletBootInfosActor::StateWork)
             HandleBackupTabletBootInfosResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_change_disk_device.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_change_disk_device.cpp
@@ -117,7 +117,10 @@ STFUNC(TChangeDiskDeviceActor::StateWork)
             HandleChangeDiskDeviceResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_change_storage_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_change_storage_config.cpp
@@ -151,7 +151,10 @@ STFUNC(TChangeStorageConfigActionActor::StateWork)
         HFunc(TEvVolume::TEvChangeStorageConfigResponse, HandleChangeStorageConfigResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_check_blob.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_check_blob.cpp
@@ -202,7 +202,10 @@ STFUNC(TCheckBlobActionActor::StateWork)
         HFunc(TEvBlobStorage::TEvGetResult, HandleGetResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_check_range.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_check_range.cpp
@@ -163,7 +163,10 @@ STFUNC(TCheckRangeActor::StateWork)
         HFunc(TEvVolume::TEvCheckRangeResponse, HandleCheckRangeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_cms.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_cms.cpp
@@ -118,7 +118,10 @@ STFUNC(TCmsActor::StateWork)
             HandleCmsActionResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_compact_range.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_compact_range.cpp
@@ -179,7 +179,10 @@ STFUNC(TCompactRangeActionActor::StateWork)
         HFunc(TEvVolume::TEvCompactRangeResponse, HandleCompactRangeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_configure_volume_balancer.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_configure_volume_balancer.cpp
@@ -119,7 +119,10 @@ STFUNC(TConfigureVolumeBalancerActionActor::StateWork)
         HFunc(TEvVolumeBalancer::TEvConfigureVolumeBalancerResponse, HandleConfigureVolumeBalancerResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME_BALANCER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME_BALANCER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_create_disk_from_devices.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_create_disk_from_devices.cpp
@@ -162,7 +162,10 @@ STFUNC(TCreateDiskFromDevicesActor::StateWork)
             HandleCreateVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_delete_checkpoint_data.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_delete_checkpoint_data.cpp
@@ -168,7 +168,10 @@ STFUNC(TDeleteCheckpointDataActionActor::StateWork)
         HFunc(TEvVolume::TEvDeleteCheckpointDataResponse, HandleDeleteCheckpointDataResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_describe.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_describe.cpp
@@ -133,7 +133,10 @@ STFUNC(TDescribeVolumeActionsActor::StateWork)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_describe_blocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_describe_blocks.cpp
@@ -159,7 +159,10 @@ STFUNC(TDescribeBlocksActionActor::StateWork)
         HFunc(TEvVolume::TEvDescribeBlocksResponse, HandleDescribeBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_disk_registry_change_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_disk_registry_change_state.cpp
@@ -239,7 +239,10 @@ STFUNC(TDiskRegistryChangeStateActor::StateWork)
             HandleDisableAgentResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
@@ -149,7 +149,10 @@ STFUNC(TDrainNodeActionActor::StateWork)
         HFunc(TEvHiveProxy::TEvDrainNodeResponse, HandleDrainNodeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_finish_fill_disk.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_finish_fill_disk.cpp
@@ -261,7 +261,10 @@ STFUNC(TFinishFillDiskActionActor::StateDescribeVolume)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -272,7 +275,10 @@ STFUNC(TFinishFillDiskActionActor::StateAlterVolume)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleAlterVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -283,7 +289,10 @@ STFUNC(TFinishFillDiskActionActor::StateWaitReady)
         HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_flush_profile_log.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_flush_profile_log.cpp
@@ -60,7 +60,10 @@ void TFlushProfileLogActor::Bootstrap(const TActorContext& ctx)
 
 STFUNC(TFlushProfileLogActor::StateWork)
 {
-    HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+    HandleUnexpectedEvent(
+        ev,
+        TBlockStoreComponents::SERVICE,
+        __PRETTY_FUNCTION__);
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_compaction_status.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_compaction_status.cpp
@@ -164,7 +164,10 @@ STFUNC(TGetCompactionStatusActionActor::StateWork)
         HFunc(TEvVolume::TEvGetCompactionStatusResponse, HandleGetCompactionStatusResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_dependent_disks.cpp
@@ -181,7 +181,10 @@ STFUNC(TGetDependentDisksActor::StateWork)
             HandleGetDependentDisksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_disk_agent_node_id.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_disk_agent_node_id.cpp
@@ -118,7 +118,10 @@ STFUNC(TGetDiskAgentNodeIdActor::StateWork)
             HandleGetAgentNodeIdResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_diskregistry_tablet_info.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_diskregistry_tablet_info.cpp
@@ -130,7 +130,10 @@ STFUNC(TGetDiskRegistryTabletInfoActor::StateWork)
             HandleGetDrTabletInfoResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_nameservice_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_nameservice_config.cpp
@@ -143,7 +143,10 @@ STFUNC(TGetDynamicNameserverNodes::StateWork)
         HFunc(TEvInterconnect::TEvNodesInfo, HandleNameserviceConfig);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_partition_info.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_partition_info.cpp
@@ -134,7 +134,10 @@ STFUNC(TGetPartitionInfoActionActor::StateWork)
         HFunc(TEvVolume::TEvGetPartitionInfoResponse, HandleGetPartitionInfoResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_storage_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_storage_config.cpp
@@ -155,7 +155,10 @@ STFUNC(TGetStorageConfigActor::StateWork)
             HandleGetStorageConfigResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_kill_tablet.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_kill_tablet.cpp
@@ -121,7 +121,10 @@ STFUNC(TKillTabletActionActor::StateWork)
 {
     switch (ev->GetTypeRewrite()) {
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_migration_disk_registry_device.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_migration_disk_registry_device.cpp
@@ -123,7 +123,10 @@ STFUNC(TForceMigrationActor::StateWork)
             HandleStartForceMigrationResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_modify_tags.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_modify_tags.cpp
@@ -324,7 +324,10 @@ STFUNC(TModifyTagsActionActor::StateDescribeVolume)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -335,7 +338,10 @@ STFUNC(TModifyTagsActionActor::StateAlterVolume)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleAlterVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -346,7 +352,10 @@ STFUNC(TModifyTagsActionActor::StateWaitReady)
         HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_reallocate_disk.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_reallocate_disk.cpp
@@ -146,7 +146,10 @@ STFUNC(TReallocateDiskActionActor::StateWork)
             HandleReallocateDiskResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_reassign_disk_registry.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_reassign_disk_registry.cpp
@@ -138,7 +138,10 @@ STFUNC(TReassignDiskRegistryActionActor::StateWork)
             TEvDiskRegistryProxy::TEvReassignResponse, HandleReassignResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebase_volume.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebase_volume.cpp
@@ -316,7 +316,10 @@ STFUNC(TRebaseVolumeActionActor::StateDescribeBaseVolume)
             HandleDescribeBaseVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -327,7 +330,10 @@ STFUNC(TRebaseVolumeActionActor::StateDescribeVolume)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -338,7 +344,10 @@ STFUNC(TRebaseVolumeActionActor::StateAlterVolume)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleAlterVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -349,7 +358,10 @@ STFUNC(TRebaseVolumeActionActor::StateWaitReady)
         HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebind_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebind_volumes.cpp
@@ -162,7 +162,10 @@ STFUNC(TRebindVolumesActor::StateWork)
             HandleChangeVolumeBindingResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebuild_metadata.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebuild_metadata.cpp
@@ -190,7 +190,10 @@ STFUNC(TRebuildMetadataActor::StateWork)
             HandleRebuildMetadataResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -331,7 +334,10 @@ STFUNC(TRebuildMetadataStatusActor::StateWork)
             HandleGetRebuildMetadataStatusResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_replace_device.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_replace_device.cpp
@@ -156,7 +156,10 @@ STFUNC(TReplaceDeviceActionActor::StateWork)
             HandleReplaceDeviceResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_reset_tablet.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_reset_tablet.cpp
@@ -190,7 +190,10 @@ STFUNC(TResetTabletActionActor::StateWork)
         HFunc(TEvTablet::TEvResetTabletResult, HandleResetTabletResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_restore_disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_restore_disk_registry_state.cpp
@@ -121,7 +121,10 @@ STFUNC(TRestoreDiskRegistryStateActor::StateWork)
             HandleRestoreDiskRegistryStateResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_scan_disk.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_scan_disk.cpp
@@ -161,7 +161,10 @@ STFUNC(TScanDiskActor::StateWork)
             HandleScanDiskResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -317,7 +320,10 @@ STFUNC(TScanDiskStatusActor::StateWork)
             HandleGetScanDiskStatusResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_set_user_id.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_set_user_id.cpp
@@ -117,7 +117,10 @@ STFUNC(TSetUserIdActor::StateWork)
             HandleSetUserIdResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_setup_channels.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_setup_channels.cpp
@@ -153,7 +153,10 @@ STFUNC(TSetupChannelsActionActor::StateWork)
         HFunc(TEvService::TEvResizeVolumeResponse, HandleSetupChannelsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_suspend_device.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_suspend_device.cpp
@@ -129,7 +129,10 @@ STFUNC(TSuspendDeviceActionActor::StateWork)
             HandleSuspendDeviceResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_suspend_disk_agent.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_suspend_disk_agent.cpp
@@ -114,7 +114,10 @@ STFUNC(TPartiallySuspendDiskAgentActor::StateWork)
             HandleSuspendDiskAgentResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_block_size.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_block_size.cpp
@@ -156,7 +156,10 @@ STFUNC(TUpdateDiskBlockSizeActionActor::StateWork)
             HandleUpdateDiskBlockSizeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_registry_params.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_registry_params.cpp
@@ -119,7 +119,10 @@ STFUNC(TUpdateDiskRegistryAgentListParamsActor::StateWork)
             HandleUpdateDiskRegistryAgentListParamsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_replica_count.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_disk_replica_count.cpp
@@ -151,7 +151,10 @@ STFUNC(TUpdateDiskReplicaCountActionActor::StateWork)
             HandleUpdateDiskReplicaCountResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_placement_group_settings.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_placement_group_settings.cpp
@@ -121,7 +121,10 @@ STFUNC(TUpdatePlacementGroupSettingsActor::StateWork)
             HandleUpdatePlacementGroupSettingsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_used_blocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_used_blocks.cpp
@@ -160,7 +160,10 @@ STFUNC(TUpdateUsedBlocksActionActor::StateWork)
             HandleUpdateUsedBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_update_volume_params.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_update_volume_params.cpp
@@ -160,7 +160,10 @@ STFUNC(TUpdateVolumeParamsActor::StateWork)
             HandleUpdateVolumeParamsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_wait_dependent_disks_switched_node.cpp
@@ -405,7 +405,10 @@ STFUNC(TWaitDependentDisksToSwitchNodeActor::StateWork)
         HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_writable_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_writable_state.cpp
@@ -124,7 +124,10 @@ STFUNC(TWritableStateActor::StateWork)
             HandleSetWritableStateResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
@@ -503,7 +503,10 @@ STFUNC(TAlterVolumeActor::StateDescribeVolume)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -514,7 +517,10 @@ STFUNC(TAlterVolumeActor::StateAlterVolume)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleAlterVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -525,7 +531,10 @@ STFUNC(TAlterVolumeActor::StateWaitReady)
         HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_assign.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_assign.cpp
@@ -135,7 +135,10 @@ STFUNC(TAssignVolumeActor::StateWork)
         HFunc(TEvSSProxy::TEvModifyVolumeResponse, HandleModifyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_balancer_stats.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_balancer_stats.cpp
@@ -62,7 +62,10 @@ STFUNC(TVolumeStatActor::StateWork)
         HFunc(TEvStatsService::TEvGetVolumeStatsResponse, HandleGetVolumeStatsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_check_liveness.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_check_liveness.cpp
@@ -84,7 +84,10 @@ STFUNC(TVolumeLivenessCheckActor::StateWork)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create.cpp
@@ -444,7 +444,10 @@ STFUNC(TCreateVolumeActor::StateWork)
             HandleCreateEncryptionKeyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_create_from_device.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create_from_device.cpp
@@ -223,7 +223,10 @@ STFUNC(TCreateVolumeFromDeviceActor::StateWork)
             HandleCreateVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_create_volume_link.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create_volume_link.cpp
@@ -210,7 +210,10 @@ STFUNC(TCreateVolumeLinkActor::StateWork)
             HandleLinkLeaderVolumeToFollowerResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_describe.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_describe.cpp
@@ -187,7 +187,10 @@ STFUNC(TDescribeVolumeActor::StateDescribeVolume)
         HFunc(TEvDiskRegistry::TEvDescribeDiskResponse, HandleDescribeDiskResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_describe_disk_registry_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_describe_disk_registry_config.cpp
@@ -132,7 +132,10 @@ STFUNC(TDescribeDiskRegistryConfigActor::StateWork)
         HFunc(TEvDiskRegistry::TEvDescribeConfigResponse, HandleDescribeConfigResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
@@ -487,7 +487,10 @@ STFUNC(TDestroyVolumeActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleTimeout);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_destroy_volume_link.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy_volume_link.cpp
@@ -164,7 +164,10 @@ STFUNC(TDestroyVolumeLinkActor::StateWork)
             HandleUnlinkLeaderVolumeFromFollowerResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -95,7 +95,10 @@ STFUNC(TDescribeActor::StateWork)
         HFunc(TEvSSProxy::TEvDescribeSchemeResponse, HandleDescribeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_monitoring_binding.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_monitoring_binding.cpp
@@ -136,7 +136,10 @@ STFUNC(THttpVolumeBindingActor::StateWork)
         HFunc(TEvService::TEvChangeVolumeBindingResponse, HandleChangeVolumeBindingResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_monitoring_search.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_monitoring_search.cpp
@@ -175,7 +175,10 @@ STFUNC(THttpFindVolumeActor::StateWork)
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_monitoring_unmount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_monitoring_unmount.cpp
@@ -131,7 +131,10 @@ STFUNC(THttpUnmountVolumeActor::StateWork)
         HFunc(TEvService::TEvUnmountVolumeResponse, HandleUnmountVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
@@ -99,7 +99,10 @@ STFUNC(TMountVolumeActor::StateWork)
             HandleInternalMountVolumeRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_readblocks.cpp
@@ -95,7 +95,10 @@ private:
             HFunc(TEvService::TEvReadBlocksRequest, HandleUndelivery);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_update_disk_registry_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_update_disk_registry_config.cpp
@@ -177,7 +177,10 @@ STFUNC(TUpdateDiskRegistryConfigActor::StateWork)
         HFunc(TEvDiskRegistry::TEvUpdateConfigResponse, HandleUpdateConfigResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_volume_binding.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_volume_binding.cpp
@@ -160,7 +160,10 @@ STFUNC(TDelayChangeBindingActor::StateWork)
             HandleUndelivery);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_writeblocks.cpp
@@ -117,7 +117,10 @@ private:
             HFunc(TEvService::TEvWriteBlocksRequest, HandleUndelivery);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
@@ -457,7 +457,10 @@ STFUNC(TVolumeClientActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -250,7 +250,10 @@ STFUNC(TVolumeSessionActor::StateDescribe)
             PostponeChangeVolumeBindingRequest);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -302,8 +305,11 @@ STFUNC(TVolumeSessionActor::StateWork)
         IgnoreFunc(TEvService::TEvUnmountVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
-        break;
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
+            break;
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -819,7 +819,10 @@ STFUNC(TMountRequestActor::StateWork)
         IgnoreFunc(TEvHiveProxy::TEvTabletLockLost);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -1247,4 +1250,3 @@ void TVolumeSessionActor::HandleMountRequestProcessed(
 }
 
 }   // namespace NCloud::NBlockStore::NStorage
-

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -956,7 +956,10 @@ STFUNC(TStartVolumeActor::StateWork)
         HFunc(TEvVolume::TEvWaitReadyResponse, HandleWaitReadyResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
@@ -254,7 +254,10 @@ STFUNC(TUnmountRequestActor::StateWork)
         HFunc(TEvServicePrivate::TEvStopVolumeResponse, HandleStopVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/volume_timed_delivery.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_timed_delivery.cpp
@@ -187,8 +187,11 @@ STFUNC(TVolumeProxyTimedDeliveryActor<TMethod>::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
-        break;
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
+            break;
     }
 }
 

--- a/cloud/blockstore/libs/storage/ss_proxy/path_description_backup.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/path_description_backup.cpp
@@ -191,7 +191,10 @@ STFUNC(TPathDescriptionBackup::StateWork)
         HFunc(TEvSSProxy::TEvBackupPathDescriptionsRequest, HandleBackupPathDescriptions);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor.cpp
@@ -137,7 +137,10 @@ STFUNC(TSSProxyActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SS_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_createvolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_createvolume.cpp
@@ -558,7 +558,10 @@ STFUNC(TCreateVolumeActor::StateDescribeVolumeBeforeCreate)
         HFunc(TEvSSProxy::TEvDescribeSchemeResponse, HandleDescribeVolumeBeforeCreateResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -569,7 +572,10 @@ STFUNC(TCreateVolumeActor::StateCreateVolume)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleCreateVolumeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -580,7 +586,10 @@ STFUNC(TCreateVolumeActor::StateCreateNextDir)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleMkDirResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -591,7 +600,10 @@ STFUNC(TCreateVolumeActor::StateDescribeVolumeAfterCreate)
         HFunc(TEvSSProxy::TEvDescribeSchemeResponse, HandleDescribeVolumeAfterCreateResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -171,7 +171,10 @@ STFUNC(TDescribeSchemeActor::StateWork)
         HFunc(TEvSchemeShard::TEvDescribeSchemeResult, HandleDescribeSchemeResult);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
@@ -264,7 +264,10 @@ STFUNC(TDescribeVolumeActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -230,7 +230,10 @@ STFUNC(TModifySchemeActor::StateWork)
         HFunc(TEvSSProxy::TEvWaitSchemeTxResponse, HandleTxDone);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyvolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyvolume.cpp
@@ -182,7 +182,10 @@ STFUNC(TModifyVolumeActor::StateWork)
         HFunc(TEvSSProxy::TEvModifySchemeResponse, HandleModifySchemeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_waitschemetx.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_waitschemetx.cpp
@@ -48,7 +48,10 @@ STFUNC(TReplyProxyActor::StateWork)
         HFunc(TEvSchemeShard::TEvNotifyTxCompletionResult, Handle);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_fallback_actor.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_fallback_actor.cpp
@@ -135,7 +135,10 @@ STFUNC(TReadPathDescriptionBackupActor<TResponse>::StateWork)
         HFunc(TReadCacheResponse, HandleReadCacheResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -182,7 +185,10 @@ STFUNC(TSSProxyFallbackActor::StateWork)
     switch (ev->GetTypeRewrite()) {
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SS_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SS_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.cpp
@@ -139,7 +139,10 @@ STFUNC(TStatsServiceActor::StateWork)
             HandleCleanupBackgroundSources);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::STATS_SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::STATS_SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_volume_stats.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_volume_stats.cpp
@@ -128,7 +128,10 @@ STFUNC(TRemoteVolumeStatActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::STATS_SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::STATS_SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
+++ b/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
@@ -154,7 +154,10 @@ private:
             IgnoreFunc(NKikimr::TEvLocal::TEvTabletMetrics);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                    __PRETTY_FUNCTION__);
         }
     }
 

--- a/cloud/blockstore/libs/storage/testlib/test_tablet.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_tablet.cpp
@@ -221,7 +221,10 @@ STFUNC(TTabletActor::StateWork)
             if (!HandleRequests(ev) &&
                 !HandleDefaultEvents(ev, SelfId()))
             {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -236,7 +239,10 @@ STFUNC(TTabletActor::StateZombie)
         IgnoreFunc(TEvTabletPipe::TEvServerDisconnected);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/undelivered/undelivered.cpp
+++ b/cloud/blockstore/libs/storage/undelivered/undelivered.cpp
@@ -92,7 +92,10 @@ STFUNC(TUndeliveredHandlerActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/volume/actors/forward_write_and_mark_used.h
+++ b/cloud/blockstore/libs/storage/volume/actors/forward_write_and_mark_used.h
@@ -334,7 +334,10 @@ STFUNC(TWriteAndMarkUsedActor<TMethod>::StateWork)
             HandleUpdateUsedBlocksResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/actors/read_and_clear_empty_blocks_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/read_and_clear_empty_blocks_actor.h
@@ -216,7 +216,10 @@ STFUNC(TReadAndClearEmptyBlocksActor<TMethod>::StateWork)
         HFunc(TMethod::TRequest, HandleUndelivery);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay.cpp
@@ -469,7 +469,10 @@ STFUNC(TReadDiskRegistryBasedOverlayActor<TMethod>::StateWork)
             HandleLongRunningBlobOperation);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/actors/release_devices_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/release_devices_actor.cpp
@@ -160,7 +160,10 @@ STFUNC(TReleaseDevicesActor::StateWork)
             HandleReleaseDevicesUndelivery);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -383,7 +383,10 @@ STFUNC(TAcquireShadowDiskActor::Work)
         HFunc(NActors::TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/multi_partition_requests.h
+++ b/cloud/blockstore/libs/storage/volume/multi_partition_requests.h
@@ -453,7 +453,10 @@ STFUNC(TMultiPartitionRequestActor<TMethod>::StateWork)
         HFunc(TMethod::TRequest, HandleUndelivery);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -94,7 +94,10 @@ private:
             IgnoreFunc(TEvLocal::TEvTabletMetrics);
 
             default:
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::HIVE_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::HIVE_PROXY,
+                    __PRETTY_FUNCTION__);
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_acquire.cpp
@@ -342,7 +342,10 @@ STFUNC(TAcquireDevicesActor::StateAcquire)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -664,7 +664,10 @@ STFUNC(TCheckpointActor<TMethod>::StateDrain)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -687,7 +690,10 @@ STFUNC(TCheckpointActor<TMethod>::StateDoAction)
         IgnoreFunc(TEvents::TEvWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -706,7 +712,10 @@ STFUNC(TCheckpointActor<TMethod>::StateUpdateCheckpointRequest)
         IgnoreFunc(TEvents::TEvWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring_checkpoint.cpp
@@ -206,7 +206,10 @@ STFUNC(THttpCheckpointActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::PARTITION_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring_removeclient.cpp
@@ -123,7 +123,10 @@ STFUNC(THttpRemoveClientActor::StateWork)
         HFunc(TEvVolume::TEvRemoveClientResponse, HandleRemoveClientResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_reallocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_reallocatedisk.cpp
@@ -163,7 +163,10 @@ STFUNC(TReallocateActor::StateWork)
             HandleUpdateDevicesResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_reset_seqnumber.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_reset_seqnumber.cpp
@@ -150,8 +150,11 @@ STFUNC(THttpResetMountSeqNumberActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
-        break;
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
+            break;
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
@@ -201,7 +201,10 @@ STFUNC(TStatPartitionActor::StateWork)
         HFunc(TEvPartition::TEvStatPartitionResponse, HandleStatPartitionResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -126,7 +126,10 @@ STFUNC(TRemoteVolumeStatActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME_BALANCER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME_BALANCER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -388,7 +391,10 @@ STFUNC(TVolumeBalancerActor::StateWork)
         HFunc(NMon::TEvHttpInfo, HandleHttpInfo);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME_BALANCER);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME_BALANCER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
@@ -829,7 +829,10 @@ STFUNC(TVolumeProxyActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TBlockStoreComponents::VOLUME_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::VOLUME_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/storage/core/libs/auth/authorizer.cpp
+++ b/cloud/storage/core/libs/auth/authorizer.cpp
@@ -224,9 +224,7 @@ private:
                 HandleParseTicketResult);
 
             default:
-                HandleUnexpectedEvent(
-                    ev,
-                    Component);
+                HandleUnexpectedEvent(ev, Component, __PRETTY_FUNCTION__);
                 break;
         }
     }
@@ -323,9 +321,7 @@ private:
                 HandleAuthorizationRequest);
 
             default:
-                HandleUnexpectedEvent(
-                    ev,
-                    Component);
+                HandleUnexpectedEvent(ev, Component, __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
@@ -543,7 +543,7 @@ STFUNC(THiveProxyActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, LogComponent);
+                HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_bootext.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_bootext.cpp
@@ -223,7 +223,7 @@ STFUNC(TBootRequestActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
@@ -113,7 +113,7 @@ STFUNC(TDrainNodeRequestActor::StateWork)
         HFunc(NKikimr::TEvHive::TEvDrainNodeResult, HandleDrainNodeResult);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_reassign.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_reassign.cpp
@@ -107,7 +107,7 @@ STFUNC(TReassignRequestActor::StateWork)
         HFunc(NKikimr::TEvHive::TEvTabletCreationResult, HandleTabletCreationResult);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
@@ -106,7 +106,7 @@ private:
             HFunc(TResponse, HandleResponse);
 
             default:
-                HandleUnexpectedEvent(ev, LogComponent);
+                HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
@@ -238,7 +238,7 @@ STFUNC(TTabletBootInfoBackup::StateWork)
         HFunc(TEvHiveProxy::TEvBackupTabletBootInfosRequest, HandleBackupTabletBootInfos);
         HFunc(TEvHiveProxy::TEvListTabletBootInfoBackupsRequest, HandleListTabletBootInfoBackups);
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/ss_proxy/path_description_backup.cpp
+++ b/cloud/storage/core/libs/ss_proxy/path_description_backup.cpp
@@ -199,7 +199,7 @@ STFUNC(TPathDescriptionBackup::StateWork)
         HFunc(TEvSSProxy::TEvBackupPathDescriptionsRequest, HandleBackupPathDescriptions);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor.cpp
@@ -121,7 +121,10 @@ STFUNC(TSSProxyActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, Config.LogComponent);
+                HandleUnexpectedEvent(
+                    ev,
+                    Config.LogComponent,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -141,7 +141,7 @@ STFUNC(TDescribeSchemeActor::StateWork)
         HFunc(TEvSchemeShard::TEvDescribeSchemeResult, HandleDescribeSchemeResult);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -243,7 +243,7 @@ STFUNC(TModifySchemeActor::StateWork)
         HFunc(TEvSSProxy::TEvWaitSchemeTxResponse, HandleTxDone);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_waitschemetx.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_waitschemetx.cpp
@@ -51,7 +51,7 @@ STFUNC(TReplyProxyActor::StateWork)
         HFunc(TEvSchemeShard::TEvNotifyTxCompletionResult, Handle);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_fallback_actor.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_fallback_actor.cpp
@@ -129,7 +129,7 @@ STFUNC(TDescribeSchemeActor::StateWork)
         HFunc(TReadBackupResponse, HandleReadBackupResponse);
 
         default:
-            HandleUnexpectedEvent(ev, LogComponent);
+            HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -178,7 +178,10 @@ STFUNC(TSSProxyFallbackActor::StateWork)
     switch (ev->GetTypeRewrite()) {
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, Config.LogComponent);
+                HandleUnexpectedEvent(
+                    ev,
+                    Config.LogComponent,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }


### PR DESCRIPTION
Если в актор прилетает неизвестное сообщение он пишет об этом сообщение в логе, но по нему совершенно непонятно в какой автор оно прилетело. Теперь будет показываться метод в котором это произошло.

```
VERIFY failed (2025-05-07T17:04:13.793742+0700): [BLOCKSTORE_PARTITION_WORKER] Unexpected event: (0x1062078F) NCloud::NBlockStore::TResponseEvent<NCloud::NBlockStore::NStorage::TEvNonreplPartitionPrivate::TGetDeviceForRangeRequest, 274859919u>, void NCloud::NBlockStore::NStorage::TLaggingAgentsReplicaProxyActor::StateWork(TAutoPtr< ::NActors::IEventHandle> &)

```