### PR TITLE
Make session logs better. Part 2. Show NBS-2 mark.

### DIFF
--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -227,7 +227,8 @@ public:
             Args.RdmaClient,
             Args.VolumeStats,
             Args.PreemptedVolumes,
-            Args.RootKmsKeyProvider);
+            Args.RootKmsKeyProvider,
+            Args.TemporaryServer);
 
         setup->LocalServices.emplace_back(
             MakeStorageServiceId(),

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -39,10 +39,12 @@ TLogTitle::TLogTitle(
         EType type,
         TString sessionId,
         TString diskId,
+        bool temporaryServer,
         ui64 startTime)
     : Type(type)
     , SessionId(std::move(sessionId))
     , StartTime(startTime)
+    , TemporaryServer(temporaryServer)
     , DiskId(std::move(diskId))
 {
     Rebuild();
@@ -190,6 +192,9 @@ void TLogTitle::RebuildForSession()
     auto builder = TStringBuilder();
 
     builder << "[";
+    if (TemporaryServer) {
+        builder << "~";
+    }
     builder << "vs:";
     if (TabletId) {
         builder << TabletId;

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -31,6 +31,7 @@ private:
     const ui64 StartTime;
     const ui32 PartitionIndex = 0;
     const ui32 PartitionCount = 0;
+    const bool TemporaryServer = false;
 
     ui64 TabletId = 0;
     ui64 Generation = 0;
@@ -50,7 +51,12 @@ public:
         ui32 partitionCount);
 
     // Constructor for Session
-    TLogTitle(EType type, TString sessionId, TString diskId, ui64 startTime);
+    TLogTitle(
+        EType type,
+        TString sessionId,
+        TString diskId,
+        bool temporaryServer,
+        ui64 startTime);
 
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -92,6 +92,7 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             TLogTitle::EType::Session,
             "session-1",
             "disk1",
+            false,
             GetCycleCount());
 
         UNIT_ASSERT_STRINGS_EQUAL(
@@ -106,6 +107,29 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
         UNIT_ASSERT_STRING_CONTAINS(
             logTitle.GetWithTime(),
             "[vs:12345 d:disk1 s:session-1 t:");
+    }
+
+    Y_UNIT_TEST(GetForSessionOnTemporaryServer)
+    {
+        TLogTitle logTitle(
+            TLogTitle::EType::Session,
+            "session-1",
+            "disk1",
+            true,
+            GetCycleCount());
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[~vs:? d:disk1 s:session-1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        logTitle.SetTabletId(12345);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[~vs:12345 d:disk1 s:session-1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            logTitle.GetWithTime(),
+            "[~vs:12345 d:disk1 s:session-1 t:");
     }
 
     Y_UNIT_TEST(GetChildLogger)

--- a/cloud/blockstore/libs/storage/service/service.cpp
+++ b/cloud/blockstore/libs/storage/service/service.cpp
@@ -19,7 +19,8 @@ IActorPtr CreateStorageService(
     NRdma::IClientPtr rdmaClient,
     IVolumeStatsPtr volumeStats,
     TManuallyPreemptedVolumesPtr preemptedVolumes,
-    IRootKmsKeyProviderPtr rootKmsKeyProvider)
+    IRootKmsKeyProviderPtr rootKmsKeyProvider,
+    bool temporaryServer)
 {
     return std::make_unique<TServiceActor>(
         std::move(config),
@@ -32,7 +33,8 @@ IActorPtr CreateStorageService(
         std::move(rdmaClient),
         std::move(volumeStats),
         std::move(preemptedVolumes),
-        std::move(rootKmsKeyProvider));
+        std::move(rootKmsKeyProvider),
+        temporaryServer);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service.h
+++ b/cloud/blockstore/libs/storage/service/service.h
@@ -25,6 +25,7 @@ NActors::IActorPtr CreateStorageService(
     NRdma::IClientPtr rdmaClient,
     IVolumeStatsPtr volumeStats,
     TManuallyPreemptedVolumesPtr preemptedVolumes,
-    IRootKmsKeyProviderPtr rootKmsKeyProvider);
+    IRootKmsKeyProviderPtr rootKmsKeyProvider,
+    bool temporaryServer);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -27,7 +27,8 @@ TServiceActor::TServiceActor(
         NRdma::IClientPtr rdmaClient,
         IVolumeStatsPtr volumeStats,
         TManuallyPreemptedVolumesPtr preemptedVolumes,
-        IRootKmsKeyProviderPtr rootKmsKeyProvider)
+        IRootKmsKeyProviderPtr rootKmsKeyProvider,
+        bool temporaryServer)
     : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
