### PR TITLE
[Disk Manager, SU] Introduce Shards service

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/config.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package shards;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/shards/config";
+
+////////////////////////////////////////////////////////////////////////////////
+
+message ZoneShards {
+    repeated string Shards = 1;
+}
+
+message ShardsConfig {
+    map<string, ZoneShards> Shards = 1;
+}

--- a/cloud/disk_manager/internal/pkg/services/shards/config/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/shards/config/ya.make
@@ -1,0 +1,9 @@
+PROTO_LIBRARY()
+
+ONLY_TAGS(GO_PROTO)
+
+SRCS(
+    config.proto
+)
+
+END()

--- a/cloud/disk_manager/internal/pkg/services/shards/interface.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/interface.go
@@ -1,0 +1,16 @@
+package shards
+
+import (
+	"context"
+
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type Service interface {
+	SelectShard(
+		ctx context.Context,
+		disk *disk_manager.DiskId,
+	) string
+}

--- a/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
@@ -7,9 +7,17 @@ import (
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
 )
 
+////////////////////////////////////////////////////////////////////////////////
+
 type ServiceMock struct {
 	mock.Mock
 }
+
+func NewServiceMock() *ServiceMock {
+	return &ServiceMock{}
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 func (s *ServiceMock) SelectShard(
 	ctx context.Context,
@@ -18,10 +26,4 @@ func (s *ServiceMock) SelectShard(
 
 	args := s.Called(ctx, disk, folderID)
 	return args.String(0), args.Error(1)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-func NewServiceMock() *ServiceMock {
-	return &ServiceMock{}
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/mocks/service_mock.go
@@ -1,0 +1,27 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+)
+
+type ServiceMock struct {
+	mock.Mock
+}
+
+func (s *ServiceMock) SelectShard(
+	ctx context.Context,
+	disk *disk_manager.DiskId,
+) string {
+
+	args := s.Called(ctx, disk, folderID)
+	return args.String(0), args.Error(1)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func NewServiceMock() *ServiceMock {
+	return &ServiceMock{}
+}

--- a/cloud/disk_manager/internal/pkg/services/shards/mocks/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/shards/mocks/ya.make
@@ -1,0 +1,7 @@
+GO_LIBRARY()
+
+SRCS(
+    service_mock.go
+)
+
+END()

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -15,6 +15,17 @@ type service struct {
 	config *shards_config.ShardsConfig
 }
 
+func NewService(
+	config *shards_config.ShardsConfig,
+) Service {
+
+	return &service{
+		config: config,
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 func (s *service) SelectShard(
 	ctx context.Context,
 	disk *disk_manager.DiskId,
@@ -31,6 +42,8 @@ func (s *service) SelectShard(
 	return shards[0], nil
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 func (s *service) getShards(zoneID string) []string {
 	shards, ok := s.config.Shards[zoneID]
 	if !ok {
@@ -38,15 +51,4 @@ func (s *service) getShards(zoneID string) []string {
 	}
 
 	return shards.Shards
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-func NewService(
-	config *shards_config.ShardsConfig,
-) Service {
-
-	return &service{
-		config: config,
-	}
 }

--- a/cloud/disk_manager/internal/pkg/services/shards/service.go
+++ b/cloud/disk_manager/internal/pkg/services/shards/service.go
@@ -1,0 +1,52 @@
+package shards
+
+import (
+	"context"
+	"slices"
+
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+	shards_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/shards/config"
+	"github.com/ydb-platform/nbs/cloud/tasks/errors"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type service struct {
+	config *shards_config.ShardsConfig
+}
+
+func (s *service) SelectShard(
+	ctx context.Context,
+	disk *disk_manager.DiskId,
+) string {
+
+	shards := s.getShards(disk.ZoneId)
+
+	if len(shards) == 0 {
+		// We end up here if an unsharded zone or a shard of a zone is
+		// provided as ZoneId.
+		return disk.ZoneId, nil
+	}
+
+	return shards[0], nil
+}
+
+func (s *service) getShards(zoneID string) []string {
+	shards, ok := s.config.Shards[zoneID]
+	if !ok {
+		return []string{}
+	}
+
+	return shards.Shards
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func NewService(
+	config *shards_config.ShardsConfig,
+) Service {
+
+	return &service{
+		config: config,
+	}
+}

--- a/cloud/disk_manager/internal/pkg/services/shards/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/shards/ya.make
@@ -1,0 +1,19 @@
+GO_LIBRARY()
+
+SRCS(
+    interface.go
+    service.go
+)
+
+GO_TEST_SRCS(
+)
+
+END()
+
+RECURSE(
+    config
+)
+
+RECURSE_FOR_TESTS(
+    mocks
+)

--- a/cloud/disk_manager/internal/pkg/services/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/ya.make
@@ -6,5 +6,6 @@ RECURSE(
     images
     placementgroup
     pools
+    shards
     snapshots
 )


### PR DESCRIPTION
We introduce a new service to manage shard selection when creating disks. By default, disks are created in the first shard defined in the configuration. 

**Added features:**

- ShardService: a new component, that would be used by DiskService to select the target shard before disk creation.
- Default selection strategy: always use the first shard from the configuration.