### PR TITLE
Make follower media kind non-optional since it immediately known

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
@@ -87,10 +87,7 @@ TString TFollowerDiskInfo::Describe() const
     auto builder = TStringBuilder();
     builder << "{ State: " << ToString(State);
 
-    if (MediaKind) {
-        builder << ", MediaKind: "
-                << NProto::EStorageMediaKind_Name(*MediaKind);
-    }
+    builder << ", MediaKind: " << NProto::EStorageMediaKind_Name(MediaKind);
 
     if (MigratedBytes) {
         builder << ", MigratedBytes: " << FormatByteSize(*MigratedBytes);

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.h
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.h
@@ -76,7 +76,7 @@ struct TFollowerDiskInfo
     TLeaderFollowerLink Link;
     TInstant CreatedAt;
     EState State = EState::None;
-    std::optional<NProto::EStorageMediaKind> MediaKind;
+    NProto::EStorageMediaKind MediaKind;
     std::optional<ui64> MigratedBytes;
     TString ErrorMessage;
 

--- a/cloud/blockstore/libs/storage/volume/partition_info.cpp
+++ b/cloud/blockstore/libs/storage/volume/partition_info.cpp
@@ -4,6 +4,11 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TActorsStack::TActorsStack(NActors::TActorId actor)
+{
+    Actors.push_back(actor);
+}
+
 void TActorsStack::Push(NActors::TActorId actorId)
 {
     if (!actorId || IsKnown(actorId)) {

--- a/cloud/blockstore/libs/storage/volume/partition_info.h
+++ b/cloud/blockstore/libs/storage/volume/partition_info.h
@@ -24,6 +24,9 @@ class TActorsStack
     TDeque<NActors::TActorId> Actors;
 
 public:
+    TActorsStack() = default;
+    explicit TActorsStack(NActors::TActorId actor);
+
     void Push(NActors::TActorId actorId);
     void Clear();
     [[nodiscard]] bool IsKnown(NActors::TActorId actorId) const;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -285,12 +285,8 @@ void RenderFollowers(IOutputStream& out, const TFollowerDisks& followers)
                             out << follower.Link.FollowerDiskIdForPrint();
                             if (follower.MediaKind) {
                                 out << "<br>(";
-                                if (follower.MediaKind) {
-                                    out << NProto::EStorageMediaKind_Name(
-                                        *follower.MediaKind);
-                                } else {
-                                    out << "unknown";
-                                }
+                                out << NProto::EStorageMediaKind_Name(
+                                    follower.MediaKind);
                                 out << ")";
                             }
                         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -781,9 +781,7 @@ void TVolumeActor::HandleTabletStatus(
 
     switch (msg->Status) {
         case TEvBootstrapper::STARTED: {
-            TActorsStack actors;
-            actors.Push(msg->TabletUser);
-            partition->SetStarted(std::move(actors));
+            partition->SetStarted(TActorsStack(msg->TabletUser));
             NCloud::Send<TEvPartition::TEvWaitReadyRequest>(
                 ctx,
                 msg->TabletUser,

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -723,6 +723,7 @@ void TVolumeDatabase::WriteFollower(const TFollowerDiskInfo& follower)
                 follower.Link.FollowerDiskId),
             NIceDb::TUpdate<TTable::FollowerShardId>(
                 follower.Link.FollowerShardId),
+            NIceDb::TUpdate<TTable::FollowerMediaKind>(follower.MediaKind),
             NIceDb::TUpdate<TTable::State>(static_cast<ui32>(follower.State)),
             NIceDb::TUpdate<TTable::ErrorMessage>(follower.ErrorMessage));
 
@@ -735,16 +736,6 @@ void TVolumeDatabase::WriteFollower(const TFollowerDiskInfo& follower)
         Table<TTable>()
             .Key(follower.Link.LinkUUID)
             .UpdateToNull<TTable::MigratedBytes>();
-    }
-
-    if (follower.MediaKind) {
-        Table<TTable>()
-            .Key(follower.Link.LinkUUID)
-            .Update(NIceDb::TUpdate<TTable::MediaKind>(*follower.MediaKind));
-    } else {
-        Table<TTable>()
-            .Key(follower.Link.LinkUUID)
-            .UpdateToNull<TTable::MediaKind>();
     }
 }
 
@@ -779,10 +770,8 @@ bool TVolumeDatabase::ReadFollowers(TFollowerDisks& followers)
                 TInstant::MicroSeconds(it.GetValue<TTable::CreatedAt>()),
             .State = static_cast<TFollowerDiskInfo::EState>(
                 it.GetValue<TTable::State>()),
-            .MediaKind = it.HaveValue<TTable::MediaKind>()
-                             ? static_cast<NProto::EStorageMediaKind>(
-                                   it.GetValue<TTable::MediaKind>())
-                             : std::optional<NProto::EStorageMediaKind>(),
+            .MediaKind = static_cast<NProto::EStorageMediaKind>(
+                it.GetValue<TTable::FollowerMediaKind>()),
             .MigratedBytes = it.HaveValue<TTable::MigratedBytes>()
                                  ? it.GetValue<TTable::MigratedBytes>()
                                  : std::optional<ui64>(),

--- a/cloud/blockstore/libs/storage/volume/volume_schema.h
+++ b/cloud/blockstore/libs/storage/volume/volume_schema.h
@@ -312,7 +312,8 @@ struct TVolumeSchema
         {
         };
 
-        struct MediaKind: public Column<9, NKikimr::NScheme::NTypeIds::Uint32>
+        struct FollowerMediaKind
+            : public Column<9, NKikimr::NScheme::NTypeIds::Uint32>
         {
         };
 
@@ -331,7 +332,7 @@ struct TVolumeSchema
             CreatedAt,
             LeaderDiskId,
             LeaderShardId,
-            MediaKind,
+            FollowerMediaKind,
             ErrorMessage>;
     };
 


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999
Делаю тип диска фолловера обязательным, так как теперь мы его знаем с самого начала и нет смысла делать его опциональным. 