### PR TITLE
issue-1223: added exporting traces in opentelemetry format 

### DIFF
--- a/cloud/blockstore/apps/server/main.cpp
+++ b/cloud/blockstore/apps/server/main.cpp
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/kms/impl/compute_client.h>
 #include <cloud/blockstore/libs/kms/impl/kms_client.h>
 #include <cloud/blockstore/libs/logbroker/iface/logbroker.h>
+#include <cloud/blockstore/libs/opentelemetry/impl/trace_service_client.h>
 #include <cloud/blockstore/libs/rdma/impl/client.h>
 #include <cloud/blockstore/libs/rdma/impl/server.h>
 #include <cloud/blockstore/libs/rdma/impl/verbs.h>
@@ -93,6 +94,19 @@ int main(int argc, char** argv)
         }
 
         return NCloud::NBlockStore::CreateRootKmsClientStub();
+    };
+
+    serverModuleFactories->TraceServiceClientFactory = [] (
+        NProto::TGrpcClientConfig config,
+        NCloud::ILoggingServicePtr logging)
+    {
+        if (config.GetAddress()) {
+            return NCloud::NBlockStore::CreateTraceServiceClient(
+                std::move(logging),
+                std::move(config));
+        }
+
+        return NCloud::NBlockStore::CreateTraceServiceClientStub();
     };
 
     serverModuleFactories->SpdkFactory = [] (

--- a/cloud/blockstore/apps/server/ya.make
+++ b/cloud/blockstore/apps/server/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     cloud/blockstore/libs/daemon/ydb
     cloud/blockstore/libs/kms/iface
     cloud/blockstore/libs/kms/impl
+    cloud/blockstore/libs/opentelemetry/impl
     cloud/blockstore/libs/logbroker/iface
     cloud/blockstore/libs/rdma/impl
     cloud/blockstore/libs/root_kms/impl

--- a/cloud/blockstore/config/opentelemetry_client.proto
+++ b/cloud/blockstore/config/opentelemetry_client.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package NCloud.NBlockStore.NProto;
+
+import "cloud/blockstore/config/grpc_client.proto";
+
+option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TOpentelemetryTraceConfig
+{
+    optional TGrpcClientConfig ClientConfig = 1;
+
+    optional string ServiceName = 2;
+}

--- a/cloud/blockstore/config/ya.make
+++ b/cloud/blockstore/config/ya.make
@@ -12,6 +12,7 @@ SRCS(
     http_proxy.proto
     logbroker.proto
     notify.proto
+    opentelemetry_client.proto
     plugin.proto
     rdma.proto
     root_kms.proto

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/endpoints_grpc/public.h>
 #include <cloud/blockstore/libs/nbd/public.h>
 #include <cloud/blockstore/libs/nvme/public.h>
+#include <cloud/blockstore/libs/opentelemetry/iface/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/server/public.h>
 #include <cloud/blockstore/libs/service/public.h>
@@ -22,6 +23,7 @@
 #include <cloud/storage/core/libs/coroutine/public.h>
 
 #include <contrib/ydb/library/actors/util/should_continue.h>
+
 #include <library/cpp/logger/log.h>
 
 namespace NCloud::NBlockStore::NServer {
@@ -114,6 +116,8 @@ protected:
     virtual IStartable* GetComputeClient() = 0;
     virtual IStartable* GetKmsClient() = 0;
     virtual IStartable* GetRootKmsClient() = 0;
+
+    virtual ITraceServiceClientPtr GetTraceServiceClient() = 0;
 
     virtual void InitSpdk() = 0;
     virtual void InitRdmaClient() = 0;

--- a/cloud/blockstore/libs/daemon/common/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/common/config_initializer.cpp
@@ -1,6 +1,8 @@
 #include "config_initializer.h"
+
 #include "options.h"
 
+#include <cloud/blockstore/config/opentelemetry_client.pb.h>
 #include <cloud/blockstore/libs/client/client.h>
 #include <cloud/blockstore/libs/client/config.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
@@ -111,6 +113,17 @@ void TConfigInitializerCommon::InitRdmaConfig()
 
     RdmaConfig =
         std::make_shared<NRdma::TRdmaConfig>(rdmaConfig);
+}
+
+void TConfigInitializerCommon::InitTraceServiceClientConfig()
+{
+    NProto::TOpentelemetryTraceConfig config;
+
+    if (Options->TraceServiceConfig) {
+        ParseProtoTextFromFile(Options->TraceServiceConfig, config);
+    }
+
+    TraceServiceClientConfig = std::move(config);
 }
 
 void TConfigInitializerCommon::InitDiskRegistryProxyConfig()

--- a/cloud/blockstore/libs/daemon/common/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/common/config_initializer.h
@@ -2,11 +2,14 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/config/grpc_client.pb.h>
+#include <cloud/blockstore/config/opentelemetry_client.pb.h>
 #include <cloud/blockstore/libs/client/public.h>
 #include <cloud/blockstore/libs/client/throttling.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/discovery/config.h>
 #include <cloud/blockstore/libs/discovery/public.h>
+#include <cloud/blockstore/libs/opentelemetry/iface/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/server/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
@@ -36,6 +39,7 @@ struct TConfigInitializerCommon
     NSpdk::TSpdkEnvConfigPtr SpdkEnvConfig;
     NClient::THostPerformanceProfile HostPerformanceProfile;
     NRdma::TRdmaConfigPtr RdmaConfig;
+    NProto::TOpentelemetryTraceConfig TraceServiceClientConfig;
 
     TString Rack;
     TLog Log;
@@ -52,6 +56,7 @@ struct TConfigInitializerCommon
     void InitServerConfig();
     void InitSpdkEnvConfig();
     void InitRdmaConfig();
+    void InitTraceServiceClientConfig();
 
     virtual bool GetUseNonreplicatedRdmaActor() const = 0;
     virtual TDuration GetInactiveClientsTimeout() const = 0;

--- a/cloud/blockstore/libs/daemon/common/options.cpp
+++ b/cloud/blockstore/libs/daemon/common/options.cpp
@@ -52,6 +52,10 @@ TOptionsCommon::TOptionsCommon()
         .DefaultValue("")
         .StoreResult(&RdmaConfig);
 
+    Opts.AddLongOption("trace-file")
+        .RequiredArgument("PATH")
+        .StoreResult(&TraceServiceConfig);
+
     Opts.AddLongOption("temporary-server", "run temporary server for blue-green deployment")
         .NoArgument()
         .StoreTrue(&TemporaryServer);

--- a/cloud/blockstore/libs/daemon/common/options.h
+++ b/cloud/blockstore/libs/daemon/common/options.h
@@ -27,6 +27,7 @@ public:
     TString DiskRegistryProxyConfig;
     TString EndpointConfig;
     TString RdmaConfig;
+    TString TraceServiceConfig;
 
     enum class EServiceKind {
         Null   /* "null"   */ ,

--- a/cloud/blockstore/libs/daemon/common/ya.make
+++ b/cloud/blockstore/libs/daemon/common/ya.make
@@ -34,6 +34,8 @@ PEERDIR(
     cloud/blockstore/libs/throttling
     cloud/blockstore/libs/validation
     cloud/blockstore/libs/vhost
+    cloud/blockstore/libs/opentelemetry/iface
+    cloud/blockstore/libs/opentelemetry/impl
 
     cloud/storage/core/libs/aio
     cloud/storage/core/libs/common

--- a/cloud/blockstore/libs/daemon/local/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.h
@@ -38,6 +38,11 @@ protected:
     IStartable* GetKmsClient() override          { return nullptr; }
     IStartable* GetRootKmsClient() override      { return nullptr; }
 
+    ITraceServiceClientPtr GetTraceServiceClient() override
+    {
+        return nullptr;
+    }
+
     void InitSpdk() override;
     void InitRdmaClient() override;
     void InitRdmaServer() override;

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -302,6 +302,11 @@ IStartable* TBootstrapYdb::GetComputeClient()      { return ComputeClient.get();
 IStartable* TBootstrapYdb::GetKmsClient()          { return KmsClient.get(); }
 IStartable* TBootstrapYdb::GetRootKmsClient()      { return RootKmsClient.get(); }
 
+ITraceServiceClientPtr TBootstrapYdb::GetTraceServiceClient()
+{
+    return TraceServiceClient;
+}
+
 void TBootstrapYdb::InitConfigs()
 {
     Configs->InitKikimrConfig();
@@ -321,6 +326,7 @@ void TBootstrapYdb::InitConfigs()
     Configs->InitKmsClientConfig();
     Configs->InitRootKmsConfig();
     Configs->InitComputeClientConfig();
+    Configs->InitTraceServiceClientConfig();
 }
 
 void TBootstrapYdb::InitSpdk()
@@ -785,6 +791,12 @@ void TBootstrapYdb::InitKikimrService()
         auto isSpareNode = serverGroup->GetCounter("IsSpareNode", false);
         *isSpareNode = 1;
     }
+
+    TraceServiceClient = ServerModuleFactories->TraceServiceClientFactory(
+        Configs->TraceServiceClientConfig.GetClientConfig(),
+        logging);
+
+    STORAGE_INFO("Trace service client initialized");
 
     auto& probes = NLwTraceMonPage::ProbeRegistry();
     probes.AddProbesList(LWTRACE_GET_PROBES(BLOCKSTORE_STORAGE_PROVIDER));

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/kms/iface/public.h>
 #include <cloud/blockstore/libs/logbroker/iface/public.h>
 #include <cloud/blockstore/libs/notify/public.h>
+#include <cloud/blockstore/libs/opentelemetry/iface/public.h>
 #include <cloud/blockstore/libs/rdma/iface/public.h>
 #include <cloud/blockstore/libs/root_kms/iface/public.h>
 #include <cloud/blockstore/libs/ydbstats/public.h>
@@ -54,6 +55,11 @@ struct TServerModuleFactories
         const NProto::TRootKmsConfig& config,
         ILoggingServicePtr logging)> RootKmsClientFactory;
 
+    std::function<ITraceServiceClientPtr(
+        const NProto::TGrpcClientConfig& config,
+        ILoggingServicePtr logging)>
+        TraceServiceClientFactory;
+
     std::function<TSpdkParts(NSpdk::TSpdkEnvConfigPtr config)> SpdkFactory;
 
     std::function<NRdma::IServerPtr(
@@ -92,6 +98,7 @@ private:
     IComputeClientPtr ComputeClient;
     IKmsClientPtr KmsClient;
     IRootKmsClientPtr RootKmsClient;
+    ITraceServiceClientPtr TraceServiceClient;
     std::function<void(TLog& log)> SpdkLogInitializer;
 
 public:
@@ -120,6 +127,8 @@ protected:
     IStartable* GetComputeClient() override;
     IStartable* GetKmsClient() override;
     IStartable* GetRootKmsClient() override;
+
+    ITraceServiceClientPtr GetTraceServiceClient() override;
 
     void InitSpdk() override;
     void InitRdmaClient() override;

--- a/cloud/blockstore/libs/opentelemetry/iface/public.h
+++ b/cloud/blockstore/libs/opentelemetry/iface/public.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <memory>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ITraceServiceClient;
+using ITraceServiceClientPtr = std::shared_ptr<ITraceServiceClient>;
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/iface/trace_service_client.cpp
+++ b/cloud/blockstore/libs/opentelemetry/iface/trace_service_client.cpp
@@ -1,0 +1,32 @@
+#include "trace_service_client.h"
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTraceServiceClientStub: public ITraceServiceClient
+{
+public:
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
+    NThreading::TFuture<TResponse> Export(
+        TRequest traces,
+        const TString& authToken) override
+    {
+        Y_UNUSED(traces);
+        Y_UNUSED(authToken);
+        return NThreading::MakeFuture<TResponse>(TErrorResponse(
+            E_NOT_IMPLEMENTED,
+            "TraceServiceClientStub can't export traces"));
+    }
+};
+
+ITraceServiceClientPtr CreateTraceServiceClientStub()
+{
+    return std::make_shared<TTraceServiceClientStub>();
+}
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/iface/trace_service_client.h
+++ b/cloud/blockstore/libs/opentelemetry/iface/trace_service_client.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/startable.h>
+
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ITraceServiceClient: public IStartable
+{
+    using TRequest =
+        opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
+    using TResponse = TResultOrError<
+        opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse>;
+
+    virtual NThreading::TFuture<TResponse> Export(
+        TRequest traces,
+        const TString& authToken) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceServiceClientPtr CreateTraceServiceClientStub();
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/iface/ya.make
+++ b/cloud/blockstore/libs/opentelemetry/iface/ya.make
@@ -1,0 +1,18 @@
+LIBRARY()
+
+SRCS(
+    trace_service_client.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/config
+    cloud/storage/core/libs/common
+    cloud/storage/core/libs/coroutine
+    cloud/storage/core/libs/iam/iface
+
+    contrib/libs/opentelemetry-proto
+
+    library/cpp/threading/future
+)
+
+END()

--- a/cloud/blockstore/libs/opentelemetry/impl/helpers.cpp
+++ b/cloud/blockstore/libs/opentelemetry/impl/helpers.cpp
@@ -1,0 +1,29 @@
+#include "helpers.h"
+
+#include <util/generic/string.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace NCloud::NBlockStore {
+
+TString ToHexString16(ui64 value)
+{
+    // std::stringstream is used here, because StringStream from arcadia doesn't
+    // support std::hex, std::setw, std::setfill.
+    std::stringstream buf;
+    buf << std::hex << std::setw(16) << std::setfill('0') << value;
+    return buf.str();
+}
+
+TString ToHexString8(ui64 value)
+{
+    // std::stringstream is used here, because StringStream from arcadia doesn't
+    // support std::hex, std::setw, std::setfill.
+    std::stringstream buf;
+    buf << std::hex << std::setw(8) << std::setfill('0') << value;
+    return buf.str();
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/helpers.h
+++ b/cloud/blockstore/libs/opentelemetry/impl/helpers.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <util/generic/fwd.h>
+
+namespace NCloud::NBlockStore {
+
+TString ToHexString16(ui64 value);
+
+TString ToHexString8(ui64 value);
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_convert.cpp
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_convert.cpp
@@ -1,0 +1,325 @@
+#include "trace_convert.h"
+
+#include "helpers.h"
+
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/common/v1/common.pb.h>
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.pb.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/vector.h>
+
+#include <algorithm>
+#include <random>
+
+namespace NCloud::NBlockStore {
+
+using namespace opentelemetry::proto::trace::v1;
+using namespace opentelemetry::proto::common::v1;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+AnyValue ConvertToOpenTelemtry(
+    const NLWTrace::TParam& param,
+    NLWTrace::EParamTypePb type)
+{
+    AnyValue value;
+    switch (type) {
+        case NLWTrace::PT_I64:
+            value.Setint_value(param.Get<i64>());
+            break;
+        case NLWTrace::PT_Ui64:
+            value.Setint_value(param.Get<ui64>());
+            break;
+        case NLWTrace::PT_Double:
+            value.Setdouble_value(param.Get<double>());
+            break;
+        case NLWTrace::PT_Str:
+            value.Setstring_value(param.Get<TString>());
+            break;
+        case NLWTrace::PT_Symbol:
+            value.Setstring_value(*param
+                                       .Get<typename NLWTrace::TParamTraits<
+                                           NLWTrace::TSymbol>::TStoreType>()
+                                       .Str);
+            break;
+        case NLWTrace::PT_Check:
+            value.Setint_value(param
+                                   .Get<typename NLWTrace::TParamTraits<
+                                       NLWTrace::TCheck>::TStoreType>()
+                                   .Value);
+            break;
+        default:
+            value.Setstring_value("unknown type");
+            break;
+    }
+
+    return value;
+}
+
+struct TReferenceTimeCycle
+{
+    TInstant ReferenceTimeStamp;
+    ui64 ReferenceTimeCycle = 0;
+};
+
+TInstant GetTimestampFromCycle(
+    TReferenceTimeCycle referenceTimeCycle,
+    ui64 timeCycles)
+{
+    if (referenceTimeCycle.ReferenceTimeCycle >= timeCycles) {
+        return referenceTimeCycle.ReferenceTimeStamp -
+               CyclesToDurationSafe(
+                   referenceTimeCycle.ReferenceTimeCycle - timeCycles);
+    }
+
+    return referenceTimeCycle.ReferenceTimeStamp +
+           CyclesToDurationSafe(
+               timeCycles - referenceTimeCycle.ReferenceTimeCycle);
+}
+
+ui64 GetTimestampInNanoSeconds(
+    TReferenceTimeCycle referenceTimeCycle,
+    ui64 timeCycles)
+{
+    return GetTimestampFromCycle(referenceTimeCycle, timeCycles).NanoSeconds();
+}
+
+Span_Event ProcessRegularItem(
+    const NLWTrace::TTrackLog::TItem& item,
+    TReferenceTimeCycle referenceTimeCycle)
+{
+    Span_Event event;
+    event.Setname(item.Probe->Event.Name);
+    event.Settime_unix_nano(
+        GetTimestampInNanoSeconds(referenceTimeCycle, item.TimestampCycles));
+
+    Y_ABORT_UNLESS(
+        item.SavedParamsCount <= LWTRACE_MAX_PARAMS,
+        "Too many params");
+    for (size_t paramIdx = 0; paramIdx < item.SavedParamsCount; ++paramIdx) {
+        KeyValue kv;
+        kv.Setkey(item.Probe->Event.Signature.ParamNames[paramIdx]);
+
+        auto type = NLWTrace::ParamTypeToProtobuf(
+            item.Probe->Event.Signature.ParamTypes[paramIdx]);
+        const auto& param = item.Params.Param[paramIdx];
+        *kv.Mutablevalue() = std::move(ConvertToOpenTelemtry(param, type));
+
+        auto* attributes = event.Mutableattributes();
+        attributes->Add(std::move(kv));
+    }
+
+    return event;
+}
+
+struct TLogItemsIterationContext
+{
+    ui64 Idx = 0;
+    ui64 Count = 0;
+
+    operator bool() const
+    {
+        return Idx < Count;
+    }
+
+    bool Next()
+    {
+        Idx += 1;
+        return Idx < Count;
+    }
+
+    // Construct iteration context that will iterate subSpanCount elements from
+    // Idx + 1. Skips next subSpanCount elements from idx.
+    TLogItemsIterationContext ConstructSubSpanIterationContext(
+        ui64 subSpanCount)
+    {
+        Idx += subSpanCount;
+        return {.Idx = Idx + 1, .Count = Min(Idx + 1 + subSpanCount, Count)};
+    }
+};
+
+template <typename T>
+T FindFirst(
+    const NLWTrace::TTrackLog& tl,
+    const char* fieldName,
+    TLogItemsIterationContext iterationContext)
+{
+    while (iterationContext) {
+        const auto& item = tl.Items[iterationContext.Idx];
+        for (size_t paramIdx = 0; paramIdx < item.SavedParamsCount; ++paramIdx)
+        {
+            if (strcmp(
+                    item.Probe->Event.Signature.ParamNames[paramIdx],
+                    fieldName) == 0)
+            {
+                return item.Params.Param[paramIdx].Get<T>();
+            }
+        }
+        iterationContext.Next();
+    }
+
+    return {};
+}
+
+ui64 FindRequestId(
+    const NLWTrace::TTrackLog& tl,
+    TLogItemsIterationContext iterationContext)
+{
+    return FindFirst<ui64>(tl, "requestId", iterationContext);
+}
+
+TString FindOperationName(
+    const NLWTrace::TTrackLog& tl,
+    TLogItemsIterationContext iterationContext)
+{
+    return FindFirst<TString>(tl, "requestType", iterationContext);
+}
+
+class TSpanTree
+{
+private:
+    TVector<Span> Spans;
+    ui64 TraceId;
+    ui64 RootSpanId;
+
+public:
+    TSpanTree(ui64 traceId, ui64 spanId)
+        : TraceId(traceId)
+        , RootSpanId(spanId)
+    {
+        Spans.emplace_back();
+        GetParentSpan().Setspan_id(ToHexString8(RootSpanId));
+        GetParentSpan().Settrace_id(ToHexString16(TraceId));
+    }
+
+    void AddSpanSubTree(TSpanTree subtree)
+    {
+        subtree.GetParentSpan().Setparent_span_id(ToHexString8(RootSpanId));
+        std::ranges::move(subtree.Spans, std::back_inserter(Spans));
+    }
+
+    [[nodiscard]] Span& GetParentSpan()
+    {
+        return Spans.front();
+    }
+
+    [[nodiscard]] const Span& GetParentSpan() const
+    {
+        return Spans.front();
+    }
+
+    static TVector<Span> ExtractSpans(TSpanTree&& spanTree)
+    {
+        return std::move(spanTree.Spans);
+    }
+};
+
+TSpanTree ProcessItemsToSpanTree(
+    const NLWTrace::TTrackLog& tl,
+    ui64 traceId,
+    ui64 currentSpanId,
+    TLogItemsIterationContext iterationContext,
+    TReferenceTimeCycle referenceTimeCycle)
+{
+    TSpanTree spanTree(traceId, currentSpanId);
+
+    THashMap<ui64, ui64> spanIdToStartTime;
+
+    ui64 startTimeCycles = tl.Items[iterationContext.Idx].TimestampCycles;
+    ui64 endTimeCycles = 0;
+
+    auto operationName = FindOperationName(tl, iterationContext);
+    spanTree.GetParentSpan().Setname(operationName);
+
+    while (iterationContext) {
+        Y_DEFER
+        {
+            iterationContext.Next();
+        };
+
+        const auto& item = tl.Items[iterationContext.Idx];
+        const auto& name = item.Probe->Event.Name;
+        auto timeCycles = item.TimestampCycles;
+
+        endTimeCycles = Max(endTimeCycles, timeCycles);
+        auto curTimeStampNano =
+            GetTimestampInNanoSeconds(referenceTimeCycle, timeCycles);
+
+        if (strcmp(name, "Fork") == 0) {
+            const auto childSpanId = item.Params.Param[0].Get<ui64>();
+            spanIdToStartTime[childSpanId] = curTimeStampNano;
+            continue;
+        }
+
+        if (strcmp(name, "Join") == 0) {
+            const auto childSpanId = item.Params.Param[0].Get<ui64>();
+            const auto itemsCount = item.Params.Param[1].Get<ui64>();
+
+            // recursively process child spans
+            auto subSpans = ProcessItemsToSpanTree(
+                tl,
+                traceId,
+                childSpanId,
+                iterationContext.ConstructSubSpanIterationContext(itemsCount),
+                referenceTimeCycle);
+
+            subSpans.GetParentSpan().Setstart_time_unix_nano(
+                spanIdToStartTime[childSpanId]);
+            subSpans.GetParentSpan().Setend_time_unix_nano(curTimeStampNano);
+
+            spanTree.AddSpanSubTree(std::move(subSpans));
+            continue;
+        }
+
+        *(spanTree.GetParentSpan()).Addevents() =
+            ProcessRegularItem(item, referenceTimeCycle);
+    }
+
+    spanTree.GetParentSpan().Setstart_time_unix_nano(
+        GetTimestampInNanoSeconds(referenceTimeCycle, startTimeCycles));
+    spanTree.GetParentSpan().Setend_time_unix_nano(
+        GetTimestampInNanoSeconds(referenceTimeCycle, endTimeCycles));
+
+    return spanTree;
+}
+
+TReferenceTimeCycle GetReferenceTimeCycle(const NLWTrace::TTrackLog& tl)
+{
+    ui64 maxTimeCycle = 0;
+    for (size_t itemIdx = 0; itemIdx < tl.Items.size(); ++itemIdx) {
+        maxTimeCycle = Max(maxTimeCycle, tl.Items[itemIdx].TimestampCycles);
+    }
+
+    return {
+        .ReferenceTimeStamp = TInstant::Now(),
+        .ReferenceTimeCycle = maxTimeCycle};
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<Span> ConvertToOpenTelemetrySpans(const NLWTrace::TTrackLog& tl)
+{
+    auto traceId = FindRequestId(tl, {0, tl.Items.size()});
+    if (!traceId) {
+        std::random_device r;
+
+        std::default_random_engine e(r());
+        std::uniform_int_distribution<ui64> uniform_dist(0, UINT64_MAX);
+
+        traceId = uniform_dist(e);
+    }
+
+    return TSpanTree::ExtractSpans(std::move(ProcessItemsToSpanTree(
+        tl,
+        traceId,                    // traceId
+        0,                          // currentSpanId
+        {0, tl.Items.size()},       // iterationContext
+        GetReferenceTimeCycle(tl)   // referenceTimeCycle
+        )));
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_convert.h
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_convert.h
@@ -1,0 +1,14 @@
+
+
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.pb.h>
+
+#include <library/cpp/lwtrace/log.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<opentelemetry::proto::trace::v1::Span> ConvertToOpenTelemetrySpans(
+    const NLWTrace::TTrackLog& tl);
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_reader.cpp
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_reader.cpp
@@ -1,0 +1,115 @@
+#include "trace_reader.h"
+
+#include "trace_convert.h"
+
+#include <cloud/blockstore/libs/opentelemetry/iface/trace_service_client.h>
+
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.pb.h>
+
+#include <library/cpp/logger/log.h>
+#include <library/cpp/protobuf/util/pb_io.h>
+
+#include <utility>
+
+namespace NCloud::NBlockStore {
+
+using namespace opentelemetry::proto::collector::trace::v1;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTraceOpenTelemetryExporter final: public ITraceReaderWithRingBuffer
+{
+private:
+    ui64 TracksCount = 0;
+    ILoggingServicePtr Logging;
+    TString ComponentName;
+    ITraceServiceClientPtr TraceServiceClient;
+    TString ServiceName;
+
+public:
+    TTraceOpenTelemetryExporter(
+            TString id,
+            ILoggingServicePtr logging,
+            TString componentName,
+            ITraceServiceClientPtr traceServiceClient,
+            TString serviceName)
+        : ITraceReaderWithRingBuffer(std::move(id))
+        , Logging(std::move(logging))
+        , ComponentName(std::move(componentName))
+        , TraceServiceClient(std::move(traceServiceClient))
+        , ServiceName(std::move(serviceName))
+    {}
+
+    void Push(TThread::TId tid, const NLWTrace::TTrackLog& tl) override
+    {
+        Y_UNUSED(tid);
+
+        if (tl.Items.empty() || ++TracksCount > DumpTracksLimit) {
+            return;
+        }
+
+        ui64 minSeenTimestamp = tl.Items[0].TimestampCycles;
+
+        auto spans = ConvertToOpenTelemetrySpans(tl);
+
+        ExportTraceServiceRequest traces;
+        auto* resourceSpans = traces.Addresource_spans();
+        auto* attribute =
+            resourceSpans->Mutableresource()->Mutableattributes()->Add();
+        attribute->Setkey("service.name");
+        attribute->Mutablevalue()->Setstring_value(ServiceName);
+
+        auto* scopedSpans = resourceSpans->Addscope_spans();
+        for (const auto& span: spans) {
+            *scopedSpans->Addspans() = span;
+        }
+
+        TraceServiceClient->Export(std::move(traces), "")
+            .Subscribe(
+                [logging = Logging, componentName = ComponentName](
+                    NThreading::TFuture<ITraceServiceClient::TResponse>
+                        responseFuture)
+                {
+                    TLog Log = logging->CreateLog(componentName);
+                    auto response = responseFuture.ExtractValue();
+                    if (HasError(response)) {
+                        STORAGE_WARN(
+                            "Failed to export traces: "
+                            << FormatError(response.GetError()));
+                    }
+                });
+
+        RingBuffer.PushBack(
+            {TInstant::Now(), minSeenTimestamp, tl, "AllRequests"});
+    }
+
+    void Reset() override
+    {
+        TracksCount = 0;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceReaderPtr CreateTraceExporter(
+    TString id,
+    ILoggingServicePtr logging,
+    TString componentName,
+    ITraceServiceClientPtr traceServiceClient,
+    TString serviceName)
+{
+    return std::make_shared<TTraceOpenTelemetryExporter>(
+        std::move(id),
+        std::move(logging),
+        std::move(componentName),
+        std::move(traceServiceClient),
+        std::move(serviceName));
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_reader.h
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_reader.h
@@ -1,0 +1,14 @@
+#include <cloud/blockstore/libs/opentelemetry/iface/public.h>
+
+#include <cloud/storage/core/libs/diagnostics/trace_reader.h>
+
+namespace NCloud::NBlockStore {
+
+ITraceReaderPtr CreateTraceExporter(
+    TString id,
+    ILoggingServicePtr logging,
+    TString componentName,
+    ITraceServiceClientPtr traceServiceClient,
+    TString serviceName);
+
+} // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_service_client.cpp
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_service_client.cpp
@@ -1,0 +1,197 @@
+#include "trace_service_client.h"
+
+#include <cloud/blockstore/libs/opentelemetry/iface/trace_service_client.h>
+
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/grpc/init.h>
+#include <cloud/storage/core/libs/grpc/time_point_specialization.h>
+
+#include <contrib/libs/grpc/include/grpcpp/channel.h>
+#include <contrib/libs/grpc/include/grpcpp/client_context.h>
+#include <contrib/libs/grpc/include/grpcpp/completion_queue.h>
+#include <contrib/libs/grpc/include/grpcpp/create_channel.h>
+#include <contrib/libs/grpc/include/grpcpp/security/credentials.h>
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h>
+#include <contrib/libs/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.h>
+
+#include <util/string/builder.h>
+#include <util/string/join.h>
+#include <util/system/thread.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NThreading;
+
+namespace trace = opentelemetry::proto::collector::trace::v1;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const char AUTH_HEADER[] = "authorization";
+const char AUTH_METHOD[] = "Bearer";
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRequestHandler final
+{
+    using TReader =
+        grpc::ClientAsyncResponseReader<trace::ExportTraceServiceResponse>;
+    using TRequest = ITraceServiceClient::TRequest;
+    using TResponse = ITraceServiceClient::TResponse;
+
+private:
+    grpc::ClientContext ClientContext;
+    grpc::Status Status;
+
+    std::unique_ptr<TReader> Reader;
+
+    trace::ExportTraceServiceRequest Request;
+    trace::ExportTraceServiceResponse Response;
+
+    TPromise<TResponse> Promise = NewPromise<TResponse>();
+
+public:
+    TRequestHandler(TDuration timeout, TString authToken, TRequest request)
+    {
+        if (timeout != TDuration::Zero()) {
+            ClientContext.set_deadline(TInstant::Now() + timeout);
+        }
+
+        if (authToken) {
+            ClientContext.AddMetadata(
+                AUTH_HEADER,
+                TStringBuilder() << AUTH_METHOD << " " << authToken);
+        }
+
+        Request = std::move(request);
+    }
+
+    TFuture<TResponse> Execute(
+        trace::TraceService::Stub& service,
+        grpc::CompletionQueue* cq,
+        void* tag)
+    {
+        Reader = service.AsyncExport(&ClientContext, Request, cq);
+        Reader->Finish(&Response, &Status, tag);
+        return Promise;
+    }
+
+    void Complete()
+    {
+        if (!Status.ok()) {
+            Promise.SetValue(MakeError(
+                MAKE_GRPC_ERROR(Status.error_code()),
+                Status.error_message()));
+        } else {
+            Promise.SetValue(std::move(Response));
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTraceServiceClient final
+    : public ISimpleThread
+    , public ITraceServiceClient
+{
+private:
+    TGrpcInitializer GrpcInitializer;
+
+    const ILoggingServicePtr Logging;
+    const NProto::TGrpcClientConfig Config;
+
+    TLog Log;
+
+    grpc::CompletionQueue CQ;
+    std::shared_ptr<trace::TraceService::Stub> Service;
+
+public:
+    TTraceServiceClient(ILoggingServicePtr logging, NProto::TGrpcClientConfig config)
+        : Logging(std::move(logging))
+        , Config(std::move(config))
+    {}
+
+    ~TTraceServiceClient()
+    {
+        Stop();
+    }
+
+    void Start() override
+    {
+        Log = Logging->CreateLog("BLOCKSTORE_SERVER");
+
+        STORAGE_INFO("Connect to " << Config.GetAddress());
+
+        auto creds = Config.GetInsecure()
+                         ? grpc::InsecureChannelCredentials()
+                         : grpc::SslCredentials(grpc::SslCredentialsOptions());
+
+        grpc::ChannelArguments args;
+        if (Config.GetSslTargetNameOverride()) {
+            args.SetSslTargetNameOverride(Config.GetSslTargetNameOverride());
+        }
+
+        auto channel = grpc::CreateCustomChannel(
+            Config.GetAddress(),
+            std::move(creds),
+            args);
+
+        Service = std::shared_ptr<trace::TraceService::Stub>(
+            trace::TraceService::NewStub(std::move(channel)));
+
+        ISimpleThread::Start();
+    }
+
+    void Stop() override
+    {
+        CQ.Shutdown();
+        Join();
+    }
+
+    TFuture<TResponse> Export(
+        TRequest traces,
+        const TString& authToken) override
+    {
+        auto requestHandler = std::make_unique<TRequestHandler>(
+            TDuration::MilliSeconds(Config.GetRequestTimeout()),
+            authToken,
+            std::move(traces));
+
+        auto future =
+            requestHandler->Execute(*Service, &CQ, requestHandler.get());
+
+        requestHandler.release();
+        return future;
+    }
+
+
+private:
+    void* ThreadProc() override
+    {
+        void* tag;
+        bool ok;
+        while (CQ.Next(&tag, &ok)) {
+            std::unique_ptr<TRequestHandler> requestHandler(
+                static_cast<TRequestHandler*>(tag));
+            requestHandler->Complete();
+        }
+        return nullptr;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceServiceClientPtr CreateTraceServiceClient(
+    ILoggingServicePtr logging,
+    NProto::TGrpcClientConfig config)
+{
+    auto a = std::make_shared<TTraceServiceClient>(
+        std::move(logging),
+        std::move(config));
+    return a;
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_service_client.h
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_service_client.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cloud/blockstore/config/grpc_client.pb.h>
+
+#include <cloud/blockstore/libs/opentelemetry/iface/public.h>
+#include <cloud/storage/core/libs/diagnostics/public.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITraceServiceClientPtr CreateTraceServiceClient(
+    ILoggingServicePtr logging,
+    NProto::TGrpcClientConfig config);
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/trace_ut.cpp
+++ b/cloud/blockstore/libs/opentelemetry/impl/trace_ut.cpp
@@ -1,0 +1,335 @@
+#include "helpers.h"
+#include "trace_convert.h"
+
+#include <library/cpp/lwtrace/all.h>
+#include <library/cpp/lwtrace/protos/lwtrace.pb.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <google/protobuf/text_format.h>
+
+namespace NCloud::NBlockStore {
+
+enum ESimpleEnum
+{
+    ValueA,
+    ValueB,
+};
+
+enum class EEnumClass
+{
+    ValueC,
+    ValueD,
+};
+
+#define LWTRACE_UT_PROVIDER(PROBE, EVENT, GROUPS, TYPES, NAMES)             \
+    PROBE(NoParam, GROUPS("Group"), TYPES(), NAMES())                       \
+    PROBE(IntParam, GROUPS("Group"), TYPES(ui32), NAMES("value"))           \
+    PROBE(                                                                  \
+        TwoIntParam,                                                        \
+        GROUPS("Group"),                                                    \
+        TYPES(ui32, ui32),                                                  \
+        NAMES("value1", "value2"))                                          \
+    PROBE(StringParam, GROUPS("Group"), TYPES(TString), NAMES("svalue"))    \
+    PROBE(                                                                  \
+        SymbolParam,                                                        \
+        GROUPS("Group"),                                                    \
+        TYPES(NLWTrace::TSymbol),                                           \
+        NAMES("symbol"))                                                    \
+    PROBE(                                                                  \
+        CheckParam,                                                         \
+        GROUPS("Group"),                                                    \
+        TYPES(NLWTrace::TCheck),                                            \
+        NAMES("value"))                                                     \
+    PROBE(                                                                  \
+        EnumParams,                                                         \
+        GROUPS("Group"),                                                    \
+        TYPES(ESimpleEnum, EEnumClass),                                     \
+        NAMES("simpleEnum", "enumClass"))                                   \
+    PROBE(InstantParam, GROUPS("Group"), TYPES(TInstant), NAMES("value"))   \
+    PROBE(DurationParam, GROUPS("Group"), TYPES(TDuration), NAMES("value")) \
+    PROBE(                                                                  \
+        ProtoEnum,                                                          \
+        GROUPS("Group"),                                                    \
+        TYPES(NLWTrace::EOperatorType),                                     \
+        NAMES("value"))                                                     \
+    PROBE(                                                                  \
+        IntIntParams,                                                       \
+        GROUPS("Group"),                                                    \
+        TYPES(ui32, ui64),                                                  \
+        NAMES("value1", "value2"))                                          \
+    /**/
+
+LWTRACE_DECLARE_PROVIDER(LWTRACE_UT_PROVIDER)
+LWTRACE_DEFINE_PROVIDER(LWTRACE_UT_PROVIDER)
+LWTRACE_USING(LWTRACE_UT_PROVIDER)
+
+using namespace NLWTrace;
+
+Y_UNIT_TEST_SUITE(TraceConverter)
+{
+    Y_UNIT_TEST(ShouldConvertSimpleSpan)
+    {
+        TManager mngr(*Singleton<TProbeRegistry>(), true);
+        TQuery q;
+        bool parsed = NProtoBuf::TextFormat::ParseFromString(
+            R"END(
+            Blocks {
+                ProbeDesc {
+                    Name: "NoParam"
+                    Provider: "LWTRACE_UT_PROVIDER"
+                }
+                Action {
+                    RunLogShuttleAction { }
+                }
+            }
+        )END",
+            &q);
+
+        UNIT_ASSERT(parsed);
+        mngr.New("Query1", q);
+
+        {
+            TOrbit a;
+
+            LWTRACK(NoParam, a);
+            LWTRACK(IntParam, a, 1);
+            LWTRACK(TwoIntParam, a, 3, 4);
+            LWTRACK(StringParam, a, "string");
+        }
+
+        struct
+        {
+            void Push(TThread::TId, const TTrackLog& tl)
+            {
+                auto spans = ConvertToOpenTelemetrySpans(tl);
+
+                UNIT_ASSERT(spans.size() == 1);
+
+                const auto& span = spans.front();
+
+                UNIT_ASSERT_VALUES_EQUAL(span.Gettrace_id(), ToHexString16(tl.Id));
+                UNIT_ASSERT_VALUES_EQUAL(span.Getspan_id(), ToHexString8(0));
+
+                UNIT_ASSERT_VALUES_EQUAL(span.Getevents().size(), 4);
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[0].Getname(),
+                    "NoParam");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[0].Getattributes().size(),
+                    0);
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[1].Getname(),
+                    "IntParam");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[1].Getattributes().size(),
+                    1);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[1].Getattributes()[0].Getkey(),
+                    "value");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[1]
+                        .Getattributes()[0]
+                        .Getvalue()
+                        .Getint_value(),
+                    1);
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[2].Getname(),
+                    "TwoIntParam");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[2].Getattributes().size(),
+                    2);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[2].Getattributes()[0].Getkey(),
+                    "value1");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[2]
+                        .Getattributes()[0]
+                        .Getvalue()
+                        .Getint_value(),
+                    3);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[2].Getattributes()[1].Getkey(),
+                    "value2");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[2]
+                        .Getattributes()[1]
+                        .Getvalue()
+                        .Getint_value(),
+                    4);
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[3].Getname(),
+                    "StringParam");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[3].Getattributes().size(),
+                    1);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[3].Getattributes()[0].Getkey(),
+                    "svalue");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    span.Getevents()[3]
+                        .Getattributes()[0]
+                        .Getvalue()
+                        .Getstring_value(),
+                    "string");
+            }
+        } reader;
+        mngr.ReadDepot("Query1", reader);
+    }
+
+    Y_UNIT_TEST(ShouldConvertForkJoinSpan)
+    {
+        TManager mngr(*Singleton<TProbeRegistry>(), true);
+        TQuery q;
+        bool parsed = NProtoBuf::TextFormat::ParseFromString(
+            R"END(
+            Blocks {
+                ProbeDesc {
+                    Name: "NoParam"
+                    Provider: "LWTRACE_UT_PROVIDER"
+                }
+                Action {
+                    RunLogShuttleAction { }
+                }
+            }
+        )END",
+            &q);
+
+        UNIT_ASSERT(parsed);
+        mngr.New("Query1", q);
+
+        {
+            TOrbit a, b, c, d;
+
+            // Graph:
+            //         c
+            //        / \
+            //     b-f-b-j-b
+            //    /         \
+            // a-f-a-f-a-j-a-j-a
+            //        \ /
+            //         d
+            //
+            // Merged track:
+            //   a-f(b)-a-f(d)-a-j(d,1)-d-a-j(b,6)-b-f(c)-b-j(c,1)-c-b-a
+
+            LWTRACK(IntParam, a, 0);
+            a.Fork(b);
+            LWTRACK(IntParam, a, 1);
+            a.Fork(d);
+            LWTRACK(IntParam, a, 2);
+
+            LWTRACK(IntParam, b, 3);
+            b.Fork(c);
+            LWTRACK(IntParam, b, 4);
+
+            LWTRACK(IntParam, c, 5);
+            b.Join(c);
+            LWTRACK(IntParam, b, 6);
+
+            LWTRACK(IntParam, d, 7);
+            a.Join(d);
+            LWTRACK(IntParam, a, 8);
+
+            a.Join(b);
+            LWTRACK(IntParam, a, 9);
+        }
+
+        struct
+        {
+            void Push(TThread::TId, const TTrackLog& tl)
+            {
+                auto spans = ConvertToOpenTelemetrySpans(tl);
+
+                UNIT_ASSERT(spans.size() == 4);
+
+                auto getValues = [](const auto& span)
+                {
+                    TVector<int> values;
+                    for (const auto& event: span.Getevents()) {
+                        UNIT_ASSERT_VALUES_EQUAL(event.Getname(), "IntParam");
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            event.Getattributes().size(),
+                            1);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            event.Getattributes()[0].Getkey(),
+                            "value");
+                        values.push_back(
+                            event.Getattributes()[0].Getvalue().Getint_value());
+                    }
+
+                    return values;
+                };
+
+                UNIT_ASSERT(AllOf(
+                    spans,
+                    [&](const auto& span)
+                    { return span.Gettrace_id() == ToHexString16(tl.Id); }));
+
+                UNIT_ASSERT(!spans[0].Getparent_span_id());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    getValues(spans[0]),
+                    (TVector<int>{0, 1, 2, 8, 9}));
+                UNIT_ASSERT_VALUES_EQUAL(8, spans[0].Getspan_id().size());
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    spans[0].Getspan_id(),
+                    spans[1].Getparent_span_id());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    (TVector<int>{3, 4, 6}),
+                    getValues(spans[1]));
+                UNIT_ASSERT_VALUES_EQUAL(8, spans[1].Getspan_id().size());
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    spans[1].Getspan_id(),
+                    spans[2].Getparent_span_id());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    (TVector<int>{5}),
+                    getValues(spans[2]));
+                UNIT_ASSERT_VALUES_EQUAL(8, spans[2].Getspan_id().size());
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    spans[0].Getspan_id(),
+                    spans[3].Getparent_span_id());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    (TVector<int>{7}),
+                    getValues(spans[3]));
+                UNIT_ASSERT_VALUES_EQUAL(8, spans[3].Getspan_id().size());
+
+                auto getTime = [](const auto& spans, int i, int j)
+                {
+                    return spans[i].Getevents()[j].Gettime_unix_nano();
+                };
+
+                TVector eventTimes{
+                    getTime(spans, 0, 0),
+                    spans[1].Getstart_time_unix_nano(),
+                    getTime(spans, 0, 1),
+                    spans[3].Getstart_time_unix_nano(),
+                    getTime(spans, 0, 2),
+                    getTime(spans, 1, 0),
+                    spans[2].Getstart_time_unix_nano(),
+                    getTime(spans, 1, 1),
+                    getTime(spans, 2, 0),
+                    spans[2].Getend_time_unix_nano(),
+                    getTime(spans, 1, 2),
+                    getTime(spans, 2, 0),
+                    spans[3].Getend_time_unix_nano(),
+                    getTime(spans, 0, 3),
+                    spans[1].Getend_time_unix_nano(),
+                    getTime(spans, 0, 4)};
+
+                for (size_t i = 0; i < eventTimes.size() - 1; ++i) {
+                    UNIT_ASSERT(eventTimes[i] < eventTimes[i + 1]);
+                }
+
+            }
+        } reader;
+        mngr.ReadDepot("Query1", reader);
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/opentelemetry/impl/ut/ya.make
+++ b/cloud/blockstore/libs/opentelemetry/impl/ut/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(cloud/blockstore/libs/opentelemetry/impl)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    trace_ut.cpp
+)
+
+END()

