### PR TITLE
issue-1541: set client_id upon start_endpoint in tests

### DIFF
--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -137,12 +137,13 @@ class FilestoreCliClient:
         names = common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout.decode().splitlines()
         return sorted(names)
 
-    def start_endpoint(self, fs, socket, mount_seqno, readonly, persistent=False):
+    def start_endpoint(self, fs, socket, mount_seqno, readonly, persistent=False, client_id=""):
         cmd = [
             self.__binary_path, "startendpoint",
             "--filesystem", fs,
             "--socket-path", socket,
             "--mount-seqno", str(mount_seqno),
+            "--client-id", client_id,
         ] + self.__cmd_opts(vhost=True)
 
         if readonly:
@@ -367,7 +368,16 @@ class FilestoreCliClient:
         return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
 
 
-def create_endpoint(client, filesystem, socket_path, socket_prefix, endpoint_storage_dir, mount_seqno=0, readonly=False):
+def create_endpoint(
+        client,
+        filesystem,
+        socket_path,
+        socket_prefix,
+        endpoint_storage_dir,
+        mount_seqno=0,
+        readonly=False,
+        client_id=""):
+
     _uid = str(uuid.uuid4())
 
     socket = os.path.join(
@@ -376,7 +386,13 @@ def create_endpoint(client, filesystem, socket_path, socket_prefix, endpoint_sto
     socket = os.path.abspath(socket)
 
     persistent = (endpoint_storage_dir is not None)
-    client.start_endpoint(filesystem, socket, mount_seqno, readonly, persistent=persistent)
+    client.start_endpoint(
+        filesystem,
+        socket,
+        mount_seqno,
+        readonly,
+        persistent=persistent,
+        client_id=client_id)
 
     return socket
 

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -137,7 +137,15 @@ class FilestoreCliClient:
         names = common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout.decode().splitlines()
         return sorted(names)
 
-    def start_endpoint(self, fs, socket, mount_seqno, readonly, persistent=False, client_id=""):
+    def start_endpoint(
+            self,
+            fs,
+            socket,
+            mount_seqno,
+            readonly,
+            persistent=False,
+            client_id=""):
+
         cmd = [
             self.__binary_path, "startendpoint",
             "--filesystem", fs,

--- a/cloud/filestore/tests/recipes/vhost-endpoint/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost-endpoint/__main__.py
@@ -77,7 +77,8 @@ def start(argv):
             args.socket_prefix,
             os.getenv("NFS_VHOST_ENDPOINT_STORAGE_DIR", None),
             args.mount_seqno,
-            args.read_only)
+            args.read_only,
+            client_id=f"localhost@{i}")
 
         set_env(env_with_index("NFS_VHOST_SOCKET", i), socket)
 


### PR DESCRIPTION
If we have multiple qemu instances in the test, only one session will be created because the session is retrieved using client_id (see: [tablet_actor_createsession](https://github.com/ydb-platform/nbs/blob/f335cf13806f31965fbf21692d17c1ea3661c57f/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp#L264)), and client_id is empty in the vhost_endpoint recipe. As a result, if we enable WriteBackCache or AsyncDestroyHandle, both clients will use the same FileRingBuffer, since the path to the FileRingBuffer is created using the SessionId, and the SessionId will be the same