### PR TITLE
The contrib/ydb/public/sdk/cpp/client was removed from implicit dependencies through nested #include (#2)

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -45,7 +45,6 @@
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
 #include <cloud/blockstore/libs/storage/init/server/actorsystem.h>
 #include <cloud/blockstore/libs/ydbstats/ydbstats.h>
-#include <cloud/blockstore/libs/ydbstats/ydbstorage.h>
 
 #include <cloud/storage/core/libs/actors/helpers.h>
 #include <cloud/storage/core/libs/aio/service.h>
@@ -293,7 +292,7 @@ IStartable* TBootstrapYdb::GetAsyncLogger()        { return AsyncLogger.get(); }
 IStartable* TBootstrapYdb::GetStatsAggregator()    { return StatsAggregator.get(); }
 IStartable* TBootstrapYdb::GetClientPercentiles()  { return ClientPercentiles.get(); }
 IStartable* TBootstrapYdb::GetStatsUploader()      { return StatsUploader.get(); }
-IStartable* TBootstrapYdb::GetYdbStorage()         { return YdbStorage.get(); }
+IStartable* TBootstrapYdb::GetYdbStorage()         { return AsStartable(YdbStorage); }
 IStartable* TBootstrapYdb::GetTraceSerializer()    { return TraceSerializer.get(); }
 IStartable* TBootstrapYdb::GetLogbrokerService()   { return LogbrokerService.get(); }
 IStartable* TBootstrapYdb::GetNotifyService()      { return NotifyService.get(); }

--- a/cloud/blockstore/libs/ydbstats/ydbstats.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.cpp
@@ -987,6 +987,11 @@ TYDBTableSchemes::TYDBTableSchemes(TDuration statsTtl, TDuration archiveTtl)
 
 TYDBTableSchemes::~TYDBTableSchemes() = default;
 
+IStartable* AsStartable(IYdbStoragePtr storagePtr)
+{
+    return storagePtr.get();
+}
+
 IYdbVolumesStatsUploaderPtr CreateYdbVolumesStatsUploader(
     TYdbStatsConfigPtr config,
     ILoggingServicePtr logging,

--- a/cloud/blockstore/libs/ydbstats/ydbstats.h
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.h
@@ -2,7 +2,6 @@
 
 #include "public.h"
 
-
 #include <cloud/blockstore/libs/diagnostics/public.h>
 
 #include <cloud/storage/core/libs/common/error.h>
@@ -54,6 +53,8 @@ IYdbStoragePtr CreateYdbStorage(
     TYdbStatsConfigPtr config,
     ILoggingServicePtr logging,
     NIamClient::IIamTokenClientPtr tokenProvider);
+
+IStartable* AsStartable(IYdbStoragePtr storagePtr);
 
 IYdbVolumesStatsUploaderPtr CreateYdbVolumesStatsUploader(
     TYdbStatsConfigPtr config,


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/pull/3557

Через `#include <cloud/blockstore/libs/ydbstats/ydbstorage.h>`
тоже пролезала зависимость. 
Убрал использование этого инклюда.