### PR TITLE
issue-1223: fix use after free in GRPC clients

### DIFF
--- a/cloud/blockstore/libs/discovery/ping.cpp
+++ b/cloud/blockstore/libs/discovery/ping.cpp
@@ -118,7 +118,7 @@ public:
             ChannelCredentials
         );
 
-        auto promise = requestContext->Promise;
+        auto future = requestContext->Promise.GetFuture();
 
         requestContext->Reader->Finish(
             &requestContext->ResponseInfo.Record,
@@ -126,9 +126,11 @@ public:
             &*requestContext
         );
 
+        // At this point, requestContext object can already be freed after
+        // request completion. It is not safe to use it.
         requestContext.release();
 
-        return promise;
+        return future;
     }
 
     void Start() override

--- a/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
+++ b/cloud/blockstore/libs/endpoint_proxy/client/client.cpp
@@ -276,7 +276,7 @@ struct TEndpointProxyClient
             now
         );
 
-        auto promise = requestContext->Promise;
+        auto future = requestContext->Promise.GetFuture();
 
         requestContext->Reader->Finish(
             &requestContext->Response,
@@ -284,7 +284,9 @@ struct TEndpointProxyClient
             requestContext.release()
         );
 
-        return promise;
+        // At this point, requestContext object can already be freed after
+        // request completion. It is not safe to use it.
+        return future;
     }
 
     TFuture<NProto::TStartProxyEndpointResponse> StartProxyEndpoint(

--- a/cloud/blockstore/libs/kms/impl/compute_client.cpp
+++ b/cloud/blockstore/libs/kms/impl/compute_client.cpp
@@ -75,9 +75,12 @@ public:
         grpc::CompletionQueue* cq,
         void* tag)
     {
+        auto future = Promise.GetFuture();
         Reader = service.AsyncCreateToken(&ClientContext, Request, cq);
         Reader->Finish(&Response, &Status, tag);
-        return Promise;
+        // At this point, this object can already be freed after request
+        // completion. It is not safe to use it.
+        return future;
     }
 
     void Complete()

--- a/cloud/blockstore/libs/kms/impl/kms_client.cpp
+++ b/cloud/blockstore/libs/kms/impl/kms_client.cpp
@@ -75,9 +75,12 @@ public:
         grpc::CompletionQueue* cq,
         void* tag)
     {
+        auto future = Promise.GetFuture();
         Reader = service.AsyncDecrypt(&ClientContext, Request, cq);
         Reader->Finish(&Response, &Status, tag);
-        return Promise;
+        // At this point, this object can already be freed after request
+        // completion. It is not safe to use it.
+        return future;
     }
 
     void Complete()

--- a/cloud/blockstore/libs/root_kms/impl/client.cpp
+++ b/cloud/blockstore/libs/root_kms/impl/client.cpp
@@ -84,9 +84,12 @@ public:
         kms::SymmetricCryptoService::Stub& service,
         grpc::CompletionQueue& cq)
     {
+        auto future = Promise.GetFuture();
         Reader = service.AsyncDecrypt(&ClientContext, Request, &cq);
         Reader->Finish(&Response, &Status, this);
-        return Promise;
+        // At this point, this object can already be freed after request
+        // completion. It is not safe to use it.
+        return future;
     }
 
     void Complete() override
