### PR TITLE
Unification for report logs and adding description

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -9,6 +9,8 @@
 
 namespace NCloud::NBlockStore {
 
+namespace {
+
 template <typename T>
 static TString FormatKeyValueList(
     const TVector<std::pair<TStringBuf, T>>& keyValues)
@@ -24,6 +26,18 @@ static TString FormatKeyValueList(
     }
     return sb;
 }
+
+TString ComposeMessageWithSuffix(const TString& message, const TString& suffix)
+{
+    if (message.empty()) {
+        return suffix;
+    }
+    if (suffix.empty()) {
+        return message;
+    }
+    return message + "; " + suffix;
+}
+}   // namespace
 
 using namespace NMonitoring;
 
@@ -56,12 +70,8 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
         const TString& message,                                                \
         const TVector<std::pair<TStringBuf, TString>>& keyValues)              \
     {                                                                          \
-        TString msg = message;                                                 \
-        const TString suffix = FormatKeyValueList(keyValues);                  \
-        if (!msg.empty() && !suffix.empty()) {                                 \
-            msg += "; ";                                                       \
-        }                                                                      \
-        msg += suffix;                                                         \
+        TString msg =                                                          \
+            ComposeMessageWithSuffix(message, FormatKeyValueList(keyValues));  \
         return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
     }                                                                          \
                                                                                \
@@ -69,12 +79,8 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
         const TString& message,                                                \
         const TVector<std::pair<TStringBuf, ui64>>& keyValues)                 \
     {                                                                          \
-        TString msg = message;                                                 \
-        const TString suffix = FormatKeyValueList(keyValues);                  \
-        if (!msg.empty() && !suffix.empty()) {                                 \
-            msg += "; ";                                                       \
-        }                                                                      \
-        msg += suffix;                                                         \
+        TString msg =                                                          \
+            ComposeMessageWithSuffix(message, FormatKeyValueList(keyValues));  \
         return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
     }                                                                          \
     const TString GetCriticalEventFor##name()                                  \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -10,6 +10,7 @@
 namespace NCloud::NBlockStore {
 
 namespace {
+////////////////////////////////////////////////////////////////////////////////
 
 template <typename... Ts>
 TStringBuilder& operator<<(TStringBuilder& sb, const std::variant<Ts...>& v)

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -11,6 +11,13 @@ namespace NCloud::NBlockStore {
 
 namespace {
 
+template <typename... Ts>
+TStringBuilder& operator<<(TStringBuilder& sb, const std::variant<Ts...>& v)
+{
+    std::visit([&sb](const auto& arg) { sb << arg; }, v);
+    return sb;
+}
+
 template <typename T>
 static TString FormatKeyValueList(
     const TVector<std::pair<TStringBuf, T>>& keyValues)
@@ -68,16 +75,7 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     }                                                                          \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, TString>>& keyValues)              \
-    {                                                                          \
-        TString msg =                                                          \
-            ComposeMessageWithSuffix(message, FormatKeyValueList(keyValues));  \
-        return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
-    }                                                                          \
-                                                                               \
-    TString Report##name(                                                      \
-        const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, ui64>>& keyValues)                 \
+        const TVector<std::pair<TStringBuf, TValue>>& keyValues)               \
     {                                                                          \
         TString msg =                                                          \
             ComposeMessageWithSuffix(message, FormatKeyValueList(keyValues));  \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -1,7 +1,7 @@
 #include "critical_events.h"
 
 #include "public.h"
-#include "util/string/builder.h"
+#include <util/string/builder.h>
 
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
@@ -19,7 +19,7 @@ TStringBuilder& operator<<(TStringBuilder& sb, const std::variant<Ts...>& v)
 }
 
 template <typename T>
-static TString FormatKeyValueList(
+TString FormatKeyValueList(
     const TVector<std::pair<TStringBuf, T>>& keyValues)
 {
     TStringBuilder sb;
@@ -79,6 +79,13 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     {                                                                          \
         TString msg =                                                          \
             ComposeMessageWithSuffix(message, FormatKeyValueList(keyValues));  \
+        return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
+    }                                                                          \
+    TString Report##name(                                                      \
+        const TVector<std::pair<TStringBuf, TValue>>& keyValues)               \
+    {                                                                          \
+        TString msg =                                                          \
+            ComposeMessageWithSuffix("", FormatKeyValueList(keyValues));       \
         return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
     }                                                                          \
     const TString GetCriticalEventFor##name()                                  \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -9,12 +9,13 @@
 
 namespace NCloud::NBlockStore {
 
+template <typename T>
 static TString FormatKeyValueList(
-    const TVector<std::pair<TString, TString>>& items)
+    const TVector<std::pair<TStringBuf, T>>& keyValues)
 {
     TStringBuilder sb;
     bool first = true;
-    for (const auto& [key, value]: items) {
+    for (const auto& [key, value]: keyValues) {
         if (!first) {
             sb << "; ";
         }
@@ -53,7 +54,7 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     }                                                                          \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TString, TString>>& keyValues)                 \
+        const TVector<std::pair<TStringBuf, TString>>& keyValues)              \
     {                                                                          \
         TString msg = message;                                                 \
         const TString suffix = FormatKeyValueList(keyValues);                  \
@@ -61,12 +62,21 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
             msg += "; ";                                                       \
         }                                                                      \
         msg += suffix;                                                         \
-        return ReportCriticalEvent(                                            \
-            GetCriticalEventFor##name(),                                       \
-            msg,                                                               \
-            false);                                                            \
+        return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
     }                                                                          \
                                                                                \
