### PR TITLE
[Disk Manager, SU] Add shard service

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/.gitignore
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/.gitignore
@@ -1,1 +1,2 @@
 disk_service_test
+disk_service_sharded_test

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	defaultZoneId = "zone-a"
-	shardedZoneId = "zone-d-sharded"
-	shardId1      = "zone-d-sharded"
-	shardId2      = "zone-d-sharded-2"
+	shardedZoneId = "zone-d"
+	shardId1      = "zone-d"
+	shardId2      = "zone-d-shard1"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	defaultZoneId = "zone-a"
-	shardedZoneId = "zone-d"
-	shardId1      = "zone-d-1"
-	shardId2      = "zone-d-2"
+	shardedZoneId = "zone-d-sharded"
+	shardId1      = "zone-d-sharded"
+	shardId2      = "zone-d-sharded-2"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_sharded_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_sharded_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	excludedFolderId = "excluded-folder"
-	includedFolderId = "included-folder"
+	otherFolderId    = "folder"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -295,7 +295,7 @@ func TestDiskServiceInShardsCreateDiskInCorrectShard(t *testing.T) {
 			ZoneId: shardedZoneId,
 			DiskId: diskID2,
 		},
-		FolderId: includedFolderId,
+		FolderId: otherFolderId,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, operation)

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_sharded_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_sharded_test.go
@@ -3,7 +3,18 @@ package disk_service_test
 import (
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+	internal_client "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/client"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/facade/testcommon"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	excludedFolderId = "excluded-folder"
+	includedFolderId = "included-folder"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -237,4 +248,60 @@ func TestDiskServiceInShardsCreateDiskFromSnapshotOfOverlayDisk(t *testing.T) {
 			)
 		})
 	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServiceInShardsCreateDiskInCorrectShard(t *testing.T) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskID1 := t.Name() + "1"
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: 32 * 1024 * 4096,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: shardedZoneId,
+			DiskId: diskID1,
+		},
+		FolderId: excludedFolderId,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID1)
+	require.NoError(t, err)
+	require.Equal(t, shardId1, diskMeta.ZoneID)
+
+	diskID2 := t.Name() + "2"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: 32 * 1024 * 4096,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: shardedZoneId,
+			DiskId: diskID2,
+		},
+		FolderId: includedFolderId,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+	diskMeta, err = testcommon.GetDiskMeta(ctx, diskID2)
+	require.NoError(t, err)
+	require.Equal(t, shardId2, diskMeta.ZoneID)
 }

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -301,7 +301,7 @@ func newNbsClientClientConfig() *nbs_config.ClientConfig {
 					),
 				},
 			},
