### PR TITLE
Add lagging devices to the reallocation response

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
@@ -179,14 +179,12 @@ void TNotifyActor::HandleReallocateDiskResponse(
             TabletID,
             diskId.Quote().c_str());
 
-        TVector<NProto::TLaggingDevice> outdatedLaggingDevices;
-        for (auto& laggingDevice: *msg->Record.MutableOutdatedLaggingDevices())
-        {
-            outdatedLaggingDevices.emplace_back(std::move(laggingDevice));
-        }
+        auto* laggingDevices = msg->Record.MutableOutdatedLaggingDevices();
         NotifiedDisks.emplace_back(
             DiskNotifications[cookie],
-            std::move(outdatedLaggingDevices));
+            TVector<NProto::TLaggingDevice>(
+                std::make_move_iterator(laggingDevices->begin()),
+                std::make_move_iterator(laggingDevices->end())));
     }
 
     if (!PendingOperations) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -40,6 +40,19 @@ struct TDiskNotification
     {}
 };
 
+struct TDiskNotificationResult
+{
+    TDiskNotification DiskNotification;
+    TVector<NProto::TLaggingDevice> OutdatedLaggingDevices;
+
+    TDiskNotificationResult(
+        TDiskNotification diskNotification,
+        TVector<NProto::TLaggingDevice> outdatedLaggingDevices)
+        : DiskNotification(std::move(diskNotification))
+        , OutdatedLaggingDevices(std::move(outdatedLaggingDevices))
+    {}
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TDiskStateUpdate
@@ -368,15 +381,16 @@ struct TEvDiskRegistryPrivate
     struct TNotifyDisksResponse
     {
         TCallContextPtr CallContext;
-        TVector<TDiskNotification> NotifiedDisks;
+        TVector<TDiskNotificationResult> NotifiedDisks;
 
         TNotifyDisksResponse() = default;
 
         TNotifyDisksResponse(
-                TCallContextPtr callContext)
+                TCallContextPtr callContext,
+                TVector<TDiskNotificationResult> notifiedDisks)
             : CallContext(std::move(callContext))
-        {
-        }
+            , NotifiedDisks(std::move(notifiedDisks))
+        {}
     };
 
     //

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5055,8 +5055,7 @@ void TDiskRegistryState::DeleteDiskToReallocate(
             STORAGE_ERROR(
                 "Failed to add outdated lagging devices: "
                 << FormatError(error));
-            ReportDiskRegistryCouldNotAddOutdatedLaggingDevice(
-                TStringBuilder() << diskId);
+            ReportDiskRegistryCouldNotAddOutdatedLaggingDevice(diskId);
         }
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1358,12 +1358,12 @@ void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
         disk,
         diskId,
         deviceId,
-        "",     // no replacement device
+        "",   // no replacement device
         timestamp,
         MakeMirroredDiskDeviceReplacementMessage(
             disk.MasterDiskId,
             std::move(reason)),
