### PR TITLE
[Disk Manager] govet fix in tests: the cancel function returned by context.WithTimeout should be called, not discarded

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go
@@ -133,7 +133,9 @@ func TestFilesystemServiceCreateExternalFilesystem(t *testing.T) {
 		operationID string,
 	) {
 
-		opCtx, _ := context.WithTimeout(ctx, timeout)
+		opCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
 		err = internal_client.WaitOperation(opCtx, client, operationID)
 		if shouldTimeout {
 			require.Error(t, err, errorMesssage)


### PR DESCRIPTION
```
$S/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go:133:10: "lostcancel: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak"
```