### PR TITLE
[Blockstore, Filestore] Fix -Wdeprecated-this-capture warning

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -241,7 +241,7 @@ bool TCommand::Execute()
     if (Timeout != TDuration::Zero()) {
         Scheduler->Schedule(
             Timer->Now() + Timeout,
-            [=] {
+            [=, this] {
                 Shutdown();
             });
     }

--- a/cloud/blockstore/apps/client/lib/read_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/read_blocks.cpp
@@ -468,7 +468,7 @@ private:
                 MakeIntrusive<TCallContext>(),
                 std::move(request));
 
-            future.Subscribe([=, holder = std::move(holder)] (const auto& f) mutable {
+            future.Subscribe([=, this, holder = std::move(holder)] (const auto& f) mutable {
                 const auto& response = f.GetValue();
                 auto buffer = holder.Extract();
 

--- a/cloud/blockstore/libs/client_spdk/spdk_client.cpp
+++ b/cloud/blockstore/libs/client_spdk/spdk_client.cpp
@@ -239,7 +239,7 @@ TStorageBuffer TEndpoint::AllocateBuffer(size_t bytesCount)
 
     Y_ABORT_UNLESS(std::align(BlockSize, bytesCount, p, space));
 
-    return { static_cast<char*>(p), [=] (auto*) {
+    return { static_cast<char*>(p), [=, this] (auto*) {
         Allocator->Release(block);
     }};
 }

--- a/cloud/blockstore/libs/discovery/fetch.cpp
+++ b/cloud/blockstore/libs/discovery/fetch.cpp
@@ -215,7 +215,7 @@ public:
 
             auto onRecv = std::make_unique<TOnRecv>(group);
             onRecv->Result.GetFuture().Subscribe(
-                [=, s = State, &instances] (auto f) mutable {
+                [=, this, s = State, &instances] (auto f) mutable {
                     TReadGuard guard(s->Lock);
 
                     if (!s->Running) {
@@ -235,7 +235,7 @@ public:
 
             Scheduler->Schedule(
                 Timer->Now() + Config->GetConductorRequestTimeout(),
-                [=, &instances] () mutable {
+                [=, this, &instances] () mutable {
                     const auto done = OnConductorResult(
                         i,
                         {group, {}, "timeout"},

--- a/cloud/blockstore/libs/discovery/healthcheck.cpp
+++ b/cloud/blockstore/libs/discovery/healthcheck.cpp
@@ -201,7 +201,7 @@ public:
         }
 
         for (auto& ping: pings) {
-            ping.Subscribe([=, &instances] (TFuture<TPingResponseInfo> f) mutable {
+            ping.Subscribe([=, this, &instances] (TFuture<TPingResponseInfo> f) mutable {
                 bool done = false;
 
                 with_lock (instances.Lock) {

--- a/cloud/blockstore/libs/discovery/test_server.cpp
+++ b/cloud/blockstore/libs/discovery/test_server.cpp
@@ -226,7 +226,7 @@ struct TFakeBlockStoreServer::TImpl
     {
         PreStart();
 
-        Thread = SystemThreadFactory()->Run([=] () {
+        Thread = SystemThreadFactory()->Run([=, this] () {
             Loop();
         });
     }

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -1088,7 +1088,7 @@ struct TServer: IEndpointProxyServer
     {
         PreStart();
 
-        Thread = SystemThreadFactory()->Run([=] () {
+        Thread = SystemThreadFactory()->Run([=, this] () {
             Loop();
         });
     }

--- a/cloud/blockstore/libs/endpoints/session_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager.cpp
@@ -410,7 +410,7 @@ TFuture<TSessionManager::TSessionOrError> TSessionManager::CreateSession(
     TCallContextPtr callContext,
     const NProto::TStartEndpointRequest& request)
 {
-    return Executor->Execute([=] () mutable {
+    return Executor->Execute([=, this] () mutable {
         return CreateSessionImpl(std::move(callContext), request);
     });
 }
@@ -476,7 +476,7 @@ TFuture<NProto::TError> TSessionManager::RemoveSession(
     const TString& socketPath,
     const NProto::THeaders& headers)
 {
-    return Executor->Execute([=] () mutable {
+    return Executor->Execute([=, this] () mutable {
         return RemoveSessionImpl(std::move(callContext), socketPath, headers);
     });
 }
@@ -514,7 +514,7 @@ TFuture<NProto::TError> TSessionManager::AlterSession(
     ui64 mountSeqNumber,
     const NProto::THeaders& headers)
 {
-    return Executor->Execute([=] () mutable {
+    return Executor->Execute([=, this] () mutable {
         return AlterSessionImpl(
             std::move(callContext),
             socketPath,
@@ -560,7 +560,7 @@ TFuture<TSessionManager::TSessionOrError> TSessionManager::GetSession(
     const TString& socketPath,
     const NProto::THeaders& headers)
 {
-    return Executor->Execute([=] () mutable {
+    return Executor->Execute([=, this] () mutable {
         return GetSessionImpl(
             std::move(callContext),
             socketPath,

--- a/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
+++ b/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
@@ -284,7 +284,7 @@ public:
         const NProto::TVolume& volume,
         ISessionPtr session) override
     {
-        return Executor->Execute([=] {
+        return Executor->Execute([=, this] {
             return DoStartEndpoint(request, volume, session);
         });
     }
@@ -301,7 +301,7 @@ public:
 
     TFuture<NProto::TError> StopEndpoint(const TString& socketPath) override
     {
-        return Executor->Execute([=] {
+        return Executor->Execute([=, this] {
             return DoStopEndpoint(socketPath);
         });
     }
@@ -461,7 +461,7 @@ public:
         const NProto::TVolume& volume,
         ISessionPtr session) override
     {
-        return Executor->Execute([=] {
+        return Executor->Execute([=, this] {
             return DoStartEndpoint(request, volume, session);
         });
     }
@@ -478,7 +478,7 @@ public:
 
     TFuture<NProto::TError> StopEndpoint(const TString& socketPath) override
     {
-        return Executor->Execute([=] {
+        return Executor->Execute([=, this] {
             return DoStopEndpoint(socketPath);
         });
     }

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -695,7 +695,7 @@ private:
             std::move(process));
         process = TChild{0};
 
-        Executor->ExecuteSimple([=] {
+        Executor->ExecuteSimple([=, this] {
             ep->Start(Executor->GetContExecutor());
         });
 

--- a/cloud/blockstore/libs/kms/iface/key_provider.cpp
+++ b/cloud/blockstore/libs/kms/iface/key_provider.cpp
@@ -44,7 +44,7 @@ public:
         const NProto::TKmsKey& kmsKey,
         const TString& diskId)
     {
-        return Executor->Execute([=] () mutable {
+        return Executor->Execute([=, this] () mutable {
             return DoReadKeyFromKMS(diskId, kmsKey);
         });
     }

--- a/cloud/blockstore/libs/nbd/client.cpp
+++ b/cloud/blockstore/libs/nbd/client.cpp
@@ -352,7 +352,7 @@ public:
         const auto& volumeClient = VolumeClient;
         const auto& connection = Connection;
 
-        return future.Apply([=, request = std::move(request)] (auto f) mutable {
+        return future.Apply([=, this, request = std::move(request)] (auto f) mutable {
             auto error = f.ExtractValue();
 
             if (HasError(error)) {
@@ -365,7 +365,7 @@ public:
                 std::move(callContext),
                 std::move(request));
 
-            return future.Apply([=] (const auto& f) {
+            return future.Apply([=, this] (const auto& f) {
                 return HandleMountVolumeResponse(
                     f.GetValue(),
                     connection->GetExportInfo().GetValue());

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -547,7 +547,7 @@ void TServerHandler::ProcessRequests(
                     requestCtx->MetricRequest,
                     *requestCtx->CallContext);
 
-                ctx->ExecuteSimple([=] () mutable {
+                ctx->ExecuteSimple([=, this] () mutable {
                     ProcessReadRequest(
                         std::move(ctx),
                         std::move(requestCtx),
@@ -582,7 +582,7 @@ void TServerHandler::ProcessRequests(
                 }
 
                 ctx->ExecuteSimple(
-                    [=, data = std::move(requestData)] () mutable {
+                    [=, this, data = std::move(requestData)] () mutable {
                         ProcessWriteRequest(
                             std::move(ctx),
                             std::move(requestCtx),
@@ -613,7 +613,7 @@ void TServerHandler::ProcessRequests(
                     requestCtx->MetricRequest,
                     *requestCtx->CallContext);
 
-                ctx->ExecuteSimple([=] () mutable {
+                ctx->ExecuteSimple([=, this] () mutable {
                     ProcessZeroRequest(
                         std::move(ctx),
                         std::move(requestCtx),

--- a/cloud/blockstore/libs/nvme/nvme_linux.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_linux.cpp
@@ -210,7 +210,7 @@ public:
         const TString& path,
         nvme_secure_erase_setting ses) override
     {
-        return Executor->Execute([=] {
+        return Executor->Execute([=, this] {
             try {
                 FormatImpl(path, ses);
                 return NProto::TError();
@@ -225,7 +225,7 @@ public:
         ui64 offsetBytes,
         ui64 sizeBytes) override
     {
-        return Executor->Execute([=] {
+        return Executor->Execute([=, this] {
             try {
                 DeallocateImpl(path, offsetBytes, sizeBytes);
                 return NProto::TError();

--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -611,7 +611,7 @@ TClientEndpoint::TClientEndpoint(
     // user data attached to connection events
     Connection->context = this;
 
-    Log.SetFormatter([=](ELogPriority p, TStringBuf msg) {
+    Log.SetFormatter([=, this](ELogPriority p, TStringBuf msg) {
         Y_UNUSED(p);
         return TStringBuilder() << "[" << Id << "] " << msg;
     });

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -372,7 +372,7 @@ TServerSession::TServerSession(
 {
     Connection->context = this;
 
-    Log.SetFormatter([=](ELogPriority p, TStringBuf msg) {
+    Log.SetFormatter([=, this](ELogPriority p, TStringBuf msg) {
         Y_UNUSED(p);
         return TStringBuilder() << "[" << Id << "] " << msg;
     });

--- a/cloud/blockstore/libs/server/server.cpp
+++ b/cloud/blockstore/libs/server/server.cpp
@@ -744,7 +744,7 @@ private:
 
         auto* tag = AcquireCompletionTag();
         Response.Subscribe(
-            [=] (const auto& response) {
+            [=, this] (const auto& response) {
                 Y_UNUSED(response);
 
                 if (AtomicCas(&RequestState, ExecutionCompleted, ExecutingRequest)) {

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -93,7 +93,7 @@ public:
                 ctx->AddTime(EProcessingStage::Postponed, TDuration::Seconds(10));
 
                 auto future = WriteTrigger.GetFuture();
-                return future.Apply([=] (const auto& f) {
+                return future.Apply([=, this] (const auto& f) {
                     Y_UNUSED(f);
 
                     auto startIndex = request->GetStartIndex();
@@ -118,7 +118,7 @@ public:
                 ctx->AddTime(EProcessingStage::Postponed, TDuration::Seconds(100));
 
                 auto future = WriteTrigger.GetFuture();
-                return future.Apply([=] (const auto& f) {
+                return future.Apply([=, this] (const auto& f) {
                     Y_UNUSED(f);
 
                     auto startIndex = request->GetStartIndex();

--- a/cloud/blockstore/libs/service/service_auth.cpp
+++ b/cloud/blockstore/libs/service/service_auth.cpp
@@ -104,7 +104,7 @@ private:
         auto promise = NewPromise<TResponse>();
 
         authResponse.Subscribe(
-            [=, request = std::move(request), ctx = std::move(ctx)] (const auto& future) mutable {
+            [=, this, request = std::move(request), ctx = std::move(ctx)] (const auto& future) mutable {
                 const auto& error = future.GetValue();
 
                 if (HasError(error)) {

--- a/cloud/blockstore/libs/service_local/service_local.cpp
+++ b/cloud/blockstore/libs/service_local/service_local.cpp
@@ -572,7 +572,7 @@ TFuture<NProto::TCreateVolumeResponse> TLocalService::CreateVolume(
     std::shared_ptr<NProto::TCreateVolumeRequest> request)
 {
     Y_UNUSED(ctx);
-    return SafeAsyncExecute<NProto::TCreateVolumeResponse>([=] {
+    return SafeAsyncExecute<NProto::TCreateVolumeResponse>([=, this] {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -606,7 +606,7 @@ TFuture<NProto::TResizeVolumeResponse> TLocalService::ResizeVolume(
     std::shared_ptr<NProto::TResizeVolumeRequest> request)
 {
     Y_UNUSED(ctx);
-    return SafeAsyncExecute<NProto::TResizeVolumeResponse>([=] {
+    return SafeAsyncExecute<NProto::TResizeVolumeResponse>([=, this] {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -630,7 +630,7 @@ TFuture<NProto::TDestroyVolumeResponse> TLocalService::DestroyVolume(
     std::shared_ptr<NProto::TDestroyVolumeRequest> request)
 {
     Y_UNUSED(ctx);
-    return SafeAsyncExecute<NProto::TDestroyVolumeResponse>([=] {
+    return SafeAsyncExecute<NProto::TDestroyVolumeResponse>([=, this] {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -649,7 +649,7 @@ TFuture<NProto::TListVolumesResponse> TLocalService::ListVolumes(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(request);
-    return SafeAsyncExecute<NProto::TListVolumesResponse>([=] {
+    return SafeAsyncExecute<NProto::TListVolumesResponse>([=, this] {
         auto response = VolumeManager.ListVolumes();
         return MakeFuture(std::move(response));
     });
@@ -660,7 +660,7 @@ TFuture<NProto::TDescribeVolumeResponse> TLocalService::DescribeVolume(
         std::shared_ptr<NProto::TDescribeVolumeRequest> request)
 {
     Y_UNUSED(ctx);
-    return SafeAsyncExecute<NProto::TDescribeVolumeResponse>([=] {
+    return SafeAsyncExecute<NProto::TDescribeVolumeResponse>([=, this] {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -678,7 +678,7 @@ TFuture<NProto::TMountVolumeResponse> TLocalService::MountVolume(
     std::shared_ptr<NProto::TMountVolumeRequest> request)
 {
     Y_UNUSED(ctx);
-    return SafeAsyncExecute<NProto::TMountVolumeResponse>([=] {
+    return SafeAsyncExecute<NProto::TMountVolumeResponse>([=, this] {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -727,7 +727,7 @@ TFuture<NProto::TReadBlocksResponse> TLocalService::ReadBlocks(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TReadBlocksRequest> request)
 {
-    return SafeAsyncExecute<NProto::TReadBlocksResponse>([=] () mutable {
+    return SafeAsyncExecute<NProto::TReadBlocksResponse>([=, this] () mutable {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -778,7 +778,7 @@ TFuture<NProto::TWriteBlocksResponse> TLocalService::WriteBlocks(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TWriteBlocksRequest> request)
 {
-    return SafeAsyncExecute<NProto::TWriteBlocksResponse>([=] () mutable {
+    return SafeAsyncExecute<NProto::TWriteBlocksResponse>([=, this] () mutable {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -830,7 +830,7 @@ TFuture<NProto::TZeroBlocksResponse> TLocalService::ZeroBlocks(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TZeroBlocksRequest> request)
 {
-    return SafeAsyncExecute<NProto::TZeroBlocksResponse>([=] () mutable {
+    return SafeAsyncExecute<NProto::TZeroBlocksResponse>([=, this] () mutable {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -879,7 +879,7 @@ TFuture<NProto::TReadBlocksLocalResponse> TLocalService::ReadBlocksLocal(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
 {
-    return SafeAsyncExecute<NProto::TReadBlocksLocalResponse>([=] () mutable {
+    return SafeAsyncExecute<NProto::TReadBlocksLocalResponse>([=, this] () mutable {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -926,7 +926,7 @@ TFuture<NProto::TWriteBlocksLocalResponse> TLocalService::WriteBlocksLocal(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TWriteBlocksLocalRequest> request)
 {
-    return SafeAsyncExecute<NProto::TWriteBlocksLocalResponse>([=] () mutable {
+    return SafeAsyncExecute<NProto::TWriteBlocksLocalResponse>([=, this] () mutable {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)
@@ -986,7 +986,7 @@ TFuture<NProto::TAssignVolumeResponse> TLocalService::AssignVolume(
     std::shared_ptr<NProto::TAssignVolumeRequest> request)
 {
     Y_UNUSED(ctx);
-    return SafeAsyncExecute<NProto::TAssignVolumeResponse>([=] {
+    return SafeAsyncExecute<NProto::TAssignVolumeResponse>([=, this] {
         const auto& diskId = request->GetDiskId();
         if (!diskId) {
             ythrow TServiceError(E_ARGUMENT)

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -420,7 +420,7 @@ private:
         TCallContextPtr callContext,
         std::shared_ptr<typename T::TRequest> request)
     {
-        return TaskQueue->Execute([=] {
+        return TaskQueue->Execute([=, this] {
             return DoHandleRequest<T>(std::move(callContext), std::move(request));
         });
     }
@@ -459,7 +459,7 @@ private:
         ui32 status,
         size_t responseBytes) override
     {
-        TaskQueue->ExecuteSimple([=, req = std::move(req)] () mutable {
+        TaskQueue->ExecuteSimple([=, this, req = std::move(req)] () mutable {
             DoHandleResponse(std::move(req), status, responseBytes);
         });
     }
@@ -569,7 +569,7 @@ public:
                         TaskQueue);
 
                     auto endpoint = Client->StartEndpoint(ep.Host, ep.Port)
-                        .Subscribe([=] (const auto& future) {
+                        .Subscribe([=, this] (const auto& future) {
                             storage->Init(future.GetValue(), Client->IsAlignedDataEnabled());
                         });
 

--- a/cloud/blockstore/libs/service_local/storage_spdk.cpp
+++ b/cloud/blockstore/libs/service_local/storage_spdk.cpp
@@ -356,7 +356,7 @@ public:
         for (int i = 0; i < devices.size(); ++i) {
             Spdk->RegisterNVMeDevices(devices[i].GetBaseName(),
                                       devices[i].GetTransportId())
-                .Subscribe([=] (const auto& future) {
+                .Subscribe([=, this] (const auto& future) {
                     try {
                         const auto& remoteDevices = future.GetValue();
                         Y_ENSURE(remoteDevices.size() == 1);

--- a/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
@@ -97,9 +97,9 @@ struct TCompositeDevice
             Devs[d] = std::make_shared<NSpdk::TTestSpdkDevice>();
 
             Devs[d]->ReadBufferHandler = // fast path
-                [=] (void* buffer, ui64 fileOffset, ui32 bytes)
+                [=, this] (void* buffer, ui64 fileOffset, ui32 bytes)
             {
-                return Execute([=] {
+                return Execute([=, this] {
                     UNIT_ASSERT(fileOffset < BlocksPerDevice * BlockSize);
                     UNIT_ASSERT(bytes <= BlocksPerDevice * BlockSize - fileOffset);
 
@@ -111,9 +111,9 @@ struct TCompositeDevice
             };
 
             Devs[d]->ReadSgListHandler =
-                [=] (TSgList sglist, ui64 fileOffset, ui32 bytes)
+                [=, this] (TSgList sglist, ui64 fileOffset, ui32 bytes)
             {
-                return Execute([=] {
+                return Execute([=, this] {
                     UNIT_ASSERT_VALUES_EQUAL(bytes, SgListGetSize(sglist));
                     UNIT_ASSERT(fileOffset < BlocksPerDevice * BlockSize);
                     UNIT_ASSERT(bytes <= BlocksPerDevice * BlockSize - fileOffset);
@@ -131,9 +131,9 @@ struct TCompositeDevice
             };
 
             Devs[d]->WriteBufferHandler = // fast path
-                [=] (void* buffer, ui64 fileOffset, ui32 bytes)
+                [=, this] (void* buffer, ui64 fileOffset, ui32 bytes)
             {
-                return Execute([=] {
+                return Execute([=, this] {
                     UNIT_ASSERT(fileOffset < BlocksPerDevice * BlockSize);
                     UNIT_ASSERT(bytes <= BlocksPerDevice * BlockSize - fileOffset);
 
@@ -145,9 +145,9 @@ struct TCompositeDevice
             };
 
             Devs[d]->WriteSgListHandler =
-                [=] (TSgList sglist, ui64 fileOffset, ui32 bytes)
+                [=, this] (TSgList sglist, ui64 fileOffset, ui32 bytes)
             {
-                return Execute([=] {
+                return Execute([=, this] {
                     UNIT_ASSERT_VALUES_EQUAL(bytes, SgListGetSize(sglist));
                     UNIT_ASSERT(fileOffset < BlocksPerDevice * BlockSize);
                     UNIT_ASSERT(bytes <= BlocksPerDevice * BlockSize - fileOffset);
@@ -164,9 +164,9 @@ struct TCompositeDevice
                 });
             };
 
-            Devs[d]->WriteZeroesHandler = [=] (ui64 fileOffset, ui32 bytes)
+            Devs[d]->WriteZeroesHandler = [=, this] (ui64 fileOffset, ui32 bytes)
             {
-                return Execute([=] {
+                return Execute([=, this] {
                     UNIT_ASSERT(fileOffset < BlocksPerDevice * BlockSize);
                     UNIT_ASSERT(bytes <= BlocksPerDevice * BlockSize - fileOffset);
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_acquire.cpp
@@ -93,7 +93,7 @@ void TDiskAgentActor::HandleAcquireDevices(
 
         WaitExceptionOrAll(futures).Subscribe(
             [
-                =,
+                =, this,
                 uuids = std::move(uuids),
                 diskId = record.GetDiskId(),
                 volumeGeneration = record.GetVolumeGeneration()

--- a/cloud/blockstore/libs/storage/disk_agent/storage_with_stats.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_with_stats.cpp
@@ -56,7 +56,7 @@ struct TStorageWithIoStats final
             std::move(callContext),
             std::move(request));
 
-        return result.Subscribe([=] (const auto& future) {
+        return result.Subscribe([=, this] (const auto& future) {
             if (HandleIoError(GetResponseErrorKind(future))) {
                 return;
             }
@@ -79,7 +79,7 @@ struct TStorageWithIoStats final
             std::move(callContext),
             std::move(request));
 
-        return result.Subscribe([=] (const auto& future) {
+        return result.Subscribe([=, this] (const auto& future) {
             if (HandleIoError(GetResponseErrorKind(future))) {
                 return;
             }
@@ -102,7 +102,7 @@ struct TStorageWithIoStats final
             std::move(callContext),
             std::move(request));
 
-        return result.Subscribe([=] (const auto& future) {
+        return result.Subscribe([=, this] (const auto& future) {
             if (HandleIoError(GetResponseErrorKind(future))) {
                 return;
             }

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
@@ -202,7 +202,7 @@ void TPartitionActor::WriteBlocks(
     IWriteBlocksHandlerPtr writeHandler,
     bool replyLocal)
 {
-    auto replyError = [=] (const TActorContext& ctx, NProto::TError error) {
+    auto replyError = [=, this] (const TActorContext& ctx, NProto::TError error) {
         LOG_DEBUG(ctx, TBlockStoreComponents::PARTITION,
             "[%lu][d:%s] WriteBlocks error: %s",
             TabletID(),

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblocks.cpp
@@ -118,7 +118,7 @@ void TPartitionActor::HandleWriteBlocksRequest(
         "WriteBlocks",
         requestInfo->CallContext->RequestId);
 
-    auto replyError = [=] (
+    auto replyError = [=, this] (
         const TActorContext& ctx,
         TRequestInfo& requestInfo,
         ui32 errorCode,

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -234,7 +234,7 @@ ui32 TTestEnv::CreateBlockStoreNode(
 
     auto subDomainPath = "/local/" + name;
 
-    auto factory = [=] (const TActorId& owner, TTabletStorageInfo* storage) {
+    auto factory = [=, this] (const TActorId& owner, TTabletStorageInfo* storage) {
         UNIT_ASSERT_EQUAL(storage->TabletType, TTabletTypes::BlockStoreVolume);
         auto actor = CreateVolumeTablet(
             owner,

--- a/cloud/blockstore/libs/throttling/throttler.cpp
+++ b/cloud/blockstore/libs/throttling/throttler.cpp
@@ -495,7 +495,7 @@ private:
         TPromise<typename T::TResponse> promise)
     {
         T::Execute(client, callContext, request).Subscribe(
-            [=, promise = std::move(promise)] (auto future) mutable {
+            [=, this, promise = std::move(promise)] (auto future) mutable {
                 auto response = ExtractResponse(future);
 
                 try {

--- a/cloud/blockstore/libs/validation/validation_client.cpp
+++ b/cloud/blockstore/libs/validation/validation_client.cpp
@@ -794,7 +794,7 @@ bool TValidationClient::HandleRequest(
     auto diskId = request->GetDiskId();
     response = Client->UnmountVolume(
         std::move(callContext), std::move(request)
-    ).Subscribe([=] (const auto& future) {
+    ).Subscribe([=, this] (const auto& future) {
         if (!IsRequestFailed(future)) {
             UnmountVolume(diskId);
         }
@@ -836,7 +836,7 @@ bool TValidationClient::HandleRequest(
         std::move(callContext), std::move(request)
     );
 
-    response = f.Subscribe([=, blocks_ = std::move(blocks)] (const auto& future) {
+    response = f.Subscribe([=, this, blocks_ = std::move(blocks)] (const auto& future) {
         if (!IsRequestFailed(future)) {
             const auto& response = future.GetValue();
 
@@ -898,7 +898,7 @@ bool TValidationClient::HandleRequest(
 
     auto f = Client->ReadBlocksLocal(std::move(callContext), request);
 
-    response = f.Subscribe([=, blocks = std::move(blocks)] (const auto& future) {
+    response = f.Subscribe([=, this, blocks = std::move(blocks)] (const auto& future) {
         if (!IsRequestFailed(future)) {
             auto guard = sgList.Acquire();
 
@@ -972,7 +972,7 @@ bool TValidationClient::HandleRequest(
 
     response = Client->WriteBlocks(
         std::move(callContext), std::move(request)
-    ).Subscribe([=, blocks_ = std::move(blocks)] (const auto& future) {
+    ).Subscribe([=, this, blocks_ = std::move(blocks)] (const auto& future) {
         if (!IsRequestFailed(future)) {
             CompleteWrite(*volume, *range, blocks_);
         } else {
@@ -1023,7 +1023,7 @@ bool TValidationClient::HandleRequest(
 
         response = Client->WriteBlocksLocal(
             std::move(callContext), std::move(request)
-        ).Subscribe([=, blocks_ = std::move(blocks)] (const auto& future) {
+        ).Subscribe([=, this, blocks_ = std::move(blocks)] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 CompleteWrite(*volume, *range, blocks_);
             } else {
@@ -1071,7 +1071,7 @@ bool TValidationClient::HandleRequest(
 
     response = Client->ZeroBlocks(
         std::move(callContext), std::move(request)
-    ).Subscribe([=] (const auto& future) {
+    ).Subscribe([=, this] (const auto& future) {
         if (!IsRequestFailed(future)) {
             CompleteZero(*volume, *range);
         } else {

--- a/cloud/blockstore/libs/validation/validation_service.cpp
+++ b/cloud/blockstore/libs/validation/validation_service.cpp
@@ -755,7 +755,7 @@ bool TValidationService::HandleRequest(
     auto diskId = request->GetDiskId();
     auto clientId = request->GetHeaders().GetClientId();
     response = Service->MountVolume(std::move(ctx), std::move(request)).Subscribe(
-            [=] (const auto& future) {
+            [=, this] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 const auto& response = future.GetValue();
                 auto timeout = InactiveClientsTimeout * 1.05;
@@ -779,7 +779,7 @@ bool TValidationService::HandleRequest(
     auto diskId = request->GetDiskId();
     auto clientId = request->GetHeaders().GetClientId();
     response = Service->UnmountVolume(std::move(ctx), std::move(request)).Subscribe(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 UnmountVolume(diskId, clientId);
             }
@@ -823,7 +823,7 @@ bool TValidationService::HandleRequest(
     Y_ABORT_UNLESS(blocks.size() == range->Size());
 
     response = Service->ReadBlocks(std::move(ctx), std::move(request)).Subscribe(
-        [=, blocks_ = std::move(blocks)] (const auto& future) {
+        [=, this, blocks_ = std::move(blocks)] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 const auto& response = future.GetValue();
 
@@ -886,7 +886,7 @@ bool TValidationService::HandleRequest(
     Y_ABORT_UNLESS(blocks.size() == range->Size());
 
     response = Service->ReadBlocksLocal(std::move(ctx), request).Subscribe(
-        [=, blocks_ = std::move(blocks)] (const auto& future) {
+        [=, this, blocks_ = std::move(blocks)] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 auto guard = request->Sglist.Acquire();
 
@@ -959,7 +959,7 @@ bool TValidationService::HandleRequest(
     PrepareWrite(*volume, *range);
 
     response = Service->WriteBlocks(std::move(ctx), std::move(request)).Subscribe(
-        [=, blocks_ = std::move(blocks)] (const auto& future) {
+        [=, this, blocks_ = std::move(blocks)] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 CompleteWrite(*volume, *range, blocks_);
             } else {
@@ -1009,7 +1009,7 @@ bool TValidationService::HandleRequest(
     PrepareWrite(*volume, *range);
 
     response = Service->WriteBlocksLocal(std::move(ctx), std::move(request))
-        .Subscribe([=, blocks_ = std::move(blocks)] (const auto& future) {
+        .Subscribe([=, this, blocks_ = std::move(blocks)] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 CompleteWrite(*volume, *range, blocks_);
             } else {
@@ -1047,7 +1047,7 @@ bool TValidationService::HandleRequest(
     PrepareZero(*volume, *range);
 
     response = Service->ZeroBlocks(std::move(ctx), std::move(request)).Subscribe(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             if (!IsRequestFailed(future)) {
                 CompleteZero(*volume, *range);
             } else {

--- a/cloud/blockstore/libs/ydbstats/ydbstats.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.cpp
@@ -533,7 +533,7 @@ TFuture<TSetupTablesResult> TYdbStatsUploader::EnsureInitialized()
             InitResponse = NewPromise<TSetupTablesResult>();
             State = EState::INITIALIZING;
             SetupTables().Subscribe(
-                [=] (const auto& future) {
+                [=, this] (const auto& future) {
                     HandleSetupTablesResult(future.GetValue());
                 });
         }
@@ -545,7 +545,7 @@ TFuture<TSetupTablesResult> TYdbStatsUploader::EnsureInitialized()
                 CleanupRunning = true;
                 STORAGE_INFO("Going to check for obsolete history tables");
                 RemoveObsoleteTables().Subscribe(
-                    [=] (const auto& future) {
+                    [=, this] (const auto& future) {
                         HandleRemoveObsoleteTablesResult(future.GetValue());
                     });
             }
@@ -692,7 +692,7 @@ TFuture<TSetupTableResult> TYdbStatsUploader::SetupPartitionsTable() const
 TFuture<TSetupTableResult> TYdbStatsUploader::SetupHistoryTable() const
 {
     return DbStorage->GetHistoryTables().Apply(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             const auto& result = future.GetValue();
             if (FAILED(result.Error.GetCode())) {
                 return MakeFuture(TSetupTableResult(result.Error));
@@ -726,7 +726,7 @@ TFuture<NProto::TError> TYdbStatsUploader::SetupTable(
     TStatsTableSchemePtr tableScheme) const
 {
     return DbStorage->DescribeTable(tableName).Apply(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             const auto& response = future.GetValue();
             if (SUCCEEDED(response.Error.GetCode())) {
                 return AlterTable(tableName, *tableScheme, response.TableScheme);

--- a/cloud/blockstore/libs/ydbstats/ydbstorage.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstorage.cpp
@@ -185,7 +185,7 @@ TFuture<NProto::TError> TYdbNativeStorage::CreateTable(
         });
 
     return future.Apply(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             auto status = ExtractStatus(future);
             if (status.IsSuccess()) {
                 return MakeError(S_OK);
@@ -207,7 +207,7 @@ TFuture<NProto::TError> TYdbNativeStorage::AlterTable(
         });
 
     return future.Apply(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             auto status = ExtractStatus(future);
             if (status.IsSuccess()) {
                 return MakeError(S_OK);
@@ -227,7 +227,7 @@ TFuture<NProto::TError> TYdbNativeStorage::DropTable(const TString& table)
         });
 
     return future.Apply(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             auto status = ExtractStatus(future);
             if (status.IsSuccess()) {
                 return MakeError(S_OK);
@@ -257,7 +257,7 @@ TFuture<NYdbStats::TDescribeTableResponse> TYdbNativeStorage::DescribeTable(
         });
     };
 
-    Client->RetryOperation(describe).Subscribe([=] (const auto& future) mutable {
+    Client->RetryOperation(describe).Subscribe([=, this] (const auto& future) mutable {
         auto status = ExtractStatus(future);
         if (status.IsSuccess()) {
             // promise result is already set
@@ -284,7 +284,7 @@ TFuture<TGetTablesResponse> TYdbNativeStorage::GetHistoryTables()
     auto future = SchemeClient->ListDirectory(database);
 
     return future.Apply(
-        [=] (const auto& future) {
+        [=, this] (const auto& future) {
             auto status = ExtractStatus(future);
             if (!status.IsSuccess()) {
                 auto out = BuildError(status, "unable to list directory ", database.Quote());

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -253,7 +253,7 @@ void TTestExecutor::DoReadRequest(ui16 rangeIdx)
         range.DataSize(),
         blockIdx * blockSize);
 
-    future.Subscribe([=] (const auto& f) mutable {
+    future.Subscribe([=, this] (const auto& f) mutable {
         OnResponse(startTs, rangeIdx, "read");
 
         try {
@@ -329,7 +329,7 @@ void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
             partSize,
             blockIdx * blockSize + partOffset);
 
-        future.Subscribe([=] (const auto& f) mutable {
+        future.Subscribe([=, this] (const auto& f) mutable {
             OnResponse(startTs, rangeIdx, "write");
 
             try {
@@ -349,7 +349,7 @@ void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
     }
 
     Futures[rangeIdx] = WaitAll(futures);
-    Futures[rangeIdx].Subscribe([=] (auto) {
+    Futures[rangeIdx].Subscribe([=, this] (auto) {
         RangesQueue.Enqueue(rangeIdx);
     });
 }

--- a/cloud/blockstore/tools/testing/loadtest/lib/action_graph.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/action_graph.cpp
@@ -44,7 +44,7 @@ void TGraphExecutor::Run()
         }
 
         for (TVertexId vertexId : ready) {
-            RunVertex(vertexId).Subscribe([=] (auto) {
+            RunVertex(vertexId).Subscribe([=, this] (auto) {
                 with_lock (Lock) {
                     for (const auto other : OutgoingEdges[vertexId]) {
                         auto& depCount = Vertex2DepCount[other];
@@ -70,7 +70,7 @@ TFuture<void> TGraphExecutor::RunVertex(TVertexId vertexId)
     TPromise<void> promise = NewPromise();
 
     ThreadPool.SafeAddFunc(
-        [=] () mutable {
+        [=, this] () mutable {
             Graph.Vertices[vertexId]();
             promise.SetValue();
         }

--- a/cloud/blockstore/tools/testing/loadtest/lib/app.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/app.cpp
@@ -113,7 +113,7 @@ int TApp::Run(TBootstrap& bootstrap)
     if (options->Timeout != TDuration::Zero()) {
         bootstrap.GetScheduler()->Schedule(
             bootstrap.GetTimer()->Now() + options->Timeout,
-            [=] {
+            [=, this] {
                 Stop(EC_TIMEOUT);
             });
     }

--- a/cloud/blockstore/tools/testing/loadtest/lib/test_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/test_runner.cpp
@@ -256,7 +256,7 @@ void TTestRunner::SendReadRequest(const TBlockRange64& range)
         std::move(request));
 
     future.Subscribe(
-        [=, p=shared_from_this()] (const auto& f) mutable {
+        [=, this, p=shared_from_this()] (const auto& f) mutable {
             guardedSgList.Close();
             Allocator->Release(buffer);
 
@@ -317,7 +317,7 @@ void TTestRunner::SendWriteRequest(const TBlockRange64& range)
         std::move(request));
 
     future.Subscribe(
-        [=, p=shared_from_this()] (const auto& f) mutable {
+        [=, this, p=shared_from_this()] (const auto& f) mutable {
             guardedSgList.Close();
             Allocator->Release(buffer);
 
@@ -364,7 +364,7 @@ void TTestRunner::SendZeroRequest(const TBlockRange64& range)
         std::move(request));
 
     future.Subscribe(
-        [=, p=shared_from_this()] (const auto& f) {
+        [=, this, p=shared_from_this()] (const auto& f) {
             const auto& response = f.GetValue();
             const auto& error = response.GetError();
             if (FAILED(error.GetCode())) {

--- a/cloud/blockstore/tools/testing/nbd-test/initiator.cpp
+++ b/cloud/blockstore/tools/testing/nbd-test/initiator.cpp
@@ -185,7 +185,7 @@ private:
             std::move(callContext),
             std::move(req));
 
-        future.Subscribe([=] (auto f) mutable {
+        future.Subscribe([=, this] (auto f) mutable {
             guardedSgList.Close();
 
             auto response = ExtractResponse(f);
@@ -214,7 +214,7 @@ private:
             std::move(callContext),
             std::move(req));
 
-        future.Subscribe([=] (auto f) mutable {
+        future.Subscribe([=, this] (auto f) mutable {
             guardedSgList.Close();
 
             auto response = ExtractResponse(f);

--- a/cloud/blockstore/tools/testing/rdma-test/initiator.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/initiator.cpp
@@ -223,7 +223,7 @@ private:
             sglist);
 
         future.Subscribe([
-            =,
+            =, this,
             callContext = std::move(callContext),
             sglist = std::move(sglist)
         ] (auto future) {
@@ -267,7 +267,7 @@ private:
             sglist);
 
         future.Subscribe([
-            =,
+            =, this,
             callContext = std::move(callContext),
             sglist = std::move(sglist)
         ] (auto future) {

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -74,8 +74,8 @@ public:
         TStringBuf in,
         TStringBuf out) override
     {
-        TaskQueue->ExecuteSimple([=] {
-            auto error = SafeExecute<NProto::TError>([=] {
+        TaskQueue->ExecuteSimple([=, this] {
+            auto error = SafeExecute<NProto::TError>([=, this] {
                 return DoHandleRequest(context, callContext, in, out);
             });
 
@@ -147,10 +147,10 @@ private:
             std::move(request),
             guardedSgList);
 
-        future.Subscribe([=] (auto future) {
+        future.Subscribe([=, this] (auto future) {
             auto response = ExtractResponse(future);
 
-            TaskQueue->ExecuteSimple([=] {
+            TaskQueue->ExecuteSimple([=, this] {
                 Y_UNUSED(buffer);
 
                 auto guard = guardedSgList.Acquire();
@@ -192,10 +192,10 @@ private:
             std::move(request),
             guardedSgList);
 
-        future.Subscribe([=] (auto future) {
+        future.Subscribe([=, this] (auto future) {
             auto response = ExtractResponse(future);
 
-            TaskQueue->ExecuteSimple([=] {
+            TaskQueue->ExecuteSimple([=, this] {
                 Y_UNUSED(guardedSgList);
 
                 size_t responseBytes =

--- a/cloud/filestore/libs/endpoint/endpoint_manager.cpp
+++ b/cloud/filestore/libs/endpoint/endpoint_manager.cpp
@@ -367,7 +367,7 @@ NProto::TStartEndpointResponse TEndpointManager::DoStartEndpoint(
             auto future = endpoint->Endpoint->AlterAsync(
                 readOnly,
                 mountSeqNumber).Apply(
-                [=] (const TFuture<NProto::TError>& future) {
+                [=, this] (const TFuture<NProto::TError>& future) {
                     NProto::TStartEndpointResponse response;
                     auto error = future.GetValue();
                     if (!HasError(error)) {

--- a/cloud/filestore/libs/endpoint/service_auth.cpp
+++ b/cloud/filestore/libs/endpoint/service_auth.cpp
@@ -108,7 +108,7 @@ private:
         auto promise = NewPromise<TResponse>();
 
         authResponse.Subscribe(
-            [=, request = std::move(request), ctx = std::move(ctx)] (const auto& future) mutable {
+            [=, this, request = std::move(request), ctx = std::move(ctx)] (const auto& future) mutable {
                 const auto& error = future.GetValue();
 
                 if (HasError(error)) {

--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -694,7 +694,7 @@ private:
 
         auto* tag = AcquireCompletionTag();
         Response.Subscribe(
-            [=] (const auto& response) {
+            [=, this] (const auto& response) {
                 Y_UNUSED(response);
 
                 if (AtomicCas(&RequestState, ExecutionCompleted, ExecutingRequest)) {

--- a/cloud/filestore/libs/service/service_auth.cpp
+++ b/cloud/filestore/libs/service/service_auth.cpp
@@ -114,7 +114,7 @@ private:
         auto promise = NewPromise<TResponse>();
 
         authResponse.Subscribe(
-            [=, request = std::move(request), ctx = std::move(ctx)] (const auto& future) mutable {
+            [=, this, request = std::move(request), ctx = std::move(ctx)] (const auto& future) mutable {
                 const auto& error = future.GetValue();
 
                 if (HasError(error)) {

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -455,7 +455,7 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
 {
     auto tabletId = ChangeDomain(Config.DomainUid, ++NextTabletId);
 
-    auto tabletFactory = [=] (const TActorId& owner, TTabletStorageInfo* storage) {
+    auto tabletFactory = [=, this] (const TActorId& owner, TTabletStorageInfo* storage) {
         Y_ABORT_UNLESS(storage->TabletType == TTabletTypes::FileStore);
         auto actor = CreateIndexTablet(
             owner,
@@ -617,7 +617,7 @@ void TTestEnv::SetupLocalServiceConfig(
     TAppData& appData,
     TLocalConfig& localConfig)
 {
-    auto tabletFactory = [=] (const TActorId& owner, TTabletStorageInfo* storage) {
+    auto tabletFactory = [=, this] (const TActorId& owner, TTabletStorageInfo* storage) {
         Y_ABORT_UNLESS(storage->TabletType == TTabletTypes::FileStore);
         auto actor = CreateIndexTablet(
             owner,

--- a/cloud/filestore/tools/testing/loadtest/bin/app.cpp
+++ b/cloud/filestore/tools/testing/loadtest/bin/app.cpp
@@ -74,7 +74,7 @@ public:
                             bootstrap.GetClientFactory());
 
                         tests.push_back(
-                            [=] () {
+                            [=, this] () {
                                 RunLoadTest(i, name, test);
                             });
 

--- a/cloud/filestore/tools/testing/loadtest/lib/executor.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/executor.cpp
@@ -28,7 +28,7 @@ void TExecutor::Run()
             current = DoneCount++;
         }
 
-        RunAction(current).Subscribe([=] (auto future) {
+        RunAction(current).Subscribe([=, this] (auto future) {
             future.GetValue();  // re-throw exception
             ReadyEvent.Signal();
         });

--- a/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
@@ -297,7 +297,7 @@ private:
             }
 
             return setAttr.Apply(
-                [=] (const TFuture<NProto::TSetNodeAttrResponse>& f) {
+                [=, this] (const TFuture<NProto::TSetNodeAttrResponse>& f) {
                     return HandleResizeAfterCreateHandle(f, name, started);
                 });
         } catch (const TServiceError& e)  {

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_fallback_actor.cpp
@@ -232,7 +232,7 @@ void THiveProxyFallbackActor::HandleBootExternal(
     const auto* msg = ev->Get();
 
     auto requestInfo = TRequestInfo(ev->Sender, ev->Cookie);
-    auto reply = [=](const auto& ctx, auto r) {
+    auto reply = [=, this](const auto& ctx, auto r) {
         if (HasError(r->Error)) {
             NCloud::Reply(
                 ctx,

--- a/cloud/vm/blockstore/lib/plugin.cpp
+++ b/cloud/vm/blockstore/lib/plugin.cpp
@@ -359,7 +359,7 @@ int TPlugin::MountVolumeAsync(
         *requestHandler->CallContext);
 
     future.Subscribe(
-        [=,
+        [=, this,
         diskId = sessionConfig.DiskId,
         requestHandler = std::move(requestHandler)] (const auto& future)
         {
@@ -483,7 +483,7 @@ int TPlugin::UnmountVolumeAsync(
         *requestHandler->CallContext);
 
     future.Subscribe(
-        [=,
+        [=, this,
         requestHandler = std::move(requestHandler)] (const auto& future)
         {
             ClientStats->ResponseReceived(
@@ -593,7 +593,7 @@ void TPlugin::HandleReadBlocks(
         *requestHandler->CallContext);
 
     future.Subscribe(
-        [=,
+        [=, this,
         sglist = std::move(guardedSgList),
         requestHandler = std::move(requestHandler)] (const auto& f) mutable
         {
@@ -661,7 +661,7 @@ void TPlugin::HandleWriteBlocks(
         *requestHandler->CallContext);
 
     future.Subscribe(
-        [=,
+        [=, this,
         sglist = std::move(guardedSgList),
         requestHandler = std::move(requestHandler)] (const auto& f) mutable
         {
@@ -725,7 +725,7 @@ void TPlugin::HandleZeroBlocks(
         *requestHandler->CallContext);
 
     future.Subscribe(
-        [=, requestHandler = std::move(requestHandler)] (const auto& f) {
+        [=, this, requestHandler = std::move(requestHandler)] (const auto& f) {
             ClientStats->ResponseReceived(
                 requestHandler->MetricRequest,
                 *requestHandler->CallContext);


### PR DESCRIPTION
tl;dr у clang-18 включили по дефолту ворнинг, который заствялет людей писать  то, как именно хочется захватывать this — по значению или по ссылке

отличие в том, что если ты захватываешь this по ссылке, то ты в лямбде можешь влиять на поля текущего объекта, если же ты пишешь *this то у тебя создается копия твоего текущего класса и внутри лямбды ты работаешь уже с ним

Ссылки для инфо, что это за правки:
https://open-std.org/JTC1/SC22/WG21/docs/papers/2018/p0806r1.html
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0409r2.html

Из важного там вот этот пункт:
```
0. This proposal: Allow [=, this]
Description:	[&], [&, this], [=], [=, this] capture *this by reference; [&, *this], [=, *this] capture *this by value.
Pros:	
Non-breaking change; this is a pure extension.
Allows for self-documenting code. Each kind of this-capture can be spelled out explicitly, no need to remember defaults.
Cons:	
Adds a redundant syntactical form.
```