### PR TITLE
Show statistics for DescribeBlocks request. Show percentiles.

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
@@ -7,6 +7,7 @@
 
 #include <util/datetime/cputimer.h>
 #include <util/string/builder.h>
+#include <span>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -29,6 +30,23 @@ constexpr std::array<size_t, BlockCountBucketsCount> RequestSizeBuckets = {
     512,
     1024,
     std::numeric_limits<size_t>::max()};
+
+const TVector<TPercentileDesc> Percentiles{
+    {0.100, "10"},
+    {0.200, "20"},
+    {0.300, "30"},
+    {0.400, "40"},
+    {0.500, "50"},
+    {0.600, "60"},
+    {0.700, "70"},
+    {0.800, "80"},
+    {0.900, "90"},
+    {0.990, "99"},
+    {0.999, "99.9"},
+    {1.0, "100"},
+};
+
+////////////////////////////////////////////////////////////////////////////////
 
 size_t GetSizeBucket(TBlockRange64 range)
 {
@@ -54,6 +72,21 @@ const TString& GetTimeBucketName(TDuration duration)
     return TimeNames[idx];
 }
 
+TVector<double> BuildPercentilesForHistogram(
+    const std::span<const ui64> histogram)
+{
+    Y_DEBUG_ABORT_UNLESS(
+        histogram.size() == TRequestUsTimeBuckets::Buckets.size());
+
+    TVector<TBucketInfo> buckets;
+    buckets.reserve(histogram.size());
+    for (size_t i = 0; i < histogram.size(); ++i) {
+        buckets.emplace_back(TRequestUsTimeBuckets::Buckets[i], histogram[i]);
+    }
+
+    return CalculateWeightedPercentiles(buckets, Percentiles);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,6 +107,10 @@ TString TRequestsTimeTracker::TKey::GetHtmlPrefix() const
         }
         case TRequestsTimeTracker::ERequestType::Zero: {
             builder << "Z_";
+            break;
+        }
+        case TRequestsTimeTracker::ERequestType::Describe: {
+            builder << "D_";
             break;
         }
     }
@@ -98,8 +135,8 @@ TString TRequestsTimeTracker::TKey::GetHtmlPrefix() const
 ui64 TRequestsTimeTracker::THash::operator()(const TKey& key) const
 {
     return IntHash(key.SizeBucket) +
-           IntHash(static_cast<size_t>(key.RequestType)) +
-           IntHash(static_cast<size_t>(key.RequestStatus));
+           IntHash(static_cast<size_t>(key.RequestType) << 5) +
+           IntHash(static_cast<size_t>(key.RequestStatus) << 8);
 }
 
 bool TRequestsTimeTracker::TEqual::operator()(
@@ -175,6 +212,41 @@ void TRequestsTimeTracker::OnRequestFinished(
     Histograms[key].BlockCount += request.BlockRange.Size();
 }
 
+NJson::TJsonValue TRequestsTimeTracker::BuildPercentilesJson() const
+{
+    static const auto PercentileBuckets =
+        TRequestsTimeTracker::GetPercentileBuckets();
+
+    NJson::TJsonValue result(NJson::EJsonValueType::JSON_MAP);
+
+    for (size_t sizeBucket = 0; sizeBucket <= TotalSizeBucket; ++sizeBucket) {
+        for (size_t requestType = 0;
+             requestType <= static_cast<size_t>(ERequestType::Last);
+             ++requestType)
+        {
+            const TKey key{
+                .SizeBucket = sizeBucket,
+                .RequestType = static_cast<ERequestType>(requestType),
+                .RequestStatus = ERequestStatus::Success};
+
+            if (const auto* histogram = Histograms.FindPtr(key)) {
+                const auto timePercentiles =
+                    BuildPercentilesForHistogram(histogram->Buckets);
+                for (size_t percentileIdx = 0;
+                     percentileIdx < timePercentiles.size();
+                     ++percentileIdx)
+                {
+                    const auto htmlKey = key.GetHtmlPrefix() +
+                                         PercentileBuckets[percentileIdx].Key;
+                    result[htmlKey] = FormatDuration(TDuration::MicroSeconds(
+                        timePercentiles[percentileIdx]));
+                }
+            }
+        }
+    }
+    return result;
+}
+
 TString TRequestsTimeTracker::GetStatJson(ui64 nowCycles, ui32 blockSize) const
 {
     NJson::TJsonValue allStat(NJson::EJsonValueType::JSON_MAP);
@@ -190,7 +262,7 @@ TString TRequestsTimeTracker::GetStatJson(ui64 nowCycles, ui32 blockSize) const
                 (histogram.Buckets[i] ? ToString(histogram.Buckets[i]) : "");
             total += histogram.Buckets[i];
         }
-        allStat[htmlPrefix + "Total"] = ToString(total);
+        allStat[htmlPrefix + "Count"] = ToString(total);
         allStat[htmlPrefix + "TotalSize"] =
             FormatByteSize(histogram.BlockCount * blockSize);
     }