+    TString Report##name(                                                      \
+        const TString& message,                                                \
+        const TVector<std::pair<TStringBuf, ui64>>& keyValues)                 \
+    {                                                                          \
+        TString msg = message;                                                 \
+        const TString suffix = FormatKeyValueList(keyValues);                  \
+        if (!msg.empty() && !suffix.empty()) {                                 \
+            msg += "; ";                                                       \
+        }                                                                      \
+        msg += suffix;                                                         \
+        return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
+    }                                                                          \
     const TString GetCriticalEventFor##name()                                  \
     {                                                                          \
         return "AppCriticalEvents/"#name;                                      \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -10,6 +10,7 @@
 namespace NCloud::NBlockStore {
 
 namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename... Ts>
@@ -85,9 +86,10 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     TString Report##name(                                                      \
         const TVector<std::pair<TStringBuf, TValue>>& keyValues)               \
     {                                                                          \
-        TString msg =                                                          \
-            ComposeMessageWithSuffix("", FormatKeyValueList(keyValues));       \
-        return ReportCriticalEvent(GetCriticalEventFor##name(), msg, false);   \
+        return ReportCriticalEvent(                                            \
+            GetCriticalEventFor##name(),                                       \
+            FormatKeyValueList(keyValues),                                     \
+            false);                                                            \
     }                                                                          \
     const TString GetCriticalEventFor##name()                                  \
     {                                                                          \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -121,7 +121,10 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TString, TString>>& keyValues);                \
+        const TVector<std::pair<TStringBuf, TString>>& keyValues);             \
+    TString Report##name(                                                      \
+        const TString& message,                                                \
+        const TVector<std::pair<TStringBuf, ui64>>& keyValues);                \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -126,6 +126,8 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
     TString Report##name(                                                      \
         const TString& message,                                                \
         const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+    TString Report##name(                                                      \
+        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -119,6 +119,9 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 
 #define BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                        \
     TString Report##name(const TString& message = "");                         \
+    TString Report##name(                                                      \
+        const TString& message,                                                \
+        const TVector<std::pair<TString, TString>>& keyValues);                \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -2,7 +2,11 @@
 
 #include "public.h"
 
