### PR TITLE
issue-1223: refactor trace readers and add traces export for slow requests

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -841,7 +841,8 @@ void TBootstrapBase::InitLWTrace(const TString& serviceNameForExporter)
                 "BLOCKSTORE_TRACE",
                 "AllRequests",
                 GetTraceServiceClient(),
-                serviceNameForExporter);
+                serviceNameForExporter,
+                TLOG_INFO);
         } else {
             reader = SetupTraceReaderWithLog(
                 TraceLoggerId,
@@ -868,13 +869,15 @@ void TBootstrapBase::InitLWTrace(const TString& serviceNameForExporter)
                 "BLOCKSTORE_TRACE",
                 GetTraceServiceClient(),
                 serviceNameForExporter,
-                diagnosticsConfig->GetRequestThresholds());
+                diagnosticsConfig->GetRequestThresholds(),
+                "SlowRequests");
         } else {
             reader = SetupTraceReaderForSlowRequests(
                 SlowRequestsFilterId,
                 traceLog,
                 "BLOCKSTORE_TRACE",
-                diagnosticsConfig->GetRequestThresholds());
+                diagnosticsConfig->GetRequestThresholds(),
+                "SlowRequests");
         }
 
         TraceReaders.push_back(std::move(reader));

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -826,33 +826,31 @@ void TBootstrapBase::InitLWTrace(const TString& serviceNameForExporter)
         diagnosticsConfig->GetTracesSyslogIdentifier()
     );
 
-    const auto regularSamplingRate = diagnosticsConfig->GetSamplingRate();
-
-    if (regularSamplingRate) {
+    if (const auto samplingRate = diagnosticsConfig->GetSamplingRate()) {
         NLWTrace::TQuery query = ProbabilisticQuery(
             desc,
-            regularSamplingRate,
+            samplingRate,
             diagnosticsConfig->GetLWTraceShuttleCount());
         lwManager.New(TraceLoggerId, query);
-        TraceReaders.push_back(CreateTraceLogger(
-            TraceLoggerId,
-            traceLog,
-            "BLOCKSTORE_TRACE"
-        ));
-    }
 
-    if (regularSamplingRate && serviceNameForExporter) {
-        NLWTrace::TQuery query = ProbabilisticQuery(
-            desc,
-            regularSamplingRate,
-            diagnosticsConfig->GetLWTraceShuttleCount());
-        lwManager.New(TraceExporterId, query);
-        TraceReaders.push_back(CreateTraceExporter(
-            TraceExporterId,
-            traceLog,
-            "BLOCKSTORE_TRACE",
-            GetTraceServiceClient(),
-            serviceNameForExporter));
+        ITraceReaderPtr reader;
+        if (serviceNameForExporter) {
+            reader = SetupTraceReaderWithOpentelemetryExport(
+                TraceLoggerId,
+                traceLog,
+                "BLOCKSTORE_TRACE",
+                "AllRequests",
+                GetTraceServiceClient(),
+                serviceNameForExporter);
+        } else {
+            reader = SetupTraceReaderWithLog(
+                TraceLoggerId,
+                traceLog,
+                "BLOCKSTORE_TRACE",
+                "AllRequests");
+        }
+
+        TraceReaders.push_back(std::move(reader));
     }
 
     if (auto samplingRate = diagnosticsConfig->GetSlowRequestSamplingRate()) {
@@ -861,11 +859,25 @@ void TBootstrapBase::InitLWTrace(const TString& serviceNameForExporter)
             samplingRate,
             diagnosticsConfig->GetLWTraceShuttleCount());
         lwManager.New(SlowRequestsFilterId, query);
-        TraceReaders.push_back(CreateSlowRequestsFilter(
-            SlowRequestsFilterId,
-            traceLog,
-            "BLOCKSTORE_TRACE",
-            diagnosticsConfig->GetRequestThresholds()));
+
+        ITraceReaderPtr reader;
+        if (serviceNameForExporter) {
+            reader = SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
+                SlowRequestsFilterId,
+                traceLog,
+                "BLOCKSTORE_TRACE",
+                GetTraceServiceClient(),
+                serviceNameForExporter,
+                diagnosticsConfig->GetRequestThresholds());
+        } else {
+            reader = SetupTraceReaderForSlowRequests(
+                SlowRequestsFilterId,
+                traceLog,
+                "BLOCKSTORE_TRACE",
+                diagnosticsConfig->GetRequestThresholds());
+        }
+
+        TraceReaders.push_back(std::move(reader));
     }
 
     lwManager.RegisterCustomAction(

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -602,11 +602,11 @@ void TBootstrap::InitLWTrace()
             samplingRate,
             diagnosticsConfig->GetLWTraceShuttleCount());
         lwManager.New(TraceLoggerId, query);