--- a/cloud/blockstore/libs/opentelemetry/impl/ya.make
+++ b/cloud/blockstore/libs/opentelemetry/impl/ya.make
@@ -1,0 +1,24 @@
+LIBRARY()
+
+SRCS(
+    helpers.cpp
+    trace_convert.cpp
+    trace_reader.cpp
+    trace_service_client.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/config
+    cloud/blockstore/libs/opentelemetry/iface
+    cloud/storage/core/libs/common
+    cloud/storage/core/libs/coroutine
+    cloud/storage/core/libs/iam/iface
+
+    contrib/libs/opentelemetry-proto
+
+    library/cpp/threading/future
+)
+
+END()
+
+RECURSE_FOR_TESTS(ut)

--- a/cloud/blockstore/libs/opentelemetry/ya.make
+++ b/cloud/blockstore/libs/opentelemetry/ya.make
@@ -1,0 +1,4 @@
+RECURSE(
+    iface
+    impl
+)

--- a/cloud/blockstore/libs/ya.make
+++ b/cloud/blockstore/libs/ya.make
@@ -23,6 +23,7 @@ RECURSE(
     nbd/bench
     notify
     nvme
+    opentelemetry
     rdma
     rdma_test
     root_kms

--- a/cloud/storage/core/libs/diagnostics/trace_reader.h
+++ b/cloud/storage/core/libs/diagnostics/trace_reader.h
@@ -5,6 +5,7 @@
 #include <cloud/storage/core/protos/media.pb.h>
 #include <cloud/storage/core/protos/trace.pb.h>
 
+#include <library/cpp/containers/ring_buffer/ring_buffer.h>
 #include <library/cpp/lwtrace/log.h>
 
 #include <util/generic/hash.h>
@@ -59,6 +60,25 @@ struct ITraceReader
     virtual void ForEach(std::function<void(const TEntry&)> fn) = 0;
     virtual void Reset() = 0;
 };
