### PR TITLE
Format logs about session and client

### DIFF
--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -23,11 +23,13 @@ public:
         Volume,
         Partition,
         Session,
+        Client,
     };
 
 private:
     const EType Type;
     const TString SessionId;
+    const TString ClientId;
     const ui64 StartTime;
     const ui32 PartitionIndex = 0;
     const ui32 PartitionCount = 0;
@@ -35,6 +37,7 @@ private:
 
     ui64 TabletId = 0;
     ui64 Generation = 0;
+    ui32 PipeGeneration = 0;
     TString DiskId;
     TString CachedPrefix;
 
@@ -58,6 +61,15 @@ public:
         bool temporaryServer,
         ui64 startTime);
 
+    // Constructor for Client
+    TLogTitle(
+        ui64 tabletId,
+        TString sessionId,
+        TString clientId,
+        TString diskId,
+        bool temporaryServer,
+        ui64 startTime);
+
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
 
@@ -70,12 +82,14 @@ public:
     void SetDiskId(TString diskId);
     void SetGeneration(ui32 generation);
     void SetTabletId(ui64 tabletId);
+    void SetPipeGeneration(ui32 pipeGeneration);
 
 private:
     void Rebuild();
     void RebuildForVolume();
     void RebuildForPartition();
     void RebuildForSession();
+    void RebuildForClient();
     TString GetPartitionPrefix() const;
 };
 

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -132,6 +132,41 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             "[~vs:12345 d:disk1 s:session-1 t:");
     }
 
