### PR TITLE
Throttling policy fix

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -344,15 +344,21 @@ void BuildChangeThrottlingPolicyButton(
         << "<input type='hidden' name='TabletID' value='" << tabletId << "'/>"
         << "<input type='hidden' name='Volume' value='" << diskId << "'/>"
         << "<input type='hidden' name='action' value='changethrottlingpolicy'/>"
+        << "<label style='font-weight: normal'> Max read Iops "
         << "<input type='text' name='MaxReadIops' value='"
-        << pp.GetMaxReadIops() << "'/>"
+        << pp.GetMaxReadIops() << "' style='font-weight: normal'/> </label>"
+        << "<label style='font-weight: normal'> Max write Iops "
         << "<input type='text' name='MaxWriteIops' value='"
-        << pp.GetMaxWriteIops() << "'/>"
+        << pp.GetMaxWriteIops() << "' style='font-weight: normal'/> </label>"
+        << "<label style='font-weight: normal'> Max read bandwidth "
         << "<input type='text' name='MaxReadBandwidth' value='"
-        << pp.GetMaxReadBandwidth() << "'/>"
+        << pp.GetMaxReadBandwidth()
+        << "' style='font-weight: normal'/> </label>"
+        << "<label style='font-weight: normal'> Max write bandwith "
         << "<input type='text' name='MaxWriteBandwidth' value='"
-        << pp.GetMaxWriteBandwidth() << "'/>"
-        << "<input class='btn btn-primary' type='button'"
+        << pp.GetMaxWriteBandwidth()
+        << "' style='font-weight: normal'/> </label>"
+        << "<br> <input class='btn btn-primary' type='button'"
         << " value='Change Throttling Policy' "
         << "data-toggle='modal' data-target='#change-throttling-policy'/>"
         << "</form>" << Endl;
@@ -2147,6 +2153,37 @@ void TVolumeActor::RenderCommonButtons(IOutputStream& out) const
             TABLE_SORTABLE_CLASS("table table-condensed") {
                 TABLER() {
                     TABLED() {
+                        TAG (TH3) {
+                            const auto& defaultConfig =
+                                State->GetConfig().GetPerformanceProfile();
+                            const auto& volumeThrottrlingPolicyConfig =
+                                State->GetThrottlingPolicy().GetConfig();
+                            bool IsSetDefaultThrottlingPolicy =
+                                defaultConfig.GetMaxReadIops() ==
+                                    volumeThrottrlingPolicyConfig
+                                        .GetMaxReadIops() &&
+                                defaultConfig.GetMaxWriteIops() ==
+                                    volumeThrottrlingPolicyConfig
+                                        .GetMaxWriteIops() &&
+                                defaultConfig.GetMaxReadBandwidth() ==
+                                    volumeThrottrlingPolicyConfig
+                                        .GetMaxReadBandwidth() &&
+                                defaultConfig.GetMaxWriteBandwidth() ==
+                                    volumeThrottrlingPolicyConfig
+                                        .GetMaxWriteBandwidth();
+
+                            TString statusText = IsSetDefaultThrottlingPolicy
+                                                     ? "Default"
+                                                     : "Custom";
+                            TString cssClass = IsSetDefaultThrottlingPolicy
+                                                   ? "label-success"
+                                                   : "label-danger";
+
+                            out << "Throttling Policy status: ";
+                            SPAN_CLASS ("label " + cssClass) {
+                                out << statusText;
+                            }
+                        }
                         BuildChangeThrottlingPolicyButton(
                             out,
                             State->GetDiskId(),

--- a/example/3-start_nbs.sh
+++ b/example/3-start_nbs.sh
@@ -25,6 +25,7 @@ nbsd \
     --storage-file       nbs/nbs-storage.txt \
     --naming-file        nbs/nbs-names.txt \
     --diag-file          nbs/nbs-diag.txt \
+    --features-file      nbs/nbs-features.txt \
     --auth-file          nbs/nbs-auth.txt \
     --dr-proxy-file      nbs/nbs-dr-proxy.txt \
     --rdma-file          nbs/nbs-rdma.txt \


### PR DESCRIPTION
Добавлены подписи полей к кнопке Change Throttling Policy
и Throttling Policy status, который отображается, 
как Default, если настроена дефолтная throttling policy:
![throttling_policy_default](https://github.com/user-attachments/assets/5da66834-e81c-4a84-82c1-4f4f408d1f5f)
и как Custom, если пользователь указал свои кастомные значения для 
throttling policy: 
![throttling_policy_custom](https://github.com/user-attachments/assets/0d86b9c0-450a-4fb1-9f38-b6d7d0b5b6db).

Также исправлены счетчики: MaxReadBandwidth, MaxWriteBandwidth, MaxReadIops, MaxWriteBandwidth, RealMaxWriteBandwidth.
В них передавались дефолтные значения, теперь передаются значения переопределённые с мон страницы.
