### PR TITLE
NodeRegistrant: Add location to logs when registering node using discovery service

### DIFF
--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -375,8 +375,16 @@ INodeRegistrantPtr CreateNodeRegistrant(
     const auto& hostName = FQDNHostName();
     const auto& hostAddress = GetNetworkAddress(hostName);
 
+    const TNodeLocation location(
+        options.DataCenter,
+        {},
+        options.Rack,
+        ToString(options.Body));
+
     if (options.UseNodeBrokerSsl) {
-        STORAGE_WARN("Trying to register with discovery service: ");
+        STORAGE_WARN("Trying to register with discovery service: "
+            << location.ToString());
+
         return std::make_unique<TDiscoveryNodeRegistrant>(
             hostName,
             hostAddress,
@@ -384,13 +392,10 @@ INodeRegistrantPtr CreateNodeRegistrant(
             nsConfig,
             dnConfig);
     }
-    const TNodeLocation location(
-        options.DataCenter,
-        {},
-        options.Rack,
-        ToString(options.Body));
+
     STORAGE_WARN(
         "Trying to register with legacy service: " << location.ToString());
+
     return std::make_unique<TLegacyNodeRegistrant>(
         hostName,
         hostAddress,


### PR DESCRIPTION
The information about location was missing when using secure node registrant.
It is needed to investigate the error
```
BLOCKSTORE_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:477: Failed to register dynamic node at "***": { <main>: Error: Another location is registered for *** }
```