### PR TITLE
Fix data race in TRdmaClientTest::TShouldForceReconnect

### DIFF
--- a/cloud/blockstore/libs/rdma/impl/client_ut.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client_ut.cpp
@@ -513,6 +513,7 @@ Y_UNIT_TEST_SUITE(TRdmaClientTest)
         auto clientConfig = std::make_shared<TClientConfig>();
         clientConfig->MaxReconnectDelay = TDuration::Seconds(1);
         clientConfig->MaxResponseDelay = TDuration::Seconds(1);
+        clientConfig->WaitMode = EWaitMode::AdaptiveWait;
 
         auto logging =
             CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});

--- a/cloud/blockstore/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/blockstore/libs/rdma/impl/test_verbs.cpp
@@ -233,8 +233,10 @@ struct TTestVerbs
                 .status = IBV_WC_SUCCESS,
                 .opcode = opcode,
             };
-            if (TestContext->HandleCompletionEvent) {
-                TestContext->HandleCompletionEvent(&wc);
+            with_lock (TestContext->CompletionLock) {
+                if (TestContext->HandleCompletionEvent) {
+                    TestContext->HandleCompletionEvent(&wc);
+                }
             }
             handler->HandleCompletionEvent(&wc);
         };


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=95883)
  Read of size 8 at 0x7b4c00000530 by thread T1:
    #0 std::__y1::__function::__value_func<void (ibv_wc *)>::operator bool /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:554:55 (cloud-blockstore-libs-rdma-impl-ut+0x2012704) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #1 std::__y1::function<void (ibv_wc *)>::operator bool /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1039:32 (cloud-blockstore-libs-rdma-impl-ut+0x2012704)
    #2 NCloud::NBlockStore::NRdma::NVerbs::TTestVerbs::PollCompletionQueue(ibv_cq *, NCloud::NBlockStore::NRdma::NVerbs::ICompletionHandler *)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/test_verbs.cpp:236:17 (cloud-blockstore-libs-rdma-impl-ut+0x2012704)
    #3 NCloud::NBlockStore::NRdma::NVerbs::TTestVerbs::PollCompletionQueue(ibv_cq*, NCloud::NBlockStore::NRdma::NVerbs::ICompletionHandler*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/test_verbs.cpp:247:13 (cloud-blockstore-libs-rdma-impl-ut+0x2012704)
    #4 NCloud::NBlockStore::NRdma::(anonymous namespace)::TClientEndpoint::HandleCompletionEvents /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1024:16 (cloud-blockstore-libs-rdma-impl-ut+0x1fc6140) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #5 NCloud::NBlockStore::NRdma::(anonymous namespace)::TCompletionPoller::HandlePollEvent /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1645:31 (cloud-blockstore-libs-rdma-impl-ut+0x1fc6140)
    #6 NCloud::NBlockStore::NRdma::(anonymous namespace)::TCompletionPoller::HandlePollEvents /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1675:17 (cloud-blockstore-libs-rdma-impl-ut+0x1fc6140)
    #7 NCloud::NBlockStore::NRdma::(anonymous namespace)::TCompletionPoller::Execute<(NCloud::NBlockStore::NRdma::EWaitMode)0> /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1760:21 (cloud-blockstore-libs-rdma-impl-ut+0x1fc6140)
    #8 NCloud::NBlockStore::NRdma::(anonymous namespace)::TCompletionPoller::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1623:17 (cloud-blockstore-libs-rdma-impl-ut+0x1fc6140)
    #9 non-virtual thunk to NCloud::NBlockStore::NRdma::(anonymous namespace)::TCompletionPoller::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp (cloud-blockstore-libs-rdma-impl-ut+0x1fc648d) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #10 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (cloud-blockstore-libs-rdma-impl-ut+0xe4c492) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #11 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (cloud-blockstore-libs-rdma-impl-ut+0xe4ffec) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
  Previous write of size 8 at 0x7b4c00000530 by main thread:
    #0 std::__y1::__function::__value_func<void (ibv_wc*)>::swap[abi:v15000](std::__y1::__function::__value_func<void (ibv_wc*)>&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:529:22 (cloud-blockstore-libs-rdma-impl-ut+0xbcf05c) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #1 std::__y1::function<void (ibv_wc *)>::swap /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1180:10 (cloud-blockstore-libs-rdma-impl-ut+0x2010182) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #2 std::__y1::function<void (ibv_wc *)>::operator=<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/test_verbs.cpp:535:42), void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1169:40 (cloud-blockstore-libs-rdma-impl-ut+0x2010182)
    #3 NCloud::NBlockStore::NRdma::NVerbs::Disconnect(TIntrusivePtr<NCloud::NBlockStore::NRdma::NVerbs::TTestContext, TDefaultIntrusivePtrOps<NCloud::NBlockStore::NRdma::NVerbs::TTestContext>>) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/test_verbs.cpp:535:40 (cloud-blockstore-libs-rdma-impl-ut+0x2010182)
    #4 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TTestCaseShouldForceReconnect::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:533:13 (cloud-blockstore-libs-rdma-impl-ut+0xbc5761) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #5 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #6 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #7 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #8 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #9 std::__y1::__function::__func<NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #10 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #11 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf)
    #12 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf)
    #13 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-rdma-impl-ut+0xe76cba) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #14 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1 (cloud-blockstore-libs-rdma-impl-ut+0xbc9216) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #15 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-rdma-impl-ut+0xe77ac3) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #16 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-rdma-impl-ut+0xe8ba6c) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #17 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-rdma-impl-ut+0xe8a9e0) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
  Location is heap block of size 448 at 0x7b4c00000380 allocated by main thread:
    #0 operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (cloud-blockstore-libs-rdma-impl-ut+0xc8fb77) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #1 MakeIntrusive<NCloud::NBlockStore::NRdma::NVerbs::TTestContext, TDefaultIntrusivePtrOps<NCloud::NBlockStore::NRdma::NVerbs::TTestContext> > /actions-runner/_work/nbs/nbs/util/generic/ptr.h:785:12 (cloud-blockstore-libs-rdma-impl-ut+0xbc4e96) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #2 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TTestCaseShouldForceReconnect::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:508:28 (cloud-blockstore-libs-rdma-impl-ut+0xbc4e96)
    #3 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #4 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #5 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #6 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #7 std::__y1::__function::__func<NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #8 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #9 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf)
    #10 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf)
    #11 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-rdma-impl-ut+0xe76cba) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #12 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1 (cloud-blockstore-libs-rdma-impl-ut+0xbc9216) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #13 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-rdma-impl-ut+0xe77ac3) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #14 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-rdma-impl-ut+0xe8ba6c) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #15 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-rdma-impl-ut+0xe8a9e0) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
  Thread T1 'cloud-bl.RDMA.C' (tid=95886, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-rdma-impl-ut+0xc06a4b) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #1 (anonymous namespace)::TPosixThread::Start /actions-runner/_work/nbs/nbs/util/system/thread.cpp:229:27 (cloud-blockstore-libs-rdma-impl-ut+0xe47891) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #2 TThread::Start() /actions-runner/_work/nbs/nbs/util/system/thread.cpp:314:34 (cloud-blockstore-libs-rdma-impl-ut+0xe47891)
    #3 NCloud::NBlockStore::NRdma::(anonymous namespace)::TCompletionPoller::Start /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1540:24 (cloud-blockstore-libs-rdma-impl-ut+0x1fbd0de) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #4 NCloud::NBlockStore::NRdma::(anonymous namespace)::TClient::Start() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client.cpp:1871:31 (cloud-blockstore-libs-rdma-impl-ut+0x1fbd0de)
    #5 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TTestCaseShouldForceReconnect::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:522:17 (cloud-blockstore-libs-rdma-impl-ut+0xbc5454) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #6 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #7 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #8 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #9 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #10 std::__y1::__function::__func<NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-rdma-impl-ut+0xbc9b54)
    #11 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #12 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf)
    #13 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-rdma-impl-ut+0xe8f6cf)
    #14 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-rdma-impl-ut+0xe76cba) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #15 NCloud::NBlockStore::NRdma::NTestSuiteTRdmaClientTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/rdma/impl/client_ut.cpp:54:1 (cloud-blockstore-libs-rdma-impl-ut+0xbc9216) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #16 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-rdma-impl-ut+0xe77ac3) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #17 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-rdma-impl-ut+0xe8ba6c) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
    #18 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-rdma-impl-ut+0xe8a9e0) (BuildId: 622a7b3eee6707380f4d71e299685cf6a9663d57)
SUMMARY: ThreadSanitizer: data race /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:554:55 in std::__y1::__function::__value_func<void (ibv_wc *)>::operator bool
```