### PR TITLE
Prepare volume unit tests to test multiple volumes

### DIFF
--- a/cloud/blockstore/libs/storage/testlib/test_runtime.h
+++ b/cloud/blockstore/libs/storage/testlib/test_runtime.h
@@ -23,6 +23,16 @@ const ui64 HiveId = NKikimr::MakeDefaultHiveID(0);
 const ui64 TestTabletId  = NKikimr::MakeTabletID(0, HiveId, 1);
 const ui64 TestTabletId2 = NKikimr::MakeTabletID(0, HiveId, 2);
 
+const ui64 TestVolumeTablets[] = {
+    TestTabletId,
+    NKikimr::MakeTabletID(0, HiveId, 100),
+};
+
+const ui64 TestPartitionTablets[] = {
+    TestTabletId2,
+    NKikimr::MakeTabletID(0, HiveId, 200),
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 inline NActors::TActorId Register(


### PR DESCRIPTION
Делаю юнит-тесты на вольюм чуть более похожими на реальное окружение:
1. можно делать два  вольюма в одном тесте (и не сложно расширяется)
2. добавляю схемшард, в который регистрируется вольюм при первом вызове UpdateVolumeConfig
