### PR TITLE
Remove encryption in zero blocks request

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -479,7 +479,8 @@ void TCommand::Init()
 
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateDefaultEncryptionKeyProvider());
+        CreateDefaultEncryptionKeyProvider(),
+        NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
 
     if (!ClientEndpoint) {
         ClientStats = CreateClientStats(

--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -480,7 +480,7 @@ void TCommand::Init()
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
         CreateDefaultEncryptionKeyProvider(),
-        NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+        NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
     if (!ClientEndpoint) {
         ClientStats = CreateClientStats(

--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -251,6 +251,7 @@ message TServerConfig
     // Disables per-client throttlers.
     optional bool DisableClientThrottlers = 125;
 
+    // Policy for encryption of zeroed blocks.
     optional EEncryptZeroPolicy EncryptZeroPolicy = 126;
 }
 

--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -36,6 +36,14 @@ message TChecksumFlags
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum EEncryptZeroPolicy
+{
+    EZP_WRITE_ENCRYPTED_ZEROS = 0;
+    EZP_WRITE_ZERO_BLOCKS = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 message TServerConfig
 {
     // Host name or address to listen on.
@@ -242,6 +250,8 @@ message TServerConfig
 
     // Disables per-client throttlers.
     optional bool DisableClientThrottlers = 125;
+
+    optional EEncryptZeroPolicy EncryptZeroPolicy = 126;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/client/bench/main.cpp
+++ b/cloud/blockstore/libs/client/bench/main.cpp
@@ -48,7 +48,7 @@ struct TBootstrap
         EncryptionClientFactory = CreateEncryptionClientFactory(
             Logging,
             CreateDefaultEncryptionKeyProvider(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
     }
 
     IBlockStorePtr CreateClient()

--- a/cloud/blockstore/libs/client/bench/main.cpp
+++ b/cloud/blockstore/libs/client/bench/main.cpp
@@ -47,7 +47,8 @@ struct TBootstrap
     {
         EncryptionClientFactory = CreateEncryptionClientFactory(
             Logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateDefaultEncryptionKeyProvider(),
+            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
     }
 
     IBlockStorePtr CreateClient()

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -348,7 +348,8 @@ void TBootstrapBase::Init()
 
     auto encryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateEncryptionKeyProvider(KmsKeyProvider, RootKmsKeyProvider));
+        CreateEncryptionKeyProvider(KmsKeyProvider, RootKmsKeyProvider),
+        Configs->ServerConfig->GetEncryptZeroPolicy());
 
     auto sessionManager = CreateSessionManager(
         Timer,

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -862,8 +862,7 @@ private:
                             std::move(logging),
                             CreateAesXtsEncryptor(std::move(key)),
                             volume,
-                            encryptZeroPolicy
-                        ));
+                            encryptZeroPolicy));
                 });
     }
 };

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -584,7 +584,7 @@ TFuture<NProto::TZeroBlocksResponse> TEncryptionClient::ZeroBlocks(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TZeroBlocksRequest> request)
 {
-    if (EncryptZeroPolicy == NProto::EEncryptZeroPolicy::EZP_WRITE_ZERO_BLOCKS) {
+    if (EncryptZeroPolicy == NProto::EZP_WRITE_ZERO_BLOCKS) {
         return Client->ZeroBlocks(callContext, std::move(request));
     }
 

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -579,47 +579,7 @@ TFuture<NProto::TZeroBlocksResponse> TEncryptionClient::ZeroBlocks(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TZeroBlocksRequest> request)
 {
-    if (request->GetBlocksCount() == 0 || BlockSize == 0) {
-        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
-            E_ARGUMENT,
-            "Request size should not be zero");
-    }
-
-    STORAGE_VERIFY(
-        BlockSize <= ZeroBlock.size(),
-        TWellKnownEntityTypes::DISK,
-        request->GetDiskId());
-    TBlockDataRef zeroDataRef(ZeroBlock.data(), BlockSize);
-    TSgList zeroSgList(request->GetBlocksCount(), zeroDataRef);
-    TGuardedSgList guardedSgList(std::move(zeroSgList));
-
-    auto writeRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
-    writeRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
-    writeRequest->SetDiskId(request->GetDiskId());
-    writeRequest->SetStartIndex(request->GetStartIndex());
-    writeRequest->SetFlags(request->GetFlags());
-    writeRequest->SetSessionId(request->GetSessionId());
-    writeRequest->BlocksCount = request->GetBlocksCount();
-    writeRequest->BlockSize = BlockSize;
-    writeRequest->Sglist = guardedSgList;
-
-    auto future = WriteBlocksLocal(
-        std::move(callContext),
-        std::move(writeRequest));
-
-    return future.Apply([
-        sgList = std::move(guardedSgList)] (const auto& f) mutable
-    {
-        sgList.Close();
-
-        const auto& response = f.GetValue();
-
-        NProto::TZeroBlocksResponse zeroResponse;
-        zeroResponse.MutableError()->CopyFrom(response.GetError());
-        zeroResponse.MutableTrace()->CopyFrom(response.GetTrace());
-        zeroResponse.SetThrottlerDelay(response.GetThrottlerDelay());
-        return zeroResponse;
-    });
+    return Client->ZeroBlocks(callContext,  std::move(request));
 }
 
 NProto::TError TEncryptionClient::Encrypt(

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -2,11 +2,12 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/config/server.pb.h>
+#include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/public/api/protos/encryption.pb.h>
 #include <cloud/blockstore/public/api/protos/volume.pb.h>
 
-#include <cloud/blockstore/libs/diagnostics/public.h>
-#include <cloud/blockstore/libs/service/public.h>
 #include <cloud/storage/core/libs/common/error.h>
 
 namespace NCloud::NBlockStore {
@@ -17,13 +18,15 @@ namespace NCloud::NBlockStore {
 IBlockStorePtr CreateVolumeEncryptionClient(
     IBlockStorePtr client,
     IEncryptionKeyProviderPtr encryptionKeyProvider,
-    ILoggingServicePtr logging);
+    ILoggingServicePtr logging,
+    NProto::EEncryptZeroPolicy encryptZeroPolicy);
 
 IBlockStorePtr CreateEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging,
     IEncryptorPtr encryptor,
-    NProto::TEncryptionDesc encryptionDesc);
+    NProto::TEncryptionDesc encryptionDesc,
+    NProto::EEncryptZeroPolicy encryptZeroPolicy);
 
 IBlockStorePtr CreateSnapshotEncryptionClient(
     IBlockStorePtr client,
@@ -48,6 +51,7 @@ struct IEncryptionClientFactory
 
 IEncryptionClientFactoryPtr CreateEncryptionClientFactory(
     ILoggingServicePtr logging,
-    IEncryptionKeyProviderPtr encryptionKeyProvider);
+    IEncryptionKeyProviderPtr encryptionKeyProvider,
+    NProto::EEncryptZeroPolicy encryptZeroPolicy);
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -397,16 +397,10 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldEncryptAllBlocksInZeroBlockUsingWriteBlocksLocal)
+    Y_UNIT_TEST(ShouldNotEncryptInZeroBlock)
     {
         auto logging = CreateLoggingService("console");
         size_t blockSize = 8;
-        size_t storageBlocksCount = 16;
-
-        TVector<TString> storageBlocks(Reserve(storageBlocksCount));
-        for (size_t i = 0; i < storageBlocksCount; ++i) {
-            storageBlocks.emplace_back(blockSize, '0');
-        }
 
         auto testClient = std::make_shared<TTestService>();
         auto testEncryptor = std::make_shared<TTestEncryptor>();
@@ -424,57 +418,47 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         zRequest->SetBlocksCount(6);
         zRequest->SetFlags(42);
         zRequest->SetSessionId("testSessionId");
-        UNIT_ASSERT_VALUES_EQUAL(6, GetFieldCount<NProto::TZeroBlocksRequest>());
-
-        NProto::TWriteBlocksLocalResponse wResponse;
-        wResponse.MutableError()->SetMessage("testMessage");
-        wResponse.MutableTrace()->SetRequestStartTime(42);
-        wResponse.SetThrottlerDelay(13);
-        UNIT_ASSERT_VALUES_EQUAL(3, GetFieldCount<NProto::TWriteBlocksResponse>());
+        UNIT_ASSERT_VALUES_EQUAL(
+            6,
+            GetFieldCount<NProto::TZeroBlocksRequest>());
 
         testClient->MountVolumeHandler =
-            [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
-                Y_UNUSED(request);
+            [&](std::shared_ptr<NProto::TMountVolumeRequest> request)
+        {
+            Y_UNUSED(request);
 
-                NProto::TMountVolumeResponse response;
-                response.MutableVolume()->SetBlockSize(blockSize);
-                return MakeFuture(std::move(response));
-            };
+            NProto::TMountVolumeResponse response;
+            response.MutableVolume()->SetBlockSize(blockSize);
+            return MakeFuture(std::move(response));
+        };
 
-        testClient->WriteBlocksLocalHandler =
-            [&] (std::shared_ptr<NProto::TWriteBlocksLocalRequest> wRequest) {
-                auto guard = wRequest->Sglist.Acquire();
-                UNIT_ASSERT(guard);
-                const auto& sglist = guard.Get();
+        size_t zRequestCount = 0;
+        testClient->ZeroBlocksHandler =
+            [&](std::shared_ptr<NProto::TZeroBlocksRequest> request)
+        {
+            ++zRequestCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                zRequest->MutableHeaders()->GetClientId(),
+                request->MutableHeaders()->GetClientId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                zRequest->GetDiskId(),
+                request->GetDiskId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                zRequest->GetStartIndex(),
+                request->GetStartIndex());
+            UNIT_ASSERT_VALUES_EQUAL(
+                zRequest->GetBlocksCount(),
+                request->GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(zRequest->GetFlags(), request->GetFlags());
+            UNIT_ASSERT_VALUES_EQUAL(
+                zRequest->GetSessionId(),
+                request->GetSessionId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                6,
+                GetFieldCount<NProto::TZeroBlocksRequest>());
 
-                for (size_t i = 0; i < sglist.size(); ++i) {
-                    size_t n = i + wRequest->GetStartIndex();
-                    UNIT_ASSERT(storageBlocks[n].size() == sglist[i].Size());
-                    auto* dst = const_cast<char*>(storageBlocks[n].data());
-                    auto* src = sglist[i].Data();
-                    memcpy(dst, src, sglist[i].Size());
-                }
-
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->MutableHeaders()->GetClientId(),
-                    wRequest->MutableHeaders()->GetClientId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetDiskId(),
-                    wRequest->GetDiskId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetStartIndex(),
-                    wRequest->GetStartIndex());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetFlags(),
-                    wRequest->GetFlags());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetSessionId(),
-                    wRequest->GetSessionId());
-                UNIT_ASSERT_VALUES_EQUAL(6, GetFieldCount<NProto::TZeroBlocksRequest>());
-                UNIT_ASSERT_VALUES_EQUAL(6, GetFieldCount<NProto::TWriteBlocksRequest>());
-
-                return MakeFuture(wResponse);
-            };
+            return MakeFuture<NProto::TZeroBlocksResponse>();
+        };
 
         auto mountResponse = MountVolume(*encryptionClient);
         UNIT_ASSERT(!HasError(mountResponse));
