### PR TITLE
The contrib/ydb/public/sdk/cpp/client was removed from implicit dependencies through nested #include

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -16,7 +16,6 @@
 #include <cloud/blockstore/libs/discovery/healthcheck.h>
 #include <cloud/blockstore/libs/discovery/ping.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_events.h>
-#include <cloud/blockstore/libs/rdma/fake/client.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kms/iface/compute_client.h>
 #include <cloud/blockstore/libs/kms/iface/key_provider.h>
@@ -26,9 +25,10 @@
 #include <cloud/blockstore/libs/notify/config.h>
 #include <cloud/blockstore/libs/notify/notify.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
-#include <cloud/blockstore/libs/rdma/iface/probes.h>
+#include <cloud/blockstore/libs/rdma/fake/client.h>
 #include <cloud/blockstore/libs/rdma/iface/client.h>
 #include <cloud/blockstore/libs/rdma/iface/config.h>
+#include <cloud/blockstore/libs/rdma/iface/probes.h>
 #include <cloud/blockstore/libs/rdma/iface/server.h>
 #include <cloud/blockstore/libs/root_kms/iface/client.h>
 #include <cloud/blockstore/libs/root_kms/iface/key_provider.h>
@@ -40,11 +40,10 @@
 #include <cloud/blockstore/libs/service_local/storage_aio.h>
 #include <cloud/blockstore/libs/service_local/storage_null.h>
 #include <cloud/blockstore/libs/spdk/iface/env.h>
-#include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/manually_preempted_volumes.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
 #include <cloud/blockstore/libs/storage/init/server/actorsystem.h>
-#include <cloud/blockstore/libs/ydbstats/ydbscheme.h>
 #include <cloud/blockstore/libs/ydbstats/ydbstats.h>
 #include <cloud/blockstore/libs/ydbstats/ydbstorage.h>
 
@@ -60,8 +59,8 @@
 #include <cloud/storage/core/libs/iam/iface/client.h>
 #include <cloud/storage/core/libs/iam/iface/config.h>
 #include <cloud/storage/core/libs/kikimr/actorsystem.h>
-#include <cloud/storage/core/libs/kikimr/node_registration_settings.h>
 #include <cloud/storage/core/libs/kikimr/node.h>
+#include <cloud/storage/core/libs/kikimr/node_registration_settings.h>
 #include <cloud/storage/core/libs/kikimr/proxy.h>
 
 #include <contrib/ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
@@ -524,12 +523,8 @@ void TBootstrapYdb::InitKikimrService()
             logging,
             YdbStorage,
             NYdbStats::TYDBTableSchemes(
-                NYdbStats::CreateStatsTableScheme(statsConfig->GetStatsTableTtl()),
-                NYdbStats::CreateHistoryTableScheme(),
-                NYdbStats::CreateArchiveStatsTableScheme(statsConfig->GetArchiveStatsTableTtl()),
-                NYdbStats::CreateBlobLoadMetricsTableScheme(),
-                NYdbStats::CreateGroupsTableScheme(),
-                NYdbStats::CreatePartitionsTableScheme()));
+                statsConfig->GetStatsTableTtl(),
+                statsConfig->GetArchiveStatsTableTtl()));
     } else {
         StatsUploader = NYdbStats::CreateVolumesStatsUploaderStub();
     }

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -4,7 +4,7 @@
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
-#include <cloud/blockstore/libs/ydbstats/ydbstats.h>
+
 #include <cloud/storage/core/libs/diagnostics/histogram.h>
 #include <cloud/storage/core/libs/diagnostics/weighted_percentile.h>
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -1,28 +1,25 @@
 #include <cloud/blockstore/config/diagnostics.pb.h>
-
+#include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
-#include <cloud/blockstore/libs/diagnostics/config.h>
-
-#include <library/cpp/testing/unittest/registar.h>
-
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
-#include <cloud/blockstore/libs/storage/stats_service/stats_service_events_private.h>
-#include <cloud/blockstore/libs/storage/stats_service/stats_service.h>
-
 #include <cloud/blockstore/libs/storage/core/config.h>
-#include <cloud/blockstore/libs/storage/testlib/test_runtime.h>
-#include <cloud/blockstore/libs/ydbstats/ydbstats.h>
-
 #include <cloud/blockstore/libs/storage/service/service_events_private.h>
