### PR TITLE
TFileRingBuffer: increase reliability is a buffer is tampered while it is in use

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -466,6 +466,14 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             TStateWithCorruptedEntryLength s(i);
             TFileRingBuffer rb(s.F.GetName(), s.Len);
             UNIT_ASSERT_VALUES_EQUAL(i != 2, rb.IsCorrupted());
+
+            // Detect corruption in PopFront
+            TStateWithCorruptedEntryLength s2(i);
+            UNIT_ASSERT(!s2.Rb.IsCorrupted());
+            while (!s2.Rb.Empty()) {
+                s2.Rb.PopFront();
+            }
+            UNIT_ASSERT_VALUES_EQUAL(i != 2, s2.Rb.IsCorrupted());
         }
     }
 


### PR DESCRIPTION
Extracted from https://github.com/ydb-platform/nbs/pull/3790
Based on https://github.com/ydb-platform/nbs/pull/3817

Resolve TODOs in the code related to the corruption.