### PR TITLE
issue-1345: changed the order of AddClient\RemoveClient transactions and Acquire\Release devices during mount operations for DR-based disks

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -273,17 +273,20 @@ private:
         ui64 MountSeqNumber;
         TClientRequestPtr ClientRequest;
         TVector<NProto::TDeviceConfig> DevicesToRelease;
+        const bool ForceTabletRestart = false;
 
         TAcquireReleaseDiskRequest(
                 TString clientId,
                 NProto::EVolumeAccessMode accessMode,
                 ui64 mountSeqNumber,
-                TClientRequestPtr clientRequest)
+                TClientRequestPtr clientRequest,
+                bool forceTabletRestart = false)
             : IsAcquire(true)
             , ClientId(std::move(clientId))
             , AccessMode(accessMode)
             , MountSeqNumber(mountSeqNumber)
             , ClientRequest(std::move(clientRequest))
+            , ForceTabletRestart(forceTabletRestart)
         {
         }
 
@@ -534,6 +537,9 @@ private:
     ui64 GetBlocksCount() const;
 
     void ProcessNextPendingClientRequest(const NActors::TActorContext& ctx);
+    void ProcessNextAcquireReleaseDiskRequestIfNeeded(
+        const NActors::TActorContext& ctx,
+        size_t requestWasAdded);
     void ProcessNextAcquireReleaseDiskRequest(const NActors::TActorContext& ctx);
     void OnClientListUpdate(const NActors::TActorContext& ctx);
 
@@ -807,6 +813,10 @@ private:
     void ReleaseReplacedDevices(
         const NActors::TActorContext& ctx,
         const TVector<NProto::TDeviceConfig>& replacedDevices);
+
+    void ReleaseDiskFromOldClients(
+        const NActors::TActorContext& ctx,
+        const TVector<TString>& removedClients);
 
     void ScheduleAcquireDiskIfNeeded(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -280,7 +280,7 @@ private:
                 NProto::EVolumeAccessMode accessMode,
                 ui64 mountSeqNumber,
                 TClientRequestPtr clientRequest,
-                bool forceTabletRestart = false)
+                bool forceTabletRestart)
             : IsAcquire(true)
             , ClientId(std::move(clientId))
             , AccessMode(accessMode)
@@ -537,9 +537,10 @@ private:
     ui64 GetBlocksCount() const;
 
     void ProcessNextPendingClientRequest(const NActors::TActorContext& ctx);
-    void ProcessNextAcquireReleaseDiskRequestIfNeeded(
+
+    void AddAcquireReleaseDiskRequest(
         const NActors::TActorContext& ctx,
-        size_t requestWasAdded);
+        TAcquireReleaseDiskRequest request);
     void ProcessNextAcquireReleaseDiskRequest(const NActors::TActorContext& ctx);
     void OnClientListUpdate(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -274,9 +274,7 @@ void TVolumeActor::HandleDevicesAcquireFinishedImpl(
             *State);
 
         NCloud::Reply(ctx, *clientRequest->RequestInfo, std::move(response));
-    }
 
-    if (clientRequest) {
         PendingClientRequests.pop_front();
         ProcessNextPendingClientRequest(ctx);
     }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -85,4 +85,27 @@ void TVolumeActor::ReleaseReplacedDevices(
     }
 }
 
