### PR TITLE
issue-1751: fix crash when server write-back cache is enabled but was not successfully initialized

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -39,6 +39,11 @@ public:
 
     ~TWriteBackCache();
 
+    explicit operator bool() const
+    {
+        return !!Impl;
+    }
+
     NThreading::TFuture<NProto::TReadDataResponse> ReadData(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadDataRequest> request);


### PR DESCRIPTION
#1751 