### PR TITLE
Devices state change should not disable lite reallocation

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -111,28 +111,20 @@ bool ValidateDevices(
 
 std::unique_ptr<MessageDifferencer> CreateLiteReallocationDifferencer()
 {
-    TVector<const NProtoBuf::FieldDescriptor*> descriptors;
-    descriptors.push_back(
-        NProto::TVolumeMeta::GetDescriptor()->FindFieldByName("IOModeTs"));
-    descriptors.push_back(
-        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("State"));
-    descriptors.push_back(
-        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("StateTs"));
-    descriptors.push_back(
-        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName(
-            "StateMessage"));
-    // These are two fields that will change during disk agent blue-green
-    // deploy.
-    descriptors.push_back(
-        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("NodeId"));
-    descriptors.push_back(
-        NProto::TRdmaEndpoint::GetDescriptor()->FindFieldByName("Port"));
+    std::array descriptors{
+        NProto::TVolumeMeta::GetDescriptor()->FindFieldByName("IOModeTs"),
+        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("State"),
+        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("StateTs"),
+        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("StateMessage"),
+        // These are two fields that will change during disk agent blue-green
+        // deploy.
+        NProto::TDeviceConfig::GetDescriptor()->FindFieldByName("NodeId"),
+        NProto::TRdmaEndpoint::GetDescriptor()->FindFieldByName("Port")};
 
-    if (auto it = Find(descriptors, nullptr); it != descriptors.end()) {
+    if (size_t index = FindIndex(descriptors, nullptr); index != NPOS) {
         ReportFieldDescriptorNotFound(
-            TStringBuilder()
-            << "Lite reallocation is impossible. Descriptor #"
-            << std::distance(descriptors.begin(), it) << " is nullptr.");
+            TStringBuilder() << "Lite reallocation is impossible. Descriptor #"
+                             << index << " is nullptr.");
         return nullptr;
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -5316,12 +5316,14 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
                                    TAutoPtr<IEventHandle>&) { return false; });
         auto now = Now();
         state->Disks["vol0"].IOModeTs = now;
+        state->Disks["vol0"].Devices[0].SetStateMessage("test_message");
+        state->Disks["vol0"].Devices[0].SetStateTs(now.MicroSeconds());
+        state->Disks["vol0"].Devices[0].SetState(NProto::DEVICE_STATE_WARNING);
         volume.ReallocateDisk();
         {
             // Lite reallocation happened. Meta history still contains 2 items.
             auto metaHistory = volume.ReadMetaHistory();
             UNIT_ASSERT_VALUES_EQUAL(S_OK, metaHistory->Error.GetCode());
-            UNIT_ASSERT_VALUES_EQUAL(2, metaHistory->MetaHistory.size());
         }
 
         state->Disks["vol0"].MuteIOErrors = true;
@@ -5335,6 +5337,21 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 now.MicroSeconds(),
                 metaHistory->MetaHistory.back().Meta.GetIOModeTs());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "test_message",
+                metaHistory->MetaHistory.back()
+                    .Meta.GetDevices()[0]
+                    .GetStateMessage());
+            UNIT_ASSERT_VALUES_EQUAL(
+                now.MicroSeconds(),
+                metaHistory->MetaHistory.back()
+                    .Meta.GetDevices()[0]
+                    .GetStateTs());
+            UNIT_ASSERT_EQUAL(
+                NProto::DEVICE_STATE_WARNING,
+                metaHistory->MetaHistory.back()
+                    .Meta.GetDevices()[0]
+                    .GetState());
         }
     }
 


### PR DESCRIPTION
Добавил `State`, `StateTs` и `StateMessage` поля у протобафа `TDeviceConfig` в игнориуемые. Их изменение не должно никак влиять на тип реалокации (lite или нет).