### PR TITLE
[Blockstore] add test that InitialAddClientTimeout increasing helps to wait for add client after tablet unlocking; add logs;

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -251,6 +251,8 @@ message TStorageServiceConfig
     optional uint32 MaxWriteCostMultiplier = 70;
 
     // Timeout to register client at volume.
+    // InitialAddClientTimeout should include the time required to release
+    // the volume lock and to bring the volume back up.
     optional uint32 InitialAddClientTimeout = 71;
 
     // Timeout to register client after tablet local start.

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -479,16 +479,25 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             NProto::VOLUME_MOUNT_REMOTE);
     }
 
-    void DoTestShouldCauseRemountWhenVolumeIsStolen(TTestEnv& env, ui32 nodeIdx)
+    Y_UNIT_TEST(ShouldCauseRemountWhenVolumeIsStolen)
     {
+        TTestEnv env(1, 2);
+        ui32 nodeIdx1 = SetupTestEnv(env);
+        ui32 nodeIdx2 = SetupTestEnv(env);
+
         auto& runtime = env.GetRuntime();
+
+        TServiceClient service1(runtime, nodeIdx1);
+        TServiceClient service2(runtime, nodeIdx2);
 
         TActorId volumeActorId;
         TActorId startVolumeActorId;
         ui64 volumeTabletId = 0;
         bool startVolumeActorStopped = false;
 
-        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& event)
+            {
                 switch (event->GetTypeRewrite()) {
                     case TEvServicePrivate::EvVolumeTabletStatus: {
                         auto* msg = event->Get<TEvServicePrivate::TEvVolumeTabletStatus>();
@@ -501,26 +510,44 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                         startVolumeActorStopped = true;
                         break;
                 }
-                return TTestActorRuntime::DefaultObserverFunc(event);
+
+                return false;
             });
 
-        TServiceClient service(runtime, nodeIdx);
-        service.CreateVolume();
-        service.AssignVolume(DefaultDiskId, "foo", "bar");
+        service1.CreateVolume();
+        service1.AssignVolume(DefaultDiskId, "foo", "bar");
 
         TString sessionId;
         {
-            auto response = service.MountVolume(DefaultDiskId, "foo", "bar");
+            auto response = service1.MountVolume(
+                DefaultDiskId,
+                "foo",
+                "bar",
+                NProto::IPC_GRPC,
+                NProto::VOLUME_ACCESS_READ_WRITE,
+                NProto::VOLUME_MOUNT_LOCAL,
+                0, // mountFlags
+                0, // mountSeqNumber
+                NProto::TEncryptionDesc(),
+                0,  // fillSeqNumber
+                0   // fillGeneration
+            );
             sessionId = response->Record.GetSessionId();
         }
 
