### PR TITLE
[Local Filestore] should respond with E_FS_WOULDBLOCK instead of E_UNAUTHORIZED when doing TestLock

### DIFF
--- a/cloud/filestore/libs/service_local/fs_lock.cpp
+++ b/cloud/filestore/libs/service_local/fs_lock.cpp
@@ -93,7 +93,7 @@ NProto::TTestLockResponse TLocalFileSystem::TestLock(
         request.GetLength(),
         shared);
     if (!tested) {
-        return TErrorResponse(E_UNAUTHORIZED, TStringBuilder()
+        return TErrorResponse(E_FS_WOULDBLOCK, TStringBuilder()
             << "lock denied for " << static_cast<FHANDLE>(*handle)
             << " at (" << request.GetOffset()
             << ", " << request.GetLength() << ")");

--- a/cloud/filestore/libs/service_local/service_ut.cpp
+++ b/cloud/filestore/libs/service_local/service_ut.cpp
@@ -1620,7 +1620,12 @@ Y_UNIT_TEST_SUITE(LocalFileStore)
         bootstrap.Headers.SessionId = id;
 
         auto handle2 = bootstrap.CreateHandle(RootNodeId, "file", TCreateHandleArgs::RDWR).GetHandle();
-        bootstrap.AssertTestLockFailed(handle2, 0, 128);
+        {
+            auto response = bootstrap.AssertTestLockFailed(handle2, 0, 128);
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_FS_WOULDBLOCK,
+                response.GetError().GetCode());
+        }
         bootstrap.AssertTestLockFailed(handle2, 32, 64);
         bootstrap.AssertTestLockFailed(handle2, 64, 128);
 
@@ -1628,7 +1633,12 @@ Y_UNIT_TEST_SUITE(LocalFileStore)
         // over the file range?
         bootstrap.TestLock(handle2, 128, 1024);
 
-        bootstrap.AssertAcquireLockFailed(handle2, 0, 128);
+        {
+            auto response = bootstrap.AssertAcquireLockFailed(handle2, 0, 128);
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_FS_WOULDBLOCK,
+                response.GetError().GetCode());
+        }
         bootstrap.AssertAcquireLockFailed(handle2, 32, 64);
         bootstrap.AssertAcquireLockFailed(handle2, 64,128);
 


### PR DESCRIPTION
By analogy with https://github.com/ydb-platform/nbs/blob/6886a8b8db0ade2e43c7c33f3c9c03559be14533/cloud/filestore/libs/storage/tablet/model/range_locks.cpp#L337