### PR TITLE
issue-1751: add TFileRingBuffer::Back method; expose TFileRingBuffer::Visit method to public; rename TFileRingBuffer::Pop to PopFront, TFileRingBuffer::Push to PushBack

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -274,12 +274,12 @@ void TFileSystem::CompleteAsyncDestroyHandle(
         if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
             ReportAsyncDestroyHandleFailed();
             with_lock (HandleOpsQueueLock) {
-                HandleOpsQueue->Pop();
+                HandleOpsQueue->PopFront();
             }
         }
     } else {
         with_lock (HandleOpsQueueLock) {
-            HandleOpsQueue->Pop();
+            HandleOpsQueue->PopFront();
         }
         with_lock (DelayedReleaseQueueLock) {
             if (!DelayedReleaseQueue.empty()) {
@@ -312,7 +312,7 @@ void TFileSystem::ProcessHandleOpsQueue()
             TStringBuilder()
             << "Failed to get TQueueEntry from queue, filesystem: "
             << Config->GetFileSystemId());
-        HandleOpsQueue->Pop();
+        HandleOpsQueue->PopFront();
         ScheduleProcessHandleOpsQueue();
         return;
     }
@@ -347,7 +347,7 @@ void TFileSystem::ProcessHandleOpsQueue()
         ReportHandleOpsQueueProcessError(
             TStringBuilder() << "Unexpected TQueueEntry in queue, filesystem: "
                              << Config->GetFileSystemId());
-        HandleOpsQueue->Pop();
+        HandleOpsQueue->PopFront();
         ScheduleProcessHandleOpsQueue();
         return;
     }

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
@@ -21,7 +21,7 @@ THandleOpsQueue::EResult THandleOpsQueue::AddDestroyRequest(
         return THandleOpsQueue::EResult::SerializationError;
     }
 
-    if (!RequestsToProcess.Push(result)) {
+    if (!RequestsToProcess.PushBack(result)) {
         return THandleOpsQueue::EResult::QueueOverflow;
     }
 
@@ -45,9 +45,9 @@ bool THandleOpsQueue::Empty() const
     return RequestsToProcess.Empty();
 }
 
-void THandleOpsQueue::Pop()
+void THandleOpsQueue::PopFront()
 {
-    RequestsToProcess.Pop();
+    RequestsToProcess.PopFront();
 }
 
 ui64 THandleOpsQueue::Size() const

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.h
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.h
@@ -27,7 +27,7 @@ public:
 
     EResult AddDestroyRequest(ui64 nodeId, ui64 handle);
     std::optional<NProto::TQueueEntry> Front();
-    void Pop();
+    void PopFront();
     ui64 Size() const;
     bool Empty() const;
 };

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -7,8 +7,6 @@
 #include <util/system/compiler.h>
 #include <util/system/filemap.h>
 
-#include <functional>
-
 namespace NCloud {
 
 namespace {
@@ -27,6 +25,7 @@ struct THeader
     ui32 Capacity = 0;
     ui32 ReadPos = 0;
     ui32 WritePos = 0;
+    ui32 LastEntrySize = 0;
 };
 
 struct Y_PACKED TEntryHeader
@@ -83,8 +82,6 @@ private:
         }
     }
 
-    using TVisitor = std::function<void(ui32 checksum, TStringBuf entry)>;
-
     ui32 VisitEntry(const TVisitor& visitor, ui32 pos) const
     {
         const auto* b = Data + pos;
@@ -107,22 +104,6 @@ private:
         return pos + sizeof(TEntryHeader) + eh->Size;
     }
 
-    void Visit(const TVisitor& visitor) const
-    {
-        ui32 pos = Header()->ReadPos;
-        while (pos > Header()->WritePos && pos != INVALID_POS) {
-            pos = VisitEntry(visitor, pos);
-        }
-
-        while (pos < Header()->WritePos && pos != INVALID_POS) {
-            pos = VisitEntry(visitor, pos);
-            if (!pos) {
-                // can happen if the buffer is corrupted
-                break;
-            }
-        }
-    }
-
 public:
     TImpl(const TString& filePath, ui32 capacity)
         : Map(filePath, TMemoryMapCommon::oRdWr)
