### PR TITLE
Fix update info in latency table

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -1244,14 +1244,17 @@ void TVolumeActor::RenderLatency(IOutputStream& out) const {
         out << "</div>";
 
         out << R"(<script>
-            function updateRequestsData(result, container) {
-                const data = { ...result.stat, ...result.percentiles };
-                for (let key in data) {
-                    const element = container.querySelector('#' + key);
+            function applyRequestsValues(stat) {
+                for (let key in stat) {
+                    const element = document.getElementById(key);
                     if (element) {
-                        element.textContent = data[key];
+                        element.textContent = stat[key];
                     }
                 }
+            }
+            function updateRequestsData(result, container) {
+                applyRequestsValues(result.stat);
+                applyRequestsValues(result.percentiles);
             }
         </script>)";
 


### PR DESCRIPTION
Починил отображение значений латенси на стороне фронтенда. 
<img width="800" height="532" alt="image" src="https://github.com/user-attachments/assets/9df93462-092a-4a39-8cbf-7a02f617c4ea" />
