### PR TITLE
[Blockstore] request from remote pipe should not deactivate local pipe

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -211,6 +211,15 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
 {
     // Don't check if there is not a single pipe.
     if (!Pipes.empty()) {
+        if (IsLocalPipeActive()) {
+            // When the local pipe is ACTIVE response with retriable error
+            // E_REJECTED because the local pipe may disconnect and then the
+            // request from remote pipe can be executed later.
+            return MakeError(
+                E_REJECTED,
+                TStringBuilder() << "Local mounter is active");
+        }
+
         TPipeInfo* pipe = Pipes.FindPtr(serverId);
         if (!pipe || pipe->State == EPipeState::DEACTIVATED) {
             return MakeError(

--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -11,46 +11,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
 
-namespace {
-
 ////////////////////////////////////////////////////////////////////////////////
-
-NProto::EVolumeMountMode AdvanceMountMode(
-    NProto::EVolumeMountMode curMode,
-    NProto::EVolumeMountMode newMode)
-{
-    switch (curMode) {
-        case NProto::VOLUME_MOUNT_REMOTE: {
-            if (newMode == NProto::VOLUME_MOUNT_LOCAL) {
-                curMode = NProto::VOLUME_MOUNT_LOCAL;
-            }
-        }
-        case NProto::VOLUME_MOUNT_LOCAL: {
-            break;
-        }
-        default: {
-            Y_ABORT_UNLESS(0);
-        }
-    }
-    return curMode;
-}
-
-}   // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
-void TVolumeClientState::UpdateClientInfo()
-{
-    NProto::EVolumeMountMode mountMode = NProto::VOLUME_MOUNT_REMOTE;
-
-    for (const auto& pipe: Pipes) {
-        if (pipe.second.State != TVolumeClientState::EPipeState::DEACTIVATED) {
-            mountMode = AdvanceMountMode(mountMode, pipe.second.MountMode);
-        }
-    }
-
-    VolumeClientInfo.SetVolumeMountMode(mountMode);
-}
 
 void TVolumeClientState::SetLastActivityTimestamp(TInstant ts)
 {
@@ -64,18 +25,16 @@ void TVolumeClientState::SetDisconnectTimestamp(TInstant ts)
 
 bool TVolumeClientState::IsPreempted(ui64 hostNodeId) const
 {
-    for (const auto& pipe: Pipes) {
-        if (pipe.second.State == TVolumeClientState::EPipeState::DEACTIVATED
-            && pipe.second.MountMode == NProto::VOLUME_MOUNT_LOCAL
-            && hostNodeId != pipe.second.SenderNodeId)
+    return AnyOf(
+        Pipes,
+        [&](const auto& pipe)
         {
-            return true;
-        }
-    }
-    return false;
+            return pipe.second.State ==
+                       TVolumeClientState::EPipeState::DEACTIVATED &&
+                   pipe.second.MountMode == NProto::VOLUME_MOUNT_LOCAL &&
+                   hostNodeId != pipe.second.SenderNodeId;
+        });
 }
-
-////////////////////////////////////////////////////////////////////////////////
 
 void TVolumeClientState::RemovePipe(
     NActors::TActorId serverId,
@@ -83,15 +42,11 @@ void TVolumeClientState::RemovePipe(
 {
     if (!serverId) {
         Pipes.clear();
-        LocalPipeInfo = Pipes.end();
-    } else if (auto it = Pipes.find(serverId); it != Pipes.end()) {
-        if (LocalPipeInfo == it) {
-            LocalPipeInfo = Pipes.end();
-        }
-        Pipes.erase(it);
+    } else {
+        Pipes.erase(serverId);
     }
 
-    UpdateClientInfo();
+    UpdateState();
 
     if (!AnyPipeAlive() && ts) {
         VolumeClientInfo.SetDisconnectTimestamp(ts.MicroSeconds());
@@ -106,56 +61,54 @@ TAddPipeResult TVolumeClientState::AddPipe(
     ui32 mountFlags)
 {
     VolumeClientInfo.SetDisconnectTimestamp(0);
-    auto it = Pipes.find(serverId);
 
-    if (it == Pipes.end()) {
+    TPipeInfo* pipe = Pipes.FindPtr(serverId);
+
+    if (!pipe) {
         Pipes.emplace(
             serverId,
             TPipeInfo{
-                mountMode,
-                EPipeState::WAIT_START,
-                senderNodeId});
+                .MountMode = mountMode,
+                .State = EPipeState::WAIT_START,
+                .SenderNodeId = senderNodeId});
 
         VolumeClientInfo.SetVolumeAccessMode(accessMode);
         VolumeClientInfo.SetMountFlags(mountFlags);
 
-        UpdateClientInfo();
+        UpdateState();
 
-        return true;
-    } else {
-        if (it->second.State == EPipeState::DEACTIVATED) {
-            return TAddPipeResult(MakeError(
-                E_REJECTED,
-                "Pipe is already deactivated"));
-        }
-
-        auto oldMountMode = it->second.MountMode;
-        auto oldAccessMode = VolumeClientInfo.GetVolumeAccessMode();
-        ui32 oldMountFlags = VolumeClientInfo.GetMountFlags();
-        it->second =
-            TPipeInfo{mountMode, it->second.State, senderNodeId};
-
-        VolumeClientInfo.SetVolumeAccessMode(accessMode);
-        VolumeClientInfo.SetMountFlags(mountFlags);
-
-        UpdateClientInfo();
-
-        bool isNew = (oldMountMode != mountMode
-            || oldAccessMode != accessMode
-            || oldMountFlags != mountFlags);
-
-        return isNew;
+        return TAddPipeResult(true);
     }
+
+    if (pipe->State == EPipeState::DEACTIVATED) {
+        return TAddPipeResult(
+            MakeError(E_REJECTED, "Pipe is already deactivated"));
+    }
+
+    const bool isNew = pipe->MountMode != mountMode ||
+                       VolumeClientInfo.GetVolumeAccessMode() != accessMode ||
+                       VolumeClientInfo.GetMountFlags() != mountFlags;
+
+    pipe->MountMode = mountMode;
+    pipe->SenderNodeId = senderNodeId;
+
+    VolumeClientInfo.SetVolumeAccessMode(accessMode);
+    VolumeClientInfo.SetMountFlags(mountFlags);
+
+    UpdateState();
+
+    return TAddPipeResult(isNew);
 }
 
 bool TVolumeClientState::AnyPipeAlive() const
 {
-    for (const auto& p: Pipes) {
-        if (p.second.State != TVolumeClientState::EPipeState::DEACTIVATED) {
-            return true;
-        }
-    }
-    return false;
+    return AnyOf(
+        Pipes,
+        [&](const auto& p)
+        {
+            return p.second.State !=
+                   TVolumeClientState::EPipeState::DEACTIVATED;
+        });
 }
 
 const TVolumeClientState::TPipes& TVolumeClientState::GetPipes() const
@@ -172,36 +125,74 @@ std::optional<TVolumeClientState::TPipeInfo> TVolumeClientState::GetPipeInfo(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TVolumeClientState::ActivatePipe(
-    TVolumeClientState::TPipes::iterator active,
-    bool isLocal)
+bool TVolumeClientState::IsLocalPipeActive() const
 {
-    Y_ABORT_UNLESS(active != Pipes.end());
-
-    for (auto it = Pipes.begin(); it != Pipes.end(); ++it) {
-        if (it != active && it->second.State == EPipeState::ACTIVE) {
-            it->second.State = EPipeState::DEACTIVATED;
-        }
-    }
-
-    UpdateClientInfo();
-
-    active->second.State = EPipeState::ACTIVE;
-    LocalPipeInfo = isLocal ? active : Pipes.end();
+    return ActivePipe && ActivePipe->IsLocal;
 }
 
-NProto::TError TVolumeClientState::GetWriteError(
-    NProto::EVolumeAccessMode accessMode,
+void TVolumeClientState::UpdateState()
+{
+    // Update ActivePipe
+    const auto it = FindIf(
+        Pipes,
+        [](const auto& p)
+        { return p.second.State == TVolumeClientState::EPipeState::ACTIVE; });
+    ActivePipe = it == Pipes.end() ? nullptr : &it->second;
+
+    // Update VolumeClientInfo
+    bool hasAliveLocalPipe = AnyOf(
+        Pipes,
+        [](const auto& p)
+        {
+            return p.second.State !=
+                       TVolumeClientState::EPipeState::DEACTIVATED &&
+                   p.second.MountMode == NProto::VOLUME_MOUNT_LOCAL;
+        });
+    VolumeClientInfo.SetVolumeMountMode(
+        hasAliveLocalPipe ? NProto::VOLUME_MOUNT_LOCAL
+                          : NProto::VOLUME_MOUNT_REMOTE);
+}
+
+void TVolumeClientState::ActivatePipe(TPipeInfo* pipe, bool isLocal)
+{
+    Y_DEBUG_ABORT_UNLESS(pipe->State == EPipeState::WAIT_START);
+
+    if (ActivePipe) {
+        ActivePipe->State = EPipeState::DEACTIVATED;
+    }
+
+    pipe->State = EPipeState::ACTIVE;
+    pipe->IsLocal = isLocal;
+
+    UpdateState();
+}
+
+bool TVolumeClientState::CanWrite() const
+{
+    const auto accessMode = VolumeClientInfo.GetVolumeAccessMode();
+    const auto mountFlags = VolumeClientInfo.GetMountFlags();
+    return IsReadWriteMode(accessMode) ||
+           HasProtoFlag(mountFlags, NProto::MF_FORCE_WRITE);
+}
+
+NProto::TError TVolumeClientState::CheckWritePermission(
+    bool isWrite,
     const TString& methodName,
     const TString& diskId) const
 {
+    if (!isWrite || CanWrite()) {
+        return MakeError(S_OK);
+    }
+
     ui32 flags = 0;
     ui32 code = E_ARGUMENT;
+    const auto accessMode = VolumeClientInfo.GetVolumeAccessMode();
     if (accessMode == NProto::VOLUME_ACCESS_USER_READ_ONLY) {
         SetProtoFlag(flags, NProto::EF_SILENT);
         // for legacy clients
         code = E_IO_SILENT;
     }
+
     // Keep in sync with TAlignedDeviceHandler::ReportCriticalError()
     return MakeError(
         code,
@@ -218,33 +209,20 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
     const TString& methodName,
     const TString& diskId)
 {
-    auto accessMode = VolumeClientInfo.GetVolumeAccessMode();
-    auto mountFlags = VolumeClientInfo.GetMountFlags();
-    if (Pipes.size()) {
-        bool checkOk = false;
-        auto it = Pipes.find(serverId);
-        if (it != Pipes.end() && it->second.State != EPipeState::DEACTIVATED) {
-            if (it->second.State == EPipeState::WAIT_START) {
-                ActivatePipe(it, false);
-            }
-            checkOk = true;
-        }
-
-        if (!checkOk) {
+    // Don't check if there is not a single pipe.
+    if (!Pipes.empty()) {
+        TPipeInfo* pipe = Pipes.FindPtr(serverId);
+        if (!pipe || pipe->State == EPipeState::DEACTIVATED) {
             return MakeError(
                 E_BS_INVALID_SESSION,
                 TStringBuilder() << "No mounter found");
         }
+        if (ActivePipe != pipe) {
+            ActivatePipe(pipe, false);
+        }
     }
 
-    if (isWrite
-            && !IsReadWriteMode(accessMode)
-            && !HasProtoFlag(mountFlags, NProto::MF_FORCE_WRITE))
-    {
-        return GetWriteError(accessMode, methodName, diskId);
-    }
-
-    return {};
+    return CheckWritePermission(isWrite, methodName, diskId);
 }
 
 NProto::TError TVolumeClientState::CheckLocalRequest(
@@ -253,44 +231,28 @@ NProto::TError TVolumeClientState::CheckLocalRequest(
     const TString& methodName,
     const TString& diskId)
 {
-    auto accessMode = VolumeClientInfo.GetVolumeAccessMode();
-    auto mountFlags = VolumeClientInfo.GetMountFlags();
-    bool checkOk = false;
-    if (LocalPipeInfo == Pipes.end()) {
-        if (Pipes.size()) {
-            auto it = std::find_if(
-                Pipes.begin(),
-                Pipes.end(),
-                [&] (const auto& p) {
-                    return p.second.SenderNodeId == nodeId
-                        && p.second.State != EPipeState::DEACTIVATED;
-                });
+    // Don't check if there is not a single pipe or if the local pipe is already
+    // active.
+    if (!Pipes.empty() && !IsLocalPipeActive()) {
+        // Find alive local pipe to activate.
+        const auto it = FindIf(
+            Pipes,
+            [&](const auto& p)
+            {
+                return p.second.SenderNodeId == nodeId &&
+                       p.second.State != EPipeState::DEACTIVATED;
+            });
 
-            if (it != Pipes.end()) {
-                if (it->second.State == EPipeState::WAIT_START) {
-                    ActivatePipe(it, true);
-                } else {
-                    LocalPipeInfo = it;
-                }
-
-                checkOk = true;
-            }
-            if (!checkOk) {
-                return MakeError(
-                    E_BS_INVALID_SESSION,
-                    TStringBuilder() << "No local mounter found");
-            }
+        if (it == Pipes.end()) {
+            return MakeError(
+                E_BS_INVALID_SESSION,
+                TStringBuilder() << "No local mounter found");
         }
+
+        ActivatePipe(&it->second, true);
     }
 
-    if (isWrite
-            && !IsReadWriteMode(accessMode)
-            && !HasProtoFlag(mountFlags, NProto::MF_FORCE_WRITE))
-    {
-        return GetWriteError(accessMode, methodName, diskId);
-    }
-
-    return {};
+    return CheckWritePermission(isWrite, methodName, diskId);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -211,6 +211,12 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
 {
     // Don't check if there is not a single pipe.
     if (!Pipes.empty()) {
+        TPipeInfo* pipe = Pipes.FindPtr(serverId);
+        if (!pipe || pipe->State == EPipeState::DEACTIVATED) {
+            return MakeError(
+                E_BS_INVALID_SESSION,
+                TStringBuilder() << "No mounter found");
+        }
         if (IsLocalPipeActive()) {
             // When the local pipe is ACTIVE response with retriable error
             // E_REJECTED because the local pipe may disconnect and then the
@@ -218,13 +224,6 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
             return MakeError(
                 E_REJECTED,
                 TStringBuilder() << "Local mounter is active");
-        }
-
-        TPipeInfo* pipe = Pipes.FindPtr(serverId);
-        if (!pipe || pipe->State == EPipeState::DEACTIVATED) {
-            return MakeError(
-                E_BS_INVALID_SESSION,
-                TStringBuilder() << "No mounter found");
         }
         if (ActivePipe != pipe) {
             ActivatePipe(pipe, false);

--- a/cloud/blockstore/libs/storage/volume/model/client_state.h
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.h
@@ -72,6 +72,8 @@ private:
     TPipeInfo* ActivePipe = nullptr;
 
 public:
+    TVolumeClientState() = default;
+
     explicit TVolumeClientState(NProto::TVolumeClientInfo info)
         : VolumeClientInfo(std::move(info))
     {}

--- a/cloud/blockstore/libs/storage/volume/model/client_state.h
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.h
@@ -32,6 +32,20 @@ struct TAddPipeResult
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// The TVolumeClientState helps to manage the access of a single client requests
+// through multiple pipes.
+// Only one pipe can be active at a time. When a new pipe is activated, the
+// previous active switched to the DEACTIVATED state. Requests received through
+// DEACTIVATED pipes are rejected with E_BS_INVALID_SESSION. State of new
+// created pipe is WAIT_START. Requests received through pipe checked with
+// CheckPipeRequest() or CheckLocalRequest(). First request from pipe with
+// WAIT_START state, permitted and change state of pipe to ACTIVE. Requests
+// received through pipe with the ACTIVE state are also allowed. The local pipes
+// has priority, when local pipe is active, requests received through the remote
+// pipe will be rejected with E_REJECT error and can not switch local pipe to
+// the DEACTIVATED state. Requests from the remote pipe will be rejected until
+// the local pipe is deleted.
+
 class TVolumeClientState
 {
 public:

--- a/cloud/blockstore/libs/storage/volume/model/client_state.h
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.h
@@ -35,7 +35,7 @@ struct TAddPipeResult
 class TVolumeClientState
 {
 public:
-    enum class EPipeState: ui32
+    enum class EPipeState : ui32
     {
         WAIT_START,
         ACTIVE,
@@ -47,6 +47,7 @@ public:
         NProto::EVolumeMountMode MountMode = NProto::VOLUME_MOUNT_REMOTE;
         EPipeState State = EPipeState::WAIT_START;
         ui32 SenderNodeId = 0;
+        bool IsLocal = false;
     };
 
     using TPipes = THashMap<NActors::TActorId, TPipeInfo>;
@@ -54,27 +55,17 @@ public:
 private:
     NProto::TVolumeClientInfo VolumeClientInfo;
     TPipes Pipes;
-    TPipes::iterator LocalPipeInfo = Pipes.end();
+    TPipeInfo* ActivePipe = nullptr;
 
 public:
-    TVolumeClientState() = default;
-
-    TVolumeClientState(TString clientId, TString instanceId)
-    {
-        VolumeClientInfo.SetClientId(std::move(clientId));
-        VolumeClientInfo.SetInstanceId(std::move(instanceId));
-    }
-
-    TVolumeClientState(NProto::TVolumeClientInfo info)
+    explicit TVolumeClientState(NProto::TVolumeClientInfo info)
         : VolumeClientInfo(std::move(info))
     {}
 
     void SetLastActivityTimestamp(TInstant ts);
     void SetDisconnectTimestamp(TInstant ts);
 
-    void RemovePipe(
-        NActors::TActorId serverId,
-        TInstant ts);
+    void RemovePipe(NActors::TActorId serverId, TInstant ts);
 
     TAddPipeResult AddPipe(
         NActors::TActorId serverId,
@@ -108,12 +99,16 @@ public:
     bool IsPreempted(ui64 hostNodeId) const;
 
 private:
-    void UpdateClientInfo();
+    bool IsLocalPipeActive() const;
 
-    void ActivatePipe(TPipes::iterator it, bool isLocal);
+    void UpdateState();
 
-    NProto::TError GetWriteError(
-        NProto::EVolumeAccessMode accessMode,
+    void ActivatePipe(TPipeInfo* pipe, bool isLocal);
+
+    bool CanWrite() const;
+
+    NProto::TError CheckWritePermission(
+        bool isWrite,
         const TString& methodName,
         const TString& diskId) const;
 };

--- a/cloud/blockstore/libs/storage/volume/model/client_state.h
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.h
@@ -39,12 +39,12 @@ struct TAddPipeResult
 // DEACTIVATED pipes are rejected with E_BS_INVALID_SESSION. State of new
 // created pipe is WAIT_START. Requests received through pipe checked with
 // CheckPipeRequest() or CheckLocalRequest(). First request from pipe with
-// WAIT_START state, permitted and change state of pipe to ACTIVE. Requests
-// received through pipe with the ACTIVE state are also allowed. The local pipes
-// has priority, when local pipe is active, requests received through the remote
-// pipe will be rejected with E_REJECT error and can not switch local pipe to
-// the DEACTIVATED state. Requests from the remote pipe will be rejected until
-// the local pipe is deleted.
+// WAIT_START state, change state of pipe to ACTIVE. Only requests received
+// through pipe with state WAIT_START or ACTIVE are allowed. The local pipes
+// have priority: when local pipe is active, requests received through the
+// remote pipe will be rejected with E_REJECT error and can not switch local
+// pipe to the DEACTIVATED state. Requests from the remote pipe will be rejected
+// until the local pipe is deleted.
 
 class TVolumeClientState
 {

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -198,7 +198,7 @@ bool TVolumeDatabase::ReadClients(THashMap<TString, TVolumeClientState>& infos)
 
     while (it.IsValid()) {
         auto info = it.GetValue<TTable::ClientInfo>();
-        infos[info.GetClientId()] = TVolumeClientState(info);
+        infos.emplace(info.GetClientId(), TVolumeClientState(info));
 
         if (!it.Next()) {
             return false;   // not ready


### PR DESCRIPTION
Лучше смотреть по-коммитно: в первом был сделан рефакторинг, во втором изменения логики.

Мы столкнулись с проблемой, когда при релизе после переключения клиента на новый NBS, из NBS-2 прилетает запоздавшее сообщение, которое деактивирует локальный пайп, и после этого на все запросы клиента отдается ошибка "E_BS_INVALID_SESSION No local mounter found".

Класс TVolumeClientState упорядочивает запросы одного клиента, которые идут через разные пайпы, так как клиент при blue-green обновлении подключается через разные процессы и в какой-то момент времени имеет несколько подключений. 
Общая идея TVolumeClientState в том что сообщения всегда принимаются только из одного пайпа, и сообщение из нового пайпа запрещает работу с предыдущим активным пайпом. Мы столкнулись с гонкой, когда NBS-2 два раза переустанавливал соединения и в последнее соединение запрос прилетал уже после того как клиент подключался по локальному пайпу и активировал его. Это запоздалое сообщение выключало локальный пайп и клиент больше не мог выполнять запросы. 
Чтобы разрулить гонку решили что локальный пайп должен иметь приоритет, и не должен деактивироваться сообщениями из других пайпов. 