### PR TITLE
Latency tab has been added to the volume mon page to view request execution latency

### DIFF
--- a/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
@@ -225,6 +225,7 @@ void BuildVolumeTabs(IOutputStream& out)
         << "<li><a href='#History' data-toggle='tab'>History</a></li>"
         << "<li><a href='#Checkpoints' data-toggle='tab'>Checkpoints</a></li>"
         << "<li><a href='#Links' data-toggle='tab'>Links</a></li>"
+        << "<li><a href='#Latency' data-toggle='tab'>Latency</a></li>"
         << "<li><a href='#Traces' data-toggle='tab'>Traces</a></li>"
         << "<li><a href='#StorageConfig' data-toggle='tab'>StorageConfig</a></li></ul>";
 }

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
@@ -1,0 +1,300 @@
+#include "requests_time_tracker.h"
+
+#include <cloud/storage/core/libs/common/format.h>
+
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/json/writer/json_value.h>
+
+#include <util/datetime/cputimer.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr size_t BlockCountBucketsCount = 12;
+constexpr size_t TotalSizeBucket = BlockCountBucketsCount;
+constexpr std::array<size_t, BlockCountBucketsCount> RequestSizeBuckets = {
+    {1,
+     2,
+     4,
+     8,
+     16,
+     32,
+     64,
+     128,
+     256,
+     512,
+     1024,
+     std::numeric_limits<size_t>::max()}};
+
+size_t GetSizeBucket(TBlockRange64 range)
+{
+    auto idx = std::distance(
+        RequestSizeBuckets.begin(),
+        LowerBound(
+            RequestSizeBuckets.begin(),
+            RequestSizeBuckets.end(),
+            range.Size()));
+    return idx;
+}
+
+const TString& GetTimeBucketName(TDuration duration)
+{
+    static const auto TimeNames = TRequestUsTimeBuckets::MakeNames();
+
+    auto idx = std::distance(
+        TRequestUsTimeBuckets::Buckets.begin(),
+        LowerBound(
+            TRequestUsTimeBuckets::Buckets.begin(),
+            TRequestUsTimeBuckets::Buckets.end(),
+            duration.MicroSeconds()));
+    return TimeNames[idx];
+}
+
+TVector<TRequestsTimeTracker::TBucketInfo> MakeSizeBuckets(ui32 blockSize)
+{
+    TVector<TRequestsTimeTracker::TBucketInfo> result;
+
+    size_t lastBucket = 0;
+    for (size_t i = 0; i < RequestSizeBuckets.size() - 1; ++i) {
+        size_t sizeBucket = RequestSizeBuckets[i];
+        TRequestsTimeTracker::TBucketInfo bucket{.Key = ToString(sizeBucket)};
+
+        if (lastBucket && lastBucket != sizeBucket) {
+            bucket.Description =
+                TStringBuilder()
+                << "[" << FormatByteSize(lastBucket * blockSize) << ".."
+                << FormatByteSize(sizeBucket * blockSize) << "]";
+        } else {
+            bucket.Description =
+                TStringBuilder()
+                << "[" << FormatByteSize(sizeBucket * blockSize) << "]";
+        }
+        lastBucket = sizeBucket + 1;
+        result.push_back(std::move(bucket));
+    }
+
+    result.emplace_back(TRequestsTimeTracker::TBucketInfo{
+        .Key = "Inf",
+        .Description =
+            "[" + FormatByteSize(lastBucket * blockSize) + "..Inf]"});
+    result.emplace_back(TRequestsTimeTracker::TBucketInfo{
+        .Key = "Total",
+        .Description = "Total"});
+    return result;
+}
+
+}   // namespace
+
+//==============================================================================
+
+TString TRequestsTimeTracker::TKey::GetHtmlPrefix() const
+{
+    static const auto Sizes = MakeSizeBuckets(1);
+
+    TStringBuilder builder;
+    switch (RequestType) {
+        case TRequestsTimeTracker::ERequestType::Read: {
+            builder << "R_";
+            break;
+        }
+        case TRequestsTimeTracker::ERequestType::Write: {
+            builder << "W_";
+            break;
+        }
+        case TRequestsTimeTracker::ERequestType::Zero: {
+            builder << "Z_";
+            break;
+        }
+        case TRequestsTimeTracker::ERequestType::Last: {
+            break;
+        }
+    }
+    builder << Sizes[SizeBucket].Key;
+    switch (RequestStatus) {
+        case ERequestStatus::Inflight: {
+            builder << "_inflight_";
+            break;
+        }
+        case ERequestStatus::Success: {
+            builder << "_ok_";
+            break;
+        }
+        case ERequestStatus::Fail: {
+            builder << "_fail_";
+            break;
+        }
+        case ERequestStatus::Last: {
+            break;
+        }
+    }
+    return builder;
+}
+
+ui64 TRequestsTimeTracker::THash::operator()(const TKey& key) const
+{
+    return IntHash(key.SizeBucket) +
+           IntHash(static_cast<size_t>(key.RequestType)) +
+           IntHash(static_cast<size_t>(key.RequestStatus));
+}
+
+bool TRequestsTimeTracker::TEqual::operator()(
+    const TKey& lhs,
+    const TKey& rhs) const
+{
+    auto makeTie = [](const TKey& val)
+    {
+        return std::tie(val.SizeBucket, val.RequestType, val.RequestStatus);
+    };
+    return makeTie(lhs) == makeTie(rhs);
+}
+
+//==============================================================================
+
+TRequestsTimeTracker::TRequestsTimeTracker()
+{
+    for (size_t sizeBucket = 0; sizeBucket <= TotalSizeBucket; ++sizeBucket) {
+        for (size_t requestType = 0;
+             requestType < static_cast<size_t>(ERequestType::Last);
+             ++requestType)
+        {
+            auto key = TKey{
+                .SizeBucket = sizeBucket,
+                .RequestType = static_cast<ERequestType>(requestType),
+                .RequestStatus = ERequestStatus::Inflight};
+            Histograms[key];
+        }
+    }
+}
+
+void TRequestsTimeTracker::OnRequestStart(
+    ERequestType requestType,
+    ui64 requestId,
+    TBlockRange64 blockRange,
+    ui64 startTime)
+{
+    InflightRequests.emplace(
+        requestId,
+        TRequestInflight{
+            .StartAt = startTime,
+            .BlockRange = blockRange,
+            .RequestType = requestType});
+}
+
+void TRequestsTimeTracker::OnRequestFinished(
+    ui64 requestId,
+    bool success,
+    ui64 finishTime)
+{
+    TRequestInflight request;
+    {
+        auto it = InflightRequests.find(requestId);
+        if (it == InflightRequests.end()) {
+            return;
+        }
+        request = it->second;
+        InflightRequests.erase(requestId);
+    }
+
+    auto duration = CyclesToDurationSafe(finishTime - request.StartAt);
+
+    TKey key{
+        .SizeBucket = GetSizeBucket(request.BlockRange),
+        .RequestType = request.RequestType,
+        .RequestStatus =
+            success ? ERequestStatus::Success : ERequestStatus::Fail};
+    Histograms[key].Increment(duration.MicroSeconds());
+
+    key.SizeBucket = TotalSizeBucket;
+    Histograms[key].Increment(duration.MicroSeconds());
+}
+
+TString TRequestsTimeTracker::GetStatJson(ui64 now) const
+{
+    NJson::TJsonValue allStat(NJson::EJsonValueType::JSON_MAP);
+
+    const auto times = TRequestUsTimeBuckets::MakeNames();
+
+    // Build finished request counters.
+    for (const auto& [key, histogram]: Histograms) {
+        size_t total = 0;
+        const auto htmlPrefix = key.GetHtmlPrefix();
+        for (size_t j = 0; j < TRequestUsTimeBuckets::BUCKETS_COUNT; ++j) {
+            allStat[htmlPrefix + times[j]] =
+                (histogram.Buckets[j] ? ToString(histogram.Buckets[j]) : "");
+            total += histogram.Buckets[j];
+        }
+        allStat[htmlPrefix + "Total"] = ToString(total);
+    }
+
+    // Build inflight requests counters
+    auto getHtmlKey = [](size_t sizeBucket,
+                         ERequestType requestType,
+                         const TString& timeBacket)
+    {
+        auto key = TKey{
+            .SizeBucket = sizeBucket,
+            .RequestType = requestType,
+            .RequestStatus = ERequestStatus::Inflight};
+        return key.GetHtmlPrefix() + timeBacket;
+    };
+
+    TMap<TString, size_t> inflight;
+    for (const auto& [requestId, request]: InflightRequests) {
+        auto requestType = request.RequestType;
+        const auto sizeBucket = GetSizeBucket(request.BlockRange);
+        const auto& timeBucketName =
+            GetTimeBucketName(CyclesToDurationSafe(now - request.StartAt));
+        const auto& totalTimeBucketName = "Total";
+
+        ++inflight[getHtmlKey(sizeBucket, requestType, timeBucketName)];
+        ++inflight[getHtmlKey(sizeBucket, requestType, totalTimeBucketName)];
+        ++inflight[getHtmlKey(TotalSizeBucket, requestType, timeBucketName)];
+        ++inflight
+            [getHtmlKey(TotalSizeBucket, requestType, totalTimeBucketName)];
+    }
+    for (const auto& [key, count]: inflight) {
+        allStat[key] = ToString(count);
+    }
+
+    NJson::TJsonValue json;
+    json["stat"] = std::move(allStat);
+
+    TStringStream out;
+    NJson::WriteJson(&out, &json);
+    return out.Str();
+}
+
+TVector<TRequestsTimeTracker::TBucketInfo> TRequestsTimeTracker::GetSizeBuckets(
+    ui32 blockSize) const
+{
+    return MakeSizeBuckets(blockSize);
+}
+
+TVector<TRequestsTimeTracker::TBucketInfo>
+TRequestsTimeTracker::GetTimeBuckets() const
+{
+    TVector<TBucketInfo> result;
+    TDuration last;
+    for (const auto& time: TRequestUsTimeBuckets::MakeNames()) {
+        const auto us = TryFromString<ui64>(time);
+
+        TBucketInfo bucket{.Key = time};
+        bucket.Description =
+            us ? FormatDuration(TDuration::MicroSeconds(*us)) : time;
+
+        bucket.Tooltip =
+            "[" + FormatDuration(last) + ".." + bucket.Description + "]";
+
+        last = TDuration::MicroSeconds(us.GetOrElse(0));
+        result.push_back(std::move(bucket));
+    }
+    result.push_back(
+        TBucketInfo{.Key = "Total", .Description = "Total", .Tooltip = ""});
+    return result;
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
@@ -14,24 +14,24 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr TStringBuf TotalTimeBucketName = "Total";
+constexpr TStringBuf TotalBucketName = "Total";
 constexpr TStringBuf TotalSizeBucketName = "TotalSize";
 
 constexpr size_t BlockCountBucketsCount = 12;
 constexpr size_t TotalSizeBucket = BlockCountBucketsCount;
 constexpr std::array<size_t, BlockCountBucketsCount> RequestSizeBuckets = {
-    {1,
-     2,
-     4,
-     8,
-     16,
-     32,
-     64,
-     128,
-     256,
-     512,
-     1024,
-     std::numeric_limits<size_t>::max()}};
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    std::numeric_limits<size_t>::max()};
 
 size_t GetSizeBucket(TBlockRange64 range)
 {
@@ -227,20 +227,20 @@ TString TRequestsTimeTracker::GetStatJson(ui64 now, ui32 blockSize) const
                 (histogram.Buckets[j] ? ToString(histogram.Buckets[j]) : "");
             total += histogram.Buckets[j];
         }
