### PR TITLE
Get rid of NCloud::HasField in storage config

### DIFF
--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -781,16 +781,9 @@ void DumpImpl(
 
 #define CONFIG_ITEM_IS_SET_CHECKER(name, ...)                                  \
     template <typename TProto>                                                 \
-    concept Is##name##RepeatedField = requires(const TProto& proto) {          \
-        {                                                                      \
-            proto.name##Size()                                                 \
-        } -> std::convertible_to<i64>;                                         \
-    };                                                                         \
-                                                                               \
-    template <typename TProto>                                                 \
     [[nodiscard]] bool Is##name##Set(const TProto& proto)                      \
     {                                                                          \
-        if constexpr (Is##name##RepeatedField<TProto>) {                       \
+        if constexpr (requires() { proto.name##Size(); }) {                    \
             return proto.name##Size() > 0;                                     \
         } else {                                                               \
             return proto.Has##name();                                          \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -859,13 +859,15 @@ struct TStorageConfig::TImpl
     {
         NProto::TStorageServiceConfig proto = StorageServiceConfig;
 
-        // Overriding fields with values from ICB
+    // Overriding fields with values from ICB
 #define BLOCKSTORE_CONFIG_COPY(name, type, ...)                                \
-        if (const ui64 value = Control##name) {                                \
-            using T = decltype(StorageServiceConfig.Get##name());              \
-            proto.Set##name(static_cast<T>(value));                            \
-        }                                                                      \
-// BLOCKSTORE_CONFIG_COPY
+    if (const ui64 value = Control##name;                                      \
+        ConvertValue<type>(value) != ConvertValue<type>(proto.Get##name()))    \
+    {                                                                          \
+        using T = decltype(StorageServiceConfig.Get##name());                  \
+        proto.Set##name(static_cast<T>(value));                                \
+    }                                                                          \
+    // BLOCKSTORE_CONFIG_COPY
 
         BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_COPY)
 


### PR DESCRIPTION
Поведение никак не меняется. Заменил вызовы `NCloud::HasField()` с лукапом по хешмапе на обычные вызовы методов `HasXxx()` или `XxxSize()`. Для этого пришлось выделить отдельный макрос для repeated полей в proto, но кажется оно того стоит.