### PR TITLE
Enable logging to file for server component (`BackendFileName` option)

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -202,13 +202,7 @@ void TBootstrapBase::ParseOptions(int argc, char** argv)
 
 void TBootstrapBase::Init()
 {
-    TLogSettings logSettings;
-    logSettings.BackendFileName = Configs->GetLogBackendFileName();
-
-    BootstrapLogging = CreateLoggingService("console", logSettings);
-    Log = BootstrapLogging->CreateLog("BLOCKSTORE_SERVER");
-    SetCriticalEventsLog(Log);
-    Configs->Log = Log;
+    InitLogs();
     STORAGE_INFO("NBS server version: " << GetFullVersionString());
 
     Timer = CreateWallClockTimer();
@@ -701,6 +695,17 @@ void TBootstrapBase::InitProfileLog()
     } else {
         ProfileLog = CreateProfileLogStub();
     }
+}
+
+void TBootstrapBase::InitLogs()
+{
+    TLogSettings logSettings;
+    logSettings.BackendFileName = Configs->GetLogBackendFileName();
+
+    BootstrapLogging = CreateLoggingService("console", logSettings);
+    Log = BootstrapLogging->CreateLog("BLOCKSTORE_SERVER");
+    SetCriticalEventsLog(Log);
+    Configs->Log = Log;
 }
 
 void TBootstrapBase::InitDbgConfigs()

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -202,7 +202,10 @@ void TBootstrapBase::ParseOptions(int argc, char** argv)
 
 void TBootstrapBase::Init()
 {
-    BootstrapLogging = CreateLoggingService("console", TLogSettings{});
+    TLogSettings logSettings;
+    logSettings.BackendFileName = Configs->GetLogBackendFileName();
+
+    BootstrapLogging = CreateLoggingService("console", logSettings);
     Log = BootstrapLogging->CreateLog("BLOCKSTORE_SERVER");
     SetCriticalEventsLog(Log);
     Configs->Log = Log;
@@ -717,6 +720,7 @@ void TBootstrapBase::InitDbgConfigs()
     TLogSettings logSettings;
     logSettings.FiltrationLevel =
         static_cast<ELogPriority>(Configs->GetLogDefaultLevel());
+    logSettings.BackendFileName = Configs->GetLogBackendFileName();
 
     Logging = CreateLoggingService("console", logSettings);
 

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -124,6 +124,7 @@ protected:
 
     void InitLWTrace();
     void InitProfileLog();
+    void InitLogs();
 
 private:
     void InitLocalService();

--- a/cloud/blockstore/libs/daemon/local/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/local/config_initializer.cpp
@@ -52,4 +52,10 @@ TDuration TConfigInitializerLocal::GetInactiveClientsTimeout() const
     return TDuration::Max();
 }
 
+TString TConfigInitializerLocal::GetLogBackendFileName() const
+{
+    return "";
+}
+
+
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/daemon/local/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/local/config_initializer.h
@@ -21,6 +21,7 @@ struct TConfigInitializerLocal final
     ui32 GetMonitoringThreads() const override;
     bool GetUseNonreplicatedRdmaActor() const override;
     TDuration GetInactiveClientsTimeout() const override;
