### PR TITLE
Add parameter to server config to configure vmpte flush threshold in the blockstore-vhost-server

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -222,13 +222,20 @@ message TServerConfig
     optional bool UseFakeRdmaClient = 120;
 
     // Enable Discard/ZeroBlocks features for vhost devices
-    optional bool VhostDiscardEnabled = 121;    
+    optional bool VhostDiscardEnabled = 121;
 
     // Maximum request size in bytes for ZeroBlocks.
     // Requests exceeding this size will be split into smaller sub-requests,
     // each with a size up to MaxZeroBlocksSubRequestSize.
     // Max value for MaxZeroBlocksSubRequestSize is 2 GiB
     optional uint32 MaxZeroBlocksSubRequestSize = 122;
+
+    // If set to a non-zero value, PTEs of the external vhost server backing
+    // the guest memory regions for blockdev are flushed (unmapped and mapped
+    // back) every N bytes processed by the backend. E.g. if this value is 4096,
+    // PTEs will be flushed after the guest reads/writes 8 512-byte blocks or
+    // 1 4KiB block.
+    optional uint64 VhostPteFlushByteThreshold = 123;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -429,15 +429,13 @@ void TBootstrapBase::Init()
                 && !Configs->Options->TemporaryServer)
         {
             vhostEndpointListener = CreateExternalVhostEndpointListener(
+                Configs->ServerConfig,
                 Logging,
                 ServerStats,
                 Executor,
-                Configs->ServerConfig->GetVhostServerPath(),
                 Configs->Options->SkipDeviceLocalityValidation
                     ? TString {}
                     : FQDNHostName(),
-                Configs->ServerConfig->GetSocketAccessMode(),
-                Configs->ServerConfig->GetVhostServerTimeoutAfterParentExit(),
                 RdmaClient && RdmaClient->IsAlignedDataEnabled(),
                 std::move(vhostEndpointListener));
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -4,10 +4,11 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/endpoints/public.h>
+#include <cloud/blockstore/libs/server/public.h>
 #include <cloud/blockstore/libs/vhost/public.h>
-#include <cloud/storage/core/libs/coroutine/public.h>
 
-#include <cloud/storage/core/protos/error.pb.h>
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/coroutine/public.h>
 
 #include <library/cpp/threading/future/fwd.h>
 
@@ -34,23 +35,20 @@ using TExternalEndpointFactory = std::function<IExternalEndpointPtr (
 ////////////////////////////////////////////////////////////////////////////////
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
+    TServerAppConfigPtr serverConfig,
     ILoggingServicePtr logging,
     IServerStatsPtr serverStats,
     TExecutorPtr executor,
-    TString binaryPath,
     TString localAgentId,
-    ui32 socketAccessMode,
-    TDuration vhostServerTimeoutAfterParentExit,
     bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener);
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
+    TServerAppConfigPtr serverConfig,
     ILoggingServicePtr logging,
     IServerStatsPtr serverStats,
     TExecutorPtr executor,
     TString localAgentId,
-    ui32 socketAccessMode,
-    TDuration vhostServerTimeoutAfterParentExit,
     bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory);

--- a/cloud/blockstore/libs/endpoints_vhost/ya.make
+++ b/cloud/blockstore/libs/endpoints_vhost/ya.make
@@ -11,8 +11,11 @@ PEERDIR(
     cloud/blockstore/libs/common
     cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/endpoints
+    cloud/blockstore/libs/server
     cloud/blockstore/libs/service
     cloud/blockstore/libs/vhost
+
+    cloud/storage/core/libs/common
 
     library/cpp/getopt/small
 )

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -106,7 +106,8 @@ constexpr TDuration Seconds(int s)
     xxx(VhostServerTimeoutAfterParentExit, TDuration,       Seconds(60)       )\
     xxx(ChecksumFlags,               NProto::TChecksumFlags, {}               )\
     xxx(VhostDiscardEnabled,         bool,                   false            )\
-    xxx(MaxZeroBlocksSubRequestSize, ui32,                   0                )
+    xxx(MaxZeroBlocksSubRequestSize, ui32,                   0                )\
+    xxx(VhostPteFlushByteThreshold,  ui64,                   0                )
 // BLOCKSTORE_SERVER_CONFIG
 
 #define BLOCKSTORE_SERVER_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -139,6 +139,7 @@ public:
     NProto::TChecksumFlags GetChecksumFlags() const;
     bool GetVhostDiscardEnabled() const;
     ui32 GetMaxZeroBlocksSubRequestSize() const;
