### PR TITLE
fix race in ShouldStatFileStore unit test

### DIFF
--- a/cloud/filestore/libs/service_local/service_ut.cpp
+++ b/cloud/filestore/libs/service_local/service_ut.cpp
@@ -2254,14 +2254,8 @@ Y_UNIT_TEST_SUITE(LocalFileStore)
         UNIT_ASSERT_VALUES_EQUAL(
             response.GetFileStore().GetNodesCount(),
             stfs.f_files);
-        UNIT_ASSERT_VALUES_EQUAL(
-            response.GetFileStore().GetBlocksCount() -
-                response.GetStats().GetUsedBlocksCount(),
-            stfs.f_bfree);
-        UNIT_ASSERT_VALUES_EQUAL(
-            response.GetFileStore().GetNodesCount() -
-                response.GetStats().GetUsedNodesCount(),
-            stfs.f_ffree);
+        // skip checking free blocks/nodes since they constantly change on current fs and it could be tricky
+        // to measure during quiescent state
     }
 };
 


### PR DESCRIPTION
Test [failure](https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/PR-check/16423472213/1/nebius-x86-64/logs/1/cloud/filestore/libs/service_local/ut/test-results/unittest/chunk12/testing_out_stuff/LocalFileStore.ShouldStatFileStore.err) due to file creation race on test filesytem

