### PR TITLE
Grpc API to cancel vhost in-flight requests

### DIFF
--- a/cloud/blockstore/apps/client/lib/cancel_endpoint_in_flight_requests.cpp
+++ b/cloud/blockstore/apps/client/lib/cancel_endpoint_in_flight_requests.cpp
@@ -1,0 +1,94 @@
+#include "cancel_endpoint_in_flight_requests.h"
+
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/request_helpers.h>
+#include <cloud/blockstore/libs/service/service.h>
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+
+namespace NCloud::NBlockStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TCancelEndpointInFlightRequestsCommand final
+    : public TCommand
+{
+private:
+    TString UnixSocketPath;
+
+public:
+    explicit TCancelEndpointInFlightRequestsCommand(IBlockStorePtr client)
+        : TCommand(std::move(client))
+    {
+        Opts.AddLongOption("socket", "unix socket path")
+            .RequiredArgument("STR")
+            .StoreResult(&UnixSocketPath);
+    }
+
+protected:
+    bool DoExecute() override
+    {
+        if (!Proto && !CheckOpts()) {
+            return false;
+        }
+
+        auto& input = GetInputStream();
+        auto& output = GetOutputStream();
+
+        STORAGE_DEBUG("Reading CancelEndpointInFlightRequests request");
+        auto request =
+            std::make_shared<NProto::TCancelEndpointInFlightRequestsRequest>();
+        if (Proto) {
+            ParseFromTextFormat(input, *request);
+        } else {
+            request->SetUnixSocketPath(UnixSocketPath);
+        }
+
+        STORAGE_DEBUG("Sending CancelEndpointInFlightRequests request");
+        const auto requestId = GetRequestId(*request);
+        auto result = WaitFor(ClientEndpoint->CancelEndpointInFlightRequests(
+            MakeIntrusive<TCallContext>(requestId),
+            std::move(request)));
+
+        STORAGE_DEBUG("Received CancelEndpointInFlightRequests response");
+        if (Proto) {
+            SerializeToTextFormat(result, output);
+            return true;
+        }
+
+        if (HasError(result)) {
+            output << FormatError(result.GetError()) << Endl;
+            return false;
+        }
+
+        output << "OK" << Endl;
+        return true;
+    }
+
+private:
+    bool CheckOpts() const
+    {
+        if (!UnixSocketPath) {
+            STORAGE_ERROR("Unix socket path is required");
+            return false;
+        }
+
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewCancelEndpointInFlightRequestsCommand(IBlockStorePtr client)
+{
+    return MakeIntrusive<TCancelEndpointInFlightRequestsCommand>(
+        std::move(client));
+}
+
+}   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/apps/client/lib/cancel_endpoint_in_flight_requests.h
+++ b/cloud/blockstore/apps/client/lib/cancel_endpoint_in_flight_requests.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "command.h"
+
+namespace NCloud::NBlockStore::NClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewCancelEndpointInFlightRequestsCommand(IBlockStorePtr client);
+
+}   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/apps/client/lib/factory.cpp
+++ b/cloud/blockstore/apps/client/lib/factory.cpp
@@ -4,6 +4,7 @@
 #include "alter_volume.h"
 #include "assign_volume.h"
 #include "backup_volume.h"
+#include "cancel_endpoint_in_flight_requests.h"
 #include "check_range.h"
 #include "create_checkpoint.h"
 #include "create_placement_group.h"
@@ -90,6 +91,7 @@ struct THandlerFactory
         { "queryavailablestorage", NewQueryAvailableStorageCommand },
         { "readblocks", NewReadBlocksCommand },
         { "refreshendpoint", NewRefreshEndpointCommand },
+        { "cancelendpointinflightrequests", NewCancelEndpointInFlightRequestsCommand },
         { "resizevolume", NewResizeVolumeCommand },
         { "restorevolume", NewRestoreVolumeCommand },
         { "resumedevice", NewResumeDeviceCommand },