-        // Lock tablet to a different owner in hive
-        {
-            TActorId edge = runtime.AllocateEdgeActor();
-            runtime.SendToPipe(env.GetHive(), edge, new TEvHive::TEvLockTabletExecution(volumeTabletId));
-            auto reply = runtime.GrabEdgeEvent<TEvHive::TEvLockTabletExecutionResult>(edge);
-            UNIT_ASSERT_VALUES_EQUAL(reply->Get()->Record.GetStatus(), NKikimrProto::OK);
-        }
+        service2.MountVolume(
+            DefaultDiskId,
+            "foo",
+            "bar",
+            NProto::IPC_GRPC,
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0, // mountFlags
+            1, // mountSeqNumber
+            NProto::TEncryptionDesc(),
+            0,  // fillSeqNumber
+            0   // fillGeneration
+        );
 
         // Wait until start volume actor is stopped
         if (!startVolumeActorStopped) {
@@ -532,12 +559,12 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         // Next write request should cause invalid session response
         {
-            service.SendWriteBlocksRequest(
+            service1.SendWriteBlocksRequest(
                 DefaultDiskId,
                 TBlockRange64::WithLength(0, 1024),
                 sessionId,
                 char(1));
-            auto response = service.RecvWriteBlocksResponse();
+            auto response = service1.RecvWriteBlocksResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_BS_INVALID_SESSION,
                 response->GetStatus(),
@@ -547,23 +574,27 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         // Should work again after remount
         {
-            auto response = service.MountVolume(DefaultDiskId, "foo", "bar");
+            auto response = service1.MountVolume(
+                DefaultDiskId,
+                "foo",
+                "bar",
+                NProto::IPC_GRPC,
+                NProto::VOLUME_ACCESS_READ_WRITE,
+                NProto::VOLUME_MOUNT_LOCAL,
+                0, // mountFlags
+                2, // mountSeqNumber
+                NProto::TEncryptionDesc(),
+                0,  // fillSeqNumber
+                0   // fillGeneration
+            );
             sessionId = response->Record.GetSessionId();
         }
 
-        service.WriteBlocks(
+        service1.WriteBlocks(
             DefaultDiskId,
             TBlockRange64::WithLength(0, 1024),
             sessionId);
-        service.UnmountVolume(DefaultDiskId, sessionId);
-    }
-
-    Y_UNIT_TEST(ShouldCauseRemountWhenVolumeIsStolen)
-    {
-        TTestEnv env;
-        ui32 nodeIdx = SetupTestEnv(env);
-
-        DoTestShouldCauseRemountWhenVolumeIsStolen(env, nodeIdx);
+        service1.UnmountVolume(DefaultDiskId, sessionId);
     }
 
     Y_UNIT_TEST(ShouldDisallowMountByAnotherClient)
@@ -1659,65 +1690,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             NProto::VOLUME_ACCESS_READ_WRITE,
             NProto::VOLUME_MOUNT_LOCAL);
         UNIT_ASSERT(response->Record.GetVolume().GetBlocksCount() == DefaultBlocksCount);
-    }
-
-    Y_UNIT_TEST(ShouldReturnTabletBackIfLocalMountedAndTabletWasStolen)
-    {
-        TTestEnv env;
-        auto unmountClientsTimeout = TDuration::Seconds(10);
-        ui32 nodeIdx = SetupTestEnvWithMultipleMount(
-            env,
-            unmountClientsTimeout);
-
-        ui64 volumeTabletId = 0;
-        bool startVolumeActorStopped = false;
-
-        auto& runtime = env.GetRuntime();
-        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
-                switch (event->GetTypeRewrite()) {
-                    case TEvServicePrivate::EvVolumeTabletStatus: {
-                        auto *msg = event->Get<TEvServicePrivate::TEvVolumeTabletStatus>();
-                        volumeTabletId = msg->TabletId;
-                        break;
-                    }
-                    case TEvServicePrivate::EvStartVolumeActorStopped: {
-                        startVolumeActorStopped = true;
-                        break;
-                    }
-                }
-                return TTestActorRuntime::DefaultObserverFunc(event);
-            });
-
-        auto fakeLocalMounter = runtime.AllocateEdgeActor();
-
-        TServiceClient service(runtime, nodeIdx);
-        service.CreateVolume();
-        service.MountVolume();
-
-        UNIT_ASSERT(volumeTabletId);
-        runtime.SendToPipe(env.GetHive(), fakeLocalMounter, new TEvHive::TEvLockTabletExecution(volumeTabletId));
-
-        // Wait until start volume actor is stopped
-        {
-            TDispatchOptions options;
-            options.FinalEvents.emplace_back(TEvServicePrivate::EvStartVolumeActorStopped);
-            runtime.DispatchEvents(options);
-            UNIT_ASSERT(startVolumeActorStopped);
-        }
-
-        bool volumeStarted = false;
-        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
-                switch (event->GetTypeRewrite()) {
-                    case TEvServicePrivate::EvStartVolumeResponse: {
-                        volumeStarted = true;
-                        break;
-                    }
-                }
-                return TTestActorRuntime::DefaultObserverFunc(event);
-            });
-
-        service.MountVolume();
-        UNIT_ASSERT(volumeStarted);
     }
 
     Y_UNIT_TEST(ShouldnotRevomeVolumeIfLastClientUnmountedWithError)
@@ -3083,6 +3055,60 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         // compete with other mount.
         runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(10));
         UNIT_ASSERT_VALUES_EQUAL(volumeDemotedByStateStorageCount, 1);
