### PR TITLE
Fix NBS going into infinite loop

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.cpp
@@ -7,7 +7,7 @@ namespace NCloud::NBlockStore::NStorage {
 TDuration TDeviceStat::WorstRequestTime() const
 {
     TDuration result;
-    for (ui32 i = ResponseTimes.FirstIndex(); i < ResponseTimes.TotalSize();
+    for (size_t i = ResponseTimes.FirstIndex(); i < ResponseTimes.TotalSize();
          ++i)
     {
         result = Max(result, ResponseTimes[i]);


### PR DESCRIPTION
После того как пользователь сделал 2^32 - 10 запросов, `ResponseTimes.TotalSize()` становится недостижим для ui32 и получается вечный цикл