### PR TITLE
fix: additional things not to store at s3

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -327,11 +327,11 @@ runs:
             find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
             echo "::endgroup::"
             echo "::group::remove-images-from-tests-data-dir"
-            find "$TESTS_DATA_DIR" -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name NVMENBS0* -o -name generated_other_big_raw_image
-            find "$TESTS_DATA_DIR" \( -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name NVMENBS0* -o -name generated_other_big_raw_image \) -delete
+            find "$TESTS_DATA_DIR" -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name 'NVMENBS0*' -o -name generated_other_big_raw_image
+            find "$TESTS_DATA_DIR" \( -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name 'NVMENBS0*' -o -name generated_other_big_raw_image \) -delete
             echo "::endgroup::"
             echo "::group::truncate-err-files"
-            find "$TESTS_DATA_DIR" -type f -name "*.err" -o -name "*.log" -o -name "*.out" -size +1G -print0 | while IFS= read -r -d '' file; do
+            find "$TESTS_DATA_DIR" -type f -name '*.err' -o -name '*.log' -o -name '*.out' -size +1G -print0 | while IFS= read -r -d '' file; do
                 orig_size=$(du -h "$file" | cut -f1)
                 echo "$file - $orig_size"
                 # shellcheck disable=SC2193

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -375,11 +375,13 @@ runs:
           cat $SUMMARY_OUT_ENV_PATH | tee -a $GITHUB_STEP_SUMMARY
           echo "::endgroup::"
 
-          echo "::group::cleaning-artifacts-log-dir"
-          find "$ARTIFACTS_DIR/logs/" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}'
-          find "$ARTIFACTS_DIR/logs/" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
-          echo "::endgroup::"
-          
+          if [ -d "$ARTIFACTS_DIR/logs/" ]; then
+            echo "::group::cleaning-artifacts-log-dir"
+            find "$ARTIFACTS_DIR/logs/" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}'
+            find "$ARTIFACTS_DIR/logs/" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
+            echo "::endgroup::"
+          fi
+
           echo "::group::s3-sync"
           sudo -E -H -u github s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$ARTIFACTS_DIR/" "$S3_BUCKET_PATH/"
           echo "::endgroup::"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -320,18 +320,18 @@ runs:
             fi
           fi
           if [ "$NEED_COPYING" -ne "0" ];
-          then 
+          then
             chown -R github:github "$TESTS_DATA_DIR"
             echo "::group::remove-binaries-from-tests-data-dir"
             find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}'
             find "$TESTS_DATA_DIR" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
             echo "::endgroup::"
             echo "::group::remove-images-from-tests-data-dir"
-            find "$TESTS_DATA_DIR" -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name NVMENBS01 -o -name generated_other_big_raw_image
-            find "$TESTS_DATA_DIR" \( -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name NVMENBS01 -o -name generated_other_big_raw_image \) -delete
+            find "$TESTS_DATA_DIR" -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name NVMENBS0* -o -name generated_other_big_raw_image
+            find "$TESTS_DATA_DIR" \( -name generated_raw_image -o -name generated_vmdk_image -o -name invalid_qcow2_image -o -name qcow2_fuzzing_image -o -name NVMENBS0* -o -name generated_other_big_raw_image \) -delete
             echo "::endgroup::"
             echo "::group::truncate-err-files"
-            find "$TESTS_DATA_DIR" -type f -name "*.err" -size +1G -print0 | while IFS= read -r -d '' file; do
+            find "$TESTS_DATA_DIR" -type f -name "*.err" -o -name "*.log" -o -name "*.out" -size +1G -print0 | while IFS= read -r -d '' file; do
                 orig_size=$(du -h "$file" | cut -f1)
                 echo "$file - $orig_size"
                 # shellcheck disable=SC2193
@@ -375,6 +375,11 @@ runs:
           cat $SUMMARY_OUT_ENV_PATH | tee -a $GITHUB_STEP_SUMMARY
           echo "::endgroup::"
 
+          echo "::group::cleaning-artifacts-log-dir"
+          find "$ARTIFACTS_DIR/logs/" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}'
+          find "$ARTIFACTS_DIR/logs/" -type f -print0 | xargs -0 -n 10 file -i  | grep "application/x-executable" | awk -F: '{print $1}' | xargs rm
+          echo "::endgroup::"
+          
           echo "::group::s3-sync"
           sudo -E -H -u github s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$ARTIFACTS_DIR/" "$S3_BUCKET_PATH/"
           echo "::endgroup::"


