### PR TITLE
Fix cpu wait sensor for disk agent

### DIFF
--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -671,6 +671,7 @@ void TBootstrap::Start()
 
     START_COMPONENT(AsyncLogger);
     START_COMPONENT(Logging);
+    START_COMPONENT(StatsFetcher);
     START_COMPONENT(Monitoring);
     START_COMPONENT(ProfileLog);
     START_COMPONENT(TraceProcessor);
@@ -724,6 +725,7 @@ void TBootstrap::Stop()
     STOP_COMPONENT(TraceProcessor);
     STOP_COMPONENT(ProfileLog);
     STOP_COMPONENT(Monitoring);
+    STOP_COMPONENT(StatsFetcher);
     STOP_COMPONENT(Logging);
     STOP_COMPONENT(AsyncLogger);
 

--- a/cloud/blockstore/libs/disk_agent/bootstrap.h
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.h
@@ -59,8 +59,9 @@ private:
     ITimerPtr Timer;
     ISchedulerPtr Scheduler;
     IActorSystemPtr ActorSystem;
-    ILoggingServicePtr Logging;
     IAsyncLoggerPtr AsyncLogger;
+    ILoggingServicePtr Logging;
+    NCloud::NStorage::IStatsFetcherPtr StatsFetcher;
     IMonitoringServicePtr Monitoring;
     TVector<ITraceReaderPtr> TraceReaders;
     ITraceProcessorPtr TraceProcessor;
@@ -73,7 +74,6 @@ private:
     IStorageProviderPtr LocalStorageProvider;
     NNvme::INvmeManagerPtr NvmeManager;
     NRdma::IServerPtr RdmaServer;
-    NCloud::NStorage::IStatsFetcherPtr StatsFetcher;
 
     TProgramShouldContinue ShouldContinue;
     TVector<TString> PostponedCriticalEvents;


### PR DESCRIPTION
У диск агента создавался `StatsFetcher`, но никогда не запускался. Из-за этого сбор метрики cpu wait не работал и сыпались крит эвенты раз в 15 секунд