### PR TITLE
issue-1345: ignore path not found error from schemeshard while removing client on StopEndpoint

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -1141,8 +1141,12 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
     auto removeClientFuture =
         Service->RemoveVolumeClient(ctx, std::move(removeClientRequest));
     const auto& removeClientResponse = Executor->WaitFor(removeClientFuture);
+    const auto& error = removeClientResponse.GetError();
 
-    if (HasError(removeClientResponse)) {
+    if (HasError(error) &&
+        error.GetCode() !=
+            MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
+    {
         return TErrorResponse(removeClientResponse.GetError());
     }
 


### PR DESCRIPTION
#1345 в случае если на StopEndpoint эндпоинт не нашелся мы делаем RemoveClient и удаляем сокет.
Если диск был удален то ошибка от схемшарда тупа прокидывапется наружу, к чему компьют не готов. Необходимо игнорировать такую ошибку и успешно завершать вызов StopEndpoint