### PR TITLE
[FileStore] Increment flush interval for WriteBackCache to 1s in unit tests

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -95,7 +95,7 @@ struct TBootstrap
             ISchedulerPtr scheduler = CreateScheduler(),
             const NProto::TFileStoreFeatures& featuresConfig = {},
             ui32 handleOpsQueueSize = 1000,
-            ui32 writeBackCacheAutomaticFlushPeriodMs = 0)
+            ui32 writeBackCacheAutomaticFlushPeriodMs = 1000)
         : Logging(CreateLoggingService("console", { TLOG_RESOURCES }))
         , Scheduler{std::move(scheduler)}
         , Timer{std::move(timer)}


### PR DESCRIPTION
Resolve failed test `TFileSystemTest.ShouldFsyncDirWithServerWriteBackCacheEnabled`:
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(ubsan)/16335419648/1/nebius-x86-64-ubsan/logs/1/cloud/filestore/libs/vfs_fuse/ut/test-results/unittest/chunk1/testing_out_stuff/TFileSystemTest.ShouldFsyncDirWithServerWriteBackCacheEnabled.err

Log details:
```
2025-07-17T03:47:09.278736Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:92: WriteData #2 [f:fs1] REQUEST
2025-07-17T03:47:09.278752Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:536: WriteBuf #123 @456 offset:0 size:4096
2025-07-17T03:47:09.396821Z :NFS_FUSE DEBUG: :    unique: 2, success, outsize: 24
2025-07-17T03:47:09.396887Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:131: WriteData #2 [f:fs1][c:] RESPONSE request 
```

The default flush interval for WriteBackCache is 100 ms. Normally, WriteData should return immediately, but here for some reason it took almost 120 ms. Looks like Flush was executed before WriteData was completed, and a race condition happened in the unit test.

Increasing flush period from 100 ms to 1 s should help.