### PR TITLE
[CSI] Split counters for fatal and retriable errors

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -354,12 +354,7 @@ func (s *nodeService) NodeStageVolume(
 	}
 
 	if err != nil {
-		var errorCode = codes.Internal
-		if s.IsMountConflictError(err, nfsBackend) {
-			errorCode = codes.AlreadyExists
-		}
-
-		return nil, s.statusErrorf(errorCode, "Failed to stage volume: %v", err)
+		return nil, s.statusErrorf(s.GetGrpcErrorCode(err), "Failed to stage volume: %v", err)
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil
@@ -394,7 +389,7 @@ func (s *nodeService) NodeUnstageVolume(
 		if stageData, err := s.readStageData(stageRecordPath); err == nil {
 			if err := s.nodeUnstageVhostSocket(ctx, nbsId, stageData); err != nil {
 				return nil, s.statusErrorf(
-					codes.InvalidArgument,
+					s.GetGrpcErrorCode(err),
 					"Failed to unstage volume: %v", err)
 			}
 			ignoreError(os.Remove(stageRecordPath))
@@ -402,7 +397,7 @@ func (s *nodeService) NodeUnstageVolume(
 	} else {
 		if err := s.nodeUnstageVolume(ctx, req); err != nil {
 			return nil, s.statusErrorf(
-				codes.InvalidArgument,
+				s.GetGrpcErrorCode(err),
 				"Failed to unstage volume: %v", err)
 		}
 	}
@@ -510,7 +505,7 @@ func (s *nodeService) NodePublishVolume(
 	}
 
 	if err != nil {
-		return nil, s.statusErrorf(codes.Internal,
+		return nil, s.statusErrorf(s.GetGrpcErrorCode(err),
 			"Failed to publish volume: %v", err)
 	}
 
@@ -542,7 +537,7 @@ func (s *nodeService) NodeUnpublishVolume(
 
 	if err := s.nodeUnpublishVolume(ctx, req); err != nil {
 		return nil, s.statusErrorf(
-			codes.InvalidArgument,
+			s.GetGrpcErrorCode(err),
 			"Failed to unpublish volume: %v", err)
 	}
 
@@ -789,34 +784,45 @@ func (s *nodeService) nodePublishDiskAsFilesystem(
 	return nil
 }
 
-func (s *nodeService) IsErrorCode(err error, errorCode uint32, isNfs bool) bool {
+func (s *nodeService) GetNbsErrorCode(err error) (uint32, bool) {
 	if err != nil {
-		if !isNfs {
-			var clientErr *nbsclient.ClientError
-			if errors.As(err, &clientErr) {
-				if clientErr.Code == errorCode {
-					return true
-				}
-			}
-		} else {
-			var clientErr *nfsclient.ClientError
-			if errors.As(err, &clientErr) {
-				if clientErr.Code == errorCode {
-					return true
-				}
-			}
+		var nbsClientErr *nbsclient.ClientError
+		if errors.As(err, &nbsClientErr) {
+			return nbsClientErr.Code, true
+		}
+
+		var nfsClientErr *nfsclient.ClientError
+		if errors.As(err, &nfsClientErr) {
+			return nfsClientErr.Code, true
 		}
 	}
 
-	return false
+	return 0, false
 }
 
-func (s *nodeService) IsGrpcTimeoutError(err error, isNfs bool) bool {
-	return s.IsErrorCode(err, nbsclient.E_GRPC_DEADLINE_EXCEEDED, isNfs)
+func (s *nodeService) GetGrpcErrorCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+
+	errorCode, ok := s.GetNbsErrorCode(err)
+
+	if ok {
+		switch errorCode {
+		case nbsclient.E_MOUNT_CONFLICT:
+			return codes.AlreadyExists
+		case nbsclient.E_GRPC_UNAVAILABLE, nfsclient.E_GRPC_UNAVAILABLE:
+			return codes.Unavailable
+		}
+	}
+
+	return codes.Internal
 }
 
-func (s *nodeService) IsMountConflictError(err error, isNfs bool) bool {
-	return s.IsErrorCode(err, nbsclient.E_MOUNT_CONFLICT, false)
+func (s *nodeService) IsGrpcTimeoutError(err error) bool {
+	code, ok := s.GetNbsErrorCode(err)
+	return ok && (code == nbsclient.E_GRPC_DEADLINE_EXCEEDED ||
+		(code == nfsclient.E_GRPC_DEADLINE_EXCEEDED))
 }
 
 func (s *nodeService) nodeStageDiskAsFilesystem(
@@ -1043,7 +1049,7 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 		},
 	})
 	if err != nil {
-		if s.IsGrpcTimeoutError(err, true /* nfs */) {
+		if s.IsGrpcTimeoutError(err) {
 			nfsClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
 				SocketPath: filepath.Join(endpointDir, nfsSocketName),
 			})
@@ -1079,7 +1085,7 @@ func (s *nodeService) nodeStageFileStoreStartEndpoint(
 		},
 	})
 	if err != nil {
-		if s.IsGrpcTimeoutError(err, true /* nfs */) {
+		if s.IsGrpcTimeoutError(err) {
 			s.nfsClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
 				SocketPath: filepath.Join(endpointDir, nfsSocketName),
 			})
@@ -1171,7 +1177,7 @@ func (s *nodeService) nodeStageLocalFileStoreStartEndpoint(
 			},
 		})
 		if err != nil {
-			if s.IsGrpcTimeoutError(err, true /* nfs */) {
+			if s.IsGrpcTimeoutError(err) {
 				s.nfsLocalClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
 					SocketPath: filepath.Join(endpointDir, nfsSocketName),
 				})
@@ -1225,7 +1231,7 @@ func (s *nodeService) nodeStageLocalFileStoreStartEndpoint(
 
 	_, err = s.nfsLocalClient.StartEndpoint(ctx, startReq)
 	if err != nil {
-		if s.IsGrpcTimeoutError(err, true /* nfs */) {
+		if s.IsGrpcTimeoutError(err) {
 			s.nfsLocalClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
 				SocketPath: filepath.Join(endpointDir, nfsSocketName),
 			})
@@ -1930,7 +1936,7 @@ func (s *nodeService) NodeExpandVolume(
 				"Volume is not found")
 		}
 		return nil, s.statusErrorf(
-			codes.Internal,
+			s.GetGrpcErrorCode(err),
 			"Failed to expand volume: %v", err)
 	}
 
@@ -1962,8 +1968,9 @@ func (s *nodeService) NodeExpandVolume(
 		ctx, &nbsapi.TListEndpointsRequest{},
 	)
 	if err != nil {
-		log.Printf("List endpoints failed %v", err)
-		return nil, err
+		return nil, s.statusErrorf(
+			s.GetGrpcErrorCode(err),
+			"List endpoints failed: %v", err)
 	}
 
 	nbdDevicePath := ""
@@ -1988,8 +1995,9 @@ func (s *nodeService) NodeExpandVolume(
 	})
 
 	if err != nil {
-		log.Printf("Resize volume failed %v", err)
-		return nil, err
+		return nil, s.statusErrorf(
+			s.GetGrpcErrorCode(err),
+			"Resize volume failed %v", err)
 	}
 
 	_, err = s.nbsClient.RefreshEndpoint(ctx, &nbsapi.TRefreshEndpointRequest{
@@ -1997,9 +2005,8 @@ func (s *nodeService) NodeExpandVolume(
 	})
 
 	if err != nil {
-		log.Printf("Resize device failed %v", err)
 		return nil, s.statusErrorf(
-			codes.Internal,
+			s.GetGrpcErrorCode(err),
 			"Failed to resize device %v", err)
 	}
 

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -788,6 +788,7 @@ func (s *nodeService) GetNbsErrorCode(err error) (uint32, bool) {
 	if err == nil {
 		return 0, false
 	}
+
 	var nbsClientErr *nbsclient.ClientError
 	if errors.As(err, &nbsClientErr) {
 		return nbsClientErr.Code, true
@@ -807,7 +808,6 @@ func (s *nodeService) GetGrpcErrorCode(err error) codes.Code {
 	}
 
 	errorCode, ok := s.GetNbsErrorCode(err)
-
 	if !ok {
 		return codes.Internal
 	}

--- a/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring.go
+++ b/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring.go
@@ -87,8 +87,13 @@ func (m *Monitoring) ReportRequestCompleted(
 		subregistry.Counter("Success").Inc()
 	} else {
 		s, ok := status.FromError(err)
-		if ok && s.Code() == codes.AlreadyExists {
-			subregistry.Counter("MountConflicts").Inc()
+		if ok {
+			switch s.Code() {
+			case codes.Aborted, codes.AlreadyExists, codes.Unavailable:
+				subregistry.Counter("RetriableErrors").Inc()
+			default:
+				subregistry.Counter("Errors").Inc()
+			}
 		} else {
 			subregistry.Counter("Errors").Inc()
 		}

--- a/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring.go
+++ b/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring.go
@@ -27,10 +27,12 @@ func isRetriableError(err error) bool {
 	if err == nil {
 		return false
 	}
+
 	status, ok := status.FromError(err)
 	if !ok {
 		return false
 	}
+
 	switch status.Code() {
 	case codes.Aborted, codes.AlreadyExists, codes.Unavailable:
 		return true

--- a/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/monitoring/monitoring_test.go
@@ -157,8 +157,12 @@ Time_count{component="server",method="/csi.v1.Controller/ControllerPublishVolume
 `)
 }
 
-func TestShouldReportMountConflicts(t *testing.T) {
+func TestShouldReportRetriableErros(t *testing.T) {
 	mon := NewTestMonitoring()
+	mon.ReportRequestReceived("/csi.v1.Node/NodeStageVolume")
+	mon.ReportRequestCompleted("/csi.v1.Node/NodeStageVolume", status.Error(codes.Unavailable, ""), -1)
+	mon.ReportRequestReceived("/csi.v1.Node/NodeStageVolume")
+	mon.ReportRequestCompleted("/csi.v1.Node/NodeStageVolume", status.Error(codes.Aborted, ""), -1)
 	mon.ReportRequestReceived("/csi.v1.Node/NodeStageVolume")
 	mon.ReportRequestCompleted("/csi.v1.Node/NodeStageVolume", status.Error(codes.AlreadyExists, ""), -1)
 
@@ -171,12 +175,12 @@ func TestShouldReportMountConflicts(t *testing.T) {
 	assert.Equal(t, getResponseBody(response),
 		`# HELP Count
 # TYPE Count counter
-Count{component="server",method="/csi.v1.Node/NodeStageVolume"} 1
+Count{component="server",method="/csi.v1.Node/NodeStageVolume"} 3
 # HELP InflightCount
 # TYPE InflightCount gauge
 InflightCount{component="server",method="/csi.v1.Node/NodeStageVolume"} 0
-# HELP MountConflicts
-# TYPE MountConflicts counter
-MountConflicts{component="server",method="/csi.v1.Node/NodeStageVolume"} 1
+# HELP RetriableErrors
+# TYPE RetriableErrors counter
+RetriableErrors{component="server",method="/csi.v1.Node/NodeStageVolume"} 3
 `)
 }


### PR DESCRIPTION
issue: https://github.com/ydb-platform/nbs/issues/3804

Count Aborted(another operation is in progress), AlreadyExists(mount conflict) and Unavailable(grpc unavailable) as retriable errors