### PR TITLE
Pass StorageMediaKind instead of boolean IsReliableMediaKind

### DIFF
--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -62,8 +62,7 @@ public:
         options.CheckBufferModificationDuringWriting =
             ChecksumFlags.GetCheckBufferModificationForMirrorDisk() &&
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
-        options.IsReliableMediaKind =
-            IsReliableMediaKind(volume.GetStorageMediaKind());
+        options.StorageMediaKind = volume.GetStorageMediaKind();
         options.MaxZeroBlocksSubRequestSize = MaxZeroBlocksSubRequestSize;
 
         auto requestFactory = CreateServerHandlerFactory(

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -50,8 +50,7 @@ public:
         options.CheckBufferModificationDuringWriting =
             ChecksumFlags.GetCheckBufferModificationForMirrorDisk() &&
             IsReliableDiskRegistryMediaKind(volume.GetStorageMediaKind());
-        options.IsReliableMediaKind =
-            IsReliableMediaKind(volume.GetStorageMediaKind());
+        options.StorageMediaKind = volume.GetStorageMediaKind();
         options.DiscardEnabled =
             VhostDiscardEnabled &&
             !IsDiskRegistryMediaKind(volume.GetStorageMediaKind());

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -956,7 +956,7 @@ IServerHandlerFactoryPtr CreateServerHandlerFactory(
         options.BlockSize,
         options.UnalignedRequestsDisabled,
         options.CheckBufferModificationDuringWriting,
-        options.IsReliableMediaKind,
+        options.StorageMediaKind,
         options.MaxZeroBlocksSubRequestSize);
 
     return std::make_shared<TServerHandlerFactory>(

--- a/cloud/blockstore/libs/nbd/server_handler.h
+++ b/cloud/blockstore/libs/nbd/server_handler.h
@@ -8,7 +8,9 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/service/request.h>
+
 #include <cloud/storage/core/libs/common/task_queue.h>
+#include <cloud/storage/core/protos/media.pb.h>
 
 #include <library/cpp/coroutine/engine/network.h>
 #include <library/cpp/threading/future/future.h>
@@ -125,7 +127,7 @@ struct TStorageOptions
     bool UnalignedRequestsDisabled = false;
     bool SendMinBlockSize = false;
     bool CheckBufferModificationDuringWriting = false;
-    bool IsReliableMediaKind = false;
+    NProto::EStorageMediaKind StorageMediaKind = NProto::STORAGE_MEDIA_DEFAULT;
     ui32 MaxZeroBlocksSubRequestSize = 0;
 };
 

--- a/cloud/blockstore/libs/service/aligned_device_handler.h
+++ b/cloud/blockstore/libs/service/aligned_device_handler.h
@@ -23,7 +23,7 @@ private:
     const ui32 BlockSize;
     const ui32 MaxBlockCount;
     const ui32 MaxBlockCountForZeroBlocksRequest;
-    const bool IsReliableMediaKind;
+    const NProto::EStorageMediaKind StorageMediaKind;
 
     std::atomic<bool> CriticalErrorReported = false;
 
@@ -36,7 +36,7 @@ public:
         ui32 maxSubRequestSize,
         ui32 maxZeroBlocksSubRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaKind);
+        NProto::EStorageMediaKind storageMediaKind);
 
     // implements IDeviceHandler
     NThreading::TFuture<NProto::TReadBlocksLocalResponse> Read(

--- a/cloud/blockstore/libs/service/device_handler.cpp
+++ b/cloud/blockstore/libs/service/device_handler.cpp
@@ -37,7 +37,7 @@ struct TDefaultDeviceHandlerFactory final
         ui32 blockSize,
         bool unalignedRequestsDisabled,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaKind,
+        NProto::EStorageMediaKind storageMediaKind,
         ui32 maxZeroBlocksSubRequestSize) override
     {
         if (maxZeroBlocksSubRequestSize != 0) {
@@ -57,7 +57,7 @@ struct TDefaultDeviceHandlerFactory final
                 MaxSubRequestSize,
                 maxZeroBlocksSubRequestSize,
                 checkBufferModificationDuringWriting,
-                isReliableMediaKind);
+                storageMediaKind);
         }
 
         return std::make_shared<TUnalignedDeviceHandler>(
@@ -69,7 +69,7 @@ struct TDefaultDeviceHandlerFactory final
             maxZeroBlocksSubRequestSize,
             MaxUnalignedRequestSize,
             checkBufferModificationDuringWriting,
-            isReliableMediaKind);
+            storageMediaKind);
     }
 };
 

--- a/cloud/blockstore/libs/service/device_handler.h
+++ b/cloud/blockstore/libs/service/device_handler.h
@@ -48,7 +48,7 @@ struct IDeviceHandlerFactory
         ui32 blockSize,
         bool unalignedRequestsDisabled,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaKind,
+        NProto::EStorageMediaKind storageMediaKind,
         ui32 MaxZeroBlocksSubRequestSize) = 0;
 };
 

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -146,7 +146,7 @@ public:
             BlockSize,
             unalignedRequestsDisabled,   // unalignedRequestsDisabled,
             false,                       // checkBufferModificationDuringWriting