-        TraceReaders.push_back(CreateTraceLogger(
+        TraceReaders.push_back(SetupTraceReaderWithLog(
             TraceLoggerId,
             traceLog,
-            "BLOCKSTORE_TRACE"
-        ));
+            "BLOCKSTORE_TRACE",
+            "AllRequests"));
     }
 
     if (auto samplingRate = diagnosticsConfig->GetSlowRequestSamplingRate()) {
@@ -615,7 +615,7 @@ void TBootstrap::InitLWTrace()
             samplingRate,
             diagnosticsConfig->GetLWTraceShuttleCount());
         lwManager.New(SlowRequestsFilterId, query);
-        TraceReaders.push_back(CreateSlowRequestsFilter(
+        TraceReaders.push_back(SetupTraceReaderForSlowRequests(
             SlowRequestsFilterId,
             traceLog,
             "BLOCKSTORE_TRACE",

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -619,7 +619,8 @@ void TBootstrap::InitLWTrace()
             SlowRequestsFilterId,
             traceLog,
             "BLOCKSTORE_TRACE",
-            diagnosticsConfig->GetRequestThresholds()));
+            diagnosticsConfig->GetRequestThresholds(),
+            "SlowRequests"));
     }
 
     lwManager.RegisterCustomAction(

--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -117,10 +117,11 @@ void TBootstrap::InitTracing()
             TraceLoggerId,
             ProbabilisticQuery(StartProbes, Options->TraceRate));
 
-        traceReaders.emplace_back(CreateTraceLogger(
+        traceReaders.emplace_back(SetupTraceReaderWithLog(
             TraceLoggerId,
             CreateLoggingService(Options->TracePath),
-            "BLOCKSTORE_TRACE"));
+            "BLOCKSTORE_TRACE",
+            "AllRequests"));
     }
 
     if (traceReaders) {

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -375,7 +375,8 @@ void TBootstrapCommon::InitLWTrace(
             SlowRequestsFilterId,
             traceLog,
             "NFS_TRACE",
-            Configs->DiagnosticsConfig->GetRequestThresholds()));
+            Configs->DiagnosticsConfig->GetRequestThresholds(),
+            "SlowRequests"));
     }
 
     if (traceReaders.size()) {

--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -355,7 +355,11 @@ void TBootstrapCommon::InitLWTrace(
             samplingRate,
             Configs->DiagnosticsConfig->GetLWTraceShuttleCount());
         lwManager.New(TraceLoggerId, query);
-        traceReaders.push_back(CreateTraceLogger(TraceLoggerId, traceLog, "NFS_TRACE"));
+        traceReaders.push_back(SetupTraceReaderWithLog(
+            TraceLoggerId,
+            traceLog,
+            "NFS_TRACE",
+            "AllRequests"));
     }
 
     auto slowRequestSamplingRate =
@@ -367,7 +371,7 @@ void TBootstrapCommon::InitLWTrace(
             Configs->DiagnosticsConfig->GetLWTraceShuttleCount());
 
         lwManager.New(SlowRequestsFilterId, query);
