### PR TITLE
[CSI] Report mount conflicts as a separate counter

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -358,6 +358,7 @@ func (s *nodeService) NodeStageVolume(
 		if s.IsMountConflictError(err, nfsBackend) {
 			errorCode = codes.AlreadyExists
 		}
+
 		return nil, s.statusErrorf(errorCode, "Failed to stage volume: %v", err)
 	}
 

--- a/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring.go
+++ b/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring.go
@@ -9,6 +9,7 @@ import (
 	"github.com/siddontang/go-log/log"
 	"github.com/ydb-platform/nbs/library/go/core/metrics"
 	"github.com/ydb-platform/nbs/library/go/core/metrics/prometheus"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -19,6 +21,7 @@ func trimTrailingWhitespace(input string) string {
 	for i, line := range lines {
 		lines[i] = strings.TrimRight(line, " \t")
 	}
+
 	return strings.Join(lines, "\n")
 }
 
@@ -163,7 +166,7 @@ func TestShouldReportMountConflicts(t *testing.T) {
 	defer serv.Close()
 
 	response, err := http.Get(serv.URL)
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	assert.Equal(t, response.StatusCode, http.StatusOK)
 	assert.Equal(t, getResponseBody(response),
 		`# HELP Count

--- a/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring_test.go
@@ -5,16 +5,27 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+func trimTrailingWhitespace(input string) string {
+	lines := strings.Split(input, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
 
 func getResponseBody(response *http.Response) string {
 	bodyBytes, err := io.ReadAll(response.Body)
 	if err == nil {
-		return string(bodyBytes)
+		return trimTrailingWhitespace(string(bodyBytes))
 	} else {
 		return err.Error()
 	}
@@ -41,7 +52,7 @@ func TestShouldReportVersion(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, response.StatusCode, http.StatusOK)
 	assert.Equal(t, getResponseBody(response),
-		`# HELP version 
+		`# HELP version
 # TYPE version gauge
 version{component="server",revision="2.5"} 1
 `)
@@ -61,12 +72,12 @@ func TestShouldReportInflightAndCount(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, response.StatusCode, http.StatusOK)
 	assert.Equal(t, getResponseBody(response),
-		`# HELP Count 
+		`# HELP Count
 # TYPE Count counter
 Count{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 1
 Count{component="server",method="/csi.v1.Controller/CreateVolume"} 2
 Count{component="server",method="/csi.v1.Controller/DeleteVolume"} 1
-# HELP InflightCount 
+# HELP InflightCount
 # TYPE InflightCount gauge
 InflightCount{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 1
 InflightCount{component="server",method="/csi.v1.Controller/CreateVolume"} 2
@@ -91,16 +102,16 @@ func TestShouldReportErrorsAndSuccess(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, response.StatusCode, http.StatusOK)
 	assert.Equal(t, getResponseBody(response),
-		`# HELP Count 
+		`# HELP Count
 # TYPE Count counter
 Count{component="server",method="/csi.v1.Controller/CreateVolume"} 4
-# HELP Errors 
+# HELP Errors
 # TYPE Errors counter
 Errors{component="server",method="/csi.v1.Controller/CreateVolume"} 1
-# HELP InflightCount 
+# HELP InflightCount
 # TYPE InflightCount gauge
 InflightCount{component="server",method="/csi.v1.Controller/CreateVolume"} 1
-# HELP Success 
+# HELP Success
 # TYPE Success counter
 Success{component="server",method="/csi.v1.Controller/CreateVolume"} 2
 `)
@@ -118,16 +129,16 @@ func TestShouldReportTimeBuckets(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, response.StatusCode, http.StatusOK)
 	assert.Equal(t, getResponseBody(response),
-		`# HELP Count 
+		`# HELP Count
 # TYPE Count counter
 Count{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 1
-# HELP InflightCount 
+# HELP InflightCount
 # TYPE InflightCount gauge
 InflightCount{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 0
-# HELP Success 
+# HELP Success
 # TYPE Success counter
 Success{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 1
-# HELP Time 
+# HELP Time
 # TYPE Time histogram
 Time_bucket{component="server",method="/csi.v1.Controller/ControllerPublishVolume",le="0.001"} 0
 Time_bucket{component="server",method="/csi.v1.Controller/ControllerPublishVolume",le="0.01"} 0
@@ -140,5 +151,29 @@ Time_bucket{component="server",method="/csi.v1.Controller/ControllerPublishVolum
 Time_bucket{component="server",method="/csi.v1.Controller/ControllerPublishVolume",le="+Inf"} 1
 Time_sum{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 7
 Time_count{component="server",method="/csi.v1.Controller/ControllerPublishVolume"} 1
+`)
+}
+
+func TestShouldReportMountConflicts(t *testing.T) {
+	mon := NewTestMonitoring()
+	mon.ReportRequestReceived("/csi.v1.Node/NodeStageVolume")
+	mon.ReportRequestCompleted("/csi.v1.Node/NodeStageVolume", status.Error(codes.AlreadyExists, ""), -1)
+
+	serv := httptest.NewServer(mon.Handler)
+	defer serv.Close()
+
+	response, err := http.Get(serv.URL)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, response.StatusCode, http.StatusOK)
+	assert.Equal(t, getResponseBody(response),
+		`# HELP Count
+# TYPE Count counter
+Count{component="server",method="/csi.v1.Node/NodeStageVolume"} 1
+# HELP InflightCount
+# TYPE InflightCount gauge
+InflightCount{component="server",method="/csi.v1.Node/NodeStageVolume"} 0
+# HELP MountConflicts
+# TYPE MountConflicts counter
+MountConflicts{component="server",method="/csi.v1.Node/NodeStageVolume"} 1
 `)
 }

--- a/cloud/blockstore/tools/csi_driver/internal/ya.make
+++ b/cloud/blockstore/tools/csi_driver/internal/ya.make
@@ -1,5 +1,6 @@
 RECURSE(
     driver
+    monitoring
     mounter
     volume
 )


### PR DESCRIPTION
issue: #3804

Report mount conflict errors using a separate counter, as we want to configure alerts differently for various CSI error types.

1. return AlreadyExists error code if StartEndpoint returned E_MOUNT_CONFLICT
2. Report mount conflicts errors as a separate counter