### PR TITLE
Fix linter error

### DIFF
--- a/cloud/storage/core/tools/common/python/core_pattern.py
+++ b/cloud/storage/core/tools/common/python/core_pattern.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from os.path import basename, join
+from os.path import basename
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
```
cloud/storage/core/tools/common/python/core_pattern.py:4: [F401] 'os.path.join' imported but unused
```