### PR TITLE
[Blockstore] Add GetClusterCapacity handler

### DIFF
--- a/cloud/blockstore/libs/storage/api/disk_registry.h
+++ b/cloud/blockstore/libs/storage/api/disk_registry.h
@@ -54,6 +54,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(SetCheckpointDataState,             __VA_ARGS__)                       \
     xxx(GetAgentNodeId,                     __VA_ARGS__)                       \
     xxx(AddOutdatedLaggingDevices,          __VA_ARGS__)                       \
+    xxx(GetClusterCapacity,                 __VA_ARGS__)                       \
 // BLOCKSTORE_DISK_REGISTRY_REQUESTS_PROTO
 
 // requests forwarded from service to disk_registry
@@ -214,6 +215,9 @@ struct TEvDiskRegistry
 
         EvAddOutdatedLaggingDevicesRequest = EvBegin + 77,
         EvAddOutdatedLaggingDevicesResponse = EvBegin + 78,
+
+        EvGetClusterCapacityRequest = EvBegin + 79,
+        EvGetClusterCapacityResponse = EvBegin + 80,
 
         EvEnd
     };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -838,6 +838,10 @@ STFUNC(TDiskRegistryActor::StateReadOnly)
         HFunc(TEvDiskRegistryPrivate::TEvCleanupDisksResponse,
             HandleCleanupDisksResponse);
 
+        HFunc(
+            TEvDiskRegistry::TEvGetClusterCapacityRequest,
+            HandleGetClusterCapacity);
+
         IgnoreFunc(
             TEvDiskRegistryPrivate::TEvSwitchAgentDisksToReadOnlyResponse);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_cluster_capacity.cpp
