### PR TITLE
issue-1345: try to remove client if endpoint is unknown on StopEndpoint

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -592,6 +592,7 @@ void TBootstrapBase::Init()
         std::move(endpointListeners),
         std::move(nbdDeviceFactory),
         NbdErrorHandlerMap,
+        Service,
         std::move(endpointManagerOptions));
 
     STORAGE_INFO("EndpointManager initialized");

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1135,7 +1135,7 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
 
     // The vhost server deletes socket files when an endpoint starts or stops.
     // We don't have a vhost server here, so we need to delete the socket file
-    // manually. "Compute" assumes we should do this.
+    // manually. Compute assumes we should do this.
     TFsPath(socketPath).DeleteIfExists();
 
     return {};

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1116,9 +1116,7 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TStopEndpointRequest> request)
 {
-    Y_ABORT_UNLESS(
-        request->HasDiskId() && request->HasHeaders() &&
-        request->GetHeaders().GetClientId());
+    Y_ABORT_UNLESS(request->GetDiskId() && request->GetHeaders().GetClientId());
     const auto& socketPath = request->GetUnixSocketPath();
 
     auto removeClientRequest =
@@ -1135,8 +1133,8 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
         return TErrorResponse(removeClientResponse.GetError());
     }
 
-    if (NFs::Exists(request->GetUnixSocketPath())) {
-        bool deleted = NFs::Remove(request->GetUnixSocketPath());
+    if (NFs::Exists(socketPath)) {
+        bool deleted = NFs::Remove(socketPath);
         if (!deleted) {
             return TErrorResponse(
                 E_REJECTED,
@@ -1157,9 +1155,7 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointImpl(
 
     auto it = Endpoints.find(socketPath);
     if (it == Endpoints.end()) {
-        if (request->HasDiskId() && request->HasHeaders() &&
-            request->GetHeaders().GetClientId())
-        {
+        if (request->GetDiskId() && request->GetHeaders().GetClientId()) {
             return StopEndpointFallback(ctx, request);
         }
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1133,16 +1133,10 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
         return TErrorResponse(removeClientResponse.GetError());
     }
 
-    if (NFs::Exists(socketPath)) {
-        bool deleted = NFs::Remove(socketPath);
-        if (!deleted) {
-            return TErrorResponse(
-                E_REJECTED,
-                TStringBuilder()
-                    << "Can't delete socket " << socketPath.Quote() << ": "
-                    << LastSystemErrorText(LastSystemError()));
-        }
-    }
+    // The vhost server deletes socket files when an endpoint starts or stops.
+    // We don't have a vhost server here, so we need to delete the socket file
+    // manually. "Compute" assumes we should do this.
+    TFsPath(socketPath).DeleteIfExists();
 
     return {};
 }

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -161,12 +161,14 @@ bool CompareRequests(
     const NProto::TStopEndpointRequest& right)
 {
     Y_DEBUG_ABORT_UNLESS(3 == GetFieldCount<NProto::TStopEndpointRequest>());
-    return left.GetUnixSocketPath() == right.GetUnixSocketPath() &&
-           (!left.HasDiskId() && !right.HasDiskId() ||
-            left.HasDiskId() && right.HasDiskId() && left.HasHeaders() &&
-                right.HasHeaders() && left.GetDiskId() == right.GetDiskId() &&
-                left.GetHeaders().GetClientId() ==
-                    right.GetHeaders().GetClientId());
+    auto doTie = [](const NProto::TStopEndpointRequest& r)
+    {
+        return std::tie(
+            r.GetUnixSocketPath(),
+            r.GetDiskId(),
+            r.GetHeaders().GetClientId());
+    };
+    return doTie(left) == doTie(right);
 }
 
 bool CompareRequests(
@@ -1109,6 +1111,7 @@ NProto::TStopEndpointResponse TEndpointManager::DoStopEndpoint(
     RemoveProcessingSocket(socketPath);
     return response;
 }
+
 NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
     TCallContextPtr ctx,
     std::shared_ptr<NProto::TStopEndpointRequest> request)

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.h
@@ -64,6 +64,7 @@ IEndpointManagerPtr CreateEndpointManager(
     THashMap<NProto::EClientIpcType, IEndpointListenerPtr> listeners,
     NBD::IDeviceFactoryPtr nbdDeviceFactory,
     NBD::IErrorHandlerMapPtr errorHandlerMap,
+    IBlockStorePtr service,
     TEndpointManagerOptions options);
 
 bool AreSameStartEndpointRequests(

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -560,6 +560,7 @@ IEndpointManagerPtr CreateEndpointManager(TBootstrap& bootstrap)
         bootstrap.EndpointListeners,
         bootstrap.NbdDeviceFactory,
         bootstrap.NbdErrorHandlerMap,
+        bootstrap.Service,
         bootstrap.Options);
 
     return bootstrap.EndpointManager;

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -267,10 +267,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {{ ipcType, listener }},
-            nullptr,    // nbdDeviceFactory
+            {{ipcType, listener}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
         endpointManager->RestoreEndpoints().Wait(5s);
 
@@ -352,10 +353,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             sessionManager,
             endpointStorage,
-            {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
-            nullptr,    // nbdDeviceFactory
+            {{NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>()}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
         endpointManager->RestoreEndpoints().Wait(5s);
 
@@ -556,10 +558,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {{ NProto::IPC_GRPC, listener }},
-            nullptr,    // nbdDeviceFactory
+            {{NProto::IPC_GRPC, listener}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
 
         endpointManager->RestoreEndpoints().Wait();
@@ -598,10 +601,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {},         // listeners
-            nullptr,    // nbdDeviceFactory
+            {},        // listeners
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
 
         endpointManager->RestoreEndpoints().Wait();
@@ -636,10 +640,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {},         // listeners
-            nullptr,    // nbdDeviceFactory
+            {},        // listeners
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
 
         endpointManager->RestoreEndpoints().Wait();
@@ -696,10 +701,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {{ NProto::IPC_GRPC, listener }},
-            nullptr,    // nbdDeviceFactory
+            {{NProto::IPC_GRPC, listener}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
 
         auto restoreFuture = endpointManager->RestoreEndpoints();
@@ -769,10 +775,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {{ NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>() }},
-            nullptr,    // nbdDeviceFactory
+            {{NProto::IPC_GRPC, std::make_shared<TTestEndpointListener>()}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
         endpointManager->RestoreEndpoints().Wait(5s);
 
@@ -930,10 +937,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {{ NProto::IPC_GRPC, listener }},
-            nullptr,    // nbdDeviceFactory
+            {{NProto::IPC_GRPC, listener}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
         endpointManager->RestoreEndpoints().Wait(5s);
 
@@ -1042,10 +1050,11 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
             CreateEndpointEventProxy(),
             std::make_shared<TTestSessionManager>(),
             endpointStorage,
-            {{ NProto::IPC_GRPC, listener }},
-            nullptr,    // nbdDeviceFactory
+            {{NProto::IPC_GRPC, listener}},
+            nullptr,   // nbdDeviceFactory
             NBD::CreateErrorHandlerMapStub(),
-            {}          // options
+            nullptr,   // service
+            {}         // options
         );
 
         endpointManager->Start();

--- a/cloud/blockstore/libs/service/auth_scheme.cpp
+++ b/cloud/blockstore/libs/service/auth_scheme.cpp
@@ -138,6 +138,9 @@ TPermissionList GetRequestPermissions(EBlockStoreRequest requestType)
         case EBlockStoreRequest::DestroyVolumeLink:
                 return CreatePermissionList({EPermission::Update});
 
+        case EBlockStoreRequest::RemoveVolumeClient:
+            return CreatePermissionList({EPermission::Delete});
+
         case EBlockStoreRequest::MAX:
             Y_ABORT("EBlockStoreRequest::MAX is not valid");
     }

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -106,6 +106,7 @@ using TWriteBlocksLocalResponse = TWriteBlocksResponse;
     xxx(QueryAgentsInfo,                    __VA_ARGS__)                       \
     xxx(CreateVolumeLink,                   __VA_ARGS__)                       \
     xxx(DestroyVolumeLink,                  __VA_ARGS__)                       \
+    xxx(RemoveVolumeClient,                 __VA_ARGS__)                       \
 // BLOCKSTORE_GRPC_STORAGE_SERVICE
 
 #define BLOCKSTORE_ENDPOINT_SERVICE(xxx, ...)                                  \

--- a/cloud/blockstore/libs/service/request_helpers.h
+++ b/cloud/blockstore/libs/service/request_helpers.h
@@ -316,6 +316,7 @@ constexpr bool IsControlRequest(EBlockStoreRequest requestType)
         case EBlockStoreRequest::QueryAgentsInfo:
         case EBlockStoreRequest::CreateVolumeLink:
         case EBlockStoreRequest::DestroyVolumeLink:
+        case EBlockStoreRequest::RemoveVolumeClient:
             return true;
         case EBlockStoreRequest::MAX:
             Y_DEBUG_ABORT_UNLESS(false);

--- a/cloud/blockstore/libs/storage/api/service.h
+++ b/cloud/blockstore/libs/storage/api/service.h
@@ -310,8 +310,8 @@ struct TEvService
         EvDescribePlacementGroupRequest = EvBegin + 69,
         EvDescribePlacementGroupResponse = EvBegin + 70,
 
-        // EvBegin + 71, unused (see NBS-2410)
-        // EvBegin + 72, unused (see NBS-2410)
+        EvRemoveVolumeClientRequest = EvBegin + 71,
+        EvRemoveVolumeClientResponse = EvBegin + 72,
 
         EvCmsActionRequest = EvBegin + 73,
         EvCmsActionResponse = EvBegin + 74,

--- a/cloud/blockstore/libs/storage/service/service_actor_remove_client.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_remove_client.cpp
@@ -1,0 +1,117 @@
+#include "service_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/ss_proxy.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/api/volume_proxy.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRemoveClientActor final: public TActorBootstrapped<TRemoveClientActor>
+{
+private:
+    const TRequestInfoPtr RequestInfo;
+    const TString ClientId;
+    const TString DiskId;
+
+public:
+    TRemoveClientActor(
+            TRequestInfoPtr requestInfo,
+            TString clientId,
+            TString diskId)
+        : RequestInfo(std::move(requestInfo))
+        , ClientId(std::move(clientId))
+        , DiskId(std::move(diskId))
+    {}
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleRemoveClientResponse(
+        const TEvVolume::TEvRemoveClientResponse::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+void TRemoveClientActor::Bootstrap(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvVolume::TEvRemoveClientRequest>();
+    request->Record.SetDiskId(DiskId);
+    request->Record.MutableHeaders()->SetClientId(ClientId);
+
+    ctx.Send(MakeVolumeProxyServiceId(), std::move(request));
+    Become(&TThis::StateWork);
+}
+
+void TRemoveClientActor::HandleRemoveClientResponse(
+    const TEvVolume::TEvRemoveClientResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto& msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Error while removing client %s from disk %s : %s",
+            ClientId.Quote().c_str(),
+            DiskId.Quote().c_str(),
+            FormatError(msg->GetError()).c_str());
+    }
+
+    auto response = std::make_unique<TEvService::TEvRemoveVolumeClientResponse>();
+    *response->Record.MutableError() = msg->GetError();
+
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+STFUNC(TRemoveClientActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvVolume::TEvRemoveClientResponse, HandleRemoveClientResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TServiceActor::HandleRemoveVolumeClient(
+    const TEvService::TEvRemoveVolumeClientRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto& request = ev->Get()->Record;
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "RemoveClient diskID: %s, clientId: %s",
+        request.GetDiskId().Quote().c_str(),
+        request.GetHeaders().GetClientId().Quote().c_str());
+
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext);
+
+    NCloud::Register<TRemoveClientActor>(
+        ctx,
+        std::move(requestInfo),
+        std::move(*request.MutableHeaders()->MutableClientId()),
+        std::move(*request.MutableDiskId()));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/ya.make
+++ b/cloud/blockstore/libs/storage/service/ya.make
@@ -77,6 +77,7 @@ SRCS(
     service_actor_monitoring_unmount.cpp
     service_actor_mount.cpp
     service_actor_readblocks.cpp
+    service_actor_remove_client.cpp
     service_actor_sync_manually_preempted_volumes.cpp
     service_actor_unmount.cpp
     service_actor_update_disk_registry_config.cpp

--- a/cloud/blockstore/public/api/grpc/service.proto
+++ b/cloud/blockstore/public/api/grpc/service.proto
@@ -96,6 +96,13 @@ service TBlockStoreService
         };
     }
 
+    rpc RemoveVolumeClient(TRemoveVolumeClientRequest) returns (TRemoveVolumeClientResponse) {
+        option (google.api.http) = {
+            post: "/remove_volume_client"
+            body: "*"
+        };
+    }
+
     //
     // Volume information and statistics.
     //

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -125,8 +125,6 @@ message TStopEndpointRequest
     string UnixSocketPath = 2;
 
     optional string DiskId = 3;
-
-    optional string ClientId = 4;
 }
 
 message TStopEndpointResponse

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -123,6 +123,10 @@ message TStopEndpointRequest
 
     // Unix-socket path.
     string UnixSocketPath = 2;
+
+    optional string DiskId = 3;
+
+    optional string ClientId = 4;
 }
 
 message TStopEndpointResponse

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -785,3 +785,21 @@ message TDestroyVolumeLinkResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Remove volume client
+
+message TRemoveVolumeClientRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Id of disk to remove client.
+    string DiskId = 2;
+}
+
+message TRemoveVolumeClientResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}

--- a/cloud/blockstore/public/sdk/python/client/client.py
+++ b/cloud/blockstore/public/sdk/python/client/client.py
@@ -472,6 +472,8 @@ class Client(_SafeClient):
     def stop_endpoint_async(
             self,
             unix_socket_path: str,
+            client_id: str | None = None,
+            disk_id: str | None = None,
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
@@ -480,6 +482,11 @@ class Client(_SafeClient):
         request = protos.TStopEndpointRequest(
             UnixSocketPath=unix_socket_path,
         )
+        if client_id is not None:
+            request.ClientId = client_id
+        if disk_id is not None:
+            request.DiskId = disk_id
+
         return self._impl.stop_endpoint_async(
             request,
             idempotence_id,
@@ -491,6 +498,8 @@ class Client(_SafeClient):
     def stop_endpoint(
             self,
             unix_socket_path: str,
+            client_id: str | None = None,
+            disk_id: str | None = None,
             idempotence_id: str | None = None,
             timestamp: datetime | None = None,
             trace_id: str | None = None,
@@ -499,6 +508,10 @@ class Client(_SafeClient):
         request = protos.TStopEndpointRequest(
             UnixSocketPath=unix_socket_path,
         )
+        if client_id is not None:
+            request.ClientId = client_id
+        if disk_id is not None:
+            request.DiskId = disk_id
         self._impl.stop_endpoint(
             request,
             idempotence_id,

--- a/cloud/blockstore/public/sdk/python/client/client.py
+++ b/cloud/blockstore/public/sdk/python/client/client.py
@@ -483,7 +483,7 @@ class Client(_SafeClient):
             UnixSocketPath=unix_socket_path,
         )
         if client_id is not None:
-            request.ClientId = client_id
+            request.Headers.ClientId = client_id
         if disk_id is not None:
             request.DiskId = disk_id
 
@@ -509,7 +509,7 @@ class Client(_SafeClient):
             UnixSocketPath=unix_socket_path,
         )
         if client_id is not None:
-            request.ClientId = client_id
+            request.Headers.ClientId = client_id
         if disk_id is not None:
             request.DiskId = disk_id
         self._impl.stop_endpoint(

--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import tempfile
+
 import pytest
 import time
 
@@ -8,7 +10,8 @@ import time
 from cloud.blockstore.tests.python.lib.test_client import CreateTestClient
 
 from cloud.blockstore.public.sdk.python.client import Session
-from cloud.blockstore.public.sdk.python.protos import STORAGE_MEDIA_SSD_NONREPLICATED
+from cloud.blockstore.public.sdk.python.protos import STORAGE_MEDIA_SSD_NONREPLICATED, \
+    IPC_VHOST, VOLUME_ACCESS_READ_WRITE
 
 from cloud.blockstore.tests.python.lib.config import NbsConfigurator, \
     generate_disk_agent_txt
@@ -38,18 +41,32 @@ def start_ydb_cluster():
     ydb_cluster.stop()
 
 
+def apply_common_params_to_config(cfg):
+    cfg.files["storage"].NonReplicatedDontSuspendDevices = True
+    cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
+    cfg.files["storage"].NonReplicatedVolumeDirectAcquireEnabled = True
+    cfg.files["storage"].AcquireNonReplicatedDevices = True
+    cfg.files["storage"].InactiveClientsTimeout = INACTIVE_CLIENTS_TIMEOUT * 1000
+
+    cfg.files["server"].ServerConfig.VhostEnabled = True
+    cfg.files["server"].ServerConfig.VhostServerPath = yatest_common.binary_path(
+        "cloud/blockstore/vhost-server/blockstore-vhost-server")
+
+
 @pytest.fixture(name='nbs_with_dr')
 def start_nbs_daemon_with_dr(request, ydb):
     cfg = NbsConfigurator(ydb)
     cfg.generate_default_nbs_configs()
 
+    apply_common_params_to_config(cfg)
     cfg.files["storage"].DisableLocalService = False
-    cfg.files["storage"].NonReplicatedDontSuspendDevices = True
-    cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
-    cfg.files["storage"].NonReplicatedAgentMinTimeout = request.param
-    cfg.files["storage"].NonReplicatedAgentMaxTimeout = request.param
-    cfg.files["storage"].NonReplicatedVolumeDirectAcquireEnabled = True
-    cfg.files["storage"].AcquireNonReplicatedDevices = True
+
+    timeout = 60000
+    if hasattr(request, 'param'):
+        timeout = request.param
+
+    cfg.files["storage"].NonReplicatedAgentMinTimeout = timeout
+    cfg.files["storage"].NonReplicatedAgentMaxTimeout = timeout
 
     daemon = start_nbs(cfg)
 
@@ -68,11 +85,8 @@ def start_nbs_daemon(ydb):
     cfg = NbsConfigurator(ydb)
     cfg.generate_default_nbs_configs()
 
+    apply_common_params_to_config(cfg)
     cfg.files["storage"].DisableLocalService = True
-    cfg.files["storage"].NonReplicatedDontSuspendDevices = True
-    cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
-    cfg.files["storage"].NonReplicatedVolumeDirectAcquireEnabled = True
-    cfg.files["storage"].AcquireNonReplicatedDevices = True
 
     daemon = start_nbs(cfg)
 
@@ -176,7 +190,6 @@ def restart_volume(client, disk_id):
     restart_tablet(client, tablet_id)
 
 
-@pytest.mark.parametrize("nbs_with_dr", [(60000)], indirect=["nbs_with_dr"])
 def test_should_mount_volume_with_unknown_devices(
         nbs_with_dr,
         nbs,
@@ -263,7 +276,6 @@ def test_should_mount_volume_with_unknown_devices(
     session.unmount_volume()
 
 
-@pytest.mark.parametrize("nbs_with_dr", [(6000)], indirect=["nbs_with_dr"])
 def test_should_mount_volume_without_dr(nbs_with_dr, nbs, agent_ids, disk_agent_configurators):
 
     logger = logging.getLogger("client")
@@ -393,3 +405,65 @@ def test_should_mount_volume_with_unavailable_agents(
         blocks = session.read_blocks(i*DEVICE_SIZE//4096, 1, checkpoint_id="")
 
     session.unmount_volume()
+
+
+def test_should_stop_not_restored_endpoint(nbs_with_dr,
+                                           nbs,
+                                           agent_ids,
+                                           disk_agent_configurators):
+
+    client = CreateTestClient(f"localhost:{nbs.port}")
+
+    test_disk_id = "vol0"
+
+    agent_id = agent_ids[0]
+    configurator = disk_agent_configurators[0]
+    agent = start_disk_agent(configurator, name=agent_id)
+    agent.wait_for_registration()
+    r = client.add_host(agent_id)
+    assert len(r.ActionResults) == 1
+    assert r.ActionResults[0].Result.Code == 0
+
+    client.create_volume(
+        disk_id=test_disk_id,
+        block_size=4096,
+        blocks_count=DEVICE_SIZE//4096,
+        storage_media_kind=STORAGE_MEDIA_SSD_NONREPLICATED,
+        cloud_id="test")
+
+    socket = tempfile.NamedTemporaryFile()
+    client.start_endpoint(
+        unix_socket_path=socket.name,
+        disk_id=test_disk_id,
+        ipc_type=IPC_VHOST,
+        access_mode=VOLUME_ACCESS_READ_WRITE,
+        client_id=f"{socket.name}-id",
+        seq_number=0
+    )
+
+    nbs.kill()
+    # sleep time should not be less than InactiveClientsTimeout parameter
+    time.sleep(INACTIVE_CLIENTS_TIMEOUT + 1)
+    nbs.start()
+
+    client.stop_endpoint(
+        unix_socket_path=socket.name,
+        client_id=f"{socket.name}-id",
+        disk_id=test_disk_id,
+    )
+
+    another_socket = tempfile.NamedTemporaryFile()
+    client.start_endpoint(
+        unix_socket_path=another_socket.name,
+        disk_id=test_disk_id,
+        ipc_type=IPC_VHOST,
+        access_mode=VOLUME_ACCESS_READ_WRITE,
+        client_id=f"{another_socket.name}-id-1",
+        seq_number=0
+    )
+
+    client.stop_endpoint(
+        unix_socket_path=another_socket.name,
+        client_id=f"{another_socket.name}-id-1",
+        disk_id=test_disk_id,
+    )

--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -46,7 +46,6 @@ def apply_common_params_to_config(cfg):
     cfg.files["storage"].AllocationUnitNonReplicatedSSD = 1
     cfg.files["storage"].NonReplicatedVolumeDirectAcquireEnabled = True
     cfg.files["storage"].AcquireNonReplicatedDevices = True
-    cfg.files["storage"].InactiveClientsTimeout = INACTIVE_CLIENTS_TIMEOUT * 1000
 
     cfg.files["server"].ServerConfig.VhostEnabled = True
     cfg.files["server"].ServerConfig.VhostServerPath = yatest_common.binary_path(
@@ -442,8 +441,6 @@ def test_should_stop_not_restored_endpoint(nbs_with_dr,
     )
 
     nbs.kill()
-    # sleep time should not be less than InactiveClientsTimeout parameter
-    time.sleep(INACTIVE_CLIENTS_TIMEOUT + 1)
     nbs.start()
 
     client.stop_endpoint(

--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -3,6 +3,8 @@ import logging
 import os
 import tempfile
 
+from pathlib import Path
+
 import pytest
 import time
 
@@ -445,9 +447,15 @@ def test_should_stop_not_restored_endpoint(nbs_with_dr,
 
     client.stop_endpoint(
         unix_socket_path=socket.name,
+    )
+
+    client.stop_endpoint(
+        unix_socket_path=socket.name,
         client_id=f"{socket.name}-id",
         disk_id=test_disk_id,
     )
+
+    assert not Path(socket.name).exists()
 
     another_socket = tempfile.NamedTemporaryFile()
     client.start_endpoint(
@@ -464,3 +472,5 @@ def test_should_stop_not_restored_endpoint(nbs_with_dr,
         client_id=f"{another_socket.name}-id-1",
         disk_id=test_disk_id,
     )
+
+    assert not Path(another_socket.name).exists()

--- a/cloud/blockstore/tests/direct_device_acquire/ya.make
+++ b/cloud/blockstore/tests/direct_device_acquire/ya.make
@@ -8,6 +8,8 @@ DEPENDS(
     cloud/blockstore/apps/client
     cloud/blockstore/apps/disk_agent
     cloud/blockstore/apps/server
+    cloud/blockstore/tools/testing/fake-vhost-server
+    cloud/blockstore/vhost-server
     contrib/ydb/apps/ydbd
 )
 

--- a/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
+++ b/cloud/blockstore/tools/testing/chaos-monkey/monkey_test.go
@@ -404,6 +404,14 @@ func (n nbsService) DestroyVolumeLink(
 	panic("implement me")
 }
 
+func (n nbsService) RemoveVolumeClient(
+	ctx context.Context,
+	request *protos.TRemoveVolumeClientRequest,
+) (*protos.TRemoveVolumeClientResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type TestContext struct {


### PR DESCRIPTION
#1345 
keyring не песистентное хранилище, поэтому когда хост перезапускается из-за отключения питания, нбс поднимается и не находит эндпоинты в кейринге и соответственно ничего не ресторит. После приходит компьют и делает StopEndpoint, поскольку мы ничего не ресторили, этого эндпоинта у нас нет и мы отвечаем "hasn't been started yet".
После этого делаем KickEndpoint и на монтирование сперва отпраляем запрос на захват девайса, однако диск агент помнит что у него еще есть клиент, который не освободил девайс и отвечает ошибкой.

Компьют начнет передавать нам DiskId  и ClientId в StopEndpoint запросе, и если мы ничего не знаем об этом эндпоинте мы будет пытаться сделать RemoveClient и удаление эндпоинта