### PR TITLE
[NBS] send current tablet generation (instead of generation parsed from commit id) in TEvBlobStorage::TEvCollectGarbage request

### DIFF
--- a/cloud/blockstore/libs/storage/model/public.h
+++ b/cloud/blockstore/libs/storage/model/public.h
@@ -21,7 +21,7 @@ constexpr ui32 MaxMergedChannelCount = 248;
 // max merged + mixed channel count + fresh channel count
 constexpr ui32 MaxDataChannelCount = 252;
 
-constexpr ui32 InvalidCollectCounter = 0xFFFFFFFFul;
+constexpr ui32 InvalidCollectPerGenerationCounter = 0xFFFFFFFFul;
 constexpr ui32 InvalidBlockIndex = 0xFFFFFFFFul;
 constexpr ui16 InvalidBlobOffset = 0xFFFFu;
 // used for marking zero blocks

--- a/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
@@ -107,8 +107,8 @@ void TPartitionActor::HandleTrimFreshLog(
 
     ui64 trimFreshLogToCommitId = State->GetTrimFreshLogToCommitId();
 
-    auto collectCounter = State->NextCollectCounter();
-    if (collectCounter == InvalidCollectCounter) {
+    auto nextPerGenerationCounter = State->NextCollectPerGenerationCounter();
+    if (nextPerGenerationCounter == InvalidCollectPerGenerationCounter) {
         RebootPartitionOnCollectCounterOverflow(ctx, "TrimFreshLog");
         return;
     }
@@ -118,7 +118,7 @@ void TPartitionActor::HandleTrimFreshLog(
         TabletID(),
         PartitionConfig.GetDiskId().c_str(),
         trimFreshLogToCommitId,
-        collectCounter);
+        nextPerGenerationCounter);
 
     State->GetTrimFreshLogState().SetStatus(EOperationStatus::Started);
 
@@ -132,8 +132,8 @@ void TPartitionActor::HandleTrimFreshLog(
         SelfId(),
         Info(),
         trimFreshLogToCommitId,
-        ParseCommitId(State->GetLastCommitId()).first,
-        collectCounter,
+        Executor()->Generation(),
+        nextPerGenerationCounter,
         std::move(freshChannels));
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -1155,7 +1155,7 @@ public:
 private:
     TOperationState CollectGarbageState;
     TGarbageQueue GarbageQueue;
-    ui32 LastCollectCounter = 0;
+    ui32 LastCollectPerGenerationCounter = 0;
     TDuration CollectTimeout;
     bool StartupGcExecuted = false;
 
@@ -1198,12 +1198,12 @@ public:
         Meta.SetLastCollectCommitId(commitId);
     }
 