@@ -139,9 +142,12 @@ public:
         kms::SymmetricCryptoService::Stub& service,
         grpc::CompletionQueue& cq)
     {
+        auto future = Promise.GetFuture();
         Reader = service.AsyncGenerateDataKey(&ClientContext, Request, &cq);
         Reader->Finish(&Response, &Status, this);
-        return Promise;
+        // At this point, this object can already be freed after request
+        // completion. It is not safe to use it.
+        return future;
     }
 
     void Complete() override

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_service_client.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_service_client.cpp
@@ -71,9 +71,12 @@ public:
         grpc::CompletionQueue* cq,
         void* tag)
     {
+        auto future = Promise.GetFuture();
         Reader = service.AsyncExport(&ClientContext, Request, cq);
         Reader->Finish(&Response, &Status, tag);
-        return Promise;
+        // At this point, this object can already be freed after request
+        // completion. It is not safe to use it.
+        return future;
     }
 
     void Complete()

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_service_client_ut.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_service_client_ut.cpp
@@ -1,0 +1,53 @@
+#include "trace_service_client.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/opentelemetry/iface/trace_service_client.h>
+
+#include <library/cpp/lwtrace/all.h>
+#include <library/cpp/lwtrace/protos/lwtrace.pb.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/random/random.h>
+
+#include <opentelemetry/proto/collector/trace/v1/trace_service.pb.h>
+
+namespace NCloud {
+
+using namespace opentelemetry::proto::collector::trace::v1;
+
+using namespace NThreading;
+
+Y_UNIT_TEST_SUITE(TraceServiceClientTest)
+{
+    Y_UNIT_TEST(ShouldNotCrashWithFailedRequests)
+    {
+        auto logging = CreateLoggingService("console");
+        NProto::TGrpcClientConfig clientConfig;
+        auto port = RandomNumber<ui64>(65535 - 1025) + 1025;
+        clientConfig.SetAddress("localhost:" + ToString(port));
+        clientConfig.SetInsecure(true);
+        clientConfig.SetRequestTimeout(1);
+
+        auto client = CreateTraceServiceClient(logging, clientConfig);
+
+        client->Start();
+
+        auto testDuration = TDuration::Seconds(10);
+        TVector<TFuture<TResultOrError<ExportTraceServiceResponse>>> results;
+
+        auto start = TInstant::Now();
+
+        while (TInstant::Now() - start < testDuration) {
+            results.push_back(client->Export(ExportTraceServiceRequest(), ""));
+        }
+
+        for (auto& result: results) {
+            UNIT_ASSERT(HasError(result.GetValueSync()));
+        }
+
+        client->Stop();
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/opentelemetry/impl/trace_service_client_ut.cpp
+++ b/cloud/storage/core/libs/opentelemetry/impl/trace_service_client_ut.cpp
@@ -18,6 +18,8 @@ using namespace opentelemetry::proto::collector::trace::v1;
 
 using namespace NThreading;
 
+////////////////////////////////////////////////////////////////////////////////
+
 Y_UNIT_TEST_SUITE(TraceServiceClientTest)
 {
     Y_UNIT_TEST(ShouldNotCrashWithFailedRequests)
@@ -32,6 +34,10 @@ Y_UNIT_TEST_SUITE(TraceServiceClientTest)
         auto client = CreateTraceServiceClient(logging, clientConfig);
 
         client->Start();
+        Y_DEFER
+        {
+            client->Stop();
+        };
 
         auto testDuration = TDuration::Seconds(10);
         TVector<TFuture<TResultOrError<ExportTraceServiceResponse>>> results;
@@ -45,8 +51,6 @@ Y_UNIT_TEST_SUITE(TraceServiceClientTest)
         for (auto& result: results) {
             UNIT_ASSERT(HasError(result.GetValueSync()));
         }
-
-        client->Stop();
     }
 }
 

--- a/cloud/storage/core/libs/opentelemetry/impl/ut/ya.make
+++ b/cloud/storage/core/libs/opentelemetry/impl/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/storage/core/libs/opentelemetry/impl)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
+    trace_service_client_ut.cpp
     trace_ut.cpp
 )
 

--- a/cloud/storage/core/libs/opentelemetry/impl/ya.make
+++ b/cloud/storage/core/libs/opentelemetry/impl/ya.make
@@ -10,8 +10,11 @@ SRCS(
 PEERDIR(
     cloud/storage/core/config
     cloud/storage/core/libs/opentelemetry/iface
+    cloud/storage/core/libs/grpc
+    cloud/storage/core/libs/common
 
     contrib/libs/opentelemetry-proto
+    contrib/libs/grpc
 
     library/cpp/threading/future
     library/cpp/lwtrace


### PR DESCRIPTION
#1223
После раскатки бинаря с трейсами на некоторых хостах, на которых не был поднят эндпоинт принимающий трейсы, начал переодически крашиться нбс, причем делал он это достаточно часто и с абсолютно рандомными стек трейсами.

Запустил бинарь под асаном и нашел UAF при неудачных попытках экспортировать трейсы.
Место в котором происходло обращение к освобожденной памяти:
```
0x557f8400e5a3 is in NCloud::(anonymous namespace)::TTraceServiceClient::Export() (/home/iajwjw/arcadia/util/generic/ptr.h:560).
```

место где память освобождалась
```
0x557f7fbc42bd is in operator delete() (/home/iajwjw/arcadia/contrib/libs/clang16-rt/lib/asan/asan_new_delete.cpp:152).
0x557f8400c230 is in NCloud::(anonymous namespace)::TTraceServiceClient::ThreadProc() (/home/iajwjw/arcadia/cloud/storage/core/libs/opentelemetry/impl/trace_service_client.cpp:178).
```
место где память была выделена
```
0x557f8400d83b is in NCloud::(anonymous namespace)::TTraceServiceClient::Export() (/home/iajwjw/arcadia/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:686).
```

Примерный сценарий такой пусть есть два треда T1 и T2
Тред T1 делает GRPC вызов и отанавливается после 75 строчки. Указатель tag совпалдает с указателем на данный объект this типа TRequestHandler
https://github.com/ydb-platform/nbs/blob/02a7558464e464f7bc4fbdd1df2f2ffed038083f/cloud/storage/core/libs/opentelemetry/impl/trace_service_client.cpp#L69-L77

После этого происходит успешный или нет GRPC вызов, тред T2 завершает обработку запроса (вызвав Complete) и освобождает память выделенную под объект типа TRequestHandler
https://github.com/ydb-platform/nbs/blob/02a7558464e464f7bc4fbdd1df2f2ffed038083f/cloud/storage/core/libs/opentelemetry/impl/trace_service_client.cpp#L168-L178

После этого тред T1 просыпается и выполняет 76 строчку, конструирует из  Promise фьючу, при этом поле Promise уже было освобождено тредом T2. Получаем UAF.
https://github.com/ydb-platform/nbs/blob/02a7558464e464f7bc4fbdd1df2f2ffed038083f/cloud/storage/core/libs/opentelemetry/impl/trace_service_client.cpp#L76


Починил данное поведение в Grpc клиентах