### PR TITLE
Better handling of mirror read errors

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -555,13 +555,14 @@ void TMirrorPartitionActor::ReadBlocks(
         blockRange,
         TMethod::Name);
 
-    bool tryToSplitRequest =
+    const bool shouldTryToSplitRequest =
         error.GetCode() == E_INVALID_STATE && !replicaIndex;
-    if (HasError(error) && !tryToSplitRequest) {
+    ProcessMirrorActorError(error);
+    if (HasError(error) && !shouldTryToSplitRequest) {
         NCloud::Reply(ctx, *ev, std::make_unique<TResponse>(std::move(error)));
         return;
     }
-    if (tryToSplitRequest) {
+    if (shouldTryToSplitRequest) {
         auto splitError = SplitReadBlocks<TMethod>(ev, ctx);
 
         if (HasError(splitError)) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_readblocks.cpp
@@ -57,6 +57,13 @@ void TMirrorPartitionResyncActor::ProcessReadRequestSyncPath(
         }
     }
 
+    if (replicas.empty()) {
+        // Something went critically wrong, mirror actor should be able to
+        // handle this.
+        ForwardRequestWithNondeliveryTracking(ctx, MirrorActorId, *ev);
+        return;
+    }
+
     ProcessReadRequestFastPath(ev, std::move(replicas), range, ctx);
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -555,7 +555,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                 TBlockRange64::MakeClosedInterval(5000, 5120));
             auto response = client.RecvReadBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_INVALID_STATE,
+                E_REJECTED,
                 response->GetStatus(),
                 response->GetErrorReason());
         }
@@ -650,7 +650,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                 )));
             auto response = client.RecvReadBlocksLocalResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_INVALID_STATE,
+                E_REJECTED,
                 response->GetStatus(),
                 response->GetErrorReason());
         }
@@ -929,7 +929,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         {
             client.SendReadBlocksRequest(range1, 4);
             auto response = client.RecvReadBlocksResponse();
-            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
             UNIT_ASSERT_STRING_CONTAINS(
                 response->GetErrorReason(),
                 "incorrect ReplicaIndex");
@@ -2379,7 +2379,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         {
             client.SendReadBlocksRequest(range, 0, 4);
             auto response = client.RecvReadBlocksResponse();
-            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
             UNIT_ASSERT_STRING_CONTAINS(
                 response->GetErrorReason(),
                 "has incorrect replica count");


### PR DESCRIPTION
1) Чиню краш в случае если у mirror диска все реплики нечитаемые, например они все fresh.
2) При этом такие состояния не должны прокидывать E_IO в пользователя. Обернул ошибки в `ProcessMirrorActorError()`