+    TString GetLogBackendFileName() const override;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -256,7 +256,10 @@ void TBootstrap::InitHTTPServer()
 
 void TBootstrap::Init()
 {
-    BootstrapLogging = CreateLoggingService("console", TLogSettings{});
+    TLogSettings logSettings;
+    logSettings.BackendFileName = Configs->GetLogConfig().GetBackendFileName();
+
+    BootstrapLogging = CreateLoggingService("console", logSettings);
     Log = BootstrapLogging->CreateLog("BLOCKSTORE_SERVER");
     STORAGE_INFO("NBS server version: " << GetFullVersionString());
 

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -68,7 +68,10 @@ TBootstrapCommon::TBootstrapCommon(
     , ModuleFactories(std::move(moduleFactories))
     , UserCounters(std::move(userCounters))
 {
-    BootstrapLogging = CreateLoggingService("console", TLogSettings{});
+    TLogSettings logSettings;
+    logSettings.BackendFileName = Configs->GetLogBackendFileName();
+
+    BootstrapLogging = CreateLoggingService("console", logSettings);
     BootstrapLogging->Start();
 
     Log = BootstrapLogging->CreateLog(logComponent);
@@ -204,6 +207,7 @@ void TBootstrapCommon::InitDiagnostics()
 {
     if (!ActorSystem) {
         TLogSettings logSettings;
+        logSettings.BackendFileName = Configs->GetLogBackendFileName();
 
         if (Configs->Options->VerboseLevel) {
             auto level = GetLogLevel(Configs->Options->VerboseLevel);

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -65,17 +65,10 @@ TBootstrapCommon::TBootstrapCommon(
         TString metricsComponent,
         std::shared_ptr<NUserStats::IUserCounterSupplier> userCounters)
     : MetricsComponent(std::move(metricsComponent))
+    , LogComponent(std::move(logComponent))
     , ModuleFactories(std::move(moduleFactories))
     , UserCounters(std::move(userCounters))
 {
-    TLogSettings logSettings;
-    logSettings.BackendFileName = Configs->GetLogBackendFileName();
-
-    BootstrapLogging = CreateLoggingService("console", logSettings);
-    BootstrapLogging->Start();
-
-    Log = BootstrapLogging->CreateLog(logComponent);
-    SetCriticalEventsLog(Log);
 }
 
 TBootstrapCommon::~TBootstrapCommon()
@@ -153,6 +146,7 @@ void TBootstrapCommon::ParseOptions(int argc, char** argv)
 void TBootstrapCommon::Init()
 {
     InitCommonConfigs();
+    InitLogs();
 
     Timer = CreateWallClockTimer();
     Scheduler = CreateScheduler();
@@ -309,6 +303,18 @@ void TBootstrapCommon::InitActorSystem()
 
     monitoring->Init(ActorSystem);
     Monitoring = monitoring;
+}
+
+void TBootstrapCommon::InitLogs()
+{
+    TLogSettings logSettings;
+    logSettings.BackendFileName = Configs->GetLogBackendFileName();
+
+    BootstrapLogging = CreateLoggingService("console", logSettings);
+    BootstrapLogging->Start();
+
+    Log = BootstrapLogging->CreateLog(LogComponent);
+    SetCriticalEventsLog(Log);
 }
 
 void TBootstrapCommon::RegisterServer(IServerPtr server)

--- a/cloud/filestore/libs/daemon/common/bootstrap.h
+++ b/cloud/filestore/libs/daemon/common/bootstrap.h
@@ -48,6 +48,7 @@ class TBootstrapCommon
 {
 private:
     const TString MetricsComponent;
+    const TString LogComponent;
 
     std::shared_ptr<NKikimr::TModuleFactories> ModuleFactories;
 
@@ -109,6 +110,7 @@ private:
     void InitCommonConfigs();
     void InitActorSystem();
     void InitDiagnostics();
+    void InitLogs();
 };
 
 } // namespace NCloud::NFileStore::NDaemon

--- a/cloud/storage/core/libs/daemon/config_initializer.h
+++ b/cloud/storage/core/libs/daemon/config_initializer.h
@@ -16,6 +16,7 @@ struct TConfigInitializerBase
     virtual ui32 GetMonitoringPort() const = 0;
     virtual TString GetMonitoringAddress() const = 0;
     virtual ui32 GetMonitoringThreads() const = 0;
+    virtual TString GetLogBackendFileName() const = 0;
 };
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/logging.cpp
+++ b/cloud/storage/core/libs/diagnostics/logging.cpp
@@ -6,6 +6,7 @@
 #include <logbroker/unified_agent/client/cpp/logger/backend.h>
 #include <logbroker/unified_agent/common/util/enum.h>
 
+#include <contrib/ydb/library/actors/core/log.h>
 #include <contrib/ydb/library/actors/prof/tag.h>
 
 #include <util/datetime/base.h>
@@ -362,6 +363,12 @@ ILoggingServicePtr CreateLoggingService(
     const TLogSettings& logSettings)
 {
     auto backend = CreateLogBackend(logName);
+
+    if (backend && logSettings.BackendFileName) {
+        backend = NActors::CreateCompositeLogBackend(
+            {backend, new TFileLogBackend(logSettings.BackendFileName)});
+    }
+
     return std::make_shared<TLoggingService>(
         std::shared_ptr<TLogBackend>(backend.Release()),
         logSettings);

--- a/cloud/storage/core/libs/diagnostics/logging.h
+++ b/cloud/storage/core/libs/diagnostics/logging.h
@@ -23,7 +23,7 @@ struct TLogSettings
     ELogPriority FiltrationLevel = TLOG_INFO;
     bool UseLocalTimestamps = false;
     bool SuppressNewLine = false;
-    TString BackendFileName;
+    TString BackendFileName = "";
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/diagnostics/logging.h
+++ b/cloud/storage/core/libs/diagnostics/logging.h
@@ -23,6 +23,7 @@ struct TLogSettings
     ELogPriority FiltrationLevel = TLOG_INFO;
     bool UseLocalTimestamps = false;
     bool SuppressNewLine = false;
+    TString BackendFileName;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/diagnostics/ya.make
+++ b/cloud/storage/core/libs/diagnostics/ya.make
@@ -32,6 +32,7 @@ PEERDIR(
 
     library/cpp/lwtrace/mon
 
+    contrib/ydb/library/actors/core
     contrib/ydb/library/actors/prof
     library/cpp/containers/ring_buffer
     library/cpp/deprecated/atomic

--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -292,4 +292,9 @@ ui32 TConfigInitializerYdbBase::GetMonitoringThreads() const
     return GetMonitoringConfig().GetMonitoringThreads();
 }
 
+TString TConfigInitializerYdbBase::GetLogBackendFileName() const
+{
+    return GetLogConfig().GetBackendFileName();
+}
+
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/kikimr/config_initializer.h
+++ b/cloud/storage/core/libs/kikimr/config_initializer.h
@@ -34,6 +34,7 @@ struct TConfigInitializerYdbBase
     ui32 GetMonitoringPort() const override;
     TString GetMonitoringAddress() const override;
     ui32 GetMonitoringThreads() const override;
+    TString GetLogBackendFileName() const override;
 
     virtual void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config) = 0;
 


### PR DESCRIPTION
This PR enables support of `BackendFileName` option for server component. 

As for now, server component use its own logging service that only write to console. For actor components `BackendFileName` option is already working (it is parsed here https://github.com/ydb-platform/nbs/blob/main/contrib/ydb/core/log_backend/log_backend_build.cpp#L12-L14)