### PR TITLE
implement automatic device allocation; resolves #1833 #3729 #3754

### DIFF
--- a/cloud/blockstore/apps/client/lib/start_endpoint.cpp
+++ b/cloud/blockstore/apps/client/lib/start_endpoint.cpp
@@ -185,7 +185,7 @@ public:
             .SetFlag(&Persistent);
 
         Opts.AddLongOption("nbd-device", "nbd device file which nbd-client connected to")
-            .RequiredArgument("STR")
+            .OptionalArgument("STR")
             .StoreResult(&NbdDeviceFile);
 
         Opts.AddLongOption("cgroup", "cgroup to place into")
@@ -236,7 +236,11 @@ protected:
                     EncryptionKeyPath,
                     EncryptionKeyHash));
             request->SetPersistent(Persistent);
-            request->SetNbdDeviceFile(NbdDeviceFile);
+            if (NbdDeviceFile) {
+                request->SetNbdDeviceFile(NbdDeviceFile);
+            } else {
+                request->SetUseFreeNbdDeviceFile(true);
+            }
             request->MutableClientCGroups()->Assign(CGroups.begin(), CGroups.end());
         }
 

--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -236,6 +236,9 @@ message TServerConfig
     // PTEs will be flushed after the guest reads/writes 8 512-byte blocks or
     // 1 4KiB block.
     optional uint64 VhostPteFlushByteThreshold = 123;
+
+    // Ask system to provide a free nbd device
+    optional bool AutomaticNbdDeviceManagement = 124;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -532,6 +532,8 @@ void TBootstrapBase::Init()
         .ClientConfig = Configs->EndpointConfig->GetClientConfig(),
         .NbdSocketSuffix = Configs->ServerConfig->GetNbdSocketSuffix(),
         .NbdDevicePrefix = Configs->ServerConfig->GetNbdDevicePrefix(),
+        .AutomaticNbdDeviceManagement =
+            Configs->ServerConfig->GetAutomaticNbdDeviceManagement(),
     };
 
     NBD::IDeviceFactoryPtr nbdDeviceFactory;
@@ -562,9 +564,7 @@ void TBootstrapBase::Init()
         nbdDeviceFactory = NBD::CreateNetlinkDeviceFactory(
             Logging,
             Configs->ServerConfig->GetNbdRequestTimeout(),
-            Configs->ServerConfig->GetNbdConnectionTimeout(),
-            true   // reconfigure
-        );
+            Configs->ServerConfig->GetNbdConnectionTimeout());
     }
 
     // The only case we want kernel to retry requests is when the socket is dead

