### PR TITLE
Fix clang-18 build

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2620,7 +2620,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             });
         };
 
-        auto checkFlushBackpressureValues = [&](ui64 value, ui64 threshold)
+        auto checkFlushBackpressureValues = [&](i64 value, i64 threshold)
         {
             TTestRegistryVisitor visitor;
             tablet.SendRequest(tablet.CreateUpdateCounters());
@@ -2636,7 +2636,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             });
         };
 
-        auto checkCompactionBackpressureValues = [&](ui64 value, ui64 threshold)
+        auto checkCompactionBackpressureValues = [&](i64 value, i64 threshold)
         {
             TTestRegistryVisitor visitor;
             tablet.SendRequest(tablet.CreateUpdateCounters());
@@ -2652,7 +2652,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             });
         };
 
-        auto checkCleanupBackpressureValues = [&](ui64 value, ui64 threshold)
+        auto checkCleanupBackpressureValues = [&](i64 value, i64 threshold)
         {
             TTestRegistryVisitor visitor;
             tablet.SendRequest(tablet.CreateUpdateCounters());
@@ -2668,7 +2668,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             });
         };
 
-        auto checkFlushBytesBackpressureValues = [&](ui64 value, ui64 threshold)
+        auto checkFlushBytesBackpressureValues = [&](i64 value, i64 threshold)
         {
             TTestRegistryVisitor visitor;
             tablet.SendRequest(tablet.CreateUpdateCounters());


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2632:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2632 |                  value},
      |                  ^~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2635:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2635 |                  threshold},
      |                  ^~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2648:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2648 |                  value},
      |                  ^~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2651:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2651 |                  threshold},
      |                  ^~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2664:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2664 |                  value},
      |                  ^~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2667:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2667 |                  threshold},
      |                  ^~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2680:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2680 |                  value},
      |                  ^~~~~
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:2683:18: error: non-constant-expression cannot be narrowed from type 'ui64' (aka 'unsigned long') to 'long' in initializer list [-Wc++11-narrowing-const-reference]
 2683 |                  threshold},
      |                  ^~~~~~~~~
8 errors generated.

```