### PR TITLE
TFileRingBuffer: do not fail when the requested capacity differs from the existing capacity

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -171,15 +171,17 @@ public:
     {
         Y_ABORT_UNLESS(sizeof(TEntryHeader) <= capacity);
 
-        const ui64 realSize = sizeof(THeader) + capacity;
-        if (static_cast<ui64>(Map.Length()) < realSize) {
+        if (static_cast<ui64>(Map.Length()) < sizeof(THeader)) {
+            const ui64 realSize = sizeof(THeader) + capacity;
             Map.ResizeAndRemap(0, realSize);
         } else {
-            Map.Map(0, realSize);
+            Map.Map(0, Map.Length());
         }
 
         if (Header()->Version) {
-            Y_ABORT_UNLESS(Header()->Capacity == capacity);
+            Y_ABORT_UNLESS(
+                sizeof(THeader) + Header()->Capacity <=
+                static_cast<ui64>(Map.Length()));
             Y_ABORT_UNLESS(Header()->Version == VERSION);
         } else {
             Header()->Capacity = capacity;

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -484,6 +484,18 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         TFileRingBuffer rb2(bad.FileHandle.GetName(), bad.Len);
         UNIT_ASSERT(!rb2.PushBack("c"));
     }
+
+    Y_UNIT_TEST(ShouldNotFailOnCapacityChange)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 16;
+        TFileRingBuffer rb(f.GetName(), len);
+        TFileRingBuffer rb1(f.GetName(), len + 1);
+        TFileRingBuffer rb2(f.GetName(), len - 1);
+
+        UNIT_ASSERT_EQUAL(f.GetLength(), len + 40);
+        UNIT_ASSERT(rb.PushBack("12345678"));
+    }
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
Mitigation for https://github.com/ydb-platform/nbs/issues/3792: do nothing when the capacity value is changed.
