### PR TITLE
 Fix filestore build

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -626,7 +626,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     }
 
     void DoShouldCheckAttrForNodeCreatedInShardViaLeader(
-        const NProto::TStorageConfig& config,
+        NProto::TStorageConfig& config,
         TSetNodeAttrArgs newArgs,
         bool shouldTriggerCriticalEvent)
     {


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/filestore/libs/storage/service/service_ut_sharding.cpp:634:9: error: 'this' argument to member function 'SetAutomaticShardCreationEnabled' has type 'const NProto::TStorageConfig', but function is not marked const
        CREATE_ENV_AND_SHARDED_FILESYSTEM();
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/service/service_ut_sharding.cpp:239:5: note: expanded from macro 'CREATE_ENV_AND_SHARDED_FILESYSTEM'
    config.SetAutomaticShardCreationEnabled(true);                            \
    ^~~~~~
$(BUILD_ROOT)/cloud/filestore/config/storage.pb.h:4427:15: note: 'SetAutomaticShardCreationEnabled' declared here
  inline void SetAutomaticShardCreationEnabled(bool value) { set_automaticshardcreationenabled(value); }
              ^
$(SOURCE_ROOT)/cloud/filestore/libs/storage/service/service_ut_sharding.cpp:634:9: error: 'this' argument to member function 'SetAutomaticallyCreatedShardSize' has type 'const NProto::TStorageConfig', but function is not marked const
        CREATE_ENV_AND_SHARDED_FILESYSTEM();
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/service/service_ut_sharding.cpp:240:5: note: expanded from macro 'CREATE_ENV_AND_SHARDED_FILESYSTEM'
    config.SetAutomaticallyCreatedShardSize(fsConfig.ShardBlockCount * 4_KB); \
    ^~~~~~
$(BUILD_ROOT)/cloud/filestore/config/storage.pb.h:4447:15: note: 'SetAutomaticallyCreatedShardSize' declared here
  inline void SetAutomaticallyCreatedShardSize(::google::protobuf::uint64 value) { set_automaticallycreatedshardsize(value); }
              ^
$(SOURCE_ROOT)/cloud/filestore/libs/storage/service/service_ut_sharding.cpp:634:9: error: 'this' argument to member function 'SetShardAllocationUnit' has type 'const NProto::TStorageConfig', but function is not marked const
        CREATE_ENV_AND_SHARDED_FILESYSTEM();
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/service/service_ut_sharding.cpp:241:5: note: expanded from macro 'CREATE_ENV_AND_SHARDED_FILESYSTEM'
    config.SetShardAllocationUnit(fsConfig.ShardBlockCount * 4_KB);           \
    ^~~~~~
$(BUILD_ROOT)/cloud/filestore/config/storage.pb.h:4432:15: note: 'SetShardAllocationUnit' declared here
  inline void SetShardAllocationUnit(::google::protobuf::uint64 value) { set_shardallocationunit(value); }
              ^
3 errors generated.

```