@@ -137,8 +118,8 @@ public:
         }
 
         if (Header()->Version) {
-            Y_ABORT_UNLESS(Header()->Version == VERSION);
             Y_ABORT_UNLESS(Header()->Capacity == capacity);
+            Y_ABORT_UNLESS(Header()->Version == VERSION);
         } else {
             Header()->Capacity = capacity;
             Header()->Version = VERSION;
@@ -156,7 +137,7 @@ public:
     }
 
 public:
-    bool Push(TStringBuf data)
+    bool PushBack(TStringBuf data)
     {
         if (data.empty()) {
             return false;
@@ -198,6 +179,7 @@ public:
         WriteEntry(mo, data);
 
         Header()->WritePos = ptr - Data + sz;
+        Header()->LastEntrySize = sz;
         ++Count;
 
         return true;
@@ -227,7 +209,37 @@ public:
         return result;
     }
 
-    void Pop()
+    TStringBuf Back() const
+    {
+        if (Empty()) {
+            return {};
+        }
+
+        if (Header()->WritePos < Header()->LastEntrySize) {
+            // corruption
+            // TODO: report?
+            return {};
+        }
+
+        const auto* b = Data + Header()->WritePos - Header()->LastEntrySize;
+        if (b + sizeof(TEntryHeader) > End) {
+            // corruption
+            // TODO: report?
+            return {};
+        }
+
+        const auto* eh = reinterpret_cast<const TEntryHeader*>(b);
+        TStringBuf result{b + sizeof(TEntryHeader), eh->Size};
+        if (result.data() + result.size() > End) {
+            // corruption
+            // TODO: report?
+            return {};
+        }
+
+        return result;
+    }
+
+    void PopFront()
     {
         auto data = Front();
         if (!data) {
@@ -268,6 +280,22 @@ public:
 
         return entries;
     }
+
+    void Visit(const TVisitor& visitor) const
+    {
+        ui32 pos = Header()->ReadPos;
+        while (pos > Header()->WritePos && pos != INVALID_POS) {
+            pos = VisitEntry(visitor, pos);
+        }
+
+        while (pos < Header()->WritePos && pos != INVALID_POS) {
+            pos = VisitEntry(visitor, pos);
+            if (!pos) {
+                // can happen if the buffer is corrupted
+                break;
+            }
+        }
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -280,9 +308,9 @@ TFileRingBuffer::TFileRingBuffer(
 
 TFileRingBuffer::~TFileRingBuffer() = default;
 
-bool TFileRingBuffer::Push(TStringBuf data)
+bool TFileRingBuffer::PushBack(TStringBuf data)
 {
-    return Impl->Push(data);
+    return Impl->PushBack(data);
 }
 
 TStringBuf TFileRingBuffer::Front() const
@@ -290,9 +318,14 @@ TStringBuf TFileRingBuffer::Front() const
     return Impl->Front();
 }
 
-void TFileRingBuffer::Pop()
+TStringBuf TFileRingBuffer::Back() const
 {
-    Impl->Pop();
+    return Impl->Back();
+}
+
+void TFileRingBuffer::PopFront()
+{
+    Impl->PopFront();
 }
 
 ui32 TFileRingBuffer::Size() const
@@ -308,6 +341,11 @@ bool TFileRingBuffer::Empty() const
 TVector<TFileRingBuffer::TBrokenFileEntry> TFileRingBuffer::Validate() const
 {
     return Impl->Validate();
+}
+
+void TFileRingBuffer::Visit(const TVisitor& visitor) const
+{
+    return Impl->Visit(visitor);
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -3,6 +3,8 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
+#include <functional>
+
 namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -17,6 +19,8 @@ public:
         ui32 ActualChecksum = 0;
     };
 
+    using TVisitor = std::function<void(ui32 checksum, TStringBuf entry)>;
+
 private:
     class TImpl;
     std::unique_ptr<TImpl> Impl;
@@ -26,12 +30,14 @@ public:
     ~TFileRingBuffer();
 
 public:
-    bool Push(TStringBuf data);
+    bool PushBack(TStringBuf data);
     TStringBuf Front() const;
-    void Pop();
+    TStringBuf Back() const;
+    void PopFront();
     ui32 Size() const;
     bool Empty() const;
     TVector<TBrokenFileEntry> Validate() const;
+    void Visit(const TVisitor& visitor) const;
 };
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -41,7 +41,7 @@ TString PopAll(TFileRingBuffer& rb)
         }
 
         sb << rb.Front();
-        rb.Pop();
+        rb.PopFront();
     }
 
     return sb;