+#include <variant>
+
 namespace NCloud::NBlockStore {
+
+using TValue = std::variant<TString, int, ui16, ui32, ui64>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -121,10 +125,7 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, TString>>& keyValues);             \
-    TString Report##name(                                                      \
-        const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, ui64>>& keyValues);                \
+        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1866,9 +1866,8 @@ TFuture<void> TEndpointManager::DoRestoreEndpoints()
             const auto& response = f.GetValue();
             if (HasError(response)) {
                 ReportEndpointRestoringError(
-                    TStringBuilder()
-                    << "Endpoint restoring error occurred for endpoint ID: "
-                    << endpointId << ", socket path: " << socketPath);
+                    "Endpoint restoring error occurred",
+                    {{"endpoint_id", endpointId}, {"socket_path", socketPath}});
             }
 
             if (auto ptr = weakPtr.lock()) {

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1866,8 +1866,9 @@ TFuture<void> TEndpointManager::DoRestoreEndpoints()
             const auto& response = f.GetValue();
             if (HasError(response)) {
                 ReportEndpointRestoringError(
-                    "Endpoint restoring error occurred",
-                    {{"endpoint_id", endpointId}, {"socket_path", socketPath}});
+                    TStringBuilder()
+                    << "Endpoint restoring error occurred for endpoint ID: "
+                    << endpointId << ", socket path: " << socketPath);
             }
 
             if (auto ptr = weakPtr.lock()) {

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -178,9 +178,7 @@ size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer)
 
     if (error.ByteSizeLong() > buffer.size()) {
         error.SetMessage("rdma error");
-        ReportFailedToSerializeRdmaError(
-            "",
-            {{"original meessage", TString(message)}, {"code", code}});
+        ReportFailedToSerializeRdmaError(FormatError(error));
     }
 
     if (error.SerializeToArray(

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -181,7 +181,7 @@ size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer)
         ReportFailedToSerializeRdmaError(
             TStringBuilder()
             << "Failed to serialize RDMA error with code " << code
-            << ", original message: \"" << message << "\"");
+            << ", original message: \"" << TString(message).Quote() << "\"");
     }
 
     if (error.SerializeToArray(

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -179,9 +179,9 @@ size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer)
     if (error.ByteSizeLong() > buffer.size()) {
         error.SetMessage("rdma error");
         ReportFailedToSerializeRdmaError(
-            TStringBuilder()
-            << "Failed to serialize RDMA error with code " << code
-            << ", original message: \"" << TString(message).Quote() << "\"");
+            "",
+            {{"original meessage", TString(message)},
+             {"code", TStringBuilder() << code}});
     }
 
     if (error.SerializeToArray(
@@ -202,9 +202,8 @@ NProto::TError ParseError(TStringBuf buffer)
         error.SetCode(E_FAIL);
         error.SetMessage("rdma error");
         ReportFailedToParseRdmaError(
-            TStringBuilder()
-            << "Failed to parse RDMA error from buffer " << buffer.size()
-            << "; error: " << FormatError(error));
+            FormatError(error),
+            {{"buffer", buffer.size()}});
     }
 
     return error;

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -180,8 +180,7 @@ size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer)
         error.SetMessage("rdma error");
         ReportFailedToSerializeRdmaError(
             "",
-            {{"original meessage", TString(message)},
-             {"code", TStringBuilder() << code}});
+            {{"original meessage", TString(message)}, {"code", code}});
     }
 
     if (error.SerializeToArray(

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -178,7 +178,10 @@ size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer)
 
     if (error.ByteSizeLong() > buffer.size()) {
         error.SetMessage("rdma error");
-        ReportFailedToSerializeRdmaError();
+        ReportFailedToSerializeRdmaError(
+            TStringBuilder()
+            << "Failed to serialize RDMA error with code " << code
+            << ", original message: \"" << message << "\"");
     }
 
     if (error.SerializeToArray(
@@ -198,7 +201,10 @@ NProto::TError ParseError(TStringBuf buffer)
     if (!error.ParseFromArray(buffer.data(), buffer.size())) {
         error.SetCode(E_FAIL);
         error.SetMessage("rdma error");
-        ReportFailedToParseRdmaError();
+        ReportFailedToParseRdmaError(
+            TStringBuilder()
+            << "Failed to parse RDMA error from buffer " << buffer.size()
+            << "; error: " << FormatError(error));
     }
 
     return error;

--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -200,7 +200,7 @@ NProto::TError ParseError(TStringBuf buffer)
         error.SetMessage("rdma error");
         ReportFailedToParseRdmaError(
             FormatError(error),
-            {{"buffer", buffer.size()}});
+            {{"bufferSize", buffer.size()}});
     }
 
     return error;

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -205,8 +205,7 @@ private:
         if constexpr (IsWriteRequest(T::Request)) {
             ReportServiceProxyWakeupTimerHit(
                 "",
-                {{"disk", DiskId},
-                 {"RequestId", TStringBuilder() << CallContext->RequestId}});
+                {{"disk", DiskId}, {"RequestId", CallContext->RequestId}});
             return;
         }
 

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -203,7 +203,9 @@ private:
             << " request wakeup timer hit");
 
         if constexpr (IsWriteRequest(T::Request)) {
-            ReportServiceProxyWakeupTimerHit();
+            ReportServiceProxyWakeupTimerHit(
+                TStringBuilder() << "Request timeout for DiskId=" << DiskId
+                                 << ", RequestId=" << CallContext->RequestId);
             return;
         }
 

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -204,7 +204,6 @@ private:
 
         if constexpr (IsWriteRequest(T::Request)) {
             ReportServiceProxyWakeupTimerHit(
-                "",
                 {{"disk", DiskId}, {"RequestId", CallContext->RequestId}});
             return;
         }

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -204,8 +204,9 @@ private:
 
         if constexpr (IsWriteRequest(T::Request)) {
             ReportServiceProxyWakeupTimerHit(
-                TStringBuilder() << "Request timeout for DiskId=" << DiskId
-                                 << ", RequestId=" << CallContext->RequestId);
+                "",
+                {{"disk", DiskId},
+                 {"RequestId", TStringBuilder() << CallContext->RequestId}});
             return;
         }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
@@ -193,7 +193,11 @@ void TDiskRegistryActor::HandleFinishMigration(
                 // to migrate again, which is inefficient but which won't
                 // break anything
 
-                ReportUnexpectedBatchMigration();
+                ReportUnexpectedBatchMigration(
+                    TStringBuilder()
+                    << "FinishMigration request contains migrations spanning "
+                       "multiple replicas for disk: "
+                    << record.GetDiskId());
 
                 break;
             }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
@@ -193,10 +193,7 @@ void TDiskRegistryActor::HandleFinishMigration(
                 // to migrate again, which is inefficient but which won't
                 // break anything
 
-                ReportUnexpectedBatchMigration(
-                    "FinishMigration request contains migrations spanning "
-                    "multiple replicas",
-                    {{"disk", record.GetDiskId()}});
+                ReportUnexpectedBatchMigration({{"disk", record.GetDiskId()}});
 
                 break;
             }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_migration.cpp
