### PR TITLE
[CSI] (Stage|Publish)Volume should reuse an existing endpoint

### DIFF
--- a/cloud/blockstore/tests/csi_driver/e2e_tests_part2/test.py
+++ b/cloud/blockstore/tests/csi_driver/e2e_tests_part2/test.py
@@ -223,3 +223,19 @@ def test_publish_volume_must_fail_after_fs_error():
         raise
     finally:
         csi.cleanup_after_test(env, volume_name, access_type, [pod_id])
+
+
+def test_stage_twice_with_different_parameters():
+    env, run = csi.init(vm_mode=True)
+    try:
+        volume_name = "example-disk"
+        volume_size = 1024 ** 3
+        access_type = "mount"
+        env.csi.create_volume(name=volume_name, size=volume_size)
+        env.csi.stage_volume(volume_name, access_type, vhost_request_queues_count=4)
+        env.csi.stage_volume(volume_name, access_type, vhost_request_queues_count=8)
+    except subprocess.CalledProcessError as e:
+        csi.log_called_process_error(e)
+        raise
+    finally:
+        csi.cleanup_after_test(env, volume_name, access_type)

--- a/cloud/blockstore/tests/csi_driver/lib/csi_runner.py
+++ b/cloud/blockstore/tests/csi_driver/lib/csi_runner.py
@@ -170,8 +170,8 @@ class NbsCsiDriverRunner:
     def delete_volume(self, name: str):
         return self._controller_run("deletevolume", "--id", name)
 
-    def stage_volume(self, volume_id: str, access_type: str, is_nfs: bool = False):
-        args = ["stagevolume", "--volume-id", volume_id, "--access-type", access_type]
+    def stage_volume(self, volume_id: str, access_type: str, is_nfs: bool = False, vhost_request_queues_count: int = 8):
+        args = ["stagevolume", "--volume-id", volume_id, "--access-type", access_type, "--vhost-request-queues-count", str(vhost_request_queues_count)]
         if is_nfs:
             args += ["--backend", "nfs"]
 

--- a/cloud/blockstore/tools/csi_driver/client/main.go
+++ b/cloud/blockstore/tools/csi_driver/client/main.go
@@ -258,7 +258,7 @@ func getTargetPath(podId string, volumeId string, accessType string) string {
 }
 
 func newNodeStageVolumeCommand(endpoint *string) *cobra.Command {
-	var volumeId, stagingTargetPath, accessType string
+	var volumeId, stagingTargetPath, accessType, vhostRequestQueuesCount string
 	backend := BackendValue("nbs")
 	cmd := cobra.Command{
 		Use:   "stagevolume",
@@ -275,8 +275,9 @@ func newNodeStageVolumeCommand(endpoint *string) *cobra.Command {
 			}
 
 			volumeContext := map[string]string{
-				"instanceId": "example-instance-id",
-				"backend":    string(backend),
+				"instanceId":         "example-instance-id",
+				"backend":            string(backend),
+				"requestQueuesCount": vhostRequestQueuesCount,
 			}
 
 			accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
@@ -320,6 +321,13 @@ func newNodeStageVolumeCommand(endpoint *string) *cobra.Command {
 		"backend",
 		"Specify backend to use [nfs, nbs]",
 	)
+	cmd.Flags().StringVar(
+		&vhostRequestQueuesCount,
+		"vhost-request-queues-count",
+		"8",
+		"Specify vhost request queues count",
+	)
+
 	err := cmd.MarkFlagRequired("volume-id")
 	if err != nil {
 		log.Fatal(err)

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -134,6 +134,7 @@ func doTestPublishUnpublishVolumeForKubevirtHelper(
 				},
 			},
 			nil)
+		nbsClient.On("ListEndpoints", ctx, &nbs.TListEndpointsRequest{}).Return(&nbs.TListEndpointsResponse{}, nil)
 		nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 			UnixSocketPath:   nbsSocketPath,
 			DiskId:           diskId,
@@ -405,6 +406,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirtHelper(
 			volumeContext[requestQueuesCountVolumeContextKey] = strconv.Itoa(int(*requestQueuesCountOpt))
 			vhostQueuesCount = virtioBlkVhostQueuesCount(*requestQueuesCountOpt)
 		}
+		nbsClient.On("ListEndpoints", ctx, &nbs.TListEndpointsRequest{}).Return(&nbs.TListEndpointsResponse{}, nil)
 		nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 			UnixSocketPath:   nbsSocketPath,
 			DiskId:           diskId,
@@ -757,6 +759,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 	volumeContext := map[string]string{}
 
 	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
+	nbsClient.On("ListEndpoints", ctx, &nbs.TListEndpointsRequest{}).Return(&nbs.TListEndpointsResponse{}, nil)
 	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 		UnixSocketPath:   socketPath,
 		DiskId:           diskId,
@@ -925,6 +928,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 	}
 
 	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
+	nbsClient.On("ListEndpoints", ctx, &nbs.TListEndpointsRequest{}).Return(&nbs.TListEndpointsResponse{}, nil)
 	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 		UnixSocketPath:   socketPath,
 		DiskId:           diskId,
@@ -1287,6 +1291,7 @@ func TestGrpcTimeoutForIKubevirt(t *testing.T) {
 	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
 	grpcError := nbsclient.ClientError{Code: nbsclient.E_GRPC_DEADLINE_EXCEEDED}
 	startEndpointError := fmt.Errorf("%w", grpcError)
+	nbsClient.On("ListEndpoints", ctx, &nbs.TListEndpointsRequest{}).Return(&nbs.TListEndpointsResponse{}, nil)
 	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 		UnixSocketPath:   nbsSocketPath,
 		DiskId:           diskId,
@@ -1367,6 +1372,7 @@ func TestGrpcTimeoutForInfrakuber(t *testing.T) {
 	hostType := nbs.EHostType_HOST_TYPE_DEFAULT
 	grpcError := nbsclient.ClientError{Code: nbsclient.E_GRPC_DEADLINE_EXCEEDED}
 	startEndpointError := fmt.Errorf("%w", grpcError)
+	nbsClient.On("ListEndpoints", ctx, &nbs.TListEndpointsRequest{}).Return(&nbs.TListEndpointsResponse{}, nil)
 	nbsClient.On("StartEndpoint", ctx, &nbs.TStartEndpointRequest{
 		UnixSocketPath:   socketPath,
 		DiskId:           diskId,


### PR DESCRIPTION
issue: #3714

Reuse existing endpoint parameters in case of kubelet restart(another NodeStageVolume invoked without NodeUnstageVolume)

Usecase:

1. volume mounted into the pod/vm
2. Default StartEndpoint parameters were changed because of new csi driver release
3. kubelet restart caused additional NodeStageVolume call