-			"zone-d-1": {
+			"zone-d-sharded": {
 				Endpoints: []string{
 					fmt.Sprintf(
 						"localhost:%v",
@@ -309,7 +309,7 @@ func newNbsClientClientConfig() *nbs_config.ClientConfig {
 					),
 				},
 			},
-			"zone-d-2": {
+			"zone-d-sharded-2": {
 				Endpoints: []string{
 					fmt.Sprintf(
 						"localhost:%v",

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -301,7 +301,7 @@ func newNbsClientClientConfig() *nbs_config.ClientConfig {
 					),
 				},
 			},
-			"zone-d-sharded": {
+			"zone-d": {
 				Endpoints: []string{
 					fmt.Sprintf(
 						"localhost:%v",
@@ -309,7 +309,7 @@ func newNbsClientClientConfig() *nbs_config.ClientConfig {
 					),
 				},
 			},
-			"zone-d-sharded-2": {
+			"zone-d-shard-1": {
 				Endpoints: []string{
 					fmt.Sprintf(
 						"localhost:%v",

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -309,7 +309,7 @@ func newNbsClientClientConfig() *nbs_config.ClientConfig {
 					),
 				},
 			},
-			"zone-d-shard-1": {
+			"zone-d-shard1": {
 				Endpoints: []string{
 					fmt.Sprintf(
 						"localhost:%v",

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -164,7 +164,7 @@ type service struct {
 
 func (s *service) prepareZoneId(
 	ctx context.Context,
-	disk *disk_manager.DiskId,
+	req *disk_manager.CreateDiskRequest,
 ) (string, error) {
 
 	diskMeta, err := s.resourceStorage.GetDiskMeta(ctx, disk.DiskId)
@@ -193,7 +193,7 @@ func (s *service) prepareCreateDiskParams(
 		)
 	}
 
-	zoneID, err := s.prepareZoneId(ctx, req.DiskId)
+	zoneID, err := s.prepareZoneId(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -167,7 +167,7 @@ func (s *service) prepareZoneId(
 	req *disk_manager.CreateDiskRequest,
 ) (string, error) {
 
-	diskMeta, err := s.resourceStorage.GetDiskMeta(ctx, disk.DiskId)
+	diskMeta, err := s.resourceStorage.GetDiskMeta(ctx, req.DiskId.DiskId)
 	if err != nil {
 		return "", err
 	}
@@ -176,7 +176,7 @@ func (s *service) prepareZoneId(
 		return diskMeta.ZoneID, nil
 	}
 
-	return s.shardsService.SelectShard(ctx, req.DiskId, req.FolderId)
+	return s.shardsService.PickShard(ctx, req.DiskId, req.FolderId)
 }
 
 func (s *service) prepareCreateDiskParams(

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -176,7 +176,7 @@ func (s *service) prepareZoneId(
 		return diskMeta.ZoneID, nil
 	}
 
-	return s.shardsService.PickShard(ctx, req.DiskId, req.FolderId)
+	return s.shardsService.PickShard(ctx, req.DiskId, req.FolderId), nil
 }
 
 func (s *service) prepareCreateDiskParams(

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -176,7 +176,7 @@ func (s *service) prepareZoneId(
 		return diskMeta.ZoneID, nil
 	}
 
-	return s.shardsService.PickShard(ctx, disk), nil
+	return s.shardsService.SelectShard(ctx, req.DiskId, req.FolderId)
 }
 
 func (s *service) prepareCreateDiskParams(

--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -12,7 +12,7 @@ message ZoneShards {
     repeated string Shards = 1;
 }
 
-message FolderRule {
+message Folders {
     repeated string Folders = 1;
 }
 
@@ -20,7 +20,7 @@ message ShardsConfig {
     map<string, ZoneShards> Shards = 1;
     oneof FolderRules
     {
-        FolderRule IncludedFolders = 2;
-        FolderRule ExcludedFolders = 3;
+        Folders IncludedFolders = 2;
+        Folders ExcludedFolders = 3;
     }
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -2,9 +2,7 @@ syntax = "proto2";
 
 package shards;
 
-option go_package =
-    "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/"
-    "shards/config";
+option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/shards/config";
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -8,18 +8,15 @@ option go_package =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-message ZoneShards
-{
+message ZoneShards {
     repeated string Shards = 1;
 }
 
-message FolderRule
-{
+message FolderRule {
     repeated string Folders = 1;
 }
 
-message ShardsConfig
-{
+message ShardsConfig {
     map<string, ZoneShards> Shards = 1;
     oneof FolderRules
     {

--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -13,7 +13,17 @@ message ZoneShards
     repeated string Shards = 1;
 }
 
+message FolderRule
+{
+    repeated string Folders = 1;
+}
+
 message ShardsConfig
 {
     map<string, ZoneShards> Shards = 1;
+    oneof FolderRules
+    {
+        FolderRule IncludedFolders = 2;
+        FolderRule ExcludedFolders = 3;
+    }
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -12,15 +12,10 @@ message ZoneShards {
     repeated string Shards = 1;
 }
 
-message Folders {
-    repeated string Folders = 1;
-}
-
 message ShardsConfig {
     map<string, ZoneShards> Shards = 1;
-    oneof FolderRules
-    {
-        Folders IncludedFolders = 2;
-        Folders ExcludedFolders = 3;
-    }
+    repeated string ExcludedFolders = 2;
+
+    // If empty, every folder is accepted.
+    repeated string IncludedFolders = 3;
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -2,14 +2,18 @@ syntax = "proto2";
 
 package shards;
 
-option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/shards/config";
+option go_package =
+    "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/"
+    "shards/config";
 
 ////////////////////////////////////////////////////////////////////////////////
 
-message ZoneShards {
+message ZoneShards
+{
     repeated string Shards = 1;
 }
 
-message ShardsConfig {
+message ShardsConfig
+{
     map<string, ZoneShards> Shards = 1;
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/interface.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/interface.go
@@ -13,5 +13,5 @@ type Service interface {
 		ctx context.Context,
 		disk *disk_manager.DiskId,
 		folderID string,
-	) (string, error)
+	) string
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/interface.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/interface.go
@@ -12,5 +12,6 @@ type Service interface {
 	PickShard(
 		ctx context.Context,
 		disk *disk_manager.DiskId,
-	) string
+		folderID string,
+	) (string, error)
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
@@ -22,8 +22,15 @@ func NewServiceMock() *ServiceMock {
 func (s *ServiceMock) PickShard(
 	ctx context.Context,
 	disk *disk_manager.DiskId,
-) string {
+	folderID string,
+) (string, error) {
 
 	args := s.Called(ctx, disk, folderID)
 	return args.String(0), args.Error(1)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func NewServiceMock() *ServiceMock {
+	return &ServiceMock{}
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
@@ -26,11 +26,5 @@ func (s *ServiceMock) PickShard(
 ) string {
 
 	args := s.Called(ctx, disk, folderID)
-	return args.String(0), args.Error(1)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-func NewServiceMock() *ServiceMock {
-	return &ServiceMock{}
+	return args.String(0)
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
@@ -23,7 +23,7 @@ func (s *ServiceMock) PickShard(
 	ctx context.Context,
 	disk *disk_manager.DiskId,
 	folderID string,
-) (string, error) {
+) string {
 
 	args := s.Called(ctx, disk, folderID)
 	return args.String(0), args.Error(1)

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -44,6 +44,7 @@ func (s *service) PickShard(
 	if err != nil {
 		return "", err
 	}
+
 	if !isShardingAllowed {
 		return disk.ZoneId, nil
 	}
@@ -64,10 +65,10 @@ func (s *service) getShards(zoneID string) []string {
 
 func (s *service) isShardingAllowedForFolder(folderID string) (bool, error) {
 	switch rule := s.config.FolderRules.(type) {
-	case *shards_config.ShardsConfig_IncludedFolders:
-		return slices.Contains(rule.IncludedFolders.GetFolders(), folderID), nil
 	case *shards_config.ShardsConfig_ExcludedFolders:
 		return !slices.Contains(rule.ExcludedFolders.GetFolders(), folderID), nil
+	case *shards_config.ShardsConfig_IncludedFolders:
+		return slices.Contains(rule.IncludedFolders.GetFolders(), folderID), nil
 	case nil:
 		return true, nil
 	default:

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -2,9 +2,11 @@ package shards
 
 import (
 	"context"
+	"slices"
 
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
 	shards_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/shards/config"
+	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -27,17 +29,26 @@ func NewService(
 func (s *service) PickShard(
 	ctx context.Context,
 	disk *disk_manager.DiskId,
-) string {
+	folderID string,
+) (string, error) {
 
 	shards := s.getShards(disk.ZoneId)
 
 	if len(shards) == 0 {
 		// We end up here if an unsharded zone or a shard of a zone is
 		// provided as ZoneId.
-		return disk.ZoneId
+		return disk.ZoneId, nil
 	}
 
-	return shards[0]
+	isShardingAllowed, err := s.isShardingAllowedForFolder(folderID)
+	if err != nil {
+		return "", err
+	}
+	if !isShardingAllowed {
+		return disk.ZoneId, nil
+	}
+
+	return shards[0], nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,4 +60,28 @@ func (s *service) getShards(zoneID string) []string {
 	}
 
 	return shards.Shards
+}
+
+func (s *service) isShardingAllowedForFolder(folderID string) (bool, error) {
+	switch rule := s.config.FolderRules.(type) {
+	case *shards_config.ShardsConfig_IncludedFolders:
+		return slices.Contains(rule.IncludedFolders.GetFolders(), folderID), nil
+	case *shards_config.ShardsConfig_ExcludedFolders:
+		return !slices.Contains(rule.ExcludedFolders.GetFolders(), folderID), nil
+	case nil:
+		return true, nil
+	default:
+		return false, errors.NewNonRetriableErrorf("unknown rule %s", rule)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func NewService(
+	config *shards_config.ShardsConfig,
+) Service {
+
+	return &service{
+		config: config,
+	}
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -58,7 +58,7 @@ func (s *service) getShards(zoneID string) []string {
 }
 
 func (s *service) isShardingAllowedForFolder(folderID string) bool {
-	return (len(rule.IncludedFolders.GetFolders()) == 0 ||
-		slices.Contains(rule.IncludedFolders.GetFolders(), folderID)) &&
-		!slices.Contains(rule.ExcludedFolders.GetFolders(), folderID)
+	return (len(s.config.GetIncludedFolders()) == 0 ||
+		slices.Contains(s.config.GetIncludedFolders(), folderID)) &&
+		!slices.Contains(s.config.GetExcludedFolders(), folderID)
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -74,14 +74,3 @@ func (s *service) isShardingAllowedForFolder(folderID string) (bool, error) {
 		return false, errors.NewNonRetriableErrorf("unknown rule %s", rule)
 	}
 }
-
-////////////////////////////////////////////////////////////////////////////////
-
-func NewService(
-	config *shards_config.ShardsConfig,
-) Service {
-
-	return &service{
-		config: config,
-	}
-}

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -6,7 +6,6 @@ import (
 
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
 	shards_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/shards/config"
-	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -30,26 +29,21 @@ func (s *service) PickShard(
 	ctx context.Context,
 	disk *disk_manager.DiskId,
 	folderID string,
-) (string, error) {
+) string {
+
+	if !s.isShardingAllowedForFolder(folderID) {
+		return disk.ZoneId
+	}
 
 	shards := s.getShards(disk.ZoneId)
 
 	if len(shards) == 0 {
 		// We end up here if an unsharded zone or a shard of a zone is
 		// provided as ZoneId.
-		return disk.ZoneId, nil
+		return disk.ZoneId
 	}
 
-	isShardingAllowed, err := s.isShardingAllowedForFolder(folderID)
-	if err != nil {
-		return "", err
-	}
-
-	if !isShardingAllowed {
-		return disk.ZoneId, nil
-	}
-
-	return shards[0], nil
+	return shards[0]
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,15 +57,8 @@ func (s *service) getShards(zoneID string) []string {
 	return shards.Shards
 }
 
-func (s *service) isShardingAllowedForFolder(folderID string) (bool, error) {
-	switch rule := s.config.FolderRules.(type) {
-	case *shards_config.ShardsConfig_ExcludedFolders:
-		return !slices.Contains(rule.ExcludedFolders.GetFolders(), folderID), nil
-	case *shards_config.ShardsConfig_IncludedFolders:
-		return slices.Contains(rule.IncludedFolders.GetFolders(), folderID), nil
-	case nil:
-		return true, nil
-	default:
-		return false, errors.NewNonRetriableErrorf("unknown rule %s", rule)
-	}
+func (s *service) isShardingAllowedForFolder(folderID string) bool {
+	return (len(rule.IncludedFolders.GetFolders()) == 0 ||
+		slices.Contains(rule.IncludedFolders.GetFolders(), folderID)) &&
+		!slices.Contains(rule.ExcludedFolders.GetFolders(), folderID)
 }

--- a/cloud/disk_manager/pkg/app/controlplane.go
+++ b/cloud/disk_manager/pkg/app/controlplane.go
@@ -377,8 +377,6 @@ func initControlplane(
 	poolService := pools.NewService(taskScheduler, poolStorage)
 	shardsService := shards.NewService(config.GetShardsConfig())
 
-	shardsService := shards.NewService(config.GetShardsConfig())
-
 	var filesystemService filesystem.Service
 	if config.GetFilesystemConfig() != nil {
 		filesystemService = filesystem.NewService(

--- a/cloud/disk_manager/pkg/app/controlplane.go
+++ b/cloud/disk_manager/pkg/app/controlplane.go
@@ -377,6 +377,8 @@ func initControlplane(
 	poolService := pools.NewService(taskScheduler, poolStorage)
 	shardsService := shards.NewService(config.GetShardsConfig())
 
+	shardsService := shards.NewService(config.GetShardsConfig())
+
 	var filesystemService filesystem.Service
 	if config.GetFilesystemConfig() != nil {
 		filesystemService = filesystem.NewService(

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -115,7 +115,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-1"
+        key: "zone-d"
         value: <
             Endpoints: [
                 "localhost:{nbs4_port}",
@@ -135,6 +135,20 @@ NbsConfig: <
     RootCertsFile: "{root_certs_file}"
     GrpcKeepAlive: <>
     UseGZIPCompression: true
+<<<<<<< HEAD
+=======
+>
+ShardsConfig: <
+    Shards: <
+        key: "zone-d"
+        value: <
+            Shards: [
+                "zone-d-2",
+                "zone-d"
+            ]
+        >
+    >
+>>>>>>> add shards service
 >
 DisksConfig: <
     DeletedDiskExpirationTimeout: "1s"
@@ -300,7 +314,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-1"
+        key: "zone-d"
         value: <
             Endpoints: [
                 "localhost:{nbs4_port}",
@@ -314,15 +328,6 @@ NbsConfig: <
             Endpoints: [
                 "localhost:{nbs5_port}",
                 "localhost:{nbs5_port}"
-            ]
-        >
-    >
-    Shards: <
-        key: "zone-d"
-        value: <
-            Shards: [
-                "zone-d-1",
-                "zone-d-2"
             ]
         >
     >

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -176,9 +176,7 @@ ShardsConfig: <
             ]
         >
     >
-    ExcludedFolders: <
-        Folders: ["excluded-folder"]
-    >
+    ExcludedFolders: ["excluded-folder"]
 >
 ImagesConfig: <
     DeletedImageExpirationTimeout: "1s"

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -135,6 +135,7 @@ NbsConfig: <
     RootCertsFile: "{root_certs_file}"
     GrpcKeepAlive: <>
     UseGZIPCompression: true
+>
 DisksConfig: <
     DeletedDiskExpirationTimeout: "1s"
     ClearDeletedDisksTaskScheduleInterval: "2s"

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -115,7 +115,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-sharded"
+        key: "zone-d"
         value: <
             Endpoints: [
                 "localhost:{nbs4_port}",
@@ -124,7 +124,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-sharded-2"
+        key: "zone-d-shard1"
         value: <
             Endpoints: [
                 "localhost:{nbs5_port}",
@@ -171,8 +171,8 @@ ShardsConfig: <
         key: "zone-d"
         value: <
             Shards: [
-                "zone-d-1",
-                "zone-d-2"
+                "zone-d-shard1",
+                "zone-d"
             ]
         >
     >
@@ -197,11 +197,11 @@ ImagesConfig: <
             Capacity: 0
         >,
         <
-            ZoneId: "zone-d-sharded"
+            ZoneId: "zone-d"
             Capacity: 0
         >,
         <
-            ZoneId: "zone-d-sharded-2"
+            ZoneId: "zone-d-shard1"
             Capacity: 0
         >
     ]
@@ -253,7 +253,7 @@ S3Config: <
 
 DATAPLANE_CONFIG_TEMPLATE = """
 TasksConfig: <
-    ZoneIds: ["zone-a", "zone-b", "zone-c", "zone-d-sharded", "zone-d-sharded-2"]
+    ZoneIds: ["zone-a", "zone-b", "zone-c", "zone-d", "zone-d-shard1"]
     TaskPingPeriod: "1s"
     PollForTaskUpdatesPeriod: "1s"
     PollForTasksPeriodMin: "1s"
@@ -302,7 +302,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-sharded"
+        key: "zone-d"
         value: <
             Endpoints: [
                 "localhost:{nbs4_port}",
@@ -311,7 +311,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-sharded-2"
+        key: "zone-d-shard1"
         value: <
             Endpoints: [
                 "localhost:{nbs5_port}",

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -115,7 +115,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d"
+        key: "zone-d-sharded"
         value: <
             Endpoints: [
                 "localhost:{nbs4_port}",
@@ -124,7 +124,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-2"
+        key: "zone-d-sharded-2"
         value: <
             Endpoints: [
                 "localhost:{nbs5_port}",
@@ -135,21 +135,6 @@ NbsConfig: <
     RootCertsFile: "{root_certs_file}"
     GrpcKeepAlive: <>
     UseGZIPCompression: true
-<<<<<<< HEAD
-=======
->
-ShardsConfig: <
-    Shards: <
-        key: "zone-d"
-        value: <
-            Shards: [
-                "zone-d-2",
-                "zone-d"
-            ]
-        >
-    >
->>>>>>> add shards service
->
 DisksConfig: <
     DeletedDiskExpirationTimeout: "1s"
     ClearDeletedDisksTaskScheduleInterval: "2s"
@@ -191,6 +176,9 @@ ShardsConfig: <
             ]
         >
     >
+    ExcludedFolders: <
+        Folders: ["excluded-folder"]
+    >
 >
 ImagesConfig: <
     DeletedImageExpirationTimeout: "1s"
@@ -209,11 +197,11 @@ ImagesConfig: <
             Capacity: 0
         >,
         <
-            ZoneId: "zone-d-1"
+            ZoneId: "zone-d-sharded"
             Capacity: 0
         >,
         <
-            ZoneId: "zone-d-2"
+            ZoneId: "zone-d-sharded-2"
             Capacity: 0
         >
     ]
@@ -265,7 +253,7 @@ S3Config: <
 
 DATAPLANE_CONFIG_TEMPLATE = """
 TasksConfig: <
-    ZoneIds: ["zone-a", "zone-b", "zone-c", "zone-d-1", "zone-d-2"]
+    ZoneIds: ["zone-a", "zone-b", "zone-c", "zone-d-sharded", "zone-d-sharded-2"]
     TaskPingPeriod: "1s"
     PollForTaskUpdatesPeriod: "1s"
     PollForTasksPeriodMin: "1s"
@@ -314,7 +302,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d"
+        key: "zone-d-sharded"
         value: <
             Endpoints: [
                 "localhost:{nbs4_port}",
@@ -323,7 +311,7 @@ NbsConfig: <
         >
     >
     Zones: <
-        key: "zone-d-2"
+        key: "zone-d-sharded-2"
         value: <
             Endpoints: [
                 "localhost:{nbs5_port}",


### PR DESCRIPTION
We introduce a new service to manage shard selection when creating disks. By default, disks are created in the first shard defined in the configuration. We also add a mechanism to restrict shard placement for premium customers.

**Changes:**

- Blacklist / Whitelist support: define folders for which shard selection is allowed or disallowed.
- Added test for blacklist 
- Renamed folders in test recipe to better match the actual cluster