### PR TITLE
[Disk Manager] Limit the number of checkpoint creation reties when create image/snapshot from disk registry based disk

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/config/config.proto
@@ -34,4 +34,8 @@ message DataplaneConfig {
     optional string ProxyOverlayDiskIdPrefix = 16 [default = "proxy-"];
     optional snapshot.SnapshotConfig MigrationDstSnapshotConfig = 17;
     optional uint32 MigratingSnapshotsInflightLimit = 18 [default = 10];
+
+    // Needed for snapshot/image creation from disk registry based disks.
+    // Limits the number of attemps of checkpoint creation.
+    optional uint32 CheckpointIterationLimit = 19 [default = 10];
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/create_dr_based_disk_checkpoint_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_dr_based_disk_checkpoint_task.go
@@ -14,9 +14,10 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type createDRBasedDiskCheckpointTask struct {
-	nbsFactory nbs_client.Factory
-	request    *protos.CreateDRBasedDiskCheckpointRequest
-	state      *protos.CreateDRBasedDiskCheckpointTaskState
+	nbsFactory               nbs_client.Factory
+	checkpointIterationLimit int32
+	request                  *protos.CreateDRBasedDiskCheckpointRequest
+	state                    *protos.CreateDRBasedDiskCheckpointTaskState
 }
 
 func (t *createDRBasedDiskCheckpointTask) Save() ([]byte, error) {
@@ -38,6 +39,12 @@ func (t *createDRBasedDiskCheckpointTask) Run(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
 ) error {
+
+	if t.state.CheckpointIteration >= t.checkpointIterationLimit {
+		return errors.NewNonRetriableErrorf(
+			"Too many failed checkpoint iterations: %v",
+			t.state.CheckpointIteration)
+	}
 
 	disk := t.request.Disk
 

--- a/cloud/disk_manager/internal/pkg/dataplane/register.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/register.go
@@ -270,7 +270,8 @@ func RegisterForExecution(
 		"dataplane.CreateDRBasedDiskCheckpoint",
 		func() tasks.Task {
 			return &createDRBasedDiskCheckpointTask{
-				nbsFactory: nbsFactory,
+				nbsFactory:               nbsFactory,
+				checkpointIterationLimit: int32(config.GetCheckpointIterationLimit()),
 			}
 		},
 	)

--- a/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_nemesis_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_nemesis_test/ya.make
@@ -5,6 +5,10 @@ SET_APPEND(RECIPE_ARGS --disk-agent-count 3)
 SET_APPEND(RECIPE_ARGS --retry-broken-disk-registry-based-disk-checkpoint)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
+# We want each test to run in separate chunk in order to avoid flaps.
+# TODO: recodsider this after https://github.com/ydb-platform/nbs/issues/3363.
+SPLIT_FACTOR(5)
+
 GO_XTEST_SRCS(
     ../with_broken_checkpoints_test/with_broken_checkpoints_test.go
 )

--- a/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/with_broken_checkpoints_test/ya.make
@@ -4,6 +4,10 @@ SET_APPEND(RECIPE_ARGS --disk-agent-count 3)
 SET_APPEND(RECIPE_ARGS --retry-broken-disk-registry-based-disk-checkpoint)
 INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
 
+# We want each test to run in separate chunk in order to avoid flaps.
+# TODO: recodsider this after https://github.com/ydb-platform/nbs/issues/3363.
+SPLIT_FACTOR(5)
+
 GO_XTEST_SRCS(
     with_broken_checkpoints_test.go
 )

--- a/cloud/disk_manager/test/recipe/disk_manager_launcher.py
+++ b/cloud/disk_manager/test/recipe/disk_manager_launcher.py
@@ -369,6 +369,7 @@ DataplaneConfig: <
     CollectSnapshotsTaskScheduleInterval: "2s"
     SnapshotCollectionInflightLimit: 10
     ProxyOverlayDiskIdPrefix: "{proxy_overlay_disk_id_prefix}"
+    CheckpointIterationLimit: 2
 {migration_config}
 >
 """


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1950

Singe task should not retry checkpoint creation too many times. Otherwise, there is a risk of overloading disk agent with checkpoint creation/deletion requests.

Add parameter CheckpointIterationLimit to dataplane config (equals 10 by default).