### PR TITLE
Fix arcadia build

### DIFF
--- a/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
@@ -42,7 +42,6 @@ bool LoadPathDescriptionBackup(
 
     TFile file(backupPath, OpenExisting | RdOnly | Seq);
     TUnbufferedFileInput input(file);
-    NProtoBuf::LogSilencer silencer;
     return TryMergeFromTextFormat(
         input,
         *backupProto,


### PR DESCRIPTION
При работе утилита пишет в лог предупреждения:
```
[libprotobuf WARNING {A}/contrib/libs/protobuf/src/google/protobuf/text_format.cc:350] Warning parsing text-format NCloud.NStorage.NSSProxy.NProto.TPathDescriptionBackup: 8647:11: Message type "NKikimrBlockStore.TVolumeConfig" has no field named "39".
```
Работе это не мешает. 