+
+struct ITraceReaderWithRingBuffer
+    : public ITraceReader
+{
+    TSimpleRingBuffer<TEntry> RingBuffer;
+
+    explicit ITraceReaderWithRingBuffer(TString id)
+        : ITraceReader(std::move(id))
+        , RingBuffer(1000)
+    {}
+
+    void ForEach(std::function<void(const TEntry&)> fn) override
+    {
+        for (ui64 i = RingBuffer.FirstIndex(); i < RingBuffer.TotalSize(); ++i) {
+            fn(RingBuffer[i]);
+        }
+    }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 ITraceReaderPtr CreateTraceLogger(


### PR DESCRIPTION
#1223

Сейчас у нас трейсы преобразуются в строку и печатаются в лог, эту логику реализует TTraceLogger. В него "пушат" новые трейсы и он перед запоминаем их сериализует в строку и печатает в лог.
В этом пре добавил класс аналогичный TTraceLogger, который вместо печати в лог конвертирует трейс в opentelemetry протобуфину и экспортирует ее в какой-нибудь трейсинг сервис.
В Jaeger'е это выглядит следующим образом 
![image_2025-06-27_19-30-02](https://github.com/user-attachments/assets/a271b181-1766-4a0d-9348-0aabd2c1fb1d)
![image_2025-06-27_19-30-18](https://github.com/user-attachments/assets/dd33ae78-d6fd-45f7-a62a-f71088555885)
![image_2025-06-27_19-30-31](https://github.com/user-attachments/assets/ef359c16-aabc-4c9e-bd15-a7a023fabdf7)

