### PR TITLE
TFileRingBuffer: refactoring - extract memory access related code to TFileRingBufferData

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -248,10 +248,6 @@ public:
                     return false;
                 }
             }
-        } else {
-            Header()->ReadPos = 0;
-            Header()->WritePos = 0;
-            writePos = 0;
         }
 
         Data.WriteEntry(writePos, data);

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -96,7 +96,7 @@ public:
 
     void WriteEntry(ui64 pos, TStringBuf data)
     {
-        auto eh = GetEntryHeader(pos);
+        auto* eh = GetEntryHeader(pos);
         Y_ABORT_UNLESS(eh != nullptr);
 
         eh->Size = data.size();

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -34,14 +34,92 @@ struct Y_PACKED TEntryHeader
     ui32 Checksum = 0;
 };
 
-void WriteEntry(IOutputStream& os, TStringBuf data)
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferData
 {
-    TEntryHeader eh;
-    eh.Size = data.size();
-    eh.Checksum = Crc32c(data.data(), data.size());
-    os.Write(&eh, sizeof(eh));
-    os.Write(data);
-}
+private:
+    char* Begin = nullptr;
+    const char* End = nullptr;
+
+    bool IsValidRegion(const char* ptr, ui64 size) const
+    {
+        const char* end = ptr + size;
+        return Begin <= ptr && ptr <= end && end <= End;
+    }
+
+    char* CheckPtr(char* ptr, ui64 size)
+    {
+        return IsValidRegion(ptr, size) ? ptr : nullptr;
+    }
+
+    const char* CheckPtr(const char* ptr, ui64 size) const
+    {
+        return IsValidRegion(ptr, size) ? ptr : nullptr;
+    }
+
+    char* GetPtr(ui64 pos, ui64 size)
+    {
+        return CheckPtr(Begin + pos, size);
+    }
+
+    const char* GetPtr(ui64 pos, ui64 size) const
+    {
+        return CheckPtr(Begin + pos, size);
+    }
+
+public:
+    void Init(char* begin, const char* end)
+    {
+        Y_ABORT_UNLESS(begin != nullptr);
+        Y_ABORT_UNLESS(end != nullptr);
+        Y_ABORT_UNLESS(begin <= end);
+
+        Begin = begin;
+        End = end;
+    }
+
+    TEntryHeader* GetEntryHeader(ui64 pos)
+    {
+        char* ptr = GetPtr(pos, sizeof(TEntryHeader));
+        return reinterpret_cast<TEntryHeader*>(ptr);
+    }
+
+    const TEntryHeader* GetEntryHeader(ui64 pos) const
+    {
+        const char* ptr = GetPtr(pos, sizeof(TEntryHeader));
+        return reinterpret_cast<const TEntryHeader*>(ptr);
+    }
+
+    char* GetEntryData(TEntryHeader* eh)
+    {
+        Y_ABORT_UNLESS(eh != nullptr);
+        return CheckPtr(
+            reinterpret_cast<char*>(eh) + sizeof(TEntryHeader),
+            eh->Size);
+    }
+
+    const char* GetEntryData(const TEntryHeader* eh) const
+    {
+        Y_ABORT_UNLESS(eh != nullptr);
+        return CheckPtr(
+            reinterpret_cast<const char*>(eh) + sizeof(TEntryHeader),
+            eh->Size);
+    }
+
+    void WriteEntry(ui64 pos, TStringBuf data)
+    {
+        auto eh = GetEntryHeader(pos);
+        Y_ABORT_UNLESS(eh != nullptr);
+
+        eh->Size = data.size();
+        eh->Checksum = Crc32c(data.data(), data.size());
+
+        auto* dst = GetEntryData(eh);
+        Y_ABORT_UNLESS(dst != nullptr);
+        memcpy(dst, data.data(), data.size());
+    }
+};
 
 }   // namespace
 
@@ -52,9 +130,8 @@ class TFileRingBuffer::TImpl
 private:
     TFileMap Map;
 
-    char* Data = nullptr;
+    TFileRingBufferData Data;
     ui64 Count = 0;
-    const char* End = nullptr;
 
 private:
     THeader* Header()
@@ -75,37 +152,25 @@ private:
             return;
         }
 
