### PR TITLE
WriteBackCache: fix race condition in TWriteBackCacheTest.ShouldFlushAutomatically 

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -193,8 +193,6 @@ struct TBootstrap
         };
 
         Session->WriteDataHandler = [&] (auto, auto request) {
-            SessionWriteDataHandlerCalled++;
-
             const auto handle = request->GetHandle();
             const auto offset = request->GetOffset();
             const auto length = request->GetBuffer().length();
@@ -240,6 +238,8 @@ struct TBootstrap
             if (EraseExpectedUnflushedDataAfterFirstUse) {
                 memset(const_cast<char*>(from.data()), char(0), from.length());
             }
+
+            SessionWriteDataHandlerCalled++;
 
             NProto::TWriteDataResponse response;
             return MakeFuture(response);


### PR DESCRIPTION
Resolve failed unit test in the nightly build
https://github.com/ydb-platform/nbs/actions/runs/16136101737

```
cloud-filestore-libs-vfs_fuse-write_back_cache-ut WARN: scheduler thread was blocked for too long: 0.112532s
[[bad]]assertion failed at cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:404, void NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrap::ValidateCacheIsFlushed(): (ExpectedData == FlushedData) failed: ({1 -> "\0\0\0\0\0\0\0\0\0\0\0abcde"} != {}) , with diff:
[[rst]]{
([[good]]    1 -> "\0\0\0\0\0\0\0\0\0\0\0abcde"
[[rst]]|[[bad]][[rst]])}[[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char> > const&, bool)+636 (0x1593FBC)
??+0 (0x10E0EE0)
NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TTestCaseShouldFlushAutomatically::Execute_(NUnitTest::TTestContext&)+832 (0x10DEA40)
std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+537 (0x10E7D69)
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char> > const&, char const*, bool)+539 (0x15CD4AB)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char> > const&, char const*, bool)+550 (0x159BEA6)
NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TCurrentTest::Execute()+1588 (0x10E6AD4)
NUnitTest::TTestFactory::Execute()+2794 (0x159DC6A)
NUnitTest::RunMain(int, char**)+7485 (0x15C58CD)
??+0 (0x7FF2B53BCD90)
__libc_start_main+128 (0x7FF2B53BCE40)
??+0 (0xFC4029)
[[rst]]
```