### PR TITLE
Rename `WalleLocation` to `Location` and remove deprecated `Body` field

### DIFF
--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -179,7 +179,7 @@ def send_two_node_nameservice_config(env):
             env.configurator.all_node_ids()[0]).ic_port,
         Host="localhost",
         InterconnectHost="localhost",
-        WalleLocation=TNodeLocation(Body=1, DataCenter="1", Rack="1")
+        Location=TNodeLocation(DataCenter="1", Rack="1")
     )
     pm = PortManager()
     second_node_port = pm.get_port()
@@ -188,7 +188,7 @@ def send_two_node_nameservice_config(env):
         Port=second_node_port,
         Host="localhost",
         InterconnectHost="localhost",
-        WalleLocation=TNodeLocation(Body=2, DataCenter="2", Rack="2")
+        Location=TNodeLocation(DataCenter="2", Rack="2")
     )
     update_cms_config(env.kikimr_cluster.client, nameservice_config)
 

--- a/cloud/blockstore/tests/config_dispatcher/test.py
+++ b/cloud/blockstore/tests/config_dispatcher/test.py
@@ -40,9 +40,8 @@ def verify_config_update(ydb, mon_port):
         Port=65535,
         Host='somewhere',
     )
-    node.WalleLocation.DataCenter = 'xyz'
-    node.WalleLocation.Rack = 'somewhere'
-    node.WalleLocation.Body = 1
+    node.Location.DataCenter = 'xyz'
+    node.Location.Rack = 'somewhere'
     app_config.NameserviceConfig.MergeFrom(naming_config)
     ydb.client.add_config_item(app_config)
 

--- a/cloud/blockstore/tools/cms/patcher/tests/data/files/dca1-ct5-13.cloud.net/nbs-names.txt
+++ b/cloud/blockstore/tools/cms/patcher/tests/data/files/dca1-ct5-13.cloud.net/nbs-names.txt
@@ -4,10 +4,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-13.cloud.net"
   InterconnectHost: "dca1-ct5-13.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-1:1"
-    Body: 103058410
   }
 }
 Node {
@@ -16,10 +15,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-14.cloud.net"
   InterconnectHost: "dca1-ct5-14.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-2:1"
-    Body: 103058412
   }
 }
 Node {
@@ -28,10 +26,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-15.cloud.net"
   InterconnectHost: "dca1-ct5-15.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-3:1"
-    Body: 103058411
   }
 }
 Node {
@@ -40,10 +37,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-16.cloud.net"
   InterconnectHost: "dca1-ct5-16.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-4:1"
-    Body: 103058413
   }
 }
 Node {
@@ -52,10 +48,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-17.cloud.net"
   InterconnectHost: "dca1-ct5-17.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-5:1"
-    Body: 103058409
   }
 }
 Node {
@@ -64,10 +59,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-18.cloud.net"
   InterconnectHost: "dca1-ct5-18.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-6:1"
-    Body: 103058405
   }
 }
 Node {
@@ -76,10 +70,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-24.cloud.net"
   InterconnectHost: "dca1-ct5-24.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-7:1"
-    Body: 103057958
   }
 }
 Node {
@@ -88,10 +81,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-25.cloud.net"
   InterconnectHost: "dca1-ct5-25.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-8:1"
-    Body: 103058207
   }
 }
 ClusterUUID: "2452520"

--- a/cloud/blockstore/tools/cms/patcher/tests/data/files/dca1-ct5-17.cloud.net/nbs-names.txt
+++ b/cloud/blockstore/tools/cms/patcher/tests/data/files/dca1-ct5-17.cloud.net/nbs-names.txt
@@ -4,10 +4,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-13.cloud.net"
   InterconnectHost: "dca1-ct5-13.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-1:1"
-    Body: 103058410
   }
 }
 Node {
@@ -16,10 +15,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-14.cloud.net"
   InterconnectHost: "dca1-ct5-14.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-2:1"
-    Body: 103058412
   }
 }
 Node {
@@ -28,10 +26,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-15.cloud.net"
   InterconnectHost: "dca1-ct5-15.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-3:1"
-    Body: 103058411
   }
 }
 Node {
@@ -40,10 +37,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-16.cloud.net"
   InterconnectHost: "dca1-ct5-16.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-4:1"
-    Body: 103058413
   }
 }
 Node {
@@ -52,10 +48,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-17.cloud.net"
   InterconnectHost: "dca1-ct5-17.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-5:1"
-    Body: 103058409
   }
 }
 Node {
@@ -64,10 +59,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-18.cloud.net"
   InterconnectHost: "dca1-ct5-18.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-6:1"
-    Body: 103058405
   }
 }
 Node {
@@ -76,10 +70,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-24.cloud.net"
   InterconnectHost: "dca1-ct5-24.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-7:1"
-    Body: 103057958
   }
 }
 Node {
@@ -88,10 +81,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-25.cloud.net"
   InterconnectHost: "dca1-ct5-25.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-8:1"
-    Body: 103058207
   }
 }
 ClusterUUID: "2452520"

--- a/cloud/blockstore/tools/cms/patcher/tests/data/files/dca1-ct5-18.cloud.net/nbs-names.txt
+++ b/cloud/blockstore/tools/cms/patcher/tests/data/files/dca1-ct5-18.cloud.net/nbs-names.txt
@@ -4,10 +4,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-13.cloud.net"
   InterconnectHost: "dca1-ct5-13.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-1:1"