@@ -23,12 +23,12 @@ void TDiskRegistryActor::HandleGetClusterCapacity(
     auto response =
         std::make_unique<TEvDiskRegistry::TEvGetClusterCapacityResponse>();
 
-    auto sumBytesByPoolKind = [&](NProto::EDevicePoolKind kind)
+    auto sumBytesByPoolKind = [&](NProto::EDevicePoolKind poolKind)
     {
         ui64 freeBytes = 0;
         ui64 totalBytes = 0;
 
-        for (const auto& poolName: State->GetPoolNames(kind)) {
+        for (const auto& poolName: State->GetPoolNames(poolKind)) {
             auto racks = State->GatherRacksInfo(poolName);
             for (const auto& rack: racks) {
                 freeBytes += rack.FreeBytes;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_cluster_capacity.cpp
@@ -55,18 +55,18 @@ void TDiskRegistryActor::HandleGetClusterCapacity(
     for (const auto& [mediaKind, replicaCount]: diskRegistryBasedSSDMediaKinds)
     {
         NProto::TClusterCapacityInfo capacityInfo;
-        capacityInfo.SetFree(freeBytesSSD / replicaCount);
-        capacityInfo.SetTotal(totalBytesSSD / replicaCount);
-        capacityInfo.SetKind(mediaKind);
+        capacityInfo.SetFreeBytes(freeBytesSSD / replicaCount);
+        capacityInfo.SetTotalBytes(totalBytesSSD / replicaCount);
+        capacityInfo.SetStorageMediaKind(mediaKind);
         *response->Record.AddCapacity() = std::move(capacityInfo);
     }
 
     for (const auto& [mediaKind, replicaCount]: diskRegistryBasedHDDMediaKinds)
     {
         NProto::TClusterCapacityInfo capacityInfo;
-        capacityInfo.SetFree(freeBytesHDD / replicaCount);
-        capacityInfo.SetTotal(totalBytesHDD / replicaCount);
-        capacityInfo.SetKind(mediaKind);
+        capacityInfo.SetFreeBytes(freeBytesHDD / replicaCount);
+        capacityInfo.SetTotalBytes(totalBytesHDD / replicaCount);
+        capacityInfo.SetStorageMediaKind(mediaKind);
         *response->Record.AddCapacity() = std::move(capacityInfo);
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_get_cluster_capacity.cpp
@@ -1,0 +1,76 @@
+#include "disk_registry_actor.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::HandleGetClusterCapacity(
+    const TEvDiskRegistry::TEvGetClusterCapacityRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    BLOCKSTORE_DISK_REGISTRY_COUNTER(GetClusterCapacity);
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "Received GetClusterCapacity request");
+
+    auto response =
+        std::make_unique<TEvDiskRegistry::TEvGetClusterCapacityResponse>();
+
+    auto sumBytesByPoolKind = [&](NProto::EDevicePoolKind kind)
+    {
+        ui64 freeBytes = 0;
+        ui64 totalBytes = 0;
+
+        for (const auto& poolName: State->GetPoolNames(kind)) {
+            auto racks = State->GatherRacksInfo(poolName);
+            for (const auto& rack: racks) {
+                freeBytes += rack.FreeBytes;
+                totalBytes += rack.TotalBytes;
+            };
+        }
+
+        return std::make_pair(freeBytes, totalBytes);
+    };
+
+    auto [freeBytesSSD, totalBytesSSD] =
+        sumBytesByPoolKind(NProto::DEVICE_POOL_KIND_DEFAULT);
+    auto [freeBytesHDD, totalBytesHDD] =
+        sumBytesByPoolKind(NProto::DEVICE_POOL_KIND_GLOBAL);
+
+    const auto diskRegistryBasedSSDMediaKinds = {
+        std::make_pair(NProto::STORAGE_MEDIA_SSD_NONREPLICATED, 1),
+        std::make_pair(NProto::STORAGE_MEDIA_SSD_MIRROR2, 2),
+        std::make_pair(NProto::STORAGE_MEDIA_SSD_MIRROR3, 3)};
+    const auto diskRegistryBasedHDDMediaKinds = {
+        std::make_pair(NProto::STORAGE_MEDIA_HDD_NONREPLICATED, 1),
+    };
+
+    for (const auto& [mediaKind, replicaCount]: diskRegistryBasedSSDMediaKinds)
+    {
+        NProto::TClusterCapacityInfo capacityInfo;
+        capacityInfo.SetFree(freeBytesSSD / replicaCount);
+        capacityInfo.SetTotal(totalBytesSSD / replicaCount);
+        capacityInfo.SetKind(mediaKind);
+        *response->Record.AddCapacity() = std::move(capacityInfo);
+    }
+
+    for (const auto& [mediaKind, replicaCount]: diskRegistryBasedHDDMediaKinds)
+    {
+        NProto::TClusterCapacityInfo capacityInfo;
+        capacityInfo.SetFree(freeBytesHDD / replicaCount);
+        capacityInfo.SetTotal(totalBytesHDD / replicaCount);
+        capacityInfo.SetKind(mediaKind);
+        *response->Record.AddCapacity() = std::move(capacityInfo);
+    }
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -7947,11 +7947,14 @@ void TDiskRegistryState::CleanupExpiredAgentListParams(
     }
 }
 
-TVector<TString> TDiskRegistryState::GetPoolNames() const
+TVector<TString> TDiskRegistryState::GetPoolNames(
+    std::optional<NProto::EDevicePoolKind> kind) const
 {
     TVector<TString> poolNames;
-    for (const auto& [poolName, _]: DevicePoolConfigs) {
-        poolNames.push_back(poolName);
+    for (const auto& [poolName, config]: DevicePoolConfigs) {
+        if (!kind.has_value() || GetDevicePoolKind(poolName) == kind) {
+            poolNames.push_back(poolName);
+        }
     }
     Sort(poolNames);
     return poolNames;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -882,7 +882,8 @@ public:
         TDiskRegistryDatabase& db,
         TInstant now);
 
-    TVector<TString> GetPoolNames() const;
+    TVector<TString> GetPoolNames(
+        std::optional<NProto::EDevicePoolKind> kind = std::nullopt) const;
 
     const NProto::TDeviceConfig* FindDevice(const TDeviceId& uuid) const;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_allocation.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_allocation.cpp
@@ -2117,6 +2117,86 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         // When the last dirty device is clean, we can allocate disk
         tryAllocateDisk(false);
     }
+
+    Y_UNIT_TEST(ShouldReturnCorrectCapacity)
+    {
+        const auto agent = CreateAgentConfig(
+            "agent-1",
+            {Device("dev-1", "uuid-1", "rack-1", 10_GB),
+             Device("dev-2", "uuid-2", "rack-1", 10_GB)});
+
+        auto runtime = TTestRuntimeBuilder().WithAgents({agent}).Build();
+
+        TDiskRegistryClient diskRegistry(*runtime);
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+
+        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent}));
+
+        RegisterAgents(*runtime, 1);
+        WaitForAgents(*runtime, 1);
+        WaitForSecureErase(*runtime, {agent});
+        {
+            auto response = diskRegistry.GetClusterCapacity();
+
+            auto& msg = response->Record;
+
+            UNIT_ASSERT_VALUES_EQUAL(4, msg.CapacitySize());
+            for (auto& cap: msg.GetCapacity()) {
+                switch (cap.GetKind()) {
+                    case NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetTotal());
+                        break;
+                    case NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetTotal());
+                        break;
+                    case NProto::STORAGE_MEDIA_SSD_MIRROR2:
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetTotal());
+                        break;
+                    case NProto::STORAGE_MEDIA_SSD_MIRROR3:
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetTotal());
+                        break;
+                    default:
+                        UNIT_ASSERT(false);   // Unhandled kind.
+                }
+            }
+        }
+        {
+            diskRegistry.AllocateDisk("disk-1", 10_GB);
+
+            auto response = diskRegistry.GetClusterCapacity();
+
+            auto& msg = response->Record;
+
+            UNIT_ASSERT_VALUES_EQUAL(4, msg.CapacitySize());
+            for (auto& cap: msg.GetCapacity()) {
+                switch (cap.GetKind()) {
+                    case NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetTotal());
+                        break;
+                    case NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+                        UNIT_ASSERT_VALUES_EQUAL(10_GB, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetTotal());
+                        break;
+                    case NProto::STORAGE_MEDIA_SSD_MIRROR2:
+                        UNIT_ASSERT_VALUES_EQUAL(10_GB / 2, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetTotal());
+                        break;
+                    case NProto::STORAGE_MEDIA_SSD_MIRROR3:
+                        UNIT_ASSERT_VALUES_EQUAL(10_GB / 3, cap.GetFree());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetTotal());
+                        break;
+                    default:
+                        UNIT_ASSERT(false);   // Unhandled kind.
+                }
+            }
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_allocation.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_allocation.cpp
@@ -2143,22 +2143,26 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
             UNIT_ASSERT_VALUES_EQUAL(4, msg.CapacitySize());
             for (auto& cap: msg.GetCapacity()) {
-                switch (cap.GetKind()) {
+                switch (cap.GetStorageMediaKind()) {
                     case NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
-                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetTotalBytes());
                         break;
                     case NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetTotalBytes());
                         break;
                     case NProto::STORAGE_MEDIA_SSD_MIRROR2:
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            20_GB / 2,
+                            cap.GetTotalBytes());
                         break;
                     case NProto::STORAGE_MEDIA_SSD_MIRROR3:
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            20_GB / 3,
+                            cap.GetTotalBytes());
                         break;
                     default:
                         UNIT_ASSERT(false);   // Unhandled kind.
