### PR TITLE
Cancel requests in all replicas when agent starts lagging

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -748,7 +748,7 @@ void TLaggingAgentsReplicaProxyActor::HandleAgentIsUnavailable(
 
     const auto& agentId = msg->LaggingAgent.GetAgentId();
     if (TAgentState* state = AgentState.FindPtr(agentId);
-        state && state->State == EAgentState::Unavailable)
+        !state || state->State == EAgentState::Unavailable)
     {
         return;
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.h
@@ -48,6 +48,7 @@ private:
     const TNonreplicatedPartitionConfigPtr PartConfig;
     const google::protobuf::RepeatedPtrField<NProto::TDeviceMigration>
         Migrations;
+    const ui32 ReplicaIndex;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
     TString RwClientId;
@@ -102,6 +103,7 @@ public:
         TDiagnosticsConfigPtr diagnosticsConfig,
         TNonreplicatedPartitionConfigPtr partConfig,
         google::protobuf::RepeatedPtrField<NProto::TDeviceMigration> migrations,
+        ui32 replicaIndex,
         IProfileLogPtr profileLog,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         TString rwClientId,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -421,6 +421,7 @@ struct TTestEnv
                     CreateDiagnosticsConfig(),
                     PartConfig->Fork(GetReplicaDevices(replicaIndex)),
                     Migrations,
+                    replicaIndex,
                     CreateProfileLogStub(),
                     CreateBlockDigestGeneratorStub(),
                     "",   // rwClientId

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_ut.cpp
@@ -392,7 +392,7 @@ struct TTestEnv
             const auto& device = devices[i];
             if (device.GetNodeId() == nodeId) {
                 laggingAgent.SetAgentId(device.GetAgentId());
-                laggingAgent.SetReplicaIndex(0);
+                laggingAgent.SetReplicaIndex(replicaIndex);
 
                 NProto::TLaggingDevice* laggingDevice =
                     laggingAgent.AddDevices();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -589,6 +589,7 @@ void TMirrorPartitionActor::HandleAddLaggingAgent(
                 DiagnosticsConfig,
                 replicaInfo.Config,
                 replicaInfo.Migrations,
+                replicaIndex,
                 ProfileLog,
                 BlockDigestGenerator,
                 State.GetRWClientId(),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -597,11 +597,13 @@ void TMirrorPartitionActor::HandleAddLaggingAgent(
         State.SetLaggingReplicaProxy(replicaIndex, proxyActorId);
     }
 
-    NCloud::Send<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
-        ctx,
-        State.GetReplicaActors()[replicaIndex],
-        0,   // cookie
-        msg->LaggingAgent);
+    for (const auto replicaActor: State.GetReplicaActors()) {
+        NCloud::Send<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
+            ctx,
+            replicaActor,
+            0,   // cookie
+            msg->LaggingAgent);
+    }
     State.AddLaggingAgent(std::move(msg->LaggingAgent));
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -621,6 +621,11 @@ void TNonreplicatedPartitionRdmaActor::HandleAgentIsUnavailable(
         return;
     }
 
+    TSet<ui32> laggingRows;
+    for (const auto& laggingDevice: msg->LaggingAgent.GetDevices()) {
+        laggingRows.insert(laggingDevice.GetRowIndex());
+    }
+
     const auto& devices = PartConfig->GetDevices();
     for (const auto& [_, requestInfo]: RequestsInProgress.AllRequests()) {
         const auto& requestCtx = requestInfo.Value;
@@ -628,11 +633,7 @@ void TNonreplicatedPartitionRdmaActor::HandleAgentIsUnavailable(
             requestCtx,
             [&](const auto& ctx)
             {
-                Y_ABORT_UNLESS(
-                    ctx.DeviceIndex < static_cast<ui64>(devices.size()));
-
-                return devices[ctx.DeviceIndex].GetAgentId() ==
-                       msg->LaggingAgent.GetAgentId();
+                return laggingRows.contains(ctx.DeviceIndex);
             });
 
         if (!needToCancel) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.h
@@ -51,7 +51,7 @@ class TNonreplicatedPartitionRdmaActor final
 {
     struct TDeviceRequestContext
     {
-        ui64 DeviceIndex = 0;
+        ui32 DeviceIndex = 0;
         ui64 SentRequestId = 0;
     };
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -485,6 +485,10 @@ public:
     {
         NProto::TLaggingAgent laggingAgent;
         laggingAgent.SetAgentId(std::move(agentId));
+        laggingAgent.SetReplicaIndex(0);
+        auto* device = laggingAgent.MutableDevices()->Add();
+        device->SetDeviceUUID("vasya");
+        device->SetRowIndex(0);
         auto msg =
             std::make_unique<TEvNonreplPartitionPrivate::TEvAgentIsUnavailable>(
                 std::move(laggingAgent));


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/1720
Здесь учимся отменять запросы, пересекающиеся по номеру девайса с залагавшей репликой.
Т.е. если у нас залагал девайс №7 в реплике №1, мы отменим  запросы на запись к девайсам №7 во всех репликах, но запросы на чтение отменим только к девайсу №7 реплики №1.