### PR TITLE
[Disk Manager] issue-3419: fix missing EndedAt when force finishing task

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,4 +1,3 @@
 cloud/filestore/tests/fio_index/mount-kikimr-test *
 cloud/filestore/tests/fio_index/mount-local-test *
-cloud/disk_manager/internal/pkg/facade/filesystem_service_nemesis_test filesystem_service_nemesis_test.TestFilesystemServiceCreateExternalFilesystem
 cloud/filestore/libs/storage/service/ut TStorageServiceShardingTest.ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShardsWithShardIdSelectionInLeader

--- a/cloud/tasks/storage/storage_ydb_impl.go
+++ b/cloud/tasks/storage/storage_ydb_impl.go
@@ -1924,6 +1924,7 @@ func (s *storageYDB) forceFinishTask(
 	state.GenerationID++
 	state.ModifiedAt = now
 	state.ChangedStateAt = now
+	state.EndedAt = now
 
 	transitions := []stateTransition{
 		stateTransition{


### PR DESCRIPTION
The `TestFilesystemServiceCreateExternalFilesystem` test was failing because
`forceFinish` didn't set the end time. This caused `ClearEndedTask` to
prematurely clean the external task, leading retries to schedule new external
tasks. This commit fixes the issue by ensuring the end time is set when
`forceFinish` is called.