@@ -484,34 +468,10 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             zRequest);
         auto zResponse = future.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT(!HasError(zResponse));
-
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.MutableError()->GetMessage(),
-            zResponse.MutableError()->GetMessage());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.MutableTrace()->GetRequestStartTime(),
-            zResponse.MutableTrace()->GetRequestStartTime());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetThrottlerDelay(),
-            zResponse.GetThrottlerDelay());
-        UNIT_ASSERT_VALUES_EQUAL(3, GetFieldCount<NProto::TWriteBlocksResponse>());
-        UNIT_ASSERT_VALUES_EQUAL(3, GetFieldCount<NProto::TZeroBlocksResponse>());
-
-        for (size_t i = 0; i < storageBlocksCount; ++i) {
-            TBlockDataRef block(storageBlocks[i].data(), storageBlocks[i].size());
-
-            if (zRequest->GetStartIndex() <= i &&
-                i < zRequest->GetStartIndex() + zRequest->GetBlocksCount())
-            {
-                TString decrypted(block.Size(), 0);
-                TBlockDataRef decryptedRef(decrypted.data(), decrypted.size());
-                auto err = testEncryptor->Decrypt(block, decryptedRef, i);
-                UNIT_ASSERT_EQUAL_C(S_OK, err.GetCode(), err);
-                UNIT_ASSERT(BlockFilledByValue(decryptedRef, 0));
-            } else {
-                UNIT_ASSERT(BlockFilledByValue(block, '0'));
-            }
-        }
+            3,
+            GetFieldCount<NProto::TZeroBlocksResponse>());
+        UNIT_ASSERT_VALUES_EQUAL(1, zRequestCount);
     }
 
     Y_UNIT_TEST(ShouldDecryptAllBlocksInReadBlocksWhenBitmaskIsEmpty)

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -171,7 +171,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 logging,
                 nullptr,
                 encryptionDesc,