-        const auto* b = Data + Header()->ReadPos;
-        if (b + sizeof(TEntryHeader) > End) {
-            Header()->ReadPos = 0;
-            return;
-        }
-
-        const auto* eh = reinterpret_cast<const TEntryHeader*>(b);
-        if (eh->Size == 0) {
+        const auto* eh = Data.GetEntryHeader(Header()->ReadPos);
+        if (eh == nullptr || eh->Size == 0) {
             Header()->ReadPos = 0;
         }
     }
 
     ui64 VisitEntry(const TVisitor& visitor, ui64 pos) const
     {
-        const auto* b = Data + pos;
-        if (b + sizeof(TEntryHeader) > End) {
-            // slack space smaller than TEntryHeader
+        const auto* eh = Data.GetEntryHeader(pos);
+        if (eh == nullptr || eh->Size == 0) {
             return 0;
         }
 
-        const auto* eh = reinterpret_cast<const TEntryHeader*>(b);
-        if (eh->Size == 0) {
-            return 0;
-        }
-
-        TStringBuf entry(b + sizeof(TEntryHeader), eh->Size);
-        if (entry.data() + entry.size() > End) {
+        const auto* data = Data.GetEntryData(eh);
+        if (data == nullptr) {
             visitor(eh->Checksum, INVALID_MARKER);
             return INVALID_POS;
         }
-        visitor(eh->Checksum, {b + sizeof(TEntryHeader), eh->Size});
+        visitor(eh->Checksum, {data, eh->Size});
         return pos + sizeof(TEntryHeader) + eh->Size;
     }
 
@@ -130,10 +195,9 @@ public:
             Header()->Version = VERSION;
         }
 
-        Data = static_cast<char*>(Map.Ptr()) + sizeof(THeader);
-        End = Data + capacity;
+        auto* begin = static_cast<char*>(Map.Ptr()) + sizeof(THeader);
+        Data.Init(begin, begin + capacity);
 
-        SkipSlackSpace();
         Visit([this] (ui32 checksum, TStringBuf entry) {
             Y_UNUSED(checksum);
             Y_UNUSED(entry);
@@ -152,7 +216,7 @@ public:
         if (sz > Header()->Capacity) {
             return false;
         }
-        auto* ptr = Data + Header()->WritePos;
+        auto writePos = Header()->WritePos;
 
         if (!Empty()) {
             // checking that we have a contiguous chunk of sz + 1 bytes
@@ -166,9 +230,11 @@ public:
                         // out of space
                         return false;
                     }
-
-                    memset(ptr, 0, Min(sizeof(TEntryHeader), freeSpace));
-                    ptr = Data;
+                    auto* eh = Data.GetEntryHeader(Header()->WritePos);
+                    if (eh != nullptr) {
+                        eh->Size = 0;
+                    }
+                    writePos = 0;
                 }
             } else {
                 // we have two occupied regions
@@ -179,12 +245,15 @@ public:
                     return false;
                 }
             }
+        } else {
+            Header()->ReadPos = 0;
+            Header()->WritePos = 0;
+            writePos = 0;
         }
 
-        TMemoryOutput mo(ptr, sz);
-        WriteEntry(mo, data);
+        Data.WriteEntry(writePos, data);
 
-        Header()->WritePos = ptr - Data + sz;
+        Header()->WritePos = writePos + sz;
         Header()->LastEntrySize = sz;
         ++Count;
 
@@ -197,22 +266,21 @@ public:
             return {};
         }
 
-        const auto* b = Data + Header()->ReadPos;
-        if (b + sizeof(TEntryHeader) > End) {
+        const auto* eh = Data.GetEntryHeader(Header()->ReadPos);
+        if (eh == nullptr) {
             // corruption
             // TODO: report?
             return {};
         }
 
-        const auto* eh = reinterpret_cast<const TEntryHeader*>(b);
-        TStringBuf result{b + sizeof(TEntryHeader), eh->Size};
-        if (result.data() + result.size() > End) {
+        const auto* data = Data.GetEntryData(eh);
+        if (data == nullptr) {
             // corruption
             // TODO: report?
             return {};
         }
 
-        return result;
+        return {data, eh->Size};
     }
 
     TStringBuf Back() const
@@ -227,22 +295,16 @@ public:
             return {};
         }
 
-        const auto* b = Data + Header()->WritePos - Header()->LastEntrySize;
-        if (b + sizeof(TEntryHeader) > End) {
+        const auto* eh =
+            Data.GetEntryHeader(Header()->WritePos - Header()->LastEntrySize);
+        const auto* data = eh ? Data.GetEntryData(eh) : nullptr;
+        if (data == nullptr) {
             // corruption
             // TODO: report?
             return {};
         }
 
-        const auto* eh = reinterpret_cast<const TEntryHeader*>(b);
-        TStringBuf result{b + sizeof(TEntryHeader), eh->Size};
-        if (result.data() + result.size() > End) {
-            // corruption
-            // TODO: report?
-            return {};
-        }
-
-        return result;
+        return {data, eh->Size};
     }
 
     void PopFront()

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -36,7 +36,7 @@ struct Y_PACKED TEntryHeader
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TFileRingBufferData
+class TEntriesData
 {
 private:
     char* Begin = nullptr;
@@ -69,7 +69,9 @@ private:
     }
 
 public:
-    void Init(char* begin, const char* end)
+    TEntriesData() = default;
+
+    TEntriesData(char* begin, const char* end)
     {
         Y_ABORT_UNLESS(begin != nullptr);
         Y_ABORT_UNLESS(end != nullptr);
@@ -130,7 +132,7 @@ class TFileRingBuffer::TImpl
 private:
     TFileMap Map;
 
-    TFileRingBufferData Data;
+    TEntriesData Data;
     ui64 Count = 0;
 
 private:
@@ -196,7 +198,7 @@ public:
         }
 
         auto* begin = static_cast<char*>(Map.Ptr()) + sizeof(THeader);
-        Data.Init(begin, begin + capacity);
+        Data = {begin, begin + capacity};
 
         Visit([this] (ui32 checksum, TStringBuf entry) {
             Y_UNUSED(checksum);

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -198,8 +198,9 @@ public:
         }
 
         auto* begin = static_cast<char*>(Map.Ptr()) + sizeof(THeader);
-        Data = {begin, begin + capacity};
+        Data = TEntriesData(begin, begin + capacity);
 
+        SkipSlackSpace();
         Visit([this] (ui32 checksum, TStringBuf entry) {
             Y_UNUSED(checksum);
             Y_UNUSED(entry);


### PR DESCRIPTION
Extracted from https://github.com/ydb-platform/nbs/pull/3790

Code deduplication: consolidate memory access code in a single place.

Motivation: the same logic should be used in `Visit`, `PopFront`, `PushBack` but currently there already exists inconsistency. For example, in the case of corruption, `Visit` and `PopFront` may produce different results.

Next: https://github.com/ydb-platform/nbs/pull/3816