### PR TITLE
issue-3314: add TConcurrentFileIOService adaptor

### DIFF
--- a/cloud/storage/core/libs/common/file_io_service.h
+++ b/cloud/storage/core/libs/common/file_io_service.h
@@ -180,4 +180,8 @@ IFileIOServicePtr CreateFileIOServiceStub();
 IFileIOServicePtr CreateRoundRobinFileIOService(
     TVector<IFileIOServicePtr> fileIOs);
 
+IFileIOServicePtr CreateConcurrentFileIOService(
+    const TString& submissionThreadName,
+    IFileIOServicePtr fileIO);
+
 }   // namespace NCloud

--- a/cloud/storage/core/libs/common/file_io_service_ut.cpp
+++ b/cloud/storage/core/libs/common/file_io_service_ut.cpp
@@ -5,6 +5,9 @@
 
 #include <util/system/file.h>
 
+#include <latch>
+#include <thread>
+
 namespace NCloud {
 
 namespace {
@@ -161,6 +164,87 @@ Y_UNIT_TEST_SUITE(TFileIOServiceTest)
                 TVector<TArrayRef<const char>>{buffer},
                 [](auto...) {});
         }
+
+        service->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldProcessConcurrentRequests)
+    {
+        using namespace ::testing;
+
+        const ui32 requestsPerClient = 1024;
+        const ui32 clientCount = 8;
+        const ui32 totalRequestCount = requestsPerClient * clientCount;
+
+        auto fileIO = std::make_shared<TTestFileIOService>();
+
+        EXPECT_CALL(*fileIO, Start()).WillOnce(Return());
+        EXPECT_CALL(*fileIO, Stop()).WillOnce(Return());
+
+        // totalRequestCount requests of each type
+        std::latch done{4 * totalRequestCount};
+
+        auto onRequest = [&done] (auto...) {
+            done.count_down();
+        };
+
+        EXPECT_CALL(*fileIO, AsyncRead(_, 0, _, _))
+            .Times(totalRequestCount)
+            .WillRepeatedly(onRequest);
+        EXPECT_CALL(*fileIO, AsyncReadV(_, 0, _, _))
+            .Times(totalRequestCount)
+            .WillRepeatedly(onRequest);
+        EXPECT_CALL(*fileIO, AsyncWrite(_, 0, _, _))
+            .Times(totalRequestCount)
+            .WillRepeatedly(onRequest);
+        EXPECT_CALL(*fileIO, AsyncWriteV(_, 0, _, _))
+            .Times(totalRequestCount)
+            .WillRepeatedly(onRequest);
+
+        auto service = CreateConcurrentFileIOService("SQ", fileIO);
+        service->Start();
+
+        TVector<std::thread> clients;
+        clients.reserve(clientCount);
+
+        TFileIOCompletion completion{
+            .Func = [] (auto...){}
+        };
+
+        TFileHandle dummy{INVALID_FHANDLE};
+        TArrayRef<char> buffer{nullptr, 1024};
+
+        std::latch sync{clientCount};
+
+        for (ui32 i = 0; i != clientCount; ++i) {
+            clients.emplace_back(
+                [&]
+                {
+                    sync.arrive_and_wait();
+
+                    for (ui32 i = 0; i != requestsPerClient; ++i) {
+                        service->AsyncRead(dummy, 0, buffer, &completion);
+                        service->AsyncWrite(dummy, 0, buffer, &completion);
+
+                        service->AsyncReadV(
+                            dummy,
+                            0,
+                            TVector<TArrayRef<char>>{buffer},
+                            &completion);
+                        service->AsyncWriteV(
+                            dummy,
+                            0,
+                            TVector<TArrayRef<const char>>{buffer},
+                            &completion);
+                    }
+                });
+        }
+
+        for (auto& client: clients) {
+            client.join();
+        }
+
+        done.wait();
 
         service->Stop();
     }


### PR DESCRIPTION
#3314

Add TConcurrentFileIOService adaptor that submits requests to underlying IFileIOService from a single thread.