--- a/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
@@ -65,7 +65,7 @@ struct TProxyDevice: NBD::IDevice
         if (!DevicePath) {
             DevicePath = NBD::FindFreeNbdDevice().replace(
                 0,
-                NBD::DEFAULT_DEVICE_PREFIX.size(),
+                NBD::DEVICE_PREFIX.size(),
                 DevicePrefix);
 
             if (DevicePath == DevicePrefix) {

--- a/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/device_factory.cpp
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/public/api/protos/endpoints.pb.h>
 
 #include <cloud/blockstore/libs/nbd/device.h>
+#include <cloud/blockstore/libs/nbd/utils.h>
 
 #include <util/string/builder.h>
 
@@ -37,7 +38,8 @@ struct TProxyDevice: NBD::IDevice
     const TProxyDeviceFactoryConfig Config;
     const IEndpointProxyClientPtr Client;
     const TString AddressString;
-    const TString DeviceName;
+    TString DevicePath;
+    const TString DevicePrefix;
     const ui64 BlockCount;
     const ui32 BlockSize;
 
@@ -45,22 +47,38 @@ struct TProxyDevice: NBD::IDevice
             TProxyDeviceFactoryConfig config,
             IEndpointProxyClientPtr client,
             const TNetworkAddress& connectAddress,
-            TString deviceName,
+            TString devicePath,
+            TString devicePrefix,
             ui64 blockCount,
             ui32 blockSize)
         : Config(config)
         , Client(std::move(client))
         , AddressString(Addr2String(connectAddress))
-        , DeviceName(std::move(deviceName))
+        , DevicePath(std::move(devicePath))
+        , DevicePrefix(std::move(devicePrefix))
         , BlockCount(blockCount)
         , BlockSize(blockSize)
     {}
 
     NThreading::TFuture<NProto::TError> Start() override
     {
+        if (!DevicePath) {
+            DevicePath = NBD::FindFreeNbdDevice().replace(
+                0,
+                NBD::DEFAULT_DEVICE_PREFIX.size(),
+                DevicePrefix);
+
+            if (DevicePath == DevicePrefix) {
+                return NThreading::MakeFuture(MakeError(
+                    E_FAIL,
+                    TStringBuilder()
+                        << "unable to find free nbd device with prefix "
+                        << DevicePrefix.Quote()));
+            }
+        }
         auto request = std::make_shared<NProto::TStartProxyEndpointRequest>();
         request->SetUnixSocketPath(AddressString);
-        request->SetNbdDevice(DeviceName);
+        request->SetNbdDevice(DevicePath);
         if (Config.DefaultSectorSize) {
             request->SetBlocksCount(
                 BlockCount * BlockSize / Config.DefaultSectorSize);
@@ -99,6 +117,11 @@ struct TProxyDevice: NBD::IDevice
         return Client->ResizeProxyDevice(std::move(request))
             .Apply([](const auto& f) { return f.GetValue().GetError(); });
     }
+
+    TString GetPath() const override
+    {
+        return DevicePath;
+    }
 };
 
 struct TProxyFactory: NBD::IDeviceFactory
@@ -115,7 +138,7 @@ struct TProxyFactory: NBD::IDeviceFactory
 
     NBD::IDevicePtr Create(
         const TNetworkAddress& connectAddress,
-        TString deviceName,
+        TString devicePath,
         ui64 blockCount,
         ui32 blockSize) override
     {
@@ -123,7 +146,24 @@ struct TProxyFactory: NBD::IDeviceFactory
             Config,
             Client,
             connectAddress,
-            std::move(deviceName),
+            std::move(devicePath),
+            "",
+            blockCount,
+            blockSize);
+    }
+
+    NBD::IDevicePtr CreateFree(
+        const TNetworkAddress& connectAddress,
+        TString devicePrefix,
+        ui64 blockCount,
+        ui32 blockSize) override
+    {
+        return std::make_shared<TProxyDevice>(
+            Config,
+            Client,
+            connectAddress,
+            "",
+            std::move(devicePrefix),
             blockCount,
             blockSize);
     }

