### PR TITLE
[Filestore] issue-3617: trust guest kernel to validate file permissions in local filestore

### DIFF
--- a/cloud/filestore/libs/service/error.cpp
+++ b/cloud/filestore/libs/service/error.cpp
@@ -161,14 +161,6 @@ NProto::TError ErrorNoSpaceLeft()
             << "no space left");
 }
 
-NProto::TError ErrorFailedToApplyCredentials(const TString& path)
-{
-    return MakeError(
-        E_FS_PERM,
-        TStringBuilder()
-            << "applying credentials failed for path " << path.Quote());
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 NProto::TError ErrorInvalidArgument()

--- a/cloud/filestore/libs/service/error.h
+++ b/cloud/filestore/libs/service/error.h
@@ -22,7 +22,6 @@ NProto::TError ErrorInvalidNodeType(ui64 nodeId);
 NProto::TError ErrorInvalidParent(ui64 nodeId);
 NProto::TError ErrorInvalidTarget(ui64 nodeId, const TString& name = {});
 NProto::TError ErrorAlreadyExists(const TString& path);
-NProto::TError ErrorFailedToApplyCredentials(const TString& path);
 
 //
 // Directories.

--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -41,7 +41,8 @@ NProto::TCreateHandleResponse TLocalFileSystem::CreateHandle(
 
     NLowLevel::UnixCredentialsGuard credGuard(
         request.GetUid(),
-        request.GetGid());
+        request.GetGid(),
+        Config->GetGuestOnlyPermissionsCheckEnabled());
     TFileHandle handle;
     TFileStat stat;
     ui64 nodeId;

--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -41,28 +41,14 @@ NProto::TCreateHandleResponse TLocalFileSystem::CreateHandle(
 
     NLowLevel::UnixCredentialsGuard credGuard(
         request.GetUid(),
-        request.GetGid(),
-        Config->GetGuestOnlyPermissionsCheckEnabled());
-    NLowLevel::TOpenOrCreateResult openResult;
+        request.GetGid());
+    TFileHandle handle;
     TFileStat stat;
     ui64 nodeId;
     if (const auto& pathname = request.GetName()) {
-        if (Config->GetGuestOnlyPermissionsCheckEnabled()) {
-            openResult = node->OpenOrCreateHandle(pathname, flags, mode);
-        } else {
-            openResult.Handle = node->OpenHandle(pathname, flags, mode);
-        }
+        handle = node->OpenHandle(pathname, flags, mode);
 
         auto newnode = TIndexNode::Create(*node, pathname);
-
-        if (openResult.WasCreated) {
-            if (!credGuard.TryApplyCredentials(newnode->GetNodeFd())) {
-                node->Unlink(pathname, false);
-                return TErrorResponse(
-                    ErrorFailedToApplyCredentials(pathname));
-            }
-        }
-
         stat = newnode->Stat();
         nodeId = newnode->GetNodeId();
 
@@ -75,7 +61,7 @@ NProto::TCreateHandleResponse TLocalFileSystem::CreateHandle(
             return TErrorResponse(ErrorNoSpaceLeft());
         }
     } else {
-        openResult.Handle = node->OpenHandle(flags);
+        handle = node->OpenHandle(flags);
         stat = node->Stat();
         nodeId = node->GetNodeId();
     }
@@ -84,7 +70,7 @@ NProto::TCreateHandleResponse TLocalFileSystem::CreateHandle(
     flags = flags & ~(O_CREAT | O_EXCL | O_TRUNC);
 
     auto [handleId, error] =
-        session->InsertHandle(std::move(openResult.Handle), nodeId, flags);
+        session->InsertHandle(std::move(handle), nodeId, flags);
     if (HasError(error)) {
         ReportLocalFsMaxSessionFileHandlesInUse();
         return TErrorResponse(error);

--- a/cloud/filestore/libs/service_local/fs_node.cpp
+++ b/cloud/filestore/libs/service_local/fs_node.cpp
@@ -51,8 +51,7 @@ NProto::TCreateNodeResponse TLocalFileSystem::CreateNode(
 
     NLowLevel::UnixCredentialsGuard credGuard(
         request.GetUid(),
-        request.GetGid(),
-        Config->GetGuestOnlyPermissionsCheckEnabled());
+        request.GetGid());
     TIndexNodePtr target;
     if (request.HasDirectory()) {
         int mode = request.GetDirectory().GetMode();
@@ -86,15 +85,6 @@ NProto::TCreateNodeResponse TLocalFileSystem::CreateNode(
         target = parent->CreateSocket(request.GetName(), mode);
     } else {
         return TErrorResponse(ErrorInvalidArgument());
-    }
-
-    if (!request.HasLink()) {
-        // For hard link no need to apply credentials since ownership is shared
-        // between the links
-        if (!credGuard.TryApplyCredentials(target->GetNodeFd())) {
-            parent->Unlink(request.GetName(), request.HasDirectory());
-            return TErrorResponse(ErrorFailedToApplyCredentials(request.GetName()));
-        }
     }
 
     auto stat = target->Stat();

--- a/cloud/filestore/libs/service_local/fs_node.cpp
+++ b/cloud/filestore/libs/service_local/fs_node.cpp
@@ -51,7 +51,8 @@ NProto::TCreateNodeResponse TLocalFileSystem::CreateNode(
 
     NLowLevel::UnixCredentialsGuard credGuard(
         request.GetUid(),
-        request.GetGid());
+        request.GetGid(),
+        Config->GetGuestOnlyPermissionsCheckEnabled());
     TIndexNodePtr target;
     if (request.HasDirectory()) {
         int mode = request.GetDirectory().GetMode();

--- a/cloud/filestore/libs/service_local/index.cpp
+++ b/cloud/filestore/libs/service_local/index.cpp
@@ -132,12 +132,6 @@ TFileHandle TIndexNode::OpenHandle(const TString& name, int flags, int mode)
     return NLowLevel::OpenAt(NodeFd, name.data(), flags, mode);
 }
 
-NLowLevel::TOpenOrCreateResult
-TIndexNode::OpenOrCreateHandle(const TString& name, int flags, int mode)
-{
-    return NLowLevel::OpenOrCreateAt(NodeFd, name.data(), flags, mode);
-}
-
 void TIndexNode::Access(int mode)
 {
     return NLowLevel::Access(NodeFd, mode);

--- a/cloud/filestore/libs/service_local/index.h
+++ b/cloud/filestore/libs/service_local/index.h
@@ -56,11 +56,6 @@ public:
         return NodeId;
     }
 
-    [[nodiscard]] const TFileHandle& GetNodeFd() const
-    {
-        return NodeFd;
-    }
-
     TIndexNodePtr CreateFile(const TString& name, int flags);
     TIndexNodePtr CreateDirectory(const TString& name, int flags);
     TIndexNodePtr CreateLink(const TIndexNode& parent, const TString& name);
@@ -86,8 +81,6 @@ public:
 
     TFileHandle OpenHandle(int flags);
     TFileHandle OpenHandle(const TString& name, int flags, int mode);
-    NLowLevel::TOpenOrCreateResult
-    OpenOrCreateHandle(const TString& name, int flags, int mode);
 
     //
     // Attrs

--- a/cloud/filestore/libs/service_local/lowlevel.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel.cpp
@@ -151,45 +151,6 @@ TFileHandle OpenAt(
     return fd;
 }
 
-TOpenOrCreateResult OpenOrCreateAt(
-    const TFileHandle& handle,
-    const TString& name,
-    int flags,
-    int mode)
-{
-    if ((flags & O_CREAT) && (flags & O_EXCL)) {
-        int fd = openat(Fd(handle), name.data(), flags, mode);
-        Y_ENSURE_EX(fd != -1, TServiceError(GetSystemErrorCode())
-            << "failed to create " << name.Quote()
-            << ": " << LastSystemErrorText());
-        return {fd, true /* new file was created */};
-    }
-
-    if (flags & O_CREAT) {
-        // try to create file exclusively and if the file already exist, fallback
-        // to trying to open without O_CREATE
-        flags |= O_EXCL;
-        int fd = openat(Fd(handle), name.data(), flags, mode);
-        if (fd != -1) {
-            return {fd, true /* new file was created */};
-        }
-
-        auto errorCode = GetSystemErrorCode();
-        Y_ENSURE_EX(errorCode == E_FS_EXIST, TServiceError(errorCode)
-            << "failed to open " << name.Quote()
-            << ": " << LastSystemErrorText());
-
-        flags &= ~O_EXCL;
-    }
-
-    int fd = openat(Fd(handle), name.data(), flags, mode);
-    Y_ENSURE_EX(fd != -1, TServiceError(GetSystemErrorCode())
-        << "failed to open " << name.Quote()
-        << ": " << LastSystemErrorText());
-
-    return {fd, false /* file was opened */};
-}
-
 void MkDirAt(const TFileHandle& handle, const TString& name, int mode)
 {
     int res = mkdirat(Fd(handle), name.data(), mode);
@@ -666,13 +627,7 @@ bool Flock(const TFileHandle& handle, int operation)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-UnixCredentialsGuard::UnixCredentialsGuard(
-        uid_t UserUid,
-        gid_t UserGid,
-        bool trustUserCredentials)
-    : UserUid(UserUid)
-    , UserGid(UserGid)
-    , TrustUserCredentials(trustUserCredentials)
+UnixCredentialsGuard::UnixCredentialsGuard(uid_t uid, gid_t gid)
 {
     OriginalUid = geteuid();
     if (OriginalUid != 0) {
@@ -680,48 +635,27 @@ UnixCredentialsGuard::UnixCredentialsGuard(
         return;
     }
 
-    if (TrustUserCredentials) {
-        // Permission check for fuse operation is performed in guest kernel
-        // https://github.com/ydb-platform/nbs/blob/2ca9a5ee2b3d77fbeb9ce2852272001d137c2178/contrib/libs/virtiofsd/fuse_lowlevel.h#L166
-        // We don't try to change euid/egid, but the caller needs to invoke
-        // `ApplyCredentials` to set permissions for newly created nodes
-        return;
-    }
-
     OriginalGid = getegid();
 
-    if (UserUid == OriginalUid && UserGid == OriginalGid) {
+    if (uid == OriginalUid && gid == OriginalGid) {
         return;
     }
 
     // use syscall directly to change uid/gid per thread instead of glibc
     // version of setresgid/setresuid since they will change uid/gid for all
     // threads
-    int ret = syscall(SYS_setresgid, -1, UserGid, -1);
+    int ret = syscall(SYS_setresgid, -1, gid, -1);
     if (ret == -1) {
         return;
     }
 
-    ret = syscall(SYS_setresuid, -1, UserUid, -1);
+    ret = syscall(SYS_setresuid, -1, uid, -1);
     if (ret == -1) {
         syscall(SYS_setresgid, -1, OriginalGid, -1);
         return;
     }
 
     IsRestoreNeeded = true;
-}
-
-bool UnixCredentialsGuard::TryApplyCredentials(const TFileHandle& handle)
-{
-    if (!TrustUserCredentials || OriginalUid != 0) {
-        // need to be root to freely apply permissions
-        return true;
-    }
-
-    char path[64] = {0};
-    sprintf(path, "/proc/self/fd/%i", Fd(handle));
-
-    return chown(path, UserUid, UserGid) == 0;
 }
 
 UnixCredentialsGuard::~UnixCredentialsGuard()

--- a/cloud/filestore/libs/service_local/lowlevel.h
+++ b/cloud/filestore/libs/service_local/lowlevel.h
@@ -20,7 +20,7 @@ private:
     bool IsRestoreNeeded = false;
 
 public:
-    UnixCredentialsGuard(uid_t uid, gid_t gid);
+    UnixCredentialsGuard(uid_t uid, gid_t gid, bool trustUserCredentials);
     ~UnixCredentialsGuard();
 };
 

--- a/cloud/filestore/libs/service_local/lowlevel.h
+++ b/cloud/filestore/libs/service_local/lowlevel.h
@@ -17,14 +17,10 @@ class UnixCredentialsGuard {
 private:
     uid_t OriginalUid = -1;
     gid_t OriginalGid = -1;
-    uid_t UserUid = -1;
-    gid_t UserGid = -1;
     bool IsRestoreNeeded = false;
-    bool TrustUserCredentials = false;
 
 public:
-    UnixCredentialsGuard(uid_t uid, gid_t gid, bool trustUserCredentials);
-    bool TryApplyCredentials(const TFileHandle& handle);
+    UnixCredentialsGuard(uid_t uid, gid_t gid);
     ~UnixCredentialsGuard();
 };
 
@@ -97,14 +93,6 @@ struct TFileSystemStat
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TOpenOrCreateResult
-{
-    TFileHandle Handle;
-    bool WasCreated = false;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 using TDirEntry = std::pair<TString, TFileStat>;
 
 struct TListDirResult
@@ -118,11 +106,6 @@ struct TListDirResult
 TFileHandle Open(const TString& path, int flags, int mode);
 TFileHandle Open(const TFileHandle& handle, int flags, int mode);
 TFileHandle OpenAt(
-    const TFileHandle& handle,
-    const TString& name,
-    int flags,
-    int mode);
-TOpenOrCreateResult OpenOrCreateAt(
     const TFileHandle& handle,
     const TString& name,
     int flags,

--- a/cloud/filestore/libs/service_local/lowlevel_ut.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel_ut.cpp
@@ -11,54 +11,6 @@ namespace NCloud::NFileStore {
 
 Y_UNIT_TEST_SUITE(TLowlevelTest)
 {
-    Y_UNIT_TEST(ShouldOpenOrCreateFile)
-    {
-        const TTempDir TempDir;
-        auto node = NLowLevel::Open(TempDir.Name(), O_PATH, 0);
-
-        // WasCreated should be true or false based on whether file already
-        // exist or not
-        auto res =
-            NLowLevel::OpenOrCreateAt(node, "1.txt", O_CREAT | O_WRONLY, 0755);
-        UNIT_ASSERT(res.WasCreated);
-
-        TString expectedData = "abdef";
-        res.Handle.Write(
-            const_cast<char*>(expectedData.c_str()),
-            expectedData.size());
-
-        res =
-            NLowLevel::OpenOrCreateAt(node, "1.txt", O_CREAT | O_RDONLY, 0755);
-        UNIT_ASSERT(!res.WasCreated);
-        res.Handle.Flush();
-
-        char buf[256] = {};
-        UNIT_ASSERT_EQUAL(
-            static_cast<i32>(expectedData.size()),
-            res.Handle.Read(buf, expectedData.size()));
-
-        // O_EXCL should still behave properly
-        res = NLowLevel::OpenOrCreateAt(
-            node,
-            "2.txt",
-            O_CREAT | O_EXCL | O_WRONLY,
-            0755);
-        UNIT_ASSERT(res.WasCreated);
-
-        UNIT_ASSERT_EXCEPTION_CONTAINS(
-            NLowLevel::OpenOrCreateAt(
-                node,
-                "2.txt",
-                O_CREAT | O_EXCL | O_WRONLY,
-                0755),
-            yexception,
-            "File exists");
-
-        // Just open existing file also works
-        res = NLowLevel::OpenOrCreateAt(node, "2.txt", O_WRONLY, 0755);
-        UNIT_ASSERT(!res.WasCreated);
-    }
-
     Y_UNIT_TEST(ShouldDoIterativeListDir)
     {
         const TTempDir TempDir;

--- a/cloud/filestore/libs/service_local/ya.make
+++ b/cloud/filestore/libs/service_local/ya.make
@@ -16,6 +16,10 @@ SRCS(
 )
 
 IF (OS_LINUX)
+    PEERDIR(
+        contrib/libs/libcap
+    )
+
     SRCS(
         lowlevel.cpp
     )


### PR DESCRIPTION
#3617

After reverting previous not atomic implementation (create + chown). Use CAP_DAC_OVERRIDE to skip permission checks on the backend fs. The file/directory are going to be created atomically with proper uid/gid since with change euid/egid before executing the creation. But the backend won't complain on permissions since we restore the CAP_DAC_OVERRIDE capability