### PR TITLE
issue-3371: fix request bytes metric for large requests

### DIFF
--- a/cloud/blockstore/libs/client/throttling_ut.cpp
+++ b/cloud/blockstore/libs/client/throttling_ut.cpp
@@ -155,7 +155,7 @@ struct TRequestStats final
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
@@ -168,7 +168,7 @@ struct TRequestStats final
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/diagnostics/request_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/request_stats.cpp
@@ -292,7 +292,7 @@ public:
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         auto requestStarted = Total.RequestStarted(
             static_cast<TRequestCounters::TRequestType>(
@@ -316,7 +316,7 @@ public:
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,
@@ -574,7 +574,7 @@ struct TRequestStatsStub final
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
@@ -587,7 +587,7 @@ struct TRequestStatsStub final
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/diagnostics/request_stats.h
+++ b/cloud/blockstore/libs/diagnostics/request_stats.h
@@ -24,14 +24,14 @@ struct IRequestStats
     virtual ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui32 requestBytes) = 0;
+        ui64 requestBytes) = 0;
 
     virtual TDuration RequestCompleted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -94,7 +94,7 @@ public:
         TString clientId,
         TString diskId,
         ui64 startIndex,
-        ui32 requestBytes,
+        ui64 requestBytes,
         bool unaligned) override;
 
     void RequestStarted(
@@ -277,7 +277,7 @@ void TServerStats::PrepareMetricRequest(
     TString clientId,
     TString diskId,
     ui64 startIndex,
-    ui32 requestBytes,
+    ui64 requestBytes,
     bool unaligned)
 {
     metricRequest.ClientId = std::move(clientId);
@@ -762,7 +762,7 @@ public:
         TString clientId,
         TString diskId,
         ui64 startIndex,
-        ui32 requestBytes,
+        ui64 requestBytes,
         bool unaligned) override
     {
         Y_UNUSED(metricRequest);

--- a/cloud/blockstore/libs/diagnostics/server_stats.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats.h
@@ -29,7 +29,7 @@ struct TMetricRequest
     ui64 StartIndex = 0;
     NCloud::NProto::EStorageMediaKind MediaKind
         = NCloud::NProto::STORAGE_MEDIA_HDD;
-    ui32 RequestBytes = 0;
+    ui64 RequestBytes = 0;
     TInstant RequestTimestamp;
     bool Unaligned = false;
 
@@ -69,7 +69,7 @@ struct IServerStats
         TString clientId,
         TString diskId,
         ui64 startIndex,
-        ui32 requestBytes,
+        ui64 requestBytes,
         bool unaligned) = 0;
 
     virtual void RequestStarted(

--- a/cloud/blockstore/libs/diagnostics/server_stats_test.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats_test.h
@@ -46,7 +46,7 @@ public:
         TString clientId,
         TString diskId,
         ui64 startIndex,
-        ui32 requestBytes,
+        ui64 requestBytes,
         bool unaligned)> PrepareMetricRequestHandler
             = std::bind_front(&IServerStats::PrepareMetricRequest, Stub.get());
 
@@ -173,7 +173,7 @@ public:
         TString clientId,
         TString diskId,
         ui64 startIndex,
-        ui32 requestBytes,
+        ui64 requestBytes,
         bool unaligned) override
     {
         PrepareMetricRequestHandler(

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -293,7 +293,7 @@ public:
 
     ui64 RequestStarted(
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         VolumeBase->PostponeTimePredictorStats.OnRequestStarted(
             GetPossiblePostponeDuration().MilliSeconds());
@@ -308,7 +308,7 @@ public:
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -40,13 +40,13 @@ struct IVolumeInfo
 
     virtual ui64 RequestStarted(
         EBlockStoreRequest requestType,
-        ui32 requestBytes) = 0;
+        ui64 requestBytes) = 0;
 
     virtual TDuration RequestCompleted(
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/diagnostics/volume_stats_test.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_test.h
@@ -56,7 +56,7 @@ public:
 
     ui64 RequestStarted(
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         Y_UNUSED(requestType);
         Y_UNUSED(requestBytes);
@@ -67,7 +67,7 @@ public:
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/proxy_storage.cpp
@@ -36,7 +36,7 @@ public:
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         Y_UNUSED(mediaKind);
 
@@ -54,7 +54,7 @@ public:
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/blockstore/libs/service_throttling/throttler_logger_ut.cpp
+++ b/cloud/blockstore/libs/service_throttling/throttler_logger_ut.cpp
@@ -184,7 +184,7 @@ struct TRequestStats final
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui32 requestBytes) override
+        ui64 requestBytes) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
@@ -197,7 +197,7 @@ struct TRequestStats final
         EBlockStoreRequest requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -437,7 +437,7 @@ struct TRequestCounters::TStatCounters
         AtomicSet(FullyInitialized, true);
     }
 
-    void Started(ui32 requestBytes)
+    void Started(ui64 requestBytes)
     {
         MaxInProgressCalc.Add(InProgress->Inc());
 
@@ -446,7 +446,7 @@ struct TRequestCounters::TStatCounters
         }
     }
 
