### PR TITLE
Log first request execution time and offset from volume creation

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
@@ -190,7 +190,7 @@ void TRequestsTimeTracker::OnRequestStarted(
             .RequestType = requestType});
 }
 
-TString TRequestsTimeTracker::CalcRequestFirstTime(
+TString TRequestsTimeTracker::MakeRequestFirstTimeSucceedMessage(
     const TRequestInflight& request,
     bool success,
     ui64 finishTime)
@@ -251,7 +251,7 @@ TString TRequestsTimeTracker::OnRequestFinished(
     Histograms[key].Increment(duration.MicroSeconds());
     Histograms[key].BlockCount += request.BlockRange.Size();
 
-    return CalcRequestFirstTime(request, success, finishTime);
+    return MakeRequestFirstTimeSucceedMessage(request, success, finishTime);
 }
 
 NJson::TJsonValue TRequestsTimeTracker::BuildPercentilesJson() const

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
@@ -7,6 +7,7 @@
 
 #include <util/datetime/cputimer.h>
 #include <util/string/builder.h>
+
 #include <span>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -152,7 +153,8 @@ bool TRequestsTimeTracker::TEqual::operator()(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TRequestsTimeTracker::TRequestsTimeTracker()
+TRequestsTimeTracker::TRequestsTimeTracker(const ui64 constructionTime)
+    : ConstructionTime(constructionTime)
 {
     for (size_t sizeBucket = 0; sizeBucket <= TotalSizeBucket; ++sizeBucket) {
         for (size_t requestType = 0;
@@ -174,6 +176,12 @@ void TRequestsTimeTracker::OnRequestStarted(
     TBlockRange64 blockRange,
     ui64 startTime)
 {
+    const auto requestTypeIndex = static_cast<size_t>(requestType);
+    auto& firstRequest = FirstRequests[requestTypeIndex];
+    if (firstRequest.StartTime == 0) {
+        firstRequest.StartTime = startTime;
+    }
+
     InflightRequests.emplace(
         requestId,
         TRequestInflight{
@@ -182,7 +190,39 @@ void TRequestsTimeTracker::OnRequestStarted(
             .RequestType = requestType});
 }
 
-void TRequestsTimeTracker::OnRequestFinished(
+TString TRequestsTimeTracker::CalcRequestFirstTime(
+    const TRequestInflight& request,
+    bool success,
+    ui64 finishTime)
+{
+    const auto requestTypeIndex = static_cast<size_t>(request.RequestType);
+    auto& firstRequest = FirstRequests[requestTypeIndex];
+    if (firstRequest.FinishTime != 0) {
+        return {};
+    }
+
+    if (!success) {
+        ++firstRequest.FailCount;
+        return {};
+    }
+
+    firstRequest.FinishTime = finishTime;
+
+    auto formatDuration = [&](ui64 finish)
+    {
+        return FormatDuration(CyclesToDurationSafe(finish - ConstructionTime));
+    };
+
+    return TStringBuilder()
+           << "The first successful " << ToString(request.RequestType)
+           << " request was started at " << formatDuration(request.StartTime)
+           << " finished at " << formatDuration(finishTime) << "."
+           << " The very first request was started at "
+           << formatDuration(firstRequest.StartTime)
+           << ", Failed requests: " << firstRequest.FailCount;
+}
+
+TString TRequestsTimeTracker::OnRequestFinished(
     ui64 requestId,
     bool success,
     ui64 finishTime)
@@ -191,7 +231,7 @@ void TRequestsTimeTracker::OnRequestFinished(
     {
         auto it = InflightRequests.find(requestId);
         if (it == InflightRequests.end()) {
-            return;
+            return {};
         }
         request = it->second;
         InflightRequests.erase(requestId);
@@ -210,6 +250,8 @@ void TRequestsTimeTracker::OnRequestFinished(
     key.SizeBucket = TotalSizeBucket;
     Histograms[key].Increment(duration.MicroSeconds());
     Histograms[key].BlockCount += request.BlockRange.Size();
+
+    return CalcRequestFirstTime(request, success, finishTime);
 }
 
 NJson::TJsonValue TRequestsTimeTracker::BuildPercentilesJson() const

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.cpp
@@ -191,7 +191,7 @@ void TRequestsTimeTracker::OnRequestStarted(
 }
 
 std::optional<TRequestsTimeTracker::TFirstSuccessStat>
-TRequestsTimeTracker::MakeRequestFirstTimeSucceedMessage(
+TRequestsTimeTracker::StatFirstSuccess(
     const TRequestInflight& request,
     bool success,
     ui64 finishTime)
@@ -250,7 +250,7 @@ TRequestsTimeTracker::OnRequestFinished(
     Histograms[key].Increment(duration.MicroSeconds());
     Histograms[key].BlockCount += request.BlockRange.Size();
 
-    return MakeRequestFirstTimeSucceedMessage(request, success, finishTime);
+    return StatFirstSuccess(request, success, finishTime);
 }
 
 NJson::TJsonValue TRequestsTimeTracker::BuildPercentilesJson() const

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -27,6 +27,13 @@ public:
         Last = Describe,
     };
 
+    enum class ERequestStatus
+    {
+        Inflight,
+        Success,
+        Fail,
+    };
+
     struct TBucketInfo
     {
         TString Key;
@@ -34,11 +41,13 @@ public:
         TString Tooltip;
     };
 
-    enum class ERequestStatus
+    struct TFirstSuccessStat
     {
-        Inflight,
-        Success,
-        Fail,
+        ERequestType RequestType = ERequestType::Read;
+        TDuration FirstRequestStartTime;
+        TDuration SuccessfulRequestStartTime;
+        TDuration SuccessfulRequestFinishTime;
+        size_t FailCount = 0;
     };
 
 private:
@@ -96,7 +105,8 @@ private:
 
     [[nodiscard]] NJson::TJsonValue BuildPercentilesJson() const;
 
-    [[nodiscard]] TString MakeRequestFirstTimeSucceedMessage(
+    [[nodiscard]] std::optional<TRequestsTimeTracker::TFirstSuccessStat>
+    MakeRequestFirstTimeSucceedMessage(
         const TRequestInflight& request,
         bool success,
         ui64 finishTime);
@@ -114,9 +124,9 @@ public:
         TBlockRange64 blockRange,
         ui64 startTime);
 
-    // Marks that the request is completed and returns a logging message when
-    // the request succeeds for the first time.
-    [[nodiscard]] TString
+    // Marks that the request is completed and returns stat when the request
+    // succeeds for the first time.
+    [[nodiscard]] std::optional<TFirstSuccessStat>
     OnRequestFinished(ui64 requestId, bool success, ui64 finishTime);
 
     [[nodiscard]] TString GetStatJson(ui64 nowCycles, ui32 blockSize) const;

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -96,7 +96,7 @@ private:
 
     [[nodiscard]] NJson::TJsonValue BuildPercentilesJson() const;
 
-    [[nodiscard]] TString CalcRequestFirstTime(
+    [[nodiscard]] TString MakeRequestFirstTimeSucceedMessage(
         const TRequestInflight& request,
         bool success,
         ui64 finishTime);
@@ -114,6 +114,8 @@ public:
         TBlockRange64 blockRange,
         ui64 startTime);
 
+    // Marks that the request is completed and returns a logging message when
+    // the request succeeds for the first time.
     [[nodiscard]] TString
     OnRequestFinished(ui64 requestId, bool success, ui64 finishTime);
 

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -106,7 +106,7 @@ private:
     [[nodiscard]] NJson::TJsonValue BuildPercentilesJson() const;
 
     [[nodiscard]] std::optional<TRequestsTimeTracker::TFirstSuccessStat>
-    MakeRequestFirstTimeSucceedMessage(
+    StatFirstSuccess(
         const TRequestInflight& request,
         bool success,
         ui64 finishTime);

--- a/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
+++ b/cloud/blockstore/libs/storage/volume/model/requests_time_tracker.h
@@ -42,6 +42,9 @@ public:
     };
 
 private:
+    constexpr static size_t RequestTypeCount =
+        static_cast<size_t>(ERequestType::Last) + 1;
+
     struct TTimeHistogram: public THistogram<TRequestUsTimeBuckets>
     {
         size_t BlockCount = 0;
@@ -87,8 +90,7 @@ private:
 
     const ui64 ConstructionTime;
 
-    std::array<TFirstRequest, static_cast<size_t>(ERequestType::Last)>
-        FirstRequests;
+    std::array<TFirstRequest, RequestTypeCount> FirstRequests;
     THashMap<ui64, TRequestInflight> InflightRequests;
     THashMap<TKey, TTimeHistogram, THash, TEqual> Histograms;
 

--- a/cloud/blockstore/libs/storage/volume/model/ya.make
+++ b/cloud/blockstore/libs/storage/volume/model/ya.make
@@ -4,6 +4,7 @@ LIBRARY()
 
 GENERATE_ENUM_SERIALIZATION(checkpoint.h)
 GENERATE_ENUM_SERIALIZATION(follower_disk.h)
+GENERATE_ENUM_SERIALIZATION(requests_time_tracker.h)
 
 SRCS(
     checkpoint.cpp

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -305,7 +305,8 @@ private:
 
     TVolumeRequestMap VolumeRequests;
     TRequestsInFlight WriteAndZeroRequestsInFlight;
-    TRequestsTimeTracker RequestTimeTracker;
+
+    TRequestsTimeTracker RequestTimeTracker{GetCycleCount()};
     TTransactionTimeTracker TransactionTimeTracker;
 
     // inflight VolumeRequestId -> duplicate request queue

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -480,10 +480,20 @@ bool TVolumeActor::ReplyToOriginalRequest(
     }
 
     VolumeRequests.erase(it);
-    RequestTimeTracker.OnRequestFinished(
+    const auto logMessage = RequestTimeTracker.OnRequestFinished(
         volumeRequestId,
         success,
         GetCycleCount());
+    if (logMessage) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "[%lu] Disk: %s, Generation: %u. %s",
+            TabletID(),
+            State->GetDiskId().Quote().c_str(),
+            Executor()->Generation(),
+            logMessage.c_str());
+    }
 
     return true;
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -12,6 +12,7 @@
 #include <cloud/blockstore/libs/storage/volume/model/merge.h>
 #include <cloud/blockstore/libs/storage/volume/model/stripe.h>
 
+#include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/media.h>
 #include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/trace_serializer.h>
@@ -480,19 +481,26 @@ bool TVolumeActor::ReplyToOriginalRequest(
     }
 
     VolumeRequests.erase(it);
-    const auto logMessage = RequestTimeTracker.OnRequestFinished(
+    const auto firstSuccess = RequestTimeTracker.OnRequestFinished(
         volumeRequestId,
         success,
         GetCycleCount());
-    if (logMessage) {
+
+    if (firstSuccess) {
         LOG_INFO(
             ctx,
             TBlockStoreComponents::VOLUME,
-            "[%lu] Disk: %s, Generation: %u. %s",
+            "[%lu] Disk: %s, Generation: %u. The first successful %s "
+            "request was started at %s finished at %s. The very first request "
+            "was started at %s. Failed requests: %lu",
             TabletID(),
             State->GetDiskId().Quote().c_str(),
             Executor()->Generation(),
-            logMessage.c_str());
+            ToString(firstSuccess->RequestType).c_str(),
+            FormatDuration(firstSuccess->SuccessfulRequestStartTime).c_str(),
+            FormatDuration(firstSuccess->SuccessfulRequestFinishTime).c_str(),
+            FormatDuration(firstSuccess->FirstRequestStartTime).c_str(),
+            firstSuccess->FailCount);
     }
 
     return true;


### PR DESCRIPTION
Сделал что по логам видно, через сколько после создания актора, диск начал отвечать на запросы. Именно в секундах, а не искать в логах старт таблетки, потом смотреть ну вот теперь ретраи кончились, наверное диск заработал

```
2025-05-24T11:52:12.109400Z :BLOCKSTORE_VOLUME INFO: [72075186224037890] Disk: "vol0", Generation: 20. The first successful Read request was started at 3.503s finished at 3.504s. The very first request was started at 3.503s Failed requests: 0
2025-05-24T11:52:12.342278Z :BLOCKSTORE_VOLUME INFO: [72075186224037890] Disk: "vol0", Generation: 20. The first successful Write request was started at 3.707s finished at 3.737s. The very first request was started at 3.707s Failed requests: 0
```