+    Y_UNIT_TEST(GetForClient)
+    {
+        TLogTitle logTitle(
+            12345,
+            "session-1",
+            "client-1",
+            "disk1",
+            false,
+            GetCycleCount());
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[vc:12345 d:disk1 s:session-1 c:client-1 pg:?]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        logTitle.SetPipeGeneration(1);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[vc:12345 d:disk1 s:session-1 c:client-1 pg:1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            logTitle.GetWithTime(),
+            "[vc:12345 d:disk1 s:session-1 c:client-1 pg:1 t:");
+
+        TLogTitle temporayLogTitle(
+            12345,
+            "session-1",
+            "client-1",
+            "disk1",
+            true,
+            GetCycleCount());
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[~vc:12345 d:disk1 s:session-1 c:client-1 pg:?]",
+            temporayLogTitle.Get(TLogTitle::EDetails::Brief));
+    }
+
     Y_UNIT_TEST(GetChildLogger)
     {
         const ui64 startTime =

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -449,6 +449,7 @@ NActors::IActorPtr CreateVolumeSessionActor(
     NRdma::IClientPtr rdmaClient,
     std::shared_ptr<NKikimr::TTabletCountersBase> counters,
     TSharedServiceCountersPtr sharedCounters,
+    TString clientId,
     bool temporaryServer);
 
 void RegisterAlterVolumeActor(

--- a/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_mount.cpp
@@ -117,6 +117,7 @@ void TServiceActor::HandleMountVolume(
 {
     auto* msg = ev->Get();
     const auto& diskId = msg->Record.GetDiskId();
+    const auto& clientId = msg->Record.GetHeaders().GetClientId();
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,
@@ -143,6 +144,7 @@ void TServiceActor::HandleMountVolume(
                 RdmaClient,
                 Counters,
                 SharedCounters,
+                clientId,
                 TemporaryServer));
     }
 

--- a/cloud/blockstore/libs/storage/service/service_state.h
+++ b/cloud/blockstore/libs/storage/service/service_state.h
@@ -84,7 +84,7 @@ struct TVolumeInfo
 
     ui64 TabletId = 0;
     TMaybe<NProto::TVolume> VolumeInfo;
-    TString SessionId;
+    const TString SessionId;
 
     NActors::TActorId VolumeSessionActor;
     NActors::TActorId VolumeClientActor;

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.h
@@ -17,6 +17,9 @@ NActors::IActorPtr CreateVolumeClient(
     ITraceSerializerPtr traceSerializer,
     NServer::IEndpointEventHandlerPtr endpointEventHandler,
     const NActors::TActorId& sessionActorId,
+    TString sessionId,
+    TString clientId,
+    bool temporaryServer,
     TString diskId,
     ui64 tabletId);
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -75,6 +75,9 @@ void TVolumeSessionActor::HandleDescribeVolumeResponse(
                 TraceSerializer,
                 EndpointEventHandler,
                 SelfId(),
+                VolumeInfo->SessionId,
+                InitialClientId,
+                TemporaryServer,
                 VolumeInfo->DiskId,
                 TabletId
             ));
@@ -362,6 +365,7 @@ IActorPtr CreateVolumeSessionActor(
     NRdma::IClientPtr rdmaClient,
     std::shared_ptr<NKikimr::TTabletCountersBase> counters,
     TSharedServiceCountersPtr sharedCounters,
+    TString clientId,
     bool temporaryServer)
 {
     return std::make_unique<TVolumeSessionActor>(
@@ -375,6 +379,7 @@ IActorPtr CreateVolumeSessionActor(
         std::move(rdmaClient),
         std::move(counters),
         std::move(sharedCounters),
+        std::move(clientId),
         temporaryServer);
 }
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -21,6 +21,8 @@
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
+#include <utility>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,6 +55,7 @@ private:
     const NRdma::IClientPtr RdmaClient;
     const std::shared_ptr<NKikimr::TTabletCountersBase> Counters;
     const TSharedServiceCountersPtr SharedCounters;
+    const TString InitialClientId;
     const bool TemporaryServer;
 
     TLogTitle LogTitle{
@@ -92,6 +95,7 @@ public:
         NRdma::IClientPtr rdmaClient,
         std::shared_ptr<NKikimr::TTabletCountersBase> counters,
         TSharedServiceCountersPtr sharedCounters,
+        TString clientId,
         bool temporaryServer)
         : VolumeInfo(std::move(volumeInfo))
         , Config(std::move(config))
@@ -103,6 +107,7 @@ public:
         , RdmaClient(std::move(rdmaClient))
         , Counters(std::move(counters))
         , SharedCounters(std::move(sharedCounters))
+        , InitialClientId(std::move(clientId))
         , TemporaryServer(temporaryServer)
     {}
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
@@ -426,9 +426,11 @@ void TVolumeSessionActor::HandleUnmountRequestProcessed(
                     TraceSerializer,
                     EndpointEventHandler,
                     SelfId(),
+                    VolumeInfo->SessionId,
+                    clientId,
+                    TemporaryServer,
                     VolumeInfo->DiskId,
-                    TabletId
-                ));
+                    TabletId));
             VolumeInfo->VolumeClientActor = VolumeClient;
         }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -610,9 +610,11 @@ void TVolumeActor::HandlePoisonTaken(
     const TEvents::TEvPoisonTaken::TPtr& ev,
     const TActorContext& ctx)
 {
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Partition %s stopped",
-        TabletID(),
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Partition %s stopped",
+        LogTitle.GetWithTime().c_str(),
         ev->Sender.ToString().c_str());
 
     OnDiskRegistryBasedPartitionStopped(
@@ -689,12 +691,13 @@ void TVolumeActor::HandleServerConnected(
 {
     const auto* msg = ev->Get();
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Pipe client %s (server %s) connected to volume %s",
-        TabletID(),
-        ToString(msg->ClientId).data(),
-        ToString(msg->ServerId).data(),
-        (State ? State->GetDiskId().Quote().data() : "<empty>"));
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Pipe client %s server %s connected to volume",
+        LogTitle.GetWithTime().c_str(),
+        ToString(msg->ClientId).c_str(),
+        ToString(msg->ServerId).c_str());
 }
 
 void TVolumeActor::HandleServerDisconnected(
@@ -704,13 +707,13 @@ void TVolumeActor::HandleServerDisconnected(
     const auto* msg = ev->Get();
     const auto now = ctx.Now();
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Pipe client %s (server %s) disconnected from volume %s at %s",
-        TabletID(),
-        ToString(msg->ClientId).data(),
-        ToString(msg->ServerId).data(),
-        (State ? State->GetDiskId().Quote().data() : "<empty>"),
-        now.ToString().data());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Pipe client %s server %s disconnected from volume",
+        LogTitle.GetWithTime().c_str(),
+        ToString(msg->ClientId).c_str(),
+        ToString(msg->ServerId).c_str());
 
     OnServicePipeDisconnect(ctx, msg->ServerId, now);
 }