-        traceReaders.push_back(CreateSlowRequestsFilter(
+        traceReaders.push_back(SetupTraceReaderForSlowRequests(
             SlowRequestsFilterId,
             traceLog,
             "NFS_TRACE",

--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
@@ -112,7 +112,7 @@ struct TEnv
         auto monitoring = CreateMonitoringServiceStub();
         auto logging = CreateLoggingService(LogBackend);
         TVector<ITraceReaderPtr> readers{
-            CreateSlowRequestsFilter(
+            SetupTraceReaderForSlowRequests(
                 "filter",
                 logging,
                 "STORAGE_TRACE",

--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
@@ -116,7 +116,8 @@ struct TEnv
                 "filter",
                 logging,
                 "STORAGE_TRACE",
-                requestThresholds
+                requestThresholds,
+                "SlowRequests"
         )};
         return NCloud::CreateTraceProcessorMon(
             monitoring,

--- a/cloud/storage/core/libs/diagnostics/trace_reader.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_reader.cpp
@@ -82,15 +82,15 @@ TString SerializeTraceToString(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TTraceLogger final
-    : public ITraceReader
+class TTraceLogger final: public ITraceReader
 {
 private:
-    ITraceReaderPtr Consumer;
+    const ITraceReaderPtr Consumer;
+    const TString Tag;
+    const ELogPriority Priority;
+
     TLog Log;
     ui64 TracksCount = 0;
-    TString Tag;
-    const ELogPriority Priority = ELogPriority::TLOG_INFO;
 
 public:
     TTraceLogger(
@@ -99,7 +99,7 @@ public:
             TString tag,
             ILoggingServicePtr logging,
             const TString& componentName,
-            ELogPriority priority = ELogPriority::TLOG_INFO)
+            ELogPriority priority)
         : ITraceReader(std::move(id))
         , Consumer(std::move(consumer))
         , Tag(std::move(tag))
@@ -332,13 +332,14 @@ ITraceReaderPtr SetupTraceReaderForSlowRequests(
     TString id,
     ILoggingServicePtr logging,
     TString componentName,
-    TRequestThresholds requestThresholds)
+    TRequestThresholds requestThresholds,
+    TString tag)
 {
     auto readerWithLog = SetupTraceReaderWithLog(
         id,
         logging,
         componentName,
-        "SlowRequests",
+        std::move(tag),
         TLOG_WARNING);
     return CreateSlowRequestsFilter(
         std::move(id),

--- a/cloud/storage/core/libs/diagnostics/trace_reader.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_reader.cpp
@@ -262,7 +262,11 @@ void TTraceReaderWithRingBuffer::Push(
 
     ui64 minSeenTimestamp = tl.Items[0].TimestampCycles;
 
-    RingBuffer.PushBack({.Ts=TInstant::Now(), .Date=minSeenTimestamp, .TrackLog=tl, .Tag=Tag});
+    RingBuffer.PushBack(
+        {.Ts = TInstant::Now(),
+         .Date = minSeenTimestamp,
+         .TrackLog = tl,
+         .Tag = Tag});
 }
 
 void TTraceReaderWithRingBuffer::Reset()

--- a/cloud/storage/core/libs/diagnostics/trace_reader.h
+++ b/cloud/storage/core/libs/diagnostics/trace_reader.h
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/protos/trace.pb.h>
 
 #include <library/cpp/containers/ring_buffer/ring_buffer.h>
+#include <library/cpp/logger/priority.h>
 #include <library/cpp/lwtrace/log.h>
 
 #include <util/generic/hash.h>
@@ -89,7 +90,8 @@ ITraceReaderPtr CreateTraceLogger(
     ITraceReaderPtr consumer,
     ILoggingServicePtr logging,
     TString componentName,
-    TString tag);
+    TString tag,
+    ELogPriority priority = ELogPriority::TLOG_INFO);
 
 ITraceReaderPtr CreateSlowRequestsFilter(
     TString id,
@@ -102,7 +104,8 @@ ITraceReaderPtr SetupTraceReaderWithLog(
     TString id,
     ILoggingServicePtr logging,
     TString componentName,
-    TString tag);
+    TString tag,
+    ELogPriority priority = ELogPriority::TLOG_INFO);
 
 ITraceReaderPtr SetupTraceReaderForSlowRequests(
     TString id,

--- a/cloud/storage/core/libs/diagnostics/trace_reader.h
+++ b/cloud/storage/core/libs/diagnostics/trace_reader.h
@@ -62,9 +62,7 @@ struct ITraceReader
     virtual void Reset() = 0;
 };
 
-
-class TTraceReaderWithRingBuffer final
-    : public ITraceReader
+class TTraceReaderWithRingBuffer final: public ITraceReader
 {
     static constexpr size_t DefaultRingBufferSize = 1000;
 
@@ -111,7 +109,8 @@ ITraceReaderPtr SetupTraceReaderForSlowRequests(
     TString id,
     ILoggingServicePtr logging,
     TString componentName,
-    TRequestThresholds requestThresholds);
+    TRequestThresholds requestThresholds,
+    TString tag);
 
 NLWTrace::TQuery ProbabilisticQuery(
     const TVector<std::tuple<TString, TString>>& probes,

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_convert.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_convert.cpp
@@ -301,20 +301,22 @@ TReferenceTimeCycle GetReferenceTimeCycle(const NLWTrace::TTrackLog& tl)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<Span> ConvertToOpenTelemetrySpans(const NLWTrace::TTrackLog& tl)
+TTraceInfo ConvertToOpenTelemetrySpans(const NLWTrace::TTrackLog& tl)
 {
-    auto traceId = FindRequestId(tl, {0, tl.Items.size()});
-    if (!traceId) {
-        traceId = RandomNumber<ui64>();
-    }
+    TTraceInfo traceInfo;
 
-    return TSpanTree::ExtractSpans(ProcessItemsToSpanTree(
+    traceInfo.RequestId = FindRequestId(tl, {0, tl.Items.size()});
+    traceInfo.DiskId = FindFirst<TString>(tl, "diskId", {0, tl.Items.size()});
+
+    traceInfo.Spans = TSpanTree::ExtractSpans(ProcessItemsToSpanTree(
         tl,
-        traceId,                    // traceId
+        RandomNumber<ui64>(),       // traceId
         0,                          // currentSpanId
         {0, tl.Items.size()},       // iterationContext
         GetReferenceTimeCycle(tl)   // referenceTimeCycle
         ));
+
+    return traceInfo;
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_convert.h
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_convert.h
@@ -8,7 +8,13 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<opentelemetry::proto::trace::v1::Span> ConvertToOpenTelemetrySpans(
-    const NLWTrace::TTrackLog& tl);
+struct TTraceInfo
+{
+    ui64 RequestId = 0;
+    TString DiskId;
+    TVector<opentelemetry::proto::trace::v1::Span> Spans;
+};
+
+TTraceInfo ConvertToOpenTelemetrySpans(const NLWTrace::TTrackLog& tl);
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_reader.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_reader.cpp
@@ -26,8 +26,8 @@ private:
     const TString ComponentName;
     const TString ServiceName;
     const TString Tag;
+    const ITraceReaderPtr Consumer;
 
-    ITraceReaderPtr Consumer;
     ILoggingServicePtr Logging;
     ITraceServiceClientPtr TraceServiceClient;
 
@@ -184,13 +184,14 @@ ITraceReaderPtr SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
     TString componentName,
     ITraceServiceClientPtr traceServiceClient,
     TString serviceName,
-    TRequestThresholds requestThresholds)
+    TRequestThresholds requestThresholds,
+    TString tag)
 {
     auto traceReader = SetupTraceReaderWithOpentelemetryExport(
         id,
         logging,
         componentName,
-        "SlowRequests",
+        std::move(tag),
         std::move(traceServiceClient),
         std::move(serviceName),
         ELogPriority::TLOG_WARNING);

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_reader.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_reader.cpp
@@ -138,7 +138,8 @@ ITraceReaderPtr SetupTraceReaderWithOpentelemetryExport(
     TString componentName,
     TString tag,
     ITraceServiceClientPtr traceServiceClient,
-    TString serviceName)
+    TString serviceName,
+    ELogPriority priority)
 {
     ITraceReaderPtr traceReader =
         std::make_shared<TTraceReaderWithRingBuffer>(id, tag);
@@ -155,7 +156,8 @@ ITraceReaderPtr SetupTraceReaderWithOpentelemetryExport(
         std::move(traceReader),
         std::move(logging),
         std::move(componentName),
-        std::move(tag));
+        std::move(tag),
+        priority);
     return traceReader;
 }
 
@@ -173,7 +175,8 @@ ITraceReaderPtr SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
         componentName,
         "SlowRequests",
         std::move(traceServiceClient),
-        std::move(serviceName));
+        std::move(serviceName),
+        ELogPriority::TLOG_WARNING);
 
     return CreateSlowRequestsFilter(
         std::move(id),

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_reader.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_reader.cpp
@@ -59,7 +59,8 @@ public:
             return;
         }
 
-        auto spans = ConvertToOpenTelemetrySpans(tl);
+        auto traceInfo = ConvertToOpenTelemetrySpans(tl);
+        const auto spans = std::move(traceInfo.Spans);
 
         ExportTraceServiceRequest traces;
         auto* resourceSpans = traces.add_resource_spans();
@@ -73,6 +74,22 @@ public:
             resourceSpans->mutable_resource()->mutable_attributes()->Add();
         tagAttribute->set_key("tag");
         tagAttribute->mutable_value()->set_string_value(Tag);
+
+        if (traceInfo.RequestId) {
+            auto* requestIdAttribute =
+                resourceSpans->mutable_resource()->mutable_attributes()->Add();
+            requestIdAttribute->set_key("requestId");
+            requestIdAttribute->mutable_value()->set_string_value(
+                ToString(traceInfo.RequestId));
+        }
+
+        if (traceInfo.DiskId) {
+            auto* diskIdAttribute =
+                resourceSpans->mutable_resource()->mutable_attributes()->Add();
+            diskIdAttribute->set_key("diskId");
+            diskIdAttribute->mutable_value()->set_string_value(
+                std::move(traceInfo.DiskId));
+        }
 
         auto* scopedSpans = resourceSpans->add_scope_spans();
         for (const auto& span: spans) {

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_reader.h
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_reader.h
@@ -22,7 +22,8 @@ ITraceReaderPtr SetupTraceReaderWithOpentelemetryExport(
     TString componentName,
     TString tag,
     ITraceServiceClientPtr traceServiceClient,
-    TString serviceName);
+    TString serviceName,
+    ELogPriority priority = ELogPriority::TLOG_INFO);
 
 ITraceReaderPtr SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
     TString id,

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_reader.h
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_reader.h
@@ -23,7 +23,7 @@ ITraceReaderPtr SetupTraceReaderWithOpentelemetryExport(
     TString tag,
     ITraceServiceClientPtr traceServiceClient,
     TString serviceName,
-    ELogPriority priority = ELogPriority::TLOG_INFO);
+    ELogPriority priority);
 
 ITraceReaderPtr SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
     TString id,
@@ -31,6 +31,7 @@ ITraceReaderPtr SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
     TString componentName,
     ITraceServiceClientPtr traceServiceClient,
     TString serviceName,
-    TRequestThresholds requestThresholds);
+    TRequestThresholds requestThresholds,
+    TString tag);
 
 } // namespace NCloud

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_reader.h
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_reader.h
@@ -11,7 +11,25 @@ ITraceReaderPtr CreateTraceExporter(
     TString id,
     ILoggingServicePtr logging,
     TString componentName,
+    TString tag,
+    ITraceReaderPtr consumer,
     ITraceServiceClientPtr traceServiceClient,
     TString serviceName);
+
+ITraceReaderPtr SetupTraceReaderWithOpentelemetryExport(
+    TString id,
+    ILoggingServicePtr logging,
+    TString componentName,
+    TString tag,
+    ITraceServiceClientPtr traceServiceClient,
+    TString serviceName);
+
+ITraceReaderPtr SetupTraceReaderForSlowRequestsWithOpentelemetryExport(
+    TString id,
+    ILoggingServicePtr logging,
+    TString componentName,
+    ITraceServiceClientPtr traceServiceClient,
+    TString serviceName,
+    TRequestThresholds requestThresholds);
 
 } // namespace NCloud

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_ut.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_ut.cpp
@@ -103,7 +103,7 @@ Y_UNIT_TEST_SUITE(TraceConverter)
         {
             void Push(TThread::TId, const TTrackLog& tl)
             {
-                auto spans = ConvertToOpenTelemetrySpans(tl);
+                auto spans = ConvertToOpenTelemetrySpans(tl).Spans;
 
                 UNIT_ASSERT(spans.size() == 1);
 
@@ -243,7 +243,7 @@ Y_UNIT_TEST_SUITE(TraceConverter)
         {
             void Push(TThread::TId, const TTrackLog& tl)
             {
-                auto spans = ConvertToOpenTelemetrySpans(tl);
+                auto spans = ConvertToOpenTelemetrySpans(tl).Spans;
 
                 UNIT_ASSERT_VALUES_EQUAL(spans.size(), 4);
 

--- a/cloud/vm/blockstore/bootstrap.cpp
+++ b/cloud/vm/blockstore/bootstrap.cpp
@@ -264,21 +264,23 @@ void TBootstrap::InitLWTrace()
     if (auto samplingRate = tracingConfig.GetSamplingRate()) {
         NLWTrace::TQuery query = ProbabilisticQuery(desc, samplingRate);
         TLWTraceSafeManager::Instance().New(TraceLoggerId, query);
-        TraceReaders.push_back(CreateTraceLogger(
+        TraceReaders.push_back(SetupTraceReaderWithLog(
             TraceLoggerId,
             traceLog,
-            "BLOCKSTORE_TRACE"
+            "BLOCKSTORE_TRACE",
+            "AllRequests"
         ));
     }
 
     if (auto samplingRate = tracingConfig.GetSlowRequestSamplingRate()) {
         NLWTrace::TQuery query = ProbabilisticQuery(desc, samplingRate);
         TLWTraceSafeManager::Instance().New(SlowRequestsFilterId, query);
-        TraceReaders.push_back(CreateSlowRequestsFilter(
+        TraceReaders.push_back(SetupTraceReaderForSlowRequests(
             SlowRequestsFilterId,
             traceLog,
             "BLOCKSTORE_TRACE",
-            ClientConfig->GetRequestThresholds()));
+            ClientConfig->GetRequestThresholds()
+        ));
     }
 }
 

--- a/cloud/vm/blockstore/bootstrap.cpp
+++ b/cloud/vm/blockstore/bootstrap.cpp
@@ -279,8 +279,8 @@ void TBootstrap::InitLWTrace()
             SlowRequestsFilterId,
             traceLog,
             "BLOCKSTORE_TRACE",
-            ClientConfig->GetRequestThresholds()
-        ));
+            ClientConfig->GetRequestThresholds(),
+            "SlowRequests"));
     }
 }
 


### PR DESCRIPTION
#1223 
В этом пре рефакторинг Trace ридеров, чтобы их код можно было переиспользовать и прикручивание экспорта трейсов для медленных запросов