### PR TITLE
fix race condition during error handler execution

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -452,7 +452,7 @@ private:
 
         TErrorHandler(
                 std::weak_ptr<TEndpointManager> manager,
-                std::share_ptr<TEndpoint> endpoint)
+                std::shared_ptr<TEndpoint> endpoint)
             : Manager(std::move(manager))
             , Endpoint(std::move(endpoint))
         {}
@@ -1437,7 +1437,7 @@ void TEndpointManager::DoProcessException(
 
     if (endpoint->Generation != context->Generation) {
         STORAGE_WARN(
-            prefix << "generation mismatch (" << endpoint->Generation.load()
+            prefix << "generation mismatch (" << endpoint->Generation
                    << " != " << context->Generation << "), cancel restart");
         return;
     }


### PR DESCRIPTION
ProcessException can potentially yield control to another coroutine executing ProcessException. This leads to a race condition if it was invoked after endpoint's generation has already been increased