@@ -38,6 +39,7 @@ TServiceActor::TServiceActor(
     , RdmaClient(std::move(rdmaClient))
     , VolumeStats(std::move(volumeStats))
     , RootKmsKeyProvider(std::move(rootKmsKeyProvider))
+    , TemporaryServer(temporaryServer)
     , SharedCounters(MakeIntrusive<TSharedServiceCounters>(Config))
     , State(std::move(preemptedVolumes))
 {}

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -49,6 +49,7 @@ private:
     const NRdma::IClientPtr RdmaClient;
     const IVolumeStatsPtr VolumeStats;
     const IRootKmsKeyProviderPtr RootKmsKeyProvider;
+    const bool TemporaryServer;
 
     TSharedServiceCountersPtr SharedCounters;
 
@@ -76,7 +77,8 @@ public:
         NRdma::IClientPtr rdmaClient,
         IVolumeStatsPtr volumeStats,
         TManuallyPreemptedVolumesPtr preemptedVolumes,
-        IRootKmsKeyProviderPtr rootKmsKeyProvider);
+        IRootKmsKeyProviderPtr rootKmsKeyProvider,
+        bool temporaryServer);
     ~TServiceActor() override;
 
     void Bootstrap(const NActors::TActorContext& ctx);
@@ -446,7 +448,8 @@ NActors::IActorPtr CreateVolumeSessionActor(
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     std::shared_ptr<NKikimr::TTabletCountersBase> counters,
-    TSharedServiceCountersPtr sharedCounters);
+    TSharedServiceCountersPtr sharedCounters,
+    bool temporaryServer);
 
 void RegisterAlterVolumeActor(
     const NActors::TActorId& sender,

--- a/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
@@ -142,9 +142,8 @@ void TServiceActor::HandleMountVolume(
                 EndpointEventHandler,
                 RdmaClient,
                 Counters,
-                SharedCounters
-            )
-        );
+                SharedCounters,
+                TemporaryServer));
     }
 
     NCloud::Register(

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -361,7 +361,8 @@ IActorPtr CreateVolumeSessionActor(
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
     NRdma::IClientPtr rdmaClient,
     std::shared_ptr<NKikimr::TTabletCountersBase> counters,
-    TSharedServiceCountersPtr sharedCounters)
+    TSharedServiceCountersPtr sharedCounters,
+    bool temporaryServer)
 {
     return std::make_unique<TVolumeSessionActor>(
         std::move(volumeInfo),
@@ -373,7 +374,8 @@ IActorPtr CreateVolumeSessionActor(
         std::move(endpointEventHandler),
         std::move(rdmaClient),
         std::move(counters),
-        std::move(sharedCounters));
+        std::move(sharedCounters),
+        temporaryServer);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -53,11 +53,13 @@ private:
     const NRdma::IClientPtr RdmaClient;
     const std::shared_ptr<NKikimr::TTabletCountersBase> Counters;
     const TSharedServiceCountersPtr SharedCounters;
+    const bool TemporaryServer;
 
     TLogTitle LogTitle{
         TLogTitle::EType::Session,
         VolumeInfo->SessionId,
         VolumeInfo->DiskId,
+        TemporaryServer,
         GetCycleCount()};
 
     TQueue<NActors::IEventHandlePtr> MountUnmountRequests;
@@ -89,7 +91,8 @@ public:
         NServer::IEndpointEventHandlerPtr endpointEventHandler,
         NRdma::IClientPtr rdmaClient,
         std::shared_ptr<NKikimr::TTabletCountersBase> counters,
-        TSharedServiceCountersPtr sharedCounters)
+        TSharedServiceCountersPtr sharedCounters,
+        bool temporaryServer)
         : VolumeInfo(std::move(volumeInfo))
         , Config(std::move(config))
         , DiagnosticsConfig(std::move(diagnosticsConfig))
@@ -100,6 +103,7 @@ public:
         , RdmaClient(std::move(rdmaClient))
         , Counters(std::move(counters))
         , SharedCounters(std::move(sharedCounters))
+        , TemporaryServer(temporaryServer)
     {}
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -378,10 +378,12 @@ ui32 TTestEnv::CreateBlockStoreNode(
         NDiscovery::CreateDiscoveryServiceStub(),
         TraceSerializer,
         NServer::CreateEndpointEventProxy(),
-        nullptr, // rdmaClient
+        nullptr,   // rdmaClient
         CreateVolumeStatsStub(),
         std::move(manuallyPreemptedVolumes),
-        CreateRootKmsKeyProviderMock());
+        CreateRootKmsKeyProviderMock(),
+        false   // temporaryServer
+    );
 
     auto storageServiceId = Runtime.Register(
         storageService.release(),


### PR DESCRIPTION
Размечаю логи сессий NBS-2, которые поднимается при blue-green обновлении значком ~.
```
2025-06-12T06:32:26.135055Z :BLOCKSTORE_SERVICE INFO: [~vs:72075186224037889 d:nrd1 s:1e1b1bd9-3a11f636-4f2bc03f-ef3d8a7b t:20.438ms] Mount completed for client "858fb7b1-522135b4-2efa48e5-675f9ad4", msg binding BINDING_REMOTE, msg source SOURCE_NONE, time "12983185534100", binding BINDING_REMOTE, source SOURCE_NONE

```