--- a/cloud/blockstore/apps/client/lib/ya.make
+++ b/cloud/blockstore/apps/client/lib/ya.make
@@ -7,6 +7,7 @@ SRCS(
     assign_volume.cpp
     backup_volume.cpp
     bootstrap.cpp
+    cancel_endpoint_in_flight_requests.cpp
     check_range.cpp
     command.cpp
     create_checkpoint.cpp

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -247,6 +247,11 @@ struct TClientStorage: NStorage::NServer::IClientStorage
     {
         Y_UNUSED(clientSocket);
     }
+
+    void CancelInFlightRequests() override
+    {
+        Y_DEBUG_ABORT_UNLESS(false);
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints/endpoint_listener.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_listener.h
@@ -41,6 +41,9 @@ struct IEndpointListener
         const NProto::TStartEndpointRequest& request,
         const NProto::TVolume& volume,
         NClient::ISessionPtr session) = 0;
+
+    virtual NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) = 0;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -108,6 +108,13 @@ struct TTestEndpointListener final
         Y_UNUSED(session);
         return MakeFuture(NProto::TError());
     }
+
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
+++ b/cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.cpp
@@ -319,6 +319,14 @@ public:
         return MakeFuture<NProto::TError>();
     }
 
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            "Can't cancel in-flight requests for GRPC endpoint");
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -113,6 +113,14 @@ public:
         return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
     }
 
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            "Can't cancel in-flight requests for NBD endpoint");
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -418,6 +418,15 @@ public:
         return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
     }
 
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            "Can't cancel in-flight requests for RDMA endpoint");
+    }
+
 
 private:
     NProto::TError DoStartEndpoint(

--- a/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
+++ b/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
@@ -326,6 +326,15 @@ public:
         return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
     }
 
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            "Can't cancel in-flight requests for NVMe endpoint");
+    }
+
 private:
     NProto::TError DoStartEndpoint(
         const NProto::TStartEndpointRequest& request,
@@ -501,6 +510,15 @@ public:
         Y_UNUSED(volume);
         Y_UNUSED(session);
         return MakeFuture(MakeError(E_NOT_IMPLEMENTED));
+    }
+
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            "Can't cancel in-flight requests for SCSI endpoint");
     }
 
 private:

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -886,6 +886,26 @@ public:
         return MakeFuture<NProto::TError>();
     }
 
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        auto it = Endpoints.find(socketPath);
+        if (it == Endpoints.end()) {
+            return MakeError(
+                S_FALSE,
+                TStringBuilder()
+                    << "endpoint " << socketPath.Quote() << "is not found");
+        }
+
+        if (!it->second) {
+            return FallbackListener->CancelEndpointInFlightRequests(socketPath);
+        }
+
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            "Can't cancel in-flight requests for external vhost endpoint");
+    }
+
 private:
     NThreading::TFuture<NProto::TError> TrySwitchEndpoint(
         const NProto::TStartEndpointRequest& request,

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -134,6 +134,13 @@ struct TTestEndpointListener
         Y_UNUSED(session);
         return MakeFuture<NProto::TError>();
     }
+
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        Y_UNUSED(socketPath);
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -96,6 +96,12 @@ public:
         Y_UNUSED(session);
         return MakeFuture<NProto::TError>();
     }
