### PR TITLE
Reduce frequency of log writes on tablet monitoring page

### DIFF
--- a/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
@@ -1325,7 +1325,6 @@ void RenderAutoRefreshScript(
         }
         const tabPane = currentScript.closest('.tab-pane');
 
-        // Конфигурация
         const CONTAINER_ID = ')"
         << containerId << R"(';
         const TOGGLE_ID = ')"
@@ -1397,7 +1396,6 @@ void RenderAutoRefreshScript(
 
         toggle.addEventListener('change', e => {
             if (e.target.checked) {
-                // Пытаемся запустить, только если контент активен
                 if (isContentActive()) startAutoRefresh();
             } else {
                 stopAutoRefresh();

--- a/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
@@ -1246,6 +1246,7 @@ void DumpLatency(
             const TOGGLE_ID = 'transactions-auto-refresh-toggle';
             const TABLET_ID = ')"
                     << ToString(tabletId) << R"(';
+            const INTERVAL_MS = 1000;
 
             const tabPane = document.getElementById(TAB_ID);
             const container = document.getElementById(CONTAINER_ID);
@@ -1288,7 +1289,7 @@ void DumpLatency(
                 if (intervalId !== null || !toggle.checked) return;
                 console.log('Starting auto-refresh for tab: ' + TAB_ID);
                 loadTransactionsLatency();
-                intervalId = setInterval(loadTransactionsLatency, 1000);
+                intervalId = setInterval(loadTransactionsLatency, INTERVAL_MS);
             }
 
             function stopAutoRefresh() {

--- a/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
@@ -1221,15 +1221,17 @@ void DumpLatency(
     HTML (out) {
         RenderAutoRefreshToggle(out, toggleId, "Auto update info", false);
 
-        out << "<div id=\"" << containerId << "\">";
-        TAG (TH3) { out << "Transactions"; }
-        DumpLatencyForTransactions(out, columnCount, transactionTimeTracker);
-        TAG (TH3) { out << "Groups"; }
-        out << "</div>";
+        DIV_CLASS_ID(" ", containerId) {
+            TAG (TH3) { out << "Transactions"; }
+            DumpLatencyForTransactions(out, columnCount, transactionTimeTracker);
+            TAG (TH3) { out << "Groups"; }
+        }
 
         out << R"(<script>
             function updateTransactionsData(result, container) {
-                if (!result.stat) return;
+                if (!result.stat) {
+                    return;
+                }
                 for (let key in result.stat) {
                     const element = container.querySelector('#' + key);
                     if (element) {
@@ -1346,8 +1348,9 @@ void RenderAutoRefreshScript(
         function isContentActive() {
             if (tabPane) {
                 return tabPane.classList.contains('active');
+            } else {
+                return true;
             }
-            return true;
         }
 
         function loadData() {
@@ -1371,13 +1374,17 @@ void RenderAutoRefreshScript(
         }
 
         function startAutoRefresh() {
-            if (intervalId !== null || !toggle.checked) return;
+            if (intervalId !== null || !toggle.checked) {
+                return;
+            }
             loadData();
             intervalId = setInterval(loadData, INTERVAL_MS);
         }
 
         function stopAutoRefresh() {
-            if (intervalId === null) return;
+            if (intervalId === null) {
+                return;
+            }
             clearInterval(intervalId);
             intervalId = null;
         }
@@ -1386,8 +1393,11 @@ void RenderAutoRefreshScript(
             const observer = new MutationObserver(mutations => {
                 mutations.forEach(mutation => {
                     if (mutation.attributeName === 'class') {
-                        if (tabPane.classList.contains('active')) startAutoRefresh();
-                        else stopAutoRefresh();
+                        if (tabPane.classList.contains('active')) {
+                            startAutoRefresh();
+                        } else {
+                            stopAutoRefresh();
+                        }
                     }
                 });
             });
@@ -1396,7 +1406,9 @@ void RenderAutoRefreshScript(
 
         toggle.addEventListener('change', e => {
             if (e.target.checked) {
-                if (isContentActive()) startAutoRefresh();
+                if (isContentActive()) {
+                    startAutoRefresh();
+                }
             } else {
                 stopAutoRefresh();
             }
@@ -1404,7 +1416,9 @@ void RenderAutoRefreshScript(
 
         document.addEventListener('visibilitychange', () => {
             if (!document.hidden) {
-                if (isContentActive()) startAutoRefresh();
+                if (isContentActive()) {
+                    startAutoRefresh();
+                }
             } else {
                 stopAutoRefresh();
             }

--- a/cloud/blockstore/libs/storage/core/monitoring_utils.h
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.h
@@ -188,4 +188,20 @@ TCgiParameters GatherHttpParameters(const NActors::NMon::TEvRemoteHttpInfo& msg)
 TCgiParameters GetHttpMethodParameters(const NActors::NMon::TEvRemoteHttpInfo& msg);
 HTTP_METHOD GetHttpMethodType(const NActors::NMon::TEvRemoteHttpInfo& msg);
 
+void RenderAutoRefreshToggle(
+    IOutputStream& out,
+    const TString& toggleId,
+    const TString& labelText,
+    bool isCheckedByDefault);
+
+void RenderAutoRefreshScript(
+    IOutputStream& out,
+    const TString& tabId,
+    const TString& containerId,
+    const TString& toggleId,
+    const TString& ajaxAction,
+    ui64 tabletId,
+    int intervalMs,
+    const TString& jsUpdateFunctionName);
+
 }   // namespace NCloud::NBlockStore::NStorage::NMonitoringUtils

--- a/cloud/blockstore/libs/storage/core/monitoring_utils.h
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.h
@@ -196,7 +196,6 @@ void RenderAutoRefreshToggle(
 
 void RenderAutoRefreshScript(
     IOutputStream& out,
-    const TString& tabId,
     const TString& containerId,
     const TString& toggleId,
     const TString& ajaxAction,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -1261,7 +1261,6 @@ void TVolumeActor::RenderLatency(IOutputStream& out) const {
 
         RenderAutoRefreshScript(
             out,
-            "Latency",
             containerId,
             toggleId,
             "getRequestsLatency",


### PR DESCRIPTION
Раньше страница перерисовывалась каждую секунду и оставляла об этом лог. Теперь должны быть соблюдены 3 условия для обновления:
- включено автообновление;
- вкладка сайта открыта;
- выбран пункт Transactions/Latency.
![Screenshot from 2025-07-09 14-06-06](https://github.com/user-attachments/assets/d7e2ebac-cf56-400a-9a27-cccc7280fe93)