### PR DESCRIPTION
Removing binaries that get into logs dir, trim logs and remove NVMENBS devices
```2025-06-20 06:51:56    4.3 GiB ydb-platform/nbs/Nightly-build-(ubsan)/15770371815/1/nebius-x86-64-ubsan/logs/cloud/blockstore/apps/server/nbsd
2025-06-22 07:04:03    4.3 GiB ydb-platform/nbs/Nightly-build-(ubsan)/15802401659/1/nebius-x86-64-ubsan/logs/cloud/blockstore/apps/server/nbsd
2025-06-23 06:58:51    4.3 GiB ydb-platform/nbs/Nightly-build-(ubsan)/15814431634/1/nebius-x86-64-ubsan/logs/cloud/blockstore/apps/server/nbsd
2025-06-24 06:48:54    4.3 GiB ydb-platform/nbs/Nightly-build-(ubsan)/15840299123/1/nebius-x86-64-ubsan/logs/cloud/blockstore/apps/server/nbsd
2025-06-20 05:59:34    7.4 GiB ydb-platform/nbs/Nightly-build/15767722792/1/nebius-x86-64/logs/cloud/blockstore/apps/server/nbsd
2025-06-21 06:25:22    7.4 GiB ydb-platform/nbs/Nightly-build/15789348360/1/nebius-x86-64/logs/cloud/blockstore/apps/server/nbsd
2025-06-22 05:57:38    7.4 GiB ydb-platform/nbs/Nightly-build/15800537299/1/nebius-x86-64/logs/cloud/blockstore/apps/server/nbsd
2025-06-24 05:22:36    7.4 GiB ydb-platform/nbs/Nightly-build/15837068415/1/nebius-x86-64/logs/cloud/blockstore/apps/server/nbsd
2025-06-18 13:30:49    7.4 GiB ydb-platform/nbs/PR-check/15730692571/1/nebius-x86-64/logs/cloud/blockstore/apps/server/nbsd
2025-06-18 14:18:56    7.4 GiB ydb-platform/nbs/PR-check/15731662713/1/nebius-x86-64/logs/cloud/blockstore/apps/server/nbsd
2025-06-27 20:01:31    6.8 GiB ydb-platform/nbs/PR-check/15932115748/1/nebius-x86-64/logs/cloud/blockstore/apps/disk_agent/diskagentd
2025-07-17 13:48:07    7.5 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/logs/1/cloud/blockstore/apps/server/nbsd
2025-07-17 16:14:00    7.5 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/logs/2/cloud/blockstore/apps/server/nbsd
2025-07-17 18:26:33    7.5 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/logs/3/cloud/blockstore/apps/server/nbsd
2025-07-17 13:25:59   18.1 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/test_data/1/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-emergency/test-results/py3test/chunk0/testing_out_stuff/test.py__test_load[default]/node_1/logfile_w6hnocyv.log
2025-07-17 15:44:15   17.1 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/test_data/2/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-emergency/test-results/py3test/chunk0/testing_out_stuff/test.py__test_load[default]/node_1/logfile_2qs756nm.log
2025-07-17 15:48:59   18.1 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/test_data/2/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-emergency/test-results/py3test/chunk0/testing_out_stuff/test.py__test_load[default]/node_1/logfile_w6hnocyv.log
2025-07-17 17:45:46   17.1 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/test_data/3/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-emergency/test-results/py3test/chunk0/testing_out_stuff/test.py__test_load[default]/node_1/logfile_2qs756nm.log
2025-07-17 17:46:58    6.0 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/test_data/3/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-emergency/test-results/py3test/chunk0/testing_out_stuff/test.py__test_load[default]/node_1/logfile_h5__8byf.log
2025-07-17 17:50:59   18.1 GiB ydb-platform/nbs/PR-check/16340473027/1/nebius-x86-64/test_data/3/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/loadtest/local-emergency/test-results/py3test/chunk0/testing_out_stuff/test.py__test_load[default]/node_1/logfile_w6hnocyv.log
2025-07-17 15:06:23    6.0 GiB ydb-platform/nbs/PR-check/16341829675/1/nebius-x86-64/test_data/1/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/direct_device_acquire/test-results/py3test/chunk1/testing_out_stuff/test.py__test_should_mount_volume_with_unknown_devices/data/agent-1/dev/disk/by-partlabel/NVMENBS02
2025-07-17 15:15:37    6.0 GiB ydb-platform/nbs/PR-check/16341829675/1/nebius-x86-64/test_data/2/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/direct_device_acquire/test-results/py3test/chunk1/testing_out_stuff/test.py__test_should_mount_volume_with_unknown_devices/data/agent-1/dev/disk/by-partlabel/NVMENBS02
2025-07-17 15:24:20    6.0 GiB ydb-platform/nbs/PR-check/16341829675/1/nebius-x86-64/test_data/3/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/direct_device_acquire/test-results/py3test/chunk1/testing_out_stuff/test.py__test_should_mount_volume_with_unknown_devices/data/agent-1/dev/disk/by-partlabel/NVMENBS02
2025-07-17 19:18:18    6.0 GiB ydb-platform/nbs/PR-check/16347041607/1/nebius-x86-64/test_data/1/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/direct_device_acquire/test-results/py3test/chunk1/testing_out_stuff/test.py__test_should_mount_volume_with_unknown_devices/data/agent-1/dev/disk/by-partlabel/NVMENBS02
2025-07-17 19:27:06    6.0 GiB ydb-platform/nbs/PR-check/16347041607/1/nebius-x86-64/test_data/2/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/direct_device_acquire/test-results/py3test/chunk1/testing_out_stuff/test.py__test_should_mount_volume_with_unknown_devices/data/agent-1/dev/disk/by-partlabel/NVMENBS02
2025-07-17 19:35:41    6.0 GiB ydb-platform/nbs/PR-check/16347041607/1/nebius-x86-64/test_data/3/actions-runner/_work/nbs/nbs/cloud/blockstore/tests/direct_device_acquire/test-results/py3test/chunk1/testing_out_stuff/test.py__test_should_mount_volume_with_unknown_devices/data/agent-1/dev/disk/by-partlabel/NVMENBS02```
221 GiB from few tests.