### PR TITLE
issue-1720: added quota for direct write requests in mirror partition

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1266,4 +1266,9 @@ message TStorageServiceConfig
     // In emergency (SSProxy/HiveProxy fallback mode), don't pass SchemeShardDir
     // when registering node in Node Broker
     optional bool DontPassSchemeShardDirWhenRegisteringNodeInEmergencyMode = 439;
+
+    // Bandwidth quota for direct write requests to mirror disks.
+    // If a disk starts sending more than the DirectWriteBandwidthQuota bytes per second,
+    // we start using MultiAgent write requests.
+    optional uint32 DirectWriteBandwidthQuota = 440;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -611,6 +611,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MaxOutOfOrderCompactionMapChunksInflight,          ui32,   5          )\
                                                                                \
     xxx(PartitionBootTimeout,                 TDuration,   Seconds(0)         )\
+    xxx(DirectWriteBandwidthQuota,           ui32,        0                  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -695,6 +695,8 @@ public:
     [[nodiscard]] ui32 GetMaxOutOfOrderCompactionMapChunksInflight() const;
 
     [[nodiscard]] TDuration GetPartitionBootTimeout() const;
+
+    [[nodiscard]] ui32 GetDirectWriteBandwidthQuota() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -144,7 +144,9 @@ void TMirrorPartitionActor::MirrorRequest(
         ev->Get()->Record.GetHeaders().GetVolumeRequestId());
 
     if constexpr (IsExactlyWriteMethod<TMethod>) {
-        if (CanMakeMultiAgentWrite(range)) {
+        if (SuggestWriteRequestType(ctx, range) ==
+            EWriteRequestType::MultiAgentWrite)
+        {
             NCloud::Register<TMultiAgentWriteActor<TMethod>>(
                 ctx,
                 std::move(requestInfo),


### PR DESCRIPTION
#1720 
Проведя замеры мульти агентных запросов мы установили, что весьма сильно страдает и пропускная способность и лэтенси если пользователь пишет маленькими запросами с маленьким иодепсом
результаты измерений:
https://disk.yandex.ru/d/qz2fFnQQyWCXsQ
Если попробовать установить квоту на Bandwidth Direct запросов, исчерпая которую мы начнем писать мультиагентными запросами, то можно получить весьма сильный прирост производительности при большом иодепсе и больших запросах.
Сравнение производительности с полностью директ запросами и с bw квотой на 600 500 и 400 мб при включенном рдма
https://disk.yandex.ru/d/6CZC_RunBk4gvA