-        false);  // manual
+        false);   // manual
 
     if (HasError(error)) {
         ReportMirroredDiskDeviceReplacementFailure(FormatError(error));
@@ -5026,13 +5026,39 @@ void TDiskRegistryState::RemoveOutdatedLaggingDevices(
 }
 
 void TDiskRegistryState::DeleteDiskToReallocate(
+    TInstant now,
     TDiskRegistryDatabase& db,
-    const TString& diskId,
-    ui64 seqNo)
+    TDiskNotificationResult notification)
 {
+    const auto& diskId = notification.DiskNotification.DiskId;
+    const ui64 seqNo = notification.DiskNotification.SeqNo;
+
     NotificationSystem.DeleteDiskToReallocate(db, diskId, seqNo);
     RemoveFinishedMigrations(db, diskId, seqNo);
     RemoveOutdatedLaggingDevices(db, diskId, seqNo);
+
+    if (!notification.OutdatedLaggingDevices.empty()) {
+        TStringBuilder logMessage;
+        logMessage << "Adding outdated lagging devices: [";
+        for (const auto& outdatedDevice: notification.OutdatedLaggingDevices) {
+            logMessage << outdatedDevice.GetDeviceUUID() << ", ";
+        }
+        logMessage << "]; DiskId: " << diskId << ", SeqNo: " << seqNo;
+        STORAGE_INFO(logMessage);
+
+        auto error = AddOutdatedLaggingDevices(
+            now,
+            db,
+            diskId,
+            std::move(notification.OutdatedLaggingDevices));
+        if (HasError(error)) {
+            STORAGE_ERROR(
+                "Failed to add outdated lagging devices: "
+                << FormatError(error));
+            ReportDiskRegistryCouldNotAddOutdatedLaggingDevice(
+                TStringBuilder() << diskId);
+        }
+    }
 }
 
 void TDiskRegistryState::AddUserNotification(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -572,9 +572,9 @@ public:
     ui64 AddReallocateRequest(TDiskRegistryDatabase& db, const TString& diskId);
 
     void DeleteDiskToReallocate(
+        TInstant now,
         TDiskRegistryDatabase& db,
-        const TString& diskId,
-        ui64 seqNo);
+        TDiskNotificationResult notification);
 
     const TVector<TDiskStateUpdate>& GetDiskStateUpdates() const;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -1081,7 +1081,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
 
                 auto notification = state.GetDisksToReallocate().find("nrd0");
                 UNIT_ASSERT(notification != state.GetDisksToReallocate().end());
-                state.DeleteDiskToReallocate(db, "nrd0", notification->second);
+                state.DeleteDiskToReallocate(
+                    Now(),
+                    db,
+                    TDiskNotificationResult{
+                        TDiskNotification{"nrd0", notification->second},
+                        {},
+                    });
             });
 
         executor.WriteTx(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
@@ -97,7 +97,9 @@ void CreateMirror3Disk(TTestExecutor& executor, TDiskRegistryState& state)
         });
 }
 
-void DeleteDisksToNotify(TTestExecutor& executor, TDiskRegistryState& state)
+void DeleteDisksToNotify(
+    TTestExecutor& executor,
+    TDiskRegistryState& state)
 {
     executor.WriteTx(
         [&](TDiskRegistryDatabase db) mutable
@@ -105,7 +107,13 @@ void DeleteDisksToNotify(TTestExecutor& executor, TDiskRegistryState& state)
             // copying needed to avoid use-after-free upon deletion
             const auto disks = state.GetDisksToReallocate();
             for (const auto& x: disks) {
-                state.DeleteDiskToReallocate(db, x.first, x.second);
+                state.DeleteDiskToReallocate(
+                    Now(),
+                    db,
+                    TDiskNotificationResult{
+                        TDiskNotification{x.first, x.second},
+                        {},
+                    });
             }
         });
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -938,14 +938,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             state.GetUserNotifications(userNotifications);
         };
 
-        auto deleteDisksToNotify = [&] () {
-            executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
-                // copying needed to avoid use-after-free upon deletion
-                const auto disks = state.GetDisksToReallocate();
-                for (const auto& x: disks) {
-                    state.DeleteDiskToReallocate(db, x.first, x.second);
-                }
-            });
+        auto deleteDisksToNotify = [&]()
+        {
+            executor.WriteTx(
+                [&](TDiskRegistryDatabase db) mutable
+                {
+                    // copying needed to avoid use-after-free upon deletion
+                    const auto disks = state.GetDisksToReallocate();
+                    for (const auto& x: disks) {
+                        state.DeleteDiskToReallocate(
+                            Now(),
+                            db,
+                            TDiskNotificationResult{
+                                TDiskNotification{x.first, x.second},
+                                {},
+                            });
+                    }
+                });
             disksToReallocate.clear();
         };
 
@@ -1282,14 +1291,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             state.GetUserNotifications(userNotifications);
         };
 
