### PR TITLE
issue-3493: stabilize and unmute `ShouldBalanceShardsRandom` and `ShouldBalanceShardsWeightedRandom` tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -2,5 +2,3 @@ cloud/filestore/tests/fio_index/mount-kikimr-test *
 cloud/filestore/tests/fio_index/mount-local-test *
 cloud/disk_manager/internal/pkg/facade/filesystem_service_nemesis_test filesystem_service_nemesis_test.TestFilesystemServiceCreateExternalFilesystem
 cloud/filestore/libs/storage/service/ut TStorageServiceShardingTest.ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShardsWithShardIdSelectionInLeader
-cloud/filestore/libs/storage/tablet/model/ut TShardBalancerTest.ShouldBalanceShardsRandom
-cloud/filestore/libs/storage/tablet/model/ut TShardBalancerTest.ShouldBalanceShardsWeightedRandom

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -183,8 +183,8 @@ NProto::TError TShardBalancerWeightedRandom::SelectShard(
     const auto randomValue = RandomNumber<ui64>(totalFreeSpace);
 
     // For array [5, 3] the prefix sums will be [0, 5, 8]
-    // random value in range [0, 5) will produce lower bound 1
-    // random value in range [5, 8) will produce lower bound 2
+    // random value in range [0, 5) will produce upper bound 1
+    // random value in range [5, 8) will produce upper bound 2
     auto* it = UpperBound(
         WeightPrefixSums.begin(),
         WeightPrefixSums.end(),

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -185,7 +185,7 @@ NProto::TError TShardBalancerWeightedRandom::SelectShard(
     // For array [5, 3] the prefix sums will be [0, 5, 8]
     // random value in range [0, 5) will produce lower bound 1
     // random value in range [5, 8) will produce lower bound 2
-    auto* it = LowerBound(
+    auto* it = UpperBound(
         WeightPrefixSums.begin(),
         WeightPrefixSums.end(),
         randomValue);


### PR DESCRIPTION
#3493 

1. This code will fail if randomValue is zero: https://github.com/ydb-platform/nbs/blob/ff695720198806609d8e769f60c8d33374da534a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp#L192

We should have been using UpperBound instead of LowerBound

2. Range toleration in tests has been increased twice to ensure the probability of false negative test failure is closer to zero. Compare: [x=100](https://www.wolframalpha.com/input?i=erf%28%28x+%2B+0.5%29+%2F+sqrt%282+*+5000+*+1%2F2+*+1%2F2%29%29+at+x+%3D+100) and [x=200](https://www.wolframalpha.com/input?i=erf%28%28x+%2B+0.5%29+%2F+sqrt%282+*+5000+*+1%2F2+*+1%2F2%29%29+at+x+%3D+200)