@@ -217,9 +289,9 @@ TString TRequestsTimeTracker::GetStatJson(ui64 nowCycles, ui32 blockSize) const
 
         // Time
         ++inflight[getHtmlKey(sizeBucket, requestType, timeBucketName)];
-        ++inflight[getHtmlKey(sizeBucket, requestType, "Total")];
+        ++inflight[getHtmlKey(sizeBucket, requestType, "Count")];
         ++inflight[getHtmlKey(TotalSizeBucket, requestType, timeBucketName)];
-        ++inflight[getHtmlKey(TotalSizeBucket, requestType, "Total")];
+        ++inflight[getHtmlKey(TotalSizeBucket, requestType, "Count")];
 
         // Size
         inflight[getHtmlKey(sizeBucket, requestType, "TotalSize")] +=
@@ -237,12 +309,14 @@ TString TRequestsTimeTracker::GetStatJson(ui64 nowCycles, ui32 blockSize) const
 
     NJson::TJsonValue json;
     json["stat"] = std::move(allStat);
+    json["percentiles"] = BuildPercentilesJson();
 
     TStringStream out;
     NJson::WriteJson(&out, &json);
     return out.Str();
 }
 
+// static
 TVector<TRequestsTimeTracker::TBucketInfo> TRequestsTimeTracker::GetSizeBuckets(
     ui32 blockSize)
 {
@@ -278,6 +352,7 @@ TVector<TRequestsTimeTracker::TBucketInfo> TRequestsTimeTracker::GetSizeBuckets(
     return result;
 }
 
+// static
 TVector<TRequestsTimeTracker::TBucketInfo>
 TRequestsTimeTracker::GetTimeBuckets()
 {
@@ -296,12 +371,28 @@ TRequestsTimeTracker::GetTimeBuckets()
         last = TDuration::MicroSeconds(us.GetOrElse(0));
         result.push_back(std::move(bucket));
     }
-    result.push_back(
-        TBucketInfo{.Key = "Total", .Description = "Total", .Tooltip = ""});
+    result.push_back(TBucketInfo{
+        .Key = "Count",
+        .Description = "Count",
+        .Tooltip = "Total request count"});
     result.push_back(TBucketInfo{
         .Key = "TotalSize",
         .Description = "Total Size",
-        .Tooltip = ""});
+        .Tooltip = "Total requests size"});
+    return result;
+}
+
+// static
+TVector<TRequestsTimeTracker::TBucketInfo>
+TRequestsTimeTracker::GetPercentileBuckets()
+{
+    TVector<TBucketInfo> result;
+    for (const auto& p: Percentiles) {
+        result.push_back(TBucketInfo{
+            .Key = "P" + ToString(p.second),
+            .Description = ToString(p.second),
+            .Tooltip = ""});
+    }
     return result;
 }
 

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -5,6 +5,8 @@
 #include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/storage/core/histogram.h>
 
+#include <library/cpp/json/writer/json_value.h>
+
 #include <util/datetime/base.h>
 #include <util/generic/hash.h>
 #include <util/generic/maybe.h>
@@ -18,10 +20,11 @@ class TRequestsTimeTracker
 public:
     enum class ERequestType
     {
-        Read = 0,
-        Write = 1,
-        Zero = 2,
-        Last = Zero,
+        Read,
+        Write,
+        Zero,
+        Describe,
+        Last = Describe,
     };
 
     struct TBucketInfo
