### PR TITLE
Fix race condition in TestTaskInflightDurationDoesNotCountWaitingStatus

### DIFF
--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1727,7 +1727,11 @@ func TestTaskInflightDurationDoesNotCountWaitingStatus(t *testing.T) {
 	db := newYDB(ctx, t)
 	defer db.Close(ctx)
 
-	s := createServices(t, ctx, db, 2)
+	// runnersCount must be at least the count of tasks + 1 (for CollectListerMetrics).
+	// Otherwise, a race condition can occur where longTask is picked up
+	// before waitingTask. This results in a WaitingDuration of zero,
+	// which causes the test to fail.
+	s := createServices(t, ctx, db, 3 /* runnersCount */)
 
 	err := registerLongTask(s.registry)
 	require.NoError(t, err)


### PR DESCRIPTION
PR #3760 introduced new test TestTaskInflightDurationDoesNotCountWaitingStatus. In #3789 I added checks for WaitingDuration field.

But current implementation of this test contains race condition, which makes the test sometimes fail and sometimes succeed. This PR fixes it.

<details>
<summary>Explanation</summary>

In the current implementation of the test, `runnersCount` is set to 2. This means only one task can run concurrently, because the second runner is occupied by the `CollectListerMetrics` system task, which runs in an infinite loop.

The test schedules two tasks: `longTask` and `waitingTask`, where `waitingTask` depends on `longTask`. The `longTask` runs for 10 seconds, so we expect the `WaitingDuration` for `waitingTask` to be 10 seconds.

The happy path is as follows: the runner picks up `waitingTask` and calls the `.WaitTask()` method. This marks `waitingTask` as dependent on `longTask`, moves it to the `WaitingToRun` status, and interrupts its execution via the [`InterruptExecutionError` mechanism](https://github.com/ydb-platform/nbs/blob/84d07af038e1485f65b8008f2a307b54bd394e5a/cloud/tasks/storage/storage_ydb_impl.go#L1609). Then, after `longTask` completes, it wakes up `waitingTask` through [`prepareUnfinishedDependencies`](https://github.com/ydb-platform/nbs/blob/84d07af038e1485f65b8008f2a307b54bd394e5a/cloud/tasks/storage/storage_ydb_impl.go#L453), where we update its `WaitingDuration`.

However, if `longTask` starts and finishes *before* `waitingTask` is picked up, the following occurs: `longTask` completes, and the runner then picks up `waitingTask` (since only one task can run at a time). Inside `waitingTask`, we call `.WaitTask()` on `longTask`, but because `longTask` has already finished, `.WaitTask()` does nothing. As a result, `waitingTask` never transitions to the `WaitingToRun` state, and its `Dependencies` and `dependants` fields are never updated.

This means that the `WaitingDuration` calculation logic worked correctly, and the flaw was solely in the test's implementation.
</details>