### PR TITLE
Set AllZeroes flag in ReadBlocks response for BlobStorage-based disks

### DIFF
--- a/cloud/blockstore/libs/common/iovector.cpp
+++ b/cloud/blockstore/libs/common/iovector.cpp
@@ -248,11 +248,22 @@ bool IsAllZeroes(const char* src, size_t size)
     return !src[0] && !memcmp(src, src + sizeof(char), size - sizeof(char));
 }
 
-bool IsAllZeroes(const NProto::TIOVector& iov) {
+bool IsAllZeroes(const NProto::TIOVector& iov)
+{
     return AllOf(
         iov.GetBuffers(),
-        [](const auto& buffer)
+        [](const TString& buffer)
         { return IsAllZeroes(buffer.data(), buffer.size()); });
+}
+
+bool IsAllZeroes(const TSgList& sglist)
+{
+    return AllOf(
+        sglist,
+        [](const TBlockDataRef& buffer)
+        {
+            return buffer.Empty() || IsAllZeroes(buffer.Data(), buffer.Size());
+        });
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/iovector.h
+++ b/cloud/blockstore/libs/common/iovector.h
@@ -60,4 +60,7 @@ size_t CopyAndTrimVoidBuffers(
 // Checks that all buffers in the TIOVector contain only zeros.
 [[nodiscard]] bool IsAllZeroes(const NProto::TIOVector& iov);
 
+// Checks that all buffers in the TSgList contain only zeros.
+[[nodiscard]] bool IsAllZeroes(const TSgList& sglist);
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/iovector_ut.cpp
+++ b/cloud/blockstore/libs/common/iovector_ut.cpp
@@ -313,6 +313,29 @@ Y_UNIT_TEST_SUITE(TIOVectorTest)
         DoShouldCopyFromIOVectorToSgList(5, big, 10, small, false, true);
         DoShouldCopyFromIOVectorToSgList(5, big, 10, small, true, true);
     }
+
+    Y_UNIT_TEST(TestIsAllZeroes)
+    {
+        TString zeroBufferData(8, 0);
+        TString nonZeroBufferData(8, 'a');
+
+        auto zeroBuffer =
+            TBlockDataRef(zeroBufferData.data(), zeroBufferData.size());
+        auto emptyBuffer = TBlockDataRef::CreateZeroBlock(8);
+        auto nonZeroBuffer =
+            TBlockDataRef(nonZeroBufferData.data(), nonZeroBufferData.size());
+
+        UNIT_ASSERT(IsAllZeroes(TSgList{}));
+        UNIT_ASSERT(IsAllZeroes(TSgList{emptyBuffer}));
+        UNIT_ASSERT(IsAllZeroes(TSgList{zeroBuffer}));
+        UNIT_ASSERT(IsAllZeroes(TSgList{emptyBuffer, zeroBuffer}));
+
+        UNIT_ASSERT(!IsAllZeroes(TSgList{nonZeroBuffer}));
+        UNIT_ASSERT(!IsAllZeroes(TSgList{emptyBuffer, nonZeroBuffer}));
+        UNIT_ASSERT(!IsAllZeroes(TSgList{zeroBuffer, nonZeroBuffer}));
+        UNIT_ASSERT(
+            !IsAllZeroes(TSgList{zeroBuffer, emptyBuffer, nonZeroBuffer}));
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/storage/core/block_handler.cpp
+++ b/cloud/blockstore/libs/storage/core/block_handler.cpp
@@ -168,6 +168,11 @@ public:
         auto stringBuf = ConvertBitMapToStringBuf(UnencryptedBlockMask);
         auto& blockMask = *response.MutableUnencryptedBlockMask();
         blockMask.assign(stringBuf);
+
+        const bool allEmpty = AllOf(
+            response.GetBlocks().GetBuffers(),
+            [](const TString& block) { return block.empty(); });
+        response.SetAllZeroes(allEmpty);
     }
 
     TGuardedSgList GetLocalResponse(
@@ -343,6 +348,8 @@ public:
                     SetBitMapValue(UnencryptedBlockMask, i, true);
                 }
             }
+
+            response.SetAllZeroes(IsAllZeroes(sglist));
         }
 
         auto stringBuf = ConvertBitMapToStringBuf(UnencryptedBlockMask);


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999
При копировании BlobStorage-based диска нужно смотреть на пустые блоки, иначе это превращается в записи кучи нулей в диск назначения.