@@ -78,11 +81,14 @@ private:
     THashMap<ui64, TRequestInflight> InflightRequests;
     THashMap<TKey, TTimeHistogram, THash, TEqual> Histograms;
 
+    [[nodiscard]] NJson::TJsonValue BuildPercentilesJson() const;
+
 public:
     explicit TRequestsTimeTracker();
 
     static TVector<TBucketInfo> GetSizeBuckets(ui32 blockSize);
     static TVector<TBucketInfo> GetTimeBuckets();
+    static TVector<TBucketInfo> GetPercentileBuckets();
 
     void OnRequestStarted(
         ERequestType requestType,

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker_ut.cpp
@@ -12,13 +12,21 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DumpValues(const NJson::TJsonValue::TMapType& map)
+size_t DumpValues(const NJson::TJsonValue::TMapType& map)
 {
+    TMap<TString, TString> ordered;
     for (const auto& [key, val]: map) {
+        ordered[key] = val.GetString();
+    }
+
+    size_t nonEmptyCount = 0;
+    for (const auto& [key, val]: ordered) {
         if (val != "" && val != "0" && val != "0 B") {
             Cout << key << "=" << val << Endl;
+            ++nonEmptyCount;
         }
     }
+    return nonEmptyCount;
 }
 
 }   // namespace
@@ -48,7 +56,7 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
             4096);
         NJson::TJsonValue value;
         NJson::ReadJsonTree(json, &value, true);
