### PR TITLE
Mute TShardBalancerTest.ShouldBalanceShardsWeightedRandom

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -3,3 +3,4 @@ cloud/filestore/tests/fio_index/mount-local-test *
 cloud/disk_manager/internal/pkg/facade/filesystem_service_nemesis_test filesystem_service_nemesis_test.TestFilesystemServiceCreateExternalFilesystem
 cloud/filestore/libs/storage/service/ut TStorageServiceShardingTest.ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShardsWithShardIdSelectionInLeader
 cloud/filestore/libs/storage/tablet/model/ut TShardBalancerTest.ShouldBalanceShardsRandom
+cloud/filestore/libs/storage/tablet/model/ut TShardBalancerTest.ShouldBalanceShardsWeightedRandom


### PR DESCRIPTION
```
[[bad]]less-or-equal assertion failed at cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp:317, virtual void NCloud::NFileStore::NStorage::NTestSuiteTShardBalancerTest::TTestCaseShouldBalanceShardsWeightedRandom::Execute_(NUnitTest::TTestContext &): count <= iterations / shardCount + rangeToleration [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char> > const&, bool)+128 (0x17AD6A0)
NCloud::NFileStore::NStorage::NTestSuiteTShardBalancerTest::TTestCaseShouldBalanceShardsWeightedRandom::Execute_(NUnitTest::TTestContext&)+6823 (0x162AB87)
NCloud::NFileStore::NStorage::NTestSuiteTShardBalancerTest::TCurrentTest::Execute()::'lambda'()::operator()() const+70 (0x16311A6)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char> > const&, char const*, bool)+124 (0x17AF51C)
NCloud::NFileStore::NStorage::NTestSuiteTShardBalancerTest::TCurrentTest::Execute()+417 (0x1630B01)
NUnitTest::TTestFactory::Execute()+784 (0x17AFC40)
NUnitTest::RunMain(int, char**)+3021 (0x17BDC4D)
??+0 (0x7F5291910D90)
__libc_start_main+128 (0x7F5291910E40)
??+0 (0x1443029)
[[rst]]
```