@@ -2174,22 +2178,26 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
             UNIT_ASSERT_VALUES_EQUAL(4, msg.CapacitySize());
             for (auto& cap: msg.GetCapacity()) {
-                switch (cap.GetKind()) {
+                switch (cap.GetStorageMediaKind()) {
                     case NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
-                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(0, cap.GetTotalBytes());
                         break;
                     case NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
-                        UNIT_ASSERT_VALUES_EQUAL(10_GB, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(10_GB, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(20_GB, cap.GetTotalBytes());
                         break;
                     case NProto::STORAGE_MEDIA_SSD_MIRROR2:
-                        UNIT_ASSERT_VALUES_EQUAL(10_GB / 2, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 2, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(10_GB / 2, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            20_GB / 2,
+                            cap.GetTotalBytes());
                         break;
                     case NProto::STORAGE_MEDIA_SSD_MIRROR3:
-                        UNIT_ASSERT_VALUES_EQUAL(10_GB / 3, cap.GetFree());
-                        UNIT_ASSERT_VALUES_EQUAL(20_GB / 3, cap.GetTotal());
+                        UNIT_ASSERT_VALUES_EQUAL(10_GB / 3, cap.GetFreeBytes());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            20_GB / 3,
+                            cap.GetTotalBytes());
                         break;
                     default:
                         UNIT_ASSERT(false);   // Unhandled kind.

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -1103,6 +1103,13 @@ public:
         return request;
     }
 
+    auto CreateGetClusterCapacityRequest()
+    {
+        auto request =
+            std::make_unique<TEvDiskRegistry::TEvGetClusterCapacityRequest>();
+        return request;
+    }
+
 #define BLOCKSTORE_DECLARE_METHOD(name, ns)                                    \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -17,6 +17,7 @@ SRCS(
     disk_registry_actor_describe.cpp
     disk_registry_actor_destroy.cpp
     disk_registry_actor_get_agent_node_id.cpp
+    disk_registry_actor_get_cluster_capacity.cpp
     disk_registry_actor_get_dependent_disks.cpp
     disk_registry_actor_initiate_realloc.cpp
     disk_registry_actor_initschema.cpp

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1821,13 +1821,13 @@ message TPartiallySuspendAgentResponse
 message TClusterCapacityInfo
 {
     // Kind of described space.
-    NCloud.NProto.EStorageMediaKind Kind = 1;
+    NCloud.NProto.EStorageMediaKind StorageMediaKind = 1;
 
     // Free space in bytes.
-    uint64 Free = 2;
+    uint64 FreeBytes = 2;
 
     // Total space in bytes.
-    uint64 Total = 3;
+    uint64 TotalBytes = 3;
 }
 
 message TGetClusterCapacityRequest

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1814,3 +1814,31 @@ message TPartiallySuspendAgentResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Get Cluster Capacity.
+
+message TClusterCapacityInfo
+{
+    // Kind of described space.
+    NCloud.NProto.EStorageMediaKind Kind = 1;
+
+    // Free space in bytes.
+    uint64 Free = 2;
+
+    // Total space in bytes.
+    uint64 Total = 3;
+}
+
+message TGetClusterCapacityRequest
+{
+}
+
+message TGetClusterCapacityResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // List of capacities.
+    repeated TClusterCapacityInfo Capacity = 2;
+}

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -425,7 +425,7 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
-    TResultOrError<NActors::IActorPtr> CreateGetCapacityActor(
+    TResultOrError<NActors::IActorPtr> CreateGetClusterCapacityActor(
         TRequestInfoPtr requestInfo,
         TString input);
 };

--- a/cloud/blockstore/libs/storage/service/service_actor.h
+++ b/cloud/blockstore/libs/storage/service/service_actor.h
@@ -424,6 +424,10 @@ private:
     TResultOrError<NActors::IActorPtr> CreateBackupTabletBootInfosActor(
         TRequestInfoPtr requestInfo,
         TString input);
+
+    TResultOrError<NActors::IActorPtr> CreateGetCapacityActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
@@ -90,6 +90,7 @@ void TServiceActor::HandleExecuteAction(
         {"getstorageconfig",                  &TServiceActor::CreateGetStorageConfigActor                  },
         {"backuppathdescriptions",            &TServiceActor::CreateBackupPathDescriptionsActor            },
         {"backuptabletbootinfos",             &TServiceActor::CreateBackupTabletBootInfosActor             },
+        {"getclustercapacity",                &TServiceActor::CreateGetCapacityActor                       },
     };
 
     NProto::TError error;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions.cpp
@@ -90,7 +90,7 @@ void TServiceActor::HandleExecuteAction(
         {"getstorageconfig",                  &TServiceActor::CreateGetStorageConfigActor                  },
         {"backuppathdescriptions",            &TServiceActor::CreateBackupPathDescriptionsActor            },
         {"backuptabletbootinfos",             &TServiceActor::CreateBackupTabletBootInfosActor             },
-        {"getclustercapacity",                &TServiceActor::CreateGetCapacityActor                       },
+        {"getclustercapacity",                &TServiceActor::CreateGetClusterCapacityActor                },
     };
 
     NProto::TError error;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -315,17 +315,17 @@ void TGetClusterCapacityActor::HandleGetYDBCapacityResponse(
         }
     }
 
-    auto& ssd_capacity = Capacities.emplace_back();
-    ssd_capacity.SetStorageMediaKind(
+    auto& ssdCapacity = Capacities.emplace_back();
+    ssdCapacity.SetStorageMediaKind(
         NProto::EStorageMediaKind::STORAGE_MEDIA_SSD);
-    ssd_capacity.SetFreeBytes(freeBytesSSD);
-    ssd_capacity.SetTotalBytes(totalBytesSSD);
+    ssdCapacity.SetFreeBytes(freeBytesSSD);
+    ssdCapacity.SetTotalBytes(totalBytesSSD);
 
-    auto& hdd_capacity = Capacities.emplace_back();
-    hdd_capacity.SetStorageMediaKind(
+    auto& hddCapacity = Capacities.emplace_back();
+    hddCapacity.SetStorageMediaKind(
         NProto::EStorageMediaKind::STORAGE_MEDIA_HDD);
-    hdd_capacity.SetFreeBytes(freeBytesHDD);
-    hdd_capacity.SetTotalBytes(totalBytesHDD);
+    hddCapacity.SetFreeBytes(freeBytesHDD);
+    hddCapacity.SetTotalBytes(totalBytesHDD);
 
     NPrivateProto::TGetClusterCapacityResponse result;
     for (auto& capacity: Capacities) {

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -218,6 +218,10 @@ void TGetClusterCapacityActor::HandleGetYDBCapacity(
             continue;
         }
 
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "PDiskFilter: " << TString(entry.GetPDiskFilter()));
         if (entry.GetPDiskFilter().find("ssd") != TString::npos) {
             freeBytesSSD += entry.GetCurrentAvailableSize();
             totalBytesSSD += entry.GetCurrentAllocatedSize();

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -63,7 +63,7 @@ private:
     STFUNC(StateGetDiskRegistryCapacity);
     STFUNC(StateGetYDBCapacity);
 
-    void HandleDiskRegistyCapacity(
+    void HandleGetDiskRegistyCapacity(
         const TEvDiskRegistry::TEvGetClusterCapacityResponse::TPtr& ev,
         const TActorContext& ctx);
 
@@ -129,7 +129,7 @@ void TGetCapacityActor::HandleEmptyList(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TGetCapacityActor::HandleDiskRegistyCapacity(
+void TGetCapacityActor::HandleGetDiskRegistyCapacity(
     const TEvDiskRegistry::TEvGetClusterCapacityResponse::TPtr& ev,
     const TActorContext& ctx)
 {
@@ -226,7 +226,7 @@ STFUNC(TGetCapacityActor::StateGetDiskRegistryCapacity)
     switch (ev->GetTypeRewrite()) {
         HFunc(
             TEvDiskRegistry::TEvGetClusterCapacityResponse,
-            HandleDiskRegistyCapacity);
+            HandleGetDiskRegistyCapacity);
 
         default:
             HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -220,10 +220,12 @@ void TGetClusterCapacityActor::HandleGetYDBCapacity(
 
         if (entry.GetPDiskFilter().find("SSD") != TString::npos) {
             freeBytesSSD += entry.GetCurrentAvailableSize();
-            totalBytesSSD += entry.GetCurrentAllocatedSize();
+            totalBytesSSD += entry.GetCurrentAllocatedSize() +
+                             entry.GetCurrentAvailableSize();
         } else if (entry.GetPDiskFilter().find("ROT") != TString::npos) {
             freeBytesHDD += entry.GetCurrentAvailableSize();
-            totalBytesHDD += entry.GetCurrentAllocatedSize();
+            totalBytesHDD += entry.GetCurrentAllocatedSize() +
+                             entry.GetCurrentAvailableSize();
         } else {
             LOG_WARN_S(
                 ctx,

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -84,8 +84,8 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TGetClusterCapacityActor::TGetClusterCapacityActor(
-    TRequestInfoPtr requestInfo,
-    TStorageConfigPtr config)
+        TRequestInfoPtr requestInfo,
+        TStorageConfigPtr config)
     : RequestInfo(std::move(requestInfo))
     , Config(config)
 {}

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -31,9 +31,9 @@ NPrivateProto::TClusterCapacityInfo ToResponse(
     const NProto::TClusterCapacityInfo& capacityInfo)
 {
     NPrivateProto::TClusterCapacityInfo info;
-    info.SetFree(capacityInfo.GetFreeBytes());
-    info.SetTotal(capacityInfo.GetTotalBytes());
-    info.SetKind(capacityInfo.GetStorageMediaKind());
+    info.SetFreeBytes(capacityInfo.GetFreeBytes());
+    info.SetTotalBytes(capacityInfo.GetTotalBytes());
+    info.SetStorageMediaKind(capacityInfo.GetStorageMediaKind());
 
     return info;
 }
@@ -169,11 +169,6 @@ void TGetCapacityActor::HandleGetYDBCapacity(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-
-    if (FAILED(msg->GetStatus())) {
-        ReplyAndDie(ctx, msg->GetError());
-        return;
-    }
 
     if (msg->Record.GetEntries().empty()) {
         HandleEmptyClusterCapacity(ctx, "BSController");

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -229,7 +229,10 @@ STFUNC(TGetCapacityActor::StateGetDiskRegistryCapacity)
             HandleGetDiskRegistyCapacity);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }
@@ -244,7 +247,10 @@ STFUNC(TGetCapacityActor::StateGetYDBCapacity)
             HandleGetYDBCapacity);
 
         default:
-            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
             break;
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -218,14 +218,10 @@ void TGetClusterCapacityActor::HandleGetYDBCapacity(
             continue;
         }
 
-        LOG_DEBUG(
-            ctx,
-            TBlockStoreComponents::SERVICE,
-            "PDiskFilter: " << TString(entry.GetPDiskFilter()));
-        if (entry.GetPDiskFilter().find("ssd") != TString::npos) {
+        if (entry.GetPDiskFilter().find("SSD") != TString::npos) {
             freeBytesSSD += entry.GetCurrentAvailableSize();
             totalBytesSSD += entry.GetCurrentAllocatedSize();
-        } else if (entry.GetPDiskFilter().find("hdd") != TString::npos) {
+        } else if (entry.GetPDiskFilter().find("ROT") != TString::npos) {
             freeBytesHDD += entry.GetCurrentAvailableSize();
             totalBytesHDD += entry.GetCurrentAllocatedSize();
         } else {

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -85,7 +85,7 @@ void TGetCapacityActor::Bootstrap(const TActorContext& ctx)
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::SERVICE,
-        "Sending get nameservice config request");
+        "Sending get cluster capacity request");
 
     NCloud::Send(
         ctx,

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_cluster_capacity.cpp
@@ -1,0 +1,264 @@
+#include "service_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/blockstore/private/api/protos/disk.pb.h>
+
+#include <contrib/ydb/core/sys_view/common/events.h>
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/hfunc.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <library/cpp/json/json_writer.h>
+
+#include <google/protobuf/util/json_util.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER)
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NPrivateProto::TClusterCapacityInfo ToResponse(
+    const NProto::TClusterCapacityInfo& capacityInfo)
+{
+    NPrivateProto::TClusterCapacityInfo info;
+    info.SetFree(capacityInfo.GetFree());
+    info.SetTotal(capacityInfo.GetTotal());
+    info.SetKind(capacityInfo.GetKind());
+
+    return info;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TGetCapacityActor final: public TActorBootstrapped<TGetCapacityActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    TVector<NPrivateProto::TClusterCapacityInfo> Capacities;
+
+public:
+    explicit TGetCapacityActor(TRequestInfoPtr requestInfo);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        std::unique_ptr<TEvService::TEvExecuteActionResponse> response);
+
+    void HandleSuccess(const TActorContext& ctx, const TString& output);
+    void HandleEmptyList(const TActorContext& ctx, const TString& component);
+
+private:
+    STFUNC(StateGetDiskRegistryCapacity);
+    STFUNC(StateGetYDBCapacity);
+
+    void HandleDiskRegistyCapacity(
+        const TEvDiskRegistry::TEvGetClusterCapacityResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleGetYDBCapacity(
+        const NSysView::TEvSysView::TEvGetStorageStatsResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TGetCapacityActor::TGetCapacityActor(TRequestInfoPtr requestInfo)
+    : RequestInfo(std::move(requestInfo))
+{}
+
+void TGetCapacityActor::Bootstrap(const TActorContext& ctx)
+{
+    Become(&TThis::StateGetDiskRegistryCapacity);
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "Sending get nameservice config request");
+
+    NCloud::Send(
+        ctx,
+        MakeDiskRegistryProxyServiceId(),
+        std::make_unique<TEvDiskRegistry::TEvGetClusterCapacityRequest>());
+}
+
+void TGetCapacityActor::ReplyAndDie(
+    const TActorContext& ctx,
+    std::unique_ptr<TEvService::TEvExecuteActionResponse> response)
+{
+    LWTRACK(
+        ResponseSent_Service,
+        RequestInfo->CallContext->LWOrbit,
+        "ExecuteAction_GetClusterCapacity",
+        RequestInfo->CallContext->RequestId);
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+void TGetCapacityActor::HandleSuccess(
+    const TActorContext& ctx,
+    const TString& output)
+{
+    auto response = std::make_unique<TEvService::TEvExecuteActionResponse>();
+    response->Record.SetOutput(output);
+    ReplyAndDie(ctx, std::move(response));
+}
+
+void TGetCapacityActor::HandleEmptyList(
+    const TActorContext& ctx,
+    const TString& component)
+{
+    NProto::TError error;
+    error.SetMessage("Got empty capacity response from " + component);
+    auto response = std::make_unique<TEvService::TEvExecuteActionResponse>(
+        std::move(error));
+    ReplyAndDie(ctx, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetCapacityActor::HandleDiskRegistyCapacity(
+    const TEvDiskRegistry::TEvGetClusterCapacityResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    const auto& error = msg->GetError();
+
+    if (HasError(error)) {
+        LOG_ERROR_S(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Getting Disk Registry capacity failed: " << FormatError(error));
+    }
+
+    if (msg->Record.GetCapacity().empty()) {
+        HandleEmptyList(ctx, "Disk Registry");
+        return;
+    }
+
+    for (const NProto::TClusterCapacityInfo& capacityInfo:
+         msg->Record.GetCapacity())
+    {
+        NPrivateProto::TClusterCapacityInfo capacity = ToResponse(capacityInfo);
+        Capacities.push_back(std::move(capacity));
+    }
+
+    Become(&TThis::StateGetYDBCapacity);
+    NCloud::Send(
+        ctx,
+        MakeBlobStorageProxyID(0),
+        std::make_unique<NSysView::TEvSysView::TEvGetStorageStatsRequest>());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TGetCapacityActor::HandleGetYDBCapacity(
+    const NSysView::TEvSysView::TEvGetStorageStatsResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (msg->Record.GetEntries().empty()) {
+        HandleEmptyList(ctx, "BSController");
+        return;
+    }
+
+    ui64 totalBytesSSD = 0;
+    ui64 freeBytesSSD = 0;
+    ui64 totalBytesHDD = 0;
+    ui64 freeBytesHDD = 0;
+
+    for (auto& entry: msg->Record.GetEntries()) {
+        if (!entry.HasPDiskFilter()) {
+            continue;
+        }
+
+        if (entry.GetPDiskFilter().find("ssd") != TString::npos) {
+            freeBytesSSD += entry.GetCurrentAvailableSize();
+            totalBytesSSD += entry.GetCurrentAllocatedSize();
+        } else if (entry.GetPDiskFilter().find("hdd") != TString::npos) {
+            freeBytesHDD += entry.GetCurrentAvailableSize();
+            totalBytesHDD += entry.GetCurrentAllocatedSize();
+        } else {
+            LOG_WARN_S(
+                ctx,
+                TBlockStoreComponents::SERVICE,
+                "Unknown PDiskFilter for YDB group entry");
+        }
+    }
+
+    auto& ssd_capacity = Capacities.emplace_back();
+    ssd_capacity.SetKind(NProto::EStorageMediaKind::STORAGE_MEDIA_SSD);
+    ssd_capacity.SetFree(freeBytesSSD);
+    ssd_capacity.SetTotal(totalBytesSSD);
+
+    auto& hdd_capacity = Capacities.emplace_back();
+    hdd_capacity.SetKind(NProto::EStorageMediaKind::STORAGE_MEDIA_HDD);
+    hdd_capacity.SetFree(freeBytesHDD);
+    hdd_capacity.SetTotal(totalBytesHDD);
+
+    NPrivateProto::TGetClusterCapacityResponse result;
+    for (auto& capacity: Capacities) {
+        *result.AddCapacity() = std::move(capacity);
+    }
+
+    TString output;
+    google::protobuf::util::MessageToJsonString(result, &output);
+    HandleSuccess(ctx, std::move(output));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TGetCapacityActor::StateGetDiskRegistryCapacity)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            TEvDiskRegistry::TEvGetClusterCapacityResponse,
+            HandleDiskRegistyCapacity);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            break;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TGetCapacityActor::StateGetYDBCapacity)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(
+            NSysView::TEvSysView::TEvGetStorageStatsResponse,
+            HandleGetYDBCapacity);
+
+        default:
+            HandleUnexpectedEvent(ev, TBlockStoreComponents::SERVICE);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TResultOrError<IActorPtr> TServiceActor::CreateGetCapacityActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    Y_UNUSED(input);
+    return {std::make_unique<TGetCapacityActor>(std::move(requestInfo))};
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -1876,30 +1876,6 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             UNIT_ASSERT_VALUES_EQUAL(blockCount, checkRangeResponse.ChecksumsSize());
         }
     }
-
-    Y_UNIT_TEST(ShouldGetClusterCapacity)
-    {
-        TTestEnv env;
-        NProto::TStorageServiceConfig config;
-        const ui32 nodeIdx = SetupTestEnv(env, std::move(config));
-
-        TServiceClient service(env.GetRuntime(), nodeIdx);
-
-        {
-            NProto::TGetClusterCapacityRequest request;
-
-            TString buf;
-            google::protobuf::util::MessageToJsonString(request, &buf);
-
-            const auto response =
-                service.ExecuteAction("getclustercapacity", buf);
-            NProto::TGetClusterCapacityResponse clusterCapacityResponse;
-            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
-                            response->Record.GetOutput(),
-                            &clusterCapacityResponse)
-                            .ok());
-        }
-    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -1876,6 +1876,30 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             UNIT_ASSERT_VALUES_EQUAL(blockCount, checkRangeResponse.ChecksumsSize());
         }
     }
+
+    Y_UNIT_TEST(ShouldGetClusterCapacity)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        const ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        {
+            NProto::TGetClusterCapacityRequest request;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+
+            const auto response =
+                service.ExecuteAction("getclustercapacity", buf);
+            NProto::TGetClusterCapacityResponse clusterCapacityResponse;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                            response->Record.GetOutput(),
+                            &clusterCapacityResponse)
+                            .ok());
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/ya.make
+++ b/cloud/blockstore/libs/storage/service/ya.make
@@ -21,6 +21,7 @@ SRCS(
     service_actor_actions_drain_node.cpp
     service_actor_actions_finish_fill_disk.cpp
     service_actor_actions_flush_profile_log.cpp
+    service_actor_actions_get_cluster_capacity.cpp
     service_actor_actions_get_compaction_status.cpp
     service_actor_actions_get_dependent_disks.cpp
     service_actor_actions_get_disk_agent_node_id.cpp

--- a/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
+++ b/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
@@ -154,6 +154,9 @@ private:
                 TEvDiskRegistry::TEvMarkReplacementDeviceRequest,
                 HandleMarkReplacementDevice);
 
+            HFunc(
+                TEvDiskRegistry::TEvGetClusterCapacityRequest,
+                HandleGetClusterCapacity);
 
             IgnoreFunc(NKikimr::TEvLocal::TEvTabletMetrics);
 
@@ -1079,6 +1082,23 @@ private:
             *ev,
             std::make_unique<TEvDiskRegistryProxy::TEvGetDrTabletInfoResponse>(
                 testDiskRegistryTabletId));
+    }
+
+    void HandleGetClusterCapacity(
+        const TEvDiskRegistry::TEvGetClusterCapacityRequest::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        auto response =
+            std::make_unique<TEvDiskRegistry::TEvGetClusterCapacityResponse>();
+
+        NProto::TClusterCapacityInfo capacityInfo;
+        capacityInfo.SetFreeBytes(93_GB);
+        capacityInfo.SetTotalBytes(93_GB);
+        capacityInfo.SetStorageMediaKind(
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
+
+        *response->Record.AddCapacity() = std::move(capacityInfo);
+        NCloud::Reply(ctx, *ev, std::move(response));
     }
 };
 

--- a/cloud/blockstore/private/api/protos/disk.proto
+++ b/cloud/blockstore/private/api/protos/disk.proto
@@ -5,6 +5,7 @@ package NCloud.NBlockStore.NPrivateProto;
 // XXX this import is prohibited by ya.make
 // that's why instead of EDeviceState and EAgentState we use integers here
 // import "cloud/blockstore/libs/storage/protos/disk.proto";
+import "cloud/storage/core/protos/media.proto";
 
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/private/api/protos";
 
@@ -80,4 +81,23 @@ message TDiskRegistrySetWritableStateRequest
 
 message TDiskRegistrySetWritableStateResponse
 {
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GetClusterCapacity request/response.
+
+message TClusterCapacityInfo
+{
+    NCloud.NProto.EStorageMediaKind Kind = 1;
+    uint64 Free = 2;
+    uint64 Total = 3;
+}
+
+message TGetClusterCapacityRequest
+{
+}
+
+message TGetClusterCapacityResponse
+{
+    repeated TClusterCapacityInfo Capacity = 1;
 }

--- a/cloud/blockstore/private/api/protos/disk.proto
+++ b/cloud/blockstore/private/api/protos/disk.proto
@@ -88,9 +88,9 @@ message TDiskRegistrySetWritableStateResponse
 
 message TClusterCapacityInfo
 {
-    NCloud.NProto.EStorageMediaKind Kind = 1;
-    uint64 Free = 2;
-    uint64 Total = 3;
+    NCloud.NProto.EStorageMediaKind StorageMediaKind = 1;
+    uint64 FreeBytes = 2;
+    uint64 TotalBytes = 3;
 }
 
 message TGetClusterCapacityRequest


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/3614

Add `GetClusterCapacity` handler that collects cluster utilization information from YDB and DiskRegistry and returns it grouped by disk types.
This handler will be used by `Disk Manager` to intelligently distribute newly created disks across shards.

For collecting data from Disk Registry, an analogous handler has been added. For collecting from YDB, `GetStorageStatsRequest` is used (https://github.com/ydb-platform/ydb/blob/911050b753e7fb532f13324f65d2a167e8045e37/ydb/core/protos/sys_view.proto#L353-L358)