+
+    NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) override
+    {
+        return Server->CancelEndpointInFlightRequests(socketPath);
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/service/auth_scheme.cpp
+++ b/cloud/blockstore/libs/service/auth_scheme.cpp
@@ -122,6 +122,7 @@ TPermissionList GetRequestPermissions(EBlockStoreRequest requestType)
         case EBlockStoreRequest::StopEndpoint:
         case EBlockStoreRequest::KickEndpoint:
         case EBlockStoreRequest::RefreshEndpoint:
+        case EBlockStoreRequest::CancelEndpointInFlightRequests:
             return CreatePermissionList({EPermission::Update});
 
         case EBlockStoreRequest::ListEndpoints:

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -101,6 +101,7 @@ using TWriteBlocksLocalResponse = TWriteBlocksResponse;
     xxx(ListKeyrings,                       __VA_ARGS__)                       \
     xxx(DescribeEndpoint,                   __VA_ARGS__)                       \
     xxx(RefreshEndpoint,                    __VA_ARGS__)                       \
+    xxx(CancelEndpointInFlightRequests,     __VA_ARGS__)                       \
 // BLOCKSTORE_ENDPOINT_SERVICE
 
 #define BLOCKSTORE_GRPC_SERVICE(xxx, ...)                                      \

--- a/cloud/blockstore/libs/service/request_helpers.h
+++ b/cloud/blockstore/libs/service/request_helpers.h
@@ -313,6 +313,7 @@ constexpr bool IsControlRequest(EBlockStoreRequest requestType)
         case EBlockStoreRequest::ListKeyrings:
         case EBlockStoreRequest::DescribeEndpoint:
         case EBlockStoreRequest::RefreshEndpoint:
+        case EBlockStoreRequest::CancelEndpointInFlightRequests:
         case EBlockStoreRequest::QueryAgentsInfo:
         case EBlockStoreRequest::CreateVolumeLink:
         case EBlockStoreRequest::DestroyVolumeLink:

--- a/cloud/blockstore/libs/throttling/throttler_ut.cpp
+++ b/cloud/blockstore/libs/throttling/throttler_ut.cpp
@@ -61,6 +61,7 @@ constexpr auto SHORT_TIMEOUT = UPDATE_THROTTLER_USED_QUOTA_INTERVAL / 10;
     xxx(ListKeyrings,                       __VA_ARGS__)                       \
     xxx(DescribeEndpoint,                   __VA_ARGS__)                       \
     xxx(RefreshEndpoint,                    __VA_ARGS__)                       \
+    xxx(CancelEndpointInFlightRequests,     __VA_ARGS__)                       \
 // BLOCKSTORE_NODISK_SERVICE
 
 #define BLOCKSTORE_NOBLOCKS_SERVICE(xxx, ...)                                  \

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -49,6 +49,9 @@ struct IServer
     virtual NProto::TError UpdateEndpoint(
         const TString& socketPath,
         ui64 blocksCount) = 0;
+
+    virtual NProto::TError CancelEndpointInFlightRequests(
+        const TString& socketPath) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -43,6 +43,7 @@ struct IVhostDevice
 
     virtual bool Start() = 0;
     virtual NThreading::TFuture<NProto::TError> Stop() = 0;
+    // virtual void CancelInFlightRequests() = 0;
     virtual void Update(ui64 blocksCount) = 0;
 };
 

--- a/cloud/blockstore/public/api/grpc/service.proto
+++ b/cloud/blockstore/public/api/grpc/service.proto
@@ -268,6 +268,13 @@ service TBlockStoreService
         };
     }
 
+    rpc CancelEndpointInFlightRequests(TCancelEndpointInFlightRequestsRequest) returns (TCancelEndpointInFlightRequestsResponse) {
+        option (google.api.http) = {
+            post: "/cancel_endpoint_in_flight_requests"
+            body: "*"
+        };
+    }
+
     //
     // Disk Registry config.
     //

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -234,6 +234,24 @@ message TRefreshEndpointResponse
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Cancel endpoint in-flight requests
+
+message TCancelEndpointInFlightRequestsRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Unix-socket path.
+    string UnixSocketPath = 2;
+}
+
+message TCancelEndpointInFlightRequestsResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Proxy endpoint
 
 message TStartProxyEndpointRequest

--- a/cloud/blockstore/public/sdk/go/client/client.go
+++ b/cloud/blockstore/public/sdk/go/client/client.go
@@ -238,6 +238,18 @@ func (client *Client) RefreshEndpoint(
 	return err
 }
 
