### PR TITLE
New format for log title

### DIFF
--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -420,7 +420,9 @@ public:
                 blockDigestGenerator,
                 traceSerializer,
                 rdmaClient,
-                endpointEventHandler
+                endpointEventHandler,
+                EVolumeStartMode::ONLINE,
+                {}   // diskId
             );
             return actor.release();
         };

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -1,4 +1,3 @@
-
 #include "log_title.h"
 
 #include <cloud/storage/core/libs/common/format.h>
@@ -9,9 +8,11 @@
 
 namespace NCloud::NBlockStore::NStorage {
 
-TLogTitle::TLogTitle(ui64 tabletId, TString diskId, ui64 now)
+////////////////////////////////////////////////////////////////////////////////
+
+TLogTitle::TLogTitle(ui64 tabletId, TString diskId, ui64 startTime)
     : Type(EType::Volume)
-    , StartTime(now)
+    , StartTime(startTime)
     , TabletId(tabletId)
     , DiskId(std::move(diskId))
 {
@@ -21,11 +22,11 @@ TLogTitle::TLogTitle(ui64 tabletId, TString diskId, ui64 now)
 TLogTitle::TLogTitle(
         ui64 tabletId,
         TString diskId,
-        ui64 now,
+        ui64 startTime,
         ui32 partitionIndex,
         ui32 partitionCount)
     : Type(EType::Partition)
-    , StartTime(now)
+    , StartTime(startTime)
     , TabletId(tabletId)
     , PartitionIndex(partitionIndex)
     , PartitionCount(partitionCount)
@@ -71,6 +72,11 @@ TString TLogTitle::Get(EDetails details) const
 
     result << "]";
     return result;
+}
+
+TString TLogTitle::GetWithTime() const
+{
+    return Get(EDetails::WithTime);
 }
 
 void TLogTitle::SetDiskId(TString diskId)

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -1,0 +1,134 @@
+
+#include "log_title.h"
+
+#include <cloud/storage/core/libs/common/format.h>
+
+#include <util/datetime/cputimer.h>
+#include <util/string/builder.h>
+#include <util/system/datetime.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+TLogTitle::TLogTitle(ui64 tabletId, TString diskId, ui64 now)
+    : Type(EType::Volume)
+    , StartTime(now)
+    , TabletId(tabletId)
+    , DiskId(std::move(diskId))
+{
+    Rebuild();
+}
+
+TLogTitle::TLogTitle(
+        ui64 tabletId,
+        TString diskId,
+        ui64 now,
+        ui32 partitionIndex,
+        ui32 partitionCount)
+    : Type(EType::Partition)
+    , StartTime(now)
+    , TabletId(tabletId)
+    , PartitionIndex(partitionIndex)
+    , PartitionCount(partitionCount)
+    , DiskId(std::move(diskId))
+{
+    Rebuild();
+}
+
+// static
+TString TLogTitle::GetPartitionPrefix(
+    ui64 tabletId,
+    ui32 partitionIndex,
+    ui32 partitionCount)
+{
+    auto builder = TStringBuilder();
+
+    builder << "p";
+    if (partitionCount > 1) {
+        builder << partitionIndex;
+    }
+    builder << ":";
+    builder << tabletId;
+
+    return builder;
+}
+
+TString TLogTitle::Get(EDetails details) const
+{
+    TStringBuilder result;
+    result << CachedPrefix;
+
+    switch (details) {
+        case EDetails::Brief: {
+            break;
+        }
+        case EDetails::WithTime: {
+            const auto duration =
+                CyclesToDurationSafe(GetCycleCount() - StartTime);
+            result << " t:" << FormatDuration(duration);
+            break;
+        }
+    }
+
+    result << "]";
+    return result;
+}
+
+void TLogTitle::SetDiskId(TString diskId)
+{
+    DiskId = std::move(diskId);
+    Rebuild();
+}
+
+void TLogTitle::SetGeneration(ui32 generation)
+{
+    Generation = generation;
+    Rebuild();
+}
+
+void TLogTitle::Rebuild()
+{
+    switch (Type) {
+        case EType::Volume: {
+            RebuildForVolume();
+            break;
+        }
+        case EType::Partition: {
+            RebuildForPartition();
+            break;
+        }
+    }
+}
+
+void TLogTitle::RebuildForVolume()
+{
+    auto builder = TStringBuilder();
+
+    builder << "[";
+    builder << "v:" << TabletId;
+    if (Generation) {
+        builder << " g:" << Generation;
+    } else {
+        builder << " g:?";
+    }
+    builder << " d:" << (DiskId.empty() ? "???" : DiskId);
+
+    CachedPrefix = builder;
+}
+
+void TLogTitle::RebuildForPartition()
+{
+    auto builder = TStringBuilder();
+
+    builder << "[";
+    builder << GetPartitionPrefix(TabletId, PartitionIndex, PartitionCount);
+    if (Generation) {
+        builder << " g:" << Generation;
+    } else {
+        builder << " g:?";
+    }
+    builder << " d:" << (DiskId.empty() ? "???" : DiskId);
+
+    CachedPrefix = builder;
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -4,6 +4,8 @@
 #include <util/system/types.h>
 namespace NCloud::NBlockStore::NStorage {
 
+////////////////////////////////////////////////////////////////////////////////
+
 class TLogTitle
 {
 public:
@@ -31,12 +33,14 @@ private:
     TString CachedPrefix;
 
 public:
-    TLogTitle(ui64 tabletId, TString diskId, ui64 now);
+    // Constructor for Volume
+    TLogTitle(ui64 tabletId, TString diskId, ui64 startTime);
 
+    // Constructor for Partition
     TLogTitle(
         ui64 tabletId,
         TString diskId,
-        ui64 now,
+        ui64 startTime,
         ui32 partitionIndex,
         ui32 partitionCount);
 
@@ -44,6 +48,8 @@ public:
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
 
     [[nodiscard]] TString Get(EDetails details) const;
+
+    [[nodiscard]] TString GetWithTime() const;
 
     void SetDiskId(TString diskId);
     void SetGeneration(ui32 generation);

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/system/types.h>
+namespace NCloud::NBlockStore::NStorage {
+
+class TLogTitle
+{
+public:
+    enum class EDetails
+    {
+        Brief,
+        WithTime,
+    };
+
+private:
+    enum class EType
+    {
+        Volume,
+        Partition,
+    };
+
+    const EType Type;
+    const ui64 StartTime;
+    const ui64 TabletId = 0;
+    const ui32 PartitionIndex = 0;
+    const ui32 PartitionCount = 0;
+
+    ui64 Generation = 0;
+    TString DiskId;
+    TString CachedPrefix;
+
+public:
+    TLogTitle(ui64 tabletId, TString diskId, ui64 now);
+
+    TLogTitle(
+        ui64 tabletId,
+        TString diskId,
+        ui64 now,
+        ui32 partitionIndex,
+        ui32 partitionCount);
+
+    static TString
+    GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
+
+    [[nodiscard]] TString Get(EDetails details) const;
+
+    void SetDiskId(TString diskId);
+    void SetGeneration(ui32 generation);
+
+private:
+    void Rebuild();
+    void RebuildForVolume();
+    void RebuildForPartition();
+    TString GetPartitionPrefix() const;
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -1,0 +1,90 @@
+#include "log_title.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/cputimer.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLogTitleTest)
+{
+    Y_UNIT_TEST(GetPartitionPrefixTest)
+    {
+        ui64 tabletId = 12345;
+
+        {
+            ui32 partitionIndex = 1;
+            ui32 partitionCount = 1;
+            auto result = TLogTitle::GetPartitionPrefix(
+                tabletId,
+                partitionIndex,
+                partitionCount);
+            UNIT_ASSERT_STRINGS_EQUAL(result, "p:12345");
+        }
+
+        {
+            ui32 partitionIndex = 0;
+            ui32 partitionCount = 2;
+            auto result = TLogTitle::GetPartitionPrefix(
+                tabletId,
+                partitionIndex,
+                partitionCount);
+            UNIT_ASSERT_STRINGS_EQUAL("p0:12345", result);
+        }
+
+        {
+            ui32 partitionIndex = 1;
+            ui32 partitionCount = 2;
+            auto result = TLogTitle::GetPartitionPrefix(
+                tabletId,
+                partitionIndex,
+                partitionCount);
+            UNIT_ASSERT_STRINGS_EQUAL("p1:12345", result);
+        }
+    }
+
+    Y_UNIT_TEST(GetForVolume)
+    {
+        TLogTitle logTitle1(12345, "", GetCycleCount());
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[v:12345 g:? d:???]",
+            logTitle1.Get(TLogTitle::EDetails::Brief));
+
+        logTitle1.SetDiskId("disk1");
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[v:12345 g:? d:disk1]",
+            logTitle1.Get(TLogTitle::EDetails::Brief));
+
+        logTitle1.SetGeneration(5);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[v:12345 g:5 d:disk1]",
+            logTitle1.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            logTitle1.Get(TLogTitle::EDetails::WithTime),
+            "[v:12345 g:5 d:disk1 t:");
+    }
+
+    Y_UNIT_TEST(GetForPartition)
+    {
+        TLogTitle logTitle1(12345, "disk1", GetCycleCount(), 1, 2);
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[p1:12345 g:? d:disk1]",
+            logTitle1.Get(TLogTitle::EDetails::Brief));
+
+        logTitle1.SetGeneration(5);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[p1:12345 g:5 d:disk1]",
+            logTitle1.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            logTitle1.Get(TLogTitle::EDetails::WithTime),
+            "[p1:12345 g:5 d:disk1 t:");
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -64,7 +64,7 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             logTitle1.Get(TLogTitle::EDetails::Brief));
 
         UNIT_ASSERT_STRING_CONTAINS(
-            logTitle1.Get(TLogTitle::EDetails::WithTime),
+            logTitle1.GetWithTime(),
             "[v:12345 g:5 d:disk1 t:");
     }
 
@@ -82,7 +82,7 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             logTitle1.Get(TLogTitle::EDetails::Brief));
 
         UNIT_ASSERT_STRING_CONTAINS(
-            logTitle1.Get(TLogTitle::EDetails::WithTime),
+            logTitle1.GetWithTime(),
             "[p1:12345 g:5 d:disk1 t:");
     }
 }

