### PR TITLE
[NBS] fix: remove unnecessary move operator

### DIFF
--- a/cloud/blockstore/libs/storage/partition_common/actor_checkrange.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_checkrange.cpp
@@ -47,7 +47,7 @@ void TCheckRangeActor::ReplyAndDie(
     const NProto::TError& error)
 {
     auto response =
-        std::make_unique<TEvVolume::TEvCheckRangeResponse>(std::move(error));
+        std::make_unique<TEvVolume::TEvCheckRangeResponse>(error);
 
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 


### PR DESCRIPTION
Std::move of the const variable 'error' has no effect; remove std::move() or make the variable non-const