### PR TITLE
[Filestore] Fix bool that was used as integer

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -231,14 +231,14 @@ TMiscNodeStats TIndexTabletState::GetMiscNodeStats() const
     };
 }
 
-bool TIndexTabletState::CalculateExpectedShardCount() const
+ui64 TIndexTabletState::CalculateExpectedShardCount() const
 {
     if (FileSystem.GetShardNo()) {
         // sharding is flat
         return 0;
     }
 
-    const auto currentShardCount = FileSystem.ShardFileSystemIdsSize();
+    const ui64 currentShardCount = FileSystem.ShardFileSystemIdsSize();
     ui64 autoShardCount = 0;
     if (FileSystem.GetAutomaticShardCreationEnabled()
             && FileSystem.GetShardAllocationUnit())

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -354,7 +354,7 @@ public:
         return AllocatorRegistry.GetAllocator(tag);
     }
 
-    bool CalculateExpectedShardCount() const;
+    ui64 CalculateExpectedShardCount() const;
 
     NProto::TError SelectShard(ui64 fileSize, TString* shardId);
 


### PR DESCRIPTION
TIndexTabletState::CalculateExpectedShardCount used to returned 'bool' that was actually restricted number of shards to 255 