### PR TITLE
Remove singletone to prevent race conditions

### DIFF
--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -366,11 +366,7 @@ void InitVhostLog(ILoggingServicePtr logging)
 
 IVhostQueueFactoryPtr CreateVhostQueueFactory()
 {
-    struct TInitializer
-    {
-        IVhostQueueFactoryPtr Factory = std::make_shared<TVhostQueueFactory>();
-    };
-    return Singleton<TInitializer>()->Factory;
+    return std::make_shared<TVhostQueueFactory>();
 }
 
 }   // namespace NCloud::NBlockStore::NVhost


### PR DESCRIPTION
Turn vhost logger into pointer to prevent race conditions.

```
==================
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=571716)
  Write of size 8 at 0x7b0400000030 by main thread:
    #0 TLogBackend::~TLogBackend() /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:60:29 (cloud-blockstore-libs-vhost-ut+0x125ce9e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TStreamLogBackend::~TStreamLogBackend /actions-runner/_work/nbs/nbs/library/cpp/logger/stream.cpp:13:1 (cloud-blockstore-libs-vhost-ut+0x125fd09) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 TStreamLogBackend::~TStreamLogBackend() /actions-runner/_work/nbs/nbs/library/cpp/logger/stream.cpp:12:41 (cloud-blockstore-libs-vhost-ut+0x125fd09)
    #3 std::__y1::default_delete<TLogBackend>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:49:5 (cloud-blockstore-libs-vhost-ut+0x1f6e094) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #4 std::__y1::__shared_ptr_pointer<TLogBackend*, std::__y1::shared_ptr<TLogBackend>::__shared_ptr_default_delete<TLogBackend, TLogBackend>, std::__y1::allocator<TLogBackend>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:289:5 (cloud-blockstore-libs-vhost-ut+0x1f6e094)
    #5 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (cloud-blockstore-libs-vhost-ut+0x1f6e813) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #6 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (cloud-blockstore-libs-vhost-ut+0x1f6e813)
    #7 std::__y1::shared_ptr<TLogBackend>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (cloud-blockstore-libs-vhost-ut+0x1f6e813)
    #8 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e813)
    #9 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e8c9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #10 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #12 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #13 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #14 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #15 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #16 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #17 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #18 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #19 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #20 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #21 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #22 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #23 cxa_at_exit_callback_installed_at(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:432:3 (cloud-blockstore-libs-vhost-ut+0xd1aaa9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 __cxx_global_var_init /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 _GLOBAL__sub_I_vhost.cpp /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604)
  Previous read of size 8 at 0x7b0400000030 by thread T1:
    #0 NCloud::(anonymous namespace)::TComponentLogBackend::WriteData(TLogRecord const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:78:22 (cloud-blockstore-libs-vhost-ut+0x1f6ee07) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TLog::TImpl::WriteData /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:100:23 (cloud-blockstore-libs-vhost-ut+0x1262b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 TLog::Write(ELogPriority, char const*, unsigned long, TVector<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>, std::__y1::allocator<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>>>) const /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:231:16 (cloud-blockstore-libs-vhost-ut+0x1262b03)
    #3 TLogElement::DoFlush() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:36:18 (cloud-blockstore-libs-vhost-ut+0x1f61d2a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #4 IOutputStream::Flush /actions-runner/_work/nbs/nbs/util/stream/output.h:119:9 (cloud-blockstore-libs-vhost-ut+0xe9b382) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #5 IOutputStream::DoFinish() /actions-runner/_work/nbs/nbs/util/stream/output.cpp:41:5 (cloud-blockstore-libs-vhost-ut+0xe9b382)
    #6 IOutputStream::Finish /actions-runner/_work/nbs/nbs/util/stream/output.h:127:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #7 TLogElement::~TLogElement() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:23:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66)
    #8 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NProto::TError> > /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:191:13 (cloud-blockstore-libs-vhost-ut+0x222352e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #9 NThreading::TFuture<NCloud::NProto::TError>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:189:34) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NProto::TError> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #10 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #11 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #12 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0x22246d4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #13 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #14 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #15 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)>, void (NThreading::TFuture<NCloud::NProto::TError> const&)>::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #16 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0x221bc57) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #17 std::__y1::function<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #18 bool NThreading::NImpl::TFutureState<NCloud::NProto::TError>::TrySetValue<NCloud::NProto::TError>(NCloud::NProto::TError&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #19 NThreading::NImpl::TFutureState<NCloud::NProto::TError>::SetValue<NCloud::NProto::TError> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (cloud-blockstore-libs-vhost-ut+0x22231a8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 NThreading::TPromise<NCloud::NProto::TError>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #21 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::OnCompletion /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:113:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #22 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::Callback(void*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:107:21 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #23 vhd_vdev_release /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1898:9 (cloud-blockstore-libs-vhost-ut+0x2229913) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 vdev_drained /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2093:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 vdev_maybe_finished /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:257:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0)
    #26 vdev_stop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2271:5 (cloud-blockstore-libs-vhost-ut+0x2229b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #27 vdev_work_fn /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1829:5 (cloud-blockstore-libs-vhost-ut+0x222a50b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #28 work_bh /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:559:5 (cloud-blockstore-libs-vhost-ut+0x2228c40) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #29 bh_call /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:184:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #30 bh_poll /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:211:13 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #31 vhd_run_event_loop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:370:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #32 vhost_evloop_func /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:26:15 (cloud-blockstore-libs-vhost-ut+0x2225808) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Location is heap block of size 16 at 0x7b0400000030 allocated by main thread:
    #0 operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (cloud-blockstore-libs-vhost-ut+0xd5f277) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 MakeHolder<TStreamLogBackend, IOutputStream *> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:351:23 (cloud-blockstore-libs-vhost-ut+0xc5d127) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 TCerrLogBackendCreator::DoCreateLogBackend() const /actions-runner/_work/nbs/nbs/library/cpp/logger/stream_creator.cpp:5:12 (cloud-blockstore-libs-vhost-ut+0xc5d127)
    #3 ILogBackendCreator::CreateLogBackend() const /actions-runner/_work/nbs/nbs/library/cpp/logger/backend_creator.cpp:11:16 (cloud-blockstore-libs-vhost-ut+0x125d5ff) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #4 TLogBackendCreatorUninitialized::DoCreateLogBackend() const /actions-runner/_work/nbs/nbs/library/cpp/logger/uninitialized_creator.cpp:9:19 (cloud-blockstore-libs-vhost-ut+0xc60efa) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #5 ILogBackendCreator::CreateLogBackend() const /actions-runner/_work/nbs/nbs/library/cpp/logger/backend_creator.cpp:11:16 (cloud-blockstore-libs-vhost-ut+0x125d5ff) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #6 CreateLogBackend(TBasicString<char, std::__y1::char_traits<char>> const&, ELogPriority, bool) /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:15:20 (cloud-blockstore-libs-vhost-ut+0x12611c8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #7 NCloud::CreateLoggingService(TBasicString<char, std::__y1::char_traits<char>> const&, NCloud::TLogSettings const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:365:20 (cloud-blockstore-libs-vhost-ut+0x1f6aba6) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #8 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:466:24 (cloud-blockstore-libs-vhost-ut+0xc7f95c) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #9 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #10 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #11 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #12 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #13 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #14 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #16 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #17 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #19 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #21 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Thread T1 (tid=571723, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-vhost-ut+0xcd614b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 vhd_start_vhost_server /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:58:11 (cloud-blockstore-libs-vhost-ut+0x2225716) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory::TVhostQueueFactory /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:343:19 (cloud-blockstore-libs-vhost-ut+0x2220c83) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #4 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #5 std::__y1::__shared_ptr_emplace<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::__shared_ptr_emplace<> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #6 std::__y1::allocate_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #7 std::__y1::make_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #8 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer::TInitializer /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:371:41 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #9 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer* NPrivate::SingletonBase<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer, 65536ul>(std::__y1::atomic<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer*>&) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:38:35 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #10 NPrivate::SingletonInt<TInitializer, 65536UL> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:69:19 (cloud-blockstore-libs-vhost-ut+0x2220bae) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 Singleton<TInitializer> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:116:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #12 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:373:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #13 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:469:34 (cloud-blockstore-libs-vhost-ut+0xc7fadc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #16 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #17 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #18 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #19 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #21 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #22 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
SUMMARY: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:60:29 in TLogBackend::~TLogBackend()
==================
==================
WARNING: ThreadSanitizer: data race (pid=571716)
  Write of size 8 at 0x7b0400000038 by main thread:
    #0 operator delete(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (cloud-blockstore-libs-vhost-ut+0xd5f90f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TStreamLogBackend::~TStreamLogBackend() /actions-runner/_work/nbs/nbs/library/cpp/logger/stream.cpp:12:41 (cloud-blockstore-libs-vhost-ut+0x125fd11) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 std::__y1::default_delete<TLogBackend>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:49:5 (cloud-blockstore-libs-vhost-ut+0x1f6e094) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::__shared_ptr_pointer<TLogBackend*, std::__y1::shared_ptr<TLogBackend>::__shared_ptr_default_delete<TLogBackend, TLogBackend>, std::__y1::allocator<TLogBackend>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:289:5 (cloud-blockstore-libs-vhost-ut+0x1f6e094)
    #4 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:187:9 (cloud-blockstore-libs-vhost-ut+0x1f6e813) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #5 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:241:27 (cloud-blockstore-libs-vhost-ut+0x1f6e813)
    #6 std::__y1::shared_ptr<TLogBackend>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:728:23 (cloud-blockstore-libs-vhost-ut+0x1f6e813)
    #7 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e813)
    #8 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e8c9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #9 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #10 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #11 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #12 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #13 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #14 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #15 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #16 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #17 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #18 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #19 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #20 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #21 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #22 cxa_at_exit_callback_installed_at(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:432:3 (cloud-blockstore-libs-vhost-ut+0xd1aaa9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 __cxx_global_var_init /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 _GLOBAL__sub_I_vhost.cpp /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604)
  Previous read of size 8 at 0x7b0400000038 by thread T1:
    #0 TStreamLogBackend::WriteData(TLogRecord const&) /actions-runner/_work/nbs/nbs/library/cpp/logger/stream.cpp:16:5 (cloud-blockstore-libs-vhost-ut+0x125fd5e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 NCloud::(anonymous namespace)::TComponentLogBackend::WriteData(TLogRecord const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:78:22 (cloud-blockstore-libs-vhost-ut+0x1f6ee14) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 TLog::TImpl::WriteData /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:100:23 (cloud-blockstore-libs-vhost-ut+0x1262b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 TLog::Write(ELogPriority, char const*, unsigned long, TVector<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>, std::__y1::allocator<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>>>) const /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:231:16 (cloud-blockstore-libs-vhost-ut+0x1262b03)
    #4 TLogElement::DoFlush() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:36:18 (cloud-blockstore-libs-vhost-ut+0x1f61d2a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #5 IOutputStream::Flush /actions-runner/_work/nbs/nbs/util/stream/output.h:119:9 (cloud-blockstore-libs-vhost-ut+0xe9b382) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #6 IOutputStream::DoFinish() /actions-runner/_work/nbs/nbs/util/stream/output.cpp:41:5 (cloud-blockstore-libs-vhost-ut+0xe9b382)
    #7 IOutputStream::Finish /actions-runner/_work/nbs/nbs/util/stream/output.h:127:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #8 TLogElement::~TLogElement() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:23:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66)
    #9 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NProto::TError> > /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:191:13 (cloud-blockstore-libs-vhost-ut+0x222352e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #10 NThreading::TFuture<NCloud::NProto::TError>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:189:34) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NProto::TError> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #11 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #12 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #13 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0x22246d4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #15 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #16 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)>, void (NThreading::TFuture<NCloud::NProto::TError> const&)>::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #17 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0x221bc57) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 std::__y1::function<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #19 bool NThreading::NImpl::TFutureState<NCloud::NProto::TError>::TrySetValue<NCloud::NProto::TError>(NCloud::NProto::TError&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #20 NThreading::NImpl::TFutureState<NCloud::NProto::TError>::SetValue<NCloud::NProto::TError> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (cloud-blockstore-libs-vhost-ut+0x22231a8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #21 NThreading::TPromise<NCloud::NProto::TError>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #22 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::OnCompletion /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:113:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #23 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::Callback(void*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:107:21 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #24 vhd_vdev_release /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1898:9 (cloud-blockstore-libs-vhost-ut+0x2229913) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 vdev_drained /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2093:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 vdev_maybe_finished /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:257:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0)
    #27 vdev_stop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2271:5 (cloud-blockstore-libs-vhost-ut+0x2229b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #28 vdev_work_fn /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1829:5 (cloud-blockstore-libs-vhost-ut+0x222a50b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #29 work_bh /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:559:5 (cloud-blockstore-libs-vhost-ut+0x2228c40) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #30 bh_call /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:184:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #31 bh_poll /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:211:13 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #32 vhd_run_event_loop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:370:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #33 vhost_evloop_func /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:26:15 (cloud-blockstore-libs-vhost-ut+0x2225808) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Thread T1 (tid=571723, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-vhost-ut+0xcd614b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 vhd_start_vhost_server /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:58:11 (cloud-blockstore-libs-vhost-ut+0x2225716) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory::TVhostQueueFactory /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:343:19 (cloud-blockstore-libs-vhost-ut+0x2220c83) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #4 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #5 std::__y1::__shared_ptr_emplace<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::__shared_ptr_emplace<> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #6 std::__y1::allocate_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #7 std::__y1::make_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #8 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer::TInitializer /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:371:41 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #9 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer* NPrivate::SingletonBase<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer, 65536ul>(std::__y1::atomic<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer*>&) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:38:35 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #10 NPrivate::SingletonInt<TInitializer, 65536UL> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:69:19 (cloud-blockstore-libs-vhost-ut+0x2220bae) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 Singleton<TInitializer> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:116:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #12 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:373:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #13 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:469:34 (cloud-blockstore-libs-vhost-ut+0xc7fadc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #16 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #17 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #18 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #19 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #21 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #22 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
SUMMARY: ThreadSanitizer: data race /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 in operator delete(void*)
==================
==================
WARNING: ThreadSanitizer: data race (pid=571716)
  Write of size 8 at 0x7b0800008be8 by main thread:
    #0 operator delete(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (cloud-blockstore-libs-vhost-ut+0xd5f90f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >::UnRef /actions-runner/_work/nbs/nbs/util/generic/string.h:98:13 (cloud-blockstore-libs-vhost-ut+0x1f6e88e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 TStringPtrOps<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > >::UnRef /actions-runner/_work/nbs/nbs/util/generic/string.h:51:16 (cloud-blockstore-libs-vhost-ut+0x1f6e88e)
    #3 TIntrusivePtr<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, TStringPtrOps<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1f6e88e)
    #4 TIntrusivePtr<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, TStringPtrOps<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1f6e88e)
    #5 TBasicString<char, std::__y1::char_traits<char> >::~TBasicString /actions-runner/_work/nbs/nbs/util/generic/fwd.h:8:7 (cloud-blockstore-libs-vhost-ut+0x1f6e88e)
    #6 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e88e)
    #7 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e8c9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #8 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #9 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #10 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #11 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #12 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #13 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #14 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #15 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #16 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #17 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #18 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #19 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #20 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #21 cxa_at_exit_callback_installed_at(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:432:3 (cloud-blockstore-libs-vhost-ut+0xd1aaa9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #22 __cxx_global_var_init /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 _GLOBAL__sub_I_vhost.cpp /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604)
  Previous read of size 7 at 0x7b0800008be9 by thread T1:
    #0 __tsan_memmove /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:3178:3 (cloud-blockstore-libs-vhost-ut+0xd1a5a0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 std::__y1::__copy_impl<const char, char, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy.h:55:5 (cloud-blockstore-libs-vhost-ut+0xd9779a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 std::__y1::__copy<const char *, const char *, char *, 0> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy.h:93:16 (cloud-blockstore-libs-vhost-ut+0xd9779a)
    #3 std::__y1::copy<const char *, char *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy.h:101:10 (cloud-blockstore-libs-vhost-ut+0xd9779a)
    #4 std::__y1::copy_n<const char *, unsigned long, char *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__algorithm/copy_n.h:61:12 (cloud-blockstore-libs-vhost-ut+0xd9779a)
    #5 std::__y1::char_traits<char>::copy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__string/char_traits.h:233:9 (cloud-blockstore-libs-vhost-ut+0xd9779a)
    #6 std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char>>::append(char const*, unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/string:2725:13 (cloud-blockstore-libs-vhost-ut+0xd9779a)
    #7 TBasicString<char, std::__y1::char_traits<char> >::append /actions-runner/_work/nbs/nbs/util/generic/string.h:754:18 (cloud-blockstore-libs-vhost-ut+0xe9fc53) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #8 TStringOutput::DoWrite(void const*, unsigned long) /actions-runner/_work/nbs/nbs/util/stream/str.cpp:37:9 (cloud-blockstore-libs-vhost-ut+0xe9fc53)
    #9 IOutputStream::Write /actions-runner/_work/nbs/nbs/util/stream/output.h:73:13 (cloud-blockstore-libs-vhost-ut+0xe9b7d5) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #10 void Out<TBasicString<char, std::__y1::char_traits<char>>>(IOutputStream&, TTypeTraits<TBasicString<char, std::__y1::char_traits<char>>>::TFuncParam) /actions-runner/_work/nbs/nbs/util/stream/output.cpp:95:7 (cloud-blockstore-libs-vhost-ut+0xe9b7d5)
    #11 operator<<<TBasicString<char, std::__y1::char_traits<char> > > /actions-runner/_work/nbs/nbs/util/stream/output.h:237:5 (cloud-blockstore-libs-vhost-ut+0x1f6ea9b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #12 NPrivateStringBuilder::operator<<<TBasicString<char, std::__y1::char_traits<char> > > /actions-runner/_work/nbs/nbs/util/string/builder.h:26:21 (cloud-blockstore-libs-vhost-ut+0x1f6ea9b)
    #13 NCloud::(anonymous namespace)::TComponentLogBackend::WriteData(TLogRecord const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:67:21 (cloud-blockstore-libs-vhost-ut+0x1f6ea9b)
    #14 TLog::TImpl::WriteData /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:100:23 (cloud-blockstore-libs-vhost-ut+0x1262b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 TLog::Write(ELogPriority, char const*, unsigned long, TVector<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>, std::__y1::allocator<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>>>) const /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:231:16 (cloud-blockstore-libs-vhost-ut+0x1262b03)
    #16 TLogElement::DoFlush() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:36:18 (cloud-blockstore-libs-vhost-ut+0x1f61d2a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #17 IOutputStream::Flush /actions-runner/_work/nbs/nbs/util/stream/output.h:119:9 (cloud-blockstore-libs-vhost-ut+0xe9b382) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 IOutputStream::DoFinish() /actions-runner/_work/nbs/nbs/util/stream/output.cpp:41:5 (cloud-blockstore-libs-vhost-ut+0xe9b382)
    #19 IOutputStream::Finish /actions-runner/_work/nbs/nbs/util/stream/output.h:127:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 TLogElement::~TLogElement() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:23:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66)
    #21 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NProto::TError> > /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:191:13 (cloud-blockstore-libs-vhost-ut+0x222352e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #22 NThreading::TFuture<NCloud::NProto::TError>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:189:34) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NProto::TError> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #23 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #24 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #25 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0x22246d4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #27 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #28 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)>, void (NThreading::TFuture<NCloud::NProto::TError> const&)>::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #29 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0x221bc57) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #30 std::__y1::function<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #31 bool NThreading::NImpl::TFutureState<NCloud::NProto::TError>::TrySetValue<NCloud::NProto::TError>(NCloud::NProto::TError&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #32 NThreading::NImpl::TFutureState<NCloud::NProto::TError>::SetValue<NCloud::NProto::TError> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (cloud-blockstore-libs-vhost-ut+0x22231a8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #33 NThreading::TPromise<NCloud::NProto::TError>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #34 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::OnCompletion /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:113:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #35 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::Callback(void*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:107:21 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #36 vhd_vdev_release /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1898:9 (cloud-blockstore-libs-vhost-ut+0x2229913) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #37 vdev_drained /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2093:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #38 vdev_maybe_finished /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:257:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0)
    #39 vdev_stop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2271:5 (cloud-blockstore-libs-vhost-ut+0x2229b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #40 vdev_work_fn /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1829:5 (cloud-blockstore-libs-vhost-ut+0x222a50b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #41 work_bh /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:559:5 (cloud-blockstore-libs-vhost-ut+0x2228c40) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #42 bh_call /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:184:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #43 bh_poll /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:211:13 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #44 vhd_run_event_loop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:370:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #45 vhost_evloop_func /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:26:15 (cloud-blockstore-libs-vhost-ut+0x2225808) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Thread T1 (tid=571723, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-vhost-ut+0xcd614b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 vhd_start_vhost_server /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:58:11 (cloud-blockstore-libs-vhost-ut+0x2225716) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory::TVhostQueueFactory /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:343:19 (cloud-blockstore-libs-vhost-ut+0x2220c83) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #4 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #5 std::__y1::__shared_ptr_emplace<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::__shared_ptr_emplace<> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #6 std::__y1::allocate_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #7 std::__y1::make_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #8 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer::TInitializer /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:371:41 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #9 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer* NPrivate::SingletonBase<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer, 65536ul>(std::__y1::atomic<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer*>&) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:38:35 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #10 NPrivate::SingletonInt<TInitializer, 65536UL> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:69:19 (cloud-blockstore-libs-vhost-ut+0x2220bae) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 Singleton<TInitializer> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:116:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #12 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:373:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #13 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:469:34 (cloud-blockstore-libs-vhost-ut+0xc7fadc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #16 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #17 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #18 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #19 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #21 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #22 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
SUMMARY: ThreadSanitizer: data race /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 in operator delete(void*)
==================
==================
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=571716)
  Write of size 8 at 0x7b1000000f80 by main thread:
    #0 TLogBackend::~TLogBackend() /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:60:29 (cloud-blockstore-libs-vhost-ut+0x125ce9e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e896) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e8c9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #4 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #5 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #6 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #7 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #8 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #9 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #10 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #11 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #12 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #13 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #14 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #15 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #16 cxa_at_exit_callback_installed_at(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:432:3 (cloud-blockstore-libs-vhost-ut+0xd1aaa9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #17 __cxx_global_var_init /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 _GLOBAL__sub_I_vhost.cpp /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604)
  Previous read of size 8 at 0x7b1000000f80 by thread T1:
    #0 TLog::TImpl::FiltrationLevel /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:113:26 (cloud-blockstore-libs-vhost-ut+0x1262421) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TLog::FiltrationLevel() const /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:197:19 (cloud-blockstore-libs-vhost-ut+0x1262421)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NProto::TError> > /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:191:13 (cloud-blockstore-libs-vhost-ut+0x2223452) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 NThreading::TFuture<NCloud::NProto::TError>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:189:34) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NProto::TError> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (cloud-blockstore-libs-vhost-ut+0x2223452)
    #4 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (cloud-blockstore-libs-vhost-ut+0x2223452)
    #5 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (cloud-blockstore-libs-vhost-ut+0x2223452)
    #6 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0x22246d4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #7 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #8 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #9 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)>, void (NThreading::TFuture<NCloud::NProto::TError> const&)>::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #10 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0x221bc57) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 std::__y1::function<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #12 bool NThreading::NImpl::TFutureState<NCloud::NProto::TError>::TrySetValue<NCloud::NProto::TError>(NCloud::NProto::TError&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #13 NThreading::NImpl::TFutureState<NCloud::NProto::TError>::SetValue<NCloud::NProto::TError> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (cloud-blockstore-libs-vhost-ut+0x22231a8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NThreading::TPromise<NCloud::NProto::TError>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #15 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::OnCompletion /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:113:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #16 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::Callback(void*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:107:21 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #17 vhd_vdev_release /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1898:9 (cloud-blockstore-libs-vhost-ut+0x2229913) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 vdev_drained /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2093:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #19 vdev_maybe_finished /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:257:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0)
    #20 vdev_stop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2271:5 (cloud-blockstore-libs-vhost-ut+0x2229b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #21 vdev_work_fn /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1829:5 (cloud-blockstore-libs-vhost-ut+0x222a50b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #22 work_bh /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:559:5 (cloud-blockstore-libs-vhost-ut+0x2228c40) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 bh_call /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:184:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 bh_poll /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:211:13 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #25 vhd_run_event_loop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:370:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #26 vhost_evloop_func /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:26:15 (cloud-blockstore-libs-vhost-ut+0x2225808) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Location is heap block of size 64 at 0x7b1000000f80 allocated by main thread:
    #0 operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (cloud-blockstore-libs-vhost-ut+0xd5f277) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 MakeHolder<NCloud::(anonymous namespace)::TComponentLogBackend, TBasicString<char, std::__y1::char_traits<char> >, std::__y1::shared_ptr<TLogBackend>, std::__y1::shared_ptr<NCloud::IAsyncLogger>, const NCloud::TLogSettings &> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:351:23 (cloud-blockstore-libs-vhost-ut+0x1f6b2c3) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::CreateComponentLog(TBasicString<char, std::__y1::char_traits<char>>, std::__y1::shared_ptr<TLogBackend>, std::__y1::shared_ptr<NCloud::IAsyncLogger>, NCloud::TLogSettings const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:393:9 (cloud-blockstore-libs-vhost-ut+0x1f6b2c3)
    #3 NCloud::(anonymous namespace)::TLoggingService::CreateLog(TBasicString<char, std::__y1::char_traits<char>> const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:211:16 (cloud-blockstore-libs-vhost-ut+0x1f6e575) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #4 NCloud::NBlockStore::NVhost::InitVhostLog(std::__y1::shared_ptr<NCloud::ILoggingService>) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:364:25 (cloud-blockstore-libs-vhost-ut+0x2220a4e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #5 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:467:9 (cloud-blockstore-libs-vhost-ut+0xc7fa93) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #6 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #7 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #8 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #9 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #10 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #11 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #12 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #13 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #14 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #16 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #17 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Thread T1 (tid=571723, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-vhost-ut+0xcd614b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 vhd_start_vhost_server /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:58:11 (cloud-blockstore-libs-vhost-ut+0x2225716) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory::TVhostQueueFactory /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:343:19 (cloud-blockstore-libs-vhost-ut+0x2220c83) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #4 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #5 std::__y1::__shared_ptr_emplace<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::__shared_ptr_emplace<> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #6 std::__y1::allocate_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #7 std::__y1::make_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #8 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer::TInitializer /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:371:41 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #9 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer* NPrivate::SingletonBase<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer, 65536ul>(std::__y1::atomic<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer*>&) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:38:35 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #10 NPrivate::SingletonInt<TInitializer, 65536UL> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:69:19 (cloud-blockstore-libs-vhost-ut+0x2220bae) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 Singleton<TInitializer> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:116:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #12 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:373:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #13 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:469:34 (cloud-blockstore-libs-vhost-ut+0xc7fadc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #16 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #17 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #18 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #19 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #21 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #22 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
SUMMARY: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:60:29 in TLogBackend::~TLogBackend()
==================
==================
WARNING: ThreadSanitizer: data race (pid=571716)
  Write of size 8 at 0x7b1000000f88 by main thread:
    #0 operator delete(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (cloud-blockstore-libs-vhost-ut+0xd5f90f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-blockstore-libs-vhost-ut+0x1f6e8d1) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #4 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #5 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #6 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #7 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #8 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #9 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #10 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #11 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #12 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #13 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #14 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-blockstore-libs-vhost-ut+0x1261b0e)
    #15 cxa_at_exit_callback_installed_at(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:432:3 (cloud-blockstore-libs-vhost-ut+0xd1aaa9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #16 __cxx_global_var_init /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #17 _GLOBAL__sub_I_vhost.cpp /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604)
  Previous read of size 8 at 0x7b1000000f88 by thread T1:
    #0 TIntrusivePtr<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, TStringPtrOps<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >::Get /actions-runner/_work/nbs/nbs/util/generic/ptr.h:560:16 (cloud-blockstore-libs-vhost-ut+0xe9b771) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TPointerCommon<TIntrusivePtr<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, TStringPtrOps<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >, TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > >::AsT /actions-runner/_work/nbs/nbs/util/generic/ptr.h:132:50 (cloud-blockstore-libs-vhost-ut+0xe9b771)
    #2 TPointerBase<TIntrusivePtr<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, TStringPtrOps<TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > > >, TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > >::operator* /actions-runner/_work/nbs/nbs/util/generic/ptr.h:148:24 (cloud-blockstore-libs-vhost-ut+0xe9b771)
    #3 TBasicString<char, std::__y1::char_traits<char> >::StdStr /actions-runner/_work/nbs/nbs/util/generic/string.h:218:16 (cloud-blockstore-libs-vhost-ut+0xe9b771)
    #4 TBasicString<char, std::__y1::char_traits<char> >::ConstRef /actions-runner/_work/nbs/nbs/util/generic/string.h:240:16 (cloud-blockstore-libs-vhost-ut+0xe9b771)
    #5 TBasicString<char, std::__y1::char_traits<char> >::data /actions-runner/_work/nbs/nbs/util/generic/string.h:303:16 (cloud-blockstore-libs-vhost-ut+0xe9b771)
    #6 void Out<TBasicString<char, std::__y1::char_traits<char>>>(IOutputStream&, TTypeTraits<TBasicString<char, std::__y1::char_traits<char>>>::TFuncParam) /actions-runner/_work/nbs/nbs/util/stream/output.cpp:95:15 (cloud-blockstore-libs-vhost-ut+0xe9b771)
    #7 operator<<<TBasicString<char, std::__y1::char_traits<char> > > /actions-runner/_work/nbs/nbs/util/stream/output.h:237:5 (cloud-blockstore-libs-vhost-ut+0x1f6ea9b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #8 NPrivateStringBuilder::operator<<<TBasicString<char, std::__y1::char_traits<char> > > /actions-runner/_work/nbs/nbs/util/string/builder.h:26:21 (cloud-blockstore-libs-vhost-ut+0x1f6ea9b)
    #9 NCloud::(anonymous namespace)::TComponentLogBackend::WriteData(TLogRecord const&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:67:21 (cloud-blockstore-libs-vhost-ut+0x1f6ea9b)
    #10 TLog::TImpl::WriteData /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:100:23 (cloud-blockstore-libs-vhost-ut+0x1262b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 TLog::Write(ELogPriority, char const*, unsigned long, TVector<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>, std::__y1::allocator<std::__y1::pair<TBasicString<char, std::__y1::char_traits<char>>, TBasicString<char, std::__y1::char_traits<char>>>>>) const /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:231:16 (cloud-blockstore-libs-vhost-ut+0x1262b03)
    #12 TLogElement::DoFlush() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:36:18 (cloud-blockstore-libs-vhost-ut+0x1f61d2a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #13 IOutputStream::Flush /actions-runner/_work/nbs/nbs/util/stream/output.h:119:9 (cloud-blockstore-libs-vhost-ut+0xe9b382) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 IOutputStream::DoFinish() /actions-runner/_work/nbs/nbs/util/stream/output.cpp:41:5 (cloud-blockstore-libs-vhost-ut+0xe9b382)
    #15 IOutputStream::Finish /actions-runner/_work/nbs/nbs/util/stream/output.h:127:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #16 TLogElement::~TLogElement() /actions-runner/_work/nbs/nbs/library/cpp/logger/element.cpp:23:9 (cloud-blockstore-libs-vhost-ut+0x1f61b66)
    #17 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NProto::TError> > /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:191:13 (cloud-blockstore-libs-vhost-ut+0x222352e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #18 NThreading::TFuture<NCloud::NProto::TError>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:189:34) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NProto::TError> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #19 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #20 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (cloud-blockstore-libs-vhost-ut+0x222352e)
    #21 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0x22246d4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #22 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #23 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #24 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)>, void (NThreading::TFuture<NCloud::NProto::TError> const&)>::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #25 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0x221bc57) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 std::__y1::function<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #27 bool NThreading::NImpl::TFutureState<NCloud::NProto::TError>::TrySetValue<NCloud::NProto::TError>(NCloud::NProto::TError&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #28 NThreading::NImpl::TFutureState<NCloud::NProto::TError>::SetValue<NCloud::NProto::TError> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (cloud-blockstore-libs-vhost-ut+0x22231a8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #29 NThreading::TPromise<NCloud::NProto::TError>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #30 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::OnCompletion /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:113:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #31 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::Callback(void*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:107:21 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #32 vhd_vdev_release /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1898:9 (cloud-blockstore-libs-vhost-ut+0x2229913) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #33 vdev_drained /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2093:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #34 vdev_maybe_finished /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:257:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0)
    #35 vdev_stop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2271:5 (cloud-blockstore-libs-vhost-ut+0x2229b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #36 vdev_work_fn /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1829:5 (cloud-blockstore-libs-vhost-ut+0x222a50b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #37 work_bh /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:559:5 (cloud-blockstore-libs-vhost-ut+0x2228c40) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #38 bh_call /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:184:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #39 bh_poll /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:211:13 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #40 vhd_run_event_loop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:370:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #41 vhost_evloop_func /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:26:15 (cloud-blockstore-libs-vhost-ut+0x2225808) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Thread T1 (tid=571723, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-vhost-ut+0xcd614b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 vhd_start_vhost_server /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:58:11 (cloud-blockstore-libs-vhost-ut+0x2225716) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory::TVhostQueueFactory /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:343:19 (cloud-blockstore-libs-vhost-ut+0x2220c83) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #4 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #5 std::__y1::__shared_ptr_emplace<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::__shared_ptr_emplace<> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #6 std::__y1::allocate_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #7 std::__y1::make_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #8 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer::TInitializer /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:371:41 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #9 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer* NPrivate::SingletonBase<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer, 65536ul>(std::__y1::atomic<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer*>&) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:38:35 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #10 NPrivate::SingletonInt<TInitializer, 65536UL> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:69:19 (cloud-blockstore-libs-vhost-ut+0x2220bae) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 Singleton<TInitializer> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:116:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #12 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:373:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #13 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:469:34 (cloud-blockstore-libs-vhost-ut+0xc7fadc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #16 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #17 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #18 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #19 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #21 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #22 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
SUMMARY: ThreadSanitizer: data race /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 in operator delete(void*)
==================
==================
WARNING: ThreadSanitizer: data race (pid=571716)
  Write of size 8 at 0x7b0800008f68 by main thread:
    #0 operator delete(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 (cloud-blockstore-libs-vhost-ut+0xd5f90f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-blockstore-libs-vhost-ut+0x1261b16) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #3 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #4 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #5 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #6 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #7 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #8 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-blockstore-libs-vhost-ut+0x1261b16)
    #9 cxa_at_exit_callback_installed_at(void*) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:432:3 (cloud-blockstore-libs-vhost-ut+0xd1aaa9) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #10 __cxx_global_var_init /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 _GLOBAL__sub_I_vhost.cpp /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp (cloud-blockstore-libs-vhost-ut+0x2225604)
  Previous read of size 8 at 0x7b0800008f68 by thread T1:
    #0 THolder<TLogBackend, TDelete>::Get /actions-runner/_work/nbs/nbs/util/generic/ptr.h:309:16 (cloud-blockstore-libs-vhost-ut+0x1261e35) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 TLog::TImpl::IsOpen /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:89:36 (cloud-blockstore-libs-vhost-ut+0x1261e35)
    #2 TLog::IsOpen() const /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:147:19 (cloud-blockstore-libs-vhost-ut+0x1261e35)
    #3 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NProto::TError> > /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:191:13 (cloud-blockstore-libs-vhost-ut+0x222343e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #4 NThreading::TFuture<NCloud::NProto::TError>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:189:34) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NProto::TError> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (cloud-blockstore-libs-vhost-ut+0x222343e)
    #5 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (cloud-blockstore-libs-vhost-ut+0x222343e)
    #6 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (cloud-blockstore-libs-vhost-ut+0x222343e)
    #7 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0x22246d4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #8 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NProto::TError> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #9 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #10 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NProto::TError>::TType>::TType> NThreading::TFuture<NCloud::NProto::TError>::Apply<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostDevice::Stop()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NProto::TError> const&)>, void (NThreading::TFuture<NCloud::NProto::TError> const&)>::operator()(NThreading::TFuture<NCloud::NProto::TError> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0x22246d4)
    #11 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0x221bc57) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #12 std::__y1::function<void (const NThreading::TFuture<NCloud::NProto::TError> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #13 bool NThreading::NImpl::TFutureState<NCloud::NProto::TError>::TrySetValue<NCloud::NProto::TError>(NCloud::NProto::TError&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (cloud-blockstore-libs-vhost-ut+0x221bc57)
    #14 NThreading::NImpl::TFutureState<NCloud::NProto::TError>::SetValue<NCloud::NProto::TError> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (cloud-blockstore-libs-vhost-ut+0x22231a8) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 NThreading::TPromise<NCloud::NProto::TError>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #16 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::OnCompletion /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:113:16 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #17 NCloud::NBlockStore::NVhost::(anonymous namespace)::TUnregisterCompletion::Callback(void*) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:107:21 (cloud-blockstore-libs-vhost-ut+0x22231a8)
    #18 vhd_vdev_release /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1898:9 (cloud-blockstore-libs-vhost-ut+0x2229913) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #19 vdev_drained /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2093:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 vdev_maybe_finished /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:257:9 (cloud-blockstore-libs-vhost-ut+0x222a1d0)
    #21 vdev_stop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:2271:5 (cloud-blockstore-libs-vhost-ut+0x2229b03) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #22 vdev_work_fn /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/vdev.c:1829:5 (cloud-blockstore-libs-vhost-ut+0x222a50b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 work_bh /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:559:5 (cloud-blockstore-libs-vhost-ut+0x2228c40) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 bh_call /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:184:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 bh_poll /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:211:13 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #26 vhd_run_event_loop /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/event.c:370:5 (cloud-blockstore-libs-vhost-ut+0x2227f0e)
    #27 vhost_evloop_func /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:26:15 (cloud-blockstore-libs-vhost-ut+0x2225808) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
  Thread T1 (tid=571723, running) created by main thread at:
    #0 pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1048:3 (cloud-blockstore-libs-vhost-ut+0xcd614b) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #1 vhd_start_vhost_server /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/server.c:58:11 (cloud-blockstore-libs-vhost-ut+0x2225716) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #2 NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory::TVhostQueueFactory /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:343:19 (cloud-blockstore-libs-vhost-ut+0x2220c83) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #3 std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #4 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::construct<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #5 std::__y1::__shared_ptr_emplace<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory> >::__shared_ptr_emplace<> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #6 std::__y1::allocate_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, std::__y1::allocator<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #7 std::__y1::make_shared<NCloud::NBlockStore::NVhost::(anonymous namespace)::TVhostQueueFactory, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #8 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer::TInitializer /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:371:41 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #9 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer* NPrivate::SingletonBase<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer, 65536ul>(std::__y1::atomic<NCloud::NBlockStore::NVhost::CreateVhostQueueFactory()::TInitializer*>&) /actions-runner/_work/nbs/nbs/util/generic/singleton.h:38:35 (cloud-blockstore-libs-vhost-ut+0x2220c83)
    #10 NPrivate::SingletonInt<TInitializer, 65536UL> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:69:19 (cloud-blockstore-libs-vhost-ut+0x2220bae) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #11 Singleton<TInitializer> /actions-runner/_work/nbs/nbs/util/generic/singleton.h:116:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #12 NCloud::NBlockStore::NVhost::CreateVhostQueueFactory() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/vhost.cpp:373:12 (cloud-blockstore-libs-vhost-ut+0x2220bae)
    #13 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TTestCaseShouldStartEndpointIfSocketAlreadyExists::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:469:34 (cloud-blockstore-libs-vhost-ut+0xc7fadc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #14 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc99ab4) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #15 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #16 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #17 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #18 std::__y1::__function::__func<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-blockstore-libs-vhost-ut+0xc99ab4)
    #19 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-blockstore-libs-vhost-ut+0xf65c1f) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #20 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #21 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-blockstore-libs-vhost-ut+0xf65c1f)
    #22 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-blockstore-libs-vhost-ut+0xf4d20a) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #23 NCloud::NBlockStore::NVhost::NTestSuiteTServerTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/vhost/server_ut.cpp:256:1 (cloud-blockstore-libs-vhost-ut+0xc98e96) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #24 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-blockstore-libs-vhost-ut+0xf4e013) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #25 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-blockstore-libs-vhost-ut+0xf61fbc) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
    #26 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-blockstore-libs-vhost-ut+0xf60f30) (BuildId: 3540626b22d0f5fd8317f24d87ec2e7d6612bc51)
SUMMARY: ThreadSanitizer: data race /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:126:3 in operator delete(void*)
==================
ThreadSanitizer: reported 6 warnings
```
