### PR TITLE
issue-1751: Resolve concerns in TWriteBackCache

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read.cpp
@@ -1,4 +1,4 @@
-#include "write_back_cache.h"
+#include "write_back_cache_impl.h"
 
 #include <util/generic/deque.h>
 #include <util/generic/vector.h>

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read.cpp
@@ -27,6 +27,9 @@ auto TWriteBackCache::TImpl::CalculateDataPartsToRead(
 
     for (size_t i = 0; i < entries.size(); i++) {
         const auto* entry = entries[i];
+        if (!entry->IsCached()) {
+            continue;
+        }
 
         auto pointBegin = entry->Begin();
         auto pointEnd = entry->End();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
@@ -110,6 +110,7 @@ struct TCalculateDataPartsToReadTestBootstrap
 {
     using TWriteDataEntry = TWriteBackCache::TImpl::TWriteDataEntry;
     using TWriteDataEntryPart = TWriteBackCache::TImpl::TWriteDataEntryPart;
+    using EWriteDataEntryStatus = TWriteBackCache::TImpl::EWriteDataEntryStatus;
 
     ILoggingServicePtr Logging;
     TLog Log;
@@ -185,11 +186,17 @@ struct TCalculateDataPartsToReadTestBootstrap
 
         return res;
     }
+
+    static void SetCached(TWriteDataEntry* entry) {
+        entry->Status = EWriteDataEntryStatus::Cached;
+    }
 };
 
 using TWriteDataEntry = TCalculateDataPartsToReadTestBootstrap::TWriteDataEntry;
 using TWriteDataEntryPart =
     TCalculateDataPartsToReadTestBootstrap::TWriteDataEntryPart;
+using EWriteDataEntryStatus =
+    TCalculateDataPartsToReadTestBootstrap::EWriteDataEntryStatus;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -240,6 +247,7 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
 
             auto entry =
                 TWriteDataEntry::CreatePendingRequest(std::move(request));
+            TCalculateDataPartsToReadTestBootstrap::SetCached(entry.get());
             entries.PushBack(entry.release());
         }
 
@@ -294,6 +302,7 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
 
             auto entry =
                 TWriteDataEntry::CreatePendingRequest(std::move(request));
+            TCalculateDataPartsToReadTestBootstrap::SetCached(entry.get());
             entries.PushBack(entry.release());
         }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
