### PR TITLE
issue-1541: add execute action to filestore python sdk; add async_close test

### DIFF
--- a/cloud/filestore/public/sdk/python/client/base_client.py
+++ b/cloud/filestore/public/sdk/python/client/base_client.py
@@ -21,6 +21,7 @@ CLIENT_METHODS = [
     "create_checkpoint",
     "destroy_checkpoint",
     "describe_filestore_model",
+    "execute_action",
 ]
 
 ENDPOINT_METHODS = [

--- a/cloud/filestore/public/sdk/python/client/client.py
+++ b/cloud/filestore/public/sdk/python/client/client.py
@@ -428,6 +428,27 @@ class Client(object):
             trace_id,
             request_timeout)
 
+    @_handle_errors
+    def execute_action(
+            self,
+            action: str,
+            input: bytes,
+            idempotence_id=None,
+            timestamp=None,
+            trace_id=None,
+            request_timeout=None):
+        request = protos.TExecuteActionRequest(
+            Action=action,
+            Input=input
+        )
+
+        return self.__impl.execute_action(
+            request,
+            idempotence_id,
+            timestamp,
+            trace_id,
+            request_timeout)
+
 
 def CreateClient(
         endpoint,

--- a/cloud/filestore/public/sdk/python/protos/__init__.py
+++ b/cloud/filestore/public/sdk/python/protos/__init__.py
@@ -1,6 +1,7 @@
 from cloud.storage.core.protos.error_pb2 import *               # noqa
 from cloud.storage.core.protos.media_pb2 import *               # noqa
 
+from cloud.filestore.public.api.protos.action_pb2 import *      # noqa
 from cloud.filestore.public.api.protos.checkpoint_pb2 import *  # noqa
 from cloud.filestore.public.api.protos.data_pb2 import *        # noqa
 from cloud.filestore.public.api.protos.endpoint_pb2 import *    # noqa

--- a/cloud/filestore/tests/async_close_test/script.py
+++ b/cloud/filestore/tests/async_close_test/script.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+def open_and_close_files(num_files):
+    fds = []
+    try:
+        for i in range(num_files):
+            path = f"testfile_{i}"
+            # Create the file if it doesn't exist
+            fd = os.open(path, os.O_RDWR | os.O_CREAT)
+            print(f"Opened: {path} (fd: {fd})")
+            fds.append(fd)
+    except OSError as e:
+        print(f"Error opening file: {e}")
+    finally:
+        for fd in fds:
+            try:
+                os.close(fd)
+                print(f"Closed fd: {fd}")
+            except OSError as e:
+                print(f"Error closing fd {fd}: {e}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <number_of_files>")
+        sys.exit(1)
+    try:
+        num = int(sys.argv[1])
+        if num <= 0:
+            raise ValueError
+    except ValueError:
+        print("Please provide a positive integer.")
+        sys.exit(1)
+
+    open_and_close_files(num)

--- a/cloud/filestore/tests/async_close_test/test.py
+++ b/cloud/filestore/tests/async_close_test/test.py
@@ -1,0 +1,82 @@
+import json
+import logging
+import os
+from time import sleep
+
+from retrying import retry
+
+import yatest.common as common
+
+import cloud.filestore.public.sdk.python.client as client
+from cloud.storage.core.tools.testing.qemu.lib.common import (
+    env_with_guest_index,
+    SshToGuest,
+)
+
+RETRY_COUNT = 3
+WAIT_TIMEOUT = 1000  # 1sec
+HANDLE_OPEN_COUNT = 10000
+MAX_WAIT_SECONDS = 600
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT)
+def get_handles_count(filestore_client: client.Client, logger) -> int:
+    res = filestore_client.execute_action(
+        action="getstoragestats",
+        input=str.encode('{"FileSystemId": "nfs_test"}'))
+
+    try:
+        stats = json.loads(res.Output)
+        handles_count = stats.get("Stats", {}).get("UsedHandlesCount", 0)
+    except (json.JSONDecodeError, AttributeError, TypeError) as e:
+        logger.error(f"Failed to parse getstoragestats answer: {e}")
+        raise
+
+    return handles_count
+
+
+def test():
+    logger = logging.getLogger("test")
+    server_port = os.getenv("NFS_SERVER_PORT")
+
+    port = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 0)))
+    ssh_key = os.getenv("QEMU_SSH_KEY")
+    mount_dir = os.getenv("NFS_MOUNT_PATH")
+
+    script_path = common.source_path(
+        "cloud/filestore/tests/async_close_test/script.py")
+
+    # Run test script. It will open HANDLE_OPEN_COUNT files
+    # and after that close them
+    ssh = SshToGuest(user="qemu", port=port, key=ssh_key)
+    res = ssh(
+        f"sudo bash -c 'cd {mount_dir} && ulimit -n 65535 && "
+        f"python3 {script_path} {HANDLE_OPEN_COUNT}'")
+
+    # Check that test script successfully finished.
+    assert 0 == res.returncode
+
+    prev = -1
+    with client.CreateClient(
+            f"localhost:{server_port}", log=logger) as filestore_client:
+
+        # Check that after test script finished,
+        # handles count in server not zero.
+        # It means that async handle destroying is working
+        assert 0 != get_handles_count(filestore_client, logger), (
+            "Expected non-zero handles count after script run, got 0")
+
+        # Check that after file closing,
+        # handles will be asynchronously freed eventually.
+        for _ in range(MAX_WAIT_SECONDS):
+            handles_count = get_handles_count(filestore_client, logger)
+            logger.info(f"Handles count: {handles_count}")
+            if handles_count == 0:
+                logger.info("All handles are destroyed")
+                break
+            if handles_count == prev:
+                raise AssertionError(f"Handles count stuck at {handles_count}")
+            prev = handles_count
+            sleep(1)
+
+        assert 0 == handles_count

