### PR TITLE
Add ability to use SchemeCache directly instead of TxProxy

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1278,4 +1278,7 @@ message TStorageServiceConfig
     // Min percentage of reassignable mixed channels after which reassign requests
     // are sent.
     optional uint32 ReassignMixedChannelsPercentageThreshold = 442;
+
+    // If true, describes will be done using SchemeCache instead of TxProxy.
+    optional bool UseSchemeCache = 443;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -492,6 +492,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(HiveProxyFallbackMode,                     bool,      false           )\
     xxx(SSProxyFallbackMode,                       bool,      false           )\
+    xxx(UseSchemeCache,                            bool,      false           )\
     xxx(DontPassSchemeShardDirWhenRegisteringNodeInEmergencyMode, bool, false )\
                                                                                \
     xxx(RdmaTargetPort,                            ui32,      10020           )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -523,6 +523,7 @@ public:
     bool GetHiveProxyFallbackMode() const;
     TString GetPathDescriptionBackupFilePath() const;
     bool GetSSProxyFallbackMode() const;
+    bool GetUseSchemeCache() const;
     bool GetDontPassSchemeShardDirWhenRegisteringNodeInEmergencyMode() const;
 
     ui32 GetRdmaTargetPort() const;

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -96,12 +96,7 @@ void TDescribeSchemeActor::DescribeScheme(const TActorContext& ctx)
         request->DatabaseName = Config->GetSchemeShardDir();
         TSchemeCacheNavigate::TEntry& entry = request->ResultSet.emplace_back();
         entry.Operation = TSchemeCacheNavigate::OpPath;
-        entry.Access = NACLib::DescribeSchema;
-        entry.RequestType =
-            NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByPath;
-        entry.RedirectRequired = true;
         entry.SyncVersion = true;
-        entry.ShowPrivatePath = false;
         entry.Path = SplitPath(Path);
 
         NCloud::Send(

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -16,6 +16,7 @@ using namespace NActors;
 
 using namespace NKikimr;
 using namespace NKikimr::NSchemeShard;
+using namespace NKikimr::NSchemeCache;
 
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER)
 
@@ -57,6 +58,10 @@ private:
     void HandleDescribeSchemeResult(
         const TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev,
         const TActorContext& ctx);