-        allStat[htmlPrefix + TotalTimeBucketName] = ToString(total);
+        allStat[htmlPrefix + TotalBucketName] = ToString(total);
         allStat[htmlPrefix + TotalSizeBucketName] =
             FormatByteSize(histogram.BlockCount * blockSize);
     }
 
     // Build inflight requests counters
     auto getHtmlKey =
-        [](size_t sizeBucket, ERequestType requestType, TStringBuf timeBacket)
+        [](size_t sizeBucket, ERequestType requestType, TStringBuf timeBucket)
     {
         auto key = TKey{
             .SizeBucket = sizeBucket,
             .RequestType = requestType,
             .RequestStatus = ERequestStatus::Inflight};
-        return key.GetHtmlPrefix() + timeBacket;
+        return key.GetHtmlPrefix() + timeBucket;
     };
 
     TMap<TString, size_t> inflight;
@@ -253,10 +253,9 @@ TString TRequestsTimeTracker::GetStatJson(ui64 now, ui32 blockSize) const
 
         // Time
         ++inflight[getHtmlKey(sizeBucket, requestType, timeBucketName)];
-        ++inflight[getHtmlKey(sizeBucket, requestType, TotalTimeBucketName)];
+        ++inflight[getHtmlKey(sizeBucket, requestType, TotalBucketName)];
         ++inflight[getHtmlKey(TotalSizeBucket, requestType, timeBucketName)];
