### PR TITLE
[Disk Manager] Add max retriable error count per task type

### DIFF
--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -72,4 +72,6 @@ message TasksConfig {
     optional uint64 TasksToListLimit = 34 [default = 10000];
 
     optional string AvailabilityMonitoringSuccessRateReportingPeriod  = 35 [default = "15s"];
+
+    map<string, uint64> MaxRetriableErrorCountByTaskType = 36;
 }

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -73,5 +73,6 @@ message TasksConfig {
 
     optional string AvailabilityMonitoringSuccessRateReportingPeriod  = 35 [default = "15s"];
 
+    // Overrides MaxRetriableErrorCount.
     map<string, uint64> MaxRetriableErrorCountByTaskType = 36;
 }

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -109,6 +109,15 @@ func (r *runnerForRun) lockTask(
 	return r.storage.LockTaskToRun(ctx, taskInfo, time.Now(), r.host, r.id)
 }
 
+func (r *runnerForRun) getMaxRetriableErrorCount(taskType string) uint64 {
+	count, ok := r.maxRetriableErrorCountByTaskType[taskType]
+	if !ok {
+		return r.maxRetriableErrorCountDefault
+	}
+
+	return count
+}
+
 func (r *runnerForRun) executeTask(
 	ctx context.Context,
 	execCtx *executionContext,
@@ -326,14 +335,6 @@ func (r *runnerForRun) lockAndExecuteTask(
 		r.missedEstimatesUntilTaskIsHanging,
 		r.maxSampledTaskGeneration,
 	)
-}
-
-func (r *runnerForRun) getMaxRetriableErrorCount(taskType string) uint64 {
-	count, ok := r.maxRetriableErrorCountByTaskType[taskType]
-	if !ok {
-		return r.maxRetriableErrorCountDefault
-	}
-	return count
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -542,8 +542,8 @@ func TestRunnerForRunGotRetriableError(t *testing.T) {
 	runnerMetrics.On("OnExecutionError", err).Return().Once()
 
 	runner := runnerForRun{
-		metrics:                runnerMetrics,
-		maxRetriableErrorCount: 1,
+		metrics:                       runnerMetrics,
+		maxRetriableErrorCountDefault: 1,
 	}
 	runner.executeTask(ctx, execCtx, task)
 	mock.AssertExpectationsForObjects(t, task, taskStorage, runnerMetrics)
@@ -585,8 +585,8 @@ func TestRunnerForRunRetriableErrorCountExceeded(t *testing.T) {
 	runnerMetrics.On("OnExecutionError", mock.AnythingOfType("*errors.NonRetriableError")).Return().Once()
 
 	runner := runnerForRun{
-		metrics:                runnerMetrics,
-		maxRetriableErrorCount: 1,
+		metrics:                       runnerMetrics,
+		maxRetriableErrorCountDefault: 1,
 	}
 	runner.executeTask(ctx, execCtx, task)
 	mock.AssertExpectationsForObjects(t, task, taskStorage, runnerMetrics)
@@ -625,8 +625,8 @@ func TestRunnerForRunIgnoreRetryLimit(t *testing.T) {
 	runnerMetrics.On("OnExecutionError", err).Return().Once()
 
 	runner := runnerForRun{
-		metrics:                runnerMetrics,
-		maxRetriableErrorCount: 1,
+		metrics:                       runnerMetrics,
+		maxRetriableErrorCountDefault: 1,
 	}
 	runner.executeTask(ctx, execCtx, task)
 	mock.AssertExpectationsForObjects(t, task, taskStorage, runnerMetrics)
@@ -795,8 +795,8 @@ func TestRunnerForRunWrongGenerationWrappedIntoRetriableError(t *testing.T) {
 	runnerMetrics.On("OnExecutionError", err).Return().Once()
 
 	runner := runnerForRun{
-		metrics:                runnerMetrics,
-		maxRetriableErrorCount: 0,
+		metrics:                       runnerMetrics,
+		maxRetriableErrorCountDefault: 0,
 	}
 	runner.executeTask(ctx, execCtx, task)
 	mock.AssertExpectationsForObjects(t, task, taskStorage, runnerMetrics)
@@ -855,8 +855,8 @@ func TestRunnerForRunInterruptExecutionWrappedIntoRetriableError(t *testing.T) {
 	runnerMetrics.On("OnExecutionError", err).Return().Once()
 
 	runner := runnerForRun{
-		metrics:                runnerMetrics,
-		maxRetriableErrorCount: 0,
+		metrics:                       runnerMetrics,
+		maxRetriableErrorCountDefault: 0,
 	}
 	runner.executeTask(ctx, execCtx, task)
 	mock.AssertExpectationsForObjects(t, task, taskStorage, runnerMetrics)

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1090,7 +1090,6 @@ func TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded(
 	failsCount, err := getTaskMetadata(ctx, s.scheduler, id)
 	require.NoError(t, err)
 	require.EqualValues(t, unstableTaskMaxRetriesCount+1, failsCount)
-
 }
 
 func TestTasksShouldNotRestoreRunningAfterNonRetriableError(t *testing.T) {


### PR DESCRIPTION
#1950

We have MaxRetriableErrorCount parameter in tasks config (100 by default). This value might not be reasonable for some types of tasks. Add ability to set this parameter by task type.

Further we are going to use this parameter for `dataplane.CreateDRBasedDiskCheckpoint` task in order to limit the number of shadow disks that can be created by a single task.