@@ -194,10 +194,9 @@ void TDiskRegistryActor::HandleFinishMigration(
                 // break anything
 
                 ReportUnexpectedBatchMigration(
-                    TStringBuilder()
-                    << "FinishMigration request contains migrations spanning "
-                       "multiple replicas for disk: "
-                    << record.GetDiskId());
+                    "FinishMigration request contains migrations spanning "
+                    "multiple replicas",
+                    {{"disk", record.GetDiskId()}});
 
                 break;
             }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
@@ -44,7 +44,6 @@ void TDiskRegistryActor::HandleRegisterAgent(
         }
 
         ReportRegisterAgentWithEmptyRackName(
-            "",
             {{"AgentId", agentConfig.GetAgentId()},
              {"NodeId", agentConfig.GetNodeId()}});
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
@@ -46,7 +46,7 @@ void TDiskRegistryActor::HandleRegisterAgent(
         ReportRegisterAgentWithEmptyRackName(
             "",
             {{"AgentId", agentConfig.GetAgentId()},
-             {"NodeId", TStringBuilder() << agentConfig.GetNodeId()}});
+             {"NodeId", agentConfig.GetNodeId()}});
 
         TString fakeRackName = "Rack-" + agentConfig.GetAgentId();
         device.SetRack(fakeRackName);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
@@ -43,7 +43,11 @@ void TDiskRegistryActor::HandleRegisterAgent(
             continue;
         }
 
-        ReportRegisterAgentWithEmptyRackName();
+        ReportRegisterAgentWithEmptyRackName(
+            TStringBuilder() << "Received RegisterAgent request with empty "
+                                "Rack name for AgentId="
+                             << agentConfig.GetAgentId()
+                             << ", NodeId=" << agentConfig.GetNodeId());
 
         TString fakeRackName = "Rack-" + agentConfig.GetAgentId();
         device.SetRack(fakeRackName);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_register.cpp