-        auto deleteDisksToNotify = [&] () {
-            executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
-                // copying needed to avoid use-after-free upon deletion
-                const auto disks = state.GetDisksToReallocate();
-                for (const auto& x: disks) {
-                    state.DeleteDiskToReallocate(db, x.first, x.second);
-                }
-            });
+        auto deleteDisksToNotify = [&]()
+        {
+            executor.WriteTx(
+                [&](TDiskRegistryDatabase db) mutable
+                {
+                    // copying needed to avoid use-after-free upon deletion
+                    const auto disks = state.GetDisksToReallocate();
+                    for (const auto& x: disks) {
+                        state.DeleteDiskToReallocate(
+                            Now(),
+                            db,
+                            TDiskNotificationResult{
+                                TDiskNotification{x.first, x.second},
+                                {},
+                            });
+                    }
+                });
             disksToReallocate.clear();
         };
 
@@ -2413,7 +2431,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             UNIT_ASSERT_VALUES_EQUAL(0, migrations.size());
             ASSERT_VECTORS_EQUAL(TVector<TString>(), deviceReplacementIds);
 
-            state.DeleteDiskToReallocate(db, "disk-1", 4);
+            state.DeleteDiskToReallocate(
+                Now(),
+                db,
+                TDiskNotificationResult{
+                    TDiskNotification{"disk-1", 4},
+                    {},
+                });
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
@@ -2605,14 +2629,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
             state.GetUserNotifications(userNotifications);
         };
 
-        auto deleteDisksToNotify = [&] () {
-            executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
-                // copying needed to avoid use-after-free upon deletion
-                const auto disks = state.GetDisksToReallocate();
-                for (const auto& x: disks) {
-                    state.DeleteDiskToReallocate(db, x.first, x.second);
-                }
-            });
+        auto deleteDisksToNotify = [&]()
+        {
+            executor.WriteTx(
+                [&](TDiskRegistryDatabase db) mutable
+                {
+                    // copying needed to avoid use-after-free upon deletion
+                    const auto disks = state.GetDisksToReallocate();
+                    for (const auto& x: disks) {
+                        state.DeleteDiskToReallocate(
+                            Now(),
+                            db,
+                            TDiskNotificationResult{
+                                TDiskNotification{x.first, x.second},
+                                {},
+                            });
+                    }
+                });
             disksToReallocate.clear();
         };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -473,13 +473,13 @@ struct TTxDiskRegistry
     struct TDeleteNotifiedDisks
     {
         const TRequestInfoPtr RequestInfo;
-        const TVector<TDiskNotification> DiskIds;
+        TVector<TDiskNotificationResult> DiskNotifications;
 
         TDeleteNotifiedDisks(
                 TRequestInfoPtr requestInfo,
-                TVector<TDiskNotification> diskIds)
+                TVector<TDiskNotificationResult> diskNotifications)
             : RequestInfo(std::move(requestInfo))