+void TVolumeActor::ReleaseDiskFromOldClients(
+    const NActors::TActorContext& ctx,
+    const TVector<TString>& removedClients)
+{
+    if (removedClients.empty()) {
+        return;
+    }
+
+    for (const auto& clientId: removedClients) {
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "[%lu] Releasing devices from old client: %s",
+            TabletID(),
+            clientId.c_str());
+
+        AcquireReleaseDiskRequests.emplace_back(
+            clientId,
+            nullptr,
+            TVector<NProto::TDeviceConfig>{});
+    }
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -89,22 +89,17 @@ void TVolumeActor::ReleaseDiskFromOldClients(
     const NActors::TActorContext& ctx,
     const TVector<TString>& removedClients)
 {
-    if (removedClients.empty()) {
-        return;
-    }
-
     for (const auto& clientId: removedClients) {
         LOG_DEBUG(
             ctx,
             TBlockStoreComponents::VOLUME,
-            "[%lu] Releasing devices from old client: %s",
-            TabletID(),
+            "%s Releasing devices from old client: %s",
+            LogTitle.GetWithTime().c_str(),
             clientId.c_str());
 
-        AcquireReleaseDiskRequests.emplace_back(
-            clientId,
-            nullptr,
-            TVector<NProto::TDeviceConfig>{});
+        AddAcquireReleaseDiskRequest(
+            ctx,
+            {clientId, nullptr, TVector<NProto::TDeviceConfig>{}});
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -95,7 +95,7 @@ void TVolumeActor::ReleaseDiskFromOldClients(
             TBlockStoreComponents::VOLUME,
             "%s Releasing devices from old client: %s",
             LogTitle.GetWithTime().c_str(),
-            clientId.c_str());
+            clientId.Quote().c_str());
 
         AddAcquireReleaseDiskRequest(
             ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -25,7 +25,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<TEvVolume::TEvRemoveClientResponse> CreateReleaseRespose(
+std::unique_ptr<TEvVolume::TEvRemoveClientResponse> CreateReleaseResponse(
     const NProto::TError& error,
     TString diskId,
     TString clientId,
@@ -119,7 +119,7 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
         NCloud::Reply(
             ctx,
             *cr->RequestInfo,
-            CreateReleaseRespose(
+            CreateReleaseResponse(
                 error,
                 cr->DiskId,
                 cr->GetClientId(),
@@ -243,7 +243,7 @@ void TVolumeActor::CompleteRemoveClient(
         NCloud::Reply(
             ctx,
             *args.RequestInfo,
-            CreateReleaseRespose(args.Error, diskId, clientId, TabletID()));
+            CreateReleaseResponse(args.Error, diskId, clientId, TabletID()));
         return;
     }
 
@@ -273,7 +273,7 @@ void TVolumeActor::CompleteRemoveClient(
         NCloud::Reply(
             ctx,
             *args.RequestInfo,
-            CreateReleaseRespose(args.Error, diskId, clientId, TabletID()));
+            CreateReleaseResponse(args.Error, diskId, clientId, TabletID()));
     }
 
     OnClientListUpdate(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -251,6 +251,8 @@ struct TTxVolume
         NProto::TError Error;
         bool ForceTabletRestart = false;
 
+        TVector<TString> RemovedClientIds;
+
         TAddClient(
                 TRequestInfoPtr requestInfo,
                 TString diskId,

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -2128,7 +2128,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         volumeGeneration = 0;
 
-        volume.RemoveClient(writer.GetClientId());
+        volume.RemoveClient(reader.GetClientId());
         UNIT_ASSERT_VALUES_EQUAL(2, volumeGeneration);
     }
 

--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import tempfile
+
 import pytest
 import time
 
@@ -8,7 +10,8 @@ import time
 from cloud.blockstore.tests.python.lib.test_client import CreateTestClient
 
 from cloud.blockstore.public.sdk.python.client import Session
-from cloud.blockstore.public.sdk.python.protos import STORAGE_MEDIA_SSD_NONREPLICATED
+from cloud.blockstore.public.sdk.python.protos import STORAGE_MEDIA_SSD_NONREPLICATED, \
+    IPC_VHOST, VOLUME_ACCESS_READ_WRITE
 
 from cloud.blockstore.tests.python.lib.config import NbsConfigurator, \
     generate_disk_agent_txt
@@ -50,6 +53,9 @@ def start_nbs_daemon_with_dr(request, ydb):
     cfg.files["storage"].NonReplicatedAgentMaxTimeout = request.param
     cfg.files["storage"].NonReplicatedVolumeDirectAcquireEnabled = True
     cfg.files["storage"].AcquireNonReplicatedDevices = True
+    cfg.files["server"].ServerConfig.VhostEnabled = True
+    cfg.files["server"].ServerConfig.VhostServerPath = yatest_common.binary_path(
+        "cloud/blockstore/vhost-server/blockstore-vhost-server")
 
     daemon = start_nbs(cfg)
 
@@ -73,6 +79,9 @@ def start_nbs_daemon(ydb):
     cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
     cfg.files["storage"].NonReplicatedVolumeDirectAcquireEnabled = True
     cfg.files["storage"].AcquireNonReplicatedDevices = True
+    cfg.files["server"].ServerConfig.VhostEnabled = True
+    cfg.files["server"].ServerConfig.VhostServerPath = yatest_common.binary_path(
+        "cloud/blockstore/vhost-server/blockstore-vhost-server")
 
     daemon = start_nbs(cfg)
 
@@ -393,3 +402,65 @@ def test_should_mount_volume_with_unavailable_agents(
         blocks = session.read_blocks(i*DEVICE_SIZE//4096, 1, checkpoint_id="")
 
     session.unmount_volume()
+
+
+@pytest.mark.parametrize("nbs_with_dr", [(6000)], indirect=["nbs_with_dr"])
+def test_should_stop_not_restored_endpoint(nbs_with_dr,
+                                           nbs,
+                                           agent_ids,
+                                           disk_agent_configurators):
+
+    client = CreateTestClient(f"localhost:{nbs.port}")
+
+    test_disk_id = "vol0-multiple_endpoints"
+
+    agent_id = agent_ids[0]
+    configurator = disk_agent_configurators[0]
+    agent = start_disk_agent(configurator, name=agent_id)
+    agent.wait_for_registration()
+    r = client.add_host(agent_id)
+    assert len(r.ActionResults) == 1
+    assert r.ActionResults[0].Result.Code == 0
+
+    # create a volume
+    client.create_volume(
+        disk_id=test_disk_id,
+        block_size=4096,
+        blocks_count=DEVICE_SIZE//4096,
+        storage_media_kind=STORAGE_MEDIA_SSD_NONREPLICATED,
+        cloud_id="test")
+
+    # Start a lot of blockstore-vhost-server processes.
+    # SOCKET_COUNT = 1
+    # for i in range(0, SOCKET_COUNT):
+    socket = tempfile.NamedTemporaryFile()
+    client.start_endpoint(
+        unix_socket_path=socket.name,
+        disk_id=test_disk_id,
+        ipc_type=IPC_VHOST,
+        access_mode=VOLUME_ACCESS_READ_WRITE,
+        client_id=f"{socket.name}-id",
+        seq_number=0
+    )
+
+    nbs.kill()
+    time.sleep(10)
+    nbs.start()
+
+    client.stop_endpoint(
+        unix_socket_path=socket.name,
+    )
+
+    another_socket = tempfile.NamedTemporaryFile()
+    client.start_endpoint(
+        unix_socket_path=another_socket.name,
+        disk_id=test_disk_id,
+        ipc_type=IPC_VHOST,
+        access_mode=VOLUME_ACCESS_READ_WRITE,
+        client_id=f"{another_socket.name}-id-1",
+        seq_number=0
+    )
+
+    client.stop_endpoint(
+        unix_socket_path=another_socket.name,
+    )

--- a/cloud/blockstore/tests/direct_device_acquire/ya.make
+++ b/cloud/blockstore/tests/direct_device_acquire/ya.make
@@ -8,6 +8,8 @@ DEPENDS(
     cloud/blockstore/apps/client
     cloud/blockstore/apps/disk_agent
     cloud/blockstore/apps/server
+    cloud/blockstore/tools/testing/fake-vhost-server
+    cloud/blockstore/vhost-server
     contrib/ydb/apps/ydbd
 )
 


### PR DESCRIPTION
#1345 
keyring не песистентное хранилище, поэтому когда хост перезапускается из-за отключения питания, нбс поднимается и не находит эндпоинты в кейринге и соответственно ничего не ресторит. После приходит компьют и делает StopEndpoint, поскольку мы ничего не ресторили, этого эндпоинта у нас нет и мы отвечаем "hasn't been started yet".
После этого делаем KickEndpoint и на монтирование сперва отпраляем запрос на захват девайса, однако диск агент помнит что у него еще есть клиент, который не освободил девайс и отвечает ошибкой.

Сейчас мы для нрд дисков сперва делаем Acquire\Release, а уже после этого выполняем транзакции AddClient\RemoveClient. И диск агент, если девайс был захвачен на RW, будет отвечать всегда ошибкой на попытку захвата другим клиентом на RW. При этом волум не перестанет посылать запросы на захват девайса со старым клиентом, пока мы не поменяем его в локальной базе (выполним транзакцию AddClient, котрая выбьет старого клиента).

В этом пре я поменял порядок действий для нрд дисков, сначала мы выполняем транзакцию AddClient\RemoveClient, и уже только после этого делаем все нужные захваты освобождения девайсов. И таким образом когда хост выйдет по питанию и стартанет заного мы придем в волум с новым запросом на монтирование, волум выбьет старого клиента (т.к. он слишком много времени был неактивен) транзакцией AddClient, после нее мы сделаем сначала Release от всех старых клиентов и сделаем Acquire для нового клиента и только после этого ответим, что успешно добавили нового клиента

Для удаления клиента ситуация аналогичная: сначала мы выполняем транзакцию RemoveClient, которое сделает все, что нужно с локальной базой, и только после этого посылаем запросы на освобождение девайссов