-        ++inflight
-            [getHtmlKey(TotalSizeBucket, requestType, TotalTimeBucketName)];
+        ++inflight[getHtmlKey(TotalSizeBucket, requestType, TotalBucketName)];
 
         // Size
         inflight[getHtmlKey(sizeBucket, requestType, TotalSizeBucketName)] +=
@@ -306,7 +305,7 @@ TRequestsTimeTracker::GetTimeBuckets() const
         result.push_back(std::move(bucket));
     }
     result.push_back(TBucketInfo{
-        .Key = TString(TotalTimeBucketName),
+        .Key = TString(TotalBucketName),
         .Description = "Total",
         .Tooltip = ""});
     result.push_back(TBucketInfo{

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/blockstore/libs/storage/core/histogram.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/hash.h>
+#include <util/generic/maybe.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRequestsTimeTracker
+{
+public:
+    enum class ERequestType
+    {
+        Read,
+        Write,
+        Zero,
+        Last,
+    };
+
+    struct TBucketInfo
+    {
+        TString Key;
+        TString Description;
+        TString Tooltip;
+    };
+
+private:
+    enum class ERequestStatus
+    {
+        Inflight,
+        Success,
+        Fail,
+        Last,
+    };
+
+    struct TTimeHistogram: public THistogram<TRequestUsTimeBuckets>
+    {
+        TTimeHistogram()
+            : THistogram<TRequestUsTimeBuckets>(
+                  EHistogramCounterOption::ReportSingleCounter)
+        {}
+    };
+
+    struct TKey
+    {
+        size_t SizeBucket;
+        ERequestType RequestType;
+        ERequestStatus RequestStatus;
+
+        [[nodiscard]] TString GetHtmlPrefix() const;
+    };
+
+    struct THash
+    {
+        ui64 operator()(const TKey& key) const;
+    };
+
+    struct TEqual
+    {
+        bool operator()(const TKey& lhs, const TKey& rhs) const;
+    };
+
+    struct TRequestInflight
+    {
+        ui64 StartAt = 0;
+        TBlockRange64 BlockRange;
+        ERequestType RequestType = ERequestType::Read;
+    };
+
+    THashMap<ui64, TRequestInflight> InflightRequests;
+    THashMap<TKey, TTimeHistogram, THash, TEqual> Histograms;
+
+public:
+    explicit TRequestsTimeTracker();
+
+    void OnRequestStart(
+        ERequestType requestType,
+        ui64 requestId,
+        TBlockRange64 blockRange,
+        ui64 startTime);
+
+    void OnRequestFinished(ui64 requestId, bool success, ui64 finishTime);
+
+    [[nodiscard]] TString GetStatJson(ui64 now) const;
+    [[nodiscard]] TVector<TBucketInfo> GetSizeBuckets(ui32 blockSize) const;
+    [[nodiscard]] TVector<TBucketInfo> GetTimeBuckets() const;
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -18,10 +18,10 @@ class TRequestsTimeTracker
 public:
     enum class ERequestType
     {
-        Read,
-        Write,
-        Zero,
-        Last,
+        Read = 0,
+        Write = 1,
+        Zero = 2,
+        Last = Zero,
     };
 
     struct TBucketInfo
@@ -37,7 +37,6 @@ private:
         Inflight,
         Success,
         Fail,
-        Last,
     };
 
     struct TTimeHistogram: public THistogram<TRequestUsTimeBuckets>

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -51,9 +51,9 @@ private:
 
     struct TKey
     {
-        size_t SizeBucket;
-        ERequestType RequestType;
-        ERequestStatus RequestStatus;
+        size_t SizeBucket = 0;
+        ERequestType RequestType = ERequestType::Read;
+        ERequestStatus RequestStatus = ERequestStatus::Fail;
 
         [[nodiscard]] TString GetHtmlPrefix() const;
     };
@@ -70,7 +70,7 @@ private:
 
     struct TRequestInflight
     {
-        ui64 StartAt = 0;
+        ui64 StartTime = 0;
         TBlockRange64 BlockRange;
         ERequestType RequestType = ERequestType::Read;
     };
@@ -81,7 +81,10 @@ private:
 public:
     explicit TRequestsTimeTracker();
 
-    void OnRequestStart(
+    static TVector<TBucketInfo> GetSizeBuckets(ui32 blockSize);
+    static TVector<TBucketInfo> GetTimeBuckets();
+
+    void OnRequestStarted(
         ERequestType requestType,
         ui64 requestId,
         TBlockRange64 blockRange,
@@ -89,9 +92,7 @@ public:
 
     void OnRequestFinished(ui64 requestId, bool success, ui64 finishTime);
 
-    [[nodiscard]] TString GetStatJson(ui64 now, ui32 blockSize) const;
-    [[nodiscard]] TVector<TBucketInfo> GetSizeBuckets(ui32 blockSize) const;
-    [[nodiscard]] TVector<TBucketInfo> GetTimeBuckets() const;
+    [[nodiscard]] TString GetStatJson(ui64 nowCycles, ui32 blockSize) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -42,6 +42,8 @@ private:
 
     struct TTimeHistogram: public THistogram<TRequestUsTimeBuckets>
     {
+        size_t BlockCount = 0;
+
         TTimeHistogram()
             : THistogram<TRequestUsTimeBuckets>(
                   EHistogramCounterOption::ReportSingleCounter)
@@ -88,7 +90,7 @@ public:
 
     void OnRequestFinished(ui64 requestId, bool success, ui64 finishTime);
 
-    [[nodiscard]] TString GetStatJson(ui64 now) const;
+    [[nodiscard]] TString GetStatJson(ui64 now, ui32 blockSize) const;
     [[nodiscard]] TVector<TBucketInfo> GetSizeBuckets(ui32 blockSize) const;
     [[nodiscard]] TVector<TBucketInfo> GetTimeBuckets() const;
 };

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
@@ -1,0 +1,165 @@
+#include "requests_time_tracker.h"
+
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/writer/json_value.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/cputimer.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
+{
+    Y_UNIT_TEST(ShouldCountInflight)
+    {
+        TRequestsTimeTracker requestsTimeTracker;
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Read,
+            1,
+            TBlockRange64::MakeOneBlock(0),
+            0);
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Read,
+            2,
+            TBlockRange64::MakeOneBlock(0),
+            1000 * GetCyclesPerMillisecond());
+
+        auto json =
+            requestsTimeTracker.GetStatJson(2000 * GetCyclesPerMillisecond());
+        NJson::TJsonValue value;
+        NJson::ReadJsonTree(json, &value, true);
+        auto get = [&](const TString& key)
+        {
+            return value["stat"][key];
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL("1", get("R_1_inflight_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("R_1_inflight_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("2", get("R_1_inflight_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("R_Total_inflight_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("R_Total_inflight_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("2", get("R_Total_inflight_Total"));
+    }
+
+    Y_UNIT_TEST(ShouldCountFinishedSuccess)
+    {
+        TRequestsTimeTracker requestsTimeTracker;
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Write,
+            1,
+            TBlockRange64::MakeOneBlock(0),
+            0);
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Write,
+            2,
+            TBlockRange64::MakeOneBlock(0),
+            1000 * GetCyclesPerMillisecond());
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Write,
+            3,
+            TBlockRange64::MakeOneBlock(0),
+            2000 * GetCyclesPerMillisecond());
+
+        requestsTimeTracker.OnRequestFinished(
+            1,
+            true,
+            3000 * GetCyclesPerMillisecond());
+        requestsTimeTracker.OnRequestFinished(
+            2,
+            true,
+            3000 * GetCyclesPerMillisecond());
+        requestsTimeTracker.OnRequestFinished(
+            3,
+            true,
+            3000 * GetCyclesPerMillisecond());
+
+        auto json =
+            requestsTimeTracker.GetStatJson(5000 * GetCyclesPerMillisecond());
+        NJson::TJsonValue value;
+        NJson::ReadJsonTree(json, &value, true);
+        auto get = [&](const TString& key)
+        {
+            return value["stat"][key];
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL("1", get("W_1_ok_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("W_1_ok_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("W_1_ok_5000000"));
+        UNIT_ASSERT_VALUES_EQUAL("3", get("W_1_ok_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_5000000"));
+        UNIT_ASSERT_VALUES_EQUAL("3", get("W_Total_ok_Total"));
+    }
+
+    Y_UNIT_TEST(ShouldCountFinishedFail)
+    {
+        TRequestsTimeTracker requestsTimeTracker;
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Zero,
+            1,
+            TBlockRange64::WithLength(0, 512),
+            0);
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Zero,
+            2,
+            TBlockRange64::WithLength(0, 600),
+            1000 * GetCyclesPerMillisecond());
+
+        requestsTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Zero,
+            3,
+            TBlockRange64::WithLength(0, 2000),
+            2000 * GetCyclesPerMillisecond());
+
+        requestsTimeTracker.OnRequestFinished(
+            1,
+            false,
+            3000 * GetCyclesPerMillisecond());
+        requestsTimeTracker.OnRequestFinished(
+            2,
+            false,
+            3000 * GetCyclesPerMillisecond());
+        requestsTimeTracker.OnRequestFinished(
+            3,
+            false,
+            3000 * GetCyclesPerMillisecond());
+
+        auto json =
+            requestsTimeTracker.GetStatJson(5000 * GetCyclesPerMillisecond());
+        NJson::TJsonValue value;
+        NJson::ReadJsonTree(json, &value, true);
+        auto get = [&](const TString& key)
+        {
+            return value["stat"][key];
+        };
+
+        for (const auto& [key, val]: value["stat"].GetMap()) {
+            if (val != "") {
+                Cout << key << "=" << val << Endl;
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_5000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_5000000"));
+        UNIT_ASSERT_VALUES_EQUAL("3", get("Z_Total_fail_Total"));
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
@@ -24,19 +24,20 @@ void DumpValues(const NJson::TJsonValue::TMapType& map)
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
+
 Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
 {
     Y_UNIT_TEST(ShouldCountInflight)
     {
         TRequestsTimeTracker requestsTimeTracker;
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Read,
             1,
             TBlockRange64::MakeOneBlock(0),
             0);
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Read,
             2,
             TBlockRange64::MakeOneBlock(0),
@@ -68,19 +69,19 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
     {
         TRequestsTimeTracker requestsTimeTracker;
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Write,
             1,
             TBlockRange64::MakeOneBlock(0),
             0);
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Write,
             2,
             TBlockRange64::MakeOneBlock(0),
             1000 * GetCyclesPerMillisecond());
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Write,
             3,
             TBlockRange64::MakeOneBlock(0),
@@ -127,19 +128,19 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
     {
         TRequestsTimeTracker requestsTimeTracker;
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Zero,
             1,
             TBlockRange64::WithLength(0, 512),
             0);
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Zero,
             2,
             TBlockRange64::WithLength(0, 600),
             1000 * GetCyclesPerMillisecond());
 
-        requestsTimeTracker.OnRequestStart(
+        requestsTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Zero,
             3,
             TBlockRange64::WithLength(0, 2000),

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
@@ -8,8 +8,22 @@
 
 namespace NCloud::NBlockStore::NStorage {
 
+namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
 
+void DumpValues(const NJson::TJsonValue::TMapType& map)
+{
+    for (const auto& [key, val]: map) {
+        if (val != "" && val != "0" && val != "0 B") {
+            Cout << key << "=" << val << Endl;
+        }
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
 Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
 {
     Y_UNIT_TEST(ShouldCountInflight)
@@ -28,10 +42,13 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
             TBlockRange64::MakeOneBlock(0),
             1000 * GetCyclesPerMillisecond());
 
-        auto json =
-            requestsTimeTracker.GetStatJson(2000 * GetCyclesPerMillisecond());
+        auto json = requestsTimeTracker.GetStatJson(
+            2000 * GetCyclesPerMillisecond(),
+            4096);
         NJson::TJsonValue value;
         NJson::ReadJsonTree(json, &value, true);
+        DumpValues(value["stat"].GetMap());
+
         auto get = [&](const TString& key)
         {
             return value["stat"][key];
@@ -43,6 +60,8 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
         UNIT_ASSERT_VALUES_EQUAL("1", get("R_Total_inflight_1000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("R_Total_inflight_2000000"));
         UNIT_ASSERT_VALUES_EQUAL("2", get("R_Total_inflight_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("8.00 KiB", get("R_1_inflight_TotalSize"));
+        UNIT_ASSERT_VALUES_EQUAL("8.00 KiB", get("R_Total_inflight_TotalSize"));
     }
 
     Y_UNIT_TEST(ShouldCountFinishedSuccess)
@@ -80,10 +99,13 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
             true,
             3000 * GetCyclesPerMillisecond());
 
-        auto json =
-            requestsTimeTracker.GetStatJson(5000 * GetCyclesPerMillisecond());
+        auto json = requestsTimeTracker.GetStatJson(
+            5000 * GetCyclesPerMillisecond(),
+            4096);
         NJson::TJsonValue value;
         NJson::ReadJsonTree(json, &value, true);
+        DumpValues(value["stat"].GetMap());
+
         auto get = [&](const TString& key)
         {
             return value["stat"][key];
@@ -97,6 +119,8 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
         UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_2000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_5000000"));
         UNIT_ASSERT_VALUES_EQUAL("3", get("W_Total_ok_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("12.00 KiB", get("W_1_ok_TotalSize"));
+        UNIT_ASSERT_VALUES_EQUAL("12.00 KiB", get("W_Total_ok_TotalSize"));
     }
 
     Y_UNIT_TEST(ShouldCountFinishedFail)
@@ -134,31 +158,35 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
             false,
             3000 * GetCyclesPerMillisecond());
 
-        auto json =
-            requestsTimeTracker.GetStatJson(5000 * GetCyclesPerMillisecond());
+        auto json = requestsTimeTracker.GetStatJson(
+            5000 * GetCyclesPerMillisecond(),
+            4096);
         NJson::TJsonValue value;
         NJson::ReadJsonTree(json, &value, true);
+        DumpValues(value["stat"].GetMap());
+
         auto get = [&](const TString& key)
         {
             return value["stat"][key];
         };
 
-        for (const auto& [key, val]: value["stat"].GetMap()) {
-            if (val != "") {
-                Cout << key << "=" << val << Endl;
-            }
-        }
-
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_5000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("2.00 MiB", get("Z_512_fail_TotalSize"));
+
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_2000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("2.34 MiB", get("Z_1024_fail_TotalSize"));
+
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_1000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("7.81 MiB", get("Z_Inf_fail_TotalSize"));
+
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_1000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_2000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_5000000"));
         UNIT_ASSERT_VALUES_EQUAL("3", get("Z_Total_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("12.16 MiB", get("Z_Total_fail_TotalSize"));
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume/model/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     client_state_ut.cpp
     merge_ut.cpp
     requests_inflight_ut.cpp
+    requests_time_tracker_ut.cpp
     retry_policy_ut.cpp
     stripe_ut.cpp
     volume_params_ut.cpp

--- a/cloud/blockstore/libs/storage/volume/model/ya.make
+++ b/cloud/blockstore/libs/storage/volume/model/ya.make
@@ -13,6 +13,7 @@ SRCS(
     helpers.cpp
     merge.cpp
     meta.cpp
+    requests_time_tracker.cpp
     requests_inflight.cpp
     retry_policy.cpp
     stripe.cpp

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -29,7 +29,9 @@
 #include <cloud/blockstore/libs/storage/partition_common/events_private.h>
 #include <cloud/blockstore/libs/storage/partition_common/long_running_operation_companion.h>
 #include <cloud/blockstore/libs/storage/volume/model/requests_inflight.h>
+#include <cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h>
 #include <cloud/blockstore/libs/storage/volume/model/volume_throttler_logger.h>
+
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/protos/trace.pb.h>
 
@@ -301,6 +303,7 @@ private:
 
     TVolumeRequestMap VolumeRequests;
     TRequestsInFlight WriteAndZeroRequestsInFlight;
+    TRequestsTimeTracker RequestTimeTracker;
 
     // inflight VolumeRequestId -> duplicate request queue
     // we respond to duplicate requests as soon as our original request is completed
@@ -451,6 +454,7 @@ private:
         IOutputStream& out) const;
     void RenderCheckpoints(IOutputStream& out) const;
     void RenderLinks(IOutputStream& out) const;
+    void RenderLatency(IOutputStream& out) const;
     void RenderTraces(IOutputStream& out) const;
     void RenderStorageConfig(IOutputStream& out) const;
     void RenderRawVolumeConfig(IOutputStream& out) const;
@@ -636,6 +640,11 @@ private:
         TRequestInfoPtr requestInfo);
 
     void HandleHttpInfo_RenderNonreplPartitionInfo(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
+
+    void HandleHttpInfo_RenderLatency(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
@@ -911,6 +920,7 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         NActors::TActorId newRecipient,
         ui64 volumeRequestId,
+        TBlockRange64 blockRange,
         ui64 traceTime,
         bool forkTraces,
         bool isMultipartition);
@@ -920,6 +930,7 @@ private:
         const NActors::TActorContext& ctx,
         const typename TMethod::TRequest::TPtr& ev,
         ui64 volumeRequestId,
+        TBlockRange64 blockRange,
         ui32 partitionId,
         ui64 traceTs);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -137,6 +137,7 @@ bool TVolumeActor::HandleMultipartitionVolumeRequest(
             ctx,
             ev,
             volumeRequestId,
+            blockRange,
             partitionRequests.front().PartitionId,
             traceTs);
 
@@ -157,6 +158,7 @@ bool TVolumeActor::HandleMultipartitionVolumeRequest(
         ev,
         TActorId{},
         volumeRequestId,
+        blockRange,
         traceTs,
         false,
         IsWriteMethod<TMethod>);
@@ -184,6 +186,7 @@ typename TMethod::TRequest::TPtr TVolumeActor::WrapRequest(
     const typename TMethod::TRequest::TPtr& ev,
     NActors::TActorId newRecipient,
     ui64 volumeRequestId,
+    TBlockRange64 blockRange,
     ui64 traceTime,
     bool forkTraces,
     bool isMultipartitionWriteOrZero)
@@ -235,6 +238,26 @@ typename TMethod::TRequest::TPtr TVolumeActor::WrapRequest(
         ++MultipartitionWriteAndZeroRequestsInProgress;
     }
 
+    if constexpr (IsReadMethod<TMethod>) {
+        RequestTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Read,
+            volumeRequestId,
+            blockRange,
+            traceTime);
+    } else if constexpr (IsExactlyWriteMethod<TMethod>) {
+        RequestTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Write,
+            volumeRequestId,
+            blockRange,
+            traceTime);
+    } else if constexpr (IsZeroMethod<TMethod>) {
+        RequestTimeTracker.OnRequestStart(
+            TRequestsTimeTracker::ERequestType::Zero,
+            volumeRequestId,
+            blockRange,
+            traceTime);
+    }
+
     return newEvent;
 }
 
@@ -243,6 +266,7 @@ void TVolumeActor::SendRequestToPartition(
     const TActorContext& ctx,
     const typename TMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
+    TBlockRange64 blockRange,
     ui32 partitionId,
     ui64 traceTime)
 {
@@ -269,6 +293,7 @@ void TVolumeActor::SendRequestToPartition(
         ev,
         partActorId,
         volumeRequestId,
+        blockRange,
         traceTime,
         true,
         false);
@@ -408,6 +433,7 @@ bool TVolumeActor::ReplyToOriginalRequest(
     ui64 volumeRequestId,
     std::unique_ptr<typename TMethod::TResponse> response)
 {
+    const bool success = !HasError(response->Record.GetError());
     if constexpr (IsWriteMethod<TMethod>) {
         ReplyToDuplicateRequests(
             ctx,
@@ -448,6 +474,10 @@ bool TVolumeActor::ReplyToOriginalRequest(
     }
 
     VolumeRequests.erase(it);
+    RequestTimeTracker.OnRequestFinished(
+        volumeRequestId,
+        success,
+        GetCycleCount());
 
     return true;
 }
@@ -752,13 +782,14 @@ void TVolumeActor::ForwardRequest(
     /*
      *  Validation of the request blocks range
      */
+    TBlockRange64 blockRange;
     if constexpr (IsReadOrWriteMethod<TMethod>) {
-        const auto range = BuildRequestBlockRange(*msg, State->GetBlockSize());
-        if (!CheckReadWriteBlockRange(range)) {
+        blockRange = BuildRequestBlockRange(*msg, State->GetBlockSize());
+        if (!CheckReadWriteBlockRange(blockRange)) {
             replyError(MakeError(
                 E_ARGUMENT,
                 TStringBuilder()
-                    << "invalid block range " << DescribeRange(range)));
+                    << "invalid block range " << DescribeRange(blockRange)));
             return;
         }
     }
@@ -784,12 +815,9 @@ void TVolumeActor::ForwardRequest(
      *  to the underlying (storage) layer.
      */
     if constexpr (IsWriteMethod<TMethod>) {
-        const auto range = BuildRequestBlockRange(
-            *msg,
-            State->GetBlockSize());
         auto addResult = WriteAndZeroRequestsInFlight.TryAddRequest(
             volumeRequestId,
-            range);
+            blockRange);
 
         if (!addResult.Added) {
             if (addResult.DuplicateRequestId
@@ -798,7 +826,7 @@ void TVolumeActor::ForwardRequest(
                 replyError(MakeError(E_REJECTED, TStringBuilder()
                     << "Request " << TMethod::Name
                     << " intersects with inflight write or zero request"
-                    << " (block range: " << DescribeRange(range) << ")"));
+                    << " (block range: " << DescribeRange(blockRange) << ")"));
                 return;
             }
 
@@ -839,7 +867,13 @@ void TVolumeActor::ForwardRequest(
     if constexpr (IsCheckpointMethod<TMethod>) {
         HandleCheckpointRequest<TMethod>(ctx, ev, isTraced, now);
     } else if (isSinglePartitionVolume) {
-        SendRequestToPartition<TMethod>(ctx, ev, volumeRequestId, 0, now);
+        SendRequestToPartition<TMethod>(
+            ctx,
+            ev,
+            volumeRequestId,
+            blockRange,
+            0,
+            now);
     } else {
         if (!HandleMultipartitionVolumeRequest<TMethod>(
                 ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -239,19 +239,19 @@ typename TMethod::TRequest::TPtr TVolumeActor::WrapRequest(
     }
 
     if constexpr (IsReadMethod<TMethod>) {
-        RequestTimeTracker.OnRequestStart(
+        RequestTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Read,
             volumeRequestId,
             blockRange,
             traceTime);
     } else if constexpr (IsExactlyWriteMethod<TMethod>) {
-        RequestTimeTracker.OnRequestStart(
+        RequestTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Write,
             volumeRequestId,
             blockRange,
             traceTime);
     } else if constexpr (IsZeroMethod<TMethod>) {
-        RequestTimeTracker.OnRequestStart(
+        RequestTimeTracker.OnRequestStarted(
             TRequestsTimeTracker::ERequestType::Zero,
             volumeRequestId,
             blockRange,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -2371,12 +2371,17 @@ void TVolumeActor::HandleHttpInfo_RenderLatency(
     TRequestInfoPtr requestInfo)
 {
     Y_UNUSED(params);
+    if (!State) {
+        return;
+    }
 
     NCloud::Reply(
         ctx,
         *requestInfo,
         std::make_unique<NMon::TEvRemoteJsonInfoRes>(
-            RequestTimeTracker.GetStatJson(GetCycleCount())));
+            RequestTimeTracker.GetStatJson(
+                GetCycleCount(),
+                State->GetBlockSize())));
 }
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -441,10 +441,7 @@ void OutputClientInfo(
     }
 }
 
-void RenderLatencyTable(
-    IOutputStream& out,
-    const TString& parentId,
-    const TRequestsTimeTracker& timeTracker)
+void RenderLatencyTable(IOutputStream& out, const TString& parentId)
 {
     HTML (out) {
         TABLE_CLASS("table-latency")
@@ -467,7 +464,7 @@ void RenderLatencyTable(
             }
 
             for (const auto& [key, descr, tooltip]:
-                 timeTracker.GetTimeBuckets())
+                 TRequestsTimeTracker::GetTimeBuckets())
             {
                 TABLER () {
                     TABLED () {
@@ -495,10 +492,7 @@ void RenderLatencyTable(
     }
 }
 
-void RenderSizeTable(
-    IOutputStream& out,
-    const TRequestsTimeTracker& timeTracker,
-    ui32 blockSize)
+void RenderSizeTable(IOutputStream& out, ui32 blockSize)
 {
     HTML (out) {
         TABLE_CLASS("table table-bordered") {
@@ -519,22 +513,22 @@ void RenderSizeTable(
                 }
             }
             for (const auto& [key, descr, tooltip]:
-                 timeTracker.GetSizeBuckets(blockSize))
+                 TRequestsTimeTracker::GetSizeBuckets(blockSize))
             {
                 TABLER () {
                     TABLED () {
                         out << descr;
                     }
                     TABLED () {
-                        RenderLatencyTable(out, "R_" + key, timeTracker);
+                        RenderLatencyTable(out, "R_" + key);
                     }
                     TABLED_ATTRS()
                     {
-                        RenderLatencyTable(out, "W_" + key, timeTracker);
+                        RenderLatencyTable(out, "W_" + key);
                     }
                     TABLED_ATTRS()
                     {
-                        RenderLatencyTable(out, "Z_" + key, timeTracker);
+                        RenderLatencyTable(out, "Z_" + key);
                     }
                 }
             }
@@ -1106,7 +1100,7 @@ void TVolumeActor::RenderLatency(IOutputStream& out) const {
         out << style;
 
         DIV_CLASS ("row") {
-            RenderSizeTable(out, RequestTimeTracker, State->GetBlockSize());
+            RenderSizeTable(out, State->GetBlockSize());
         }
     }
 }

--- a/cloud/blockstore/tests/monitoring/test.py
+++ b/cloud/blockstore/tests/monitoring/test.py
@@ -327,7 +327,7 @@ class TestKikimrVolumeTablet:
         check_tablet_get(
             self.session, self.base_url,
             self.volume_id, {},
-            ["Overview", "History", "Checkpoints", "Links", "Traces", "StorageConfig"])
+            ["Overview", "History", "Checkpoints", "Links", "Latency", "Traces", "StorageConfig"])
 
     def run(self, nbs, nbs_http_port):
         self.volume_id, self.partition_id = prepare_volume(nbs, self.disk_id)


### PR DESCRIPTION
Новая вкладка на страничке мониторинга.
1. количество выполненных запросов в разбивке по размеру и типу запроса
2. гистограмма времени выполнения запросов
3. количество запросов "в полете" и сколько времени они уже выполняются
4. итоги по всем временам выполнения
5. итоги по всем размерам запросов
6. запросы завершившиеся ошибкой
7. суммарный размер запросов
8. данные в табличке обновляются раз в секунду

Это позволяет отвечать на вопросы:
1. почему какие-то запросы выполняются быстро, а другие медленно (потому что они разных размеров)
2. Видеть зависшие запросы, они оказываются в колонке inflight и перемещаются в перцентили с бОльшим временем 
3. видеть что запросы по какой-то причине отменяются партишеном (они оказываются в колонке failed)
4. видеть что запросы таймаутятся 
5. видеть с каким iodeps работает клиент

 
![image](https://github.com/user-attachments/assets/d080ae3a-a278-4a54-b988-f12875abfb91)
![image](https://github.com/user-attachments/assets/65d5d7fc-d916-40e5-979d-7e13e85d055f)