--- a/cloud/filestore/tests/async_close_test/ya.make
+++ b/cloud/filestore/tests/async_close_test/ya.make
@@ -1,0 +1,33 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+SPLIT_FACTOR(1)
+
+TEST_SRCS(
+    test.py
+)
+
+PEERDIR(
+    cloud/filestore/public/sdk/python/client
+    cloud/filestore/tests/python/lib
+
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INSTANCE_COUNT 1)
+SET(FILESTORE_VHOST_ENDPOINT_COUNT 1)
+SET(VIRTIOFS_SERVER_COUNT 1)
+SET(QEMU_INVOKE_TEST NO)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -17,3 +17,4 @@ InMemoryIndexCacheLoadOnTabletStartRowsPerTx: 1
 UseMixedBlocksInsteadOfAliveBlocksInCompaction: true
 MixedBlocksOffloadedRangesCapacity: 1024
 CalculateCleanupScoreBasedOnUsedBlocksCount: true
+AsyncDestroyHandleEnabled: true

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -67,6 +67,10 @@ def start(argv):
     config.VhostServiceConfig.EndpointStorageType = EEndpointStorageType.ENDPOINT_STORAGE_FILE
     config.VhostServiceConfig.EndpointStorageDir = endpoint_storage_dir
 
+    handle_ops_queue_path = common.work_path() + "/handleopsqueue-" + uid
+    pathlib.Path(handle_ops_queue_path).mkdir(parents=True, exist_ok=True)
+    config.VhostServiceConfig.HandleOpsQueuePath = handle_ops_queue_path
+
     service_type = args.service or "local"
     kikimr_port = 0
     domain = None

--- a/cloud/filestore/tests/ya.make
+++ b/cloud/filestore/tests/ya.make
@@ -4,6 +4,7 @@ RECURSE(
 )
 
 RECURSE_FOR_TESTS(
+    async_close_test
     auth
     build_arcadia_test
     client


### PR DESCRIPTION
#1541 
This pull request adds a test that verifies files are indeed being closed asynchronously. The test opens 100k files, closes them afterward, and then checks that the number of used handles decreases