@@ -44,10 +44,9 @@ void TDiskRegistryActor::HandleRegisterAgent(
         }
 
         ReportRegisterAgentWithEmptyRackName(
-            TStringBuilder() << "Received RegisterAgent request with empty "
-                                "Rack name for AgentId="
-                             << agentConfig.GetAgentId()
-                             << ", NodeId=" << agentConfig.GetNodeId());
+            "",
+            {{"AgentId", agentConfig.GetAgentId()},
+             {"NodeId", TStringBuilder() << agentConfig.GetNodeId()}});
 
         TString fakeRackName = "Rack-" + agentConfig.GetAgentId();
         device.SetRack(fakeRackName);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5556,7 +5556,7 @@ NProto::TError TDiskRegistryState::PurgeHost(
 
     if (HasError(removeHostError)) {
         ReportDiskRegistryPurgeHostError(
-            "",
+            FormatError(removeHostError),
             {{"AgentId", agent->GetAgentId()}});
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5555,7 +5555,9 @@ NProto::TError TDiskRegistryState::PurgeHost(
         timeout);
 
     if (HasError(removeHostError)) {
-        ReportDiskRegistryPurgeHostError();
+        ReportDiskRegistryPurgeHostError(
+            TStringBuilder()
+            << "Failed to purge host: AgentId=" << agent->GetAgentId().Quote());
     }
 
     STORAGE_LOG(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5556,8 +5556,8 @@ NProto::TError TDiskRegistryState::PurgeHost(
 
     if (HasError(removeHostError)) {
         ReportDiskRegistryPurgeHostError(
-            TStringBuilder()
-            << "Failed to purge host: AgentId=" << agent->GetAgentId().Quote());
+            "",
+            {{"AgentId", agent->GetAgentId()}});
     }
 
     STORAGE_LOG(

--- a/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
+++ b/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
@@ -77,7 +77,7 @@ void TCompositeTaskList::FinishDependentTaskAwait(
     if (nestedTaskIt == DependentTasks.end()) {
         ReportReceivedUnknownTaskId(
             "Received unknown dependent",
-            {{"dependentTaskId", dependentTaskId}});)
+            {{"dependentTaskId", dependentTaskId}});
         return;
     }
     auto compositeTaskId = nestedTaskIt->second;

--- a/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
+++ b/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
@@ -52,7 +52,7 @@ TDependentTaskId TCompositeTaskList::StartDependentTaskAwait(
     auto* compositeTask = PrincipalTasks.FindPtr(principalTaskId);
     Y_DEBUG_ABORT_UNLESS(compositeTask);
     if (!compositeTask) {
-        ReportReceivedUnknownTaskId("", {{"principalTaskId", principalTaskId}});
+        ReportReceivedUnknownTaskId({{"principalTaskId", principalTaskId}});
         return INVALID_TASK_ID;
     }
     compositeTask->IncCounter();
@@ -75,9 +75,7 @@ void TCompositeTaskList::FinishDependentTaskAwait(
     auto nestedTaskIt = DependentTasks.find(dependentTaskId);
     Y_DEBUG_ABORT_UNLESS(nestedTaskIt != DependentTasks.end());
     if (nestedTaskIt == DependentTasks.end()) {
-        ReportReceivedUnknownTaskId(
-            "Received unknown dependent",
-            {{"dependentTaskId", dependentTaskId}});
+        ReportReceivedUnknownTaskId({{"dependentTaskId", dependentTaskId}});
         return;
     }
     auto compositeTaskId = nestedTaskIt->second;

--- a/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
+++ b/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
@@ -52,9 +52,7 @@ TDependentTaskId TCompositeTaskList::StartDependentTaskAwait(
     auto* compositeTask = PrincipalTasks.FindPtr(principalTaskId);
     Y_DEBUG_ABORT_UNLESS(compositeTask);
     if (!compositeTask) {
-        ReportReceivedUnknownTaskId(
-            TStringBuilder()
-            << "Received unknown task id: principalTaskId=" << principalTaskId);
+        ReportReceivedUnknownTaskId("", {{"principalTaskId", principalTaskId}});
         return INVALID_TASK_ID;
     }
     compositeTask->IncCounter();
@@ -78,9 +76,8 @@ void TCompositeTaskList::FinishDependentTaskAwait(
     Y_DEBUG_ABORT_UNLESS(nestedTaskIt != DependentTasks.end());
     if (nestedTaskIt == DependentTasks.end()) {
         ReportReceivedUnknownTaskId(
-            TStringBuilder()
-            << "Received unknown dependent task id: dependentTaskId="
-            << dependentTaskId);
+            "Received unknown dependent",
+            {{"dependentTaskId", dependentTaskId}});)
         return;
     }
     auto compositeTaskId = nestedTaskIt->second;

--- a/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
+++ b/cloud/blockstore/libs/storage/model/composite_task_waiter.cpp
@@ -52,7 +52,9 @@ TDependentTaskId TCompositeTaskList::StartDependentTaskAwait(
     auto* compositeTask = PrincipalTasks.FindPtr(principalTaskId);
     Y_DEBUG_ABORT_UNLESS(compositeTask);
     if (!compositeTask) {
-        ReportReceivedUnknownTaskId();
+        ReportReceivedUnknownTaskId(
+            TStringBuilder()
+            << "Received unknown task id: principalTaskId=" << principalTaskId);
         return INVALID_TASK_ID;
     }
     compositeTask->IncCounter();
@@ -75,7 +77,10 @@ void TCompositeTaskList::FinishDependentTaskAwait(
     auto nestedTaskIt = DependentTasks.find(dependentTaskId);
     Y_DEBUG_ABORT_UNLESS(nestedTaskIt != DependentTasks.end());
     if (nestedTaskIt == DependentTasks.end()) {
-        ReportReceivedUnknownTaskId();
+        ReportReceivedUnknownTaskId(
+            TStringBuilder()
+            << "Received unknown dependent task id: dependentTaskId="
+            << dependentTaskId);
         return;
     }
     auto compositeTaskId = nestedTaskIt->second;

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1126,7 +1126,7 @@ NProto::TError VerifyBlockChecksum(
     const ui64 blockIndex,
     const ui16 blobOffset,
     const ui32 expectedChecksum,
-    const TString diskId)
+    const TString& diskId)
 {
     if (expectedChecksum == 0) {
         // 0 is a special case - block digest calculation can be

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1140,9 +1140,9 @@ NProto::TError VerifyBlockChecksum(
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob(
             "",
-            {{"BlockIndex", TStringBuilder() << blockIndex},
-             {"blobOffset", TStringBuilder() << blobOffset},
-             {"blob", TStringBuilder() << blobID}});
+            {{"BlockIndex", blockIndex},
+             {"blobOffset", blobOffset},
+             {"blob", blobID.ToString()}});
         // we might read proper data upon retry - let's give it a chance
         return MakeError(
             E_REJECTED,

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1139,8 +1139,10 @@ NProto::TError VerifyBlockChecksum(
 
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob(
-            TStringBuilder() << "BlockIndex=" << blockIndex << ", blobOffset="
-                             << blobOffset << ", blobId=" << blobID);
+            "",
+            {{"BlockIndex", TStringBuilder() << blockIndex},
+             {"blobOffset", TStringBuilder() << blobOffset},
+             {"blob", TStringBuilder() << blobID}});
         // we might read proper data upon retry - let's give it a chance
         return MakeError(
             E_REJECTED,

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1125,7 +1125,8 @@ NProto::TError VerifyBlockChecksum(
     const NKikimr::TLogoBlobID& blobID,
     const ui64 blockIndex,
     const ui16 blobOffset,
-    const ui32 expectedChecksum)
+    const ui32 expectedChecksum,
+    const TString diskId)
 {
     if (expectedChecksum == 0) {
         // 0 is a special case - block digest calculation can be
@@ -1139,8 +1140,8 @@ NProto::TError VerifyBlockChecksum(
 
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob(
-            "",
-            {{"BlockIndex", blockIndex},
+            {{"disk", diskId},
+             {"BlockIndex", blockIndex},
              {"blobOffset", blobOffset},
              {"blob", blobID.ToString()}});
         // we might read proper data upon retry - let's give it a chance

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1139,9 +1139,8 @@ NProto::TError VerifyBlockChecksum(
 
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob(
-            TStringBuilder()
-            << "Block digest mismatch detected: blockIndex=" << blockIndex
-            << ", blobOffset=" << blobOffset << ", blobId=" << blobID);
+            TStringBuilder() << "BlockIndex=" << blockIndex << ", blobOffset="
+                             << blobOffset << ", blobId=" << blobID);
         // we might read proper data upon retry - let's give it a chance
         return MakeError(
             E_REJECTED,

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1138,7 +1138,10 @@ NProto::TError VerifyBlockChecksum(
     }
 
     if (actualChecksum != expectedChecksum) {
-        ReportBlockDigestMismatchInBlob();
+        ReportBlockDigestMismatchInBlob(
+            TStringBuilder()
+            << "Block digest mismatch detected: blockIndex=" << blockIndex
+            << ", blobOffset=" << blobOffset << ", blobId=" << blobID);
         // we might read proper data upon retry - let's give it a chance
         return MakeError(
             E_REJECTED,

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -717,6 +717,6 @@ NProto::TError VerifyBlockChecksum(
     const ui64 blockIndex,
     const ui16 blobOffset,
     const ui32 expectedChecksum,
-    const TString diskId);
+    const TString& diskId);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -716,6 +716,7 @@ NProto::TError VerifyBlockChecksum(
     const NKikimr::TLogoBlobID& blobID,
     const ui64 blockIndex,
     const ui16 blobOffset,
-    const ui32 expectedChecksum);
+    const ui32 expectedChecksum,
+    const TString diskId);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -331,14 +331,11 @@ void TPartitionActor::HandleAddConfirmedBlobsCompleted(
 
     Actors.Erase(ev->Sender);
     if (FAILED(msg->GetStatus())) {
-        LOG_WARN(
-            ctx,
-            TBlockStoreComponents::PARTITION,
-            "%s Stop tablet because of AddConfirmedBlobs error: %s",
-            LogTitle.GetWithTime().c_str(),
-            FormatError(msg->GetError()).c_str());
-
-        ReportAddConfirmedBlobsError();
+        ReportAddConfirmedBlobsError(
+            TStringBuilder()
+            << LogTitle.GetWithTime()
+            << " Stop tablet because of AddConfirmedBlobs error: "
+            << FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -331,11 +331,16 @@ void TPartitionActor::HandleAddConfirmedBlobsCompleted(
 
     Actors.Erase(ev->Sender);
     if (FAILED(msg->GetStatus())) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "%s Stop tablet because of AddConfirmedBlobs error: %s",
+            LogTitle.GetWithTime().c_str(),
+            FormatError(msg->GetError()).c_str());
+
         ReportAddConfirmedBlobsError(
-            TStringBuilder()
-            << LogTitle.GetWithTime()
-            << " Stop tablet because of AddConfirmedBlobs error: "
-            << FormatError(msg->GetError()));
+            TStringBuilder() << "DiskId: " << PartitionConfig.GetDiskId()
+                             << ", error: " << FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -339,8 +339,8 @@ void TPartitionActor::HandleAddConfirmedBlobsCompleted(
             FormatError(msg->GetError()).c_str());
 
         ReportAddConfirmedBlobsError(
-            TStringBuilder() << "DiskId: " << PartitionConfig.GetDiskId()
-                             << ", error: " << FormatError(msg->GetError()));
+            FormatError(msg->GetError()),
+            {{"disk", PartitionConfig.GetDiskId()}});
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -878,7 +878,8 @@ void TCompactionActor::HandleReadBlobResponse(
             MakeBlobId(TabletId, r->BlobId),
             r->BlockIndex,
             r->BlobOffset,
-            expectedChecksum);
+            expectedChecksum,
+            DiskId);
 
         if (HasError(error)) {
             HandleError(ctx, error);

--- a/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
@@ -231,8 +231,8 @@ void TPartitionActor::HandleConfirmBlobsCompleted(
             msg->GetStatus(),
             FormatError(msg->GetError()).c_str());
         ReportConfirmBlobsError(
-            TStringBuilder() << "DiskId: " << PartitionConfig.GetDiskId()
-                             << " error: " << FormatError(msg->GetError()));
+            FormatError(msg->GetError()),
+            {{"disk", PartitionConfig.GetDiskId()}});
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
@@ -223,10 +223,16 @@ void TPartitionActor::HandleConfirmBlobsCompleted(
     auto* msg = ev->Get();
 
     if (FAILED(msg->GetStatus())) {
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "%s ConfirmBlobs failed: %u reason: %s",
+            LogTitle.GetWithTime().c_str(),
+            msg->GetStatus(),
+            FormatError(msg->GetError()).c_str());
         ReportConfirmBlobsError(
-            TStringBuilder()
-            << LogTitle.GetWithTime()
-            << " ConfirmBlobs failed: " << FormatError(msg->GetError()));
+            TStringBuilder() << "DiskId: " << PartitionConfig.GetDiskId()
+                             << " error: " << FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
@@ -223,14 +223,10 @@ void TPartitionActor::HandleConfirmBlobsCompleted(
     auto* msg = ev->Get();
 
     if (FAILED(msg->GetStatus())) {
-        LOG_ERROR(
-            ctx,
-            TBlockStoreComponents::PARTITION,
-            "%s ConfirmBlobs failed: %u reason: %s",
-            LogTitle.GetWithTime().c_str(),
-            msg->GetStatus(),
-            FormatError(msg->GetError()).c_str());
-        ReportConfirmBlobsError();
+        ReportConfirmBlobsError(
+            TStringBuilder()
+            << LogTitle.GetWithTime()
+            << " ConfirmBlobs failed: " << FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -1200,7 +1200,7 @@ void TPartitionActor::CompleteReadBlocks(
     if (describeBlocksRange.Defined() || requests) {
         const auto readBlocksActorId = NCloud::Register<TReadBlocksActor>(
             ctx,
-            State->GetBaseDiskId(),
+            PartitionConfig.diskid(),
             args.RequestInfo,
             BlockDigestGenerator,
             State->GetBlockSize(),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -209,10 +209,9 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
             ScheduleResyncNextRange(ctx);
         } else {
             ReportResyncFailed(
-                TStringBuilder()
-                << "Disk: " << PartConfig->GetName() << ", Range "
-                << DescribeRange(range)
-                << " resync failed: " << FormatError(msg->GetError()));
+                FormatError(msg->GetError()),
+                {{"range", DescribeRange(range)},
+                 {"disk", PartConfig->GetName()}});
         }
 
         TDeque<TPostponedRead> postponedReads;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -208,7 +208,11 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
             State.AddPendingResyncRange(rangeId.first);
             ScheduleResyncNextRange(ctx);
         } else {
-            ReportResyncFailed();
+            ReportResyncFailed(
+                TStringBuilder()
+                << "[" << PartConfig->GetName() << "] "
+                << "Range " << DescribeRange(range)
+                << " resync failed: " << FormatError(msg->GetError()));
         }
 
         TDeque<TPostponedRead> postponedReads;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -210,8 +210,8 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
         } else {
             ReportResyncFailed(
                 FormatError(msg->GetError()),
-                {{"range", DescribeRange(range)},
-                 {"disk", PartConfig->GetName()}});
+                {{"disk", PartConfig->GetName()},
+                 {"range", DescribeRange(range)}});
         }
 
         TDeque<TPostponedRead> postponedReads;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -210,8 +210,8 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
         } else {
             ReportResyncFailed(
                 TStringBuilder()
-                << "[" << PartConfig->GetName() << "] "
-                << "Range " << DescribeRange(range)
+                << "Disk: " << PartConfig->GetName() << ", Range "
+                << DescribeRange(range)
                 << " resync failed: " << FormatError(msg->GetError()));
         }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -141,7 +141,6 @@ bool TMirrorPartitionState::PrepareMigrationConfigForWarningDevices()
     }
 
     ReportMigrationSourceNotFound(
-        "No migration source device found among replicas",
         {{"disk", PartConfig->GetName()}, {"RWClientId", RWClientId}});
 
     // TODO: log details

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -142,7 +142,7 @@ bool TMirrorPartitionState::PrepareMigrationConfigForWarningDevices()
 
     ReportMigrationSourceNotFound(
         TStringBuilder()
-        << "No migration source device found among replicas for "
+        << "No migration source device found among replicas for disk"
         << PartConfig->GetName() << ", RWClientId: " << RWClientId);
 
     // TODO: log details
@@ -201,7 +201,7 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
         TStringBuilder() << "PrepareMigrationConfigForFreshDevices failed: no "
                             "suitable source device found"
                          << " for fresh device at index " << deviceIdx
-                         << ", namr: " << PartConfig->GetName()
+                         << ", disk: " << PartConfig->GetName()
                          << ", total replicas: " << ReplicaInfos.size());
     return false;
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -140,7 +140,11 @@ bool TMirrorPartitionState::PrepareMigrationConfigForWarningDevices()
         }
     }
 
-    ReportMigrationSourceNotFound();
+    ReportMigrationSourceNotFound(
+        TStringBuilder()
+        << "No migration source device found among replicas for "
+        << PartConfig->GetName() << ", RWClientId: " << RWClientId);
+
     // TODO: log details
     return false;
 }
@@ -193,7 +197,12 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
         }
     }
 
-    ReportMigrationSourceNotFound();
+    ReportMigrationSourceNotFound(
+        TStringBuilder() << "PrepareMigrationConfigForFreshDevices failed: no "
+                            "suitable source device found"
+                         << " for fresh device at index " << deviceIdx
+                         << ", namr: " << PartConfig->GetName()
+                         << ", total replicas: " << ReplicaInfos.size());
     return false;
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -198,8 +198,8 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
     ReportMigrationSourceNotFound(
         "PrepareMigrationConfigForFreshDevices failed: no suitable source "
         "device found for fresh device",
-        {{"index", deviceIdx},
-         {"disk", PartConfig->GetName()},
+        {{"disk", PartConfig->GetName()},
+         {"index", deviceIdx},
          {"total_replicas", ReplicaInfos.size()}});
     return false;
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -199,9 +199,9 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
     ReportMigrationSourceNotFound(
         "PrepareMigrationConfigForFreshDevices failed: no suitable source "
         "device found for fresh device",
-        {{"index", TStringBuilder() << deviceIdx},
+        {{"index", deviceIdx},
          {"disk", PartConfig->GetName()},
-         {"total_replicas", TStringBuilder() << ReplicaInfos.size()}});
+         {"total_replicas", ReplicaInfos.size()}});
     return false;
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -141,9 +141,8 @@ bool TMirrorPartitionState::PrepareMigrationConfigForWarningDevices()
     }
 
     ReportMigrationSourceNotFound(
-        TStringBuilder()
-        << "No migration source device found among replicas for disk"
-        << PartConfig->GetName() << ", RWClientId: " << RWClientId);
+        "No migration source device found among replicas",
+        {{"disk", PartConfig->GetName()}, {"RWClientId", RWClientId}});
 
     // TODO: log details
     return false;
@@ -198,11 +197,11 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
     }
 
     ReportMigrationSourceNotFound(
-        TStringBuilder() << "PrepareMigrationConfigForFreshDevices failed: no "
-                            "suitable source device found"
-                         << " for fresh device at index " << deviceIdx
-                         << ", disk: " << PartConfig->GetName()
-                         << ", total replicas: " << ReplicaInfos.size());
+        "PrepareMigrationConfigForFreshDevices failed: no suitable source "
+        "device found for fresh device",
+        {{"index", TStringBuilder() << deviceIdx},
+         {"disk", PartConfig->GetName()},
+         {"total_replicas", TStringBuilder() << ReplicaInfos.size()}});
     return false;
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -57,8 +57,13 @@ void TSyncManuallyPreemptedVolumesActor::Bootstrap(const TActorContext& ctx)
     try {
         WriteFile(std::move(FilePath), std::move(Data));
     } catch (...) {
-        ReportManuallyPreemptedVolumesFileError(
-            TStringBuilder() << CurrentExceptionMessage());
+        LOG_ERROR_S(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            TStringBuilder()
+                << "Failed to write manually preempted volumes: "
+                << CurrentExceptionMessage());
+        ReportManuallyPreemptedVolumesFileError(CurrentExceptionMessage());
     }
 
     using TResponse = TEvServicePrivate::TEvSyncManuallyPreemptedVolumesComplete;

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -58,8 +58,7 @@ void TSyncManuallyPreemptedVolumesActor::Bootstrap(const TActorContext& ctx)
         WriteFile(std::move(FilePath), std::move(Data));
     } catch (...) {
         ReportManuallyPreemptedVolumesFileError(
-            TStringBuilder() << "Failed to write manually preempted volumes: "
-                             << CurrentExceptionMessage());
+            TStringBuilder() << CurrentExceptionMessage());
     }
 
     using TResponse = TEvServicePrivate::TEvSyncManuallyPreemptedVolumesComplete;

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -57,13 +57,9 @@ void TSyncManuallyPreemptedVolumesActor::Bootstrap(const TActorContext& ctx)
     try {
         WriteFile(std::move(FilePath), std::move(Data));
     } catch (...) {
-        ReportManuallyPreemptedVolumesFileError();
-        LOG_ERROR_S(
-            ctx,
-            TBlockStoreComponents::SERVICE,
-            TStringBuilder()
-                << "Failed to write manually preempted volumes: "
-                << CurrentExceptionMessage());
+        ReportManuallyPreemptedVolumesFileError(
+            TStringBuilder() << "Failed to write manually preempted volumes: "
+                             << CurrentExceptionMessage());
     }
 
     using TResponse = TEvServicePrivate::TEvSyncManuallyPreemptedVolumesComplete;


### PR DESCRIPTION
Теперь функции Report<EventName> принимают дополнительно список пар ключ-значение, которые форматируются в строку и добавляются к основному сообщению.

Так было раньше: `CRITICAL_EVENT:AppCriticalEvents/EndpointRestoringError:Endpoint restoring error occurred for endpoint ID: 5, socket path: wrongSocket1`

так сейчас:  `CRITICAL_EVENT:AppCriticalEvents/EndpointRestoringError:Endpoint restoring error occurred; endpoint_id=5; socket_path=wrongSocket1`
То есть структура лога —` <сообщение>; <ключ1>=<значение1>; <ключ2>=<значение2>; ...`

апдейт репортов с ResyncFailed до ReleaseShadowDiskError

<img width="1068" height="154" alt="image" src="https://github.com/user-attachments/assets/14eb4504-b935-4f87-ab31-1176c2f0ed19" />