-                NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+                NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
             auto mountResponse = MountVolume(*encryptionClient);
             UNIT_ASSERT(!HasError(mountResponse));
@@ -209,7 +209,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 logging,
                 nullptr,
                 encryptionDesc,
-                NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+                NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
             auto mountResponse1 = MountVolume(*encryptionClient1);
             UNIT_ASSERT(!HasError(mountResponse1));
@@ -219,7 +219,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 logging,
                 nullptr,
                 encryptionDesc,
-                NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+                NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
             auto mountResponse2 = MountVolume(*encryptionClient2);
             UNIT_ASSERT(HasError(mountResponse2));
@@ -263,7 +263,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -337,7 +337,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -421,7 +421,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto zRequest = std::make_shared<NProto::TZeroBlocksRequest>();
         zRequest->MutableHeaders()->SetClientId("testClientId");
@@ -533,7 +533,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ZERO_BLOCKS);
+            NProto::EZP_WRITE_ZERO_BLOCKS);
 
         auto zRequest = std::make_shared<NProto::TZeroBlocksRequest>();
         zRequest->MutableHeaders()->SetClientId("testClientId");
@@ -612,7 +612,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -676,7 +676,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -740,7 +740,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -805,7 +805,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -911,7 +911,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             testEncryptor,
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
@@ -1139,7 +1139,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             std::make_shared<TTestEncryptor>(),
             GetDefaultEncryption(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         testClient->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest>) {
@@ -1372,7 +1372,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 testClient,
                 KeyProvider,
                 Logging,
-                NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+                NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
             auto response = MountVolume(*encryptionClient);
             UNIT_ASSERT_VALUES_EQUAL_C(
@@ -1432,7 +1432,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 testClient,
                 KeyProvider,
                 Logging,
-                NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+                NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
             auto response = MountVolume(*encryptionClient);
             UNIT_ASSERT_VALUES_EQUAL_C(
@@ -1533,7 +1533,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 testClient,
                 KeyProvider,
                 Logging,
-                NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+                NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
             auto response = MountVolume(*encryptionClient);
             UNIT_ASSERT_VALUES_EQUAL_C(

--- a/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
@@ -269,7 +269,8 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
 
         auto clientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateDefaultEncryptionKeyProvider(),
+            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto service = std::make_shared<TTestService>();
         service->CreateVolumeHandler =
@@ -342,8 +343,10 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
             return encryptionKey;
         };
 
-        auto clientFactory =
-            CreateEncryptionClientFactory(logging, encryptionKeyProvider);
+        auto clientFactory = CreateEncryptionClientFactory(
+            logging,
+            encryptionKeyProvider,
+            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto service = std::make_shared<TTestService>();
         service->CreateVolumeHandler =

--- a/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_service_ut.cpp
@@ -270,7 +270,7 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
         auto clientFactory = CreateEncryptionClientFactory(
             logging,
             CreateDefaultEncryptionKeyProvider(),
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto service = std::make_shared<TTestService>();
         service->CreateVolumeHandler =
@@ -346,7 +346,7 @@ Y_UNIT_TEST_SUITE(TMultipleEncryptionServiceTest)
         auto clientFactory = CreateEncryptionClientFactory(
             logging,
             encryptionKeyProvider,
-            NProto::EEncryptZeroPolicy::EZP_WRITE_ENCRYPTED_ZEROS);
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto service = std::make_shared<TTestService>();
         service->CreateVolumeHandler =

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -487,7 +487,8 @@ IEndpointManagerPtr CreateEndpointManager(TBootstrap& bootstrap)
 
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             bootstrap.Logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateDefaultEncryptionKeyProvider(),
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         bootstrap.SessionManager = CreateSessionManager(
             bootstrap.Timer,

--- a/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
@@ -143,7 +143,8 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
 
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateDefaultEncryptionKeyProvider(),
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto sessionManager = CreateSessionManager(
             CreateWallClockTimer(),
@@ -258,7 +259,8 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
 
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateDefaultEncryptionKeyProvider(),
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         auto sessionManager = CreateSessionManager(
             CreateWallClockTimer(),
@@ -379,7 +381,8 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         auto logging = CreateLoggingService("console");
         auto encryptionClientFactory = CreateEncryptionClientFactory(
             logging,
-            CreateDefaultEncryptionKeyProvider());
+            CreateDefaultEncryptionKeyProvider(),
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
         TSessionManagerOptions options;
         options.DisableClientThrottler = disableClientThrottler;

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -108,6 +108,9 @@ constexpr TDuration Seconds(int s)
     xxx(ChecksumFlags,               NProto::TChecksumFlags, {}               )\
     xxx(VhostDiscardEnabled,         bool,                   false            )\
     xxx(MaxZeroBlocksSubRequestSize, ui32,                   0                )\
+    xxx(EncryptZeroPolicy,                                                     \
+        NProto::EEncryptZeroPolicy,                                            \
+        NProto::EZP_WRITE_ENCRYPTED_ZEROS                                     )\
     xxx(VhostPteFlushByteThreshold,  ui64,                   0                )\
     xxx(AutomaticNbdDeviceManagement,bool,                   false            )
 // BLOCKSTORE_SERVER_CONFIG
@@ -227,6 +230,12 @@ void DumpImpl(
                 << ")";
             break;
     }
+}
+
+template <>
+void DumpImpl(const NProto::EEncryptZeroPolicy& value, IOutputStream& os)
+{
+    os << NProto::EEncryptZeroPolicy_Name(value);
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -140,6 +140,7 @@ public:
     NProto::TChecksumFlags GetChecksumFlags() const;
     bool GetVhostDiscardEnabled() const;
     ui32 GetMaxZeroBlocksSubRequestSize() const;
+    NProto::EEncryptZeroPolicy GetEncryptZeroPolicy() const;
     ui64 GetVhostPteFlushByteThreshold() const;
     bool GetAutomaticNbdDeviceManagement() const;
 

--- a/cloud/vm/blockstore/lib/plugin.cpp
+++ b/cloud/vm/blockstore/lib/plugin.cpp
@@ -246,7 +246,8 @@ TPlugin::TPlugin(
 {
     EncryptionClientFactory = CreateEncryptionClientFactory(
         Logging,
-        CreateDefaultEncryptionKeyProvider());
+        CreateDefaultEncryptionKeyProvider(),
+        NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
При чтениях мы смотрим на содержимое блока, и если он заполнен нулями, то его не нужно расшифровывать.
Это позволяет для TZeroBlocksRequest не писать шифрованные блоки с нулями, а делать обычный ZeroBlocks. 

Discard запросы от клиента могут быть очень большие, и шифровать гигабайтные блоки и писать их выходит очень медленно. 