### PR TITLE
[Disk Manager] Support other disk operations in scale units

### DIFF
--- a/cloud/disk_manager/internal/pkg/cells/cells.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells.go
@@ -45,6 +45,10 @@ func (s *cellSelector) SelectCell(
 	return cells[0]
 }
 
+func (s *cellSelector) IsCellOfZone(cellID string, zoneID string) bool {
+	return slices.Contains(s.getCells(zoneID), cellID)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func (s *cellSelector) getCells(zoneID string) []string {

--- a/cloud/disk_manager/internal/pkg/cells/interface.go
+++ b/cloud/disk_manager/internal/pkg/cells/interface.go
@@ -13,4 +13,6 @@ type CellSelector interface {
 		ctx context.Context,
 		req *disk_manager.CreateDiskRequest,
 	) string
+
+	IsCellOfZone(cellID string, zoneID string) bool
 }

--- a/cloud/disk_manager/internal/pkg/cells/mocks/cells_mock.go
+++ b/cloud/disk_manager/internal/pkg/cells/mocks/cells_mock.go
@@ -27,3 +27,8 @@ func (s *CellSelectorMock) SelectCell(
 	args := s.Called(ctx, req)
 	return args.String(0)
 }
+
+func (s *CellSelectorMock) IsCellOfZone(cellID string, zoneID string) bool {
+	args := s.Called(ctx, req)
+	return args.Bool(0)
+}

--- a/cloud/disk_manager/internal/pkg/cells/mocks/cells_mock.go
+++ b/cloud/disk_manager/internal/pkg/cells/mocks/cells_mock.go
@@ -29,6 +29,6 @@ func (s *CellSelectorMock) SelectCell(
 }
 
 func (s *CellSelectorMock) IsCellOfZone(cellID string, zoneID string) bool {
-	args := s.Called(ctx, req)
+	args := s.Called(cellID, zoneID)
 	return args.Bool(0)
 }

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
@@ -261,3 +261,94 @@ func testDiskServiceCreateDiskFromSnapshotWithZoneID(
 
 	testcommon.CheckConsistency(t, ctx)
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+func testDiskServiceResizeDiskWithZoneID(t *testing.T, zoneID string) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: 4096,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.ResizeDisk(reqCtx, &disk_manager.ResizeDiskRequest{
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		Size: 40960,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func testDiskServiceAlterDiskWithZoneID(t *testing.T, zoneID string) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskID := testcommon.ReplaceUnacceptableSymbolsFromResourceID(t)
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: 4096,
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		CloudId:  "cloud",
+		FolderId: "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.AlterDisk(reqCtx, &disk_manager.AlterDiskRequest{
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		CloudId:  "newCloud",
+		FolderId: "newFolder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_cells_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_cells_test.go
@@ -67,3 +67,23 @@ func TestDiskServiceCellsCreateDiskFromSnapshot(t *testing.T) {
 		})
 	}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServiceCellsResizeDisk(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceResizeDiskWithZoneID(t, testCase.zoneID)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServiceCellsAlterDisk(t *testing.T) {
+	for _, testCase := range cellsTestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			testDiskServiceAlterDiskWithZoneID(t, testCase.zoneID)
+		})
+	}
+}

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -817,90 +817,11 @@ func TestDiskServiceCreateZonalTaskInAnotherZone(t *testing.T) {
 }
 
 func TestDiskServiceResizeDisk(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	diskID := t.Name()
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
-			SrcEmpty: &empty.Empty{},
-		},
-		Size: 4096,
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.ResizeDisk(reqCtx, &disk_manager.ResizeDiskRequest{
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-		Size: 40960,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
+	testDiskServiceResizeDiskWithZoneID(t, defaultZoneID)
 }
 
 func TestDiskServiceAlterDisk(t *testing.T) {
-	ctx := testcommon.NewContext()
-
-	client, err := testcommon.NewClient(ctx)
-	require.NoError(t, err)
-	defer client.Close()
-
-	diskID := t.Name()
-
-	reqCtx := testcommon.GetRequestContext(t, ctx)
-	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
-		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
-			SrcEmpty: &empty.Empty{},
-		},
-		Size: 4096,
-		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-		CloudId:  "cloud",
-		FolderId: "folder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	reqCtx = testcommon.GetRequestContext(t, ctx)
-	operation, err = client.AlterDisk(reqCtx, &disk_manager.AlterDiskRequest{
-		DiskId: &disk_manager.DiskId{
-			ZoneId: "zone-a",
-			DiskId: diskID,
-		},
-		CloudId:  "newCloud",
-		FolderId: "newFolder",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, operation)
-	err = internal_client.WaitOperation(ctx, client, operation.Id)
-	require.NoError(t, err)
-
-	testcommon.CheckConsistency(t, ctx)
+	testDiskServiceAlterDiskWithZoneID(t, defaultZoneID)
 }
 
 func TestDiskServiceAssignDisk(t *testing.T) {

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -580,7 +580,7 @@ func (s *service) AssignDisk(
 		"",
 		&protos.AssignDiskRequest{
 			Disk: &types.Disk{
-				ZoneId: req.ZoneId.ZoneId,
+				ZoneId: req.DiskId.ZoneId,
 				DiskId: req.DiskId.DiskId,
 			},
 			InstanceId: req.InstanceId,
@@ -608,7 +608,7 @@ func (s *service) UnassignDisk(
 		"",
 		&protos.UnassignDiskRequest{
 			Disk: &types.Disk{
-				ZoneId: req.ZoneId.ZoneId,
+				ZoneId: req.DiskId.ZoneId,
 				DiskId: req.DiskId.DiskId,
 			},
 		},

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -167,7 +167,7 @@ type service struct {
 	cellSelector    cells.CellSelector
 }
 
-func (s *service) prepareZoneIDForExistingDisk(
+func (s *service) getZoneIDForExistingDisk(
 	ctx context.Context,
 	diskID *disk_manager.DiskId,
 ) (string, error) {
@@ -511,7 +511,7 @@ func (s *service) ResizeDisk(
 		)
 	}
 
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	zoneID, err := s.getZoneIDForExistingDisk(ctx, req.DiskId)
 	if err != nil {
 		return "", err
 	}
@@ -542,7 +542,7 @@ func (s *service) AlterDisk(
 		)
 	}
 
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	zoneID, err := s.getZoneIDForExistingDisk(ctx, req.DiskId)
 	if err != nil {
 		return "", err
 	}
@@ -715,7 +715,7 @@ func (s *service) StatDisk(
 		)
 	}
 
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	zoneID, err := s.getZoneIDForExistingDisk(ctx, req.DiskId)
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +753,7 @@ func (s *service) MigrateDisk(
 		)
 	}
 
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	zoneID, err := s.getZoneIDForExistingDisk(ctx, req.DiskId)
 	if err != nil {
 		return "", err
 	}
@@ -832,7 +832,7 @@ func (s *service) DescribeDisk(
 		)
 	}
 
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	zoneID, err := s.getZoneIDForExistingDisk(ctx, req.DiskId)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -580,7 +580,7 @@ func (s *service) AssignDisk(
 		"",
 		&protos.AssignDiskRequest{
 			Disk: &types.Disk{
-				ZoneId: zoneID,
+				ZoneId: req.ZoneId.ZoneId,
 				DiskId: req.DiskId.DiskId,
 			},
 			InstanceId: req.InstanceId,
@@ -608,7 +608,7 @@ func (s *service) UnassignDisk(
 		"",
 		&protos.UnassignDiskRequest{
 			Disk: &types.Disk{
-				ZoneId: zoneID,
+				ZoneId: req.ZoneId.ZoneId,
 				DiskId: req.DiskId.DiskId,
 			},
 		},

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -574,11 +574,6 @@ func (s *service) AssignDisk(
 		)
 	}
 
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
-	if err != nil {
-		return "", err
-	}
-
 	return s.taskScheduler.ScheduleTask(
 		ctx,
 		"disks.AssignDisk",
@@ -605,11 +600,6 @@ func (s *service) UnassignDisk(
 			"some of parameters are empty, req=%v",
 			req,
 		)
-	}
-
-	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
-	if err != nil {
-		return "", err
 	}
 
 	return s.taskScheduler.ScheduleTask(

--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -187,7 +187,7 @@ func (s *service) prepareZoneIDForExistingDisk(
 	if diskMeta.ZoneID != diskID.ZoneId &&
 		!s.cellSelector.IsCellOfZone(diskMeta.ZoneID, diskID.ZoneId) {
 		return "", errors.NewInvalidArgumentError(
-			"provided zone id %v does not match with an actual zone id %v",
+			"provided zone ID %v does not match with an actual zone ID %v",
 			diskID.ZoneId,
 			diskMeta.ZoneID,
 		)
@@ -574,13 +574,18 @@ func (s *service) AssignDisk(
 		)
 	}
 
+	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	if err != nil {
+		return "", err
+	}
+
 	return s.taskScheduler.ScheduleTask(
 		ctx,
 		"disks.AssignDisk",
 		"",
 		&protos.AssignDiskRequest{
 			Disk: &types.Disk{
-				ZoneId: req.DiskId.ZoneId,
+				ZoneId: zoneID,
 				DiskId: req.DiskId.DiskId,
 			},
 			InstanceId: req.InstanceId,
@@ -602,13 +607,18 @@ func (s *service) UnassignDisk(
 		)
 	}
 
+	zoneID, err := s.prepareZoneIDForExistingDisk(ctx, req.DiskId)
+	if err != nil {
+		return "", err
+	}
+
 	return s.taskScheduler.ScheduleTask(
 		ctx,
 		"disks.UnassignDisk",
 		"",
 		&protos.UnassignDiskRequest{
 			Disk: &types.Disk{
-				ZoneId: req.DiskId.ZoneId,
+				ZoneId: zoneID,
 				DiskId: req.DiskId.DiskId,
 			},
 		},

--- a/cloud/disk_manager/internal/pkg/services/disks/service_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service_test.go
@@ -13,7 +13,7 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func TestDiskServicePrepareZoneIDForExistingDisk(
+func TestDiskServicegetZoneIDForExistingDisk(
 	t *testing.T,
 ) {
 	testCases := []struct {
@@ -78,7 +78,7 @@ func TestDiskServicePrepareZoneIDForExistingDisk(
 				resourceStorage: storage,
 			}
 
-			zoneID, err := diskService.prepareZoneIDForExistingDisk(
+			zoneID, err := diskService.getZoneIDForExistingDisk(
 				ctx,
 				&disk_manager.DiskId{
 					DiskId: "disk",

--- a/cloud/disk_manager/internal/pkg/services/disks/service_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service_test.go
@@ -13,7 +13,7 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func TestDiskServicePrepareZoneIDForExistingDiskCorrectZonerequested(
+func TestDiskServicePrepareZoneIDForExistingDisk(
 	t *testing.T,
 ) {
 	testCases := []struct {

--- a/cloud/disk_manager/internal/pkg/services/disks/service_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service_test.go
@@ -1,0 +1,99 @@
+package disks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+	cells_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/cells/mocks"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/resources"
+	storage_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/resources/mocks"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestDiskServicePrepareZoneIDForExistingDiskCorrectZonerequested(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name                string
+		actualDiskZoneID    string
+		requestedDiskZoneID string
+		isCellOfZone        bool
+		expectedZoneID      string
+		expectedErrorText   string
+	}{
+		{
+			name:                "Actual disk's zone ID equals the requested disk's zone ID",
+			requestedDiskZoneID: "zone-a",
+			actualDiskZoneID:    "zone-a",
+			isCellOfZone:        false,
+			expectedZoneID:      "zone-a",
+			expectedErrorText:   "",
+		},
+		{
+			name:                "Actual disk's zone ID is a cell and is equal to the requested zone ID",
+			requestedDiskZoneID: "zone-a",
+			actualDiskZoneID:    "zone-a",
+			isCellOfZone:        true,
+			expectedZoneID:      "zone-a",
+			expectedErrorText:   "",
+		},
+		{
+			name:                "The disk is located in a cell of requested disks's zone ID",
+			requestedDiskZoneID: "zone-a",
+			actualDiskZoneID:    "zone-a-shard1",
+			isCellOfZone:        true,
+			expectedZoneID:      "zone-a-shard1",
+			expectedErrorText:   "",
+		},
+		{
+			name:                "Requested zone ID does not match with an actual zone ID",
+			requestedDiskZoneID: "zone-a",
+			actualDiskZoneID:    "zone-b",
+			isCellOfZone:        false,
+			expectedZoneID:      "",
+			expectedErrorText:   "does not match with an actual zone ID",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := storage_mocks.NewStorageMock()
+			cellSelector := cells_mocks.NewCellSelectorMock()
+
+			storage.On("GetDiskMeta", ctx, "disk").Return(&resources.DiskMeta{
+				ZoneID: testCase.actualDiskZoneID,
+			}, nil)
+			cellSelector.On(
+				"IsCellOfZone",
+				testCase.actualDiskZoneID,
+				testCase.requestedDiskZoneID,
+			).Return(testCase.isCellOfZone)
+
+			diskService := &service{
+				cellSelector:    cellSelector,
+				resourceStorage: storage,
+			}
+
+			zoneID, err := diskService.prepareZoneIDForExistingDisk(
+				ctx,
+				&disk_manager.DiskId{
+					DiskId: "disk",
+					ZoneId: testCase.requestedDiskZoneID,
+				},
+			)
+
+			require.Equal(t, testCase.expectedZoneID, zoneID)
+			if len(testCase.expectedErrorText) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.ErrorContains(t, err, testCase.expectedErrorText)
+			}
+		})
+	}
+
+}

--- a/cloud/disk_manager/internal/pkg/services/disks/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/disks/ya.make
@@ -23,6 +23,7 @@ GO_TEST_SRCS(
     create_overlay_disk_task_test.go
     delete_disk_task_test.go
     migrate_disk_task_test.go
+    service_test.go
 )
 
 END()


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/3614
This pull request adds support for the following operations in the Disk Manager API when working with cells:
- `ResizeDisk`
- `AlterDisk`
- `StatDisk`
- `MigrateDisk`
- `DescribeDisk`

To implement this, a new method `prepareZoneIDForExistingDisks` has been introduced in the `diskService`. Its main responsibility is to verify that a requested operation targets a valid disk in the correct zone.

The method will return an error if:
- The specified disk is not found.
- The disk's actual zone does not match the zone provided in the request.