--- a/cloud/blockstore/libs/storage/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/model/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 SRCS(
     composite_id_ut.cpp
     composite_task_waiter_ut.cpp
+    log_title_ut.cpp
     request_bounds_tracker_ut.cpp
     requests_in_progress_ut.cpp
 )

--- a/cloud/blockstore/libs/storage/model/ya.make
+++ b/cloud/blockstore/libs/storage/model/ya.make
@@ -14,6 +14,7 @@ SRCS(
     channel_data_kind.cpp
     channel_permissions.cpp
     composite_task_waiter.cpp
+    log_title.cpp
     request_bounds_tracker.cpp
     requests_in_progress.cpp
 )

--- a/cloud/blockstore/libs/storage/partition/part.cpp
+++ b/cloud/blockstore/libs/storage/partition/part.cpp
@@ -19,6 +19,7 @@ IActorPtr CreatePartitionTablet(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     NProto::TPartitionConfig partitionConfig,
     EStorageAccessMode storageAccessMode,
+    ui32 partitionIndex,
     ui32 siblingCount,
     const NActors::TActorId& volumeActorId)
 {
@@ -31,6 +32,7 @@ IActorPtr CreatePartitionTablet(
         std::move(blockDigestGenerator),
         std::move(partitionConfig),
         storageAccessMode,
+        partitionIndex,
         siblingCount,
         volumeActorId);
 }

