### PR TITLE
Make session logs better. Part 1

### DIFF
--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -27,9 +27,22 @@ TLogTitle::TLogTitle(
         ui32 partitionCount)
     : Type(EType::Partition)
     , StartTime(startTime)
-    , TabletId(tabletId)
     , PartitionIndex(partitionIndex)
     , PartitionCount(partitionCount)
+    , TabletId(tabletId)
+    , DiskId(std::move(diskId))
+{
+    Rebuild();
+}
+
+TLogTitle::TLogTitle(
+        EType type,
+        TString diskId,
+        TString sessionId,
+        ui64 startTime)
+    : Type(type)
+    , StartTime(startTime)
+    , SessionId(std::move(sessionId))
     , DiskId(std::move(diskId))
 {
     Rebuild();
@@ -101,6 +114,12 @@ void TLogTitle::SetGeneration(ui32 generation)
     Rebuild();
 }
 
+void TLogTitle::SetTabletId(ui64 tabletId)
+{
+    TabletId = tabletId;
+    Rebuild();
+}
+
 void TLogTitle::Rebuild()
 {
     switch (Type) {
@@ -110,6 +129,10 @@ void TLogTitle::Rebuild()
         }
         case EType::Partition: {
             RebuildForPartition();
+            break;
+        }
+        case EType::Session: {
+            RebuildForSession();
             break;
         }
     }
@@ -160,6 +183,23 @@ TString TChildLogTitle::GetWithTime() const
     TStringBuilder builder;
     builder << CachedPrefix << " + " << FormatDuration(duration) << "]";
     return builder;
+}
+
+void TLogTitle::RebuildForSession()
+{
+    auto builder = TStringBuilder();
+
+    builder << "[";
+    builder << "vs:";
+    if (TabletId) {
+        builder << TabletId;
+    } else {
+        builder << "?";
+    }
+    builder << " d:" << DiskId;
+    builder << " s:" << SessionId;
+
+    CachedPrefix = builder;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -2,6 +2,7 @@
 
 #include <util/generic/string.h>
 #include <util/system/types.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -17,19 +18,21 @@ public:
         WithTime,
     };
 
-private:
     enum class EType
     {
         Volume,
         Partition,
+        Session,
     };
 
+private:
     const EType Type;
     const ui64 StartTime;
-    const ui64 TabletId = 0;
     const ui32 PartitionIndex = 0;
     const ui32 PartitionCount = 0;
+    const TString SessionId;
 
+    ui64 TabletId = 0;
     ui64 Generation = 0;
     TString DiskId;
     TString CachedPrefix;
@@ -46,6 +49,9 @@ public:
         ui32 partitionIndex,
         ui32 partitionCount);
 
+    // Constructor for Session
+    TLogTitle(EType type, TString diskId, TString sessionId, ui64 startTime);
+
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
 
@@ -57,11 +63,13 @@ public:
 
     void SetDiskId(TString diskId);
     void SetGeneration(ui32 generation);
+    void SetTabletId(ui64 tabletId);
 
 private:
     void Rebuild();
     void RebuildForVolume();
     void RebuildForPartition();
+    void RebuildForSession();
     TString GetPartitionPrefix() const;
 };
 

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -86,6 +86,28 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             "[p1:12345 g:5 d:disk1 t:");
     }
 
