### PR TITLE
Add lagging replaced device to AutomaticallyReplaced; Update device state message

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -813,6 +813,10 @@ public:
         return AutomaticallyReplacedDeviceIds.contains(deviceId);
     }
 
+    void AddAutomaticallyReplacedDevice(
+        TDiskRegistryDatabase& db,
+        const TAutomaticallyReplacedDeviceInfo& deviceInfo);
+
     ui32 DeleteAutomaticallyReplacedDevices(
         TDiskRegistryDatabase& db,
         const TInstant until);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
@@ -463,6 +463,25 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateLaggingAgentsTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, replicaInfo.FinishedMigrations.size());
         }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "Lagging source migration was aborted; diskId=disk-1/0",
+            state.FindDevice("uuid-1")->GetStateMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "Lagging source migration was aborted; diskId=disk-1/0",
+            state.FindDevice("uuid-2")->GetStateMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            state.GetAutomaticallyReplacedDevices().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            CountIf(
+                state.GetAutomaticallyReplacedDevices(),
+                [&](const auto& deviceInfo)
+                {
+                    return deviceInfo.DeviceId == "uuid-1" ||
+                           deviceInfo.DeviceId == "uuid-2";
+                }));
     }
 
     Y_UNIT_TEST(ShouldAddOutdatedLaggingDevices_MigrationSourceButHasNotStarted)


### PR DESCRIPTION
Если лагал источник миграции, то мы заменяем его на цель миграции (и делаем его фрешом). После этого ПРа замененённые девайсы попадут в "AutomaticallyReplacedDevices". Плюс выставляю сообщение в девайс для прозрачности