### PR TITLE
issue-3635: skip test_publish_volume_must_fail_after_fs_error test

### DIFF
--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part2/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part2/test.py
@@ -191,6 +191,7 @@ def test_node_volume_expand_vm_mode():
         csi.cleanup_after_test(env, volume_name, access_type, [pod_id])
 
 
+@pytest.mark.skip(reason="issue-3635")
 def test_publish_volume_must_fail_after_fs_error():
     env, run = csi.init()
     try:


### PR DESCRIPTION
issue: #3635 

Test is failing after update the image to Ubuntu 24