### PR TITLE
Fix arcadia build

### DIFF
--- a/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
@@ -3,8 +3,6 @@
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/ss_proxy/protos/path_description_backup.pb.h>
 
-#include <contrib/libs/protobuf/src/google/protobuf/stubs/logging.h>
-
 #include <library/cpp/protobuf/util/pb_io.h>
 
 #include <util/datetime/base.h>


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp:6:10: fatal error: 'contrib/libs/protobuf/src/google/protobuf/stubs/logging.h' file not found
    6 | #include <contrib/libs/protobuf/src/google/protobuf/stubs/logging.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```