### PR TITLE
fix failing TestFilesystemServiceCreateExternalFilesystem test

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go
@@ -154,7 +154,7 @@ func TestFilesystemServiceCreateExternalFilesystem(t *testing.T) {
 	waitOperationOrTimeout(
 		"CreateFilesystem.1",
 		true, /* should timeout */
-		10*time.Second,
+		60*time.Second,
 		operation.Id,
 	)
 
@@ -194,7 +194,7 @@ func TestFilesystemServiceCreateExternalFilesystem(t *testing.T) {
 	waitOperationOrTimeout(
 		"DeleteFilesystem.1",
 		true, /* should timeout */
-		10*time.Second,
+		60*time.Second,
 		operation.Id,
 	)
 


### PR DESCRIPTION
It's not enough to wait for 10 seconds for external task to be scheduled.

https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/15512548490/1/nebius-x86-64/logs/cloud/disk_manager/internal/pkg/facade/filesystem_service_nemesis_test/test-results/filesystem_service_nemesis_test/chunk1/testing_out_stuff/filesystem_service_nemesis_test.TestFilesystemServiceCreateExternalFilesystem.log