-            false,                       // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
     }
 
@@ -370,7 +370,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         std::array<bool, deviceBlocksCount> zeroBlocks;
@@ -441,7 +441,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         std::array<bool, deviceBlocksCount> zeroBlocks;
@@ -487,7 +487,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             true,    // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         ui32 startIndex = 42;
@@ -579,7 +579,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             true,    // unalignedRequestsDisabled,
             false,   // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         {
@@ -721,7 +721,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             unalignedRequestDisabled,   // unalignedRequestsDisabled,
             false,                      // checkBufferModificationDuringWriting
-            false,                      // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         storage->ZeroBlocksHandler = [&] (
@@ -842,7 +842,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
                 blockSize,
                 false,   // unalignedRequestsDisabled,
                 false,   // checkBufferModificationDuringWriting
-                false,   // isReliableMediaKind
+                NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
                 maxZeroBlocksSubRequestSize);
 
         storage->WriteBlocksLocalHandler = [&] (
@@ -912,7 +912,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
                 blockSize,
                 false,   // unalignedRequestsDisabled,
                 false,   // checkBufferModificationDuringWriting
-                false,   // isReliableMediaKind
+                NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
                 maxZeroBlocksSubRequestSize);
 
         storage->WriteBlocksLocalHandler = [&] (
@@ -1041,7 +1041,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         ui32 writeAttempts  = 0;
@@ -1126,7 +1126,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            true,    // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_MIRROR3,
             maxZeroBlocksSubRequestSize);
         auto deviceHandlerForNonReliableDisk = factory->CreateDeviceHandler(
             storage,
@@ -1135,7 +1135,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         auto buffer = TString(DefaultBlockSize, 'g');
@@ -1281,7 +1281,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            true,    // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD,
             maxZeroBlocksSubRequestSize);
         auto deviceHandlerForNonReliableDisk = factory->CreateDeviceHandler(
             storage,
@@ -1290,7 +1290,7 @@ Y_UNIT_TEST_SUITE(TDeviceHandlerTest)
             blockSize,
             false,   // unalignedRequestsDisabled,
             true,    // checkBufferModificationDuringWriting
-            false,   // isReliableMediaKind
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             maxZeroBlocksSubRequestSize);
 
         auto buffer = TString(DefaultBlockSize, 'g');

--- a/cloud/blockstore/libs/service/unaligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/unaligned_device_handler.cpp
@@ -475,7 +475,7 @@ TUnalignedDeviceHandler::TUnalignedDeviceHandler(
         ui32 maxZeroBlocksSubRequestSize,
         ui32 maxUnalignedRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaKind)
+        NProto::EStorageMediaKind storageMediaKind)
     : Backend(std::make_shared<TAlignedDeviceHandler>(
           std::move(storage),
           std::move(diskId),
@@ -484,7 +484,7 @@ TUnalignedDeviceHandler::TUnalignedDeviceHandler(
           maxSubRequestSize,
           maxZeroBlocksSubRequestSize,
           checkBufferModificationDuringWriting,
-          isReliableMediaKind))
+          storageMediaKind))
     , BlockSize(blockSize)
     , MaxUnalignedBlockCount(maxUnalignedRequestSize / BlockSize)
 {}

--- a/cloud/blockstore/libs/service/unaligned_device_handler.h
+++ b/cloud/blockstore/libs/service/unaligned_device_handler.h
@@ -50,7 +50,7 @@ public:
         ui32 maxZeroBlocksSubRequestSize,
         ui32 maxUnalignedRequestSize,
         bool checkBufferModificationDuringWriting,
-        bool isReliableMediaKind);
+        NProto::EStorageMediaKind storageMediaKind);
 
     ~TUnalignedDeviceHandler() override;
 

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -446,7 +446,7 @@ public:
             options.BlockSize,
             options.UnalignedRequestsDisabled,
             options.CheckBufferModificationDuringWriting,
-            options.IsReliableMediaKind,
+            options.StorageMediaKind,
             options.MaxZeroBlocksSubRequestSize);
 
         auto endpoint = std::make_shared<TEndpoint>(

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -5,9 +5,11 @@
 #include <cloud/blockstore/libs/diagnostics/incomplete_requests.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/service/public.h>
+
 #include <cloud/storage/core/libs/common/affinity.h>
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/startable.h>
+#include <cloud/storage/core/protos/media.pb.h>
 
 #include <library/cpp/threading/future/future.h>
 
@@ -27,7 +29,7 @@ struct TStorageOptions
     ui32 VhostQueuesCount = 0;
     bool UnalignedRequestsDisabled = false;
     bool CheckBufferModificationDuringWriting = false;
-    bool IsReliableMediaKind = false;
+    NProto::EStorageMediaKind StorageMediaKind = NProto::STORAGE_MEDIA_DEFAULT;
     bool DiscardEnabled = false;
     ui32 MaxZeroBlocksSubRequestSize = 0;
 };


### PR DESCRIPTION
#2988
Подготовка почвы для расчёта чексумм запросов. Нужен честый тип диска внутри `TAlignedDeviceHandler`