### PR TITLE
[Disk Manager, SU] Support folder restrictions for cells feature 

### DIFF
--- a/cloud/disk_manager/internal/pkg/cells/cells.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells.go
@@ -2,6 +2,7 @@ package cells
 
 import (
 	"context"
+	"slices"
 
 	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
 	cells_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells/config"
@@ -26,15 +27,19 @@ func NewCellSelector(
 
 func (s *cellSelector) SelectCell(
 	ctx context.Context,
-	disk *disk_manager.DiskId,
+	req *disk_manager.CreateDiskRequest,
 ) string {
 
-	cells := s.getCells(disk.ZoneId)
+	if !s.isFolderAllowed(req.FolderId) {
+		return req.DiskId.ZoneId
+	}
+
+	cells := s.getCells(req.DiskId.ZoneId)
 
 	if len(cells) == 0 {
 		// We end up here if a zone not divided into cells or a cell
 		// of a zone is provided as ZoneId.
-		return disk.ZoneId
+		return req.DiskId.ZoneId
 	}
 
 	return cells[0]
@@ -49,4 +54,13 @@ func (s *cellSelector) getCells(zoneID string) []string {
 	}
 
 	return cells.Cells
+}
+
+func (s *cellSelector) isFolderAllowed(folderID string) bool {
+	if slices.Contains(s.config.GetExcludedFolders(), folderID) {
+		return false
+	}
+
+	return len(s.config.GetIncludedFolders()) == 0 ||
+		slices.Contains(s.config.GetIncludedFolders(), folderID)
 }

--- a/cloud/disk_manager/internal/pkg/cells/cells_test.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells_test.go
@@ -1,0 +1,62 @@
+package cells
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cells_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells/config"
+)
+
+func TestCellsIsFolderAllowed(t *testing.T) {
+
+	{
+		config := &cells_config.CellsConfig{}
+
+		selector := cellSelector{
+			config: config,
+		}
+
+		require.True(t, selector.isFolderAllowed("anyFolder"))
+	}
+
+	{
+		config := &cells_config.CellsConfig{
+			ExcludedFolders: []string{"excludedFolderID"},
+		}
+
+		selector := cellSelector{
+			config: config,
+		}
+
+		require.False(t, selector.isFolderAllowed("excludedFolderID"))
+		require.True(t, selector.isFolderAllowed("otherFolderID"))
+	}
+
+	{
+		config := &cells_config.CellsConfig{
+			ExcludedFolders: []string{"excludedFolderID"},
+			IncludedFolders: []string{"includedFolderID"},
+		}
+
+		selector := cellSelector{
+			config: config,
+		}
+
+		require.False(t, selector.isFolderAllowed("excludedFolderID"))
+		require.True(t, selector.isFolderAllowed("includedFolderID"))
+		require.False(t, selector.isFolderAllowed("otherFolderID"))
+	}
+
+	{
+		config := &cells_config.CellsConfig{
+			ExcludedFolders: []string{"includedAndExcludedFolderID"},
+			IncludedFolders: []string{"includedAndExcludedFolderID"},
+		}
+
+		selector := cellSelector{
+			config: config,
+		}
+
+		require.False(t, selector.isFolderAllowed("includedAndExcludedFolderID"))
+	}
+}

--- a/cloud/disk_manager/internal/pkg/cells/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/cells/config/config.proto
@@ -13,4 +13,9 @@ message ZoneCells {
 message CellsConfig {
     // Mapping from zone ID to cell ID.
     map<string, ZoneCells> Cells = 1;
+
+    repeated string ExcludedFolders = 2;
+
+    // If empty, every folder is included.
+    repeated string IncludedFolders = 3;
 }

--- a/cloud/disk_manager/internal/pkg/cells/interface.go
+++ b/cloud/disk_manager/internal/pkg/cells/interface.go
@@ -11,6 +11,6 @@ import (
 type CellSelector interface {
 	SelectCell(
 		ctx context.Context,
-		disk *disk_manager.DiskId,
+		req *disk_manager.CreateDiskRequest,
 	) string
 }

--- a/cloud/disk_manager/internal/pkg/cells/mocks/cells_mock.go
+++ b/cloud/disk_manager/internal/pkg/cells/mocks/cells_mock.go
@@ -21,9 +21,9 @@ func NewCellSelectorMock() *CellSelectorMock {
 
 func (s *CellSelectorMock) SelectCell(
 	ctx context.Context,
-	disk *disk_manager.DiskId,
+	req *disk_manager.CreateDiskRequest,
 ) string {
 
-	args := s.Called(ctx, disk)
+	args := s.Called(ctx, req)
 	return args.String(0)
 }

--- a/cloud/disk_manager/internal/pkg/cells/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/cells/tests/ya.make
@@ -1,0 +1,5 @@
+GO_TEST_FOR(cloud/disk_manager/internal/pkg/cells)
+
+SIZE(SMALL)
+
+END()

--- a/cloud/disk_manager/internal/pkg/cells/ya.make
+++ b/cloud/disk_manager/internal/pkg/cells/ya.make
@@ -6,6 +6,7 @@ SRCS(
 )
 
 GO_TEST_SRCS(
+    cells_test.go
 )
 
 END()
@@ -16,4 +17,5 @@ RECURSE(
 
 RECURSE_FOR_TESTS(
     mocks
+    tests
 )

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -188,7 +188,7 @@ func (s *service) prepareZoneID(
 		return diskMeta.ZoneID, nil
 	}
 
-	return s.cellSelector.SelectCell(ctx, req.DiskId), nil
+	return s.cellSelector.SelectCell(ctx, req), nil
 }
 
 func (s *service) prepareCreateDiskParams(


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/pull/3638#

This pull request introduces a filtering mechanism to control which folders the `SU` selection mechanism can be applied to. This allows for more granular control over the feature's scope.

The implementation includes two new configuration options:
- `ExcludedFolders`: A blacklist of folders where the mechanism is explicitly disallowed.
- `IncludedFolders`: A whitelist of folders where the mechanism is allowed.

**Filtering Logic:**

The logic is resolved as follows:
1.  **Exclusion Check:** If a folder is present in the `ExcludedFolders` list, it is **always** considered invalid.
2.  **Inclusion Check:**
    - If the `IncludedFolders` list is **empty**, any folder that is *not* in `ExcludedFolders` is considered valid.
    - If the `IncludedFolders` list is **not empty**, a folder must be explicitly listed in `IncludedFolders` to be considered valid.

In summary, `ExcludedFolders` acts as a permanent blacklist, while a non-empty `IncludedFolders` list activates a whitelist mode.
