### PR TITLE
For multi-agent request make timeout on disk-agent side

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1232,4 +1232,8 @@ message TStorageServiceConfig
     // Max migration io depth used during the lagging migration after the
     // replica becomes online
     optional uint32 LaggingDeviceMaxMigrationIoDepth = 429;
+
+    // Additional time to receive a response from the DiskAgent through which
+    // the MultiAgentWrite request was executed.
+    optional uint32 NetworkForwardingTimeout = 430;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -569,6 +569,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(ResyncAfterLaggingAgentMigration,         bool,      false               )\
     xxx(MultiAgentWriteEnabled,                   bool,      false               )\
     xxx(MultiAgentWriteRequestSizeThreshold,      ui32,      0                   )\
+    xxx(NetworkForwardingTimeout,                 TDuration, MSeconds(100)       )\
                                                                                   \
     xxx(OptimizeVoidBuffersTransferForReadsEnabled,     bool,      false         )\
     xxx(VolumeHistoryCleanupItemCount,                  ui32,      100'000       )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -646,6 +646,7 @@ public:
     [[nodiscard]] bool GetResyncAfterLaggingAgentMigration() const;
     [[nodiscard]] bool GetMultiAgentWriteEnabled() const;
     [[nodiscard]] ui32 GetMultiAgentWriteRequestSizeThreshold() const;
+    [[nodiscard]] TDuration GetNetworkForwardingTimeout() const;
 
     NCloud::NProto::TConfigDispatcherSettings GetConfigDispatcherSettings() const;
 

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -748,8 +748,8 @@ struct TTransportCounters
             "RequestBytes",
             "WriteBlocks"),
         MakeMetaWithTag<&TTransportCounters::WriteBytesMultiAgent>(
-            "RequestBytesMultiAgent",
-            "WriteBlocks"),
+            "RequestBytes",
+            "WriteBlocksMultiAgent"),
         MakeMetaWithTag<&TTransportCounters::ReadCount>(
             "Count",
             "ReadBlocks"),

--- a/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.cpp
@@ -2,6 +2,8 @@
 
 #include <cloud/blockstore/libs/common/iovector.h>
 
+#include <cloud/storage/core/libs/common/format.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -79,10 +81,21 @@ void TMultiAgentWriteDeviceBlocksActor::Bootstrap(const TActorContext& ctx)
         );
 
         ctx.Send(event.release());
+
+        auto timeout =
+            additionalTarget.GetTimeout()
+                ? TDuration::MilliSeconds(additionalTarget.GetTimeout())
+                : MaxRequestTimeout;
+        ctx.Schedule(timeout, new TEvents::TEvWakeup(requestId));
         ++requestId;
     }
+}
 
-    ctx.Schedule(MaxRequestTimeout, new NActors::TEvents::TEvWakeup());
+bool TMultiAgentWriteDeviceBlocksActor::IsAllResponsesHaveBeenReceived() const
+{
+    return AllOf(
+        Responses,
+        [](const std::optional<NProto::TError>& r) { return r.has_value(); });
 }
 
 void TMultiAgentWriteDeviceBlocksActor::ReplyAndDie(
@@ -121,11 +134,7 @@ void TMultiAgentWriteDeviceBlocksActor::HandleWriteBlocksResponse(
         return;
     }
 
-    bool allDone = AllOf(
-        Responses,
-        [](const std::optional<NProto::TError>& r) { return r.has_value(); });
-
-    if (allDone) {
+    if (IsAllResponsesHaveBeenReceived()) {
         ReplyAndDie(ctx, MakeError(S_OK));
     }
 }
@@ -148,17 +157,42 @@ void TMultiAgentWriteDeviceBlocksActor::HandleTimeout(
     const NActors::TEvents::TEvWakeup::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    Y_UNUSED(ev);
+    const auto * msg = ev->Get();
+    const size_t requestId = msg->Tag;
+
+    if (Responses[requestId]) {
+        // The response has already been received, ignore the timeout.
+        return;
+    }
+
+    const auto timeout = TDuration::MilliSeconds(
+        Request.GetReplicationTargets(requestId).GetTimeout());
+
+    Responses[requestId] = MakeError(
+        E_TIMEOUT,
+        TStringBuilder() << "Subrequest #" << requestId << " timeout "
+                         << FormatDuration(timeout));
+
+    if (!IsAllResponsesHaveBeenReceived()) {
+        // Not all responses have been received, continue to wait.
+        return;
+    }
+
+    TStringBuilder timedOutDevices;
+    for (size_t i = 0; i < Responses.size(); ++i) {
+        if (Responses[i]->GetCode() == E_TIMEOUT) {
+            if (!timedOutDevices.empty()) {
+                timedOutDevices << ", ";
+            }
+            timedOutDevices
+                << Request.GetReplicationTargets(i).GetDeviceUUID().Quote();
+        }
+    }
 
     auto error = MakeError(
         E_TIMEOUT,
-        TStringBuilder() << "MultiAgentWriteDeviceBlocks timeout");
-
-    for (auto& subResponse: Responses) {
-        if (!subResponse) {
-            subResponse = error;
-        }
-    }
+        TStringBuilder() << "MultiAgentWriteDeviceBlocks timeout ["
+                         << timedOutDevices << "]");
 
     ReplyAndDie(ctx, std::move(error));
 }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.cpp