--- a/cloud/blockstore/libs/endpoint_proxy/client/ya.make
+++ b/cloud/blockstore/libs/endpoint_proxy/client/ya.make
@@ -6,6 +6,7 @@ SRCS(
 )
 
 PEERDIR(
+    cloud/blockstore/libs/nbd
     cloud/blockstore/public/api/grpc
     cloud/blockstore/public/api/protos
 

--- a/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/server/server.cpp
@@ -59,9 +59,6 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr auto NBD_CONNECTION_TIMEOUT = TDuration::Days(1);
-constexpr auto NBD_RECONFIGURE_CONNECTED = true;
-constexpr auto NBD_DELETE_DEVICE = false;
-
 constexpr auto MAX_RECONNECT_DELAY = TDuration::Minutes(10);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1003,8 +1000,7 @@ struct TServer: IEndpointProxyServer
                 *ep.ListenAddress,
                 ep.NbdDevicePath,
                 Config.NbdRequestTimeout,
-                NBD_CONNECTION_TIMEOUT,
-                NBD_RECONFIGURE_CONNECTED);
+                NBD_CONNECTION_TIMEOUT);
         } else {
             // The only case we want kernel to retry requests is when the socket
             // is dead due to nbd server restart. And since we can't configure
@@ -1057,7 +1053,7 @@ struct TServer: IEndpointProxyServer
     bool DoProcessAlarm(TEndpoint& ep, const TString& tag)
     {
         if (ep.NbdDevice) {
-            auto err = ep.NbdDevice->Stop(NBD_DELETE_DEVICE).GetValueSync();
+            auto err = ep.NbdDevice->Stop(false).GetValueSync();
             if (HasError(err)) {
                 STORAGE_ERROR(
                     tag << "Failed to stop NBD device: " << err.GetCode());

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.h
@@ -46,6 +46,7 @@ struct TEndpointManagerOptions
     NProto::TClientConfig ClientConfig;
     TString NbdSocketSuffix;
     TString NbdDevicePrefix = "/dev/nbd";
+    bool AutomaticNbdDeviceManagement = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -172,7 +172,7 @@ struct TTestDeviceFactory
     : public NBD::IDeviceFactory
 {
     TVector<TString> Devices;
-    ui64 Index;
+    ui64 Index = 0;
 
     NBD::IDevicePtr Create(
         const TNetworkAddress& connectAddress,

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -172,6 +172,7 @@ struct TTestDeviceFactory
     : public NBD::IDeviceFactory
 {
     TVector<TString> Devices;
+    ui64 Index;
 
     NBD::IDevicePtr Create(
         const TNetworkAddress& connectAddress,
@@ -185,61 +186,18 @@ struct TTestDeviceFactory
         Devices.push_back(deviceName);
         return NBD::CreateDeviceStub();
     }
-};
 
-////////////////////////////////////////////////////////////////////////////////
-
-class TControlledDevice final: public NBD::IDevice
-{
-public:
-    explicit TControlledDevice(
-        std::function<NThreading::TFuture<NProto::TError>()> deviceStubFunction)
-        : DeviceStubFunction(std::move(deviceStubFunction))
-    {}
-
-    NThreading::TFuture<NProto::TError> Start() override
-    {
-        return DeviceStubFunction();
-    }
-
-    NThreading::TFuture<NProto::TError> Stop(bool deleteDevice) override
-    {
-        Y_UNUSED(deleteDevice);
-
-        return DeviceStubFunction();
-    }
-
-    NThreading::TFuture<NProto::TError> Resize(ui64 deviceSizeInBytes) override
-    {
-        Y_UNUSED(deviceSizeInBytes);
-
-        return DeviceStubFunction();
-    }
-
-private:
-    std::function<NThreading::TFuture<NProto::TError>()> DeviceStubFunction;
-};
-
-struct TTestControlledDeviceFactory: public NBD::IDeviceFactory
-{
-    std::function<NThreading::TFuture<NProto::TError>()> DeviceStubFunction;
-
-    explicit TTestControlledDeviceFactory(
-        std::function<NThreading::TFuture<NProto::TError>()> deviceStubFunction)
-        : DeviceStubFunction(std::move(deviceStubFunction))
-    {}
-
-    NBD::IDevicePtr Create(
+    NBD::IDevicePtr CreateFree(
         const TNetworkAddress& connectAddress,
-        TString deviceName,
+        TString devicePrefix,
         ui64 blockCount,
         ui32 blockSize) override
     {
         Y_UNUSED(connectAddress);
-        Y_UNUSED(deviceName);
         Y_UNUSED(blockCount);
         Y_UNUSED(blockSize);
-        return std::make_shared<TControlledDevice>(DeviceStubFunction);
+        Devices.push_back(devicePrefix + Index++);
+        return NBD::CreateDeviceStub();
     }
 };
 

--- a/cloud/blockstore/libs/nbd/client_handler.cpp
+++ b/cloud/blockstore/libs/nbd/client_handler.cpp
@@ -458,7 +458,10 @@ void TClientHandler::SendRequest(
             return;
         }
     }
-
+    // if request is still active, client has probably retried it
+    if (RequestsInFlight.contains(requestId)) {
+        return;
+    }
     auto [it, inserted] = RequestsInFlight.emplace(
         requestId,
         std::move(request));

--- a/cloud/blockstore/libs/nbd/device.cpp
+++ b/cloud/blockstore/libs/nbd/device.cpp
@@ -82,7 +82,7 @@ public:
         if (!DevicePath) {
             DevicePath = FindFreeNbdDevice().replace(
                 0,
-                DEFAULT_DEVICE_PREFIX.size(),
+                DEVICE_PREFIX.size(),
                 DevicePrefix);
 
             if (DevicePath == DevicePrefix) {
@@ -376,6 +376,22 @@ IDevicePtr CreateDevice(
         connectAddress,
         std::move(devicePath),
         "",
+        0, // blockCount
+        0, // blockSize
+        timeout);
+}
+
+IDevicePtr CreateFreeDevice(
+    ILoggingServicePtr logging,
+    const TNetworkAddress& connectAddress,
+    TString devicePrefix,
+    TDuration timeout)
+{
+    return std::make_shared<TDevice>(
+        std::move(logging),
+        connectAddress,
+        "",
+        std::move(devicePrefix),
         0, // blockCount
         0, // blockSize
         timeout);

--- a/cloud/blockstore/libs/nbd/device.h
+++ b/cloud/blockstore/libs/nbd/device.h
@@ -29,6 +29,8 @@ struct IDevice
 
     virtual NThreading::TFuture<NProto::TError> Resize(
         ui64 deviceSizeInBytes) = 0;
+
+    virtual TString GetPath() const = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -42,7 +44,13 @@ struct IDeviceFactory
     // establishment
     virtual IDevicePtr Create(
         const TNetworkAddress& connectAddress,
-        TString deviceName,
+        TString devicePath,
+        ui64 blockCount,
+        ui32 blockSize) = 0;
+
+    virtual IDevicePtr CreateFree(
+        const TNetworkAddress& connectAddress,
+        TString devicePrefix,
         ui64 blockCount,
         ui32 blockSize) = 0;
 };
@@ -52,7 +60,7 @@ struct IDeviceFactory
 IDevicePtr CreateDevice(
     ILoggingServicePtr logging,
     const TNetworkAddress& connectAddress,
-    TString deviceName,
+    TString devicePath,
     TDuration timeout);
 
 IDevicePtr CreateDeviceStub();

--- a/cloud/blockstore/libs/nbd/device.h
+++ b/cloud/blockstore/libs/nbd/device.h
@@ -63,6 +63,12 @@ IDevicePtr CreateDevice(
     TString devicePath,
     TDuration timeout);
 
+IDevicePtr CreateFreeDevice(
+    ILoggingServicePtr logging,
+    const TNetworkAddress& connectAddress,
+    TString devicePrefix,
+    TDuration timeout);
+
 IDevicePtr CreateDeviceStub();
 
 IDeviceFactoryPtr CreateDeviceFactory(

--- a/cloud/blockstore/libs/nbd/netlink_device.h
+++ b/cloud/blockstore/libs/nbd/netlink_device.h
@@ -9,15 +9,20 @@ namespace NCloud::NBlockStore::NBD {
 IDevicePtr CreateNetlinkDevice(
     ILoggingServicePtr logging,
     TNetworkAddress connectAddress,
-    TString deviceName,
+    TString devicePath,
     TDuration requestTimeout,
-    TDuration connectionTimeout,
-    bool reconfigure);
+    TDuration connectionTimeout);
+
+IDevicePtr CreateFreeNetlinkDevice(
+    ILoggingServicePtr logging,
+    TNetworkAddress connectAddress,
+    TString devicePrefix,
+    TDuration requestTimeout,
+    TDuration connectionTimeout);
 
 IDeviceFactoryPtr CreateNetlinkDeviceFactory(
     ILoggingServicePtr logging,
     TDuration requestTimeout,
-    TDuration connectionTimeout,
-    bool reconfigure);
+    TDuration connectionTimeout);
 
 }   // namespace NCloud::NBlockStore::NBD

--- a/cloud/blockstore/libs/nbd/utils.h
+++ b/cloud/blockstore/libs/nbd/utils.h
@@ -15,7 +15,7 @@ namespace NCloud::NBlockStore::NBD {
 
 constexpr auto MOUNT_INFO_FILE = "/proc/self/mountinfo";
 constexpr auto SYS_BLOCK_DIR = "/sys/block/";
-const TString DEVICE_PREFIX = "/dev/nbd";
+constexpr TStringBuf DEVICE_PREFIX = "/dev/nbd";
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/nbd/utils.h
+++ b/cloud/blockstore/libs/nbd/utils.h
@@ -15,6 +15,7 @@ namespace NCloud::NBlockStore::NBD {
 
 constexpr auto MOUNT_INFO_FILE = "/proc/self/mountinfo";
 constexpr auto SYS_BLOCK_DIR = "/sys/block/";
+const TString DEFAULT_DEVICE_PREFIX = "/dev/nbd";
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/nbd/utils.h
+++ b/cloud/blockstore/libs/nbd/utils.h
@@ -15,7 +15,7 @@ namespace NCloud::NBlockStore::NBD {
 
 constexpr auto MOUNT_INFO_FILE = "/proc/self/mountinfo";
 constexpr auto SYS_BLOCK_DIR = "/sys/block/";
-const TString DEFAULT_DEVICE_PREFIX = "/dev/nbd";
+const TString DEVICE_PREFIX = "/dev/nbd";
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -107,7 +107,8 @@ constexpr TDuration Seconds(int s)
     xxx(ChecksumFlags,               NProto::TChecksumFlags, {}               )\
     xxx(VhostDiscardEnabled,         bool,                   false            )\
     xxx(MaxZeroBlocksSubRequestSize, ui32,                   0                )\
-    xxx(VhostPteFlushByteThreshold,  ui64,                   0                )
+    xxx(VhostPteFlushByteThreshold,  ui64,                   0                )\
+    xxx(AutomaticNbdDeviceManagement,bool,                   false            )
 // BLOCKSTORE_SERVER_CONFIG
 
 #define BLOCKSTORE_SERVER_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -140,6 +140,7 @@ public:
     bool GetVhostDiscardEnabled() const;
     ui32 GetMaxZeroBlocksSubRequestSize() const;
     ui64 GetVhostPteFlushByteThreshold() const;
+    bool GetAutomaticNbdDeviceManagement() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -125,6 +125,7 @@ def init(
 
 
 def cleanup_after_test(env: LocalLoadTest):
+    subprocess.call(["rmmod", "nbd"], timeout=20)
     if env is None:
         return
     env.tear_down()

--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -153,24 +153,24 @@ def test_free_device_allocation(with_netlink):
         with_endpoint_proxy=False,
         nbds_max=nbds_max)
 
-    def createvolume(disk, socket):
+    def createvolume(i):
         return run(
             "createvolume",
             "--disk-id",
-            disk,
+            disk + str(i),
             "--blocks-count",
             str(blocks_count),
             "--block-size",
-            str(block_size),
+            str(block_size)
         ).returncode
 
-    def startendpoint(disk, socket):
+    def startendpoint(i):
         return run(
             "startendpoint",
             "--disk-id",
-            disk,
+            disk + str(i),
             "--socket",
-            socket,
+            socket + str(i),
             "--ipc-type",
             "nbd",
             "--persistent",
@@ -179,18 +179,18 @@ def test_free_device_allocation(with_netlink):
 
     try:
         for i in range(0, nbds_max):
-            assert createvolume(disk + str(i), socket + str(i)) == 0
-            assert startendpoint(disk + str(i), socket + str(i)) == 0
+            assert createvolume(i) == 0
+            assert startendpoint(i) == 0
 
         if with_netlink:
             # netlink implementation can allocate new devices on the fly,
             # so we should be able to go beyond configured limit
-            assert createvolume(disk + str(nbds_max), socket + str(nbds_max)) == 0
-            assert startendpoint(disk + str(nbds_max), socket + str(nbds_max)) == 0
+            assert createvolume(nbds_max) == 0
+            assert startendpoint(nbds_max) == 0
         else:
             # ioctl implementation won't be able to find free device
-            assert createvolume(disk + str(nbds_max), socket + str(nbds_max)) != 0
-            assert startendpoint(disk + str(nbds_max), socket + str(nbds_max)) != 0
+            assert createvolume(nbds_max) == 0
+            assert startendpoint(nbds_max) != 0
 
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)
@@ -204,7 +204,7 @@ def test_free_device_allocation(with_netlink):
                 socket + str(i),
             )
 
-            result = run(
+            run(
                 "destroyvolume",
                 "--disk-id",
                 disk + str(i),

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -305,7 +305,7 @@ void TBootstrap::Start()
                 NbdDevice = CreateFreeNetlinkDevice(
                     Logging,
                     listenAddress,
-                    DEVICE_PREFIX,
+                    TString(DEVICE_PREFIX),
                     Options->RequestTimeout,
                     Options->ConnectionTimeout);
             }
@@ -323,7 +323,7 @@ void TBootstrap::Start()
             NbdDevice = CreateFreeDevice(
                 Logging,
                 listenAddress,
-                DEVICE_PREFIX,
+                TString(DEVICE_PREFIX),
                 Options->ConnectionTimeout);
         }
         auto status = NbdDevice->Start().GetValueSync();

--- a/cloud/blockstore/tools/nbd/options.cpp
+++ b/cloud/blockstore/tools/nbd/options.cpp
@@ -1,7 +1,6 @@
 #include "options.h"
 
 #include <cloud/blockstore/libs/encryption/model/utils.h>
-#include <cloud/blockstore/libs/nbd/utils.h>
 
 #include <library/cpp/getopt/small/last_getopt.h>
 
@@ -178,7 +177,7 @@ void TOptions::Parse(int argc, char** argv)
 
     const auto& device = opts.AddLongOption("connect-device")
         .OptionalArgument("STR")
-        .StoreResult(&ConnectDevice);
+        .StoreResult(&ConnectDevicePath);
 
     opts.AddLongOption("null-blocksize")
         .RequiredArgument("NUM")
@@ -224,14 +223,6 @@ void TOptions::Parse(int argc, char** argv)
         .NoArgument()
         .SetFlag(&Netlink);
 
-    opts.AddLongOption("disconnect", "disconnect device before exiting")
-        .NoArgument()
-        .SetFlag(&Disconnect);
-
-    opts.AddLongOption("reconfigure", "reconfigure connected device")
-        .NoArgument()
-        .SetFlag(&Reconfigure);
-
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.Has(&verbose) && !VerboseLevel) {
@@ -245,10 +236,8 @@ void TOptions::Parse(int argc, char** argv)
             "'--listen-path' option is required for endpoint device-mode");
     }
 
-    if (res.Has(&device) && ConnectDevice.empty()) {
-        ConnectDevice = FindFreeNbdDevice();
-        Y_ENSURE(ConnectDevice,
-            "unable to find free nbd device");
+    if (res.Has(&device)) {
+        ConnectDevice = true;
     }
 }
 

--- a/cloud/blockstore/tools/nbd/options.h
+++ b/cloud/blockstore/tools/nbd/options.h
@@ -51,7 +51,8 @@ struct TOptions
     TString ListenAddress;
     TString ListenUnixSocketPath;
 
-    TString ConnectDevice;
+    bool ConnectDevice = false;
+    TString ConnectDevicePath;
 
     bool Netlink = false;
     bool Disconnect = false;


### PR DESCRIPTION
- generalize netlink library to easily construct new messages
- use sysfs to find free nbd device when using ioctl
- let the driver find or allocate free device when using netlink
- add config option to toggle between new and old behavior
- remove 'reconfigure' parameter from TNetlinkDevice, because it was never used
- modify nbd client to correctly handle retries