### PR TITLE
issue-1751: TWriteBackCache: refactoring - move implementation details to a separate header (v2)

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read.cpp
@@ -9,7 +9,7 @@ namespace NCloud::NFileStore::NFuse {
 ////////////////////////////////////////////////////////////////////////////////
 
 // static
-auto TWriteBackCache::TDataPartsUtil::CalculateDataPartsToRead(
+auto TWriteBackCache::TUtil::CalculateDataPartsToRead(
     const TVector<TWriteDataEntry*>& entries,
     ui64 startingFromOffset,
     ui64 length) -> TVector<TWriteDataEntryPart>

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/calculate_data_parts_to_read_ut.cpp
@@ -128,7 +128,7 @@ struct TCalculateDataPartsToReadTestBootstrap
         ui64 startingFromOffset,
         ui64 length)
     {
-        return TWriteBackCache::TDataPartsUtil::CalculateDataPartsToRead(
+        return TWriteBackCache::TUtil::CalculateDataPartsToRead(
             entries,
             startingFromOffset,
             length);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -148,7 +148,7 @@ public:
             return {};
         }
 
-        return TDataPartsUtil::CalculateDataPartsToRead(
+        return TUtil::CalculateDataPartsToRead(
             entriesIter->second,
             startingFromOffset,
             length);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -58,7 +58,7 @@ private:
     enum class EFlushStatus;
     struct TWriteDataEntry;
     struct TWriteDataEntryPart;
-    class TDataPartsUtil;
+    class TUtil;
 };
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -2,9 +2,15 @@
 
 #include "write_back_cache.h"
 
+#include <cloud/filestore/libs/service/filestore.h>
+
 #include <util/generic/intrlist.h>
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
 
 namespace NCloud::NFileStore::NFuse {
+
+////////////////////////////////////////////////////////////////////////////////
 
 enum class TWriteBackCache::EFlushStatus
 {
@@ -72,7 +78,7 @@ struct TWriteBackCache::TWriteDataEntryPart
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TWriteBackCache::TDataPartsUtil
+class TWriteBackCache::TUtil
 {
 public:
     static TVector<TWriteDataEntryPart> CalculateDataPartsToRead(


### PR DESCRIPTION
Extracted from https://github.com/ydb-platform/nbs/pull/3690
Relates to https://github.com/ydb-platform/nbs/issues/1751
An alternative to https://github.com/ydb-platform/nbs/pull/3924 with the less diff size.