### PR TITLE
Introduce LogTitle for child actor. Use LogTitle for TAcquireDeviceActor and start-stop logs

### DIFF
--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -53,6 +53,16 @@ TString TLogTitle::GetPartitionPrefix(
     return builder;
 }
 
+TChildLogTitle TLogTitle::GetChild(const ui64 startTime) const
+{
+    TStringBuilder childPrefix;
+    childPrefix << CachedPrefix;
+    const auto duration = CyclesToDurationSafe(startTime - StartTime);
+    childPrefix << " t:" << FormatDuration(duration);
+
+    return TChildLogTitle(childPrefix, startTime);
+}
+
 TString TLogTitle::Get(EDetails details) const
 {
     TStringBuilder result;
@@ -135,6 +145,21 @@ void TLogTitle::RebuildForPartition()
     builder << " d:" << (DiskId.empty() ? "???" : DiskId);
 
     CachedPrefix = builder;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TChildLogTitle::TChildLogTitle(TString cachedPrefix, ui64 startTime)
+    : CachedPrefix(std::move(cachedPrefix))
+    , StartTime(startTime)
+{}
+
+TString TChildLogTitle::GetWithTime() const
+{
+    const auto duration = CyclesToDurationSafe(GetCycleCount() - StartTime);
+    TStringBuilder builder;
+    builder << CachedPrefix << " + " << FormatDuration(duration) << "]";
+    return builder;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -6,6 +6,8 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TChildLogTitle;
+
 class TLogTitle
 {
 public:
@@ -47,6 +49,8 @@ public:
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
 
+    [[nodiscard]] TChildLogTitle GetChild(const ui64 startTime) const;
+
     [[nodiscard]] TString Get(EDetails details) const;
 
     [[nodiscard]] TString GetWithTime() const;
@@ -59,6 +63,20 @@ private:
     void RebuildForVolume();
     void RebuildForPartition();
     TString GetPartitionPrefix() const;
+};
+
+class TChildLogTitle
+{
+private:
+    friend class TLogTitle;
+
+    const TString CachedPrefix;
+    const ui64 StartTime;
+
+    TChildLogTitle(TString cachedPrefix, ui64 startTime);
+
+public:
+    [[nodiscard]] TString GetWithTime() const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -85,6 +85,21 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             logTitle1.GetWithTime(),
             "[p1:12345 g:5 d:disk1 t:");
     }
+
+    Y_UNIT_TEST(GetChildLogger)
+    {
+        const ui64 startTime =
+            GetCycleCount() - GetCyclesPerMillisecond() * 2001;
+        TLogTitle logTitle1(12345, "disk1", startTime);
+        logTitle1.SetGeneration(5);
+
+        auto childLogTitle =
+            logTitle1.GetChild(startTime + GetCyclesPerMillisecond() * 1001);
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            childLogTitle.GetWithTime(),
+            "[v:12345 g:5 d:disk1 t:1.001s + 1.");
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_acquire.cpp
@@ -276,7 +276,6 @@ void TAcquireDevicesActor::OnAcquireResponse(
             "error: %s, PendingAgents: %s",
             LogTitle.GetWithTime().c_str(),
             ClientId.Quote().c_str(),
-            DiskId.Quote().c_str(),
             nodeId,
             PendingAgents.at(nodeId).Quote().c_str(),
             FormatError(error).c_str(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_acquire.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_acquire.cpp
@@ -35,12 +35,14 @@ private:
     const ui32 VolumeGeneration;
     const TDuration RequestTimeout;
     const bool MuteIOErrors;
+    TChildLogTitle LogTitle;
 
     THashMap<TNodeId, TAgentId> PendingAgents;
 
 public:
     TAcquireDevicesActor(
         const TActorId& owner,
+        TChildLogTitle logTitle,
         TVector<NProto::TDeviceConfig> devices,
         TString diskId,
         TString clientId,
@@ -107,6 +109,7 @@ private:
 
 TAcquireDevicesActor::TAcquireDevicesActor(
         const TActorId& owner,
+        TChildLogTitle logTitle,
         TVector<NProto::TDeviceConfig> devices,
         TString diskId,
         TString clientId,
@@ -124,6 +127,7 @@ TAcquireDevicesActor::TAcquireDevicesActor(
     , VolumeGeneration(volumeGeneration)
     , RequestTimeout(requestTimeout)
     , MuteIOErrors(muteIOErrors)
+    , LogTitle(std::move(logTitle))
 {
     SortBy(Devices, [](auto& d) { return d.GetNodeId(); });
 }
@@ -142,9 +146,9 @@ void TAcquireDevicesActor::Bootstrap(const TActorContext& ctx)
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::VOLUME,
-        "[%s] Sending acquire devices requests for disk %s, targets %s",
-        ClientId.c_str(),
-        DiskId.Quote().c_str(),
+        "%s Sending acquire devices requests for client: %s, targets: %s",
+        LogTitle.GetWithTime().c_str(),
+        ClientId.Quote().c_str(),
         LogTargets().c_str());
 
     auto acquireRequests =
@@ -167,9 +171,9 @@ void TAcquireDevicesActor::ReplyAndDie(
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::VOLUME,
-            "[%s] AcquireDevices DiskId: %s PendingAgents %s error: %s",
-            ClientId.c_str(),
-            DiskId.c_str(),
+            "%s AcquireDevices for client: %s PendingAgents %s error: %s",
+            LogTitle.GetWithTime().c_str(),
+            ClientId.Quote().c_str(),
             LogPendingAgents().c_str(),
             FormatError(error).c_str());
     }
@@ -227,8 +231,9 @@ void TAcquireDevicesActor::SendRequests(
         LOG_DEBUG(
             ctx,
             TBlockStoreComponents::VOLUME,
-            "[%s] Send an acquire request to node #%d. Devices: %s",
-            ClientId.c_str(),
+            "%s Send an acquire request for client: %s to node #%d. Devices: [%s]",
+            LogTitle.GetWithTime().c_str(),
+            ClientId.Quote().c_str(),
             r.NodeId,
             JoinSeq(", ", request->Record.GetDeviceUUIDs()).c_str());
 
@@ -267,12 +272,13 @@ void TAcquireDevicesActor::OnAcquireResponse(
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::VOLUME,
-            "[%s] AcquireDevices for disk %s on the node #%d and agent %s "
+            "%s AcquireDevices for client: %s on the node #%d and agent %s "
             "error: %s, PendingAgents: %s",
-            ClientId.c_str(),
+            LogTitle.GetWithTime().c_str(),
+            ClientId.Quote().c_str(),
             DiskId.Quote().c_str(),
             nodeId,
-            PendingAgents.at(nodeId).c_str(),
+            PendingAgents.at(nodeId).Quote().c_str(),
             FormatError(error).c_str(),
             LogPendingAgents().c_str());
 
@@ -280,9 +286,9 @@ void TAcquireDevicesActor::OnAcquireResponse(
             LOG_DEBUG(
                 ctx,
                 TBlockStoreComponents::VOLUME,
-                "[%s] Canceling acquire operation for disk %s, targets %s",
-                ClientId.c_str(),
-                DiskId.c_str(),
+                "%s Canceling acquire operation for client: %s, targets: [%s]",
+                LogTitle.GetWithTime().c_str(),
+                ClientId.Quote().c_str(),
                 LogTargets().c_str());
 
             SendRequests(
@@ -335,7 +341,12 @@ void TAcquireDevicesActor::HandleWakeup(
                      << " VolumeGeneration: " << VolumeGeneration
                      << " MuteIoErrors: " << MuteIOErrors;
 
-    LOG_ERROR(ctx, TBlockStoreComponents::VOLUME, err);
+    LOG_ERROR(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s %s",
+        LogTitle.GetWithTime().c_str(),
+        err.c_str());
 
     NProto::TError errorToReply;
     if (!MuteIOErrors) {
@@ -356,7 +367,6 @@ TString TAcquireDevicesActor::LogPendingAgents() const
 {
     TStringBuilder sb;
     sb << "(";
-
     for (const auto& [nodeId, agent]: PendingAgents) {
         sb << "(NodeId: " << nodeId << ", AgentId: " << agent << ") ";
     }
@@ -405,6 +415,7 @@ void TVolumeActor::SendAcquireDevicesToAgents(
     auto actor = NCloud::Register<TAcquireDevicesActor>(
         ctx,
         ctx.SelfID,
+        LogTitle.GetChild(GetCycleCount()),
         std::move(devices),
         State->GetDiskId(),
         std::move(clientId),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -521,12 +521,10 @@ bool TVolumeActor::ReplyToOriginalRequest(
         LOG_INFO(
             ctx,
             TBlockStoreComponents::VOLUME,
-            "[%lu] Disk: %s, Generation: %u. The first successful %s "
-            "request was started at %s finished at %s. The very first request "
-            "was started at %s. Failed requests: %lu",
-            TabletID(),
-            State->GetDiskId().Quote().c_str(),
-            Executor()->Generation(),
+            "%s The first successful %s request was started at %s finished at "
+            "%s. The very first request was started at %s. Failed requests: "
+            "%lu",
+            LogTitle.GetWithTime().c_str(),
             ToString(firstSuccess->RequestType).c_str(),
             FormatDuration(firstSuccess->SuccessfulRequestStartTime).c_str(),
             FormatDuration(firstSuccess->SuccessfulRequestFinishTime).c_str(),


### PR DESCRIPTION
1. Сделал новый класс, который нужно использовать в дочерних акторах. Он печатает заголовок, указывая два времени, когда актор был рожден относительно времени родительского актора и когда случилось событие относительно времени рождения дочернего актора.  [v:72075186224037889 g:23 d:nrd1 t:1m 36s + 37us] означает что дочерний актор был создан в 1 мин 36 секунд, а событие залогировалось через 37 нс.
2. Привел к единому стилю логи вольюма про start-stop.

```
2025-06-10T17:01:58.757674Z :BLOCKSTORE_VOLUME INFO: [v:72075186224037889 g:23 d:nrd1 t:1m 36s + 37us] Sending acquire devices requests for client: "6d2f0c6-53c5462a-dc5efec1-2c1a93b3", targets: ( remote1-1024-1@remote1.cloud-example.net )
```