--- a/cloud/blockstore/libs/storage/partition/part.h
+++ b/cloud/blockstore/libs/storage/partition/part.h
@@ -21,6 +21,7 @@ NActors::IActorPtr CreatePartitionTablet(
     IBlockDigestGeneratorPtr blockDigestGenerator,
     NProto::TPartitionConfig partitionConfig,
     EStorageAccessMode storageAccessMode,
+    ui32 partitionIndex,
     ui32 siblingCount,
     const NActors::TActorId& volumeActorId);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -132,7 +132,7 @@ void TPartitionActor::Activate(const TActorContext& ctx)
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s State initialization finished",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 }
 
 void TPartitionActor::Suicide(const TActorContext& ctx)
@@ -331,7 +331,7 @@ void TPartitionActor::OnActivateExecutor(const TActorContext& ctx)
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s Activated executor",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     BecomeAux(ctx, STATE_INIT);
 
@@ -575,7 +575,7 @@ void TPartitionActor::SendGarbageCollectorCompleted(
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s Send garbage collector completed",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
     NCloud::Send(
         ctx,
         LauncherID(),

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -54,6 +54,7 @@ TPartitionActor::TPartitionActor(
         IBlockDigestGeneratorPtr blockDigestGenerator,
         NProto::TPartitionConfig partitionConfig,
         EStorageAccessMode storageAccessMode,
+        ui32 partitionIndex,
         ui32 siblingCount,
         const TActorId& volumeActorId)
     : TActor(&TThis::StateBoot)
@@ -68,6 +69,12 @@ TPartitionActor::TPartitionActor(
     , VolumeActorId(volumeActorId)
     , ChannelHistorySize(CalcChannelHistorySize())
     , BlobCodec(NBlockCodecs::Codec(Config->GetBlobCompressionCodec()))
+    , LogTitle(
+          TabletID(),
+          PartitionConfig.GetDiskId(),
+          StartTime,
+          partitionIndex,
+          siblingCount)
     , TransactionTimeTracker(PartitionTransactions)
 {}
 
@@ -121,9 +128,11 @@ void TPartitionActor::Activate(const TActorContext& ctx)
 
     State->FinishLoadState();
 
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu] State initialization finished",
-        TabletID());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s State initialization finished",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 }
 
 void TPartitionActor::Suicide(const TActorContext& ctx)
@@ -316,9 +325,13 @@ bool TPartitionActor::OnRenderAppHtmlPage(
 
 void TPartitionActor::OnActivateExecutor(const TActorContext& ctx)
 {
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu] Activated executor",
-        TabletID());
+    LogTitle.SetGeneration(Executor()->Generation());
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Activated executor",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     BecomeAux(ctx, STATE_INIT);
 
@@ -558,10 +571,11 @@ void TPartitionActor::SendBackpressureReport(const TActorContext& ctx) const
 void TPartitionActor::SendGarbageCollectorCompleted(
     const TActorContext& ctx) const
 {
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu][d:%s] Send garbage collector completed",
-        TabletID(),
-        PartitionConfig.GetDiskId().c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Send garbage collector completed",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
     NCloud::Send(
         ctx,
         LauncherID(),

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -22,6 +22,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/core/tablet.h>
 #include <cloud/blockstore/libs/storage/core/transaction_time_tracker.h>
+#include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
 #include <cloud/blockstore/libs/storage/partition_common/events_private.h>
 #include <cloud/blockstore/libs/storage/partition_common/long_running_operation_companion.h>
@@ -100,6 +101,7 @@ class TPartitionActor final
     };
 
 private:
+    const ui64 StartTime = GetCycleCount();
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
@@ -110,6 +112,8 @@ private:
     const NActors::TActorId VolumeActorId;
     const ui64 ChannelHistorySize;
     const NBlockCodecs::ICodec* BlobCodec;
+
+    TLogTitle LogTitle;
 
     std::unique_ptr<TPartitionState> State;
 
@@ -157,6 +161,7 @@ public:
         IBlockDigestGeneratorPtr blockDigestGenerator,
         NProto::TPartitionConfig partitionConfig,
         EStorageAccessMode storageAccessMode,
+        ui32 partitionIndex,
         ui32 siblingCount,
         const NActors::TActorId& volumeActorId);
     ~TPartitionActor() override;

