### PR TITLE
issue-1751: TWriteBackCache::ReadData should not crash when reading empty data from underlying session

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -240,6 +240,11 @@ public:
 
                     // TODO(svartmetal): handle response error
 
+                    if (response.GetBuffer().empty()) {
+                        *response.MutableBuffer() = std::move(buffer);
+                        return response;
+                    }
+
                     Y_ABORT_UNLESS(
                         length == response.GetBuffer().length());
                     // TODO(svartmetal): support buffer offsetting


### PR DESCRIPTION
#1751 

```
VERIFY failed (2025-06-08T14:30:00.666455Z): 
  cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:244
  operator()(): requirement length == response.GetBuffer().length() failed
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char> >, char const*, unsigned long)+663 (0xFEBADF7)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+284 (0xFEB108C)
auto NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ReadData(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TReadDataRequest>)::'lambda'(auto)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse> >(auto) const+559 (0x20027C0F)
void NThreading::NImpl::SetValue<NCloud::NFileStore::NProto::TReadDataResponse, NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TReadDataResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse>::Apply<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ReadData(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TReadDataRequest>)::'lambda'(auto)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse> const&)::operator()(NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse> const&)::'lambda'()>(NThreading::TPromise<auto>&, NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TReadDataResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse>::Appl+64 (0x20027680)
std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TReadDataResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse>::Apply<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ReadData(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TReadDataRequest>)::'lambda'(auto)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TReadDataResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TReadDataResponse>::Apply<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ReadData(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCa+35 (0x20027443)
bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TReadDataResponse>::TrySetValue<NCloud::NFileStore::NProto::TReadDataResponse>(NCloud::NFileStore::NProto::TReadDataResponse&&)+438 (0x20026B16)
??+0 (0x20034A70)
bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TReadDataResponse>::TrySetValue<NCloud::NFileStore::NProto::TReadDataResponse>(NCloud::NFileStore::NProto::TReadDataResponse&&)+438 (0x20026B16)
??+0 (0x20498EF9)
bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TReadDataResponse>::TrySetValue<NCloud::NFileStore::NProto::TReadDataResponse>(NCloud::NFileStore::NProto::TReadDataResponse&&)+438 (0x20026B16)
??+0 (0x20415B72)
bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TReadDataResponse>::TrySetValue<NCloud::NFileStore::NProto::TReadDataResponse>(NCloud::NFileStore::NProto::TReadDataResponse&&)+438 (0x20026B16)
??+0 (0x202DDBC0)
NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TSimpleMailbox>(NActors::TMailboxTable::TSimpleMailbox*, unsigned int, bool)+2021 (0x1033C9C5)
??+0 (0x1033A051)
NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)+424 (0x10339A58)
NActors::TExecutorThread::ThreadProc()+188 (0x1033A92C)
??+0 (0xFEBC26C)
??+0 (0x7FF193DFBAC3)
??+0 (0x7FF193E8D850)
```