### PR TITLE
Show function in unexpected event message in filestore. Remove overload with two arguments.

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -769,7 +769,8 @@ STFUNC(TDiskRegistryActor::StateRestore)
             if (!RejectRequests(ev)) {
                 LogUnexpectedEvent(
                     ev,
-                    TBlockStoreComponents::DISK_REGISTRY);
+                    TBlockStoreComponents::DISK_REGISTRY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -836,7 +837,8 @@ STFUNC(TDiskRegistryActor::StateReadOnly)
             if (!RejectRequests(ev)) {
                 LogUnexpectedEvent(
                     ev,
-                    TBlockStoreComponents::DISK_REGISTRY);
+                    TBlockStoreComponents::DISK_REGISTRY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_actor.cpp
@@ -282,8 +282,10 @@ void TDiskRegistryProxyActor::HandleResponse(
     if (it == ActiveRequests.end()) {
         // ActiveRequests are cleared upon connection reset
         if (!LogLateMessage(ev)) {
-            LogUnexpectedEvent(ev,
-                TBlockStoreComponents::DISK_REGISTRY_PROXY);
+            LogUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                __PRETTY_FUNCTION__);
         }
         return;
     }

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/disk_registry_proxy_actor_create.cpp
@@ -251,7 +251,10 @@ STFUNC(TCreateDiskRegistryActor::StateWork)
         HFunc(TEvHiveProxy::TEvCreateTabletResponse, HandleCreateTablet);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::DISK_REGISTRY_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/service_kikimr/auth_provider_kikimr.cpp
+++ b/cloud/filestore/libs/service_kikimr/auth_provider_kikimr.cpp
@@ -128,7 +128,10 @@ private:
             HFunc(TEvents::TEvWakeup, HandleTimeout);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE_PROXY,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/service_kikimr/service.cpp
+++ b/cloud/filestore/libs/service_kikimr/service.cpp
@@ -132,7 +132,10 @@ private:
             HFunc(TResponseEvent, HandleResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE_PROXY,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }
@@ -238,7 +241,10 @@ private:
             HFunc(TEvents::TEvCompleted, HandleCompleted)
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE_PROXY,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/service_actor.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor.cpp
@@ -161,7 +161,10 @@ STFUNC(TStorageServiceActor::StateWork)
     switch (ev->GetTypeRewrite()) {
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_change_storage_config.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_change_storage_config.cpp
@@ -140,7 +140,10 @@ STFUNC(TChangeStorageConfigActionActor::StateWork)
             HandleChangeStorageConfigResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_configure_as_shard.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_configure_as_shard.cpp
@@ -120,7 +120,10 @@ STFUNC(TConfigureAsShardActionActor::StateWork)
             HandleConfigureAsShardResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_configure_shards.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_configure_shards.cpp
@@ -120,7 +120,10 @@ STFUNC(TConfigureShardsActionActor::StateWork)
             HandleConfigureShardsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_describe_sessions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_describe_sessions.cpp
@@ -120,7 +120,10 @@ STFUNC(TDescribeSessionsActionActor::StateWork)
             HandleDescribeSessionsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
@@ -44,7 +44,10 @@ struct TDrainTabletsActionActor final
             HFunc(TEvHiveProxy::TEvDrainNodeResponse, HandleDrainResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_get_storage_config.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_get_storage_config.cpp
@@ -146,7 +146,10 @@ STFUNC(TGetStorageConfigActionActor::StateWork)
             HandleGetStorageConfigResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_get_storage_config_fields.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_get_storage_config_fields.cpp
@@ -124,7 +124,10 @@ STFUNC(TGetStorageConfigFieldsActionActor::StateWork)
             HandleGetStorageConfigFieldsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_list_local_filestores.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_list_local_filestores.cpp
@@ -64,7 +64,10 @@ private:
     {
         switch (ev->GetTypeRewrite()) {
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_reassign_tablet.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_reassign_tablet.cpp
@@ -47,7 +47,10 @@ struct TReassignTabletActionActor final
             HFunc(TEvHiveProxy::TEvReassignTabletResponse, HandleReassignResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_write_compaction_map.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_write_compaction_map.cpp
@@ -119,7 +119,10 @@ STFUNC(TWriteCompactionMapActionActor::StateWork)
             HandleWriteCompactionMapResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -572,7 +572,10 @@ STFUNC(TAlterFileStoreActor::StateWork)
             HandleConfigureMainFileStoreResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -418,7 +418,10 @@ STFUNC(TCreateFileStoreActor::StateWork)
             HandleConfigureMainFileStoreResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -241,7 +241,10 @@ STFUNC(TCreateHandleActor::StateWork)
             HandleCreateHandleResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -267,7 +267,10 @@ STFUNC(TLinkActor::StateWork)
         HFunc(TEvService::TEvCreateNodeResponse, HandleCreateResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -611,7 +611,10 @@ STFUNC(TCreateSessionActor::StateResolve)
         HFunc(TEvSSProxy::TEvDescribeFileStoreResponse, HandleDescribeFileStoreResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -632,7 +635,10 @@ STFUNC(TCreateSessionActor::StateWork)
         HFunc(TEvService::TEvGetSessionEventsResponse, HandleGetSessionEventsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -652,7 +658,10 @@ STFUNC(TCreateSessionActor::StateShutdown)
         IgnoreFunc(TEvService::TEvGetSessionEventsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -309,7 +309,10 @@ STFUNC(TDestroyFileStoreActor::StateWork)
             HandleDestroyFileStoreResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -183,7 +183,10 @@ STFUNC(TDestroySessionActor::StateWork)
         IgnoreFunc(TEvServicePrivate::TEvPingSession);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_getfsinfo.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getfsinfo.cpp
@@ -131,7 +131,10 @@ STFUNC(TGetFileStoreInfoActor::StateWork)
         HFunc(TEvSSProxy::TEvDescribeFileStoreResponse, HandleDescribeFileStoreResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -216,7 +216,10 @@ STFUNC(TGetNodeAttrActor::StateWork)
             HandleGetNodeAttrResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_list.cpp
@@ -77,7 +77,10 @@ private:
             HFunc(TEvStorageSSProxy::TEvDescribeSchemeResponse, HandleDescribeResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -600,7 +600,10 @@ STFUNC(TListNodesActor::StateWork)
             HandleGetNodeAttrBatchResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -615,7 +618,10 @@ STFUNC(TListNodesActor::StateCheck)
             HandleGetNodeAttrResponseCheck);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_monitoring_search.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_monitoring_search.cpp
@@ -47,7 +47,10 @@ private:
             HFunc(TEvSSProxy::TEvDescribeFileStoreResponse, HandleDescribeResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -627,7 +627,10 @@ STFUNC(TReadDataActor::StateWork)
         HFunc(TEvBlobStorage::TEvGetResult, HandleReadBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
@@ -163,7 +163,10 @@ STFUNC(TStatFileStoreActor::StateWork)
         HFunc(TEvIndexTablet::TEvGetStorageStatsResponse, HandleStorageStats);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SERVICE_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -147,7 +147,10 @@ private:
             HFunc(TEvService::TEvWriteDataResponse, HandleWriteDataResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE_WORKER);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE_WORKER,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/service/tablet_action_actor.h
+++ b/cloud/filestore/libs/storage/service/tablet_action_actor.h
@@ -43,7 +43,10 @@ private:
             HFunc(TResponse, HandleResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SERVICE);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SERVICE,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor.cpp
@@ -52,7 +52,10 @@ bool TSSProxyActor::HandleRequests(STFUNC_SIG)
 STFUNC(TSSProxyActor::StateWork)
 {
     if (!HandleRequests(ev)) {
-        HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+        HandleUnexpectedEvent(
+            ev,
+            TFileStoreComponents::SS_PROXY,
+            __PRETTY_FUNCTION__);
     }
 }
 

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_alterfs.cpp
@@ -140,7 +140,10 @@ STFUNC(TAlterFileStoreActor::StateWork)
         HFunc(TEvStorageSSProxy::TEvModifySchemeResponse, HandleModifySchemeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_createfs.cpp
@@ -230,7 +230,10 @@ STFUNC(TCreateFileStoreActor::StateCreateFileStore)
         HFunc(TEvStorageSSProxy::TEvModifySchemeResponse, HandleCreateFileStoreResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -241,7 +244,10 @@ STFUNC(TCreateFileStoreActor::StateCreateDir)
         HFunc(TEvStorageSSProxy::TEvModifySchemeResponse, HandleCreateDirResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_describefs.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_describefs.cpp
@@ -172,9 +172,12 @@ STFUNC(TDescribeFileStoreActor::StateWork)
 
         CFunc(TEvents::TSystem::Wakeup, HandleWakeup)
 
-        default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
-            break;
+            default
+            : HandleUnexpectedEvent(
+                  ev,
+                  TFileStoreComponents::SS_PROXY,
+                  __PRETTY_FUNCTION__);
+        break;
     }
 }
 

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_actor_destroyfs.cpp
@@ -142,7 +142,10 @@ STFUNC(TDestroyFileStoreActor::StateWork)
         HFunc(TEvStorageSSProxy::TEvModifySchemeResponse, HandleModifySchemeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/ss_proxy/ss_proxy_fallback_actor.cpp
+++ b/cloud/filestore/libs/storage/ss_proxy/ss_proxy_fallback_actor.cpp
@@ -87,7 +87,10 @@ STFUNC(TDescribeFileStoreActor::StateWork)
         HFunc(TEvStorageSSProxy::TEvDescribeSchemeResponse, HandleDescribeSchemeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::SS_PROXY,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -139,7 +142,10 @@ STFUNC(TSSProxyFallbackActor::StateWork)
     switch (ev->GetTypeRewrite()) {
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TFileStoreComponents::SS_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::SS_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
@@ -138,7 +138,10 @@ STFUNC(TAddDataActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -161,7 +161,10 @@ STFUNC(TWriteDataActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/shard_request_actor.h
+++ b/cloud/filestore/libs/storage/tablet/shard_request_actor.h
@@ -47,7 +47,10 @@ private:
             HFunc(TResponse, HandleResponse);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET_WORKER,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1034,7 +1034,10 @@ STFUNC(TIndexTabletActor::StateInit)
             if (!RejectRequests(ev) &&
                 !HandleDefaultEvents(ev, SelfId()))
             {
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -1101,7 +1104,10 @@ STFUNC(TIndexTabletActor::StateWork)
 
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -1168,7 +1174,10 @@ STFUNC(TIndexTabletActor::StateZombie)
 
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }
@@ -1221,7 +1230,10 @@ STFUNC(TIndexTabletActor::StateBroken)
             HandleShardRequestCompleted);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
@@ -215,7 +215,10 @@ STFUNC(TSyncShardSessionsActor::StateWork)
             HandleSyncShardSessionsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -353,7 +356,10 @@ STFUNC(TCleanupSessionsActor::StateWork)
         HFunc(TEvIndexTablet::TEvDestroySessionResponse, HandleSessionDestroyed);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -313,7 +313,10 @@ STFUNC(TCollectGarbageActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvDeleteGarbageResponse, HandleDeleteGarbageResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -310,7 +310,10 @@ STFUNC(TCompactionActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -130,7 +130,10 @@ STFUNC(
         HFunc(TResponseType, HandleRangeOperationResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -203,7 +203,10 @@ STFUNC(TGetShardStatsActor::StateWork)
             HandleGetStorageStatsResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -380,7 +380,10 @@ STFUNC(TCreateNodeInShardActor::StateWork)
         HFunc(TEvService::TEvGetNodeAttrResponse, HandleGetNodeAttrResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroycheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroycheckpoint.cpp
@@ -192,7 +192,10 @@ STFUNC(TDestroyCheckpointActor::StateMarkCheckpointDeleted)
             MarkCheckpointDeleted_HandleDeleteCheckpointResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -207,7 +210,10 @@ STFUNC(TDestroyCheckpointActor::StateRemoveCheckpointNodes)
             RemoveCheckpointNodes_HandleDeleteCheckpointResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -222,7 +228,10 @@ STFUNC(TDestroyCheckpointActor::StateRemoveCheckpointBlobs)
             RemoveCheckpointBlobs_HandleDeleteCheckpointResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -237,7 +246,10 @@ STFUNC(TDestroyCheckpointActor::StateRemoveCheckpoint)
             RemoveCheckpoint_HandleDeleteCheckpointResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -216,7 +216,10 @@ STFUNC(TFlushActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -476,7 +476,10 @@ STFUNC(TFlushBytesActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -869,7 +869,10 @@ struct TIndexTabletMonitoringActor
             HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET_WORKER,
+                    __PRETTY_FUNCTION__);
                 break;
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
@@ -308,7 +308,10 @@ STFUNC(TReadBlobActor::StateWork)
         HFunc(TEvBlobStorage::TEvGetResult, HandleGetResult);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -509,7 +509,10 @@ STFUNC(TReadDataActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvReadBlobResponse, HandleReadBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -189,7 +189,10 @@ STFUNC(TRenameNodeInDestinationActor::StateWork)
             HandleRenameNodeInDestinationResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
@@ -66,7 +66,10 @@ private:
             HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
             default:
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET_WORKER,
+                    __PRETTY_FUNCTION__);
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -252,7 +252,10 @@ STFUNC(TUnlinkNodeInShardActor::StateWork)
         HFunc(TEvService::TEvUnlinkNodeResponse, HandleUnlinkNodeResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -218,7 +218,10 @@ STFUNC(TWriteBatchActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvAddBlobResponse, HandleAddBlobResponse);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -248,7 +248,10 @@ STFUNC(TWriteBlobActor::StateWork)
         HFunc(TEvBlobStorage::TEvPutResult, HandlePutResult);
 
         default:
-            HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_WORKER);
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
@@ -359,7 +359,10 @@ void TIndexTabletProxyActor::HandleResponse(
     if (it == ActiveRequests.end()) {
         // ActiveRequests are cleared upon connection reset
         if (!LogLateMessage(ev)) {
-            LogUnexpectedEvent(ev, TFileStoreComponents::TABLET_PROXY);
+            LogUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_PROXY,
+                __PRETTY_FUNCTION__);
         }
         return;
     }
@@ -480,7 +483,10 @@ STFUNC(TIndexTabletProxyActor::StateWork)
 
         default:
             if (!HandleRequests(ev)) {
-                HandleUnexpectedEvent(ev, TFileStoreComponents::TABLET_PROXY);
+                HandleUnexpectedEvent(
+                    ev,
+                    TFileStoreComponents::TABLET_PROXY,
+                    __PRETTY_FUNCTION__);
             }
             break;
     }

--- a/cloud/storage/core/libs/actors/helpers.cpp
+++ b/cloud/storage/core/libs/actors/helpers.cpp
@@ -10,23 +10,13 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TString EventInfo(IEventHandle& ev)
+TString EventInfo(const IEventHandle& ev)
 {
     return ev.GetTypeName();
 }
 
-void LogUnexpectedEvent(
-    IEventHandle& ev,
-    int component)
-{
-    LOG_ERROR(*TlsActivationContext, component,
-        "Unexpected event: (0x%08X) %s",
-        ev.GetTypeRewrite(),
-        EventInfo(ev).c_str());
-}
-
 [[maybe_unused]] void LogUnexpectedEvent(
-    IEventHandle& ev,
+    const IEventHandle& ev,
     int component,
     const TString& location)
 {
@@ -39,23 +29,9 @@ void LogUnexpectedEvent(
         location.c_str());
 }
 
-void HandleUnexpectedEvent(
-    IEventHandle& ev,
-    int component)
-{
-#if defined(NDEBUG)
-    LogUnexpectedEvent(ev, component);
-#else
-    Y_ABORT(
-        "[%s] Unexpected event: (0x%08X) %s",
-        TlsActivationContext->LoggerSettings()->ComponentName(component),
-        ev.GetTypeRewrite(),
-        EventInfo(ev).c_str());
-#endif
-}
 
 void HandleUnexpectedEvent(
-    IEventHandle& ev,
+    const IEventHandle& ev,
     int component,
     const TString& location)
 {
@@ -76,22 +52,9 @@ void HandleUnexpectedEvent(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void HandleUnexpectedEvent(
-    TAutoPtr<IEventHandle>& ev,
-    int component)
-{
-    HandleUnexpectedEvent(*ev, component);
-}
 
 void HandleUnexpectedEvent(
-    NActors::IEventHandlePtr& ev,
-    int component)
-{
-    HandleUnexpectedEvent(*ev, component);
-}
-
-void HandleUnexpectedEvent(
-    TAutoPtr<IEventHandle>& ev,
+    const TAutoPtr<IEventHandle>& ev,
     int component,
     const TString& location)
 {
@@ -99,7 +62,7 @@ void HandleUnexpectedEvent(
 }
 
 void HandleUnexpectedEvent(
-    NActors::IEventHandlePtr& ev,
+    const NActors::IEventHandlePtr& ev,
     int component,
     const TString& location)
 {
@@ -107,10 +70,11 @@ void HandleUnexpectedEvent(
 }
 
 void LogUnexpectedEvent(
-    TAutoPtr<IEventHandle>& ev,
-    int component)
+    const TAutoPtr<IEventHandle>& ev,
+    int component,
+    const TString& location)
 {
-    LogUnexpectedEvent(*ev, component);
+    LogUnexpectedEvent(*ev, component, location);
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/actors/helpers.h
+++ b/cloud/storage/core/libs/actors/helpers.h
@@ -10,26 +10,19 @@ namespace NCloud {
 ////////////////////////////////////////////////////////////////////////////////
 
 void HandleUnexpectedEvent(
-    TAutoPtr<NActors::IEventHandle>& ev,
-    int component);
-
-void HandleUnexpectedEvent(
-    NActors::IEventHandlePtr& ev,
-    int component);
-
-void HandleUnexpectedEvent(
-    TAutoPtr<NActors::IEventHandle>& ev,
+    const TAutoPtr<NActors::IEventHandle>& ev,
     int component,
     const TString& location);
 
 void HandleUnexpectedEvent(
-    NActors::IEventHandlePtr& ev,
+    const NActors::IEventHandlePtr& ev,
     int component,
     const TString& location);
 
 void LogUnexpectedEvent(
-    TAutoPtr<NActors::IEventHandle>& ev,
-    int component);
+    const TAutoPtr<NActors::IEventHandle>& ev,
+    int component,
+    const TString& location);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
@@ -154,7 +154,7 @@ bool THiveProxyFallbackActor::HandleRequests(STFUNC_SIG)
 STFUNC(THiveProxyFallbackActor::StateWork)
 {
     if (!HandleRequests(ev)) {
-        LogUnexpectedEvent(ev, Config.LogComponent);
+        LogUnexpectedEvent(ev, Config.LogComponent, __PRETTY_FUNCTION__);
     }
 }
 

--- a/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
+++ b/cloud/storage/core/libs/user_stats/user_stats_actor.cpp
@@ -170,7 +170,7 @@ STFUNC(TUserStatsActor::StateWork)
         HFunc(TEvUserStats::TEvUserStatsProviderCreate, HandleUserStatsProviderCreate);
 
         default:
-            HandleUnexpectedEvent(ev, Component);
+            HandleUnexpectedEvent(ev, Component, __PRETTY_FUNCTION__);
     }
 }
 


### PR DESCRIPTION
1 Продолжение https://github.com/ydb-platform/nbs/pull/3471, теперь в файлсторе
2 убрал перегрузку с двумя параметрами