--- a/cloud/blockstore/libs/storage/partition/part_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_initfreshblocks.cpp
@@ -50,7 +50,7 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s Loaded fresh blobs",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     Actors.Erase(ev->Sender);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_initfreshblocks.cpp
@@ -46,10 +46,11 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
         return;
     }
 
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu][d:%s] Loaded fresh blobs",
-        TabletID(),
-        PartitionConfig.GetDiskId().c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Loaded fresh blobs",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     Actors.Erase(ev->Sender);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_initschema.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_initschema.cpp
@@ -44,7 +44,7 @@ void TPartitionActor::CompleteInitSchema(
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s Schema initialized",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     ExecuteTx(ctx, CreateTx<TLoadState>(args.BlocksCount));
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_initschema.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_initschema.cpp
@@ -40,10 +40,11 @@ void TPartitionActor::CompleteInitSchema(
 {
     Y_UNUSED(args);
 
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu][d:%s] Schema initialized",
-        TabletID(),
-        PartitionConfig.GetDiskId().c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Schema initialized",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     ExecuteTx(ctx, CreateTx<TLoadState>(args.BlocksCount));
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -60,10 +60,11 @@ bool TPartitionActor::PrepareLoadState(
     TTransactionContext& tx,
     TTxPartition::TLoadState& args)
 {
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu][d:%s] Reading state from local db",
-        TabletID(),
-        PartitionConfig.GetDiskId().c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Reading state from local db",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     // TRequestScope timer(*args.RequestInfo);
     TPartitionDatabase db(tx.DB);
@@ -99,10 +100,11 @@ void TPartitionActor::ExecuteLoadState(
     TTransactionContext& tx,
     TTxPartition::TLoadState& args)
 {
-    LOG_INFO(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu][d:%s] State data loaded",
-        TabletID(),
-        PartitionConfig.GetDiskId().c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s State data loaded",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     // TRequestScope timer(*args.RequestInfo);
     TPartitionDatabase db(tx.DB);

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -64,7 +64,7 @@ bool TPartitionActor::PrepareLoadState(
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s Reading state from local db",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     // TRequestScope timer(*args.RequestInfo);
     TPartitionDatabase db(tx.DB);
@@ -104,7 +104,7 @@ void TPartitionActor::ExecuteLoadState(
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s State data loaded",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     // TRequestScope timer(*args.RequestInfo);
     TPartitionDatabase db(tx.DB);

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -208,6 +208,7 @@ void InitTestActorRuntime(
                 CreateBlockDigestGeneratorStub(),
                 partConfig,
                 storageAccessMode,
+                0,  // partitionIndex
                 1,  // siblingCount
                 VolumeActorId
             );

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -457,7 +457,7 @@ void TStartVolumeActor::BootExternal(const TActorContext& ctx)
         ctx,
         TBlockStoreComponents::SERVICE,
         "%s Requesting external boot for volume tablet",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     PendingRequest = EPendingRequest::BOOT_EXTERNAL;
 
@@ -531,7 +531,7 @@ void TStartVolumeActor::StartTablet(const TActorContext& ctx)
         ctx,
         TBlockStoreComponents::SERVICE,
         "%s Starting volume tablet",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     const auto* appData = AppData(ctx);
 

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -244,8 +244,10 @@ ui32 TTestEnv::CreateBlockStoreNode(
             CreateProfileLogStub(),
             CreateBlockDigestGeneratorStub(),
             TraceSerializer,
-            nullptr, // RdmaClient
-            NServer::CreateEndpointEventProxy()
+            nullptr,   // RdmaClient
+            NServer::CreateEndpointEventProxy(),
+            EVolumeStartMode::ONLINE,
+            {}   // diskId
         );
         return actor.release();
     };

--- a/cloud/blockstore/libs/storage/volume/partition_info.cpp
+++ b/cloud/blockstore/libs/storage/volume/partition_info.cpp
@@ -35,9 +35,11 @@ NActors::TActorId TActorsStack::GetTop() const
 TPartitionInfo::TPartitionInfo(
         ui64 tabletId,
         NProto::TPartitionConfig partitionConfig,
+        ui32 partitionIndex,
         TDuration timeoutIncrement,
         TDuration timeoutMax)
     : TabletId(tabletId)
+    , PartitionIndex(partitionIndex)
     , PartitionConfig(std::move(partitionConfig))
     , RetryPolicy(timeoutIncrement, timeoutMax)
 {}

--- a/cloud/blockstore/libs/storage/volume/partition_info.h
+++ b/cloud/blockstore/libs/storage/volume/partition_info.h
@@ -43,6 +43,7 @@ struct TPartitionInfo
     };
 
     const ui64 TabletId;
+    const ui32 PartitionIndex;
     const NProto::TPartitionConfig PartitionConfig;
 
     TRetryPolicy RetryPolicy;
@@ -63,6 +64,7 @@ struct TPartitionInfo
     TPartitionInfo(
         ui64 tabletId,
         NProto::TPartitionConfig partitionConfig,
+        ui32 partitionIndex,
         TDuration timeoutIncrement,
         TDuration timeoutMax);
 

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -794,7 +794,8 @@ std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
         std::move(featuresConfig));
     auto diagConfig = CreateTestDiagnosticsConfig();
 
-    auto createFunc = [=] (const TActorId& owner, TTabletStorageInfo* info) {
+    auto createFunc = [=](const TActorId& owner, TTabletStorageInfo* info)
+    {
         auto tablet = CreateVolumeTablet(
             owner,
             info,
@@ -807,7 +808,9 @@ std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
                 "BLOCKSTORE_TRACE",
                 NLwTraceMonPage::TraceManager(false)),
             rdmaClient,
-            NServer::CreateEndpointEventProxy()
+            NServer::CreateEndpointEventProxy(),
+            EVolumeStartMode::ONLINE,
+            {}   // diskId
         );
         return tablet.release();
     };

--- a/cloud/blockstore/libs/storage/volume/volume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume.cpp
@@ -20,7 +20,8 @@ IActorPtr CreateVolumeTablet(
     ITraceSerializerPtr traceSerializer,
     NRdma::IClientPtr rdmaClient,
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
-    EVolumeStartMode startMode)
+    EVolumeStartMode startMode,
+    TString diskId)
 {
     return std::make_unique<TVolumeActor>(
         owner,
@@ -32,7 +33,8 @@ IActorPtr CreateVolumeTablet(
         std::move(traceSerializer),
         std::move(rdmaClient),
         std::move(endpointEventHandler),
-        startMode);
+        startMode,
+        std::move(diskId));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume.h
+++ b/cloud/blockstore/libs/storage/volume/volume.h
@@ -32,6 +32,7 @@ NActors::IActorPtr CreateVolumeTablet(
     ITraceSerializerPtr traceSerializer,
     NRdma::IClientPtr rdmaClient,
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
-    EVolumeStartMode startMode = EVolumeStartMode::ONLINE);
+    EVolumeStartMode startMode,
+    TString diskId);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -8,10 +8,8 @@
 #include <cloud/blockstore/libs/storage/api/undelivered.h>
 #include <cloud/blockstore/libs/storage/core/monitoring_utils.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+#include <cloud/blockstore/libs/storage/service/service_events_private.h>   // TODO: invalid reference
 #include <cloud/blockstore/libs/storage/volume/model/volume_throttler_logger.h>
-
-// TODO: invalid reference
-#include <cloud/blockstore/libs/storage/service/service_events_private.h>
 
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>
@@ -24,8 +22,8 @@
 #include <library/cpp/lwtrace/protos/lwtrace.pb.h>
 #include <library/cpp/lwtrace/signature.h>
 
-#include <util/string/builder.h>
 #include <util/stream/str.h>
+#include <util/string/builder.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -71,7 +69,8 @@ TVolumeActor::TVolumeActor(
         ITraceSerializerPtr traceSerializer,
         NRdma::IClientPtr rdmaClient,
         NServer::IEndpointEventHandlerPtr endpointEventHandler,
-        EVolumeStartMode startMode)
+        EVolumeStartMode startMode,
+        TString diskId)
     : TActor(&TThis::StateBoot)
     , TTabletBase(owner, std::move(storage), &TransactionTimeTracker)
     , GlobalStorageConfig(config)
