### PR TITLE
[Disk Manager] Fix test flaps with nemesis

### DIFF
--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -638,6 +638,8 @@ class DiskManagerLauncher:
                 data = response.read().decode()
         except urllib.error.URLError:
             return result
+        except ConnectionError:
+            return result
 
         for line in data.splitlines():
             if not line:


### PR DESCRIPTION
Handle connection errors which occur because the nemesis process restarts disk-manager.