-    Body: 103058410
   }
 }
 Node {
@@ -16,10 +15,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-14.cloud.net"
   InterconnectHost: "dca1-ct5-14.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-2:1"
-    Body: 103058412
   }
 }
 Node {
@@ -28,10 +26,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-15.cloud.net"
   InterconnectHost: "dca1-ct5-15.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-3:1"
-    Body: 103058411
   }
 }
 Node {
@@ -40,10 +37,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-16.cloud.net"
   InterconnectHost: "dca1-ct5-16.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-4:1"
-    Body: 103058413
   }
 }
 Node {
@@ -52,10 +48,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-17.cloud.net"
   InterconnectHost: "dca1-ct5-17.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-5:1"
-    Body: 103058409
   }
 }
 Node {
@@ -64,10 +59,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-18.cloud.net"
   InterconnectHost: "dca1-ct5-18.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-6:1"
-    Body: 103058405
   }
 }
 Node {
@@ -76,10 +70,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-24.cloud.net"
   InterconnectHost: "dca1-ct5-24.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-7:1"
-    Body: 103057958
   }
 }
 Node {
@@ -88,10 +81,9 @@ Node {
   Port: 19001
   Host: "dca1-ct5-25.cloud.net"
   InterconnectHost: "dca1-ct5-25.cloud.net"
-  WalleLocation {
+  Location {
     DataCenter: "dca"
     Rack: "dca-8:1"
-    Body: 103058207
   }
 }
 ClusterUUID: "2452520"

--- a/cloud/filestore/bin/dynamic/Configure-Root.txt
+++ b/cloud/filestore/bin/dynamic/Configure-Root.txt
@@ -58,10 +58,9 @@ ConfigureRequest {
               Port: 29501
               Host: "localhost"
               InterconnectHost: "localhost"
-              WalleLocation {
+              Location {
                 DataCenter: "1"
                 Rack: "1"
-                Body: 1
               }
             }
             ClusterUUID: "local"

--- a/cloud/filestore/bin/nfs/names.txt
+++ b/cloud/filestore/bin/nfs/names.txt
@@ -3,10 +3,9 @@ Node {
   Port: 29501
   Host: "localhost"
   InterconnectHost: "localhost"
-  WalleLocation {
+  Location {
     DataCenter: "1"
     Rack: "1"
-    Body: 1
   }
 }
 ClusterUUID: "local"

--- a/cloud/filestore/bin/static/names.txt
+++ b/cloud/filestore/bin/static/names.txt
@@ -3,10 +3,9 @@ Node {
   Port: 29501
   Host: "localhost"
   InterconnectHost: "localhost"
-  WalleLocation {
+  Location {
     DataCenter: "1"
     Rack: "1"
-    Body: 1
   }
 }
 ClusterUUID: "local"

--- a/cloud/filestore/tests/config_dispatcher/test.py
+++ b/cloud/filestore/tests/config_dispatcher/test.py
@@ -83,9 +83,8 @@ def check_configs(mon_port, kikimr_configurator, kikimr_cluster):
         Port=65535,
         Host='somewhere',
     )
-    node.WalleLocation.DataCenter = 'xyz'
-    node.WalleLocation.Rack = 'somewhere'
-    node.WalleLocation.Body = 1
+    node.Location.DataCenter = 'xyz'
+    node.Location.Rack = 'somewhere'
     app_config.NameserviceConfig.MergeFrom(naming_config)
     kikimr_cluster.client.add_config_item(app_config)
 

--- a/example/dynamic/Configure-Root.txt
+++ b/example/dynamic/Configure-Root.txt
@@ -58,10 +58,9 @@ ConfigureRequest {
               Port: 29501
               Host: "localhost"
               InterconnectHost: "localhost"
-              WalleLocation {
+              Location {
                 DataCenter: "1"
                 Rack: "1"
-                Body: 1
               }
             }
             ClusterUUID: "local"

--- a/example/nbs/nbs-names.txt
+++ b/example/nbs/nbs-names.txt
@@ -3,8 +3,7 @@ Node {
   Port: 29501
   Host: "localhost"
   InterconnectHost: "localhost"
-  WalleLocation {
-    Body: 1
+  Location {
     DataCenter: "1"
     Rack: "1"
   }

--- a/example/static/names.txt
+++ b/example/static/names.txt
@@ -3,10 +3,9 @@ Node {
   Port: 29501
   Host: "localhost"
   InterconnectHost: "localhost"
-  WalleLocation {
+  Location {
     DataCenter: "1"
     Rack: "1"
-    Body: 1
   }
 }
 ClusterUUID: "local"


### PR DESCRIPTION
Get rid of warnings in examples:
```
[libprotobuf WARNING /home/dvrazumov/nbs/contrib/libs/protobuf/src/google/protobuf/text_format.cc:350] Warning parsing text-format NKikimrClient.TConsoleRequest: 65:15: text format contains deprecated field "Body"
[libprotobuf WARNING /home/dvrazumov/nbs/contrib/libs/protobuf/src/google/protobuf/text_format.cc:350] Warning parsing text-format NKikimrClient.TConsoleRequest: 66:13: text format contains deprecated field "WalleLocation"
```