@@ -83,6 +82,7 @@ TVolumeActor::TVolumeActor(
     , RdmaClient(std::move(rdmaClient))
     , EndpointEventHandler(std::move(endpointEventHandler))
     , StartMode(startMode)
+    , LogTitle(TabletID(), std::move(diskId), StartTime)
     , ThrottlerLogger(
           TabletID(),
           [this](ui32 opType, TDuration time)
@@ -135,12 +135,16 @@ void TVolumeActor::BecomeAux(const TActorContext& ctx, EState state)
     }
 
     Become(States[state].Func);
+    const auto prevState = CurrentState;
     CurrentState = state;
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Switched to state %s (system: %s, user: %s, executor: %s)",
-        TabletID(),
-        States[state].Name.data(),
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Switched state %s -> %s (system: %s, user: %s, executor: %s)",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        GetStateName(prevState).Quote().c_str(),
+        GetStateName(state).Quote().c_str(),
         ToString(Tablet()).data(),
         ToString(SelfId()).data(),
         ToString(ExecutorID()).data());
@@ -263,9 +267,13 @@ void TVolumeActor::OnActivateExecutor(const TActorContext& ctx)
 {
     ExecutorActivationTimestamp = ctx.Now();
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Activated executor",
-        TabletID());
+    LogTitle.SetGeneration(Executor()->Generation());
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Activated executor",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     ScheduleRegularUpdates(ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -142,7 +142,7 @@ void TVolumeActor::BecomeAux(const TActorContext& ctx, EState state)
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Switched state %s -> %s (system: %s, user: %s, executor: %s)",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        LogTitle.GetWithTime().c_str(),
         GetStateName(prevState).Quote().c_str(),
         GetStateName(state).Quote().c_str(),
         ToString(Tablet()).data(),
