### PR TITLE
Add private API to mark devices as replacements

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -295,6 +295,10 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    TResultOrError<NActors::IActorPtr> CreateMarkReplacementDeviceActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
     TResultOrError<NActors::IActorPtr> CreateUpdateDiskBlockSizeActionActor(
         TRequestInfoPtr requestInfo,
         TString input);

--- a/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
@@ -68,6 +68,7 @@ void TServiceActor::HandleExecuteAction(
         {"restorediskregistrystate",          &TServiceActor::CreateRestoreDiskRegistryStateActor          },
         {"scandisk",                          &TServiceActor::CreateScanDiskActionActor                    },
         {"setuserid",                         &TServiceActor::CreateSetUserIdActionActor                   },
+        {"markreplacementdevice",             &TServiceActor::CreateMarkReplacementDeviceActor             },
         {"suspenddevice",                     &TServiceActor::CreateSuspendDeviceActionActor               },
         {"updatediskblocksize",               &TServiceActor::CreateUpdateDiskBlockSizeActionActor         },
         {"updatediskreplicacount",            &TServiceActor::CreateUpdateDiskReplicaCountActionActor      },

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_mark_replacement_device.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_mark_replacement_device.cpp
@@ -1,0 +1,142 @@
+#include "service_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <google/protobuf/util/json_util.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER)
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMarkReplacementDeviceActor final
+    : public TActorBootstrapped<TMarkReplacementDeviceActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString Input;
+
+    NProto::TError Error;
+
+public:
+    TMarkReplacementDeviceActor(TRequestInfoPtr requestInfo, TString input);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ReplyAndDie(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleMarkReplacementDeviceResponse(
+        const TEvDiskRegistry::TEvMarkReplacementDeviceResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TMarkReplacementDeviceActor::TMarkReplacementDeviceActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+    : RequestInfo(std::move(requestInfo))
+    , Input(std::move(input))
+{}
+
+void TMarkReplacementDeviceActor::Bootstrap(const TActorContext& ctx)
+{
+    auto request =
+        std::make_unique<TEvDiskRegistry::TEvMarkReplacementDeviceRequest>();
+
+    if (!google::protobuf::util::JsonStringToMessage(Input, &request->Record)
+             .ok())
+    {
+        Error = MakeError(E_ARGUMENT, "Failed to parse input");
+        ReplyAndDie(ctx);
+        return;
+    }
+
+    Become(&TThis::StateWork);
+
+    NCloud::Send(ctx, MakeDiskRegistryProxyServiceId(), std::move(request));
+}
+
+void TMarkReplacementDeviceActor::ReplyAndDie(const TActorContext& ctx)
+{
+    auto response =
+        std::make_unique<TEvService::TEvExecuteActionResponse>(Error);
+    google::protobuf::util::MessageToJsonString(
+        NProto::TSetWritableStateResponse(),
+        response->Record.MutableOutput());
+
+    LWTRACK(
+        ResponseSent_Service,
+        RequestInfo->CallContext->LWOrbit,
+        "ExecuteAction_markreplacementdevice",
+        RequestInfo->CallContext->RequestId);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TMarkReplacementDeviceActor::HandleMarkReplacementDeviceResponse(
+    const TEvDiskRegistry::TEvMarkReplacementDeviceResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        Error = msg->GetError();
+    }
+
+    ReplyAndDie(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TMarkReplacementDeviceActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvDiskRegistry::TEvMarkReplacementDeviceResponse,
+            HandleMarkReplacementDeviceResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TResultOrError<IActorPtr> TServiceActor::CreateMarkReplacementDeviceActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    return {std::make_unique<TMarkReplacementDeviceActor>(
+        std::move(requestInfo),
+        std::move(input))};
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/ya.make
+++ b/cloud/blockstore/libs/storage/service/ya.make
@@ -29,6 +29,7 @@ SRCS(
     service_actor_actions_get_partition_info.cpp
     service_actor_actions_get_storage_config.cpp
     service_actor_actions_kill_tablet.cpp
+    service_actor_actions_mark_replacement_device.cpp
     service_actor_actions_migration_disk_registry_device.cpp
     service_actor_actions_modify_tags.cpp
     service_actor_actions_reallocate_disk.cpp

--- a/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
+++ b/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
@@ -150,6 +150,10 @@ private:
                 TEvDiskRegistryProxy::TEvGetDrTabletInfoRequest,
                 HandleGetDrTabletInfo);
 
+            HFunc(
+                TEvDiskRegistry::TEvMarkReplacementDeviceRequest,
+                HandleMarkReplacementDevice);
+
 
             IgnoreFunc(NKikimr::TEvLocal::TEvTabletMetrics);
 
@@ -362,6 +366,24 @@ private:
 
         NCloud::Reply(ctx, *ev,
             std::make_unique<TEvDiskRegistry::TEvMarkDiskForCleanupResponse>());
+    }
+
+    void HandleMarkReplacementDevice(
+        const TEvDiskRegistry::TEvMarkReplacementDeviceRequest::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        const auto* msg = ev->Get();
+        if (msg->Record.GetIsReplacement()) {
+            State->DeviceReplacementUUIDs.insert(msg->Record.GetDeviceId());
+        } else {
+            State->DeviceReplacementUUIDs.erase(msg->Record.GetDeviceId());
+        }
+
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<
+                TEvDiskRegistry::TEvMarkReplacementDeviceResponse>());
     }
 
     void HandleFinishMigration(


### PR DESCRIPTION
На всякий случай добавляю ручку в blockstore-client, которая умеет менять состояние девайса fresh/не fresh