+    ui64 GetVhostPteFlushByteThreshold() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -296,7 +296,8 @@ vhd_bdev_info TAioBackend::Init(const TOptions& options)
         .block_size = BlockSize,
         .num_queues = options.QueueCount,   // Max count of virtio queues
         .total_blocks = totalBytes / BlockSize,
-        .features = options.ReadOnly ? VHD_BDEV_F_READONLY : 0};
+        .features = options.ReadOnly ? VHD_BDEV_F_READONLY : 0,
+        .pte_flush_byte_threshold = options.PteFlushByteThreshold};
 }
 
 void TAioBackend::Start()

--- a/cloud/blockstore/vhost-server/backend_null.cpp
+++ b/cloud/blockstore/vhost-server/backend_null.cpp
@@ -57,7 +57,8 @@ vhd_bdev_info TNullBackend::Init(const TOptions& options)
         .block_size = BlockSize,
         .num_queues = options.QueueCount,   // Max count of virtio queues
         .total_blocks = totalBytes / BlockSize,
-        .features = options.ReadOnly ? VHD_BDEV_F_READONLY : 0};
+        .features = options.ReadOnly ? VHD_BDEV_F_READONLY : 0,
+        .pte_flush_byte_threshold = options.PteFlushByteThreshold};
 }
 
 void TNullBackend::Start()

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -252,7 +252,8 @@ vhd_bdev_info TRdmaBackend::Init(const TOptions& options)
         .block_size = BlockSize,
         .num_queues = options.QueueCount,   // Max count of virtio queues
         .total_blocks = totalBytes / BlockSize,
-        .features = ReadOnly ? VHD_BDEV_F_READONLY : 0};
+        .features = ReadOnly ? VHD_BDEV_F_READONLY : 0,
+        .pte_flush_byte_threshold = options.PteFlushByteThreshold};
 
 }
 

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -110,6 +110,10 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("INT")
         .StoreResult(&SocketAccessMode);
 
+    opts.AddLongOption("vmpte-flush-threshold", "Flush VmPTEs every threshold bytes")
+        .RequiredArgument("INT")
+        .StoreResult(&PteFlushByteThreshold);
+
     opts.AddLongOption('v', "verbose", "output level for diagnostics messages")
         .OptionalArgument("STR")
         .StoreResultDef(&VerboseLevel);

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -33,6 +33,7 @@ struct TOptions
     ui32 BatchSize = 1024;
     ui32 BlockSize = 512;
     ui32 QueueCount = 0;
+    ui64 PteFlushByteThreshold = 0;
     ui32 SocketAccessMode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
 
     TString LogType = "json";

--- a/cloud/blockstore/vhost-server/options_ut.cpp
+++ b/cloud/blockstore/vhost-server/options_ut.cpp
@@ -20,6 +20,7 @@ Y_UNIT_TEST_SUITE(TOptionsTest)
             "--device", "path-nvme:v3-1:1000000:0",
             "--device", "path-nvme:v3-2:2000042:1111111",
             "--device", "path-nvme:v3-3:3001000:0",
+            "--vmpte-flush-threshold", "12345678900",
             "--read-only"
         };
 
@@ -37,6 +38,7 @@ Y_UNIT_TEST_SUITE(TOptionsTest)
         UNIT_ASSERT(!options.NoSync);
         UNIT_ASSERT(!options.NoChmod);
         UNIT_ASSERT_VALUES_EQUAL(1024, options.BatchSize);
+        UNIT_ASSERT_VALUES_EQUAL(12345678900, options.PteFlushByteThreshold);
         UNIT_ASSERT_VALUES_EQUAL(3, options.QueueCount);
         UNIT_ASSERT_VALUES_EQUAL(3, options.Layout.size());
         UNIT_ASSERT_VALUES_EQUAL("path-nvme:v3-1", options.Layout[0].DevicePath);

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1037,6 +1037,113 @@ TEST_P(TServerTest, ShouldStatAllZeroesBlocks)
     }
 }
 