-        DumpValues(value["stat"].GetMap());
+        const auto nonEmptyStatCount = DumpValues(value["stat"].GetMap());
 
         auto get = [&](const TString& key)
         {
@@ -57,12 +65,17 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
 
         UNIT_ASSERT_VALUES_EQUAL("1", get("R_1_inflight_1000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("R_1_inflight_2000000"));
-        UNIT_ASSERT_VALUES_EQUAL("2", get("R_1_inflight_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("2", get("R_1_inflight_Count"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("R_Total_inflight_1000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("R_Total_inflight_2000000"));
-        UNIT_ASSERT_VALUES_EQUAL("2", get("R_Total_inflight_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("2", get("R_Total_inflight_Count"));
         UNIT_ASSERT_VALUES_EQUAL("8.00 KiB", get("R_1_inflight_TotalSize"));
         UNIT_ASSERT_VALUES_EQUAL("8.00 KiB", get("R_Total_inflight_TotalSize"));
+        UNIT_ASSERT_VALUES_EQUAL(8, nonEmptyStatCount);
+
+        const auto nonEmptyPercentilesCount =
+            DumpValues(value["percentiles"].GetMap());
+        UNIT_ASSERT_VALUES_EQUAL(0, nonEmptyPercentilesCount);
     }
 
     Y_UNIT_TEST(ShouldCountFinishedSuccess)
@@ -105,23 +118,37 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
             4096);
         NJson::TJsonValue value;
         NJson::ReadJsonTree(json, &value, true);
-        DumpValues(value["stat"].GetMap());
 
-        auto get = [&](const TString& key)
+        const auto nonEmptyStatCount = DumpValues(value["stat"].GetMap());
+        auto getStat = [&](const TString& key)
         {
             return value["stat"][key];
         };
+        UNIT_ASSERT_VALUES_EQUAL("1", getStat("W_1_ok_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", getStat("W_1_ok_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", getStat("W_1_ok_5000000"));
+        UNIT_ASSERT_VALUES_EQUAL("3", getStat("W_1_ok_Count"));
+        UNIT_ASSERT_VALUES_EQUAL("1", getStat("W_Total_ok_1000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", getStat("W_Total_ok_2000000"));
+        UNIT_ASSERT_VALUES_EQUAL("1", getStat("W_Total_ok_5000000"));
+        UNIT_ASSERT_VALUES_EQUAL("3", getStat("W_Total_ok_Count"));
+        UNIT_ASSERT_VALUES_EQUAL("12.00 KiB", getStat("W_1_ok_TotalSize"));
+        UNIT_ASSERT_VALUES_EQUAL("12.00 KiB", getStat("W_Total_ok_TotalSize"));
+        UNIT_ASSERT_VALUES_EQUAL(10, nonEmptyStatCount);
 
-        UNIT_ASSERT_VALUES_EQUAL("1", get("W_1_ok_1000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("W_1_ok_2000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("W_1_ok_5000000"));
-        UNIT_ASSERT_VALUES_EQUAL("3", get("W_1_ok_Total"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_1000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_2000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("W_Total_ok_5000000"));
-        UNIT_ASSERT_VALUES_EQUAL("3", get("W_Total_ok_Total"));
-        UNIT_ASSERT_VALUES_EQUAL("12.00 KiB", get("W_1_ok_TotalSize"));
-        UNIT_ASSERT_VALUES_EQUAL("12.00 KiB", get("W_Total_ok_TotalSize"));
+        const auto nonEmptyPercentilesCount =
+            DumpValues(value["percentiles"].GetMap());
+        auto getPercentile = [&](const TString& key)
+        {
+            return value["percentiles"][key];
+        };
+        UNIT_ASSERT_VALUES_EQUAL("1.500s", getPercentile("W_1_ok_P50"));
+        UNIT_ASSERT_VALUES_EQUAL("4.100s", getPercentile("W_1_ok_P90"));
+        UNIT_ASSERT_VALUES_EQUAL("5.000s", getPercentile("W_1_ok_P100"));
+        UNIT_ASSERT_VALUES_EQUAL("1.500s", getPercentile("W_Total_ok_P50"));
+        UNIT_ASSERT_VALUES_EQUAL("4.100s", getPercentile("W_Total_ok_P90"));
+        UNIT_ASSERT_VALUES_EQUAL("5.000s", getPercentile("W_Total_ok_P100"));
+        UNIT_ASSERT_VALUES_EQUAL(24, nonEmptyPercentilesCount);
     }
 
     Y_UNIT_TEST(ShouldCountFinishedFail)
@@ -164,30 +191,35 @@ Y_UNIT_TEST_SUITE(TRequestsTimeTrackerTest)
             4096);
         NJson::TJsonValue value;
         NJson::ReadJsonTree(json, &value, true);
-        DumpValues(value["stat"].GetMap());
 
+        const auto nonEmptyStatCount = DumpValues(value["stat"].GetMap());
         auto get = [&](const TString& key)
         {
             return value["stat"][key];
         };
-
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_5000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_512_fail_Count"));
         UNIT_ASSERT_VALUES_EQUAL("2.00 MiB", get("Z_512_fail_TotalSize"));
 
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_2000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_1024_fail_Count"));
         UNIT_ASSERT_VALUES_EQUAL("2.34 MiB", get("Z_1024_fail_TotalSize"));
 
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_1000000"));
-        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Inf_fail_Count"));
         UNIT_ASSERT_VALUES_EQUAL("7.81 MiB", get("Z_Inf_fail_TotalSize"));
 
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_1000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_2000000"));
         UNIT_ASSERT_VALUES_EQUAL("1", get("Z_Total_fail_5000000"));
-        UNIT_ASSERT_VALUES_EQUAL("3", get("Z_Total_fail_Total"));
+        UNIT_ASSERT_VALUES_EQUAL("3", get("Z_Total_fail_Count"));
         UNIT_ASSERT_VALUES_EQUAL("12.16 MiB", get("Z_Total_fail_TotalSize"));
+
+        UNIT_ASSERT_VALUES_EQUAL(14, nonEmptyStatCount);
+
+        const auto nonEmptyPercentilesCount =
+            DumpValues(value["percentiles"].GetMap());
+        UNIT_ASSERT_VALUES_EQUAL(0, nonEmptyPercentilesCount);
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -446,14 +446,11 @@ void RenderTextWithTooltip(
     const TString& text,
     const TString& tooltip)
 {
-    HTML(out)
-    {
-        DIV_CLASS("tooltip-latency")
-        {
+    HTML (out) {
+        DIV_CLASS ("tooltip-latency") {
             out << text;
             if (tooltip) {
-                SPAN_CLASS("tooltiptext-latency")
-                {
+                SPAN_CLASS ("tooltiptext-latency") {
                     out << tooltip;
                 }
             }
@@ -464,8 +461,7 @@ void RenderTextWithTooltip(
 void RenderLatencyTable(IOutputStream& out, const TString& parentId)
 {
     HTML (out) {
-        TABLE_CLASS("table-latency")
-        {
+        TABLE_CLASS ("table-latency") {
             TABLEHEAD () {
                 TABLER () {
                     TABLEH () {
@@ -490,12 +486,12 @@ void RenderLatencyTable(IOutputStream& out, const TString& parentId)
                     TABLED () {
                         RenderTextWithTooltip(out, descr, tooltip);
                     }
-                    TABLED_ATTRS({{"id", parentId + "_ok_" + key}})
-                    {}
-                    TABLED_ATTRS({{"id", parentId + "_fail_" + key}})
-                    {}
-                    TABLED_ATTRS({{"id", parentId + "_inflight_" + key}})
-                    {}
+                    TABLED_ATTRS ({{"id", parentId + "_ok_" + key}}) {
+                    }
+                    TABLED_ATTRS ({{"id", parentId + "_fail_" + key}}) {
+                    }
+                    TABLED_ATTRS ({{"id", parentId + "_inflight_" + key}}) {
+                    }
                 }
             }
         }
@@ -505,30 +501,22 @@ void RenderLatencyTable(IOutputStream& out, const TString& parentId)
 void RenderPercentilesTable(IOutputStream& out, const TString& parentId)
 {
     HTML (out) {
-        TABLE_CLASS("table-latency")
-        {
-            TABLEHEAD()
-            {
-                TABLER()
-                {
-                    TABLEH()
-                    {
+        TABLE_CLASS ("table-latency") {
+            TABLEHEAD () {
+                TABLER () {
+                    TABLEH () {
                         RenderTextWithTooltip(out, "Perc", "Percentile");
                     }
-                    TABLEH()
-                    {
+                    TABLEH () {
                         RenderTextWithTooltip(out, "R", "Read");
                     }
-                    TABLEH()
-                    {
+                    TABLEH () {
                         RenderTextWithTooltip(out, "W", "Write");
                     }
-                    TABLEH()
-                    {
+                    TABLEH () {
                         RenderTextWithTooltip(out, "Z", "Zero");
                     }
-                    TABLEH()
-                    {
+                    TABLEH () {
                         RenderTextWithTooltip(out, "D", "Describe");
                     }
                 }
@@ -539,26 +527,16 @@ void RenderPercentilesTable(IOutputStream& out, const TString& parentId)
             {
                 TABLER () {
                     TABLED () {
-                        DIV_CLASS("tooltip-latency")
-                        {
-                            out << descr;
-
-                            if (tooltip) {
-                                SPAN_CLASS("tooltiptext-latency")
-                                {
-                                    out << tooltip;
-                                }
-                            }
-                        }
+                        RenderTextWithTooltip(out, descr, tooltip);
                     }
-                    TABLED_ATTRS({{"id", "R_" + parentId + "_ok_" + key}})
-                    {}
-                    TABLED_ATTRS({{"id", "W_" + parentId + "_ok_" + key}})
-                    {}
-                    TABLED_ATTRS({{"id", "Z_" + parentId + "_ok_" + key}})
-                    {}
-                    TABLED_ATTRS({{"id", "D_" + parentId + "_ok_" + key}})
-                    {}
+                    TABLED_ATTRS ({{"id", "R_" + parentId + "_ok_" + key}}) {
+                    }
+                    TABLED_ATTRS ({{"id", "W_" + parentId + "_ok_" + key}}) {
+                    }
+                    TABLED_ATTRS ({{"id", "Z_" + parentId + "_ok_" + key}}) {
+                    }
+                    TABLED_ATTRS ({{"id", "D_" + parentId + "_ok_" + key}}) {
+                    }
                 }
             }
         }
@@ -593,7 +571,7 @@ void RenderSizeTable(IOutputStream& out, ui32 blockSize)
             {
                 TABLER () {
                     TABLED () {
-                        TAG(TH4) {
+                        TAG (TH4) {
                             out << "Size: " << descr;
                         }
                         RenderPercentilesTable(out, key);


### PR DESCRIPTION
1. Добавил отображение запросов DescribeBlocks. Нужно чтобы смотреть как себя ведет базовый диск.
2. добавил табличку с перцентилями времени выполнения запросов.
![image](https://github.com/user-attachments/assets/286a86b7-d217-4517-a8c5-148c93f54aa5)