@@ -722,13 +725,13 @@ void TVolumeActor::HandleServerDestroyed(
     const auto* msg = ev->Get();
     const auto now = ctx.Now();
 
-    LOG_INFO(ctx, TBlockStoreComponents::VOLUME,
-        "[%lu] Pipe client %s's server %s got destroyed for volume %s at %s",
-        TabletID(),
-        ToString(msg->ClientId).data(),
-        ToString(msg->ServerId).data(),
-        (State ? State->GetDiskId().Quote().data() : "<empty>"),
-        now.ToString().data());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Pipe client %s server %s got destroyed for volume",
+        LogTitle.GetWithTime().c_str(),
+        ToString(msg->ClientId).c_str(),
+        ToString(msg->ServerId).c_str());
 
     OnServicePipeDisconnect(ctx, msg->ServerId, now);
 }


### PR DESCRIPTION
1. Отформатировал логи в TVolumeClientActor
```
[vc:72075186224037890 d:nrd0 s:f8c12aa7-f850920c-8fd5c7e0-f1eedce8 c:288611d4-c1a67b56-e145d84c-73aa3f2d pg:1 t:743us] Connection to tablet has been established
```
vc: - сокращение VolumeClient
s:  - идентификатор сессии
c: - идентификатор клиента
pg: - PipeGeneration 

Теперь часть логов про монтирование вольюма выглядит так:
```
2025-06-17T10:13:42.478991Z :BLOCKSTORE_SERVICE INFO: [vs:72075186224037890 d:nrd0 s:f8c12aa7-f850920c-8fd5c7e0-f1eedce8 t:578us] Mounting volume: "nrd0" (client: "288611d4-c1a67b56-e145d84c-73aa3f2d" instance: "" access: read-write mount mode: VOLUME_MOUNT_LOCAL throttling: enabled seq_num: 0 binding: BINDING_NOT_SET source: SOURCE_NONE cur binding: BINDING_REMOTE cur source: SOURCE_NONE) ts: 2488017406624988
2025-06-17T10:13:42.479012Z :BLOCKSTORE_SERVICE INFO: [vs:72075186224037890 d:nrd0 s:f8c12aa7-f850920c-8fd5c7e0-f1eedce8 t:595us + 12us] Start mounting volume with mount mode: VOLUME_MOUNT_LOCAL binding: BINDING_LOCAL source: SOURCE_NONE
2025-06-17T10:13:42.479469Z :BLOCKSTORE_SERVICE INFO: Sending AddClient "288611d4-c1a67b56-e145d84c-73aa3f2d" to volume "nrd0"
2025-06-17T10:13:42.479725Z :BLOCKSTORE_SERVICE INFO: [vc:72075186224037890 d:nrd0 s:f8c12aa7-f850920c-8fd5c7e0-f1eedce8 c:288611d4-c1a67b56-e145d84c-73aa3f2d pg:1 t:743us] Connection to tablet has been established
2025-06-17T10:13:42.479726Z :BLOCKSTORE_VOLUME INFO: [v:72075186224037890 g:9 d:nrd0 t:84.439ms] Pipe client [50000:7516859445123728106:8189] server [50000:7516859445123728108:272] connected to volume
2025-06-17T10:13:42.479762Z :BLOCKSTORE_VOLUME INFO: [v:72075186224037890 g:9 d:nrd0 t:84.477ms] Received add client "288611d4-c1a67b56-e145d84c-73aa3f2d":"" request; pipe server [50000:7516859445123728108:272], sender [50000:7516859445123728096:4148]

```