### PR TITLE
fix: handle multiple paged response for list operations

### DIFF
--- a/.github/scripts/nebius-manage-vm.py
+++ b/.github/scripts/nebius-manage-vm.py
@@ -631,9 +631,11 @@ async def remove_disk_by_name(sdk: SDK, args: argparse.Namespace, instance_name:
 
     except Exception as e:
         logger.exception(
-            "Failed to get Disk with name %s", instance_name, exc_info=True
+            "Failed to get Disk with name %s, response: %s",
+            instance_name,
+            response,
+            exc_info=True,
         )
-        logger.error("Response: %s", response, exc_info=True)
         raise e
 
     await remove_disk_by_id(sdk, args, disk_id)


### PR DESCRIPTION
```2025-05-13 12:33:35,037: INFO: Runner with name computeinstance-e00cv993pbh4axbemm found
2025-05-13 12:33:35,389: INFO: Removed runner with name computeinstance-e00cv993pbh4axbemm and id 13543
2025-05-13 12:35:12,037: INFO: Deleted VM with ID computeinstance-e00cv993pbh4axbemm
2025-05-13 12:35:12,208: ERROR: Failed to find disk with name disk-pr-3494-14994259836-1
```
https://github.com/ydb-platform/nbs/actions/runs/14994259836/job/42132612469

There was a situation where there was ~30vms/disks created at given time and page_size is 10. 