### PR TITLE
Fix infinite vhost run when parent exit immediately after fork

### DIFF
--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -281,6 +281,8 @@ TChild SpawnChild(
     const TString& binaryPath,
     TVector<TString> args)
 {
+    args.push_back("--blockstore-service-pid=" + ToString(::getpid()));
+
     TPipe stdOut;
     TPipe stdErr;
 

--- a/cloud/blockstore/tests/vhost-server/run_and_die/__main__.py
+++ b/cloud/blockstore/tests/vhost-server/run_and_die/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import subprocess
 import sys
 import json
@@ -8,10 +9,13 @@ from time import sleep
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--cmd', required=True)
+    parser.add_argument('--immediately', action='store_true', required=False)
     args = parser.parse_args()
+    cmd = json.loads(args.cmd)
+    cmd.append('--blockstore-service-pid=' + str(os.getpid()))
 
     server = subprocess.Popen(
-        json.loads(args.cmd),
+        cmd,
         stdin=sys.stdin,
         stdout=sys.stdout,
         stderr=sys.stderr,
@@ -19,4 +23,5 @@ if __name__ == '__main__':
         universal_newlines=True)
 
     print(server.pid)
-    sleep(1)
+    if not args.immediately:
+        sleep(2)

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -159,6 +159,12 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("INT")
         .StoreResult(&EncryptionKeyringId);
 
+    opts.AddLongOption(
+            "blockstore-service-pid",
+            "PID of blockstore service")
+        .RequiredArgument("INT")
+        .StoreResult(&BlockstoreServicePid);
+
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.FindLongOptParseResult("verbose") && VerboseLevel.empty()) {

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -45,6 +45,7 @@ struct TOptions
     NProto::EEncryptionMode EncryptionMode = NProto::NO_ENCRYPTION;
     TString EncryptionKeyPath;
     ui32 EncryptionKeyringId = 0;
+    __pid_t BlockstoreServicePid = 0;
 
     NProto::TEncryptionSpec GetEncryptionSpec() const;
 


### PR DESCRIPTION
Флакающие тесты нашли проблему, что если процесс blockstore умирал сразу после запуска external_vhost_server, то external_vhost_server не успевал получить сигнал о смерти родителя и продолжал работать бесконечное время, вместо того чтобы выйти по таймауту. 

https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(asan)/15965969456/1/nebius-x86-64-asan/test_data/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/vhost-server/test-results/py3test/chunk1/testing_out_stuff/stdout