### PR TITLE
[Blockstore] mark request to mirror disk as dirty when starting ReadBlocks, not when completing (Write|Zero)Blocks; add additional check when inserting request to DirtyReadRequestIds to prevent this structure's slow bloating

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -231,6 +231,11 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    // returns new request identity key
+    [[nodiscard]] ui64 RegisterNewReadBlocksRequest(
+        ui64 volumeRequestId,
+        TBlockRange64 blockRange);
+
     template <typename TMethod>
     void ReadBlocks(
         const typename TMethod::TRequest::TPtr& ev,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -30,13 +30,9 @@ void TMirrorPartitionActor::HandleWriteOrZeroCompleted(
     if (!completeRequest) {
         return;
     }
+
     DrainActorCompanion.ProcessDrainRequests(ctx);
-    auto [volumeRequestId, _, range] = completeRequest.value();
-    for (const auto& [id, request]: RequestsInProgress.AllRequests()) {
-        if (range.Overlaps(request.BlockRange)) {
-            DirtyReadRequestIds.insert(id);
-        }
-    }
+    auto [volumeRequestId, _, __] = completeRequest.value();
 
     if (ResyncActorId) {
         auto completion = std::make_unique<
@@ -93,7 +89,6 @@ void TMirrorPartitionActor::MirrorRequest(
         ev->Cookie,
         msg->CallContext);
 
-
     const auto range = BuildRequestBlockRange(
         *ev->Get(),
         State.GetBlockSize());
@@ -114,7 +109,6 @@ void TMirrorPartitionActor::MirrorRequest(
             *requestInfo,
             std::make_unique<typename TMethod::TResponse>(Status)
         );
-
         return;
     }
 
@@ -132,8 +126,9 @@ void TMirrorPartitionActor::MirrorRequest(
         }
         WriteIntersectsWithScrubbing = true;
     }
+
     for (const auto& [id, request]: RequestsInProgress.AllRequests()) {
-        if (range.Overlaps(request.BlockRange)) {
+        if (!request.IsWrite && range.Overlaps(request.BlockRange)) {
             DirtyReadRequestIds.insert(id);
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -2159,25 +2159,24 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         bool interceptReadDeviceBlocks = false;
         bool interceptWriteDeviceBlocks = false;
 
-        runtime.SetEventFilter([&] (auto&, auto& event) {
-            if (!toSend) {
-                if (
-                    (
-                        interceptReadDeviceBlocks &&
-                        event->GetTypeRewrite() == TEvDiskAgent::EvReadDeviceBlocksRequest
-                    ) ||
-                    (
-                        interceptWriteDeviceBlocks &&
-                        event->GetTypeRewrite() == TEvDiskAgent::EvWriteDeviceBlocksRequest
-                    )
-                ) {
-                    toSend = event;
-                    return true;
+        runtime.SetEventFilter(
+            [&] (auto&, auto& event)
+            {
+                if (!toSend) {
+                    if ((interceptReadDeviceBlocks &&
+                        event->GetTypeRewrite() ==
+                            TEvDiskAgent::EvReadDeviceBlocksRequest) ||
+                        (interceptWriteDeviceBlocks &&
+                        event->GetTypeRewrite() ==
+                            TEvDiskAgent::EvWriteDeviceBlocksRequest))
+                    {
+                        toSend = event;
+                        return true;
+                    }
                 }
-            }
 
-            return false;
-        });
+                return false;
+            });
 
         TDynamicCountersPtr critEventsCounters = new TDynamicCounters();
         InitCriticalEventsCounter(critEventsCounters);


### PR DESCRIPTION
Fixes a possible bug where a read request may not be marked dirty (but it should). Scenario:
* Read request starts after all overlapping in-flight write/zero requests passed this point: https://github.com/ydb-platform/nbs/blob/11033ffccb3a538de2e9cd9c4c2cde74adaf9ca9/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp#L137
* Read request finishes before any overlapping in-flight write/zero request is completed, so this code is no-op: https://github.com/ydb-platform/nbs/blob/11033ffccb3a538de2e9cd9c4c2cde74adaf9ca9/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp#L37