### PR TITLE
[Filestore] stabilize and unmute `TStorageServiceShardingTest.ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShardsWithShardIdSelectionInLeader` test

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,3 +1,2 @@
 cloud/filestore/tests/fio_index/mount-kikimr-test *
 cloud/filestore/tests/fio_index/mount-local-test *
-cloud/filestore/libs/storage/service/ut TStorageServiceShardingTest.ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShardsWithShardIdSelectionInLeader

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -4463,6 +4463,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // triggering background shard stats collection
 
         env.GetRuntime().AdvanceCurrentTime(TDuration::Seconds(15));
+        env.GetRuntime().DispatchEvents(
+            TDispatchOptions{
+                .FinalEvents = {TDispatchOptions::TFinalEventCondition(
+                    TEvIndexTablet::EvGetStorageStatsResponse,
+                    2)}});
 
         {
             using TRequest = TEvIndexTabletPrivate::TEvUpdateCounters;


### PR DESCRIPTION
Advancing time was not enough in this test. Also explicitly waiting for the internal events was necessary