+    }
+
+    Y_UNIT_TEST(ShouldWaitForAddClientAfterTabletUnlocking)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetInitialAddClientTimeout(
+            TDuration::Seconds(30).MilliSeconds());
+
+        TTestEnv env;
+        ui32 nodeIdx = SetupTestEnv(env, storageServiceConfig);
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume();
+        service.AssignVolume();
+        bool mountRequestProcessed = false;
+        bool unlockRequestProcessed = false;
+
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvHiveProxy::EvUnlockTabletRequest: {
+                        if (!unlockRequestProcessed) {
+                            unlockRequestProcessed = true;
+
+                            runtime.Schedule(
+                                event,
+                                TDuration::Seconds(10),
+                                nodeIdx);
+                            return true;
+                        }
+                        break;
+                    }
+                    case TEvServicePrivate::EvMountRequestProcessed: {
+                        if (!mountRequestProcessed) {
+                            auto* msg = event->Get<
+                                TEvServicePrivate::TEvMountRequestProcessed>();
+                            const_cast<NProto::TError&>(msg->Error) = MakeKikimrError(
+                                NKikimrProto::ERROR);
+                            mountRequestProcessed = true;
+                        }
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        service.SendMountVolumeRequest();
+        auto response = service.RecvMountVolumeResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+        service.SendMountVolumeRequest();
+        response = service.RecvMountVolumeResponse();
+        UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
     }
 
     Y_UNIT_TEST(ShouldShutdownVolumeAfterLockLostOnVolumeDeletionDuringMounting)

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
@@ -289,6 +289,13 @@ void TVolumeClientActor::HandleRequest(
     }
 
     if (!PipeClient) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s Creating pipe to volume %d from volume client",
+            LogTitle.GetWithTime().c_str(),
+            TabletId);
+
         PipeClient = ctx.Register(CreateClient(SelfId(), TabletId, ClientConfig));
         ++Generation;
         LogTitle.SetGeneration(Generation);

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -214,6 +214,13 @@ void TVolumeSessionActor::NotifyAndDie(const TActorContext& ctx)
     VolumeInfo->VolumeSessionActor = {};
 
     if (StartVolumeActor) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s Sending PoisonPill to StartVolumeActor %s",
+            LogTitle.GetWithTime().c_str(),
+            ToString(StartVolumeActor).c_str());
+
         NCloud::Send<TEvents::TEvPoisonPill>(ctx, StartVolumeActor);
         StartVolumeActor = {};
     }
@@ -221,6 +228,13 @@ void TVolumeSessionActor::NotifyAndDie(const TActorContext& ctx)
     auto notification = std::make_unique<TEvServicePrivate::TEvSessionActorDied>();
     notification->DiskId = VolumeInfo->DiskId;
     NCloud::Send(ctx, MakeStorageServiceId(), std::move(notification));
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s Sending PoisonPill to VolumeClient %s",
+        LogTitle.GetWithTime().c_str(),
+        ToString(VolumeClient).c_str());
 
     NCloud::Send<TEvents::TEvPoisonPill>(ctx, VolumeClient);
 

--- a/cloud/blockstore/libs/storage/service/volume_timed_delivery.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_timed_delivery.cpp
@@ -137,7 +137,7 @@ void TVolumeProxyTimedDeliveryActor<TMethod>::HandleWakeup(
     const auto* msg = ev->Get();
 
     if (msg->Tag) {
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+        LOG_INFO(ctx, TBlockStoreComponents::SERVICE,
             "Resend %s %s request to volume %s. Last error %s",
             TMethod::Name,
             Request->Record.GetHeaders().GetClientId().Quote().c_str(),


### PR DESCRIPTION
чиню сценарий гонки:
- пришел запрос на монтирование
- локи на таблетку взялись
- монтирование завершилось ошибкой
- таблетка была убита и было послано сообщение на освобождение локов
- на этом этапе приходит еще одно монтирование. оно не дожидается addClient из-за очень маленького таймаута, поэтому пробует поднять волум локально (для того чтобы выполнить addClient локально, а не удаленно)
- при этом локи могут быть еще не освобождены, что приводит к крит ивентам и бесконечному монтированию 
___
сейчас таймаут очень маленький. он должен включать время на поднятие таблетки hive'ом на контролах.

я предлагаю начать с того, что увеличим таймаут и далее будем наблюдать (возможно, стоит добавить еще ретраев в volume client)
___
решил сначала увеличить таймаут только в тестинге и препроде и если все ок - закоммитить изменение дефолта