@@ -63,7 +63,7 @@ struct TReferenceImplementation
         : MaxWeight(maxWeight)
     {}
 
-    bool Push(TStringBuf data)
+    bool PushBack(TStringBuf data)
     {
         if (data.empty() || data.size() > MaxWeight) {
             return false;
@@ -109,7 +109,16 @@ struct TReferenceImplementation
         return Q.front();
     }
 
-    void Pop()
+    TStringBuf Back() const
+    {
+        if (!Q) {
+            return {};
+        }
+
+        return Q.back();
+    }
+
+    void PopFront()
     {
         if (!Q) {
             return;
@@ -166,44 +175,51 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
         UNIT_ASSERT(rb.Empty());
 
-        UNIT_ASSERT(!rb.Push(GenerateData(rb.Size())));   // too long
-        UNIT_ASSERT(!rb.Push(""));              // empty
-        UNIT_ASSERT(rb.Push("vasya"));
-        UNIT_ASSERT(rb.Push("petya"));
-        UNIT_ASSERT(rb.Push("vasya2"));
-        UNIT_ASSERT(rb.Push("petya2"));
-        UNIT_ASSERT(!rb.Push("vasya3"));        // out of space
+        UNIT_ASSERT(!rb.PushBack(GenerateData(rb.Size())));   // too long
+        UNIT_ASSERT(!rb.PushBack(""));              // empty
+
+        UNIT_ASSERT(rb.PushBack("vasya"));
+        UNIT_ASSERT_VALUES_EQUAL("vasya", rb.Back());
+
+        UNIT_ASSERT(rb.PushBack("petya"));
+        UNIT_ASSERT_VALUES_EQUAL("petya", rb.Back());
+
+        UNIT_ASSERT(rb.PushBack("vasya2"));
+        UNIT_ASSERT_VALUES_EQUAL("vasya2", rb.Back());
+
+        UNIT_ASSERT(rb.PushBack("petya2"));
+        UNIT_ASSERT(!rb.PushBack("vasya3"));        // out of space
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(4, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya", rb.Front());
-        rb.Pop();
+        rb.PopFront();
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
-        UNIT_ASSERT(!rb.Push("vasya3"));
+        UNIT_ASSERT(!rb.PushBack("vasya3"));
 
         UNIT_ASSERT_VALUES_EQUAL("petya", rb.Front());
-        rb.Pop();
+        rb.PopFront();
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
-        UNIT_ASSERT(rb.Push("vasya3"));
+        UNIT_ASSERT(rb.PushBack("vasya3"));
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya2", rb.Front());
-        rb.Pop();
+        rb.PopFront();
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("petya2", rb.Front());
-        rb.Pop();
+        rb.PopFront();
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya3", rb.Front());
-        rb.Pop();
+        rb.PopFront();
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
@@ -235,14 +251,14 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             f.GetName(),
             len);
 
-        UNIT_ASSERT(rb->Push("vasya"));
-        UNIT_ASSERT(rb->Push("petya"));
-        UNIT_ASSERT(rb->Push("vasya2"));
-        UNIT_ASSERT(rb->Push("petya2"));
-        rb->Pop();
-        rb->Pop();
-        UNIT_ASSERT(rb->Push("vasya3"));
-        UNIT_ASSERT(rb->Push("xxx"));
+        UNIT_ASSERT(rb->PushBack("vasya"));
+        UNIT_ASSERT(rb->PushBack("petya"));
+        UNIT_ASSERT(rb->PushBack("vasya2"));
+        UNIT_ASSERT(rb->PushBack("petya2"));
+        rb->PopFront();
+        rb->PopFront();
+        UNIT_ASSERT(rb->PushBack("vasya3"));
+        UNIT_ASSERT(rb->PushBack("xxx"));
 
         rb = std::make_unique<TFileRingBuffer>(
             f.GetName(),
@@ -257,19 +273,19 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     Y_UNIT_TEST(ShouldValidate)
     {
         const auto f = TTempFileHandle();
-        const ui32 len = 64;
+        const ui32 len = 128;
         TFileRingBuffer rb(f.GetName(), len);
 
-        UNIT_ASSERT(rb.Push("vasya"));
-        UNIT_ASSERT(rb.Push("petya"));
-        UNIT_ASSERT(rb.Push("vasya2"));
-        UNIT_ASSERT(rb.Push("petya2"));
+        UNIT_ASSERT(rb.PushBack("vasya"));
+        UNIT_ASSERT(rb.PushBack("petya"));
+        UNIT_ASSERT(rb.PushBack("vasya2"));
+        UNIT_ASSERT(rb.PushBack("petya2"));
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
         TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
         m.Map(0, len);
         char* data = static_cast<char*>(m.Ptr());
-        data[20] = 'A';
+        data[24] = 'A';
 
         UNIT_ASSERT_VALUES_EQUAL(
             "data=vasya ecsum=3387363649 csum=3387363646",
@@ -289,11 +305,11 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const TString data2(entryDataLen, 'b');
         const TString data3(entryDataLen, 'c');
 
-        UNIT_ASSERT(rb.Push(data));
-        UNIT_ASSERT(rb.Push(data2));
-        UNIT_ASSERT(!rb.Push(data3));
-        rb.Pop();
-        UNIT_ASSERT(rb.Push(data3));
+        UNIT_ASSERT(rb.PushBack(data));
+        UNIT_ASSERT(rb.PushBack(data2));
+        UNIT_ASSERT(!rb.PushBack(data3));
+        rb.PopFront();
+        UNIT_ASSERT(rb.PushBack(data3));
 
         /*
          * Buffer data:
@@ -328,17 +344,19 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
                 const ui32 entrySize =
                     RandomNumber(Min(remainingBytes + 1, testUpToEntrySize));
                 const auto data = GenerateData(entrySize);
-                const bool pushed = ri.Push(data);
-                UNIT_ASSERT_VALUES_EQUAL(pushed, rb->Push(data));
+                const bool pushed = ri.PushBack(data);
+                UNIT_ASSERT_VALUES_EQUAL(pushed, rb->PushBack(data));
                 if (pushed) {
+                    UNIT_ASSERT_VALUES_EQUAL(ri.Back(), rb->Back());
                     remainingBytes -= entrySize;
                     // Cerr << "PUSH\t" << data << Endl;
                 }
             } else {
+                UNIT_ASSERT_VALUES_EQUAL(ri.Back(), rb->Back());
                 UNIT_ASSERT_VALUES_EQUAL(ri.Front(), rb->Front());
                 // Cerr << "POP\t" << ri.Front() << Endl;
-                ri.Pop();
-                rb->Pop();
+                ri.PopFront();
+                rb->PopFront();
             }
 
             // Cerr << ri.Size() << " " << remainingBytes << Endl;


### PR DESCRIPTION
#1751 

Needed for write-back cache implementation https://github.com/ydb-platform/nbs/pull/3395