### PR TITLE
[Blockstore, Filestore] Treat --node-broker argument as host if a port is provided by a separate argument

### DIFF
--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -428,13 +428,18 @@ TRegisterDynamicNodeResult RegisterDynamicNode(
     const auto& hostName = FQDNHostName();
     const auto& hostAddress = GetNetworkAddress(hostName);
 
+    auto port = options.UseNodeBrokerSsl && options.NodeBrokerSecurePort
+        ? options.NodeBrokerSecurePort
+        : options.NodeBrokerPort;
+
     TVector<TString> addrs;
     if (options.NodeBrokerAddress) {
-        addrs.push_back(options.NodeBrokerAddress);
+        if (port != 0 && !options.NodeBrokerAddress.Contains(':')) {
+            addrs.push_back(Join(":", options.NodeBrokerAddress, port));
+        } else {
+            addrs.push_back(options.NodeBrokerAddress);
+        }
     } else {
-        auto port = options.UseNodeBrokerSsl && options.NodeBrokerSecurePort
-            ? options.NodeBrokerSecurePort
-            : options.NodeBrokerPort;
         if (port) {
             for (const auto& node: nsConfig.GetNode()) {
                 addrs.emplace_back(Join(":", node.GetHost(), port));


### PR DESCRIPTION
For secure node registration, a different port provided by `--node-broker-secure-port` is used.

Current logic: both host and port are provided by `--node-broker` in `host:port` format, and `--node-broker-secure-port` is ignored. This makes seamless switch using CMS config impossible.

New logic: if a port number is provided by separate arguments (`--node-broker-port` and `--node-broker-secure-port`) and is not included into `--node-broker` value, the value of `--node-broker` is treated as `host`.