+
+    void HandleDescribeSchemeResult(
+        const TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev,
+        const TActorContext& ctx);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +74,7 @@ TDescribeSchemeActor::TDescribeSchemeActor(
     : RequestInfo(std::move(requestInfo))
     , Config(std::move(config))
     , Path(std::move(path))
-    , PathDescriptionBackup(std::move(pathDescriptionBackup))
+    , PathDescriptionBackup(pathDescriptionBackup)
 {}
 
 void TDescribeSchemeActor::Bootstrap(const TActorContext& ctx)
@@ -80,17 +85,37 @@ void TDescribeSchemeActor::Bootstrap(const TActorContext& ctx)
 
 void TDescribeSchemeActor::DescribeScheme(const TActorContext& ctx)
 {
-    auto request = std::make_unique<TEvTxUserProxy::TEvNavigate>();
-    request->Record.MutableDescribePath()->SetPath(Path);
-    request->Record.SetDatabaseName(Config->GetSchemeShardDir());
-
     LWTRACK(
         RequestSent_Proxy,
         RequestInfo->CallContext->LWOrbit,
         "Navigate",
         RequestInfo->CallContext->RequestId);
 
-    NCloud::Send(ctx, MakeTxProxyID(), std::move(request));
+    if (Config->GetUseSchemeCache()) {
+        auto request = std::make_unique<TSchemeCacheNavigate>();
+        request->DatabaseName = Config->GetSchemeShardDir();
+        TSchemeCacheNavigate::TEntry& entry = request->ResultSet.emplace_back();
+        entry.Operation = TSchemeCacheNavigate::OpPath;
+        entry.Access = NACLib::DescribeSchema;
+        entry.RequestType =
+            NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByPath;
+        entry.RedirectRequired = true;
+        entry.SyncVersion = true;
+        entry.ShowPrivatePath = false;
+        entry.Path = SplitPath(Path);
+
+        NCloud::Send(
+            ctx,
+            MakeSchemeCacheID(),
+            std::make_unique<TEvTxProxySchemeCache::TEvNavigateKeySet>(
+                request.release()));
+    } else {
+        auto request = std::make_unique<TEvTxUserProxy::TEvNavigate>();
+        request->Record.MutableDescribePath()->SetPath(Path);
+        request->Record.SetDatabaseName(Config->GetSchemeShardDir());
+
+        NCloud::Send(ctx, MakeTxProxyID(), std::move(request));
+    }
 }
 
 bool TDescribeSchemeActor::HandleError(
@@ -165,10 +190,79 @@ void TDescribeSchemeActor::HandleDescribeSchemeResult(
     ReplyAndDie(ctx, std::move(response));
 }
 
+void TDescribeSchemeActor::HandleDescribeSchemeResult(
+    const TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev,
+    const TActorContext& ctx)
+{
+    TEvTxProxySchemeCache::TEvNavigateKeySetResult* msg = ev->Get();
+    const TSchemeCacheNavigate* record = msg->Request.Get();
+
+    Y_ABORT_UNLESS(record->ResultSet.size() == 1);
+    const auto& entry = record->ResultSet.front();
+
+    if (record->ErrorCount > 0) {
+        switch (entry.Status) {
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown:
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::RootUnknown:
+                HandleError(
+                    ctx,
+                    MakeSchemeShardError(
+                        NKikimrScheme::StatusPathDoesNotExist,
+                        "Path doesn't exist"));
+                return;
+            default: {
+                HandleError(
+                    ctx,
+                    MakeError(
+                        E_REJECTED,
+                        TStringBuilder()
+                            << "SchemeCache resolve failed with uncertain "
+                               "result. Error Code: "
+                            << static_cast<ui32>(entry.Status)));
+                return;
+            }
+        }
+    }
+
+    if (entry.Kind !=
+            NSchemeCache::TSchemeCacheNavigate::KindBlockStoreVolume ||
+        !entry.BlockStoreVolumeInfo)
+    {
+        HandleError(
+            ctx,
+            MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "Described path " << Path.Quote()
+                                 << " is not a blockstore volume"));
+        return;
+    }
+
+    NKikimrSchemeOp::TPathDescription pathDescription;
+    pathDescription.MutableBlockStoreVolumeDescription()->CopyFrom(
+        entry.BlockStoreVolumeInfo->Description);
+    pathDescription.MutableSelf()->SetPathType(
+        NKikimrSchemeOp::EPathTypeBlockStoreVolume);
+
+    if (PathDescriptionBackup) {
+        auto updateRequest = std::make_unique<
+            TEvSSProxyPrivate::TEvUpdatePathDescriptionBackupRequest>(
+            Path,
+            pathDescription);
+        NCloud::Send(ctx, PathDescriptionBackup, std::move(updateRequest));
+    }
+
+    ReplyAndDie(
+        ctx,
+        std::make_unique<TEvSSProxy::TEvDescribeSchemeResponse>(
+            Path,
+            std::move(pathDescription)));
+}
+
 STFUNC(TDescribeSchemeActor::StateWork)
 {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvSchemeShard::TEvDescribeSchemeResult, HandleDescribeSchemeResult);
+        HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleDescribeSchemeResult);
 
         default:
             HandleUnexpectedEvent(

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -192,7 +192,18 @@ void TDescribeSchemeActor::HandleDescribeSchemeResult(
     TEvTxProxySchemeCache::TEvNavigateKeySetResult* msg = ev->Get();
     const TSchemeCacheNavigate* record = msg->Request.Get();
 
-    Y_ABORT_UNLESS(record->ResultSet.size() == 1);
+    Y_DEBUG_ABORT_UNLESS(record->ResultSet.size() == 1);
+    if (record->ResultSet.size() != 1) {
+        HandleError(
+            ctx,
+            MakeError(
+                E_REJECTED,
+                TStringBuilder() << "SchemeCache ResultSet returned unexpected "
+                                    "number of entries: "
+                                 << record->ResultSet.size()));
+        return;
+    }
+
     const auto& entry = record->ResultSet.front();
 
     if (record->ErrorCount > 0) {

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -11,8 +11,8 @@
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/discovery/discovery.h>
-#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/encryption/encryption_key.h>
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
@@ -24,8 +24,8 @@
 #include <cloud/blockstore/libs/storage/core/manually_preempted_volumes.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/service/service.h>
-#include <cloud/blockstore/libs/storage/stats_service/stats_service.h>
 #include <cloud/blockstore/libs/storage/ss_proxy/ss_proxy.h>
+#include <cloud/blockstore/libs/storage/stats_service/stats_service.h>
 #include <cloud/blockstore/libs/storage/undelivered/undelivered.h>
 #include <cloud/blockstore/libs/storage/volume/volume.h>
 #include <cloud/blockstore/libs/storage/volume_balancer/volume_balancer.h>
@@ -42,10 +42,10 @@
 #include <contrib/ydb/core/mind/bscontroller/bsc.h>
 #include <contrib/ydb/core/mind/hive/hive.h>
 #include <contrib/ydb/core/mind/tenant_pool.h>
-#include <contrib/ydb/core/mind/tenant_pool.h>
 #include <contrib/ydb/core/security/ticket_parser.h>
 #include <contrib/ydb/core/tx/coordinator/coordinator.h>
 #include <contrib/ydb/core/tx/mediator/mediator.h>
+#include <contrib/ydb/core/tx/scheme_board/cache.h>
 #include <contrib/ydb/core/tx/schemeshard/schemeshard.h>
 #include <contrib/ydb/core/tx/tx_allocator/txallocator.h>
 #include <contrib/ydb/core/tx/tx_proxy/proxy.h>

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -48,6 +48,7 @@ LinkedDiskFillBandwidth {
 }
 
 # SchemeShard proxy
+UseSchemeCache: true
 PathDescriptionBackupFilePath: "backups/nbs-path-description-backup.txt"
 #SSProxyFallbackMode: true
 


### PR DESCRIPTION
Коллеги из YDB посоветовали отказаться от использования TxProxy для дескрайбов и перейти на SchemeCache. 
Во-первых, TxProxy считается deprecated кодом. Во-вторых, он и так ходит в SchemeCache для получения нужной информации. То есть логика здесь сильно не поменяется. 