### PR TITLE
issue-3295: do not enable `GCT_SECOND_READ` guest caching policy by default

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -269,7 +269,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(GuestKeepCacheAllowed,                     bool,      false           )\
     xxx(GuestCachingType,                                                      \
         NProto::EGuestCachingType,                                             \
-        NProto::GCT_SECOND_READ                                               )\
+        NProto::GCT_NONE                                                      )\
     xxx(SessionHandleOffloadedStatsCapacity,       ui64,      0               )\
 // FILESTORE_STORAGE_CONFIG
 


### PR DESCRIPTION
Accidentally, this policy was enabled by default due to the backward compatibility concerns:

https://github.com/ydb-platform/nbs/blob/2d4fa644857b0da0f94929f0d511d5cc766acfec/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp#L391-L393