### PR TITLE
[Filestore] Introduce stats-collector recipe to the `cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test` to record stats during the execution

### DIFF
--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
@@ -26,6 +26,11 @@ SET(NFS_FORCE_VERBOSE 1)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+
+SET(FILESTORE_STATS_COLLECTOR_PERIOD 5)
+SET(FILESTORE_STATS_COLLECTOR_ENDPOINT 'http://localhost:$NFS_VHOST_MON_PORT/counters')
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/stats-collector.inc)
+
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 

--- a/cloud/filestore/tests/recipes/stats-collector.inc
+++ b/cloud/filestore/tests/recipes/stats-collector.inc
@@ -1,0 +1,20 @@
+DEPENDS(
+    cloud/filestore/tests/recipes/stats-collector
+)
+
+IF (FILESTORE_STATS_COLLECTOR_PERIOD)
+    SET(RECIPE_ARGS --period $FILESTORE_STATS_COLLECTOR_PERIOD)
+ELSE()
+    MESSAGE(FATAL_ERROR FILESTORE_STATS_COLLECTOR_PERIOD should be set for the stats-collector recipe to work)
+ENDIF()
+
+IF (FILESTORE_STATS_COLLECTOR_ENDPOINT)
+    SET_APPEND(RECIPE_ARGS --endpoint $FILESTORE_STATS_COLLECTOR_ENDPOINT)
+ELSE()
+    MESSAGE(FATAL_ERROR FILESTORE_STATS_COLLECTOR_ENDPOINT should be set for the stats-collector recipe to work)
+ENDIF()
+
+USE_RECIPE(
+    cloud/filestore/tests/recipes/stats-collector/filestore-stats-collector
+    ${RECIPE_ARGS}
+)

--- a/cloud/filestore/tests/recipes/stats-collector/README.md
+++ b/cloud/filestore/tests/recipes/stats-collector/README.md
@@ -1,0 +1,7 @@
+### stats-collector
+
+Include this recipe to get a process that regularly collects stats from a given monitoring endpoint
+
+Arguments:
+- `FILESTORE_STATS_COLLECTOR_PERIOD` - The period in seconds at which the stats collector will run.
+- `FILESTORE_STATS_COLLECTOR_ENDPOINT`  - The endpoint to collect stats from. Something like `http://localhost:8768/counters`.

--- a/cloud/filestore/tests/recipes/stats-collector/__main__.py
+++ b/cloud/filestore/tests/recipes/stats-collector/__main__.py
@@ -1,0 +1,112 @@
+import argparse
+import datetime
+import logging
+import re
+import os
+import time
+
+from cloud.filestore.tests.python.lib.common import shutdown
+
+from library.python.testing.recipe import declare_recipe
+import yatest.common as common
+
+process = None
+
+logger = logging.getLogger(__name__)
+
+PID_FILE_NAME = "stats_collector_recipe.pid"
+
+
+def collect_stats(logger, endpoint):
+    try:
+        import requests
+    except ImportError:
+        logger.error(
+            "requests module is not installed. Please install it to use the stats collector."
+        )
+        return
+
+    try:
+        response = requests.get(endpoint)
+        logger.info(f"Stats collected from {endpoint}: {response.status_code}")
+        if response.status_code == 200:
+            logger.info(f"Response: {response.text}")
+        else:
+            logger.error(f"Failed to collect stats from {endpoint}")
+    except Exception as e:
+        logger.error(f"Error collecting stats from {endpoint}: {e}")
+
+
+def expand_vars(s, env):
+    # Pattern matches $VAR or ${VAR}
+    pattern = re.compile(r'\$(\w+)|\$\{([^}]+)\}')
+
+    def replacer(match):
+        var1, var2 = match.groups()
+        var_name = var1 or var2
+        return env.get(var_name, '')
+
+    return pattern.sub(replacer, s)
+
+
+def start(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--period", type=int, help="Period in seconds to collect stats"
+    )
+    parser.add_argument(
+        "--endpoint",
+        type=str,
+        help="Endpoint to collect stats from. Note that it can contain env variables, so it will be expanded using os.environ",
+        required=True,
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Output file for the stats collector log",
+        default="stats_collector.log",
+    )
+    args = parser.parse_args(argv)
+
+    start_ts = datetime.datetime.now()
+    interval = datetime.timedelta(seconds=args.period)
+    endpoint = expand_vars(args.endpoint, os.environ)
+
+    pid = os.fork()
+    if pid:
+        with open(PID_FILE_NAME, "w") as f:
+            f.write(str(pid))
+            logger.info(f"Started stats collector process with PID {pid}")
+            exit()
+
+    os.setsid()
+
+    collector_log_name = os.path.join(common.output_path(), args.output)
+    logfile = open(collector_log_name, "w")
+    if logfile is None:
+        raise ValueError(f"Could not open log file: {collector_log_name}")
+    os.dup2(logfile.fileno(), os.sys.stdout.fileno())
+    os.dup2(logfile.fileno(), os.sys.stderr.fileno())
+
+    while True:
+        now = datetime.datetime.now()
+        deadline = start_ts + interval
+        if deadline is None or now >= deadline:
+            start_ts = now
+
+            collect_stats(logger, endpoint)
+        else:
+            time.sleep(min((deadline - now).seconds, 1))
+
+
+def stop(argv):
+    if not os.path.exists(PID_FILE_NAME):
+        return
+
+    with open(PID_FILE_NAME) as f:
+        pid = int(f.read())
+        shutdown(pid)
+
+
+if __name__ == "__main__":
+    declare_recipe(start, stop)

--- a/cloud/filestore/tests/recipes/stats-collector/ya.make
+++ b/cloud/filestore/tests/recipes/stats-collector/ya.make
@@ -1,0 +1,1 @@
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/stats-collector/ya.make.inc)

--- a/cloud/filestore/tests/recipes/stats-collector/ya.make.inc
+++ b/cloud/filestore/tests/recipes/stats-collector/ya.make.inc
@@ -1,0 +1,19 @@
+PY3_PROGRAM(filestore-stats-collector)
+
+
+DEPENDS(
+    cloud/filestore/apps/client
+)
+
+PEERDIR(
+    cloud/filestore/tests/python/lib
+
+    library/python/testing/recipe
+    library/python/testing/yatest_common
+)
+
+PY_SRCS(
+    __main__.py
+)
+
+END()

--- a/cloud/filestore/tests/recipes/tablets-restarter/__main__.py
+++ b/cloud/filestore/tests/recipes/tablets-restarter/__main__.py
@@ -78,8 +78,6 @@ def start(argv):
         else:
             time.sleep(min((deadline - now).seconds, 1))
 
-    logfile.close()
-
 
 def stop(argv):
     if not os.path.exists(PID_FILE_NAME):

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -166,6 +166,7 @@ def start(argv):
 
     set_env("NFS_VHOST_MON_PORT", str(vhost_configurator.mon_port))
 
+
 def stop(argv):
     logging.info(os.system("ss -tpna"))
     logging.info(os.system("ps aux"))

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -164,6 +164,7 @@ def start(argv):
     if service_type == "local-noserver":
         set_env("NFS_SERVER_PORT", str(vhost_configurator.local_service_port))
 
+    set_env("NFS_VHOST_MON_PORT", str(vhost_configurator.mon_port))
 
 def stop(argv):
     logging.info(os.system("ss -tpna"))


### PR DESCRIPTION
Simple recipe that will collect vhost counters for the proper debugging of `qemu-kikimr-multishard-tablets-restart-test` observed here: https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(msan)/15918831050/1/nebius-x86-64-msan/summary/1/ya-test.html#FAIL