+TEST_P(TServerTest, ShouldReadAndWriteWithPteFlushEnabled)
+{
+    Options.PteFlushByteThreshold = 4096;
+    StartServer();
+
+    auto getFillChar = [](size_t block) -> ui8
+    {
+        const TString allowedChars{
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"};
+        return allowedChars[block % allowedChars.size()];
+    };
+    auto makePatten = [&](size_t startBlock) -> TString
+    {
+        TString result;
+        result.resize(RequestSize);
+        for (size_t i = 0; i < BlocksPerRequest; ++i) {
+            memset(
+                const_cast<char*>(result.data()) + BlockSize * i,
+                getFillChar(startBlock + i),
+                BlockSize);
+        }
+        return result;
+    };
+
+    // write data
+    size_t writesCount = 0;
+    {
+        std::span hdr = Hdr(Memory, {.type = VIRTIO_BLK_T_OUT});
+        std::span writeBuffer =
+            Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+        std::span status = Memory.Allocate(1);
+
+        for (ui64 i = 0; i <= TotalBlockCount - BlocksPerRequest; ++i) {
+            reinterpret_cast<virtio_blk_req_hdr*>(hdr.data())->sector =
+                i * SectorsPerBlock;
+            TString expectedData = makePatten(i);
+            memcpy(
+                writeBuffer.data(),
+                expectedData.data(),
+                expectedData.size());
+            auto writeOp =
+                Client.WriteAsync(QueueIndex, {hdr, writeBuffer}, {status});
+            EXPECT_EQ(status.size(), writeOp.GetValueSync());
+            EXPECT_EQ(VIRTIO_BLK_S_OK, status[0]);
+            ++writesCount;
+        }
+    }
+
+    // read data
+    size_t readsCount = 0;
+    {
+        std::span hdr = Hdr(Memory, {.type = VIRTIO_BLK_T_IN});
+        std::span readBuffer =
+            Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+        std::span status = Memory.Allocate(1);
+        for (ui64 i = 0; i <= TotalBlockCount - BlocksPerRequest; ++i) {
+            reinterpret_cast<virtio_blk_req_hdr*>(hdr.data())->sector =
+                i * SectorsPerBlock;
+            auto readOp =
+                Client.WriteAsync(QueueIndex, {hdr}, {readBuffer, status});
+            EXPECT_EQ(status.size() + readBuffer.size(), readOp.GetValueSync());
+            EXPECT_EQ(VIRTIO_BLK_S_OK, status[0]);
+
+            TString readData(readBuffer.data(), readBuffer.size());
+            EXPECT_EQ(makePatten(i), readData);
+            ++readsCount;
+        }
+    }
+
+    // validate storage
+    for (ui64 i = 0; i < TotalBlockCount; ++i) {
+        const TString expectedData(BlockSize, getFillChar(i));
+        const TString realData = LoadBlockAndDecrypt(i);
+        EXPECT_EQ(expectedData, realData);
+    }
+
+    // validate stats
+    const auto splittedReads = (BlocksPerRequest - 1) * (ChunkCount - 1);
+    const auto splittedWrites = (BlocksPerRequest - 1) * (ChunkCount - 1);
+    const auto expectedTotalRequestCount =
+        writesCount + readsCount + splittedReads + splittedWrites;
+    const auto completeStats = GetStats(expectedTotalRequestCount);
+    const auto& stats = completeStats.SimpleStats;
+
+    EXPECT_EQ(0u, stats.CompFailed);
+    EXPECT_EQ(0u, stats.SubFailed);
+    EXPECT_EQ(expectedTotalRequestCount, stats.Completed);
+    EXPECT_EQ(expectedTotalRequestCount, stats.Dequeued);
+    EXPECT_EQ(expectedTotalRequestCount, stats.Submitted);
+    {
+        const auto& read = stats.Requests[0];
+        EXPECT_EQ(readsCount, read.Count);
+        EXPECT_EQ(readsCount * RequestSize, read.Bytes);
+        EXPECT_EQ(0u, read.Errors);
+        EXPECT_EQ(Unaligned ? readsCount - splittedReads : 0, read.Unaligned);
+    }
+    {
+        const auto& write = stats.Requests[1];
+        EXPECT_EQ(writesCount, write.Count);
+        EXPECT_EQ(writesCount * RequestSize, write.Bytes);
+        EXPECT_EQ(0u, write.Errors);
+        EXPECT_EQ(
+            Unaligned ? writesCount - splittedWrites : 0,
+            write.Unaligned);
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ,
     TServerTest,


### PR DESCRIPTION
#3743

Столкнулись с проблемой повышенного потребления памяти процессами blockstore-vhost-server из-за VmPTE. Это происходит из-за маппинга памяти гостя в наш процесс. При этом чем больше дисков у ВМки и чем она жирнее, тем хуже проблема. 

В качестве припарки я добавляю в конфиг параметр, который позводит включить сброс маппингов каждые N байт пропущенных через диск. 