### PR TITLE
issue-1223: parse traces even if span IDs are invalid

### DIFF
--- a/cloud/storage/core/libs/opentelemetry/impl/trace_convert.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_convert.cpp
@@ -229,7 +229,7 @@ private:
     const TReferenceTimeCycle ReferenceTimeCycle;
     const bool HasConflicts;
 
-    ui32 SpanIdPool = 0;
+    ui32 NextSpanId = 0;
 
 public:
     TTraceConverter(
@@ -319,7 +319,7 @@ private:
 
     ui32 TakeSpanId()
     {
-        return SpanIdPool++;
+        return NextSpanId++;
     }
 };
 


### PR DESCRIPTION
#1223 
В SU из-за  передачи тейсов между хостами spanId зануляются и у нас получаются невалидные трейсы: 
```
[["RequestStarted",0,"WriteBlocks","1","12195966460240083936","fsahing5ucj5vjbjqmjr","5256160","4096"],
["RequestReceived",10,"WriteBlocksLocal","1","12195966460240083936","fsahing5ucj5vjbjqmjr"],
["RequestEnqueued",19,"12195966460240083936"],
["SendRequestStarted",34,"12195966460240083936"],
["SendRequestCompleted",63,"12195966460240083936"],
["RecvResponseCompleted",725,"12195966460240083936"],
["RequestReceived_Cells",108],
["RequestSent_Proxy",120,"WriteBlocksLocal","0"],
["RequestReceived_Service",124,"WriteBlocksLocal","0"],
["RequestReceived_Volume",127,"WriteBlocksLocal","0"],
["RequestAdvanced_Volume",129,"WriteBlocksLocal","0"],
["Fork",131,"0"],
["Join",637,"0","11"],
["RequestReceived_Partition",135,"WriteBlocks","0"],
["RequestReceived_PartitionWorker",144,"WriteFreshBlocks","0"],
["Fork",145,"0"],
["Join",631,"0","6"],
["RequestReceived_Partition",150,"WriteBlob","0"],
["RequestReceived_PartitionWorker_DSProxy",155,"WriteBlob","0","2181038092"],
["DSProxyPutHandle",161],
["DSProxyPutBootstrapStart",176],
["DSProxyPutReply",609],
["ResponseSent_Partition",618,"WriteBlob","0"],
["ResponseSent_Partition",633,"WriteFreshBlocks","0"],
["ResponseSent_Volume",638,"WriteBlocksLocal","0"],
["RequestCompleted",774,"WriteBlocks","12195966460240083936","fsahing5ucj5vjbjqmjr","4096","768","768","0"],
["AllRequests"]]
```
Как можно заметить, во всех форках и джоинах на месте SpanId находятся нули. Понять почему они зануляются пока не получилось, но мы относительно без потерь можем сконвертировать трейс без spanId. Просто временная отметка начала спана будет браться не из fork'а, а из первого ивента этого спана. В этом пре добавляю обработку этого случая в функцию конвертации трейсов.