-            , DiskIds(std::move(diskIds))
+            , DiskNotifications(std::move(diskNotifications))
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor.cpp
@@ -187,6 +187,20 @@ bool TNonreplicatedPartitionRdmaActor::InitRequests(
     }
 
     for (auto& r: *deviceRequests) {
+        if (PartConfig->GetOutdatedDeviceIds().contains(
+                r.Device.GetDeviceUUID()))
+        {
+            reply(
+                ctx,
+                requestInfo,
+                PartConfig->MakeError(
+                    E_REJECTED,
+                    TStringBuilder() << "Device " << r.Device.GetDeviceUUID()
+                                     << " is lagging behind on data. All IO "
+                                        "operations are prohibited."));
+            return false;
+        }
+
         auto& ep = AgentId2Endpoint[r.Device.GetAgentId()];
         if (!ep) {
             auto* f = AgentId2EndpointFuture.FindPtr(r.Device.GetAgentId());

--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/libs/storage/p
 
 import "cloud/blockstore/config/storage.proto";
 
+import "cloud/blockstore/libs/storage/protos/disk.proto";
 import "cloud/blockstore/public/api/protos/headers.proto";
 import "cloud/blockstore/public/api/protos/volume.proto";
 
@@ -331,6 +332,9 @@ message TReallocateDiskResponse
 
     // Request traces.
     NCloud.NProto.TTraceInfo Trace = 2;
+
+    // Outdated lagging devices of the volume.
+    repeated TLaggingDevice OutdatedLaggingDevices = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -2184,9 +2184,9 @@ void TVolumeActor::RenderLaggingStateForDevice(
     IOutputStream& out,
     const NProto::TDeviceConfig& d)
 {
-    const auto* stateMsg = "ok";
-    const auto* color = "green";
-    auto laggingDevices = State->GetLaggingDevices();
+    const char* stateMsg = "ok";
+    const char* color = "green";
+    auto laggingDevices = State->GetLaggingDeviceIds();
 
     if (laggingDevices.contains(d.GetDeviceUUID())) {
         stateMsg = "lagging";
@@ -2433,8 +2433,6 @@ void TVolumeActor::HandleHttpInfo_RenderNonreplPartitionInfo(
 
                 bool renderLaggingState = IsReliableDiskRegistryMediaKind(
                     State->GetConfig().GetStorageMediaKind());
-                auto laggingDevices = State->GetLaggingDevices();
-
                 auto outputDevices = [&] (const TDevices& devices) {
                     TABLED() {
                         TABLE_CLASS("table table-bordered") {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_reallocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_reallocatedisk.cpp
@@ -35,7 +35,10 @@ public:
     void Bootstrap(const TActorContext& ctx);
 
 private:
-    void ReplyAndDie(const TActorContext& ctx, NProto::TError error);
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        NProto::TError error,
+        TVector<NProto::TLaggingDevice> laggingDevices);
 
 private:
     STFUNC(StateWork);
@@ -77,10 +80,17 @@ void TReallocateActor::Bootstrap(const TActorContext& ctx)
         std::move(request));
 }
 
-void TReallocateActor::ReplyAndDie(const TActorContext& ctx, NProto::TError error)
+void TReallocateActor::ReplyAndDie(
+    const TActorContext& ctx,
+    NProto::TError error,
+    TVector<NProto::TLaggingDevice> laggingDevices)
 {
     auto response = std::make_unique<TEvVolume::TEvReallocateDiskResponse>(
         std::move(error));
+    for (auto& laggingDevice: laggingDevices) {
+        *response->Record.AddOutdatedLaggingDevices() =
+            std::move(laggingDevice);
+    }
 
     NCloud::Reply(ctx, *Request, std::move(response));
     Die(ctx);
@@ -100,7 +110,7 @@ void TReallocateActor::HandleAllocateDiskResponse(
             FormatError(msg->GetError()).c_str(),
             DiskId.Quote().c_str());
 
-        ReplyAndDie(ctx, msg->GetError());
+        ReplyAndDie(ctx, msg->GetError(), {});
         return;
     }
 
@@ -154,7 +164,7 @@ void TReallocateActor::HandleUpdateDevicesResponse(
 {
     auto* msg = ev->Get();
 
-    ReplyAndDie(ctx, msg->GetError());
+    ReplyAndDie(ctx, msg->GetError(), std::move(msg->LaggingDevices));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -152,6 +152,7 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
     const auto& volumeParams = State->GetVolumeParams();
 
     State->SetBlockCountToMigrate(std::nullopt);
+    ReportOutdatedLaggingDevicesToDR(ctx);
 
     auto maxTimedOutDeviceStateDuration =
         volumeParams.GetMaxTimedOutDeviceStateDurationOverride(ctx.Now());
@@ -193,7 +194,7 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
             State->GetMeta().GetIOMode(),
             State->GetMeta().GetMuteIOErrors(),
             State->GetFilteredFreshDevices(),
-            State->GetLaggingDevices(),
+            State->GetOutdatedDeviceIds(),
             LaggingDevicesAreAllowed(),
             maxTimedOutDeviceStateDuration,
             maxTimedOutDeviceStateDurationOverridden,
@@ -284,7 +285,6 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
     State->SetDiskRegistryBasedPartitionActor(
         WrapNonreplActorIfNeeded(ctx, nonreplicatedActorId, nonreplicatedConfig),
         nonreplicatedConfig);
-    ReportOutdatedLaggingDevicesToDR(ctx);
 }
 
 TActorsStack TVolumeActor::WrapNonreplActorIfNeeded(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -543,7 +543,7 @@ void TVolumeActor::SendSelfStatsToService(const TActorContext& ctx)
     );
 
     simple.HasLaggingDevices.Set(State->HasLaggingAgents());
-    simple.LaggingDevicesCount.Set(State->GetLaggingDevices().size());
+    simple.LaggingDevicesCount.Set(State->GetLaggingDeviceIds().size());
     {
         const auto& laggingInfos = State->GetLaggingAgentsMigrationInfo();
         ui64 cleanBlockCount = 0;

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -237,7 +237,16 @@ struct TEvVolumePrivate
     };
 
     struct TUpdateDevicesResponse
-    {};
+    {
+        TVector<NProto::TLaggingDevice> LaggingDevices;
+
+        TUpdateDevicesResponse() = default;
+
+        explicit TUpdateDevicesResponse(
+            TVector<NProto::TLaggingDevice> laggingDevices)
+            : LaggingDevices(std::move(laggingDevices))
+        {}
+    };
 
     //
     // PartStatsSaved

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -215,7 +215,7 @@ bool TVolumeState::HasLaggingInReplica(ui32 replicaIndex) const
     return false;
 }
 
-THashSet<TString> TVolumeState::GetLaggingDevices() const
+THashSet<TString> TVolumeState::GetLaggingDeviceIds() const
 {
     THashSet<TString> laggingDevices;
     for (const auto& agent: Meta.GetLaggingAgentsInfo().GetAgents()) {
@@ -224,6 +224,29 @@ THashSet<TString> TVolumeState::GetLaggingDevices() const
         }
     }
     return laggingDevices;
+}
+
+void TVolumeState::FillOutdatedDevices() {
+    OutdatedDevices.clear();
+    for (const auto& agent: Meta.GetLaggingAgentsInfo().GetAgents()) {
+        for (const auto& device: agent.GetDevices()) {
+            OutdatedDevices.push_back(device);
+        }
+    }
+}
+
+[[nodiscard]] THashSet<TString> TVolumeState::GetOutdatedDeviceIds() const
+{
+    THashSet<TString> outdatedDeviceIds;
+    for (const auto& device: OutdatedDevices) {
+        outdatedDeviceIds.insert(device.GetDeviceUUID());
+    }
+    return outdatedDeviceIds;
+}
+
+const TVector<NProto::TLaggingDevice>& TVolumeState::GetOutdatedDevices() const
+{
+    return OutdatedDevices;
 }
 
 void TVolumeState::UpdateLaggingAgentMigrationState(

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -265,6 +265,8 @@ private:
     };
     THashMap<TString, TLaggingAgentMigrationInfo>
         CurrentlyMigratingLaggingAgents;
+    // Devices that were lagging and can't be restored.
+    TVector<NProto::TLaggingDevice> OutdatedDevices;
 
     TScrubbingInfo ScrubbingInfo;
 
@@ -346,7 +348,15 @@ public:
         const TString& agentId);
     [[nodiscard]] bool HasLaggingAgents() const;
     [[nodiscard]] bool HasLaggingInReplica(ui32 replicaIndex) const;
-    [[nodiscard]] THashSet<TString> GetLaggingDevices() const;
+    [[nodiscard]] THashSet<TString> GetLaggingDeviceIds() const;
+
+    // Once the partition is restarted, the lagging devices can not be restored.
+    // So they must become outdated.
+    void FillOutdatedDevices();
+    [[nodiscard]] THashSet<TString> GetOutdatedDeviceIds() const;
+    [[nodiscard]] const TVector<NProto::TLaggingDevice>&
+    GetOutdatedDevices() const;
+
     void UpdateLaggingAgentMigrationState(
         const TString& agentId,
         ui64 cleanBlocks,


### PR DESCRIPTION
#3505
Сейячас есть проблема: DR может "за раз" отстрелить 2 реплики у диска и пронотифицировать его об этом. А у того третья реплика может быть в lagging. В итоге получаем три fresh девайса в ряду.

Здесь первый шаг чтобы это починить: добавляю в ответ реаллокации текущие лагающие девайсы. 

Следущий шаг: менять только одну реплику за нотификацию. 