@@ -91,7 +91,7 @@ void TMultiAgentWriteDeviceBlocksActor::Bootstrap(const TActorContext& ctx)
     }
 }
 
-bool TMultiAgentWriteDeviceBlocksActor::IsAllResponsesHaveBeenReceived() const
+bool TMultiAgentWriteDeviceBlocksActor::AllResponsesHaveBeenReceived() const
 {
     return AllOf(
         Responses,
@@ -134,7 +134,7 @@ void TMultiAgentWriteDeviceBlocksActor::HandleWriteBlocksResponse(
         return;
     }
 
-    if (IsAllResponsesHaveBeenReceived()) {
+    if (AllResponsesHaveBeenReceived()) {
         ReplyAndDie(ctx, MakeError(S_OK));
     }
 }
@@ -173,7 +173,7 @@ void TMultiAgentWriteDeviceBlocksActor::HandleTimeout(
         TStringBuilder() << "Subrequest #" << requestId << " timeout "
                          << FormatDuration(timeout));
 
-    if (!IsAllResponsesHaveBeenReceived()) {
+    if (!AllResponsesHaveBeenReceived()) {
         // Not all responses have been received, continue to wait.
         return;
     }

--- a/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.h
@@ -33,9 +33,7 @@ public:
     void Bootstrap(const NActors::TActorContext& ctx);
 
 private:
-    bool HandleError(
-        const NActors::TActorContext& ctx,
-        const NProto::TError& error);
+    bool IsAllResponsesHaveBeenReceived() const;
 
     void ReplyAndDie(const NActors::TActorContext& ctx, NProto::TError error);
 

--- a/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_device_blocks_actor.h
@@ -33,7 +33,7 @@ public:
     void Bootstrap(const NActors::TActorContext& ctx);
 
 private:
-    bool IsAllResponsesHaveBeenReceived() const;
+    bool AllResponsesHaveBeenReceived() const;
 
     void ReplyAndDie(const NActors::TActorContext& ctx, NProto::TError error);
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -6318,7 +6318,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
                 TBlockRange64::WithLength(0, 10)));
     }
 
-    Y_UNIT_TEST_F(ShouldHandleTimeoutForMultiWrite, TMultiWriteFixture)
+    Y_UNIT_TEST_F(ShouldHandleTimeoutForMultiWriteOnRemote, TMultiWriteFixture)
     {
         // Setup message filter for intercepting write.
         auto timeoutWrite = [&](auto& runtime, TAutoPtr<IEventHandle>& event)
@@ -6343,6 +6343,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             target.SetNodeId(DiskAgent1->GetNodeId());
             target.SetDeviceUUID("DA1-1");
             target.SetStartIndex(1);
+            target.SetTimeout(1000);
             replicationTargets.push_back(std::move(target));
         }
         {
@@ -6350,6 +6351,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             target.SetNodeId(DiskAgent2->GetNodeId());
             target.SetDeviceUUID("DA2-1");
             target.SetStartIndex(2);
+            target.SetTimeout(2000);
             replicationTargets.push_back(std::move(target));
         }
         auto response = MultiWriteBlocks(
@@ -6358,7 +6360,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             5,
             'a');
 
-        Runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(2));
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
         UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetError().GetCode());
@@ -6372,11 +6374,85 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             const auto& subResponse2 =
                 response->Record.GetReplicationResponses(1);
             UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, subResponse2.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "Subrequest #1 timeout 2.000s",