@@ -273,7 +273,7 @@ void TVolumeActor::OnActivateExecutor(const TActorContext& ctx)
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Activated executor",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     ScheduleRegularUpdates(ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -27,6 +27,7 @@
 #include <cloud/blockstore/libs/storage/core/tablet.h>
 #include <cloud/blockstore/libs/storage/core/transaction_time_tracker.h>
 #include <cloud/blockstore/libs/storage/model/composite_id.h>
+#include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/partition_common/events_private.h>
 #include <cloud/blockstore/libs/storage/partition_common/long_running_operation_companion.h>
 #include <cloud/blockstore/libs/storage/volume/model/requests_inflight.h>
@@ -192,6 +193,7 @@ public:
     };
 
 private:
+    const ui64 StartTime = GetCycleCount();
     TStorageConfigPtr GlobalStorageConfig;
     TStorageConfigPtr Config;
     bool HasStorageConfigPatch = false;
@@ -203,6 +205,7 @@ private:
     const NRdma::IClientPtr RdmaClient;
     NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const EVolumeStartMode StartMode;
+    TLogTitle LogTitle;
     TVolumeThrottlerLogger ThrottlerLogger;
 
     std::unique_ptr<TVolumeState> State;
@@ -306,7 +309,7 @@ private:
     TVolumeRequestMap VolumeRequests;
     TRequestsInFlight WriteAndZeroRequestsInFlight;
 
-    TRequestsTimeTracker RequestTimeTracker{GetCycleCount()};
+    TRequestsTimeTracker RequestTimeTracker{StartTime};
     TTransactionTimeTracker TransactionTimeTracker;
 
     // inflight VolumeRequestId -> duplicate request queue
@@ -388,7 +391,8 @@ public:
         ITraceSerializerPtr traceSerializer,
         NRdma::IClientPtr rdmaClient,
         NServer::IEndpointEventHandlerPtr endpointEventHandler,
