### PR TITLE
[Disk Manager] Integration of cell selection mechanism into disk creation

### DIFF
--- a/cloud/disk_manager/internal/pkg/cells/cells.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells.go
@@ -4,10 +4,16 @@ import (
 	"context"
 
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+<<<<<<< HEAD
 	cells_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells/config"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
+=======
+)
+
+// //////////////////////////////////////////////////////////////////////////////
+>>>>>>> add cells component
 
 type cellSelector struct {
 	config *cells_config.CellsConfig

--- a/cloud/disk_manager/internal/pkg/cells/cells.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells.go
@@ -4,16 +4,10 @@ import (
 	"context"
 
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
-<<<<<<< HEAD
 	cells_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells/config"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
-=======
-)
-
-// //////////////////////////////////////////////////////////////////////////////
->>>>>>> add cells component
 
 type cellSelector struct {
 	config *cells_config.CellsConfig

--- a/cloud/disk_manager/internal/pkg/configs/server/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/configs/server/config/config.proto
@@ -4,6 +4,7 @@ package server;
 
 import "google/protobuf/duration.proto";
 import "cloud/disk_manager/internal/pkg/auth/config/config.proto";
+import "cloud/disk_manager/internal/pkg/cells/config/config.proto";
 import "cloud/disk_manager/internal/pkg/clients/nbs/config/config.proto";
 import "cloud/disk_manager/internal/pkg/clients/nfs/config/config.proto";
 import "cloud/disk_manager/internal/pkg/dataplane/config/config.proto";
@@ -70,4 +71,5 @@ message ServerConfig {
     optional performance.PerformanceConfig PerformanceConfig = 16;
     optional bool LockProcessMemory = 17 [default = true];
     optional tracing.TracingConfig TracingConfig = 18;
+    optional cells.CellsConfig CellsConfig = 19;
 }

--- a/cloud/disk_manager/internal/pkg/configs/server/config/ya.make
+++ b/cloud/disk_manager/internal/pkg/configs/server/config/ya.make
@@ -8,6 +8,7 @@ SRCS(
 
 PEERDIR(
     cloud/disk_manager/internal/pkg/auth/config
+    cloud/disk_manager/internal/pkg/cells/config
     cloud/disk_manager/internal/pkg/clients/nbs/config
     cloud/disk_manager/internal/pkg/clients/nfs/config
     cloud/disk_manager/internal/pkg/dataplane/config

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/.gitignore
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/.gitignore
@@ -1,1 +1,2 @@
 disk_service_test
+disk_service_test_cells

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
@@ -1,0 +1,632 @@
+package disk_service_test
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/api"
+	internal_client "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/client"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/facade/testcommon"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/disks"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	defaultZoneId = "zone-a"
+	shardedZoneId = "zone-d"
+	cellId1       = "zone-d"
+	cellId2       = "zone-d-shard1"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func testDiskServiceCreateEmptyDiskWithZoneID(t *testing.T, zoneID string) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	request := disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: 4096,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+	}
+
+	operation, err := client.CreateDisk(reqCtx, &request)
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	// Check idempotency.
+	operation, err = client.CreateDisk(reqCtx, &request)
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func testCreateDiskFromImage(
+	t *testing.T,
+	diskKind disk_manager.DiskKind,
+	imageSize uint64,
+	pooled bool,
+	diskSize uint64,
+	diskFolderId string,
+	encryptionDesc *disk_manager.EncryptionDesc,
+	zoneID string,
+) {
+
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	imageID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "_image"
+
+	diskContentInfo := testcommon.CreateImage(
+		t,
+		ctx,
+		imageID,
+		imageSize,
+		"folder",
+		pooled,
+	)
+
+	diskID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcImageId{
+			SrcImageId: imageID,
+		},
+		Size: int64(diskSize),
+		Kind: diskKind,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		FolderId:       diskFolderId,
+		EncryptionDesc: encryptionDesc,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	require.NoError(t, err)
+	// We should provide correct zone for NBS client because only unsharded
+	// zones and shards are configured in the NBS client config.
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
+
+	if encryptionDesc != nil {
+		encryption, err := disks.PrepareEncryptionDesc(encryptionDesc)
+		require.NoError(t, err)
+
+		err = nbsClient.ValidateCrc32WithEncryption(
+			ctx,
+			diskID,
+			diskContentInfo,
+			encryption,
+		)
+		require.NoError(t, err)
+	} else {
+		err = nbsClient.ValidateCrc32(
+			ctx,
+			diskID,
+			diskContentInfo,
+		)
+		require.NoError(t, err)
+	}
+
+	diskParams, err := nbsClient.Describe(ctx, diskID)
+	require.NoError(t, err)
+	if pooled {
+		// Check that disk is overlay.
+		require.NotEmpty(t, diskParams.BaseDiskID)
+	} else {
+		// Check that disk is not overlay.
+		require.Empty(t, diskParams.BaseDiskID)
+	}
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.DeleteDisk(reqCtx, &disk_manager.DeleteDiskRequest{
+		DiskId: &disk_manager.DiskId{
+			DiskId: diskID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func testDiskServiceCreateDiskFromImageWithForceNotLayeredWithZoneID(
+	t *testing.T,
+	zoneID string,
+) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	imageID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateImage(reqCtx, &disk_manager.CreateImageRequest{
+		Src: &disk_manager.CreateImageRequest_SrcUrl{
+			SrcUrl: &disk_manager.ImageUrl{
+				Url: testcommon.GetRawImageFileURL(),
+			},
+		},
+		DstImageId: imageID,
+		FolderId:   "folder",
+		Pooled:     true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcImageId{
+			SrcImageId: imageID,
+		},
+		Size: 134217728,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		ForceNotLayered: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	require.NoError(t, err)
+	// We should provide correct zone for NBS client because only unsharded
+	// zones and shards are configured in the NBS client config.
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
+	err = nbsClient.ValidateCrc32(
+		ctx,
+		diskID,
+		nbs.DiskContentInfo{
+			ContentSize: testcommon.GetRawImageSize(t),
+			Crc32:       testcommon.GetRawImageCrc32(t),
+			BlockCrc32s: []uint32{}, // We do not know blockCrc32s for image.
+		},
+	)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+func testDiskServiceCancelCreateDiskFromImageWithZoneID(
+	t *testing.T,
+	zoneID string,
+) {
+
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	imageID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+	imageSize := uint64(64 * 1024 * 1024)
+
+	_ = testcommon.CreateImage(
+		t,
+		ctx,
+		imageID,
+		imageSize,
+		"folder",
+		true, // pooled
+	)
+
+	diskID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+	diskSize := 2 * imageSize
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcImageId{
+			SrcImageId: imageID,
+		},
+		Size: int64(diskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	testcommon.CancelOperation(t, ctx, client, operation.Id)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func testDiskServiceCreateDiskFromSnapshotWithZoneID(
+	t *testing.T,
+	zoneID string,
+) {
+
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskSize := uint64(32 * 1024 * 4096)
+	diskID1 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "1"
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: int64(diskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID1,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, defaultZoneId)
+	diskContentInfo, err := nbsClient.FillDisk(ctx, diskID1, diskSize)
+	require.NoError(t, err)
+
+	snapshotID1 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "1"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
+		Src: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID1,
+		},
+		SnapshotId: snapshotID1,
+		FolderId:   "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	snapshotMeta := disk_manager.CreateSnapshotMetadata{}
+	err = internal_client.GetOperationMetadata(ctx, client, operation.Id, &snapshotMeta)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), snapshotMeta.Progress)
+
+	diskID2 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "2"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
+			SrcSnapshotId: snapshotID1,
+		},
+		Size: int64(diskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID2,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	createDiskMeta := disk_manager.CreateDiskMetadata{}
+	err = internal_client.GetOperationMetadata(
+		ctx,
+		client,
+		operation.Id,
+		&createDiskMeta,
+	)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), createDiskMeta.Progress)
+
+	err = nbsClient.ValidateCrc32(ctx, diskID1, diskContentInfo)
+	require.NoError(t, err)
+
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID2)
+	require.NoError(t, err)
+	// We should provide correct zone for NBS client because only unsharded
+	// zones and shards are configured in the NBS client config.
+	nbsClient = testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
+	err = nbsClient.ValidateCrc32(ctx, diskID2, diskContentInfo)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+func testCreateDiskFromIncrementalSnapshot(
+	t *testing.T,
+	diskKind disk_manager.DiskKind,
+	diskSize uint64,
+	zoneID string,
+) {
+
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskID1 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "1"
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: int64(diskSize),
+		Kind: diskKind,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID1,
+		},
+		FolderId: "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, defaultZoneId)
+	_, err = nbsClient.FillDisk(ctx, diskID1, diskSize)
+	require.NoError(t, err)
+
+	snapshotID1 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "1"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
+		Src: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID1,
+		},
+		SnapshotId: snapshotID1,
+		FolderId:   "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	_, err = nbsClient.FillDisk(ctx, diskID1, diskSize)
+	require.NoError(t, err)
+
+	snapshotID2 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "2"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
+		Src: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID1,
+		},
+		SnapshotId: snapshotID2,
+		FolderId:   "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskID2 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "2"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
+			SrcSnapshotId: snapshotID2,
+		},
+		Size: int64(diskSize),
+		Kind: diskKind,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID2,
+		},
+		FolderId: "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskContentInfo, err := nbsClient.CalculateCrc32(diskID1, diskSize)
+	require.NoError(t, err)
+
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID2)
+	require.NoError(t, err)
+	// We should provide correct zone for NBS client because only unsharded
+	// zones and shards are configured in the NBS client config.
+	nbsClient = testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
+	err = nbsClient.ValidateCrc32(ctx, diskID2, diskContentInfo)
+	require.NoError(t, err)
+
+	testcommon.DeleteDisk(t, ctx, client, diskID1)
+	testcommon.DeleteDisk(t, ctx, client, diskID2)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+func testDiskServiceCreateDiskFromSnapshotOfOverlayDiskInZone(
+	t *testing.T,
+	zoneID string,
+) {
+
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	imageSize := uint64(64 * 1024 * 1024)
+
+	diskID1 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: int64(imageSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID1,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, defaultZoneId)
+
+	diskContentInfo, err := nbsClient.FillDisk(ctx, diskID1, imageSize)
+	require.NoError(t, err)
+
+	imageID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "_image"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateImage(reqCtx, &disk_manager.CreateImageRequest{
+		Src: &disk_manager.CreateImageRequest_SrcDiskId{
+			SrcDiskId: &disk_manager.DiskId{
+				ZoneId: defaultZoneId,
+				DiskId: diskID1,
+			},
+		},
+		DstImageId: imageID,
+		FolderId:   "folder",
+		Pooled:     false,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	privateClient, err := testcommon.NewPrivateClient(ctx)
+	require.NoError(t, err)
+	defer privateClient.Close()
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = privateClient.ConfigurePool(reqCtx, &api.ConfigurePoolRequest{
+		ImageId:      imageID,
+		ZoneId:       defaultZoneId,
+		Capacity:     1,
+		UseImageSize: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	largeDiskSize := uint64(128 * 1024 * 1024 * 1024)
+	diskID2 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "2"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcImageId{
+			SrcImageId: imageID,
+		},
+		Size: int64(largeDiskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID2,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	snapshotID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "_snapshot"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
+		Src: &disk_manager.DiskId{
+			ZoneId: defaultZoneId,
+			DiskId: diskID2,
+		},
+		SnapshotId: snapshotID,
+		FolderId:   "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskID3 := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t) + "3"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
+			SrcSnapshotId: snapshotID,
+		},
+		Size: int64(largeDiskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID3,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	err = nbsClient.ValidateCrc32(ctx, diskID1, diskContentInfo)
+	require.NoError(t, err)
+
+	err = nbsClient.ValidateCrc32(ctx, diskID2, diskContentInfo)
+	require.NoError(t, err)
+
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID3)
+	require.NoError(t, err)
+	// We should provide correct zone for NBS client because only unsharded
+	// zones and shards are configured in the NBS client config.
+	nbsClient = testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
+	err = nbsClient.ValidateCrc32(ctx, diskID3, diskContentInfo)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_cells_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_cells_test.go
@@ -1,0 +1,240 @@
+package disk_service_test
+
+import (
+	"testing"
+
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type TestCase struct {
+	name   string
+	zoneId string
+}
+
+func cellsTestCases() []TestCase {
+	return []TestCase{
+		{
+			name:   "Sharded zone",
+			zoneId: shardedZoneId,
+		},
+		{
+			name:   "Cell in sharded zone",
+			zoneId: cellId1,
+		},
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServiceInCellsCreateEmptyDisk(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceCreateEmptyDiskWithZoneID(
+				t,
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServiceInCellsCreateDiskFromImage(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromImage(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD,
+				32*1024*4096, // imageSize
+				false,        // pooled
+				32*1024*4096, // diskSize
+				"folder",
+				nil, // encryptionDesc
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCreateSsdNonreplDiskFromPooledImage(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromImage(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+				32*1024*4096, // imageSize
+				true,         // pooled
+				262144*4096,  // diskSize
+				"folder",
+				nil, // encryptionDesc
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+/*
+// TODO: enable after issue #3071 has been completed
+func TestDiskServiceCreateSsdNonreplDiskWithDefaultEncryptionFromPooledImage(
+	t *testing.T,
+) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromImage(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+				32*1024*4096, // imageSize
+				true,         // pooled
+				262144*4096,  // diskSize
+				"encrypted-folder",
+				nil, // encryptionDesc
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceCreateEncryptedSsdNonreplDiskFromPooledImage(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromImage(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+				32*1024*4096, // imageSize
+				true,         // pooled
+				262144*4096,  // diskSize
+				"folder",
+				&disk_manager.EncryptionDesc{
+					Mode: disk_manager.EncryptionMode_ENCRYPTION_AES_XTS,
+					Key: &disk_manager.EncryptionDesc_KmsKey{
+						KmsKey: &disk_manager.KmsKey{
+							KekId:        "kekid",
+							EncryptedDek: []byte("encrypteddek"),
+							TaskId:       "taskid",
+						},
+					},
+				},
+				testCase.zoneId,
+			)
+		})
+	}
+}
+*/
+
+func TestDiskServiceInCellsCreateEncryptedSsdNonreplDiskFromImage(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			testCreateDiskFromImage(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+				32*1024*4096, // imageSize
+				false,        // pooled
+				262144*4096,  // diskSize
+				"folder",
+				&disk_manager.EncryptionDesc{
+					Mode: disk_manager.EncryptionMode_ENCRYPTION_AES_XTS,
+					Key: &disk_manager.EncryptionDesc_KmsKey{
+						KmsKey: &disk_manager.KmsKey{
+							KekId:        "kekid",
+							EncryptedDek: []byte("encrypteddek"),
+							TaskId:       "taskid",
+						},
+					},
+				},
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCreateSsdNonreplDiskWithDefaultEncryptionFromImage(
+	t *testing.T,
+) {
+
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromImage(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+				32*1024*4096, // imageSize
+				false,        // pooled
+				262144*4096,  // diskSize
+				"encrypted-folder",
+				nil, // encryptionDesc
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCreateDiskFromImageWithForceNotLayered(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceCreateDiskFromImageWithForceNotLayeredWithZoneID(
+				t,
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCancelCreateDiskFromImageWithZoneID(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceCancelCreateDiskFromImageWithZoneID(
+				t,
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServiceInCellsCreateDiskFromSnapshot(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceCreateDiskFromSnapshotWithZoneID(t, testCase.zoneId)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCreateDiskFromIncrementalSnapshot(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromIncrementalSnapshot(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD,
+				128*1024*1024,
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCreateSsdNonreplDiskFromIncrementalSnapshot(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCreateDiskFromIncrementalSnapshot(
+				t,
+				disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
+				262144*4096,
+				testCase.zoneId,
+			)
+		})
+	}
+}
+
+func TestDiskServiceInCellsCreateDiskFromSnapshotOfOverlayDisk(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceCreateDiskFromSnapshotOfOverlayDiskInZone(
+				t,
+				testCase.zoneId,
+			)
+		})
+	}
+}

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -11,7 +11,6 @@ import (
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/api"
 	internal_client "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/client"
-	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/common"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/facade/testcommon"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/disks"
@@ -21,32 +20,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 func TestDiskServiceCreateEmptyDisk(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	diskID := t.Name()
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
-			SrcEmpty: &empty.Empty{},
-		},
-		Size: 4096,
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
+	testDiskServiceCreateEmptyDiskWithZoneID(t, defaultZoneId)
 }
 
 func TestDiskServiceShouldCreateSsdNonreplIfFolderIsInAllowedList(t *testing.T) {
@@ -145,104 +119,14 @@ func TestDiskServiceShouldFailCreateDiskFromNonExistingImage(t *testing.T) {
 }
 
 func TestDiskServiceCreateDiskFromImageWithForceNotLayered(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	imageID := t.Name()
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateImage(reqCtx, &disk_manager.CreateImageRequest{
-		Src: &disk_manager.CreateImageRequest_SrcUrl{
-			SrcUrl: &disk_manager.ImageUrl{
-				Url: testcommon.GetRawImageFileURL(),
-			},
-		},
-		DstImageId: imageID,
-		FolderId:   "folder",
-		Pooled:     true,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	diskID := t.Name()
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcImageId{
-			SrcImageId: imageID,
-		},
-		Size: 134217728,
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-		ForceNotLayered: true,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	nbsClient := testcommon.NewNbsTestingClient(t, ctx, "zone-a")
-	err = nbsClient.ValidateCrc32(
-		ctx,
-		diskID,
-		nbs.DiskContentInfo{
-			ContentSize: testcommon.GetRawImageSize(t),
-			Crc32:       testcommon.GetRawImageCrc32(t),
-			BlockCrc32s: []uint32{}, // We do not know blockCrc32s for image.
-		},
+	testDiskServiceCreateDiskFromImageWithForceNotLayeredWithZoneID(
+		t,
+		defaultZoneId,
 	)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
 }
 
 func TestDiskServiceCancelCreateDiskFromImage(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	imageID := t.Name()
-	imageSize := uint64(64 * 1024 * 1024)
-
-	_ = testcommon.CreateImage(
-		t,
-		ctx,
-		imageID,
-		imageSize,
-		"folder",
-		true, // pooled
-	)
-
-	diskID := t.Name()
-	diskSize := 2 * imageSize
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcImageId{
-			SrcImageId: imageID,
-		},
-		Size: int64(diskSize),
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	testcommon.CancelOperation(t, ctx, client, operation.Id)
-
-	testcommon.CheckConsistency(t, ctx)
+	testDiskServiceCancelCreateDiskFromImageWithZoneID(t, defaultZoneId)
 }
 
 func TestDiskServiceDeleteDiskWhenCreationIsInFlight(t *testing.T) {
@@ -403,114 +287,12 @@ func TestDiskServiceCreateDisksFromImageWithConfiguredPool(t *testing.T) {
 	testcommon.CheckConsistency(t, ctx)
 }
 
-func testCreateDiskFromIncrementalSnapshot(
-	t *testing.T,
-	diskKind disk_manager.DiskKind,
-	diskSize uint64,
-) {
-
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	diskID1 := t.Name() + "1"
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
-			SrcEmpty: &empty.Empty{},
-		},
-		Size: int64(diskSize),
-		Kind: diskKind,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID1,
-		},
-		FolderId: "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	nbsClient := testcommon.NewNbsTestingClient(t, ctx, "zone-a")
-	_, err = nbsClient.FillDisk(ctx, diskID1, diskSize)
-	require.NoError(t, err)
-
-	snapshotID1 := t.Name() + "1"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
-		Src: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID1,
-		},
-		SnapshotId: snapshotID1,
-		FolderId:   "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	_, err = nbsClient.FillDisk(ctx, diskID1, diskSize)
-	require.NoError(t, err)
-
-	snapshotID2 := t.Name() + "2"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
-		Src: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID1,
-		},
-		SnapshotId: snapshotID2,
-		FolderId:   "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	diskID2 := t.Name() + "2"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
-			SrcSnapshotId: snapshotID2,
-		},
-		Size: int64(diskSize),
-		Kind: diskKind,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID2,
-		},
-		FolderId: "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	diskContentInfo, err := nbsClient.CalculateCrc32(diskID1, diskSize)
-	require.NoError(t, err)
-
-	err = nbsClient.ValidateCrc32(ctx, diskID2, diskContentInfo)
-	require.NoError(t, err)
-
-	testcommon.DeleteDisk(t, ctx, client, diskID1)
-	testcommon.DeleteDisk(t, ctx, client, diskID2)
-
-	testcommon.CheckConsistency(t, ctx)
-}
-
 func TestDiskServiceCreateDiskFromIncrementalSnapshot(t *testing.T) {
 	testCreateDiskFromIncrementalSnapshot(
 		t,
 		disk_manager.DiskKind_DISK_KIND_SSD,
 		128*1024*1024,
+		defaultZoneId,
 	)
 }
 
@@ -519,191 +301,17 @@ func TestDiskServiceCreateSsdNonreplDiskFromIncrementalSnapshot(t *testing.T) {
 		t,
 		disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
 		262144*4096,
+		defaultZoneId,
 	)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 func TestDiskServiceCreateDiskFromSnapshot(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	diskSize := uint64(32 * 1024 * 4096)
-	diskID1 := t.Name() + "1"
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
-			SrcEmpty: &empty.Empty{},
-		},
-		Size: int64(diskSize),
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID1,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	nbsClient := testcommon.NewNbsTestingClient(t, ctx, "zone-a")
-	diskContentInfo, err := nbsClient.FillDisk(ctx, diskID1, diskSize)
-	require.NoError(t, err)
-
-	snapshotID1 := t.Name() + "1"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
-		Src: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID1,
-		},
-		SnapshotId: snapshotID1,
-		FolderId:   "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	snapshotMeta := disk_manager.CreateSnapshotMetadata{}
-	err = internal_client.GetOperationMetadata(ctx, client, operation.Id, &snapshotMeta)
-	require.NoError(t, err)
-	require.Equal(t, float64(1), snapshotMeta.Progress)
-
-	diskID2 := t.Name() + "2"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
-			SrcSnapshotId: snapshotID1,
-		},
-		Size: int64(diskSize),
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID2,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	diskMeta := disk_manager.CreateDiskMetadata{}
-	err = internal_client.GetOperationMetadata(ctx, client, operation.Id, &diskMeta)
-	require.NoError(t, err)
-	require.Equal(t, float64(1), diskMeta.Progress)
-
-	err = nbsClient.ValidateCrc32(ctx, diskID1, diskContentInfo)
-	require.NoError(t, err)
-
-	err = nbsClient.ValidateCrc32(ctx, diskID2, diskContentInfo)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
+	testDiskServiceCreateDiskFromSnapshotWithZoneID(t, defaultZoneId)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-func testCreateDiskFromImage(
-	t *testing.T,
-	diskKind disk_manager.DiskKind,
-	imageSize uint64,
-	pooled bool,
-	diskSize uint64,
-	diskFolderId string,
-	encryptionDesc *disk_manager.EncryptionDesc,
-) {
-
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	imageID := t.Name() + "_image"
-
-	diskContentInfo := testcommon.CreateImage(
-		t,
-		ctx,
-		imageID,
-		imageSize,
-		"folder",
-		pooled,
-	)
-
-	diskID := t.Name()
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcImageId{
-			SrcImageId: imageID,
-		},
-		Size: int64(diskSize),
-		Kind: diskKind,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-		FolderId:       diskFolderId,
-		EncryptionDesc: encryptionDesc,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	nbsClient := testcommon.NewNbsTestingClient(t, ctx, "zone-a")
-
-	if encryptionDesc != nil {
-		encryption, err := disks.PrepareEncryptionDesc(encryptionDesc)
-		require.NoError(t, err)
-
-		err = nbsClient.ValidateCrc32WithEncryption(
-			ctx,
-			diskID,
-			diskContentInfo,
-			encryption,
-		)
-		require.NoError(t, err)
-	} else {
-		err = nbsClient.ValidateCrc32(
-			ctx,
-			diskID,
-			diskContentInfo,
-		)
-		require.NoError(t, err)
-	}
-
-	diskParams, err := nbsClient.Describe(ctx, diskID)
-	require.NoError(t, err)
-	if pooled {
-		// Check that disk is overlay.
-		require.NotEmpty(t, diskParams.BaseDiskID)
-	} else {
-		// Check that disk is not overlay.
-		require.Empty(t, diskParams.BaseDiskID)
-	}
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.DeleteDisk(reqCtx, &disk_manager.DeleteDiskRequest{
-		DiskId: &disk_manager.DiskId{
-			DiskId: diskID,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
-}
 
 func TestDiskServiceCreateDiskFromImage(t *testing.T) {
 	testCreateDiskFromImage(
@@ -714,6 +322,7 @@ func TestDiskServiceCreateDiskFromImage(t *testing.T) {
 		32*1024*4096, // diskSize
 		"folder",
 		nil, // encryptionDesc
+		defaultZoneId,
 	)
 }
 
@@ -726,6 +335,7 @@ func TestDiskServiceCreateSsdNonreplDiskFromPooledImage(t *testing.T) {
 		262144*4096,  // diskSize
 		"folder",
 		nil, // encryptionDesc
+		defaultZoneId,
 	)
 }
 
@@ -785,12 +395,14 @@ func TestDiskServiceCreateEncryptedSsdNonreplDiskFromImage(t *testing.T) {
 				},
 			},
 		},
+		defaultZoneId,
 	)
 }
 
 func TestDiskServiceCreateSsdNonreplDiskWithDefaultEncryptionFromImage(
 	t *testing.T,
 ) {
+
 	testCreateDiskFromImage(
 		t,
 		disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED,
@@ -799,144 +411,17 @@ func TestDiskServiceCreateSsdNonreplDiskWithDefaultEncryptionFromImage(
 		262144*4096,  // diskSize
 		"encrypted-folder",
 		nil, // encryptionDesc
+		defaultZoneId,
 	)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 func TestDiskServiceCreateDiskFromSnapshotOfOverlayDisk(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	imageSize := uint64(64 * 1024 * 1024)
-
-	diskID1 := t.Name() + "1"
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
-			SrcEmpty: &empty.Empty{},
-		},
-		Size: int64(imageSize),
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID1,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	nbsClient := testcommon.NewNbsTestingClient(t, ctx, "zone-a")
-
-	diskContentInfo, err := nbsClient.FillDisk(ctx, diskID1, imageSize)
-	require.NoError(t, err)
-
-	imageID := t.Name() + "_image"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateImage(reqCtx, &disk_manager.CreateImageRequest{
-		Src: &disk_manager.CreateImageRequest_SrcDiskId{
-			SrcDiskId: &disk_manager.DiskId{
-				ZoneId: "zone-a",
-				DiskId: diskID1,
-			},
-		},
-		DstImageId: imageID,
-		FolderId:   "folder",
-		Pooled:     false,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	privateClient, err := testcommon.NewPrivateClient(ctx)
-	require.NoError(t, err)
-	defer privateClient.Close()
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = privateClient.ConfigurePool(reqCtx, &api.ConfigurePoolRequest{
-		ImageId:      imageID,
-		ZoneId:       "zone-a",
-		Capacity:     1,
-		UseImageSize: true,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	largeDiskSize := uint64(128 * 1024 * 1024 * 1024)
-	diskID2 := t.Name() + "2"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcImageId{
-			SrcImageId: imageID,
-		},
-		Size: int64(largeDiskSize),
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID2,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	snapshotID := t.Name() + "_snapshot"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
-		Src: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID2,
-		},
-		SnapshotId: snapshotID,
-		FolderId:   "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	diskID3 := t.Name() + "3"
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
-			SrcSnapshotId: snapshotID,
-		},
-		Size: int64(largeDiskSize),
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID3,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	err = nbsClient.ValidateCrc32(ctx, diskID1, diskContentInfo)
-	require.NoError(t, err)
-
-	err = nbsClient.ValidateCrc32(ctx, diskID2, diskContentInfo)
-	require.NoError(t, err)
-
-	err = nbsClient.ValidateCrc32(ctx, diskID3, diskContentInfo)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
+	testDiskServiceCreateDiskFromSnapshotOfOverlayDiskInZone(
+		t,
+		defaultZoneId,
+	)
 }
 
 func TestDiskServiceCreateZonalTaskInAnotherZone(t *testing.T) {

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/ya.make
@@ -11,7 +11,9 @@ INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common
 
 GO_XTEST_SRCS(
     disk_relocation_test.go
+    disk_service_cells_test.go
     disk_service_test.go
+    common_test.go
 )
 
 END()

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/common"
 	dataplane_protos "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/protos"
@@ -71,6 +72,11 @@ func prepareDiskKind(kind disk_manager.DiskKind) (types.DiskKind, error) {
 			kind,
 		)
 	}
+}
+
+func isLocalDiskKind(kind disk_manager.DiskKind) bool {
+	return (kind == disk_manager.DiskKind_DISK_KIND_HDD_LOCAL ||
+		kind == disk_manager.DiskKind_DISK_KIND_SSD_LOCAL)
 }
 
 func prepareEncryptionMode(
@@ -158,6 +164,30 @@ type service struct {
 	nbsFactory      nbs.Factory
 	poolService     pools.Service
 	resourceStorage resources.Storage
+	cellSelector    cells.CellSelector
+}
+
+func (s *service) prepareZoneId(
+	ctx context.Context,
+	req *disk_manager.CreateDiskRequest,
+) (string, error) {
+
+	if isLocalDiskKind(req.Kind) {
+		// When creating a local disk, we need to find a cell for its agentId.
+		// TODO: implement this selection.
+		return req.DiskId.ZoneId, nil
+	}
+
+	diskMeta, err := s.resourceStorage.GetDiskMeta(ctx, req.DiskId.DiskId)
+	if err != nil {
+		return "", err
+	}
+
+	if diskMeta != nil {
+		return diskMeta.ZoneID, nil
+	}
+
+	return s.cellSelector.PickCell(ctx, req.DiskId), nil
 }
 
 func (s *service) prepareCreateDiskParams(
@@ -171,6 +201,11 @@ func (s *service) prepareCreateDiskParams(
 			"invalid disk id: %v",
 			req.DiskId,
 		)
+	}
+
+	zoneId, err := s.prepareZoneId(ctx, req)
+	if err != nil {
+		return nil, err
 	}
 
 	diskIDPrefix := s.config.GetCreationAndDeletionAllowedOnlyForDisksWithIdPrefix()
@@ -247,7 +282,7 @@ func (s *service) prepareCreateDiskParams(
 	return &protos.CreateDiskParams{
 		BlocksCount: blocksCount,
 		Disk: &types.Disk{
-			ZoneId: req.DiskId.ZoneId,
+			ZoneId: zoneId,
 			DiskId: req.DiskId.DiskId,
 		},
 		BlockSize:               blockSize,
@@ -773,6 +808,7 @@ func NewService(
 	nbsFactory nbs.Factory,
 	poolService pools.Service,
 	resourceStorage resources.Storage,
+	cellSelector cells.CellSelector,
 ) Service {
 
 	return &service{
@@ -782,5 +818,6 @@ func NewService(
 		nbsFactory:      nbsFactory,
 		poolService:     poolService,
 		resourceStorage: resourceStorage,
+		cellSelector:    cellSelector,
 	}
 }

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -187,10 +187,11 @@ func (s *service) prepareZoneId(
 		return diskMeta.ZoneID, nil
 	}
 
-	return s.cellSelector.PickCell(ctx, req.DiskId), nil
+	return s.cellSelector.SelectCell(ctx, req.DiskId), nil
 }
 
 func (s *service) prepareCreateDiskParams(
+	ctx context.Context,
 	req *disk_manager.CreateDiskRequest,
 ) (*protos.CreateDiskParams, error) {
 
@@ -371,7 +372,7 @@ func (s *service) CreateDisk(
 	req *disk_manager.CreateDiskRequest,
 ) (string, error) {
 
-	params, err := s.prepareCreateDiskParams(req)
+	params, err := s.prepareCreateDiskParams(ctx, req)
 	if err != nil {
 		return "", err
 	}

--- a/cloud/disk_manager/internal/pkg/ya.make
+++ b/cloud/disk_manager/internal/pkg/ya.make
@@ -1,6 +1,7 @@
 RECURSE(
     accounting
     auth
+    cells
     client
     clients
     common

--- a/cloud/disk_manager/pkg/app/controlplane.go
+++ b/cloud/disk_manager/pkg/app/controlplane.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells"
+	cells_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells/config"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs"
 	server_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/configs/server/config"
@@ -438,6 +440,13 @@ func initControlplane(
 		return nil, err
 	}
 
+	cellsConfig := config.GetCellsConfig()
+	if cellsConfig == nil {
+		cellsConfig = &cells_config.CellsConfig{}
+	}
+
+	cellSelector := cells.NewCellSelector(cellsConfig)
+
 	facade.RegisterDiskService(
 		server,
 		taskScheduler,
@@ -448,6 +457,7 @@ func initControlplane(
 			nbsFactory,
 			poolService,
 			resourceStorage,
+			cellSelector,
 		),
 	)
 	facade.RegisterImageService(

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -119,9 +119,38 @@ NbsConfig: <
             ]
         >
     >
+    Zones: <
+        key: "zone-d"
+        value: <
+            Endpoints: [
+                "localhost:{nbs2_port}",
+                "localhost:{nbs2_port}"
+            ]
+        >
+    >
+    Zones: <
+        key: "zone-d-shard1"
+        value: <
+            Endpoints: [
+                "localhost:{nbs3_port}",
+                "localhost:{nbs3_port}"
+            ]
+        >
+    >
     RootCertsFile: "{root_certs_file}"
     GrpcKeepAlive: <>
     UseGZIPCompression: true
+>
+CellsConfig: <
+    Cells: <
+        key: "zone-d"
+        value: <
+            ZoneCells: [
+                "zone-d-shard1",
+                "zone-d"
+            ]
+        >
+    >
 >
 DisksConfig: <
     DeletedDiskExpirationTimeout: "1s"
@@ -168,6 +197,14 @@ ImagesConfig: <
         >,
         <
             ZoneId: "zone-c"
+            Capacity: 0
+        >,
+        <
+            ZoneId: "zone-d"
+            Capacity: 0
+        >,
+        <
+            ZoneId: "zone-d-shard1"
             Capacity: 0
         >
     ]
@@ -219,7 +256,7 @@ S3Config: <
 
 DATAPLANE_CONFIG_TEMPLATE = """
 TasksConfig: <
-    ZoneIds: ["zone-a", "zone-b", "zone-c"]
+    ZoneIds: ["zone-a", "zone-b", "zone-c", "zone-d", "zone-d-shard1"]
     TaskPingPeriod: "1s"
     PollForTaskUpdatesPeriod: "1s"
     PollForTasksPeriodMin: "1s"
@@ -260,6 +297,24 @@ NbsConfig: <
     >
     Zones: <
         key: "zone-c"
+        value: <
+            Endpoints: [
+                "localhost:{nbs3_port}",
+                "localhost:{nbs3_port}"
+            ]
+        >
+    >
+    Zones: <
+        key: "zone-d"
+        value: <
+            Endpoints: [
+                "localhost:{nbs2_port}",
+                "localhost:{nbs2_port}"
+            ]
+        >
+    >
+    Zones: <
+        key: "zone-d-shard1"
         value: <
             Endpoints: [
                 "localhost:{nbs3_port}",


### PR DESCRIPTION
A `prepareZoneId` step has been added to the disk creation process. It calls the `CellSelector` to determine which cell should be used for disk creation. This functionality only works for non-local disks.

The `CellSelector` is initialized when the controlplane part of the service starts up. If its config is not specified, a default one is created.

Tests for the disks service have been modified. Test cases that verify different creation scenarios have been moved to common_test.go, while disk_service_test_cells.go contains cases where a disk is requested to be created in a zone divided into cells or in a specific cell within a zone.

Methods have been added to testcommon for proper test functionality.