+                subResponse2.GetMessage());
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldHandleTimeoutForMultiWriteOnLocal, TMultiWriteFixture)
+    {
+        // Setup message filter for intercepting write.
+        auto timeoutWrite = [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            if (event->GetTypeRewrite() ==
+                TEvDiskAgent::EvWriteDeviceBlocksRequest)
+            {
+                const auto* msg =
+                    event->Get<TEvDiskAgent::TEvWriteDeviceBlocksRequest>();
+
+                const bool isMultiWrite =
+                    msg->Record.ReplicationTargetsSize() != 0;
+                if (event->Recipient == DiskAgent1->DiskAgentActorId() &&
+                    !isMultiWrite)
+                {
+                    // Don't reply to request.
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        Runtime->SetEventFilter(timeoutWrite);
+
+        TVector<NProto::TReplicationTarget> replicationTargets;
+        {
+            NProto::TReplicationTarget target;
+            target.SetNodeId(DiskAgent1->GetNodeId());
+            target.SetDeviceUUID("DA1-1");
+            target.SetStartIndex(1);
+            target.SetTimeout(1000);
+            replicationTargets.push_back(std::move(target));
+        }
+        {
+            NProto::TReplicationTarget target;
+            target.SetNodeId(DiskAgent2->GetNodeId());
+            target.SetDeviceUUID("DA2-1");
+            target.SetStartIndex(2);
+            target.SetTimeout(2000);
+            replicationTargets.push_back(std::move(target));
+        }
+        auto response = MultiWriteBlocks(
+            *DiskAgent1,
+            std::move(replicationTargets),
+            5,
+            'a');
+
+        Runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+        Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response->GetError().GetCode());
+
+        {
+            const auto& subResponse1 =
+                response->Record.GetReplicationResponses(0);
+            UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, subResponse1.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "Subrequest #0 timeout 1.000s",
+                subResponse1.GetMessage());
+        }
+        {
+            const auto& subResponse2 =
+                response->Record.GetReplicationResponses(1);
+
+            UNIT_ASSERT(subResponse2.GetCode() == S_OK);
         }
     }
 
     Y_UNIT_TEST_F(
-        ShouldReponseWithArgumentErrorForMultiWrite,
+        ShouldResponseWithArgumentErrorForMultiWrite,
         TMultiWriteFixture)
     {
         auto request =

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -1123,6 +1123,9 @@ STFUNC(TLaggingAgentsReplicaProxyActor::StateWork)
         HFunc(
             TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest,
             HandleChecksumBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.HandleGetDeviceForRange);
 
         HFunc(
             TEvNonreplPartitionPrivate::TEvAgentIsUnavailable,
@@ -1170,6 +1173,9 @@ STFUNC(TLaggingAgentsReplicaProxyActor::StateZombie)
         HFunc(
             TEvNonreplPartitionPrivate::TEvChecksumBlocksRequest,
             RejectChecksumBlocks);
+        HFunc(
+            TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,
+            GetDeviceForRangeCompanion.RejectGetDeviceForRange);
         HFunc(
             NPartition::TEvPartition::TEvWaitForInFlightWritesRequest,
             RejectWaitForInFlightWrites);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/partition_common/get_device_for_range_companion.h>
 #include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
 
 #include <cloud/storage/core/libs/actors/poison_pill_helper.h>
@@ -81,6 +82,9 @@ private:
     // To determine which agent has drained in-flight writes by cookie in the
     // response.
     THashMap<ui64, TString> CurrentDrainingAgents;
+
+    TGetDeviceForRangeCompanion GetDeviceForRangeCompanion{
+        TGetDeviceForRangeCompanion::EAllowedOperation::None};
 
     TPoisonPillHelper PoisonPillHelper;
 

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -577,6 +577,9 @@ message TReplicationTarget
 
     // Start block index on target device.
     uint64 StartIndex = 3;
+
+    // Operation timeout (in milliseconds)
+    uint32 Timeout = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/1720
1. в запросе к агенту теперь на каждый подзапрос задается свой таймаут, что позволяет узнавать какой из диск-агентов затаймаутил
2. если таймаутит агент, через который делается запрос, то обновляется статистика по девайсу и девайс может быть признан сломаным 
3. поправил отправку статистики 
4. добавил обработку TEvGetDeviceForRangeRequest в TLaggingAgentsReplicaProxyActor
