### PR TITLE
Move StringSet to cloud/tasks/common

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/migrate_snapshot_database_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/migrate_snapshot_database_task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/tasks"
+	tasks_common "github.com/ydb-platform/nbs/cloud/tasks/common"
 	"github.com/ydb-platform/nbs/cloud/tasks/headers"
 	tasks_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
 )
@@ -156,7 +157,7 @@ func (m *migrateSnapshotDatabaseTask) GetResponse() proto.Message {
 func (m *migrateSnapshotDatabaseTask) migrateSnapshots(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
-	snapshotsToMigrate tasks_storage.StringSet,
+	snapshotsToMigrate tasks_common.StringSet,
 ) error {
 
 	mapping := newSnapshotToTasksMapping()

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/mocks/storage_mock.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
-	task_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
+	tasks_common "github.com/ydb-platform/nbs/cloud/tasks/common"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -246,10 +246,10 @@ func (s *StorageMock) GetIncremental(
 
 func (s *StorageMock) ListSnapshots(
 	ctx context.Context,
-) (task_storage.StringSet, error) {
+) (tasks_common.StringSet, error) {
 
 	args := s.Called(ctx)
-	return args.Get(0).(task_storage.StringSet), args.Error(1)
+	return args.Get(0).(tasks_common.StringSet), args.Error(1)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/common"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
-	task_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
+	tasks_common "github.com/ydb-platform/nbs/cloud/tasks/common"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -145,5 +145,5 @@ type Storage interface {
 		disk *types.Disk,
 	) (snapshotID string, checkpointID string, err error)
 
-	ListSnapshots(ctx context.Context) (task_storage.StringSet, error)
+	ListSnapshots(ctx context.Context) (tasks_common.StringSet, error)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_legacy.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_legacy.go
@@ -8,9 +8,9 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	tasks_common "github.com/ydb-platform/nbs/cloud/tasks/common"
 	task_errors "github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
-	task_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -289,8 +289,8 @@ func (s *legacyStorage) GetIncremental(
 
 func (s *legacyStorage) ListSnapshots(
 	ctx context.Context,
-) (task_storage.StringSet, error) {
+) (tasks_common.StringSet, error) {
 
-	return task_storage.NewStringSet(),
+	return tasks_common.NewStringSet(),
 		task_errors.NewNonRetriableErrorf("not implemented")
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	tasks_common "github.com/ydb-platform/nbs/cloud/tasks/common"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
-	task_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -261,7 +261,7 @@ func (s *storageYDB) GetIncremental(
 
 func (s *storageYDB) ListSnapshots(
 	ctx context.Context,
-) (ids task_storage.StringSet, err error) {
+) (ids tasks_common.StringSet, err error) {
 
 	err = s.db.Execute(
 		ctx,

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_impl.go
@@ -12,10 +12,10 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	tasks_common "github.com/ydb-platform/nbs/cloud/tasks/common"
 	task_errors "github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
-	task_storage "github.com/ydb-platform/nbs/cloud/tasks/storage"
 	"github.com/ydb-platform/nbs/contrib/go/cityhash"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -1425,9 +1425,9 @@ func (s *storageYDB) getSnapshotMeta(
 func (s *storageYDB) listSnapshots(
 	ctx context.Context,
 	session *persistence.Session,
-) (task_storage.StringSet, error) {
+) (tasks_common.StringSet, error) {
 
-	snapshots := task_storage.NewStringSet()
+	snapshots := tasks_common.NewStringSet()
 	res, err := session.StreamExecuteRO(ctx, fmt.Sprintf(`
 		--!syntax_v1
 		pragma TablePathPrefix = "%v";

--- a/cloud/tasks/common/stringset.go
+++ b/cloud/tasks/common/stringset.go
@@ -1,0 +1,78 @@
+package common
+
+type StringSet struct {
+	vals map[string]struct{}
+}
+
+func (s *StringSet) Has(val string) bool {
+	if s.vals != nil {
+		_, ok := s.vals[val]
+		return ok
+	}
+
+	return false
+}
+
+func (s *StringSet) Vals() map[string]struct{} {
+	return s.vals
+}
+
+func (s *StringSet) Size() int {
+	return len(s.vals)
+}
+
+func (s *StringSet) Add(val string) {
+	if s.vals == nil {
+		s.vals = make(map[string]struct{})
+	}
+
+	s.vals[val] = struct{}{}
+}
+
+func (s *StringSet) Remove(val string) {
+	if s.vals != nil {
+		delete(s.vals, val)
+	}
+}
+
+func (s *StringSet) List() []string {
+	if s.vals == nil {
+		return []string{}
+	}
+
+	vals := make([]string, 0, len(s.vals))
+	for v := range s.vals {
+		vals = append(vals, v)
+	}
+	return vals
+}
+
+func (s *StringSet) DeepCopy() StringSet {
+	return NewStringSet(s.List()...)
+}
+
+func (s *StringSet) Subtract(other StringSet) StringSet {
+	result := NewStringSet()
+
+	for v := range s.vals {
+		if !other.Has(v) {
+			result.Add(v)
+		}
+	}
+
+	return result
+}
+
+func NewStringSet(vals ...string) StringSet {
+	if len(vals) == 0 {
+		return StringSet{}
+	}
+
+	set := StringSet{
+		vals: make(map[string]struct{}),
+	}
+	for _, val := range vals {
+		set.Add(val)
+	}
+	return set
+}

--- a/cloud/tasks/common/ya.make
+++ b/cloud/tasks/common/ya.make
@@ -2,6 +2,7 @@ GO_LIBRARY()
 
 SRCS(
     marshal.go
+    stringset.go
     util.go
 )
 

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/nbs/cloud/tasks/common"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 	"github.com/ydb-platform/nbs/cloud/tasks/storage"
@@ -230,7 +231,7 @@ func TestExecutionContextAddTaskDependency(t *testing.T) {
 		taskStorage,
 		storage.TaskState{
 			ID:           "taskId1",
-			Dependencies: storage.NewStringSet(),
+			Dependencies: common.NewStringSet(),
 		},
 		time.Hour,
 		2,
@@ -238,7 +239,7 @@ func TestExecutionContextAddTaskDependency(t *testing.T) {
 
 	state := storage.TaskState{
 		ID:           "taskId1",
-		Dependencies: storage.NewStringSet("taskId2"),
+		Dependencies: common.NewStringSet("taskId2"),
 	}
 	task.On("Save").Return(state.State, nil)
 	taskStorage.On("UpdateTask", ctx, mock.MatchedBy(matchesState(t, state))).Return(state, nil)
@@ -295,7 +296,7 @@ func TestExecutionContextAddAnotherTaskDependency(t *testing.T) {
 		task,
 		taskStorage, storage.TaskState{
 			ID:           "taskId1",
-			Dependencies: storage.NewStringSet("taskId2"),
+			Dependencies: common.NewStringSet("taskId2"),
 		},
 		time.Hour,
 		2,
@@ -303,7 +304,7 @@ func TestExecutionContextAddAnotherTaskDependency(t *testing.T) {
 
 	state := storage.TaskState{
 		ID:           "taskId1",
-		Dependencies: storage.NewStringSet("taskId2", "taskId3"),
+		Dependencies: common.NewStringSet("taskId2", "taskId3"),
 	}
 	task.On("Save").Return(state.State, nil)
 	taskStorage.On("UpdateTask", ctx, mock.MatchedBy(matchesState(t, state))).Return(state, nil)

--- a/cloud/tasks/scheduler_impl.go
+++ b/cloud/tasks/scheduler_impl.go
@@ -98,7 +98,7 @@ func (s *scheduler) ScheduleZonalTask(
 		Status:         tasks_storage.TaskStatusReadyToRun,
 		Request:        marshalledRequest,
 		Metadata:       metadata,
-		Dependencies:   tasks_storage.NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		ZoneID:         zoneID,
 	})
 	if err != nil {
@@ -208,7 +208,7 @@ func (s *scheduler) ScheduleRegularTasks(
 				GenerationID: 0,
 				Status:       tasks_storage.TaskStatusReadyToRun,
 				Metadata:     metadata,
-				Dependencies: tasks_storage.NewStringSet(),
+				Dependencies: common.NewStringSet(),
 			}, schedule)
 			if err != nil {
 				logging.Warn(ctx, "failed to persist task %v: %v", taskType, err)

--- a/cloud/tasks/storage/common.go
+++ b/cloud/tasks/storage/common.go
@@ -378,14 +378,14 @@ func (s *storageYDB) scanTaskState(res persistence.Result) (state TaskState, err
 		return TaskState{}, errors.NewNonRetriableError(err)
 	}
 
-	state.Dependencies = NewStringSet(depsValues...)
+	state.Dependencies = common.NewStringSet(depsValues...)
 
 	dependantValues, err := common.UnmarshalStrings(dependants)
 	if err != nil {
 		return TaskState{}, errors.NewNonRetriableError(err)
 	}
 
-	state.dependants = NewStringSet(dependantValues...)
+	state.dependants = common.NewStringSet(dependantValues...)
 
 	eventsValues, err := common.UnmarshalInts(events)
 	if err != nil {

--- a/cloud/tasks/storage/storage.go
+++ b/cloud/tasks/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/ydb-platform/nbs/cloud/tasks/common"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
 	grpc_codes "google.golang.org/grpc/codes"
@@ -113,85 +114,6 @@ func NewMetadata(vals map[string]string) Metadata {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type StringSet struct {
-	vals map[string]struct{}
-}
-
-func (s *StringSet) Has(val string) bool {
-	if s.vals != nil {
-		_, ok := s.vals[val]
-		return ok
-	}
-
-	return false
-}
-
-func (s *StringSet) Vals() map[string]struct{} {
-	return s.vals
-}
-
-func (s *StringSet) Size() int {
-	return len(s.vals)
-}
-
-func (s *StringSet) Add(val string) {
-	if s.vals == nil {
-		s.vals = make(map[string]struct{})
-	}
-
-	s.vals[val] = struct{}{}
-}
-
-func (s *StringSet) Remove(val string) {
-	if s.vals != nil {
-		delete(s.vals, val)
-	}
-}
-
-func (s *StringSet) List() []string {
-	if s.vals == nil {
-		return []string{}
-	}
-
-	vals := make([]string, 0, len(s.vals))
-	for v := range s.vals {
-		vals = append(vals, v)
-	}
-	return vals
-}
-
-func (s *StringSet) DeepCopy() StringSet {
-	return NewStringSet(s.List()...)
-}
-
-func (s *StringSet) Subtract(other StringSet) StringSet {
-	result := NewStringSet()
-
-	for v := range s.vals {
-		if !other.Has(v) {
-			result.Add(v)
-		}
-	}
-
-	return result
-}
-
-func NewStringSet(vals ...string) StringSet {
-	if len(vals) == 0 {
-		return StringSet{}
-	}
-
-	set := StringSet{
-		vals: make(map[string]struct{}),
-	}
-	for _, val := range vals {
-		set.Add(val)
-	}
-	return set
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 // This is mapped into a DB row. If you change this struct, make sure to update
 // the mapping code.
 type TaskState struct {
@@ -215,7 +137,7 @@ type TaskState struct {
 	Request             []byte
 	State               []byte
 	Metadata            Metadata
-	Dependencies        StringSet
+	Dependencies        common.StringSet
 	ChangedStateAt      time.Time
 	EndedAt             time.Time
 	LastHost            string
@@ -228,7 +150,7 @@ type TaskState struct {
 	// Internal part of the state. Fully managed by DB and can't be overwritten
 	// by client.
 	// TODO: Should be extracted from TaskState.
-	dependants StringSet
+	dependants common.StringSet
 }
 
 func (s *TaskState) DeepCopy() TaskState {

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/nbs/cloud/tasks/common"
 	tasks_config "github.com/ydb-platform/nbs/cloud/tasks/config"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
@@ -102,7 +103,7 @@ func TestStorageYDBCreateTask(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	metricsRegistry.GetCounter(
@@ -142,7 +143,7 @@ func TestStorageYDBCreateTaskIgnoresID(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	metricsRegistry.GetCounter(
@@ -182,7 +183,7 @@ func TestStorageYDBCreateTwoTasks(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	metricsRegistry.GetCounter(
@@ -234,7 +235,7 @@ func TestStorageYDBCreateTwoTasksWithDifferentIdempotencyKeys(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	metricsRegistry.GetCounter(
@@ -287,7 +288,7 @@ func TestStorageYDBCreateTwoTasksWithSameIdempotencyKey(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	metricsRegistry.GetCounter(
@@ -334,7 +335,7 @@ func TestStorageYDBFailCreationOfTwoTasksWithSameIdempotencyKeyButDifferentTypes
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	metricsRegistry.GetCounter(
@@ -393,7 +394,7 @@ func TestStorageYDBGetTask(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{1, 2, 3},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		ZoneID:         "zone",
 	})
 	require.NoError(t, err)
@@ -409,7 +410,7 @@ func TestStorageYDBGetTask(t *testing.T) {
 	require.EqualValues(t, 42, taskState.GenerationID)
 	require.EqualValues(t, TaskStatusReadyToRun, taskState.Status)
 	require.EqualValues(t, []byte{1, 2, 3}, taskState.State)
-	require.EqualValues(t, NewStringSet(), taskState.Dependencies)
+	require.EqualValues(t, common.NewStringSet(), taskState.Dependencies)
 	require.WithinDuration(t, time.Time(createdAt), time.Time(taskState.ChangedStateAt), time.Microsecond)
 	require.EqualValues(t, "zone", taskState.ZoneID)
 	metricsRegistry.AssertAllExpectations(t)
@@ -453,7 +454,7 @@ func TestStorageYDBGetTaskWithDependencies(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -467,7 +468,7 @@ func TestStorageYDBGetTaskWithDependencies(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -481,7 +482,7 @@ func TestStorageYDBGetTaskWithDependencies(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{1, 2, 3},
-		Dependencies:   NewStringSet(depID1, depID2),
+		Dependencies:   common.NewStringSet(depID1, depID2),
 	})
 	require.NoError(t, err)
 
@@ -496,7 +497,7 @@ func TestStorageYDBGetTaskWithDependencies(t *testing.T) {
 	require.EqualValues(t, 42, taskState.GenerationID)
 	require.EqualValues(t, TaskStatusWaitingToRun, taskState.Status)
 	require.EqualValues(t, []byte{1, 2, 3}, taskState.State)
-	require.EqualValues(t, NewStringSet(depID1, depID2), taskState.Dependencies)
+	require.EqualValues(t, common.NewStringSet(depID1, depID2), taskState.Dependencies)
 	require.WithinDuration(t, time.Time(createdAt), time.Time(taskState.ChangedStateAt), time.Microsecond)
 	metricsRegistry.AssertAllExpectations(t)
 }
@@ -554,7 +555,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -568,7 +569,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -582,7 +583,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -596,7 +597,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -610,7 +611,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -624,7 +625,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -638,7 +639,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -652,7 +653,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -666,7 +667,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -680,7 +681,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -694,7 +695,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -708,7 +709,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -722,7 +723,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -736,7 +737,7 @@ func TestStorageYDBListTasksReadyToRun(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -794,7 +795,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -808,7 +809,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -822,7 +823,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -836,7 +837,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -850,7 +851,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -864,7 +865,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -878,7 +879,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -892,7 +893,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -906,7 +907,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -920,7 +921,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -934,7 +935,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -948,7 +949,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -962,7 +963,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -976,7 +977,7 @@ func TestStorageYDBListTasksReadyToCancel(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -1030,7 +1031,7 @@ func (f hangingTaskTestFixture) createTask(
 		GenerationID:   10,
 		Status:         taskStatus,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 	if estimatedDuration > 0 {
 		state.EstimatedTime = createdAt.Add(estimatedDuration)
@@ -1235,7 +1236,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1249,7 +1250,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1263,7 +1264,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1277,7 +1278,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1291,7 +1292,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1305,7 +1306,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1319,7 +1320,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1333,7 +1334,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1347,7 +1348,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1361,7 +1362,7 @@ func TestStorageYDBListTasksRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1413,7 +1414,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1427,7 +1428,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1441,7 +1442,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1455,7 +1456,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1469,7 +1470,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1483,7 +1484,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1497,7 +1498,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1511,7 +1512,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1525,7 +1526,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1539,7 +1540,7 @@ func TestStorageYDBListTasksCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1596,7 +1597,7 @@ func TestStorageYDBListFailedTasks(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{0},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1610,7 +1611,7 @@ func TestStorageYDBListFailedTasks(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{0},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	_, err = storage.UpdateTask(ctx, TaskState{
@@ -1640,7 +1641,7 @@ func TestStorageYDBListFailedTasks(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{0},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	_, err = storage.UpdateTask(ctx, TaskState{
@@ -1709,7 +1710,7 @@ func TestStorageYDBListSlowTasks(t *testing.T) {
 			GenerationID:   generationID,
 			Status:         TaskStatusFinished,
 			State:          []byte{0},
-			Dependencies:   NewStringSet(),
+			Dependencies:   common.NewStringSet(),
 			EndedAt:        created.Add(time.Duration(durationMinutes) * time.Minute),
 			EstimatedTime:  created.Add(time.Duration(estimated) * time.Minute),
 		}
@@ -1798,7 +1799,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1812,7 +1813,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1826,7 +1827,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1840,7 +1841,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -1855,7 +1856,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1869,7 +1870,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1883,7 +1884,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1897,7 +1898,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1911,7 +1912,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1925,7 +1926,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -1939,7 +1940,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -1953,7 +1954,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -1967,7 +1968,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -1981,7 +1982,7 @@ func TestStorageYDBListTasksStallingWhileRunning(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -2039,7 +2040,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2053,7 +2054,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2067,7 +2068,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2081,7 +2082,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2095,7 +2096,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2109,7 +2110,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2123,7 +2124,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2137,7 +2138,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2151,7 +2152,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -2166,7 +2167,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2180,7 +2181,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -2194,7 +2195,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -2208,7 +2209,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToRun, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -2222,7 +2223,7 @@ func TestStorageYDBListTasksStallingWhileCancelling(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(taskIDFinished, taskIDReadyToCancel),
+		Dependencies:   common.NewStringSet(taskIDFinished, taskIDReadyToCancel),
 	})
 	require.NoError(t, err)
 
@@ -2279,7 +2280,7 @@ func TestStorageYDBListTasksReadyToRunWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2293,7 +2294,7 @@ func TestStorageYDBListTasksReadyToRunWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2343,7 +2344,7 @@ func TestStorageYDBListTasksReadyToCancelWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2357,7 +2358,7 @@ func TestStorageYDBListTasksReadyToCancelWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -2407,7 +2408,7 @@ func TestStorageYDBListTasksStallingWhileRunningWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -2422,7 +2423,7 @@ func TestStorageYDBListTasksStallingWhileRunningWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -2474,7 +2475,7 @@ func TestStorageYDBListTasksStallingWhileCancellingWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -2489,7 +2490,7 @@ func TestStorageYDBListTasksStallingWhileCancellingWithWhitelist(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -2543,7 +2544,7 @@ func TestStorageYDBListTasksReadyToRunInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		ZoneID:         "zone0",
 	})
 	require.NoError(t, err)
@@ -2558,7 +2559,7 @@ func TestStorageYDBListTasksReadyToRunInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		ZoneID:         "zone1",
 	})
 	require.NoError(t, err)
@@ -2607,7 +2608,7 @@ func TestStorageYDBListTasksReadyToCancelInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		ZoneID:         "zone0",
 	})
 	require.NoError(t, err)
@@ -2622,7 +2623,7 @@ func TestStorageYDBListTasksReadyToCancelInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		ZoneID:         "zone1",
 	})
 	require.NoError(t, err)
@@ -2671,7 +2672,7 @@ func TestStorageYDBListTasksStallingWhileRunningInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 		ZoneID:         "zone0",
 	})
@@ -2687,7 +2688,7 @@ func TestStorageYDBListTasksStallingWhileRunningInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 		ZoneID:         "zone1",
 	})
@@ -2742,7 +2743,7 @@ func TestStorageYDBListTasksStallingWhileCancellingInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 		ZoneID:         "zone0",
 	})
@@ -2758,7 +2759,7 @@ func TestStorageYDBListTasksStallingWhileCancellingInCertainZone(t *testing.T) {
 		GenerationID:   generationID,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 		ZoneID:         "zone1",
 	})
@@ -2815,7 +2816,7 @@ func TestStorageYDBLockTaskToRun(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -2868,7 +2869,7 @@ func TestStorageYDBLockTaskToRunWrongGeneration(t *testing.T) {
 		GenerationID:   1,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -2914,7 +2915,7 @@ func TestStorageYDBLockTaskToRunWrongState(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -2961,7 +2962,7 @@ func TestStorageYDBLockTaskToCancel(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToCancel,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -3014,7 +3015,7 @@ func TestStorageYDBLockTaskToCancelWrongGeneration(t *testing.T) {
 		GenerationID:   1,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3060,7 +3061,7 @@ func TestStorageYDBLockTaskToCancelWrongState(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3107,7 +3108,7 @@ func TestStorageYDBMarkForCancellation(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -3159,7 +3160,7 @@ func TestStorageYDBMarkForCancellationIfAlreadyCancelling(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3209,7 +3210,7 @@ func TestStorageYDBMarkForCancellationIfAlreadyFinished(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3258,7 +3259,7 @@ func TestStorageYDBMarkForCancellationIfAlreadyCancelled(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusCancelled,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3307,7 +3308,7 @@ func TestStorageYDBUpdateTask(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{0},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -3321,7 +3322,7 @@ func TestStorageYDBUpdateTask(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -3335,7 +3336,7 @@ func TestStorageYDBUpdateTask(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusFinished,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3353,7 +3354,7 @@ func TestStorageYDBUpdateTask(t *testing.T) {
 		ErrorCode:      grpc_codes.InvalidArgument,
 		ErrorMessage:   "invalid argument",
 		State:          []byte{1},
-		Dependencies:   NewStringSet(taskIDDependent1, taskIDDependent2),
+		Dependencies:   common.NewStringSet(taskIDDependent1, taskIDDependent2),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3384,7 +3385,7 @@ func TestStorageYDBUpdateTask(t *testing.T) {
 		ErrorCode:      grpc_codes.InvalidArgument,
 		ErrorMessage:   "invalid argument",
 		State:          []byte{1},
-		Dependencies:   NewStringSet(taskIDDependent1, taskIDDependent2),
+		Dependencies:   common.NewStringSet(taskIDDependent1, taskIDDependent2),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3436,7 +3437,7 @@ func TestStorageYDBUpdateTaskStatus(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{0},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3452,7 +3453,7 @@ func TestStorageYDBUpdateTaskStatus(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{1},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -3480,7 +3481,7 @@ func TestStorageYDBUpdateTaskStatus(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusRunning,
 		State:          []byte{2},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3524,7 +3525,7 @@ func TestStorageYDBUpdateTaskWrongGeneration(t *testing.T) {
 		GenerationID:   2,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3540,7 +3541,7 @@ func TestStorageYDBUpdateTaskWrongGeneration(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusRunning,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.Truef(t, errors.Is(err, errors.NewWrongGenerationError()), "Expected WrongGenerationError got %v", err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3584,7 +3585,7 @@ func TestStorageYDBLockInParallel(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -3649,7 +3650,7 @@ func TestStorageYDBMarkForCancellationInParallel(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -3706,7 +3707,7 @@ func TestStorageYDBLockAlreadyCancellingTask(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 	metricsRegistry.AssertAllExpectations(t)
@@ -3758,7 +3759,7 @@ func TestStorageYDBCheckStallingTimeout(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusCancelling,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastHost:       "other_host",
 	})
 	require.NoError(t, err)
@@ -4418,7 +4419,7 @@ func TestStorageYDBClearEndedTasks(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{0},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -4432,7 +4433,7 @@ func TestStorageYDBClearEndedTasks(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 	taskID2, err := storage.CreateTask(ctx, task)
 	require.NoError(t, err)
@@ -4452,7 +4453,7 @@ func TestStorageYDBClearEndedTasks(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	taskID3, err := storage.CreateTask(ctx, task)
@@ -4476,7 +4477,7 @@ func TestStorageYDBClearEndedTasks(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	}
 
 	taskID4, err := storage.CreateTask(ctx, task)
@@ -4539,7 +4540,7 @@ func TestStorageYDBPauseResumeTask(t *testing.T) {
 		GenerationID:   0,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 		LastRunner:     "runner_42",
 	})
 	require.NoError(t, err)
@@ -4735,7 +4736,7 @@ func TestForceFinishTaskWithDependencies(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -4749,7 +4750,7 @@ func TestForceFinishTaskWithDependencies(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{},
-		Dependencies:   NewStringSet(),
+		Dependencies:   common.NewStringSet(),
 	})
 	require.NoError(t, err)
 
@@ -4763,7 +4764,7 @@ func TestForceFinishTaskWithDependencies(t *testing.T) {
 		GenerationID:   42,
 		Status:         TaskStatusReadyToRun,
 		State:          []byte{1, 2, 3},
-		Dependencies:   NewStringSet(depID1, depID2),
+		Dependencies:   common.NewStringSet(depID1, depID2),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
StringSet is located in cloud/tasks/storage, which depends on cloud/tasks/persistence. For #1965 I wanted to use StringSet in cloud/tasks/persistence, but can't right now due to recursive imports.

This PR moves StringSet into "neutral" place - cloud/tasks/common and updates all usages to use the new location.