-    void Completed(ui32 requestBytes)
+    void Completed(ui64 requestBytes)
     {
         InProgress->Dec();
 
@@ -459,7 +459,7 @@ struct TRequestCounters::TStatCounters
         TDuration requestTime,
         TDuration requestCompletionTime,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         bool unaligned,
         ECalcMaxTime calcMaxTime)
@@ -761,7 +761,7 @@ void TRequestCounters::Subscribe(TRequestCountersPtr subscriber)
 
 ui64 TRequestCounters::RequestStarted(
     TRequestType requestType,
-    ui32 requestBytes)
+    ui64 requestBytes)
 {
     RequestStartedImpl(requestType, requestBytes);
     return GetCycleCount();
@@ -771,7 +771,7 @@ TDuration TRequestCounters::RequestCompleted(
     TRequestType requestType,
     ui64 requestStarted,
     TDuration postponedTime,
-    ui32 requestBytes,
+    ui64 requestBytes,
     EDiagnosticsErrorKind errorKind,
     ui32 errorFlags,
     bool unaligned,
@@ -926,7 +926,7 @@ void TRequestCounters::UpdateStats(bool updatePercentiles)
 
 void TRequestCounters::RequestStartedImpl(
     TRequestType requestType,
-    ui32 requestBytes)
+    ui64 requestBytes)
 {
     if (ShouldReport(requestType)) {
         AccessRequestStats(requestType).Started(requestBytes);
@@ -942,7 +942,7 @@ void TRequestCounters::RequestCompletedImpl(
     TDuration requestTime,
     TDuration requestCompletionTime,
     TDuration postponedTime,
-    ui32 requestBytes,
+    ui64 requestBytes,
     EDiagnosticsErrorKind errorKind,
     ui32 errorFlags,
     bool unaligned,

--- a/cloud/storage/core/libs/diagnostics/request_counters.h
+++ b/cloud/storage/core/libs/diagnostics/request_counters.h
@@ -66,14 +66,14 @@ public:
 
     ui64 RequestStarted(
         TRequestType requestType,
-        ui32 requestBytes);
+        ui64 requestBytes);
 
     //TODO: rollback commit after NBS-4239 is fixed
     TDuration RequestCompleted(
         TRequestType requestType,
         ui64 requestStarted,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,
@@ -115,14 +115,14 @@ public:
 private:
     void RequestStartedImpl(
         TRequestType requestType,
-        ui32 requestBytes);
+        ui64 requestBytes);
 
     void RequestCompletedImpl(
         TRequestType requestType,
         TDuration requestTime,
         TDuration requestCompletionTime,
         TDuration postponedTime,
-        ui32 requestBytes,
+        ui64 requestBytes,
         EDiagnosticsErrorKind errorKind,
         ui32 errorFlags,
         bool unaligned,

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -799,7 +799,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         UNIT_ASSERT(!histogram);
     }
 
-    Y_UNIT_TEST(ShouldReportStatsforLargeRequests)
+    Y_UNIT_TEST(ShouldReportStatsForLargeRequests)
     {
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = MakeRequestCountersPtr();

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -804,17 +804,6 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = MakeRequestCountersPtr();
         counters->Register(*monitoring->GetCounters());
-
-        auto outerSubscriber = MakeRequestCountersPtr();
-        outerSubscriber->Register(
-            *monitoring->GetCounters()->GetSubgroup("subscribers", "outer"));
-        counters->Subscribe(outerSubscriber);
-
-        auto innerSubscriber = MakeRequestCountersPtr();
-        innerSubscriber->Register(
-            *monitoring->GetCounters()->GetSubgroup("subscribers", "inner"));
-        outerSubscriber->Subscribe(innerSubscriber);
-
         AddRequestStats(
             *counters,
             WriteRequestType,


### PR DESCRIPTION
issue: #3371 

zero blocks requests can exceed 4 GiB