@@ -1,4 +1,4 @@
-#include "write_back_cache.h"
+#include "write_back_cache_impl.h"
 
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
@@ -108,8 +108,8 @@ IOutputStream& operator<<(
 
 struct TCalculateDataPartsToReadTestBootstrap
 {
-    using TWriteDataEntry = TWriteBackCache::TWriteDataEntry;
-    using TWriteDataEntryPart = TWriteBackCache::TWriteDataEntryPart;
+    using TWriteDataEntry = TWriteBackCache::TImpl::TWriteDataEntry;
+    using TWriteDataEntryPart = TWriteBackCache::TImpl::TWriteDataEntryPart;
 
     ILoggingServicePtr Logging;
     TLog Log;
@@ -128,7 +128,7 @@ struct TCalculateDataPartsToReadTestBootstrap
         ui64 startingFromOffset,
         ui64 length)
     {
-        return TWriteBackCache::CalculateDataPartsToRead(
+        return TWriteBackCache::TImpl::CalculateDataPartsToRead(
             entries,
             startingFromOffset,
             length);
@@ -198,9 +198,9 @@ IOutputStream& operator<<(
     const TWriteDataEntry& e)
 {
     out << "{"
-        << "Handle: " << e.Request->GetHandle() << ", "
-        << "Offset: " << e.Request->GetOffset() << ", "
-        << "Length: " << e.Request->GetBuffer().Size()
+        << "Handle: " << e.GetRequest()->GetHandle() << ", "
+        << "Offset: " << e.GetRequest()->GetOffset() << ", "
+        << "Length: " << e.GetRequest()->GetBuffer().Size()
         << "}";
     return out;
 }
@@ -238,7 +238,8 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
             request->SetOffset(e.Offset);
             request->SetBuffer(TString(e.Length, 'a')); // dummy buffer
 
-            auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
+            auto entry =
+                TWriteDataEntry::CreatePendingRequest(std::move(request));
             entries.PushBack(entry.release());
         }
 
@@ -291,7 +292,8 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
             request->SetOffset(e.Offset);
             request->SetBuffer(TString(e.Length, 'a')); // dummy buffer
 
-            auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
+            auto entry =
+                TWriteDataEntry::CreatePendingRequest(std::move(request));
             entries.PushBack(entry.release());
         }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
@@ -198,9 +198,9 @@ IOutputStream& operator<<(
     const TWriteDataEntry& e)
 {
     out << "{"
-        << "Handle: " << e.GetRequest()->GetHandle() << ", "
-        << "Offset: " << e.GetRequest()->GetOffset() << ", "
-        << "Length: " << e.GetRequest()->GetBuffer().Size()
+        << "Handle: " << e.GetHandle() << ", "
+        << "Offset: " << e.Begin() << ", "
+        << "Length: " << e.GetBuffer().Size()
         << "}";
     return out;
 }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/session_sequencer.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/session_sequencer.cpp
@@ -1,9 +1,5 @@
 #include "session_sequencer.h"
 
-#include <util/generic/algorithm.h>
-#include <util/generic/hash.h>
-#include <util/system/mutex.h>
-
 namespace NCloud::NFileStore::NFuse {
 
 using namespace NThreading;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -23,706 +23,788 @@ using namespace NThreading;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TWriteBackCache::TImpl final
-    : public std::enable_shared_from_this<TImpl>
+TWriteBackCache::TImpl::TImpl(
+    IFileStorePtr session,
+    ISchedulerPtr scheduler,
+    ITimerPtr timer,
+    const TString& filePath,
+    ui64 capacityBytes,
+    TDuration automaticFlushPeriod)
+    : Session(CreateSessionSequencer(std::move(session)))
+    , Scheduler(std::move(scheduler))
+    , Timer(std::move(timer))
+    , AutomaticFlushPeriod(automaticFlushPeriod)
+    , CachedEntriesPersistentQueue(filePath, capacityBytes)
 {
-private:
-    using TWriteDataEntry = TWriteBackCache::TWriteDataEntry;
-    using TWriteDataEntryPart = TWriteBackCache::TWriteDataEntryPart;
-
-    const TSessionSequencerPtr Session;
-    const ISchedulerPtr Scheduler;
-    const ITimerPtr Timer;
-    const TDuration AutomaticFlushPeriod;
-
-    // All fields below should be protected by this lock
-    TMutex Lock;
-
-    TIntrusiveListWithAutoDelete<TWriteDataEntry, TDelete>
-        WriteDataEntriesQueue;
-
-    TIntrusiveList<TWriteDataEntry> PendingWriteDataEntriesQueue;
-
-    // Must be synchronized with WriteDataEntriesQueue
-    TFileRingBuffer WriteDataRequestsPersistentQueue;
-
-    struct THandleEntry
-    {
-        // Entries with statues Cached and CachedFlushRequested
-        // The order corresponds to WriteDataEntriesQueue
-        TDeque<TWriteDataEntry*> WriteDataEntries;
-
-        // Entries with statuses Pending and PendingFlushRequested
-        // The order corresponds to PendingWriteDataEntriesQueue
-        TDeque<TWriteDataEntry*> PendingWriteDataEntries;
-
-        size_t WriteDataEntriesWithFlushRequested = 0;
-        size_t PendingWriteDataEntriesWithFlushRequested = 0;
-    };
-
-    THashMap<ui64, THandleEntry> WriteDataEntriesByHandle;
-
-    THashSet<ui64> HandlesWithUpdates;
-
-    struct TFlushState
-    {
-        const ui64 Handle = 0;
-        TVector<std::shared_ptr<NProto::TWriteDataRequest>> WriteRequests;
-        TVector<std::shared_ptr<NProto::TWriteDataRequest>> FailedWriteRequests;
-        size_t AffectedWriteDataEntriesCount = 0;
-        size_t RemainingWriteRequestsCount = 0;
-
-        explicit TFlushState(ui64 handle)
-            : Handle(handle)
-        {}
-    };
-
-    THashMap<ui64, std::unique_ptr<TFlushState>> FlushStateByHandle;
-
-    // Accumulate operations to be executed ouside |Lock|
-    struct TPendingOperations
-    {
-        TVector<TFlushState*> FlushOperations;
-        TVector<NThreading::TPromise<NProto::TWriteDataResponse>> PromisesToSet;
-        TVector<NThreading::TPromise<void>> FinishedPromisesToSet;
-    };
-
-public:
-    TImpl(
-        IFileStorePtr session,
-        ISchedulerPtr scheduler,
-        ITimerPtr timer,
-        const TString& filePath,
-        ui64 capacityBytes,
-        TDuration automaticFlushPeriod)
-        : Session(CreateSessionSequencer(std::move(session)))
-        , Scheduler(std::move(scheduler))
-        , Timer(std::move(timer))
-        , AutomaticFlushPeriod(automaticFlushPeriod)
-        , WriteDataRequestsPersistentQueue(filePath, capacityBytes)
-    {
-        // should fit 1 MiB of data plus some headers (assume 1 KiB is enough)
-        Y_ABORT_UNLESS(capacityBytes >= 1024 * 1024 + 1024);
-
-        WriteDataRequestsPersistentQueue.Visit(
-            [&](auto, TStringBuf serializedRequest)
-            {
-                ui32 bufferSize = 0;
-                TMemoryInput mi(serializedRequest);
-                mi.Read(&bufferSize, sizeof(ui32));
-                mi.Skip(bufferSize);
-
-                auto parsedRequest =
-                    std::make_shared<NProto::TWriteDataRequest>();
-                Y_ABORT_UNLESS(parsedRequest->ParseFromArray(
-                    mi.Buf(),
-                    static_cast<int>(mi.Avail())));
-
-                auto entry =
-                    std::make_unique<TWriteDataEntry>(std::move(parsedRequest));
-                entry->Status = EWriteDataEntryStatus::Cached;
-                entry->Buffer = TStringBuf(
-                    serializedRequest.Data() + sizeof(ui32),
-                    bufferSize);
-
-                auto handle = entry->Request->GetHandle();
-                auto& handleEntry = WriteDataEntriesByHandle[handle];
-
-                handleEntry.WriteDataEntries.emplace_back(entry.get());
-                WriteDataEntriesQueue.PushBack(entry.release());
-            });
-
-        ScheduleAutomaticFlushIfNeeded();
-    }
-
-    void ScheduleAutomaticFlushIfNeeded()
-    {
-        if (!AutomaticFlushPeriod) {
-            return;
-        }
-
-        Scheduler->Schedule(
-            Timer->Now() + AutomaticFlushPeriod,
-            [ptr = weak_from_this()] () {
-                if (auto self = ptr.lock()) {
-                    TPendingOperations pendingOperations;
-                    with_lock (self->Lock) {
-                        self->RequestFlushAll(pendingOperations);
-                    }
-                    self->StartPendingOperations(pendingOperations);
-                    self->ScheduleAutomaticFlushIfNeeded();
-                }
-            });
-    }
-
-    // should be protected by |Lock|
-    TVector<TWriteDataEntryPart> CalculateCachedDataPartsToRead(
-        ui64 handle,
-        ui64 startingFromOffset,
-        ui64 length)
-    {
-        auto entriesIter = WriteDataEntriesByHandle.find(handle);
-        if (entriesIter == WriteDataEntriesByHandle.end()) {
-            return {};
-        }
-
-        return TWriteBackCache::CalculateDataPartsToRead(
-            entriesIter->second.WriteDataEntries,
-            startingFromOffset,
-            length);
-    }
-
-    // should be protected by |Lock|
-    TVector<TWriteDataEntryPart> CalculateCachedDataPartsToRead(ui64 handle)
-    {
-        return CalculateCachedDataPartsToRead(handle, 0, 0);
-    }
-
-    // should be protected by |Lock|
-    void ReadDataPart(
-        TWriteDataEntryPart part,
-        ui64 startingFromOffset,
-        TString* out)
-    {
-        const char* from = part.Source->Buffer.data();
-        from += part.OffsetInSource;
-
-        char* to = out->begin();
-        to += (part.Offset - startingFromOffset);
-
-        MemCopy(to, from, part.Length);
-    }
-
-    TFuture<NProto::TReadDataResponse> ReadData(
-        TCallContextPtr callContext,
-        std::shared_ptr<NProto::TReadDataRequest> request)
-    {
-        TString buffer(request->GetLength(), 0);
-        TVector<TWriteDataEntryPart> parts;
-
-        with_lock (Lock) {
-            parts = CalculateCachedDataPartsToRead(
-                request->GetHandle(),
-                request->GetOffset(),
-                request->GetLength());
-
-            for (const auto& part: parts)  {
-                ReadDataPart(part, request->GetOffset(), &buffer);
-            }
-
-            if (!parts.empty() &&
-                parts.front().Offset == request->GetOffset() &&
-                parts.back().End() ==
-                    request->GetOffset() + request->GetLength()
-            ) {
-                bool sufficient = true;
-
-                for (size_t i = 1; i < parts.size(); i++) {
-                    Y_DEBUG_ABORT_UNLESS(parts[i-1].End() <= parts[i].Offset);
-
-                    if (parts[i-1].End() != parts[i].Offset) {
-                        sufficient = false;
-                        break;
-                    }
-                }
-
-                if (sufficient) {
-                    // serve request from cache
-
-                    NProto::TReadDataResponse response;
-                    response.SetBuffer(std::move(buffer));
-
-                    auto promise = NewPromise<NProto::TReadDataResponse>();
-                    promise.SetValue(std::move(response));
-                    return promise.GetFuture();
-                }
-            }
-
-            // cache is not sufficient to serve the request - read all the data
-            // and apply cache on top of it
-            return Session->ReadData(std::move(callContext), request).Apply(
-                [handle = request->GetHandle(),
-                 startingFromOffset = request->GetOffset(),
-                 length = request->GetLength(),
-                 buffer = std::move(buffer),
-                 parts = std::move(parts)] (auto future)
-                {
-                    auto response = future.ExtractValue();
-
-                    // TODO(svartmetal): handle response error
-                    Y_ABORT_UNLESS(SUCCEEDED(response.GetError().GetCode()));
-
-                    if (response.GetBuffer().empty()) {
-                        *response.MutableBuffer() = std::move(buffer);
-                        return response;
-                    }
-
-                    Y_ABORT_UNLESS(
-                        length >= response.GetBuffer().length(),
-                        "expected length %lu to be >= than %lu",
-                        length,
-                        response.GetBuffer().length());
-                    // TODO(svartmetal): get rid of reallocation here
-                    response.MutableBuffer()->resize(length, 0);
-
-                    // TODO(svartmetal): support buffer offsetting
-                    Y_ABORT_UNLESS(0 == response.GetBufferOffset());
-
-                    // be careful and don't touch |part.Source| here as it may
-                    // be already deleted
-                    for (const auto& part: parts) {
-                        const char* from = buffer.data();
-                        from += (part.Offset - startingFromOffset);
-
-                        char* to = response.MutableBuffer()->begin();
-                        to += (part.Offset - startingFromOffset);
-
-                        MemCopy(to, from, part.Length);
-                    }
-
-                    return response;
-                });
-        }
-    }
-
-    // should be protected by |Lock|
-    bool TryAddWriteDataEntryToPersistentQueue(TWriteDataEntry* entry)
-    {
-        if (entry->Buffer.size() >= Max<ui32>()) {
-            return false;
-        }
-
-        int serializedRequestSize = entry->Request->ByteSize();
-        ui32 bufferSize = static_cast<ui32>(entry->Buffer.size());
-        auto totalSize = sizeof(ui32) + bufferSize +
-            static_cast<size_t>(serializedRequestSize);
-
-        char* ptr = WriteDataRequestsPersistentQueue.AllocateBack(totalSize);
-        if (!ptr) {
-            return false;
-        }
-
-        // TODO(nasonov): perform copy of enter->Buffer to the persistent queue
-        // outside lock
-        TMemoryOutput mo(ptr, totalSize);
-        mo.Write(&bufferSize, sizeof(bufferSize));
-        mo.Write(entry->Buffer);
-        Y_ABORT_UNLESS(entry->Request->SerializeToArray(
-            mo.Buf(),
-            static_cast<int>(mo.Avail())));
-
-        entry->Buffer = TStringBuf(ptr + sizeof(ui32), bufferSize);
-        entry->RequestBuffer.clear();
-
-        WriteDataRequestsPersistentQueue.CompleteAllocation(ptr);
-        return true;
-    }
-
-    TFuture<NProto::TWriteDataResponse> WriteData(
-        TCallContextPtr callContext,
-        std::shared_ptr<NProto::TWriteDataRequest> request)
-    {
-        if (request->GetFileSystemId().empty()) {
-            request->SetFileSystemId(callContext->FileSystemId);
-        }
-
-        auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
-        entry->Promise = NewPromise<NProto::TWriteDataResponse>();
-        auto future = entry->Promise.GetFuture();
-
-        TPendingOperations pendingOperations;
-
-        with_lock (Lock) {
-            auto handle = entry->Request->GetHandle();
-            auto& handleEntry = WriteDataEntriesByHandle[handle];
-
-            if (handleEntry.PendingWriteDataEntries.empty() &&
-                TryAddWriteDataEntryToPersistentQueue(entry.get()))
-            {
-                entry->Promise.SetValue({});
-                entry->Status = EWriteDataEntryStatus::Cached;
-                handleEntry.WriteDataEntries.emplace_back(entry.get());
-                WriteDataEntriesQueue.PushBack(entry.release());
-                HandlesWithUpdates.insert(handle);
-            } else {
-                entry->Status = EWriteDataEntryStatus::Pending;
-                handleEntry.PendingWriteDataEntries.emplace_back(entry.get());
-                PendingWriteDataEntriesQueue.PushBack(entry.release());
-                RequestFlushAll(pendingOperations);
-            }
-        }
-
-        StartPendingOperations(pendingOperations);
-
-        return future;
-    }
-
-    // should be protected by |Lock|
-    void RequestFlush(ui64 handle, TPendingOperations& pendingOperations)
-    {
-        auto& flushState = FlushStateByHandle[handle];
-        if (!flushState) {
-            flushState = std::make_unique<TFlushState>(handle);
-            pendingOperations.FlushOperations.push_back(flushState.get());
-        }
-    }
-
-    // should be protected by |Lock|
-    void RequestFlushAll(TPendingOperations& pendingOperations)
-    {
-        for (auto handle: HandlesWithUpdates) {
-            auto handleEntryIter = WriteDataEntriesByHandle.find(handle);
-            if (handleEntryIter == WriteDataEntriesByHandle.end()) {
-                continue;
-            }
-            auto& handleEntry = handleEntryIter->second;
-            if (handleEntry.WriteDataEntries.empty()) {
-                continue;
-            }
-            auto* entry = handleEntry.WriteDataEntries.back();
-            if (entry->Status == EWriteDataEntryStatus::Cached) {
-                entry->Status = EWriteDataEntryStatus::CachedFlushRequested;
-                handleEntry.WriteDataEntriesWithFlushRequested++;
-            }
-            RequestFlush(handle, pendingOperations);
-        }
-        HandlesWithUpdates.clear();
-    }
-
-    // should be executed outside |Lock|
-    void StartPendingOperations(TPendingOperations& pendingOperations)
-    {
-        // TODO(nasonov): execute asynchronously
-        for (auto* flushState: pendingOperations.FlushOperations) {
-            PerformFlush(flushState);
-        }
-        for (auto& promise: pendingOperations.PromisesToSet) {
-            promise.SetValue({});
-        }
-
-        for (auto& promise: pendingOperations.FinishedPromisesToSet) {
-            promise.SetValue();
-        }
-    }
-
-    // should be protected by |Lock|
-    void OnEntriesFlushed(
-        ui64 handle,
-        size_t entriesCount,
-        TPendingOperations& pendingOperations)
-    {
-        auto handleEntry = WriteDataEntriesByHandle[handle];
-        Y_ABORT_UNLESS(entriesCount <= handleEntry.WriteDataEntries.size());
-
-        while (entriesCount-- > 0) {
-            auto* entry = handleEntry.WriteDataEntries.front();
-
-            Y_ABORT_UNLESS(
-                entry->Status == EWriteDataEntryStatus::Cached ||
-                entry->Status == EWriteDataEntryStatus::CachedFlushRequested);
-
-            if (entry->Status == EWriteDataEntryStatus::CachedFlushRequested) {
-                Y_ABORT_UNLESS(
-                    handleEntry.WriteDataEntriesWithFlushRequested > 0);
-                handleEntry.WriteDataEntriesWithFlushRequested--;
-            }
-            entry->Status = EWriteDataEntryStatus::Finished;
-
-            if (entry->FinishedPromise.Initialized()) {
-                pendingOperations.FinishedPromisesToSet.push_back(
-                    std::move(entry->FinishedPromise));
-            }
-
-            handleEntry.WriteDataEntries.pop_front();
-            if (handleEntry.WriteDataEntries.empty() &&
-                handleEntry.PendingWriteDataEntries.empty())
-            {
-                WriteDataEntriesByHandle.erase(handle);
-            }
-        }
-
-        while (!WriteDataEntriesQueue.Empty() &&
-               WriteDataEntriesQueue.Front()->Status ==
-                   EWriteDataEntryStatus::Finished)
+    // should fit 1 MiB of data plus some headers (assume 1 KiB is enough)
+    Y_ABORT_UNLESS(capacityBytes >= 1024 * 1024 + 1024);
+
+    CachedEntriesPersistentQueue.Visit(
+        [&](auto, TStringBuf serializedRequest)
         {
-            WriteDataEntriesQueue.PopFront();
-            WriteDataRequestsPersistentQueue.PopFront();
-        }
-
-        bool isWriteDataEntriesPersistentQueueFull = false;
-
-        while (!PendingWriteDataEntriesQueue.Empty()) {
-            auto* entry = PendingWriteDataEntriesQueue.Front();
-
+            auto entry = TWriteDataEntry::DeserializeCachedRequest(
+                serializedRequest);
             Y_ABORT_UNLESS(
-                entry->Status == EWriteDataEntryStatus::Pending ||
-                entry->Status == EWriteDataEntryStatus::PendingFlushRequested);
+                entry->GetStatus() == EWriteDataEntryStatus::Cached);
 
-            if (!TryAddWriteDataEntryToPersistentQueue(entry)) {
-                isWriteDataEntriesPersistentQueueFull = true;
-                break;
-            }
+            auto& handleEntry = EntriesByHandle[entry->GetHandle()];
+            handleEntry.CachedEntries.emplace_back(entry.get());
+            CachedEntries.PushBack(entry.release());
+        });
+}
 
-            auto handle = entry->Request->GetHandle();
-            auto handleEntry = WriteDataEntriesByHandle[handle];
-
-            handleEntry.PendingWriteDataEntries.pop_front();
-            handleEntry.WriteDataEntries.push_back(entry);
-
-            PendingWriteDataEntriesQueue.PopFront();
-            WriteDataEntriesQueue.PushFront(entry);
-            HandlesWithUpdates.insert(handle);
-
-            if (entry->Status == EWriteDataEntryStatus::PendingFlushRequested) {
-                Y_ABORT_UNLESS(
-                    handleEntry.PendingWriteDataEntriesWithFlushRequested > 0);
-                handleEntry.PendingWriteDataEntriesWithFlushRequested--;
-                handleEntry.WriteDataEntriesWithFlushRequested++;
-                entry->Status = EWriteDataEntryStatus::CachedFlushRequested;
-                RequestFlush(handle, pendingOperations);
-            } else {
-                entry->Status = EWriteDataEntryStatus::Cached;
-            }
-
-            if (entry->Promise.Initialized()) {
-                pendingOperations.PromisesToSet.push_back(
-                    std::move(entry->Promise));
-            }
-        }
-
-        if (isWriteDataEntriesPersistentQueueFull) {
-            RequestFlushAll(pendingOperations);
-        }
+void TWriteBackCache::TImpl::ScheduleAutomaticFlushIfNeeded()
+{
+    if (!AutomaticFlushPeriod) {
+        return;
     }
 
-    // should be protected by |Lock|
-    TVector<std::shared_ptr<NProto::TWriteDataRequest>>
-    MakeWriteDataRequestsForFlush(
-        ui64 handle,
-        const TVector<TWriteDataEntryPart>& parts)
-    {
-        TVector<std::shared_ptr<NProto::TWriteDataRequest>> res;
+    Scheduler->Schedule(
+        Timer->Now() + AutomaticFlushPeriod,
+        [ptr = weak_from_this()] () {
+            if (auto self = ptr.lock()) {
+                TPendingOperations pendingOperations;
+                with_lock (self->Lock) {
+                    self->RequestFlushAll(pendingOperations);
+                }
+                self->StartPendingOperations(pendingOperations);
+                self->ScheduleAutomaticFlushIfNeeded();
+            }
+        });
+}
 
-        size_t partIndex = 0;
-        while (partIndex < parts.size()) {
-            auto rangeEndIndex = partIndex;
+// should be protected by |Lock|
+TVector<TWriteBackCache::TImpl::TWriteDataEntryPart>
+TWriteBackCache::TImpl::CalculateCachedDataPartsToRead(
+    ui64 handle,
+    ui64 startingFromOffset,
+    ui64 length)
+{
+    auto entriesIter = EntriesByHandle.find(handle);
+    if (entriesIter == EntriesByHandle.end()) {
+        return {};
+    }
 
-            while (++rangeEndIndex < parts.size()) {
-                const auto& prevPart = parts[rangeEndIndex - 1];
-                Y_DEBUG_ABORT_UNLESS(
-                    prevPart.End() <= parts[rangeEndIndex].Offset);
+    return CalculateDataPartsToRead(
+        entriesIter->second.CachedEntries,
+        startingFromOffset,
+        length);
+}
 
-                if (prevPart.End() != parts[rangeEndIndex].Offset) {
+// should be protected by |Lock|
+TVector<TWriteBackCache::TImpl::TWriteDataEntryPart>
+TWriteBackCache::TImpl::CalculateCachedDataPartsToRead(ui64 handle)
+{
+    return CalculateCachedDataPartsToRead(handle, 0, 0);
+}
+
+// should be protected by |Lock|
+void TWriteBackCache::TImpl::ReadDataPart(
+    TWriteDataEntryPart part,
+    ui64 startingFromOffset,
+    TString* out)
+{
+    const char* from = part.Source->GetBuffer().data();
+    from += part.OffsetInSource;
+
+    char* to = out->begin();
+    to += (part.Offset - startingFromOffset);
+
+    MemCopy(to, from, part.Length);
+}
+
+TFuture<NProto::TReadDataResponse> TWriteBackCache::TImpl::ReadData(
+    TCallContextPtr callContext,
+    std::shared_ptr<NProto::TReadDataRequest> request)
+{
+    TString buffer(request->GetLength(), 0);
+    TVector<TWriteDataEntryPart> parts;
+
+    with_lock (Lock) {
+        parts = CalculateCachedDataPartsToRead(
+            request->GetHandle(),
+            request->GetOffset(),
+            request->GetLength());
+
+        for (const auto& part: parts)  {
+            ReadDataPart(part, request->GetOffset(), &buffer);
+        }
+
+        if (!parts.empty() &&
+            parts.front().Offset == request->GetOffset() &&
+            parts.back().End() ==
+                request->GetOffset() + request->GetLength()
+        ) {
+            bool sufficient = true;
+
+            for (size_t i = 1; i < parts.size(); i++) {
+                Y_DEBUG_ABORT_UNLESS(parts[i-1].End() <= parts[i].Offset);
+
+                if (parts[i-1].End() != parts[i].Offset) {
+                    sufficient = false;
                     break;
                 }
             }
 
-            ui64 rangeLength = 0;
-            for (size_t i = partIndex; i < rangeEndIndex; i++) {
-                rangeLength += parts[i].Length;
-            }
-            TString buffer(rangeLength, 0);
-
-            const auto startingFromOffset = parts[partIndex].Offset;
-            for (size_t i = partIndex; i < rangeEndIndex; i++) {
-                ReadDataPart(parts[i], startingFromOffset, &buffer);
-            }
-
-            auto request = std::make_shared<NProto::TWriteDataRequest>();
-            request->SetFileSystemId(
-                parts[partIndex].Source->Request->GetFileSystemId());
-            *request->MutableHeaders() =
-                parts[partIndex].Source->Request->GetHeaders();
-            request->SetHandle(handle);
-            request->SetOffset(parts[partIndex].Offset);
-            request->SetBuffer(std::move(buffer));
-
-            res.push_back(std::move(request));
-
-            partIndex = rangeEndIndex;
-        }
-
-        return res;
-    }
-
-    void PerformFlush(TFlushState* flushState)
-    {
-        if (flushState->WriteRequests.empty()) {
-            TVector<TWriteDataEntryPart> parts;
-
-            with_lock (Lock) {
-                auto entriesIter =
-                    WriteDataEntriesByHandle.find(flushState->Handle);
-                if (entriesIter == WriteDataEntriesByHandle.end()) {
-                    FlushStateByHandle.erase(flushState->Handle);
-                    return;
-                }
-
-                auto& handleEntry = entriesIter->second;
-                if (handleEntry.WriteDataEntries.empty()) {
-                    FlushStateByHandle.erase(flushState->Handle);
-                    return;
-                }
-
-                parts = CalculateCachedDataPartsToRead(flushState->Handle);
-                flushState->AffectedWriteDataEntriesCount =
-                    handleEntry.WriteDataEntries.size();
-            }
-
-            flushState->WriteRequests =
-                MakeWriteDataRequestsForFlush(flushState->Handle, parts);
-
-            if (flushState->WriteRequests.empty()) {
-                CompleteFlush(flushState);
-                return;
+            if (sufficient) {
+                // serve request from cache
+                NProto::TReadDataResponse response;
+                response.SetBuffer(std::move(buffer));
+                return MakeFuture(std::move(response));
             }
         }
 
-        flushState->RemainingWriteRequestsCount =
-            flushState->WriteRequests.size();
-
-        for (size_t i = 0; i < flushState->WriteRequests.size(); i++) {
-            auto responseHandler =
-                [flushState, i, ptr = weak_from_this()](
-                    NThreading::TFuture<NProto::TWriteDataResponse> future)
+        // cache is not sufficient to serve the request - read all the data
+        // and combine the result with cached parts
+        return Session->ReadData(std::move(callContext), request).Apply(
+            [handle = request->GetHandle(),
+             startingFromOffset = request->GetOffset(),
+             length = request->GetLength(),
+             buffer = std::move(buffer),
+             parts = std::move(parts)] (auto future) mutable
             {
-                auto self = ptr.lock();
-                if (!self) {
-                    return;
+                NProto::TReadDataResponse response = future.ExtractValue();
+
+                if (HasError(response.GetError())) {
+                    return response;
                 }
 
-                auto response = future.ExtractValue();
+                if (response.GetBuffer().empty()) {
+                    *response.MutableBuffer() = std::move(buffer);
+                    return response;
+                }
 
-                with_lock (self->Lock) {
-                    if (FAILED(response.GetError().GetCode())) {
-                        flushState->FailedWriteRequests.push_back(
-                            std::move(flushState->WriteRequests[i]));
+                char* responseBufferData = response.MutableBuffer()->begin() +
+                                           response.GetBufferOffset();
+
+                auto responseBufferLength =
+                    response.GetBuffer().length() - response.GetBufferOffset();
+
+                Y_ABORT_UNLESS(
+                    responseBufferLength <= length,
+                    "response buffer length %lu is expected to be <= than %lu",
+                    responseBufferLength,
+                    length);
+
+                // Determine if it is better to apply cached data parts on top
+                // of the ReadData response or copy non-cached data from the
+                // response to the buffer with cached data parts
+                bool useResponseBuffer = responseBufferLength == length;
+                if (useResponseBuffer) {
+                    size_t sumPartsSize = 0;
+                    for (const auto& part: parts) {
+                        sumPartsSize += part.Length;
                     }
-
-                    Y_ABORT_UNLESS(flushState->RemainingWriteRequestsCount > 0);
-                    if (--flushState->RemainingWriteRequestsCount > 0) {
-                        return;
+                    if (sumPartsSize > responseBufferLength / 2) {
+                        useResponseBuffer = false;
                     }
                 }
 
-                if (!flushState->FailedWriteRequests.empty()) {
-                    swap(
-                        flushState->WriteRequests,
-                        flushState->FailedWriteRequests);
-                    flushState->FailedWriteRequests.clear();
+                useResponseBuffer = false;
 
-                    // TODO(nasonov): retry policy
-                    self->Scheduler->Schedule(
-                        self->Timer->Now() + TDuration::MilliSeconds(100),
-                        [flushState, ptr]()
-                        {
-                            if (auto self = ptr.lock()) {
-                                self->PerformFlush(flushState);
-                            }
-                        });
-
-                    return;
+                if (useResponseBuffer) {
+                    // be careful and don't touch |part.Source| here as it may
+                    // be already deleted
+                    for (const auto& part: parts) {
+                        ui64 offset = part.Offset - startingFromOffset;
+                        const char* from = buffer.data() + offset;
+                        char *to = responseBufferData + offset;
+                        MemCopy(to, from, part.Length);
+                    }
+                } else {
+                    // Note that responseBufferLength may be < length
+                    parts = InvertDataParts(parts, startingFromOffset, responseBufferLength);
+                    for (const auto& part: parts) {
+                        ui64 offset = part.Offset - startingFromOffset;
+                        const char* from = responseBufferData + offset;
+                        char *to = buffer.begin() + offset;
+                        MemCopy(to, from, part.Length);
+                    }
+                    response.MutableBuffer()->swap(buffer);
+                    response.ClearBufferOffset();
                 }
 
-                self->CompleteFlush(flushState);
-            };
+                return response;
+            });
+    }
+}
 
-            auto callContext = MakeIntrusive<TCallContext>(
-                flushState->WriteRequests[i]->GetFileSystemId());
-            Session
-                ->WriteData(
-                    std::move(callContext),
-                    flushState->WriteRequests[i])
-                .Subscribe(std::move(responseHandler));
+// should be protected by |Lock|
+bool TWriteBackCache::TImpl::TryAddEntryToPersistentQueue(
+    TWriteDataEntry* entry,
+    TPendingOperations& pendingOperations)
+{
+    if (entry->GetBuffer().size() >= Max<ui32>()) {
+        return false;
+    }
+
+    auto size = entry->GetSerializedSize();
+    char* ptr = CachedEntriesPersistentQueue.AllocateBack(size);
+    if (!ptr) {
+        return false;
+    }
+
+    entry->MoveToCache(ptr, pendingOperations);
+    return true;
+}
+
+TFuture<NProto::TWriteDataResponse> TWriteBackCache::TImpl::WriteData(
+    TCallContextPtr callContext,
+    std::shared_ptr<NProto::TWriteDataRequest> request)
+{
+    if (request->GetFileSystemId().empty()) {
+        request->SetFileSystemId(callContext->FileSystemId);
+    }
+
+    auto entry = TWriteDataEntry::CreatePendingRequest(std::move(request));
+    auto future = entry->GetFuture();
+
+    TPendingOperations pendingOperations;
+
+    with_lock (Lock) {
+        auto& handleEntry = EntriesByHandle[entry->GetHandle()];
+        if (handleEntry.PendingEntries.empty() &&
+            TryAddEntryToPersistentQueue(entry.get(), pendingOperations))
+        {
+            handleEntry.CachedEntries.emplace_back(entry.get());
+            HandlesWithNewCachedEntries.insert(entry->GetHandle());
+            CachedEntries.PushBack(entry.release());
+        } else {
+            handleEntry.PendingEntries.emplace_back(entry.get());
+            PendingEntries.PushBack(entry.release());
+            RequestFlushAll(pendingOperations);
         }
     }
 
-    // flushState becomes unusable after this call
-    void CompleteFlush(TFlushState *flushState)
-    {
-        TPendingOperations pendingOperations;
+    StartPendingOperations(pendingOperations);
 
-        with_lock (Lock) {
-            auto iter = FlushStateByHandle.find(flushState->Handle);
-            Y_ABORT_UNLESS(iter != FlushStateByHandle.end());
+    return future;
+}
 
-            auto ptr = std::move(iter->second);
-            FlushStateByHandle.erase(iter);
-
-            OnEntriesFlushed(
-                flushState->Handle,
-                flushState->AffectedWriteDataEntriesCount,
-                pendingOperations);
-        }
-        StartPendingOperations(pendingOperations);
+// should be protected by |Lock|
+void TWriteBackCache::TImpl::RequestFlush(
+    ui64 handle,
+    TPendingOperations& pendingOperations)
+{
+    auto& flushState = FlushStateByHandle[handle];
+    if (!flushState) {
+        flushState = std::make_unique<TFlushOperation>(handle);
+        pendingOperations.FlushOperations.push_back(flushState.get());
     }
+}
 
-    // should be protected by |Lock|
-    TFuture<void> RequestFlushData(
-        ui64 handle,
-        TPendingOperations& pendingOperations)
-    {
-        auto handleEntryIter = WriteDataEntriesByHandle.find(handle);
-        if (handleEntryIter == WriteDataEntriesByHandle.end()) {
-            return NThreading::MakeFuture();
+// should be protected by |Lock|
+void TWriteBackCache::TImpl::RequestFlushAll(TPendingOperations& pendingOperations)
+{
+    for (auto handle: HandlesWithNewCachedEntries) {
+        auto handleEntryIter = EntriesByHandle.find(handle);
+        if (handleEntryIter == EntriesByHandle.end()) {
+            continue;
         }
         auto& handleEntry = handleEntryIter->second;
+        if (handleEntry.CachedEntries.empty()) {
+            continue;
+        }
+        auto* entry = handleEntry.CachedEntries.back();
+        if (entry->RequestFlush()) {
+            handleEntry.EntriesWithFlushRequested++;
+        }
+        RequestFlush(handle, pendingOperations);
+    }
+    HandlesWithNewCachedEntries.clear();
+}
 
-        if (!handleEntry.PendingWriteDataEntries.empty()) {
-            auto* entry = handleEntry.PendingWriteDataEntries.back();
-            if (entry->Status == EWriteDataEntryStatus::Pending) {
-                entry->Status = EWriteDataEntryStatus::PendingFlushRequested;
-                handleEntry.PendingWriteDataEntriesWithFlushRequested++;
-                RequestFlush(handle, pendingOperations);
-            }
-            if (!entry->FinishedPromise.Initialized()) {
-                entry->FinishedPromise = NewPromise();
-            }
-            return entry->FinishedPromise.GetFuture();
+// should be executed outside |Lock|
+void TWriteBackCache::TImpl::StartPendingOperations(
+    TPendingOperations& pendingOperations)
+{
+    // TODO(nasonov): execute asynchronously
+    for (auto* flushState: pendingOperations.FlushOperations) {
+        flushState->Start(this);
+    }
+
+    for (auto& promise: pendingOperations.PromisesToSet) {
+        promise.SetValue({});
+    }
+
+    for (auto& promise: pendingOperations.FinishedPromisesToSet) {
+        promise.SetValue();
+    }
+}
+
+// should be protected by |Lock|
+void TWriteBackCache::TImpl::OnEntriesFlushed(
+    ui64 handle,
+    size_t entriesCount,
+    TPendingOperations& pendingOperations)
+{
+    auto handleEntry = EntriesByHandle[handle];
+    Y_ABORT_UNLESS(entriesCount <= handleEntry.CachedEntries.size());
+
+    while (entriesCount-- > 0) {
+        auto* entry = handleEntry.CachedEntries.front();
+        handleEntry.CachedEntries.pop_front();
+
+        if (entry->FlushRequested()) {
+            Y_ABORT_UNLESS(handleEntry.EntriesWithFlushRequested > 0);
+            handleEntry.EntriesWithFlushRequested--;
         }
 
-        if (!handleEntry.WriteDataEntries.empty()) {
-            auto* entry = handleEntry.WriteDataEntries.back();
-            if (entry->Status == EWriteDataEntryStatus::Cached) {
-                entry->Status = EWriteDataEntryStatus::CachedFlushRequested;
-                handleEntry.WriteDataEntriesWithFlushRequested++;
-                RequestFlush(handle, pendingOperations);
-            }
-            if (!entry->FinishedPromise.Initialized()) {
-                entry->FinishedPromise = NewPromise();
-            }
-            return entry->FinishedPromise.GetFuture();
+        entry->Finish(pendingOperations);
+    }
+
+    while (!CachedEntries.Empty() &&
+            CachedEntries.Front()->GetStatus() ==
+                EWriteDataEntryStatus::Finished)
+    {
+        CachedEntries.PopFront();
+        CachedEntriesPersistentQueue.PopFront();
+    }
+
+    bool isWriteDataEntriesPersistentQueueFull = false;
+
+    while (!PendingEntries.Empty()) {
+        auto* entry = PendingEntries.Front();
+
+        if (!TryAddEntryToPersistentQueue(entry, pendingOperations)) {
+            isWriteDataEntriesPersistentQueueFull = true;
+            break;
         }
 
+        auto handleEntry = EntriesByHandle[entry->GetHandle()];
+
+        handleEntry.PendingEntries.pop_front();
+        handleEntry.CachedEntries.push_back(entry);
+
+        PendingEntries.PopFront();
+        CachedEntries.PushFront(entry);
+
+        HandlesWithNewCachedEntries.insert(handle);
+
+        if (handleEntry.ShouldFlush()) {
+            RequestFlush(entry->GetHandle(), pendingOperations);
+        }
+    }
+
+    if (handleEntry.ShouldFlush()) {
+        RequestFlush(handle, pendingOperations);
+    }
+
+    if (handleEntry.Empty()) {
+        EntriesByHandle.erase(handle);
+    }
+
+    if (isWriteDataEntriesPersistentQueueFull) {
+        RequestFlushAll(pendingOperations);
+    }
+}
+
+// should be protected by |Lock|
+TVector<std::shared_ptr<NProto::TWriteDataRequest>>
+TWriteBackCache::TImpl::MakeWriteDataRequestsForFlush(
+    ui64 handle,
+    const TVector<TWriteDataEntryPart>& parts)
+{
+    TVector<std::shared_ptr<NProto::TWriteDataRequest>> res;
+
+    size_t partIndex = 0;
+    while (partIndex < parts.size()) {
+        auto rangeEndIndex = partIndex;
+
+        while (++rangeEndIndex < parts.size()) {
+            const auto& prevPart = parts[rangeEndIndex - 1];
+            Y_DEBUG_ABORT_UNLESS(
+                prevPart.End() <= parts[rangeEndIndex].Offset);
+
+            if (prevPart.End() != parts[rangeEndIndex].Offset) {
+                break;
+            }
+        }
+
+        ui64 rangeLength = 0;
+        for (size_t i = partIndex; i < rangeEndIndex; i++) {
+            rangeLength += parts[i].Length;
+        }
+        TString buffer(rangeLength, 0);
+
+        const auto startingFromOffset = parts[partIndex].Offset;
+        for (size_t i = partIndex; i < rangeEndIndex; i++) {
+            ReadDataPart(parts[i], startingFromOffset, &buffer);
+        }
+
+        auto request = std::make_shared<NProto::TWriteDataRequest>();
+        request->SetFileSystemId(
+            parts[partIndex].Source->GetRequest()->GetFileSystemId());
+        *request->MutableHeaders() =
+            parts[partIndex].Source->GetRequest()->GetHeaders();
+        request->SetHandle(handle);
+        request->SetOffset(parts[partIndex].Offset);
+        request->SetBuffer(std::move(buffer));
+
+        res.push_back(std::move(request));
+
+        partIndex = rangeEndIndex;
+    }
+
+    return res;
+}
+
+// should be protected by |Lock|
+TFuture<void> TWriteBackCache::TImpl::RequestFlushData(
+    ui64 handle,
+    TPendingOperations& pendingOperations)
+{
+    auto handleEntryIter = EntriesByHandle.find(handle);
+    if (handleEntryIter == EntriesByHandle.end()) {
+        return NThreading::MakeFuture();
+    }
+    auto& handleEntry = handleEntryIter->second;
+
+    auto* entry = handleEntry.GetLastEntry();
+    if (entry == nullptr) {
         return NThreading::MakeFuture();
     }
 
-    TFuture<void> FlushData(ui64 handle)
-    {
-        TFuture<void> result;
-        TPendingOperations pendingOperations;
-
-        with_lock (Lock) {
-            result = RequestFlushData(handle, pendingOperations);
-        }
-        StartPendingOperations(pendingOperations);
-        return result;
+    if (entry->RequestFlush()) {
+        handleEntry.EntriesWithFlushRequested++;
+        RequestFlush(handle, pendingOperations);
     }
 
-    TFuture<void> FlushAllData()
-    {
-        TVector<TFuture<void>> futures;
-        TPendingOperations pendingOperations;
+    return entry->GetFinishedFuture();
+}
 
-        with_lock (Lock) {
-            for (const auto& [handle, _]: WriteDataEntriesByHandle) {
-                futures.push_back(RequestFlushData(handle, pendingOperations));
+TFuture<void> TWriteBackCache::TImpl::FlushData(ui64 handle)
+{
+    TFuture<void> result;
+    TPendingOperations pendingOperations;
+
+    with_lock (Lock) {
+        result = RequestFlushData(handle, pendingOperations);
+    }
+    StartPendingOperations(pendingOperations);
+    return result;
+}
+
+TFuture<void> TWriteBackCache::TImpl::FlushAllData()
+{
+    TVector<TFuture<void>> futures;
+    TPendingOperations pendingOperations;
+
+    with_lock (Lock) {
+        for (const auto& [handle, _]: EntriesByHandle) {
+            futures.push_back(RequestFlushData(handle, pendingOperations));
+        }
+    }
+    StartPendingOperations(pendingOperations);
+    return NWait::WaitAll(futures);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<TWriteBackCache::TImpl::TWriteDataEntry>
+TWriteBackCache::TImpl::TWriteDataEntry::CreatePendingRequest(
+    std::shared_ptr<NProto::TWriteDataRequest> request)
+{
+    auto res = std::make_unique<TWriteDataEntry>();
+    res->Status = EWriteDataEntryStatus::Pending;
+    res->Request.swap(request);
+    res->RequestBuffer.swap(*res->Request->MutableBuffer());
+    res->Buffer =
+        TStringBuf(res->RequestBuffer).Skip(res->Request->GetBufferOffset());
+    res->Request->ClearBufferOffset();
+    return res;
+}
+
+std::unique_ptr<TWriteBackCache::TImpl::TWriteDataEntry>
+TWriteBackCache::TImpl::TWriteDataEntry::DeserializeCachedRequest(
+    TStringBuf serializedRequest)
+{
+    ui32 bufferSize = 0;
+    TMemoryInput mi(serializedRequest);
+    mi.Read(&bufferSize, sizeof(ui32));
+    mi.Skip(bufferSize);
+
+    auto res = std::make_unique<TWriteDataEntry>();
+    auto parsedRequest = std::make_shared<NProto::TWriteDataRequest>();
+    if (parsedRequest->ParseFromArray(mi.Buf(), static_cast<int>(mi.Avail()))) {
+        res->Status = EWriteDataEntryStatus::Cached;
+        res->Buffer =
+            TStringBuf(serializedRequest.Data() + sizeof(ui32), bufferSize);
+        res->Request.swap(parsedRequest);
+    }
+
+    return res;
+}
+
+size_t TWriteBackCache::TImpl::TWriteDataEntry::GetSerializedSize() const
+{
+    return Request->ByteSizeLong() + sizeof(ui32) + Buffer.size();
+}
+
+void TWriteBackCache::TImpl::TWriteDataEntry::MoveToCache(
+    char* data,
+    TWriteBackCache::TImpl::TPendingOperations& pendingOperations)
+{
+    switch (Status) {
+        case EWriteDataEntryStatus::Pending:
+            Status = EWriteDataEntryStatus::Cached;
+            break;
+        case EWriteDataEntryStatus::PendingFlushRequested:
+            Status = EWriteDataEntryStatus::CachedFlushRequested;
+            break;
+        default:
+            Y_ABORT();
+    }
+
+    Y_ABORT_UNLESS(Buffer.size() < Max<ui32>());
+
+    ui32 bufferSize = static_cast<ui32>(Buffer.size());
+    auto serializedSize = GetSerializedSize();
+
+    TMemoryOutput mo(data, serializedSize);
+    mo.Write(&bufferSize, sizeof(bufferSize));
+    // TODO(nasonov): copy Buffer to cache outside lock
+    mo.Write(Buffer);
+
+    Y_ABORT_UNLESS(
+        Request->SerializeToArray(mo.Buf(), static_cast<int>(mo.Avail())));
+
+    Buffer = TStringBuf(data + sizeof(ui32), bufferSize);
+    RequestBuffer.clear();
+
+    if (Promise.Initialized()) {
+        pendingOperations.PromisesToSet.push_back(std::move(Promise));
+    }
+}
+
+void TWriteBackCache::TImpl::TWriteDataEntry::Finish(
+    TWriteBackCache::TImpl::TPendingOperations& pendingOperations)
+{
+    Y_ABORT_UNLESS(
+        Status == EWriteDataEntryStatus::Cached ||
+        Status == EWriteDataEntryStatus::CachedFlushRequested);
+
+    Status = EWriteDataEntryStatus::Finished;
+    Buffer.Clear();
+
+    if (FinishedPromise.Initialized()) {
+        pendingOperations.FinishedPromisesToSet.push_back(
+            std::move(FinishedPromise));
+    }
+}
+
+bool TWriteBackCache::TImpl::TWriteDataEntry::FlushRequested() const
+{
+    return Status == EWriteDataEntryStatus::CachedFlushRequested ||
+           Status == EWriteDataEntryStatus::PendingFlushRequested;
+}
+
+bool TWriteBackCache::TImpl::TWriteDataEntry::RequestFlush()
+{
+    switch (Status) {
+        case EWriteDataEntryStatus::Cached:
+            Status = EWriteDataEntryStatus::CachedFlushRequested;
+            return true;
+
+        case EWriteDataEntryStatus::Pending:
+            Status = EWriteDataEntryStatus::PendingFlushRequested;
+            return true;
+
+        case EWriteDataEntryStatus::CachedFlushRequested:
+        case EWriteDataEntryStatus::PendingFlushRequested:
+            return false;
+
+        default:
+            Y_ABORT();
+    }
+}
+
+NThreading::TFuture<NProto::TWriteDataResponse>
+TWriteBackCache::TImpl::TWriteDataEntry::GetFuture()
+{
+    if (!Promise.Initialized()) {
+        switch (Status) {
+            case EWriteDataEntryStatus::Cached:
+            case EWriteDataEntryStatus::CachedFlushRequested:
+            case EWriteDataEntryStatus::Finished:
+                return MakeFuture<NProto::TWriteDataResponse>({});
+
+            case EWriteDataEntryStatus::Pending:
+            case EWriteDataEntryStatus::PendingFlushRequested:
+                Promise = NewPromise<NProto::TWriteDataResponse>();
+                break;
+
+            default:
+                Y_ABORT();
+        }
+    }
+    return Promise.GetFuture();
+}
+
+NThreading::TFuture<void>
+TWriteBackCache::TImpl::TWriteDataEntry::GetFinishedFuture()
+{
+    if (!FinishedPromise.Initialized()) {
+        if (Status == EWriteDataEntryStatus::Finished) {
+            return MakeFuture();
+        }
+        FinishedPromise = NewPromise();
+    }
+    return FinishedPromise.GetFuture();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TWriteBackCache::TImpl::THandleEntry::Empty() const
+{
+    return CachedEntries.empty() && PendingEntries.empty();
+}
+
+bool TWriteBackCache::TImpl::THandleEntry::ShouldFlush() const
+{
+    return !CachedEntries.empty() && EntriesWithFlushRequested > 0;
+}
+
+TWriteBackCache::TImpl::TWriteDataEntry*
+TWriteBackCache::TImpl::THandleEntry::GetLastEntry() const
+{
+    if (!PendingEntries.empty()) {
+        return PendingEntries.back();
+    }
+    if (!CachedEntries.empty()) {
+        return CachedEntries.back();
+    }
+    return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TWriteBackCache::TImpl::TFlushOperation::Start(TImpl* impl)
+{
+    if (!Prepare(impl)) {
+        return;
+    }
+
+    Y_ABORT_UNLESS(!WriteRequests.empty());
+
+    RemainingWriteRequestsCount = WriteRequests.size();
+
+    for (size_t i = 0; i < WriteRequests.size(); i++) {
+        auto callContext =
+            MakeIntrusive<TCallContext>(WriteRequests[i]->GetFileSystemId());
+
+        impl->Session->WriteData(std::move(callContext), WriteRequests[i])
+            .Subscribe(
+                [this, i, ptr = impl->weak_from_this()](auto future)
+                {
+                    auto impl = ptr.lock();
+                    if (impl) {
+                        WriteDataRequestCompleted(
+                            impl.get(),
+                            i,
+                            future.GetValue());
+                    }
+                });
+    }
+}
+
+bool TWriteBackCache::TImpl::TFlushOperation::Prepare(TImpl* impl)
+{
+    if (!WriteRequests.empty()) {
+        return true;
+    }
+
+    TVector<TWriteDataEntryPart> parts;
+
+    with_lock (impl->Lock) {
+        auto entriesIter = impl->EntriesByHandle.find(Handle);
+        if (entriesIter == impl->EntriesByHandle.end()) {
+            impl->FlushStateByHandle.erase(Handle);
+            return false;
+        }
+
+        auto& handleEntry = entriesIter->second;
+        if (handleEntry.CachedEntries.empty()) {
+            impl->FlushStateByHandle.erase(Handle);
+            return false;
+        }
+
+        parts = impl->CalculateCachedDataPartsToRead(Handle);
+        AffectedWriteDataEntriesCount = handleEntry.CachedEntries.size();
+    }
+
+    WriteRequests = impl->MakeWriteDataRequestsForFlush(Handle, parts);
+
+    if (WriteRequests.empty()) {
+        Complete(impl);
+        return false;
+    }
+
+    return true;
+}
+
+void TWriteBackCache::TImpl::TFlushOperation::WriteDataRequestCompleted(
+    TImpl* impl,
+    size_t index,
+    const NProto::TWriteDataResponse& response)
+{
+    with_lock (impl->Lock) {
+        if (FAILED(response.GetError().GetCode())) {
+            FailedWriteRequests.push_back(
+                std::move(WriteRequests[index]));
+        }
+
+        Y_ABORT_UNLESS(RemainingWriteRequestsCount > 0);
+        if (--RemainingWriteRequestsCount > 0) {
+            return;
+        }
+    }
+
+    if (!FailedWriteRequests.empty()) {
+        swap(WriteRequests, FailedWriteRequests);
+        FailedWriteRequests.clear();
+        ScheduleRetry(impl);
+        return;
+    }
+
+    Complete(impl);
+}
+
+void TWriteBackCache::TImpl::TFlushOperation::ScheduleRetry(TImpl* impl)
+{
+    // TODO(nasonov): use retry policy
+    impl->Scheduler->Schedule(
+        impl->Timer->Now() + TDuration::MilliSeconds(100),
+        [this, ptr = impl->weak_from_this()]()
+        {
+            auto self = ptr.lock();
+            if (self) {
+                Start(self.get());
             }
-        }
-        StartPendingOperations(pendingOperations);
-        return NWait::WaitAll(futures);
+        });
+}
+
+// |this| becomes unusable after this call
+void TWriteBackCache::TImpl::TFlushOperation::Complete(TImpl* impl)
+{
+    TPendingOperations pendingOperations;
+
+    with_lock (impl->Lock) {
+        auto iter = impl->FlushStateByHandle.find(Handle);
+        Y_ABORT_UNLESS(iter != impl->FlushStateByHandle.end());
+
+        // Keep alive for |this|
+        auto ptr = std::move(iter->second);
+        impl->FlushStateByHandle.erase(iter);
+
+        impl->OnEntriesFlushed(
+            Handle,
+            AffectedWriteDataEntriesCount,
+            pendingOperations);
     }
-};
+
+    impl->StartPendingOperations(pendingOperations);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -1,4 +1,4 @@
-#include "write_back_cache.h"
+#include "write_back_cache_impl.h"
 
 #include "session_sequencer.h"
 
@@ -10,14 +10,11 @@
 
 #include <util/generic/hash_set.h>
 #include <util/generic/intrlist.h>
-#include <util/generic/mem_copy.h>
-#include <util/generic/strbuf.h>
 #include <util/generic/vector.h>
 #include <util/stream/mem.h>
 #include <util/system/mutex.h>
 
 #include <algorithm>
-#include <atomic>
 
 namespace NCloud::NFileStore::NFuse {
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -17,9 +17,7 @@ namespace NCloud::NFileStore::NFuse {
 class TWriteBackCache final
 {
 private:
-    friend class TImpl;
     class TImpl;
-
     std::shared_ptr<TImpl> Impl;
 
 public:
@@ -50,15 +48,6 @@ public:
 private:
     // only for testing purposes
     friend struct TCalculateDataPartsToReadTestBootstrap;
-
-    enum class EWriteDataEntryStatus;
-    struct TWriteDataEntry;
-    struct TWriteDataEntryPart;
-
-    static TVector<TWriteDataEntryPart> CalculateDataPartsToRead(
-        const TDeque<TWriteDataEntry*>& entries,
-        ui64 startingFromOffset,
-        ui64 length);
 };
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "write_back_cache.h"
+
+namespace NCloud::NFileStore::NFuse {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class TWriteBackCache::EWriteDataEntryStatus
+{
+    NotStarted,
+    Pending,
+    PendingFlushRequested,
+    Cached,
+    CachedFlushRequested,
+    Finished
+};
+
+struct TWriteBackCache::TWriteDataEntry
+    : public TIntrusiveListItem<TWriteDataEntry>
+{
+    std::shared_ptr<NProto::TWriteDataRequest> Request;
+    TString RequestBuffer;
+    NThreading::TPromise<NProto::TWriteDataResponse> Promise;
+    NThreading::TPromise<void> FinishedPromise;
+    EWriteDataEntryStatus Status = EWriteDataEntryStatus::NotStarted;
+
+    // Is not valid when WriteDataRequestStatus is Finished
+    TStringBuf Buffer;
+
+    explicit TWriteDataEntry(
+            std::shared_ptr<NProto::TWriteDataRequest> request)
+        : Request(std::move(request))
+        , RequestBuffer(std::move(*Request->MutableBuffer()))
+        , Buffer(RequestBuffer)
+    {
+        Buffer.Skip(Request->GetBufferOffset());
+        Request->ClearBuffer();
+        Request->ClearBufferOffset();
+    }
+
+    ui64 Begin() const
+    {
+        return Request->GetOffset();
+    }
+
+    ui64 End() const
+    {
+        return Request->GetOffset() + Buffer.size();
+    }
+};
+
+struct TWriteBackCache::TWriteDataEntryPart
+{
+    const TWriteDataEntry* Source = nullptr;
+    ui64 OffsetInSource = 0;
+    ui64 Offset = 0;
+    ui64 Length = 0;
+
+    ui64 End() const
+    {
+        return Offset + Length;
+    }
+
+    bool operator==(const TWriteDataEntryPart& p) const
+    {
+        return std::tie(Source, OffsetInSource, Offset, Length) ==
+               std::tie(p.Source, p.OffsetInSource, p.Offset, p.Length);
+    }
+};
+
+}   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -1,14 +1,131 @@
 #pragma once
 
 #include "write_back_cache.h"
+#include "session_sequencer.h"
+
+#include <cloud/storage/core/libs/common/file_ring_buffer.h>
+
+#include <util/generic/hash_set.h>
 
 namespace NCloud::NFileStore::NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class TWriteBackCache::EWriteDataEntryStatus
+class TWriteBackCache::TImpl final
+    : public std::enable_shared_from_this<TImpl>
 {
-    NotStarted,
+private:
+    enum class EWriteDataEntryStatus;
+    class TWriteDataEntry;
+    struct TWriteDataEntryPart;
+    struct THandleEntry;
+    class TFlushOperation;
+    struct TPendingOperations;
+
+    const TSessionSequencerPtr Session;
+    const ISchedulerPtr Scheduler;
+    const ITimerPtr Timer;
+    const TDuration AutomaticFlushPeriod;
+
+    // All fields below should be protected by this lock
+    TMutex Lock;
+
+    // Entries with statues Cached and CachedFlushRequested
+    TIntrusiveListWithAutoDelete<TWriteDataEntry, TDelete> CachedEntries;
+
+    // Entries with statues Pending and PendingFlushRequested
+    TIntrusiveList<TWriteDataEntry> PendingEntries;
+
+    // Serialized entries from CachedEntries with one-by-one correspondence.
+    TFileRingBuffer CachedEntriesPersistentQueue;
+
+    // Cached and pending WriteData entries grouped by handle
+    THashMap<ui64, THandleEntry> EntriesByHandle;
+
+    // Handles with new cached WriteData entries since last FlushAll
+    THashSet<ui64> HandlesWithNewCachedEntries;
+
+    // Pending and executing flush operations
+    THashMap<ui64, std::unique_ptr<TFlushOperation>> FlushStateByHandle;
+
+public:
+    TImpl(
+        IFileStorePtr session,
+        ISchedulerPtr scheduler,
+        ITimerPtr timer,
+        const TString& filePath,
+        ui64 capacityBytes,
+        TDuration automaticFlushPeriod);
+
+    NThreading::TFuture<NProto::TReadDataResponse> ReadData(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TReadDataRequest> request);
+
+    NThreading::TFuture<NProto::TWriteDataResponse> WriteData(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteDataRequest> request);
+
+    NThreading::TFuture<void> FlushData(ui64 handle);
+
+    NThreading::TFuture<void> FlushAllData();
+
+    void ScheduleAutomaticFlushIfNeeded();
+
+    static TVector<TWriteDataEntryPart> CalculateDataPartsToRead(
+        const TDeque<TWriteDataEntry*>& entries,
+        ui64 startingFromOffset,
+        ui64 length);
+
+    static TVector<TWriteDataEntryPart> InvertDataParts(
+        const TVector<TWriteDataEntryPart>& parts,
+        ui64 startingFromOffset,
+        ui64 length);
+
+private:
+    TVector<TWriteDataEntryPart> CalculateCachedDataPartsToRead(
+        ui64 handle,
+        ui64 startingFromOffset,
+        ui64 length);
+
+    TVector<TWriteDataEntryPart> CalculateCachedDataPartsToRead(ui64 handle);
+
+    void ReadDataPart(
+        TWriteDataEntryPart part,
+        ui64 startingFromOffset,
+        TString* out);
+
+    bool TryAddEntryToPersistentQueue(
+        TWriteDataEntry* entry,
+        TPendingOperations& pendingOperations);
+
+    void RequestFlush(ui64 handle, TPendingOperations& pendingOperations);
+    void RequestFlushAll(TPendingOperations& pendingOperations);
+
+    void StartPendingOperations(TPendingOperations& pendingOperations);
+
+    void OnEntriesFlushed(
+        ui64 handle,
+        size_t entriesCount,
+        TPendingOperations& pendingOperations);
+
+    TVector<std::shared_ptr<NProto::TWriteDataRequest>>
+    MakeWriteDataRequestsForFlush(
+        ui64 handle,
+        const TVector<TWriteDataEntryPart>& parts);
+
+    NThreading::TFuture<void> RequestFlushData(
+        ui64 handle,
+        TPendingOperations& pendingOperations);
+
+    // only for testing purposes
+    friend struct TCalculateDataPartsToReadTestBootstrap;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class TWriteBackCache::TImpl::EWriteDataEntryStatus
+{
+    Invalid,
     Pending,
     PendingFlushRequested,
     Cached,
@@ -16,27 +133,42 @@ enum class TWriteBackCache::EWriteDataEntryStatus
     Finished
 };
 
-struct TWriteBackCache::TWriteDataEntry
+////////////////////////////////////////////////////////////////////////////////
+
+class TWriteBackCache::TImpl::TWriteDataEntry
     : public TIntrusiveListItem<TWriteDataEntry>
 {
+private:
+    // Store request metadata and request buffer separately
+    // The idea is to deduplicate memory and to reference request buffer
+    // directly in the cache if the request is cached.
     std::shared_ptr<NProto::TWriteDataRequest> Request;
     TString RequestBuffer;
-    NThreading::TPromise<NProto::TWriteDataResponse> Promise;
-    NThreading::TPromise<void> FinishedPromise;
-    EWriteDataEntryStatus Status = EWriteDataEntryStatus::NotStarted;
-
-    // Is not valid when WriteDataRequestStatus is Finished
     TStringBuf Buffer;
 
-    explicit TWriteDataEntry(
-            std::shared_ptr<NProto::TWriteDataRequest> request)
-        : Request(std::move(request))
-        , RequestBuffer(std::move(*Request->MutableBuffer()))
-        , Buffer(RequestBuffer)
+    NThreading::TPromise<NProto::TWriteDataResponse> Promise;
+    NThreading::TPromise<void> FinishedPromise;
+    EWriteDataEntryStatus Status = EWriteDataEntryStatus::Invalid;
+
+public:
+    EWriteDataEntryStatus GetStatus() const
     {
-        Buffer.Skip(Request->GetBufferOffset());
-        Request->ClearBuffer();
-        Request->ClearBufferOffset();
+        return Status;
+    }
+
+    const NProto::TWriteDataRequest* GetRequest() const
+    {
+        return Request.get();
+    }
+
+    ui64 GetHandle() const
+    {
+        return Request->GetHandle();
+    }
+
+    TStringBuf GetBuffer() const
+    {
+        return Buffer;
     }
 
     ui64 Begin() const
@@ -48,9 +180,27 @@ struct TWriteBackCache::TWriteDataEntry
     {
         return Request->GetOffset() + Buffer.size();
     }
+
+    static std::unique_ptr<TWriteDataEntry> CreatePendingRequest(
+        std::shared_ptr<NProto::TWriteDataRequest> request);
+
+    static std::unique_ptr<TWriteDataEntry> DeserializeCachedRequest(
+        TStringBuf serializedRequest);
+
+    size_t GetSerializedSize() const;
+    void MoveToCache(char* data, TPendingOperations& pendingOperations);
+    void Finish(TPendingOperations& pendingOperations);
+
+    bool FlushRequested() const;
+    bool RequestFlush();
+
+    NThreading::TFuture<NProto::TWriteDataResponse> GetFuture();
+    NThreading::TFuture<void> GetFinishedFuture();
 };
 
-struct TWriteBackCache::TWriteDataEntryPart
+////////////////////////////////////////////////////////////////////////////////
+
+struct TWriteBackCache::TImpl::TWriteDataEntryPart
 {
     const TWriteDataEntry* Source = nullptr;
     ui64 OffsetInSource = 0;
@@ -67,6 +217,66 @@ struct TWriteBackCache::TWriteDataEntryPart
         return std::tie(Source, OffsetInSource, Offset, Length) ==
                std::tie(p.Source, p.OffsetInSource, p.Offset, p.Length);
     }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TWriteBackCache::TImpl::THandleEntry
+{
+    // Entries from TWriteBackCache::TImpl::CachedEntries
+    // with statues Cached and CachedFlushRequested filtered by handle
+    // The order is preserved
+    TDeque<TWriteDataEntry*> CachedEntries;
+
+    // Entries from TWriteBackCache::TImpl::PendingEntries
+    // with statues Pending and PendingFlushRequested filtered by handle
+    // The order is preserved
+    TDeque<TWriteDataEntry*> PendingEntries;
+
+    // Count entries with statues CachedFlushRequested and PendingFlushRequested
+    size_t EntriesWithFlushRequested = 0;
+
+    bool Empty() const;
+    bool ShouldFlush() const;
+    TWriteDataEntry* GetLastEntry() const;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TWriteBackCache::TImpl::TFlushOperation
+{
+private:
+    const ui64 Handle = 0;
+    TVector<std::shared_ptr<NProto::TWriteDataRequest>> WriteRequests;
+    TVector<std::shared_ptr<NProto::TWriteDataRequest>> FailedWriteRequests;
+    size_t AffectedWriteDataEntriesCount = 0;
+    size_t RemainingWriteRequestsCount = 0;
+
+public:
+    explicit TFlushOperation(ui64 handle)
+        : Handle(handle)
+    {}
+
+    void Start(TImpl* impl);
+
+private:
+    bool Prepare(TImpl* impl);
+    void WriteDataRequestCompleted(
+        TImpl* impl,
+        size_t index,
+        const NProto::TWriteDataResponse& response);
+    void ScheduleRetry(TImpl* impl);
+    void Complete(TImpl* impl);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Accumulate operations to be executed ouside |Lock|
+struct TWriteBackCache::TImpl::TPendingOperations
+{
+    TVector<TFlushOperation*> FlushOperations;
+    TVector<NThreading::TPromise<NProto::TWriteDataResponse>> PromisesToSet;
+    TVector<NThreading::TPromise<void>> FinishedPromisesToSet;
 };
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -193,6 +193,9 @@ struct TBootstrap
         };
 
         Session->WriteDataHandler = [&] (auto, auto request) {
+            std::unique_lock lock1(UnflushedDataMutex);
+            std::unique_lock lock2(FlushedDataMutex);
+
             SessionWriteDataHandlerCalled++;
 
             const auto handle = request->GetHandle();
@@ -211,9 +214,6 @@ struct TBootstrap
             Y_DEFER {
                 InFlightWriteRequestTracker[handle].Remove(offset, length);
             };
-
-            std::unique_lock lock1(UnflushedDataMutex);
-            std::unique_lock lock2(FlushedDataMutex);
 
             STORAGE_INFO("Flushing " << request->GetBuffer().Quote()
                 << " to @" << request->GetHandle()

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -375,6 +375,11 @@ ui64 TFileRingBuffer::MaximalEntrySize() const
     return Impl->MaximalEntrySize();
 }
 
+ui64 TFileRingBuffer::Size() const
+{
+    return Impl->Size();
+}
+
 bool TFileRingBuffer::Empty() const
 {
     return Impl->Empty();

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -277,6 +277,13 @@ public:
         SkipSlackSpace();
     }
 
+    ui64 MaximalEntrySize() const
+    {
+        return Min(
+            Header()->Capacity & ~(sizeof(ui32) - 1),
+            static_cast<ui64>(Max<ui32>()));
+    }
+
     ui64 Size() const
     {
         return Count;
@@ -363,9 +370,9 @@ void TFileRingBuffer::PopFront()
     Impl->PopFront();
 }
 
-ui64 TFileRingBuffer::Size() const
+ui64 TFileRingBuffer::MaximalEntrySize() const
 {
-    return Impl->Size();
+    return Impl->MaximalEntrySize();
 }
 
 bool TFileRingBuffer::Empty() const

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -20,21 +20,24 @@ public:
     };
 
     using TVisitor = std::function<void(ui32 checksum, TStringBuf entry)>;
+    using TBufferWriter = std::function<void(TStringBuf buffer)>;
 
 private:
     class TImpl;
     std::unique_ptr<TImpl> Impl;
 
 public:
-    TFileRingBuffer(const TString& filePath, ui32 capacity);
+    TFileRingBuffer(const TString& filePath, ui64 capacity);
     ~TFileRingBuffer();
 
 public:
     bool PushBack(TStringBuf data);
+    char* AllocateBack(size_t size);
+    void CompleteAllocation(char* ptr);
     TStringBuf Front() const;
     TStringBuf Back() const;
     void PopFront();
-    ui32 Size() const;
+    ui64 Size() const;
     bool Empty() const;
     TVector<TBrokenFileEntry> Validate() const;
     void Visit(const TVisitor& visitor) const;

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -37,6 +37,7 @@ public:
     TStringBuf Front() const;
     TStringBuf Back() const;
     void PopFront();
+    ui64 MaximalEntrySize() const;
     ui64 Size() const;
     bool Empty() const;
     TVector<TBrokenFileEntry> Validate() const;

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -285,7 +285,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
         m.Map(0, len);
         char* data = static_cast<char*>(m.Ptr());
-        data[24] = 'A';
+        data[44] = 'A';
 
         UNIT_ASSERT_VALUES_EQUAL(
             "data=vasya ecsum=3387363649 csum=3387363646",
@@ -299,21 +299,22 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         TFileRingBuffer rb(f.GetName(), len);
 
         const ui32 entryHeaderSize = 8;
-        const ui32 entryLen = 29;
+        const ui32 entryLen = 28;
         const ui32 entryDataLen = entryLen - entryHeaderSize;
-        const TString data(entryDataLen + 1, 'a');
-        const TString data2(entryDataLen, 'b');
-        const TString data3(entryDataLen, 'c');
+        const TString data(entryDataLen + 1, 'a');   // with padding: 32
+        const TString data2(entryDataLen, 'b');      // with padding: 28
+        const TString data3(entryDataLen, 'c');      // with padding: 28
 
         UNIT_ASSERT(rb.PushBack(data));
         UNIT_ASSERT(rb.PushBack(data2));
         UNIT_ASSERT(!rb.PushBack(data3));
         rb.PopFront();
+        UNIT_ASSERT(!rb.PushBack(data));
         UNIT_ASSERT(rb.PushBack(data3));
 
         /*
-         * Buffer data:
-         *  hhhhhhhhccccccccccccccccccccc0hhhhhhhhbbbbbbbbbbbbbbbbbbbbb00000
+         * Buffer data (grouped by 4 bytes):
+         *  hhccccccc0hhbbbbbbb0
          */
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));


### PR DESCRIPTION
-- This PR is to be split into several PRs --

TRingBuffer:
* Implement in-place allocation - https://github.com/ydb-platform/nbs/pull/3895
* Support size >= 4GB (ui32 -> ui64) - https://github.com/ydb-platform/nbs/pull/3734
* Add padding (properly align header fields) - https://github.com/ydb-platform/nbs/pull/3734
* Add IsCorrupted flag; prohibit adding new elements when the flag is set - https://github.com/ydb-platform/nbs/pull/3816
* Resolve inconsistency in logic between PushBack, PopFront, Visit - https://github.com/ydb-platform/nbs/pull/3817

TWriteBackCache:
* Refactoring - https://github.com/ydb-platform/nbs/pull/3978
* Replace SessionSequencer with ReadWriteRangeLock and change synchronization point - https://github.com/ydb-platform/nbs/pull/4064
* Limit the amount and size of WriteData operations generated by Flush - https://github.com/ydb-platform/nbs/pull/4093
* Get rid of double copy (multiple places) - https://github.com/ydb-platform/nbs/pull/3925
* Store request buffer only once - https://github.com/ydb-platform/nbs/pull/3926
* Execute simultaneously only one Flush operation per handle - https://github.com/ydb-platform/nbs/pull/4059
* Copy request buffer to cache outside lock - https://github.com/ydb-platform/nbs/pull/3928

Unit test:
* Fix data race - https://github.com/ydb-platform/nbs/pull/3869

ToDo:
* Unit tests for TWriteBackCache::TImpl::InvertDataParts
* Asynchronous execution of pending actions
* Use retry policy