### PR TITLE
[Disk Manager] enable test on mirror disk migration

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_nemesis_test/ya.make
@@ -9,6 +9,7 @@ SET_APPEND(RECIPE_ARGS --encryption)
 SET_APPEND(RECIPE_ARGS --min-restart-period-sec 30)
 SET_APPEND(RECIPE_ARGS --max-restart-period-sec 60)
 SET_APPEND(RECIPE_ARGS --disable-disk-registry-based-disks)
+SET_APPEND(RECIPE_ARGS --disk-agent-count 3)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
 FORK_SUBTESTS()

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
@@ -583,24 +583,21 @@ func TestDiskServiceMigrateHddNonreplDisk(t *testing.T) {
 }
 
 func TestDiskServiceMigrateMirroredDisk(t *testing.T) {
-	/*
-		TODO: NBS-4747: Fix creation of mirrored disks in large tests on Disk Manager.
-		param := migrationTestParams{
-			SrcZoneID: "zone-a",
-			DstZoneID: "zone-b",
-			DiskID:    t.Name(),
-			DiskKind:  disk_manager.DiskKind_DISK_KIND_SSD_MIRROR3,
-			DiskSize:  1073741824,
-			FillDisk:  false,
-		}
+	param := migrationTestParams{
+		SrcZoneID: "zone-a",
+		DstZoneID: "zone-b",
+		DiskID:    t.Name(),
+		DiskKind:  disk_manager.DiskKind_DISK_KIND_SSD_MIRROR3,
+		DiskSize:  1073741824,
+		FillDisk:  false,
+	}
 
-		ctx, client := setupMigrationTest(t, param)
-		defer client.Close()
+	ctx, client := setupMigrationTest(t, param)
+	defer client.Close()
 
-		successfullyMigrateDisk(t, ctx, client, param)
+	successfullyMigrateDisk(t, ctx, client, param)
 
-		testcommon.CheckConsistency(t, ctx)
-	*/
+	testcommon.CheckConsistency(t, ctx)
 }
 
 func TestDiskServiceMigrateDisk(t *testing.T) {

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_relocation_test.go
@@ -590,6 +590,7 @@ func TestDiskServiceMigrateMirroredDisk(t *testing.T) {
 		DiskKind:  disk_manager.DiskKind_DISK_KIND_SSD_MIRROR3,
 		DiskSize:  1073741824,
 		FillDisk:  false,
+		FolderID:  "folder",
 	}
 
 	ctx, client := setupMigrationTest(t, param)

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/ya.make
@@ -7,6 +7,7 @@ SET_APPEND(RECIPE_ARGS --multiple-nbs)
 SET_APPEND(RECIPE_ARGS --encryption)
 SET_APPEND(RECIPE_ARGS --creation-and-deletion-allowed-only-for-disks-with-id-prefix "Test")
 SET_APPEND(RECIPE_ARGS --disable-disk-registry-based-disks)
+SET_APPEND(RECIPE_ARGS --disk-agent-count 3)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
 GO_XTEST_SRCS(

--- a/cloud/disk_manager/test/recipe/nbs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nbs_launcher.py
@@ -69,6 +69,8 @@ class NbsLauncher:
         storage_config_patch = TStorageServiceConfig()
         storage_config_patch.AllocationUnitNonReplicatedSSD = 1
         storage_config_patch.AllocationUnitNonReplicatedHDD = 1
+        storage_config_patch.AllocationUnitMirror2SSD = 1
+        storage_config_patch.AllocationUnitMirror3SSD = 1
         storage_config_patch.AcquireNonReplicatedDevices = True
         storage_config_patch.ClientRemountPeriod = 1000
         storage_config_patch.NonReplicatedMigrationStartAllowed = True


### PR DESCRIPTION
Since recently we can start multiple disk agents in tests, so we can fix the TestDiskServiceMigrateMirroredDisk test easily.