### PR TITLE
Refactor actors ownership for migration-related actors

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -55,14 +55,17 @@ void TLaggingAgentMigrationActor::OnBootstrap(const TActorContext& ctx)
 {
     InitWork(
         ctx,
-        SourceActorId,
-        SourceActorId,
-        TargetActorId,
-        false,   // takeOwnershipOverActors
-        std::make_unique<TMigrationTimeoutCalculator>(
-            Config->GetLaggingDeviceMaxMigrationBandwidth(),
-            Config->GetExpectedDiskAgentSize(),
-            PartConfig));
+        TInitParams{
+            .MigrationSrcActorId = SourceActorId,
+            .SrcActorId = SourceActorId,
+            .DstActorId = TargetActorId,
+            .TakeOwnershipOverSrcActor = false,
+            .TakeOwnershipOverDstActor = false,
+            .SendWritesToSrc = false,
+            .TimeoutCalculator = std::make_unique<TMigrationTimeoutCalculator>(
+                Config->GetLaggingDeviceMaxMigrationBandwidth(),
+                Config->GetExpectedDiskAgentSize(),
+                PartConfig)});
 }
 
 bool TLaggingAgentMigrationActor::OnMessage(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -54,14 +54,18 @@ void TNonreplicatedPartitionMigrationActor::OnBootstrap(
     auto srcActorId = CreateSrcActor(ctx);
     InitWork(
         ctx,
-        MigrationSrcActorId ? MigrationSrcActorId : srcActorId,
-        srcActorId,
-        CreateDstActor(ctx),
-        true,   // takeOwnershipOverActors
-        std::make_unique<TMigrationTimeoutCalculator>(
-            GetConfig()->GetMaxMigrationBandwidth(),
-            GetConfig()->GetExpectedDiskAgentSize(),
-            SrcConfig));
+        TInitParams{
+            .MigrationSrcActorId =
+                MigrationSrcActorId ? MigrationSrcActorId : srcActorId,
+            .SrcActorId = srcActorId,
+            .DstActorId = CreateDstActor(ctx),
+            .TakeOwnershipOverSrcActor = true,
+            .TakeOwnershipOverDstActor = true,
+            .SendWritesToSrc = true,
+            .TimeoutCalculator = std::make_unique<TMigrationTimeoutCalculator>(
+                GetConfig()->GetMaxMigrationBandwidth(),
+                GetConfig()->GetExpectedDiskAgentSize(),
+                SrcConfig)});
 
     PrepareForMigration(ctx);
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -104,6 +104,18 @@ class TNonreplicatedPartitionMigrationCommonActor
           TNonreplicatedPartitionMigrationCommonActor>
     , IPoisonPillHelperOwner
 {
+public:
+    struct TInitParams
+    {
+        NActors::TActorId MigrationSrcActorId;
+        NActors::TActorId SrcActorId;
+        NActors::TActorId DstActorId;
+        bool TakeOwnershipOverSrcActor = true;
+        bool TakeOwnershipOverDstActor = true;
+        bool SendWritesToSrc = true;
+        std::unique_ptr<TMigrationTimeoutCalculator> TimeoutCalculator;
+    };
+
 private:
     using TBase = NActors::TActorBootstrapped<
         TNonreplicatedPartitionMigrationCommonActor>;
@@ -127,7 +139,7 @@ private:
     NActors::TActorId MigrationSrcActorId;
     NActors::TActorId SrcActorId;
     NActors::TActorId DstActorId;
-    bool ActorOwner = false;
+    bool SendWritesToSrc = true;
     std::unique_ptr<TMigrationTimeoutCalculator> TimeoutCalculator;
 
     TProcessingBlocks ProcessingBlocks;
@@ -222,13 +234,7 @@ public:
     virtual void Bootstrap(const NActors::TActorContext& ctx);
 
     // Called from the inheritor to initialize migration.
-    void InitWork(
-        const NActors::TActorContext& ctx,
-        NActors::TActorId migrationSrcActorId,
-        NActors::TActorId srcActorId,
-        NActors::TActorId dstActorId,
-        bool takeOwnershipOverActors,
-        std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator);
+    void InitWork(const NActors::TActorContext& ctx, TInitParams initParams);
 
     // Called from the inheritor to start migration.
     void StartWork(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -23,21 +23,19 @@ LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 void TNonreplicatedPartitionMigrationCommonActor::InitWork(
     const NActors::TActorContext& ctx,
-    NActors::TActorId migrationSrcActorId,
-    NActors::TActorId srcActorId,
-    NActors::TActorId dstActorId,
-    bool takeOwnershipOverActors,
-    std::unique_ptr<TMigrationTimeoutCalculator> timeoutCalculator)
+    TInitParams initParams)
 {
-    MigrationSrcActorId = migrationSrcActorId;
-    SrcActorId = srcActorId;
-    DstActorId = dstActorId;
-    TimeoutCalculator = std::move(timeoutCalculator);
+    MigrationSrcActorId = initParams.MigrationSrcActorId;
+    SrcActorId = initParams.SrcActorId;
+    DstActorId = initParams.DstActorId;
+    TimeoutCalculator = std::move(initParams.TimeoutCalculator);
     STORAGE_CHECK_PRECONDITION(TimeoutCalculator);
 
-    ActorOwner = takeOwnershipOverActors;
-    if (ActorOwner) {
+    SendWritesToSrc = initParams.SendWritesToSrc;
+    if (initParams.TakeOwnershipOverSrcActor) {
         PoisonPillHelper.TakeOwnership(ctx, SrcActorId);
+    }
+    if (initParams.TakeOwnershipOverDstActor) {
         PoisonPillHelper.TakeOwnership(ctx, DstActorId);
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_mirror.cpp
@@ -101,7 +101,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
     }
 
     if (TargetMigrationIsLagging) {
-        STORAGE_VERIFY(ActorOwner, TWellKnownEntityTypes::DISK, DiskId);
+        STORAGE_VERIFY(SendWritesToSrc, TWellKnownEntityTypes::DISK, DiskId);
 
         // TMirrorRequestActor is used here just as a simple request actor.
         NCloud::Register<TMirrorRequestActor<TMethod>>(
@@ -116,7 +116,7 @@ void TNonreplicatedPartitionMigrationCommonActor::MirrorRequest(
         NCloud::Register<TMigrationRequestActor<TMethod>>(
             ctx,
             CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
-            ActorOwner ? SrcActorId : TActorId{},
+            SendWritesToSrc ? SrcActorId : TActorId{},
             DstActorId,
             std::move(msg->Record),
             DiskId,

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -856,14 +856,18 @@ void TShadowDiskActor::CreateShadowDiskPartitionActor(
         State = EActorState::Preparing;
         InitWork(
             ctx,
-            SrcActorId,
-            SrcActorId,
-            DstActorId,
-            true,   // takeOwnershipOverActors
-            std::make_unique<TMigrationTimeoutCalculator>(
-                GetConfig()->GetMaxShadowDiskFillBandwidth(),
-                GetConfig()->GetExpectedDiskAgentSize(),
-                DstConfig));
+            TInitParams{
+                .MigrationSrcActorId = SrcActorId,
+                .SrcActorId = SrcActorId,
+                .DstActorId = DstActorId,
+                .TakeOwnershipOverSrcActor = true,
+                .TakeOwnershipOverDstActor = true,
+                .SendWritesToSrc = true,
+                .TimeoutCalculator =
+                    std::make_unique<TMigrationTimeoutCalculator>(
+                        GetConfig()->GetMaxShadowDiskFillBandwidth(),
+                        GetConfig()->GetExpectedDiskAgentSize(),
+                        DstConfig)});
         StartWork(ctx);
 
         // Persist state.

--- a/cloud/blockstore/libs/storage/volume/partition_info.h
+++ b/cloud/blockstore/libs/storage/volume/partition_info.h
@@ -21,16 +21,37 @@ namespace NCloud::NBlockStore::NStorage {
 // itself and its wrappers.
 class TActorsStack
 {
-    TDeque<NActors::TActorId> Actors;
+public:
+    enum class EActorPurpose
+    {
+        BlobStoragePartitionTablet,
+        DiskRegistryBasedPartitionActor,
+        FollowerWrapper,
+        ShadowDiskWrapper,
+    };
+
+private:
+    struct TActorInfo
+    {
+        TActorInfo(NActors::TActorId actorId, EActorPurpose purpose)
+            : ActorId(actorId)
+            , ActorPurpose(purpose)
+        {}
+        NActors::TActorId ActorId;
+        EActorPurpose ActorPurpose;
+    };
+
+    TDeque<TActorInfo> Actors;
 
 public:
     TActorsStack() = default;
-    explicit TActorsStack(NActors::TActorId actor);
+    TActorsStack(NActors::TActorId actor, EActorPurpose purpose);
 
-    void Push(NActors::TActorId actorId);
+    void Push(NActors::TActorId actorId, EActorPurpose purpose);
     void Clear();
     [[nodiscard]] bool IsKnown(NActors::TActorId actorId) const;
     [[nodiscard]] NActors::TActorId GetTop() const;
+    [[nodiscard]] NActors::TActorId GetTopWrapper() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/partition_info.h
+++ b/cloud/blockstore/libs/storage/volume/partition_info.h
@@ -19,6 +19,44 @@ namespace NCloud::NBlockStore::NStorage {
 
 // Used to store the partition-related actors, the actor of the partitions
 // itself and its wrappers.
+//
+// Examples:
+//
+// 1. No wrappers (DiskRegistry-based)
+// Stack:
+//   [TNonreplicatedPartitionActor]     (owned by TVolumeActor)
+//
+//
+// 2. No wrappers (BlobStorage-based)
+// Stack:
+//   [TPartitionActor]                  (owned by bootstraper)
+//
+//
+// 3. Shadow Disk (make sense only for DiskRegistry-based)
+// Stack:
+//   [TShadowDiskActor] (wrapper)       (owned by TVolumeActor)
+//   [TNonreplicatedPartitionActor]     (owned by TShadowDiskActor)
+//
+//
+// 4. Linked Disk (DiskRegistry-based)
+// Stack:
+//   [TFollowerDiskActor] (wrapper)     (owned by TVolumeActor)
+//   [TNonreplicatedPartitionActor]     (owned by TFollowerDiskActor)
+//
+//
+// 5. Linked Disk for Shadow disk  (DiskRegistry-based)
+// Stack:
+//   [TFollowerDiskActor] (wrapper)     (owned by TVolumeActor)
+//   [TShadowDiskActor]   (wrapper)     (owned by TFollowerDiskActor)
+//   [TNonreplicatedPartitionActor]     (owned by TShadowDiskActor)
+//
+//
+// 6. Linked Disk (BlobStorage-based)
+// Stack:
+//   [TFollowerDiskActor] (wrapper)     (owned by TVolumeActor)
+//   [TPartitionActor]                  (owned by bootstraper)
+
+
 class TActorsStack
 {
 public:

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -1104,9 +1104,9 @@ private:
         const TEvPartitionCommonPrivate::TEvLongRunningOperation::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    TActorsStack WrapNonreplActorIfNeeded(
+    TActorsStack WrapWithShadowDiskActorIfNeeded(
         const NActors::TActorContext& ctx,
-        NActors::TActorId nonreplicatedActorId,
+        TActorsStack actors,
         std::shared_ptr<TNonreplicatedPartitionConfig> srcConfig);
 
     void HandleCreateLinkFinished(


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999
1. При помещении актора или обертка и стек явно указываю что это за актор
2. даю возможность тонкой настройки владения акторами источника и назначения для миграционного актора.
3. При удалении реплицированного партишена явно удаляю актор-обертку (если он есть). 