-    ui32 NextCollectCounter()
+    ui32 NextCollectPerGenerationCounter()
     {
-        if (LastCollectCounter == InvalidCollectCounter) {
-            return InvalidCollectCounter;
+        if (LastCollectPerGenerationCounter == InvalidCollectPerGenerationCounter) {
+            return InvalidCollectPerGenerationCounter;
         }
-        return ++LastCollectCounter;
+        return ++LastCollectPerGenerationCounter;
     }
 
     ui64 GetCollectCommitId() const;

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
@@ -104,8 +104,8 @@ void TPartitionActor::HandleTrimFreshLog(
 
     const ui64 trimFreshLogToCommitId = State->GetTrimFreshLogToCommitId();
 
-    auto collectCounter = State->NextCollectCounter();
-    if (collectCounter == InvalidCollectCounter) {
+    auto nextPerGenerationCounter = State->NextCollectPerGenerationCounter();
+    if (nextPerGenerationCounter == InvalidCollectPerGenerationCounter) {
         RebootPartitionOnCollectCounterOverflow(ctx, "TrimFreshLog");
         return;
     }
@@ -114,7 +114,7 @@ void TPartitionActor::HandleTrimFreshLog(
         "[%lu] Start TrimFreshLog @%lu @%lu",
         TabletID(),
         trimFreshLogToCommitId,
-        collectCounter);
+        nextPerGenerationCounter);
 
     State->GetTrimFreshLogState().SetStatus(EOperationStatus::Started);
 
@@ -129,7 +129,7 @@ void TPartitionActor::HandleTrimFreshLog(
         Info(),
         trimFreshLogToCommitId,
         ParseCommitId(State->GetLastCommitId()).first,
-        collectCounter,
+        nextPerGenerationCounter,
         std::move(freshChannels));
 
     Actors.insert(actor);

--- a/cloud/blockstore/libs/storage/partition2/part2_state.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_state.h
@@ -1005,7 +1005,7 @@ private:
     TOperationState CollectGarbageState;
 
     TGarbageQueue GarbageQueue;
-    ui32 LastCollectCounter = 0;
+    ui32 LastCollectPerGenerationCounter = 0;
     TDuration CollectTimeout;
     bool StartupGcExecuted = false;
 
@@ -1053,9 +1053,9 @@ public:
         Meta.SetLastCollectCommitId(commitId);
     }
 
-    ui32 NextCollectCounter()
+    ui32 NextCollectPerGenerationCounter()
     {
-        return ++LastCollectCounter;
+        return ++LastCollectPerGenerationCounter;
     }
 
     void InitGarbage(

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -24,14 +24,14 @@ TTrimFreshLogActor::TTrimFreshLogActor(
         TTabletStorageInfoPtr tabletInfo,
         ui64 trimFreshLogToCommitId,
         ui32 recordGeneration,
-        ui32 collectCounter,
+        ui32 perGenerationCounter,
         TVector<ui32> freshChannels)
     : RequestInfo(std::move(requestInfo))
     , PartitionActorId(partitionActorId)
     , TabletInfo(std::move(tabletInfo))
     , TrimFreshLogToCommitId(trimFreshLogToCommitId)
     , RecordGeneration(recordGeneration)
-    , CollectCounter(collectCounter)
+    , PerGenerationCounter(perGenerationCounter)
     , FreshChannels(std::move(freshChannels))
 {}
 
@@ -65,18 +65,18 @@ void TTrimFreshLogActor::TrimFreshLog(const TActorContext& ctx)
             auto [barrierGen, barrierStep] = ParseCommitId(barrier.CollectCommitId);
 
             auto request = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(
-                tabletId,         // tabletId
-                RecordGeneration, // record generation
-                CollectCounter,   // per generation counter
-                channelId,        // channel
-                true,             // yes, collect
-                barrierGen,       // barrier gen
-                barrierStep,      // barrier step
-                nullptr,          // keep
-                nullptr,          // do not keep
-                TInstant::Max(),  // deadline
-                false,            // multicollect not allowed
-                false);           // soft barrier
+                tabletId,               // tabletId
+                RecordGeneration,       // record generation
+                PerGenerationCounter,   // per generation counter
+                channelId,              // channel
+                true,                   // yes, collect
+                barrierGen,             // barrier gen
+                barrierStep,            // barrier step
+                nullptr,                // keep
+                nullptr,                // do not keep
+                TInstant::Max(),        // deadline
+                false,                  // multicollect not allowed
+                false);                 // soft barrier
 
             LOG_DEBUG(ctx, TBlockStoreComponents::PARTITION,
                 "[%lu] %s",

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -24,7 +24,7 @@ private:
     const NKikimr::TTabletStorageInfoPtr TabletInfo;
     const ui64 TrimFreshLogToCommitId;
     const ui32 RecordGeneration;
-    const ui32 CollectCounter;
+    const ui32 PerGenerationCounter;
     const TVector<ui32> FreshChannels;
 
     ui32 RequestsInFlight = 0;
@@ -37,7 +37,7 @@ public:
         NKikimr::TTabletStorageInfoPtr tabletInfo,
         ui64 trimFreshLogToCommitId,
         ui32 recordGeneration,
-        ui32 collectCounter,
+        ui32 perGenerationCounter,
         TVector<ui32> freshChannels);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -102,7 +102,7 @@ void TIndexTabletState::LoadState(
     // https://github.com/ydb-platform/nbs/issues/1714
     // because of possible race in vdisks we should not start with 0
     LastStep = 1;
-    LastCollectCounter = 0;
+    LastCollectPerGenerationCounter = 0;
 
     TruncateBlocksThreshold = config.GetMaxBlocksPerTruncateTx();
     SessionHistoryEntryCount = config.GetSessionHistoryEntryCount();

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -198,7 +198,7 @@ private:
 
     ui32 Generation = 0;
     ui32 LastStep = 0;
-    ui32 LastCollectCounter = 0;
+    ui32 LastCollectPerGenerationCounter = 0;
     bool StartupGcExecuted = false;
 
     NProto::TFileSystem FileSystem;
@@ -1034,9 +1034,9 @@ public:
     //
 
 public:
-    ui32 NextCollectCounter()
+    ui32 NextCollectPerGenerationCounter()
     {
-        return ++LastCollectCounter;
+        return ++LastCollectPerGenerationCounter;
     }
 
     void SetStartupGcExecuted()


### PR DESCRIPTION
В BS барьеры складываются по ключу и значению.
Ключ это поколение таблетки и счетчик в рамках данного поколения. Значение это поколение барьера (у нас оно такое же как и таблетки) и шаг.
Если послать в BS барьер с уже существующим ключом, но другим значением, то сработает верифайка и соотв-но рестарт.
В текущей схеме мы берем commitId из очереди GarbageQueue и из него получаем поколение и шаг, попадает оно туда вызовом AcquireBarrier.
Сама очередь никак не сохраняется и существует только в памяти.
С включением фичи UncorfimedBlobs мы получили, ситуацию, когда после рестарта таблетки для всех загруженных неподтвержденных блобов мы дергаем AcquireBarrier, в который передаем commit id из "прошлого" и соответственно при следующей сборке мусора мы пошлем барьеры с прошлым поколением и счетчиком, который снова пошел с 1 и попадем в верифайку на стороне BS.
Мы получили такую ситуаци, когда место в кластере кончилось и была высокая нагрузка.
Данный PR исправляет ситуацию тем, что всегда шлет текущее поколение таблетки для ключа и то, что было в commitId для значения. 