+    Y_UNIT_TEST(GetForSession)
+    {
+        TLogTitle logTitle(
+            TLogTitle::EType::Session,
+            "disk1",
+            "session-1",
+            GetCycleCount());
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[vs:? d:disk1 s:session-1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        logTitle.SetTabletId(12345);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[vs:12345 d:disk1 s:session-1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            logTitle.GetWithTime(),
+            "[vs:12345 d:disk1 s:session-1 t:");
+    }
+
     Y_UNIT_TEST(GetChildLogger)
     {
         const ui64 startTime =

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -16,6 +16,7 @@
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/volume_proxy/volume_proxy.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -52,6 +53,11 @@ private:
     const NRdma::IClientPtr RdmaClient;
     const std::shared_ptr<NKikimr::TTabletCountersBase> Counters;
     const TSharedServiceCountersPtr SharedCounters;
+    TLogTitle LogTitle{
+        TLogTitle::EType::Session,
+        VolumeInfo->DiskId,
+        VolumeInfo->SessionId,
+        GetCycleCount()};
 
     TQueue<NActors::IEventHandlePtr> MountUnmountRequests;
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -993,9 +993,11 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     const auto& diskId = VolumeInfo->DiskId;
 
     if (!StartVolumeActor) {
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-            "Starting volume %s locally",
-            diskId.Quote().data());
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s Starting volume locally",
+            LogTitle.GetWithTime().c_str());
 
         CurrentRequest = START_REQUEST;
         StartVolumeActor = NCloud::Register<TStartVolumeActor>(
@@ -1017,8 +1019,12 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
         auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
             MakeError(E_REJECTED, TStringBuilder()
                 << "Volume " << diskId << " is being stopped"));
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-            FormatError(response->GetError()));
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s %s",
+            LogTitle.GetWithTime().c_str(),
+            FormatError(response->GetError()).c_str());
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }
@@ -1039,24 +1045,25 @@ void TVolumeSessionActor::HandleVolumeTabletStatus(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
-    const auto& diskId = VolumeInfo->DiskId;
 
     if (!msg->VolumeActor) {
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-            "[%lu] Volume %s failed: %s",
-            VolumeInfo->TabletId,
-            diskId.Quote().data(),
-            ToString(msg->Error).data());
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s Volume start failed: %s",
+            LogTitle.GetWithTime().c_str(),
+            FormatError(msg->Error).c_str());
 
         VolumeInfo->VolumeActor = {};
         VolumeInfo->SetFailed(msg->Error);
         return;
     }
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-        "[%lu] Volume %s started",
-        msg->TabletId,
-        diskId.Quote().data());
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s Volume started",
+        LogTitle.GetWithTime().c_str());
 
     VolumeInfo->SetStarted(msg->TabletId, msg->VolumeInfo, msg->VolumeActor);
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
@@ -18,22 +18,30 @@ void TVolumeSessionActor::HandleStopVolumeRequest(
         auto response = std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>(
             MakeError(S_ALREADY, TStringBuilder()
                 << "Volume " << diskId << " is already stopped"));
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-            FormatError(response->GetError()));
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s %s",
+            LogTitle.GetWithTime().c_str(),
+            FormatError(response->GetError()).c_str());
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }
 
     if (VolumeInfo->State == TVolumeInfo::STOPPING) {
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-            "Volume %s is already being stopped",
-            diskId.Quote().data());
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s Volume is already being stopped",
+            LogTitle.GetWithTime().c_str());
         return;
     }
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
-        "Shutting down start volume actor for volume %s",
-        diskId.Quote().data());
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s Shutting down StartVolumeActor",
+        LogTitle.GetWithTime().c_str());
 
     VolumeInfo->State = TVolumeInfo::STOPPING;
     CurrentRequest = STOP_REQUEST;
@@ -46,10 +54,11 @@ void TVolumeSessionActor::HandleStartVolumeActorStopped(
 {
     const auto* msg = ev->Get();
 
-    LOG_INFO(ctx, TBlockStoreComponents::SERVICE,
-        "[%lu] Start volume actor stopped for volume %s",
-        VolumeInfo->TabletId,
-        VolumeInfo->DiskId.Quote().data());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s StartVolumeActor stopped",
+        LogTitle.GetWithTime().c_str());
 
     VolumeInfo->VolumeActor = {};
     StartVolumeActor = {};

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -517,7 +517,6 @@ void TVolumeActor::OnDiskRegistryBasedPartitionStopped(
         }
     }
 
-    size_t removed = 0;
     while (WaitForPartitionDestroy) {
         auto& callback = WaitForPartitionDestroy.front();
         if (!callback.Destroyed) {
@@ -527,7 +526,6 @@ void TVolumeActor::OnDiskRegistryBasedPartitionStopped(
             std::invoke(std::move(callback.PoisonCallback), ctx, error);
         }
         WaitForPartitionDestroy.pop_front();
-        ++removed;
     }
 
     TVector<TString> stillWait;
@@ -542,9 +540,8 @@ void TVolumeActor::OnDiskRegistryBasedPartitionStopped(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
-        "%s Partitions removed from the wait list: count=%lu. Still wait [%s]",
+        "%s Partition stoped. Still wait [%s]",
         LogTitle.GetWithTime().c_str(),
-        removed,
         JoinSeq(", ", stillWait).c_str());
 }
 


### PR DESCRIPTION
```
2025-06-11T13:30:56.184459Z :BLOCKSTORE_SERVICE INFO: [vs:72075186224037889 d:nrd1 s:f73eec3d-68271526-2204bf93-454a5e90 t:4.080s + 29us] Start mounting volume with mount mode: VOLUME_MOUNT_LOCAL binding: BINDING_LOCAL source: SOURCE_NONE

2025-06-11T13:30:56.204344Z :BLOCKSTORE_SERVICE INFO: [vs:72075186224037889 d:nrd1 s:f73eec3d-68271526-2204bf93-454a5e90 t:4.100s] Mount completed for client "17ea9637-b2290406-c12ddfe6-a3051aa2", msg binding BINDING_LOCAL, msg source SOURCE_NONE, time "10172429225854", binding BINDING_LOCAL, source SOURCE_NONE

```