### PR TITLE
Return E_FAIL error code instead of E_REJECTED on GetChangedBlocks if shadow disk is broken; check GetChangedBlocks error in dm tests with broken checkpoints

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -1216,9 +1216,16 @@ void TShadowDiskActor::HandleGetChangedBlocks(
 
         auto response =
             std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
-        *response->Record.MutableError() = MakeError(
-            E_REJECTED,
-            "Can't GetChangedBlocks when shadow disk is not ready.");
+
+        if (State == EActorState::Error) {
+            *response->Record.MutableError() = MakeError(
+                E_INVALID_STATE,
+                "Can't GetChangedBlocks when shadow disk is broken.");
+        } else {
+            *response->Record.MutableError() = MakeError(
+                E_REJECTED,
+                "Can't GetChangedBlocks when shadow disk is not ready.");
+        }
 
         NCloud::Reply(ctx, *ev, std::move(response));
         return;

--- a/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_test/with_broken_checkpoints_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_test/with_broken_checkpoints_test.go
@@ -247,7 +247,8 @@ func testCreateSnapshotOrImageFromDiskWithFailedShadowDisk(
 			return
 		}
 
-		if strings.Contains(err.Error(), "Device disabled") {
+		if strings.Contains(err.Error(), "Device disabled") ||
+			strings.Contains(err.Error(), "Can't GetChangedBlocks when shadow disk is broken") {
 			// Dataplane task failed with 'Device disabled' error, but shadow
 			// disk was filled successfully.
 			// TODO: improve this test after https://github.com/ydb-platform/nbs/issues/1950#issuecomment-2541530203


### PR DESCRIPTION
Fix `with_broken_checkpoints_test` the tests. There tests timeouted with the repeated error:

```
2025-05-06T01:34:42.312537Z :BLOCKSTORE_VOLUME ERROR: Shadow disk: "TestImageServiceCreateImageFromDiskWithFailedShadowDisk1-TestImageServiceCreateImageFromDiskWithFailedShadowDisk_0" Can't GetChangedBlocks when shadow disk is not ready.
```

In this pr we:
- Make this error non-retriable in case of broken shadow disk (see https://github.com/ydb-platform/nbs/pull/3467)
- Handle this error in the test

E_FAIL is nonretrialble, while E_REJECTED is retriable.
If shadow disk actor is in error state, we should no retry GetChangedBlocks request.