+func (client *Client) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	unixSocketPath string,
+) error {
+	req := &protos.TCancelEndpointInFlightRequestsRequest{
+		UnixSocketPath: unixSocketPath,
+	}
+
+	_, err := client.Impl.CancelEndpointInFlightRequests(ctx, req)
+	return err
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func IsDiskNotFoundError(e error) bool {

--- a/cloud/blockstore/public/sdk/go/client/discovery.go
+++ b/cloud/blockstore/public/sdk/go/client/discovery.go
@@ -737,6 +737,14 @@ func (client *discoveryClient) RefreshEndpoint(
 	panic("not implemented")
 }
 
+func (client *discoveryClient) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	req *protos.TCancelEndpointInFlightRequestsRequest,
+) (*protos.TCancelEndpointInFlightRequestsResponse, error) {
+
+	panic("not implemented")
+}
+
 func (client *discoveryClient) CreateCheckpoint(
 	ctx context.Context,
 	req *protos.TCreateCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/durable.go
+++ b/cloud/blockstore/public/sdk/go/client/durable.go
@@ -448,6 +448,22 @@ func (client *durableClient) RefreshEndpoint(
 	return resp.(*protos.TRefreshEndpointResponse), err
 }
 
+func (client *durableClient) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	req *protos.TCancelEndpointInFlightRequestsRequest,
+) (*protos.TCancelEndpointInFlightRequestsResponse, error) {
+
+	resp, err := client.executeRequest(
+		ctx,
+		req,
+		func(ctx context.Context) (response, error) {
+			return client.impl.CancelEndpointInFlightRequests(ctx, req)
+		},
+	)
+
+	return resp.(*protos.TCancelEndpointInFlightRequestsResponse), err
+}
+
 func (client *durableClient) CreateCheckpoint(
 	ctx context.Context,
 	req *protos.TCreateCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/grpc.go
+++ b/cloud/blockstore/public/sdk/go/client/grpc.go
@@ -559,6 +559,24 @@ func (client *grpcClient) RefreshEndpoint(
 	return resp.(*protos.TRefreshEndpointResponse), err
 }
 
+func (client *grpcClient) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	req *protos.TCancelEndpointInFlightRequestsRequest,
+) (*protos.TCancelEndpointInFlightRequestsResponse, error) {
+
+	if req.Headers == nil {
+		req.Headers = &protos.THeaders{}
+	}
+	resp, err := client.executeRequest(
+		ctx,
+		req,
+		func(ctx context.Context) (response, error) {
+			return client.impl.CancelEndpointInFlightRequests(ctx, req)
+		})
+
+	return resp.(*protos.TCancelEndpointInFlightRequestsResponse), err
+}
+
 func (client *grpcClient) CreateCheckpoint(
 	ctx context.Context,
 	req *protos.TCreateCheckpointRequest,

--- a/cloud/blockstore/public/sdk/go/client/iface.go
+++ b/cloud/blockstore/public/sdk/go/client/iface.go
@@ -148,6 +148,11 @@ type ClientIface interface {
 		req *protos.TRefreshEndpointRequest,
 	) (*protos.TRefreshEndpointResponse, error)
 
+	CancelEndpointInFlightRequests(
+		ctx context.Context,
+		req *protos.TCancelEndpointInFlightRequestsRequest,
+	) (*protos.TCancelEndpointInFlightRequestsResponse, error)
+
 	//
 	// Checkpoint operations.
 	//

--- a/cloud/blockstore/public/sdk/go/client/test_client.go
+++ b/cloud/blockstore/public/sdk/go/client/test_client.go
@@ -26,6 +26,7 @@ type kickEndpointHandlerFunc func(ctx context.Context, req *protos.TKickEndpoint
 type listKeyringsHandlerFunc func(ctx context.Context, req *protos.TListKeyringsRequest) (*protos.TListKeyringsResponse, error)
 type describeEndpointHandlerFunc func(ctx context.Context, req *protos.TDescribeEndpointRequest) (*protos.TDescribeEndpointResponse, error)
 type refreshEndpointHandlerFunc func(ctx context.Context, req *protos.TRefreshEndpointRequest) (*protos.TRefreshEndpointResponse, error)
+type cancelEndpointInFlightRequestsHandlerFunc func(ctx context.Context, req *protos.TCancelEndpointInFlightRequestsRequest) (*protos.TCancelEndpointInFlightRequestsResponse, error)
 type createCheckpointHandlerFunc func(ctx context.Context, req *protos.TCreateCheckpointRequest) (*protos.TCreateCheckpointResponse, error)
 type getCheckpointStatusHandlerFunc func(ctx context.Context, req *protos.TGetCheckpointStatusRequest) (*protos.TGetCheckpointStatusResponse, error)
 type deleteCheckpointHandlerFunc func(ctx context.Context, req *protos.TDeleteCheckpointRequest) (*protos.TDeleteCheckpointResponse, error)
@@ -50,45 +51,46 @@ type closeHandlerFunc func() error
 ////////////////////////////////////////////////////////////////////////////////
 
 type testClient struct {
-	PingHandler                          pingHandlerFunc
-	CreateVolumeHandler                  createVolumeHandlerFunc
-	DestroyVolumeHandler                 destroyVolumeHandlerFunc
-	ResizeVolumeHandler                  resizeVolumeHandlerFunc
-	AlterVolumeHandler                   alterVolumeHandlerFunc
-	AssignVolumeHandler                  assignVolumeHandlerFunc
-	StatVolumeHandler                    statVolumeHandlerFunc
-	MountVolumeHandler                   mountVolumeHandlerFunc
-	UnmountVolumeHandler                 unmountVolumeHandlerFunc
-	ReadBlocksHandler                    readBlocksHandlerFunc
-	WriteBlocksHandler                   writeBlocksHandlerFunc
-	ZeroBlocksHandler                    zeroBlocksHandlerFunc
-	StartEndpointHandler                 startEndpointHandlerFunc
-	StopEndpointHandler                  stopEndpointHandlerFunc
-	ListEndpointsHandler                 listEndpointsHandlerFunc
-	KickEndpointHandler                  kickEndpointHandlerFunc
-	ListKeyringsHandler                  listKeyringsHandlerFunc
-	DescribeEndpointHandler              describeEndpointHandlerFunc
-	RefreshEndpointHandler               refreshEndpointHandlerFunc
-	CreateCheckpointHandler              createCheckpointHandlerFunc
-	GetCheckpointStatusHandler           getCheckpointStatusHandlerFunc
-	DeleteCheckpointHandler              deleteCheckpointHandlerFunc
-	GetChangedBlocksHandler              getChangedBlocksHandlerFunc
-	DescribeVolumeHandler                describeVolumeHandlerFunc
-	DescribeVolumeModelHandler           describeVolumeModelHandlerFunc
-	ListVolumesHandler                   listVolumesHandlerFunc
-	DiscoverInstancesHandler             discoverInstancesHandlerFunc
-	QueryAvailableStorageHandler         queryAvailableStorageHandler
-	ResumeDeviceHandler                  resumeDeviceHandler
-	CreateVolumeFromDeviceHandler        createVolumeFromDeviceHandler
-	ExecuteActionHandler                 executeActionFunc
-	CreatePlacementGroupHandler          createPlacementGroupHandlerFunc
-	DestroyPlacementGroupHandler         destroyPlacementGroupHandlerFunc
-	DescribePlacementGroupHandler        describePlacementGroupHandlerFunc
-	AlterPlacementGroupMembershipHandler alterPlacementGroupMembershipHandlerFunc
-	ListPlacementGroupsHandler           listPlacementGroupsHandlerFunc
-	CmsActionHandler                     cmsActionHandlerFunc
-	QueryAgentsInfoHandler               queryAgentsInfoHandler
-	CloseHandlerFunc                     closeHandlerFunc
+	PingHandler                           pingHandlerFunc
+	CreateVolumeHandler                   createVolumeHandlerFunc
+	DestroyVolumeHandler                  destroyVolumeHandlerFunc
+	ResizeVolumeHandler                   resizeVolumeHandlerFunc
+	AlterVolumeHandler                    alterVolumeHandlerFunc
+	AssignVolumeHandler                   assignVolumeHandlerFunc
+	StatVolumeHandler                     statVolumeHandlerFunc
+	MountVolumeHandler                    mountVolumeHandlerFunc
+	UnmountVolumeHandler                  unmountVolumeHandlerFunc
+	ReadBlocksHandler                     readBlocksHandlerFunc
+	WriteBlocksHandler                    writeBlocksHandlerFunc
+	ZeroBlocksHandler                     zeroBlocksHandlerFunc
+	StartEndpointHandler                  startEndpointHandlerFunc
+	StopEndpointHandler                   stopEndpointHandlerFunc
+	ListEndpointsHandler                  listEndpointsHandlerFunc
+	KickEndpointHandler                   kickEndpointHandlerFunc
+	ListKeyringsHandler                   listKeyringsHandlerFunc
+	DescribeEndpointHandler               describeEndpointHandlerFunc
+	RefreshEndpointHandler                refreshEndpointHandlerFunc
+	CancelEndpointInFlightRequestsHandler cancelEndpointInFlightRequestsHandlerFunc
+	CreateCheckpointHandler               createCheckpointHandlerFunc
+	GetCheckpointStatusHandler            getCheckpointStatusHandlerFunc
+	DeleteCheckpointHandler               deleteCheckpointHandlerFunc
+	GetChangedBlocksHandler               getChangedBlocksHandlerFunc
+	DescribeVolumeHandler                 describeVolumeHandlerFunc
+	DescribeVolumeModelHandler            describeVolumeModelHandlerFunc
+	ListVolumesHandler                    listVolumesHandlerFunc
+	DiscoverInstancesHandler              discoverInstancesHandlerFunc
+	QueryAvailableStorageHandler          queryAvailableStorageHandler
+	ResumeDeviceHandler                   resumeDeviceHandler
+	CreateVolumeFromDeviceHandler         createVolumeFromDeviceHandler
+	ExecuteActionHandler                  executeActionFunc
+	CreatePlacementGroupHandler           createPlacementGroupHandlerFunc
+	DestroyPlacementGroupHandler          destroyPlacementGroupHandlerFunc
+	DescribePlacementGroupHandler         describePlacementGroupHandlerFunc
+	AlterPlacementGroupMembershipHandler  alterPlacementGroupMembershipHandlerFunc
+	ListPlacementGroupsHandler            listPlacementGroupsHandlerFunc
+	CmsActionHandler                      cmsActionHandlerFunc
+	QueryAgentsInfoHandler                queryAgentsInfoHandler
+	CloseHandlerFunc                      closeHandlerFunc
 }
 
 func (client *testClient) Close() error {
@@ -361,6 +363,18 @@ func (client *testClient) RefreshEndpoint(
 	}
 
 	return &protos.TRefreshEndpointResponse{}, nil
+}
+
+func (client *testClient) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	req *protos.TCancelEndpointInFlightRequestsRequest,
+) (*protos.TCancelEndpointInFlightRequestsResponse, error) {
+
+	if client.CancelEndpointInFlightRequestsHandler != nil {
+		return client.CancelEndpointInFlightRequestsHandler(ctx, req)
+	}
+
+	return &protos.TCancelEndpointInFlightRequestsResponse{}, nil
 }
 
 func (client *testClient) CreateCheckpoint(

--- a/cloud/blockstore/public/sdk/python/client/base_client.py
+++ b/cloud/blockstore/public/sdk/python/client/base_client.py
@@ -41,6 +41,7 @@ NBS_CLIENT_METHODS = [
     "start_endpoint",
     "stop_endpoint",
     "refresh_endpoint",
+    "cancel_endpoint_in_flight_requests",
     "execute_action",
     "kick_endpoint",
     "cms_action",

--- a/cloud/blockstore/public/sdk/python/client/client.py
+++ b/cloud/blockstore/public/sdk/python/client/client.py
@@ -545,6 +545,44 @@ class Client(_SafeClient):
             request_timeout)
 
     @_handle_errors
+    def cancel_endpoint_in_flight_requests_async(
+            self,
+            unix_socket_path: str,
+            idempotence_id: str | None = None,
+            timestamp: datetime | None = None,
+            trace_id: str | None = None,
+            request_timeout: int | None = None) -> futures.Future:
+
+        request = protos.TCancelEndpointInFlightRequestsRequest(
+            UnixSocketPath=unix_socket_path,
+        )
+        return self._impl.cancel_endpoint_in_flight_requests_async(
+            request,
+            idempotence_id,
+            timestamp,
+            trace_id,
+            request_timeout)
+
+    @_handle_errors
+    def cancel_endpoint_in_flight_requests(
+            self,
+            unix_socket_path: str,
+            idempotence_id: str | None = None,
+            timestamp: datetime | None = None,
+            trace_id: str | None = None,
+            request_timeout: int | None = None):
+
+        request = protos.TCancelEndpointInFlightRequestsRequest(
+            UnixSocketPath=unix_socket_path,
+        )
+        self._impl.cancel_endpoint_in_flight_requests(
+            request,
+            idempotence_id,
+            timestamp,
+            trace_id,
+            request_timeout)
+
+    @_handle_errors
     def list_endpoints_async(
             self,
             idempotence_id: str | None = None,

--- a/cloud/blockstore/public/sdk/python/client/ut/client_methods.py
+++ b/cloud/blockstore/public/sdk/python/client/ut/client_methods.py
@@ -23,4 +23,5 @@ client_methods = [
     ("stop_endpoint", "StopEndpoint"),
     ("refresh_endpoint", "RefreshEndpoint"),
     ("list_endpoints", "ListEndpoints"),
+    ("cancel_endpoint_in_flight_requests", "CancelEndpointInFlightRequests"),
 ]

--- a/cloud/blockstore/public/sdk/python/client/ut/client_ut.py
+++ b/cloud/blockstore/public/sdk/python/client/ut/client_ut.py
@@ -135,6 +135,9 @@ def _test_every_method_impl(sync):
         "refresh_endpoint": {
             "unix_socket_path": "DefaultUnixSocketPath",
         },
+        "cancel_endpoint_in_flight_requests": {
+            "unix_socket_path": "DefaultUnixSocketPath",
+        },
         "list_endpoints": {},
         "kick_endpoint": {
             "keyring_id": 42,

--- a/cloud/blockstore/tools/csi_driver/internal/driver/mocks/nbs_client_mock.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/mocks/nbs_client_mock.go
@@ -217,6 +217,15 @@ func (c *NbsClientMock) RefreshEndpoint(
 	return args.Get(0).(*protos.TRefreshEndpointResponse), args.Error(1)
 }
 
+func (c *NbsClientMock) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	req *protos.TCancelEndpointInFlightRequestsRequest,
+) (*protos.TCancelEndpointInFlightRequestsResponse, error) {
+
+	args := c.Called(ctx, req)
+	return args.Get(0).(*protos.TCancelEndpointInFlightRequestsResponse), args.Error(1)
+}
+
 func (c *NbsClientMock) CreateCheckpoint(
 	ctx context.Context,
 	req *protos.TCreateCheckpointRequest,

--- a/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
+++ b/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
@@ -272,6 +272,14 @@ func (n nbsService) RefreshEndpoint(
 	panic("implement me")
 }
 
+func (n nbsService) CancelEndpointInFlightRequests(
+	ctx context.Context,
+	request *protos.TCancelEndpointInFlightRequestsRequest,
+) (*protos.TCancelEndpointInFlightRequestsResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (n nbsService) UpdateDiskRegistryConfig(
 	ctx context.Context,
 	request *protos.TUpdateDiskRegistryConfigRequest,


### PR DESCRIPTION
#3553
Добавляю возможность с помощью либо grpc запроса, либо ручки в blockstore-client, отменить все запросы в полёте для vhost эндпоинтов. 