+#include <cloud/blockstore/libs/storage/stats_service/stats_service.h>
+#include <cloud/blockstore/libs/storage/stats_service/stats_service_events_private.h>
+#include <cloud/blockstore/libs/storage/testlib/test_runtime.h>
+#include <cloud/blockstore/libs/ydbstats/ydbrow.h>
+#include <cloud/blockstore/libs/ydbstats/ydbstats.h>
 
 #include <cloud/storage/core/config/features.pb.h>
 
-#include <util/generic/size_literals.h>
-#include <util/string/printf.h>
+#include <library/cpp/testing/unittest/registar.h>
+
 #include <util/datetime/base.h>
+#include <util/generic/size_literals.h>
 #include <util/generic/string.h>
+#include <util/string/printf.h>
 
 namespace NCloud::NBlockStore::NStorage {
 

--- a/cloud/blockstore/libs/ydbstats/public.h
+++ b/cloud/blockstore/libs/ydbstats/public.h
@@ -12,6 +12,8 @@ namespace NYdbStats {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TYdbRowData;
+
 struct IYdbVolumesStatsUploader;
 using IYdbVolumesStatsUploaderPtr = std::shared_ptr<IYdbVolumesStatsUploader>;
 

--- a/cloud/blockstore/libs/ydbstats/ya.make
+++ b/cloud/blockstore/libs/ydbstats/ya.make
@@ -2,8 +2,8 @@ LIBRARY()
 
 SRCS(
     config.cpp
-    ydbrow.cpp
     ydbauth.cpp
+    ydbrow.cpp
     ydbscheme.cpp
     ydbstats.cpp
     ydbstorage.cpp

--- a/cloud/blockstore/libs/ydbstats/ydbscheme.h
+++ b/cloud/blockstore/libs/ydbstats/ydbscheme.h
@@ -114,29 +114,4 @@ TStatsTableSchemePtr CreateBlobLoadMetricsTableScheme();
 TStatsTableSchemePtr CreateGroupsTableScheme();
 TStatsTableSchemePtr CreatePartitionsTableScheme();
 
-struct TYDBTableSchemes
-{
-    TStatsTableSchemePtr Stats;
-    TStatsTableSchemePtr History;
-    TStatsTableSchemePtr Archive;
-    TStatsTableSchemePtr Metrics;
-    TStatsTableSchemePtr Groups;
-    TStatsTableSchemePtr Partitions;
-
-    TYDBTableSchemes(
-            TStatsTableSchemePtr stats,
-            TStatsTableSchemePtr history,
-            TStatsTableSchemePtr archive,
-            TStatsTableSchemePtr metrics,
-            TStatsTableSchemePtr groups,
-            TStatsTableSchemePtr partitions)
-        : Stats(std::move(stats))
-        , History(std::move(history))
-        , Archive(std::move(archive))
-        , Metrics(std::move(metrics))
-        , Groups(std::move(groups))
-        , Partitions(std::move(partitions))
-    {}
-};
-
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/ydbstats.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.cpp
@@ -69,6 +69,18 @@ struct TSetupTableResult
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TYDBTableNames
+{
+    TString Stats;
+    TString History;
+    TString Archive;
+    TString Metrics;
+    TString Groups;
+    TString Partitions;
+
+    TYDBTableNames() = default;
+};
+
 struct TSetupTablesResult
 {
     const NProto::TError Error;
@@ -948,6 +960,32 @@ public:
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
+
+TYDBTableSchemes::TYDBTableSchemes(
+        TStatsTableSchemePtr stats,
+        TStatsTableSchemePtr history,
+        TStatsTableSchemePtr archive,
+        TStatsTableSchemePtr metrics,
+        TStatsTableSchemePtr groups,
+        TStatsTableSchemePtr partitions)
+    : Stats(std::move(stats))
+    , History(std::move(history))
+    , Archive(std::move(archive))
+    , Metrics(std::move(metrics))
+    , Groups(std::move(groups))
+    , Partitions(std::move(partitions))
+{}
+
+TYDBTableSchemes::TYDBTableSchemes(TDuration statsTtl, TDuration archiveTtl)
+    : Stats(CreateStatsTableScheme(statsTtl))
+    , History(CreateHistoryTableScheme())
+    , Archive(CreateArchiveStatsTableScheme(archiveTtl))
+    , Metrics(CreateBlobLoadMetricsTableScheme())
+    , Groups(CreateGroupsTableScheme())
+    , Partitions(CreatePartitionsTableScheme())
+{}
+
+TYDBTableSchemes::~TYDBTableSchemes() = default;
 
 IYdbVolumesStatsUploaderPtr CreateYdbVolumesStatsUploader(
     TYdbStatsConfigPtr config,

--- a/cloud/blockstore/libs/ydbstats/ydbstats.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "public.h"
-#include "ydbrow.h"
-#include "ydbscheme.h"
+
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/startable.h>
+#include <cloud/storage/core/libs/iam/iface/public.h>
 
 #include <library/cpp/threading/future/future.h>
 
@@ -17,6 +18,26 @@
 namespace NCloud::NBlockStore::NYdbStats {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+struct TYDBTableSchemes
+{
+    TStatsTableSchemePtr Stats;
+    TStatsTableSchemePtr History;
+    TStatsTableSchemePtr Archive;
+    TStatsTableSchemePtr Metrics;
+    TStatsTableSchemePtr Groups;
+    TStatsTableSchemePtr Partitions;
+
+    TYDBTableSchemes(
+        TStatsTableSchemePtr stats,
+        TStatsTableSchemePtr history,
+        TStatsTableSchemePtr archive,
+        TStatsTableSchemePtr metrics,
+        TStatsTableSchemePtr groups,
+        TStatsTableSchemePtr partitions);
+    TYDBTableSchemes(TDuration statsTtl, TDuration archiveTtl);
+    ~TYDBTableSchemes();
+};
 
 struct IYdbVolumesStatsUploader
     : public IStartable
@@ -29,6 +50,11 @@ struct IYdbVolumesStatsUploader
 
 ////////////////////////////////////////////////////////////////////////////////
 
+IYdbStoragePtr CreateYdbStorage(
+    TYdbStatsConfigPtr config,
+    ILoggingServicePtr logging,
+    NIamClient::IIamTokenClientPtr tokenProvider);
+
 IYdbVolumesStatsUploaderPtr CreateYdbVolumesStatsUploader(
     TYdbStatsConfigPtr config,
     ILoggingServicePtr logging,
@@ -40,15 +66,3 @@ IYdbVolumesStatsUploaderPtr CreateVolumesStatsUploaderStub();
 }   // namespace NCloud::NBlockStore::NYdbStats
 
 ////////////////////////////////////////////////////////////////////////////////
-
-struct TYDBTableNames
-{
-    TString Stats;
-    TString History;
-    TString Archive;
-    TString Metrics;
-    TString Groups;
-    TString Partitions;
-
-    TYDBTableNames() = default;
-};

--- a/cloud/blockstore/libs/ydbstats/ydbstorage.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstorage.cpp
@@ -2,7 +2,6 @@
 
 #include "config.h"
 #include "ydbauth.h"
-#include "ydbstats.h"
 
 #include <cloud/blockstore/libs/kikimr/events.h>
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/blockstore/libs/ydbstats/ydbstorage.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstorage.h
@@ -89,9 +89,4 @@ struct IYdbStorage
     virtual NThreading::TFuture<TGetTablesResponse> GetHistoryTables() = 0;
 };
 
-IYdbStoragePtr CreateYdbStorage(
-    TYdbStatsConfigPtr config,
-    ILoggingServicePtr logging,
-    NIamClient::IIamTokenClientPtr tokenProvider);
-
 }   // namespace NCloud::NBlockStore::NYdbStats


### PR DESCRIPTION
Перегруппировал зависимости  так, чтобы те кто инклюдят из `cloud/blockstore/libs/ydbstats` не подключали (явно или неявно) `cloud/blockstore/libs/ydbstats/ydbscheme.h` потому что он подключает в себя `contrib/ydb/public/sdk/cpp/client`, а эта зависимость может вызывает совершенно неожиданные неоднозначности разрешения имен. 
```
In file included from $(SOURCE_ROOT)/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp:47:
$(SOURCE_ROOT)/cloud/blockstore/libs/ydbstats/ydbscheme.h:24:24: error: reference to 'NTable' is ambiguous
   24 |     const TMaybe<NYdb::NTable::TTtlSettings> Ttl;
      |                  ~~~~~~^
$(SOURCE_ROOT)/contrib/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h:14:28: note: candidate found by name lookup is 'NYdb::V3::NTable'
   14 | namespace NYdb::inline V3::NTable {
      |                            ^
$(SOURCE_ROOT)/contrib/ydb/public/sdk/cpp/client/ydb_table/table.h:60:11: note: candidate found by name lookup is 'NYdb::V2::NTable'
   60 | namespace NTable {
      |           ^
```