### PR TITLE
Multi-agent writes. Cancel write requests for all replicas with rdma backend

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -551,6 +551,10 @@ void TNonreplicatedPartitionActor::HandleAgentIsUnavailable(
         PartConfig->GetName().c_str(),
         laggingAgentId.Quote().c_str());
 
+    if (!PartConfig->GetLaggingDevicesAllowed()) {
+        return;
+    }
+
     auto getAgentIdByRow = [&](int row) -> const TString&
     {
         return PartConfig->GetDevices()[row].GetAgentId();


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/1720
Здесь синхронизируем код TNonreplicatedPartitionRdmaActor и TNonreplicatedPartitionActor который отменяет запросы в залагавшую реплику, чтобы было одинаково.
Начало было тут: https://github.com/ydb-platform/nbs/pull/3496