-        EVolumeStartMode startMode);
+        EVolumeStartMode startMode,
+        TString diskId);
     ~TVolumeActor() override;
 
     static constexpr ui32 LogComponent = TBlockStoreComponents::VOLUME;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -388,10 +388,11 @@ void TVolumeActor::ExecuteAddClient(
     TString prevWriter = State->GetReadWriteAccessClientId();
     args.WriterLastActivityTimestamp = State->GetLastActivityTimestamp(prevWriter);
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Volume %s received add client %s:%s request; pipe server %s, sender %s",
-        TabletID(),
-        args.DiskId.Quote().c_str(),
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Received add client %s:%s request; pipe server %s, sender %s",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
         args.Info.GetClientId().Quote().c_str(),
         args.Info.GetInstanceId().Quote().c_str(),
         ToString(args.PipeServerActorId).c_str(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -392,7 +392,7 @@ void TVolumeActor::ExecuteAddClient(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Received add client %s:%s request; pipe server %s, sender %s",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        LogTitle.GetWithTime().c_str(),
         args.Info.GetClientId().Quote().c_str(),
         args.Info.GetInstanceId().Quote().c_str(),
         ToString(args.PipeServerActorId).c_str(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -225,7 +225,7 @@ void TVolumeActor::AllocateDisk(const TActorContext& ctx)
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s AllocateDiskRequest: %s",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        LogTitle.GetWithTime().c_str(),
         request->Record.Utf8DebugString().Quote().c_str());
 
     NCloud::Send(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -221,9 +221,11 @@ void TVolumeActor::AllocateDisk(const TActorContext& ctx)
     auto request = std::make_unique<TEvDiskRegistry::TEvAllocateDiskRequest>();
     request->Record = MakeAllocateDiskRequest();
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] AllocateDiskRequest: %s",
-        TabletID(),
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s AllocateDiskRequest: %s",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
         request->Record.Utf8DebugString().Quote().c_str());
 
     NCloud::Send(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_initschema.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_initschema.cpp
@@ -45,7 +45,7 @@ void TVolumeActor::CompleteInitSchema(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Schema initialized",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     ExecuteTx<TLoadState>(
         ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_initschema.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_initschema.cpp
@@ -41,9 +41,11 @@ void TVolumeActor::CompleteInitSchema(
 {
     Y_UNUSED(args);
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Schema initialized",
-        TabletID());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Schema initialized",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     ExecuteTx<TLoadState>(
         ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -163,7 +163,7 @@ void TVolumeActor::CompleteLoadState(
             ctx,
             TBlockStoreComponents::VOLUME,
             "%s State initialization finished",
-            LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+            LogTitle.GetWithTime().c_str());
 
         RegisterCounters(ctx);
         RegisterVolume(ctx);
@@ -189,7 +189,7 @@ void TVolumeActor::CompleteLoadState(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s State data loaded, time: %s",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        LogTitle.GetWithTime().c_str(),
         FormatDuration(GetLoadTime()).c_str());
 
     ctx.Send(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/storage/core/config.h>
 
+#include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/media.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -50,6 +51,10 @@ bool TVolumeActor::PrepareLoadState(
         db.ReadStorageConfig(args.StorageConfig),
         db.ReadFollowers(args.FollowerDisks),
     };
+
+    if (args.Meta) {
+        LogTitle.SetDiskId(args.Meta->GetConfig().GetDiskId());
+    }
 
     bool ready = std::accumulate(
         results.begin(),
@@ -154,9 +159,11 @@ void TVolumeActor::CompleteLoadState(
         Y_ABORT_UNLESS(CurrentState == STATE_INIT);
         BecomeAux(ctx, STATE_WORK);
 
-        LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-            "[%lu] State initialization finished",
-            TabletID());
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s State initialization finished",
+            LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
         RegisterCounters(ctx);
         RegisterVolume(ctx);
@@ -178,10 +185,12 @@ void TVolumeActor::CompleteLoadState(
     StateLoadTimestamp = ctx.Now();
     NextVolumeConfigVersion = GetCurrentConfigVersion();
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] State data loaded, time: %lu",
-        TabletID(),
-        GetLoadTime().MicroSeconds());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s State data loaded, time: %s",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        FormatDuration(GetLoadTime()).c_str());
 
     ctx.Send(
         MakeDiskRegistryProxyServiceId(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -13,6 +13,7 @@
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration.h>
 #include <cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h>
 
+#include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/media.h>
 
 #include <contrib/ydb/core/base/tablet.h>
@@ -40,9 +41,16 @@ bool TVolumeActor::SendBootExternalRequest(
         return false;
     }
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Requesting external boot for tablet",
-        partition.TabletId);
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Requesting external boot for partition tablet: [%s]",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        TLogTitle::GetPartitionPrefix(
+            partition.TabletId,
+            partition.PartitionIndex,
+            State->GetMeta().GetPartitions().size())
+            .c_str());
 
     NCloud::Send<TEvHiveProxy::TEvBootExternalRequest>(
         ctx,
@@ -93,14 +101,15 @@ void TVolumeActor::OnStarted(const TActorContext& ctx)
     if (!StartCompletionTimestamp) {
         StartCompletionTimestamp = ctx.Now();
 
-        LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-            "[%lu] Volume %s started. MountSeqNumber: %lu, generation: %lu, "
-            "time: %lu",
-            TabletID(),
-            State->GetDiskId().Quote().c_str(),
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s Volume started. MountSeqNumber: %lu, load time: %s, start "
+            "time: %s",
+            LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
             State->GetMountSeqNumber(),
-            Executor()->Generation(),
-            GetStartTime().MicroSeconds());
+            FormatDuration(GetLoadTime()).c_str(),
+            FormatDuration(GetStartTime()).c_str());
     }
 
     while (!PendingRequests.empty()) {
@@ -655,6 +664,7 @@ void TVolumeActor::HandleBootExternalResponse(
     auto profileLog = ProfileLog;
     auto blockDigestGenerator = BlockDigestGenerator;
     auto storageAccessMode = State->GetStorageAccessMode();
+    auto partitionIndex = part->PartitionIndex;
     auto siblingCount = State->GetPartitions().size();
     auto selfId = SelfId();
 
@@ -676,6 +686,7 @@ void TVolumeActor::HandleBootExternalResponse(
                        std::move(blockDigestGenerator),
                        std::move(partitionConfig),
                        storageAccessMode,
+                       partitionIndex,
                        siblingCount,
                        selfId)
                 .release();
@@ -716,10 +727,13 @@ void TVolumeActor::HandleBootExternalResponse(
 
     NCloud::Send<TEvBootstrapper::TEvStart>(ctx, bootstrapper);
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Starting partition %lu with bootstrapper %s",
-        TabletID(),
-        partTabletId,
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Starting partition [%s g:%u] with bootstrapper %s",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        TLogTitle::GetPartitionPrefix(partTabletId, partitionIndex, siblingCount).c_str(),
+        bootConfig.SuggestedGeneration,
         ToString(bootstrapper).c_str());
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -45,7 +45,7 @@ bool TVolumeActor::SendBootExternalRequest(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Requesting external boot for partition tablet: [%s]",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        LogTitle.GetWithTime().c_str(),
         TLogTitle::GetPartitionPrefix(
             partition.TabletId,
             partition.PartitionIndex,
@@ -106,7 +106,7 @@ void TVolumeActor::OnStarted(const TActorContext& ctx)
             TBlockStoreComponents::VOLUME,
             "%s Volume started. MountSeqNumber: %lu, load time: %s, start "
             "time: %s",
-            LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+            LogTitle.GetWithTime().c_str(),
             State->GetMountSeqNumber(),
             FormatDuration(GetLoadTime()).c_str(),
             FormatDuration(GetStartTime()).c_str());
@@ -731,7 +731,7 @@ void TVolumeActor::HandleBootExternalResponse(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Starting partition [%s g:%u] with bootstrapper %s",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str(),
+        LogTitle.GetWithTime().c_str(),
         TLogTitle::GetPartitionPrefix(partTabletId, partitionIndex, siblingCount).c_str(),
         bootConfig.SuggestedGeneration,
         ToString(bootstrapper).c_str());

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -382,7 +382,7 @@ void TVolumeActor::CompleteUpdateConfig(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s State initialization finished",
-        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
+        LogTitle.GetWithTime().c_str());
 
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/volume/model/helpers.h>
+
 #include <cloud/storage/core/libs/common/media.h>
 
 #include <library/cpp/protobuf/util/pb_io.h>
@@ -377,9 +378,11 @@ void TVolumeActor::CompleteUpdateConfig(
         BecomeAux(ctx, STATE_WORK);
     }
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] State initialization finished",
-        TabletID());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s State initialization finished",
+        LogTitle.Get(TLogTitle::EDetails::WithTime).c_str());
 
     StartPartitionsForUse(ctx);
     ResetServicePipes(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -307,10 +307,12 @@ void TVolumeState::Reset()
     }
 
     if (!IsDiskRegistryMediaKind()) {
+        ui32 partitionIndex = 0;
         for (ui64 tabletId: Meta.GetPartitions()) {
             Partitions.emplace_back(
                 tabletId,
                 Meta.GetConfig(),
+                partitionIndex++,
                 StorageConfig->GetTabletRebootCoolDownIncrement(),
                 StorageConfig->GetTabletRebootCoolDownMax());
             CreatePartitionStatInfo(GetDiskId(), tabletId);


### PR DESCRIPTION
Начинаю приводить все логи NBS к единообразию.
пример:
```
2025-05-30T08:14:12.246206Z :BLOCKSTORE_VOLUME INFO: [v:72075186224037901 g:6 d:a7lqlcq73epjevval9 t:9.192ms] Activated executor
2025-05-30T08:14:12.266864Z :BLOCKSTORE_PARTITION INFO: [p1:72075186224037900 g:6 d:a7lqlcq73epjevval9 t:9.885ms] Schema initialized
2025-05-30T08:14:12.266865Z :BLOCKSTORE_PARTITION INFO: [p0:72075186224037899 g:6 d:a7lqlcq73epjevval9 t:9.894ms] Schema initialized
2025-05-30T11:06:47.617523Z :BLOCKSTORE_PARTITION INFO: [p:72075186224037890 g:15 d:dfgdgdfgdfgdfg t:35.351ms] Send garbage collector completed

```
Где:
v - таблетка вольюма
p - таблетка партишена, если партишен один
p0 - таблетка первого партишена
p1 - таблетка второго партишена
g - поколение
d - идентификатор диска
t - время в человеко-читаемом формате от старта актора

1. В данном ПРе сделан общий класс, который умеет формировать заголовок
2. Сделан пример использования для небольшого количества логов
