### PR TITLE
issue-1345: changed the order of AddClient\RemoveClient transactions and Acquire\Release devices during mount operations for DR-based disks

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1297,4 +1297,14 @@ message TStorageServiceConfig
     optional bool VolumeThrottlingManagerEnabled = 447;
     // Duration between VolumeThrottlingManager notifications to volumes
     optional uint32 VolumeThrottlingManagerNotificationPeriodSeconds = 448;
+
+    // Initial delay to retry acquire request (in milliseconds).
+    optional uint32 RetryAcquireReleaseDiskInitialDelay = 449;
+
+    // Max delay to retry acquire request (in milliseconds).
+    optional uint32 RetryAcquireReleaseDiskMaxDelay = 450;
+
+    // Do AddClient/RemoveClient transaction
+    // and then do right Acquire/Release devices requests.
+    optional bool DoAcquireReleaseDevicesAfterTransaction = 451;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1306,5 +1306,5 @@ message TStorageServiceConfig
 
     // Do AddClient/RemoveClient transaction
     // and then do right Acquire/Release devices requests.
-    optional bool DoAcquireReleaseDevicesAfterTransaction = 451;
+    optional bool NonReplicatedVolumeAcquireDiskAfterAddClientEnabled = 451;
 }

--- a/cloud/blockstore/libs/storage/api/volume.h
+++ b/cloud/blockstore/libs/storage/api/volume.h
@@ -273,6 +273,14 @@ struct TEvVolume
     };
 
     //
+    // RetryAcquireDisk
+    //
+
+    struct TRetryAcquireDisk
+    {
+    };
+
+    //
     // Events declaration
     //
 
@@ -383,6 +391,8 @@ struct TEvVolume
         EvUpdateLinkOnFollowerRequest = EvBegin + 69,
         EvUpdateLinkOnFollowerResponse = EvBegin + 70,
 
+        EvRetryAcquireDisk = EvBegin + 71,
+
         EvEnd
     };
 
@@ -460,6 +470,9 @@ struct TEvVolume
         TRequestEvent<TScrubberCounters,
         EvScrubberCounters
     >;
+
+    using TEvRetryAcquireDisk =
+        TRequestEvent<TRetryAcquireDisk, EvRetryAcquireDisk>;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -625,7 +625,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   Seconds(0)         )\
     xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(0)         )\
                                                                                \
-    xxx(DoAcquireReleaseDevicesAfterTransaction,           bool,   false      )\
+    xxx(NonReplicatedVolumeAcquireDiskAfterAddClientEnabled bool,   false     )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -622,8 +622,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(VolumeThrottlingManagerNotificationPeriodSeconds,                      \
         TDuration,                                                             \
         Seconds(5)                                                            )\
-    xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   Seconds(0)         )\
-    xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(0)         )\
+    xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   MilliSeconds(100)  )\
+    xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(5)         )\
                                                                                \
     xxx(NonReplicatedVolumeAcquireDiskAfterAddClientEnabled, bool,   false    )\
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -622,7 +622,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(VolumeThrottlingManagerNotificationPeriodSeconds,                      \
         TDuration,                                                             \
         Seconds(5)                                                            )\
-    xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   MilliSeconds(100)  )\
+    xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   MSeconds(100)      )\
     xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(5)         )\
                                                                                \
     xxx(NonReplicatedVolumeAcquireDiskAfterAddClientEnabled, bool,   false    )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -625,7 +625,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   Seconds(0)         )\
     xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(0)         )\
                                                                                \
-    xxx(NonReplicatedVolumeAcquireDiskAfterAddClientEnabled bool,   false     )\
+    xxx(NonReplicatedVolumeAcquireDiskAfterAddClientEnabled, bool,   false    )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -622,6 +622,10 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(VolumeThrottlingManagerNotificationPeriodSeconds,                      \
         TDuration,                                                             \
         Seconds(5)                                                            )\
+    xxx(RetryAcquireReleaseDiskInitialDelay,  TDuration,   Seconds(0)         )\
+    xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(0)         )\
+                                                                               \
+    xxx(DoAcquireReleaseDevicesAfterTransaction,           bool,   false      )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -709,6 +709,11 @@ public:
     [[nodiscard]] bool GetVolumeThrottlingManagerEnabled() const;
     [[nodiscard]] TDuration
     GetVolumeThrottlingManagerNotificationPeriodSeconds() const;
+
+    [[nodiscard]] TDuration GetRetryAcquireReleaseDiskInitialDelay() const;
+    [[nodiscard]] TDuration GetRetryAcquireReleaseDiskMaxDelay() const;
+
+    [[nodiscard]] bool GetDoAcquireReleaseDevicesAfterTransaction() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -713,7 +713,8 @@ public:
     [[nodiscard]] TDuration GetRetryAcquireReleaseDiskInitialDelay() const;
     [[nodiscard]] TDuration GetRetryAcquireReleaseDiskMaxDelay() const;
 
-    [[nodiscard]] bool GetDoAcquireReleaseDevicesAfterTransaction() const;
+    [[nodiscard]] bool
+    GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -283,9 +283,8 @@ private:
         bool RetryIfTimeoutOrUndelivery = false;
     };
 
-    class TAcquireReleaseDiskRequest
+    struct TAcquireReleaseDiskRequest
     {
-    public:
         bool IsAcquire;
         TString ClientId;
         NProto::EVolumeAccessMode AccessMode =
@@ -585,6 +584,12 @@ private:
     void AddAcquireReleaseDiskRequest(
         const NActors::TActorContext& ctx,
         TAcquireReleaseDiskRequest request);
+    void AddAcquireDiskRequest(
+        const NActors::TActorContext& ctx,
+        TAcquireDiskRequest request);
+    void AddReleaseDiskRequest(
+        const NActors::TActorContext& ctx,
+        TReleaseDiskRequest request);
     void ProcessNextAcquireReleaseDiskRequest(const NActors::TActorContext& ctx);
     void OnClientListUpdate(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -306,9 +306,40 @@ private:
             , DevicesToRelease(std::move(devicesToRelease))
             , RetryIfTimeoutOrUndelivery(retryIfTimeoutOrUndelivery)
         {}
+
+        static TAcquireReleaseDiskRequest MakeAcquire(
+            TString clientId,
+            NProto::EVolumeAccessMode accessMode,
+            ui64 mountSeqNumber,
+            TClientRequestPtr clientRequest,
+            bool forceTabletRestart)
+        {
+            return TAcquireReleaseDiskRequest(
+                std::move(clientId),
+                accessMode,
+                mountSeqNumber,
+                std::move(clientRequest),
+                forceTabletRestart);
+        }
+
+        static TAcquireReleaseDiskRequest MakeRelease(
+            TString clientId,
+            TClientRequestPtr clientRequest,
+            TVector<NProto::TDeviceConfig> devicesToRelease,
+            bool retryIfTimeoutOrUndelivery)
+        {
+            return TAcquireReleaseDiskRequest(
+                std::move(clientId),
+                std::move(clientRequest),
+                std::move(devicesToRelease),
+                retryIfTimeoutOrUndelivery);
+        }
     };
     TList<TAcquireReleaseDiskRequest> AcquireReleaseDiskRequests;
     bool AcquireDiskScheduled = false;
+    TBackoffDelayProvider BackoffDelayProviderForAcquireReleaseDiskRequests{
+        Config->GetRetryAcquireReleaseDiskInitialDelay(),
+        Config->GetRetryAcquireReleaseDiskMaxDelay()};
 
     NProto::TError StorageAllocationResult;
     bool DiskAllocationScheduled = false;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -266,8 +266,9 @@ private:
 
     TVolumeSelfCountersPtr VolumeSelfCounters;
 
-    struct TAcquireReleaseDiskRequest
+    class TAcquireReleaseDiskRequest
     {
+    public:
         bool IsAcquire;
         TString ClientId;
         NProto::EVolumeAccessMode AccessMode;
@@ -277,6 +278,35 @@ private:
         const bool RetryIfTimeoutOrUndelivery = false;
         const bool ForceTabletRestart = false;
 
+        static TAcquireReleaseDiskRequest MakeAcquire(
+            TString clientId,
+            NProto::EVolumeAccessMode accessMode,
+            ui64 mountSeqNumber,
+            TClientRequestPtr clientRequest,
+            bool forceTabletRestart)
+        {
+            return {
+                std::move(clientId),
+                accessMode,
+                mountSeqNumber,
+                std::move(clientRequest),
+                forceTabletRestart};
+        }
+
+        static TAcquireReleaseDiskRequest MakeRelease(
+            TString clientId,
+            TClientRequestPtr clientRequest,
+            TVector<NProto::TDeviceConfig> devicesToRelease,
+            bool retryIfTimeoutOrUndelivery)
+        {
+            return {
+                std::move(clientId),
+                std::move(clientRequest),
+                std::move(devicesToRelease),
+                retryIfTimeoutOrUndelivery};
+        }
+
+    private:
         TAcquireReleaseDiskRequest(
                 TString clientId,
                 NProto::EVolumeAccessMode accessMode,
@@ -289,8 +319,7 @@ private:
             , MountSeqNumber(mountSeqNumber)
             , ClientRequest(std::move(clientRequest))
             , ForceTabletRestart(forceTabletRestart)
-        {
-        }
+        {}
 
         TAcquireReleaseDiskRequest(
                 TString clientId,
@@ -306,34 +335,6 @@ private:
             , DevicesToRelease(std::move(devicesToRelease))
             , RetryIfTimeoutOrUndelivery(retryIfTimeoutOrUndelivery)
         {}
-
-        static TAcquireReleaseDiskRequest MakeAcquire(
-            TString clientId,
-            NProto::EVolumeAccessMode accessMode,
-            ui64 mountSeqNumber,
-            TClientRequestPtr clientRequest,
-            bool forceTabletRestart)
-        {
-            return TAcquireReleaseDiskRequest(
-                std::move(clientId),
-                accessMode,
-                mountSeqNumber,
-                std::move(clientRequest),
-                forceTabletRestart);
-        }
-
-        static TAcquireReleaseDiskRequest MakeRelease(
-            TString clientId,
-            TClientRequestPtr clientRequest,
-            TVector<NProto::TDeviceConfig> devicesToRelease,
-            bool retryIfTimeoutOrUndelivery)
-        {
-            return TAcquireReleaseDiskRequest(
-                std::move(clientId),
-                std::move(clientRequest),
-                std::move(devicesToRelease),
-                retryIfTimeoutOrUndelivery);
-        }
     };
     TList<TAcquireReleaseDiskRequest> AcquireReleaseDiskRequests;
     bool AcquireDiskScheduled = false;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -24,6 +24,35 @@ using namespace NKikimr::NTabletFlatExecutor;
 
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<TEvVolume::TEvAddClientResponse> CreateAddClientResponse(
+    NProto::TError error,
+    ui64 tabletId,
+    TString clientId,
+    bool forceTabletRestart,
+    TString instanceId,
+    const TVolumeState& state)
+{
+    auto response = std::make_unique<TEvVolume::TEvAddClientResponse>();
+    *response->Record.MutableError() = std::move(error);
+    response->Record.SetTabletId(tabletId);
+    response->Record.SetClientId(std::move(clientId));
+    response->Record.SetForceTabletRestart(forceTabletRestart);
+
+    auto& volumeConfig = state.GetMeta().GetVolumeConfig();
+    auto* volumeInfo = response->Record.MutableVolume();
+    VolumeConfigToVolume(volumeConfig, *volumeInfo);
+    volumeInfo->SetInstanceId(std::move(instanceId));
+    state.FillDeviceInfo(*volumeInfo);
+
+    return response;
+}
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TVolumeActor::AcquireDisk(
@@ -61,6 +90,26 @@ void TVolumeActor::AcquireDisk(
         ctx,
         MakeDiskRegistryProxyServiceId(),
         std::move(request));
+}
+
+void TVolumeActor::AddAcquireReleaseDiskRequest(
+    const NActors::TActorContext& ctx,
+    TAcquireReleaseDiskRequest request)
+{
+    AcquireReleaseDiskRequests.emplace_back(std::move(request));
+
+    if (AcquireReleaseDiskRequests.size() == 1) {
+        ProcessNextAcquireReleaseDiskRequest(ctx);
+    } else {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s Postponing AcquireReleaseRequest[%s] for volume %s: "
+            "another request in flight",
+            LogTitle.GetWithTime().c_str(),
+            AcquireReleaseDiskRequests.back().ClientId.Quote().data(),
+            State->GetDiskId().Quote().data());
+    }
 }
 
 void TVolumeActor::ProcessNextAcquireReleaseDiskRequest(const TActorContext& ctx)
@@ -110,7 +159,8 @@ void TVolumeActor::AcquireDiskIfNeeded(const TActorContext& ctx)
             x.first,
             x.second.GetVolumeClientInfo().GetVolumeAccessMode(),
             x.second.GetVolumeClientInfo().GetMountSeqNumber(),
-            nullptr
+            nullptr,   // clientRequest
+            false      // forceTabletRestart
         );
 
         LOG_DEBUG(
@@ -168,7 +218,8 @@ void TVolumeActor::HandleReacquireDisk(
         AcquireReleaseDiskRequests.emplace_back(
             TString(AnyWriterClientId),
             nullptr,
-            TVector<NProto::TDeviceConfig>{});
+            TVector<NProto::TDeviceConfig>{},
+            false);   // retryIfTimeoutOrUndelivery
         if (AcquireReleaseDiskRequests.size() == 1) {
             ProcessNextAcquireReleaseDiskRequest(ctx);
         }
@@ -208,7 +259,7 @@ void TVolumeActor::HandleDevicesAcquireFinishedImpl(
     }
 
     auto& request = AcquireReleaseDiskRequests.front();
-    auto& cr = request.ClientRequest;
+    auto clientRequest = request.ClientRequest;
 
     if (HasError(error)) {
         LOG_ERROR(
@@ -217,27 +268,31 @@ void TVolumeActor::HandleDevicesAcquireFinishedImpl(
             "%s Can't acquire disk error : %s",
             LogTitle.GetWithTime().c_str(),
             FormatError(error).c_str());
+    }
 
-        if (cr) {
-            auto response =
-                std::make_unique<TEvVolume::TEvAddClientResponse>(error);
-            response->Record.MutableVolume()->SetDiskId(cr->DiskId);
-            response->Record.SetClientId(cr->GetClientId());
-            response->Record.SetTabletId(TabletID());
+    if (clientRequest &&
+        (Config->GetDoAcquireReleaseDevicesAfterTransaction() ||
+         HasError(error)))
+    {
+        auto response = CreateAddClientResponse(
+            error,
+            TabletID(),
+            clientRequest->GetClientId(),
+            request.ForceTabletRestart,
+            request.ClientRequest->AddedClientInfo.GetInstanceId(),
+            *State);
 
-            NCloud::Reply(ctx, *cr->RequestInfo, std::move(response));
+        NCloud::Reply(ctx, *clientRequest->RequestInfo, std::move(response));
 
-            PendingClientRequests.pop_front();
-            ProcessNextPendingClientRequest(ctx);
-        }
-    } else if (cr) {
+        PendingClientRequests.pop_front();
+        ProcessNextPendingClientRequest(ctx);
+    } else if (clientRequest) {
         ExecuteTx<TAddClient>(
             ctx,
-            cr->RequestInfo,
-            cr->DiskId,
-            cr->PipeServerActorId,
-            cr->AddedClientInfo
-        );
+            clientRequest->RequestInfo,
+            clientRequest->DiskId,
+            clientRequest->PipeServerActorId,
+            clientRequest->AddedClientInfo);
     }
 
     AcquireReleaseDiskRequests.pop_front();
@@ -317,20 +372,23 @@ void TVolumeActor::ProcessNextPendingClientRequest(const TActorContext& ctx)
         const auto mediaKind =
             State->GetMeta().GetConfig().GetStorageMediaKind();
 
-        if (IsDiskRegistryMediaKind(mediaKind)
-            && Config->GetAcquireNonReplicatedDevices())
+        if (IsDiskRegistryMediaKind(mediaKind) &&
+            Config->GetAcquireNonReplicatedDevices() &&
+            !Config->GetDoAcquireReleaseDevicesAfterTransaction())
         {
             if (request->RemovedClientId) {
                 AcquireReleaseDiskRequests.emplace_back(
                     request->RemovedClientId,
                     request,
-                    TVector<NProto::TDeviceConfig>{});
+                    TVector<NProto::TDeviceConfig>{},
+                    false);   // retryIfTimeoutOrUndelivery
             } else {
                 AcquireReleaseDiskRequests.emplace_back(
                     request->AddedClientInfo.GetClientId(),
                     request->AddedClientInfo.GetVolumeAccessMode(),
                     request->AddedClientInfo.GetMountSeqNumber(),
-                    request
+                    request,
+                    false   // ForceTabletRestart
                 );
             }
 
@@ -449,6 +507,7 @@ void TVolumeActor::ExecuteAddClient(
         for (const auto& clientId: res.RemovedClientIds) {
             db.RemoveClient(clientId);
             State->RemoveClient(clientId, TActorId());
+            args.RemovedClientIds.emplace_back(clientId);
 
             auto builder = TStringBuilder() << "Preempted by " << args.Info.GetClientId();
             db.WriteHistory(
@@ -467,6 +526,7 @@ void TVolumeActor::ExecuteAddClient(
         for (const auto& clientId: staleClientIds) {
             db.RemoveClient(clientId);
             State->RemoveClient(clientId, TActorId());
+            args.RemovedClientIds.emplace_back(clientId);
             db.WriteHistory(
                 State->LogRemoveClient(ctx.Now(), clientId, "Stale", {}));
         }
@@ -487,9 +547,18 @@ void TVolumeActor::CompleteAddClient(
     const TActorContext& ctx,
     TTxVolume::TAddClient& args)
 {
-    Y_DEFER {
-        PendingClientRequests.pop_front();
-        ProcessNextPendingClientRequest(ctx);
+    const bool needToAcquireOrReleaseDevices =
+        State->IsDiskRegistryMediaKind() &&
+        Config->GetAcquireNonReplicatedDevices() &&
+        Config->GetDoAcquireReleaseDevicesAfterTransaction() &&
+        !HasError(args.Error);
+
+    Y_DEFER
+    {
+        if (!needToAcquireOrReleaseDevices) {
+            PendingClientRequests.pop_front();
+            ProcessNextPendingClientRequest(ctx);
+        }
     };
 
     const auto& clientId = args.Info.GetClientId();
@@ -513,24 +582,36 @@ void TVolumeActor::CompleteAddClient(
         LogTitle.GetWithTime().c_str(),
         clientId.Quote().c_str());
 
-    auto response = std::make_unique<TEvVolume::TEvAddClientResponse>();
-    *response->Record.MutableError() = std::move(args.Error);
-    response->Record.SetTabletId(TabletID());
-    response->Record.SetClientId(clientId);
-    response->Record.SetForceTabletRestart(args.ForceTabletRestart);
+    if (needToAcquireOrReleaseDevices) {
+        ReleaseDiskFromOldClients(ctx, args.RemovedClientIds);
 
-    auto& volumeConfig = State->GetMeta().GetVolumeConfig();
-    auto* volumeInfo = response->Record.MutableVolume();
-    VolumeConfigToVolume(volumeConfig, *volumeInfo);
-    volumeInfo->SetInstanceId(args.Info.GetInstanceId());
-    State->FillDeviceInfo(*volumeInfo);
+        // Acquire disk for new client.
+        TAcquireReleaseDiskRequest request{
+            args.Info.GetClientId(),
+            args.Info.GetVolumeAccessMode(),
+            args.Info.GetMountSeqNumber(),
+            std::make_shared<TClientRequest>(
+                args.RequestInfo,
+                args.DiskId,
+                args.PipeServerActorId,
+                args.Info),
+            args.ForceTabletRestart};
+        AddAcquireReleaseDiskRequest(ctx, std::move(request));
+    } else {
+        auto response = CreateAddClientResponse(
+            args.Error,
+            TabletID(),
+            clientId,
+            args.ForceTabletRestart,
+            args.Info.GetInstanceId(),
+            *State);
 
-    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+    }
 
     OnClientListUpdate(ctx);
 
-    const auto mediaKind =
-        State->GetMeta().GetConfig().GetStorageMediaKind();
+    const auto mediaKind = State->GetMeta().GetConfig().GetStorageMediaKind();
 
     if (IsReliableDiskRegistryMediaKind(mediaKind)) {
         const bool shouldResyncDueToInactivity = args.WriterLastActivityTimestamp

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -215,7 +215,7 @@ void TVolumeActor::HandleReacquireDisk(
             && ctx.Now() > StateLoadTimestamp + TDuration::Seconds(5))
     {
         auto releaseRequest = TAcquireReleaseDiskRequest::MakeRelease(
-            AnyWriterClientId,
+            TString(AnyWriterClientId),
             nullptr,
             TVector<NProto::TDeviceConfig>{},
             false);   // retryIfTimeoutOrUndelivery

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -81,31 +81,12 @@ void TVolumeActor::ReleaseReplacedDevices(
             LogTitle.GetWithTime().c_str(),
             clientId.Quote().c_str());
 
-        auto request = TReleaseDiskRequest{
-            .ClientId = clientId,
-            .DevicesToRelease = replacedDevices,
-        };
-        AddAcquireReleaseDiskRequest(ctx, std::move(request));
-    }
-}
-
-void TVolumeActor::ReleaseDiskFromOldClients(
-    const NActors::TActorContext& ctx,
-    const TVector<TString>& removedClients)
-{
-    for (const auto& clientId: removedClients) {
-        LOG_DEBUG(
+        AddReleaseDiskRequest(
             ctx,
-            TBlockStoreComponents::VOLUME,
-            "%s Releasing devices from old client: %s",
-            LogTitle.GetWithTime().c_str(),
-            clientId.Quote().c_str());
-
-        AddAcquireReleaseDiskRequest(
-            ctx,
-            TReleaseDiskRequest{
+            {
                 .ClientId = clientId,
-                .RetryIfTimeoutOrUndelivery = true});
+                .DevicesToRelease = replacedDevices,
+            });
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -86,7 +86,7 @@ void TVolumeActor::ReleaseReplacedDevices(
             nullptr,   // clientRequest
             replacedDevices,
             false);   // retryIfTimeoutOrUndelivery
-        AcquireReleaseDiskRequests.push_back(std::move(request));
+        AddAcquireReleaseDiskRequest(ctx, std::move(request));
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -81,11 +81,11 @@ void TVolumeActor::ReleaseReplacedDevices(
             LogTitle.GetWithTime().c_str(),
             clientId.Quote().c_str());
 
-        TAcquireReleaseDiskRequest request{
+        auto request = TAcquireReleaseDiskRequest::MakeRelease(
             clientId,
             nullptr,   // clientRequest
             replacedDevices,
-            false};   // retryIfTimeoutOrUndelivery
+            false);   // retryIfTimeoutOrUndelivery
         AcquireReleaseDiskRequests.push_back(std::move(request));
     }
 }
@@ -104,12 +104,12 @@ void TVolumeActor::ReleaseDiskFromOldClients(
 
         AddAcquireReleaseDiskRequest(
             ctx,
-            {
+            TAcquireReleaseDiskRequest::MakeRelease(
                 clientId,
                 nullptr,   // clientRequest
                 TVector<NProto::TDeviceConfig>{},
                 true   // retryIfTimeoutOrUndelivery
-            });
+                ));
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_release.cpp
@@ -81,11 +81,10 @@ void TVolumeActor::ReleaseReplacedDevices(
             LogTitle.GetWithTime().c_str(),
             clientId.Quote().c_str());
 
-        auto request = TAcquireReleaseDiskRequest::MakeRelease(
-            clientId,
-            nullptr,   // clientRequest
-            replacedDevices,
-            false);   // retryIfTimeoutOrUndelivery
+        auto request = TReleaseDiskRequest{
+            .ClientId = clientId,
+            .DevicesToRelease = replacedDevices,
+        };
         AddAcquireReleaseDiskRequest(ctx, std::move(request));
     }
 }
@@ -104,12 +103,9 @@ void TVolumeActor::ReleaseDiskFromOldClients(
 
         AddAcquireReleaseDiskRequest(
             ctx,
-            TAcquireReleaseDiskRequest::MakeRelease(
-                clientId,
-                nullptr,   // clientRequest
-                TVector<NProto::TDeviceConfig>{},
-                true   // retryIfTimeoutOrUndelivery
-                ));
+            TReleaseDiskRequest{
+                .ClientId = clientId,
+                .RetryIfTimeoutOrUndelivery = true});
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -142,7 +142,9 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
         return;
     }
 
-    if (Config->GetDoAcquireReleaseDevicesAfterTransaction() || hasError) {
+    if (Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() ||
+        hasError)
+    {
         NCloud::Reply(
             ctx,
             *clientRequest->RequestInfo,
@@ -269,7 +271,7 @@ void TVolumeActor::CompleteRemoveClient(
     const bool needToReleaseDevices =
         State->IsDiskRegistryMediaKind() &&
         Config->GetAcquireNonReplicatedDevices() &&
-        Config->GetDoAcquireReleaseDevicesAfterTransaction() &&
+        Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() &&
         args.Error.GetCode() == S_OK;
 
     Y_DEFER
@@ -300,9 +302,9 @@ void TVolumeActor::CompleteRemoveClient(
 
     if (needToReleaseDevices) {
         // Release all devices for client.
-        AddAcquireReleaseDiskRequest(
+        AddReleaseDiskRequest(
             ctx,
-            TReleaseDiskRequest{
+            {
                 .ClientId = args.ClientId,
                 .ClientRequest = std::make_shared<TClientRequest>(
                     args.RequestInfo,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -114,8 +114,7 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
             FormatError(error).c_str());
 
         if (request.RetryIfTimeoutOrUndelivery &&
-            GetErrorKind(error) == EErrorKind::ErrorRetriable &&
-            Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled())
+            GetErrorKind(error) == EErrorKind::ErrorRetriable)
         {
             auto delay = BackoffDelayProviderForAcquireReleaseDiskRequests
                              .GetDelayAndIncrease();

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -104,7 +104,6 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
     auto& request = AcquireReleaseDiskRequests.front();
     auto clientRequest = request.ClientRequest;
 
-
     const bool hasError = HasError(error) && (error.GetCode() != E_NOT_FOUND);
     if (hasError) {
         LOG_ERROR(
@@ -116,7 +115,7 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
 
         if (request.RetryIfTimeoutOrUndelivery &&
             GetErrorKind(error) == EErrorKind::ErrorRetriable &&
-            Config->GetRetryAcquireReleaseDiskInitialDelay())
+            Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled())
         {
             auto delay = BackoffDelayProviderForAcquireReleaseDiskRequests
                              .GetDelayAndIncrease();
@@ -312,7 +311,6 @@ void TVolumeActor::CompleteRemoveClient(
                     args.PipeServerActorId,
                     args.ClientId,
                     args.IsMonRequest),
-                .DevicesToRelease = TVector<NProto::TDeviceConfig>{},
             });
     } else {
         NCloud::Reply(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -8,6 +8,8 @@
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
+#include <cloud/storage/core/libs/common/media.h>
+
 #include <util/generic/scope.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -18,6 +20,27 @@ using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<TEvVolume::TEvRemoveClientResponse> CreateReleaseResponse(
+    const NProto::TError& error,
+    TString diskId,
+    TString clientId,
+    ui64 tabletId)
+{
+    auto response = std::make_unique<TEvVolume::TEvRemoveClientResponse>(error);
+
+    response->Record.SetDiskId(std::move(diskId));
+    response->Record.SetClientId(std::move(clientId));
+    response->Record.SetTabletId(tabletId);
+
+    return response;
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -79,9 +102,11 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
     }
 
     auto& request = AcquireReleaseDiskRequests.front();
-    auto& cr = request.ClientRequest;
+    auto clientRequest = request.ClientRequest;
 
-    if (HasError(error) && (error.GetCode() != E_NOT_FOUND)) {
+
+    const bool hasError = HasError(error) && (error.GetCode() != E_NOT_FOUND);
+    if (hasError) {
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::VOLUME,
@@ -89,28 +114,42 @@ void TVolumeActor::HandleDevicesReleasedFinishedImpl(
             LogTitle.GetWithTime().c_str(),
             FormatError(error).c_str());
 
-        if (cr) {
-            auto response = std::make_unique<TEvVolume::TEvRemoveClientResponse>(
-                error);
-            response->Record.SetDiskId(cr->DiskId);
-            response->Record.SetClientId(cr->GetClientId());
-            response->Record.SetTabletId(TabletID());
-
-            NCloud::Reply(ctx, *cr->RequestInfo, std::move(response));
-
-            PendingClientRequests.pop_front();
-            ProcessNextPendingClientRequest(ctx);
+        if (request.RetryIfTimeoutOrUndelivery &&
+            GetErrorKind(error) == EErrorKind::ErrorRetriable &&
+            Config->GetRetryAcquireReleaseDiskInitialDelay())
+        {
+            ctx.Schedule(
+                Config->GetRetryAcquireReleaseDiskInitialDelay(),
+                std::make_unique<TEvVolume::TEvRetryAcquireDisk>().release());
+            return;
         }
-    } else if (cr) {
-        // This shouldn't be release of replaced devices.
-        Y_DEBUG_ABORT_UNLESS(request.DevicesToRelease.empty());
+    }
+
+    // This shouldn't be release of replaced devices.
+    Y_DEBUG_ABORT_UNLESS(!clientRequest || request.DevicesToRelease.empty());
+
+    if (clientRequest &&
+        (Config->GetDoAcquireReleaseDevicesAfterTransaction() || hasError))
+    {
+        NCloud::Reply(
+            ctx,
+            *clientRequest->RequestInfo,
+            CreateReleaseResponse(
+                error.GetCode() == E_NOT_FOUND ? NProto::TError() : error,
+                clientRequest->DiskId,
+                clientRequest->GetClientId(),
+                TabletID()));
+
+        PendingClientRequests.pop_front();
+        ProcessNextPendingClientRequest(ctx);
+    } else if (clientRequest) {
         ExecuteTx<TRemoveClient>(
             ctx,
-            std::move(cr->RequestInfo),
-            std::move(cr->DiskId),
-            cr->PipeServerActorId,
-            std::move(cr->RemovedClientId),
-            cr->IsMonRequest);
+            std::move(clientRequest->RequestInfo),
+            std::move(clientRequest->DiskId),
+            clientRequest->PipeServerActorId,
+            std::move(clientRequest->RemovedClientId),
+            clientRequest->IsMonRequest);
     }
 
     AcquireReleaseDiskRequests.pop_front();
@@ -217,22 +256,28 @@ void TVolumeActor::CompleteRemoveClient(
     const TActorContext& ctx,
     TTxVolume::TRemoveClient& args)
 {
-    Y_DEFER {
-        PendingClientRequests.pop_front();
-        ProcessNextPendingClientRequest(ctx);
+    const bool needToReleaseDevices =
+        State->IsDiskRegistryMediaKind() &&
+        Config->GetAcquireNonReplicatedDevices() &&
+        Config->GetDoAcquireReleaseDevicesAfterTransaction() &&
+        !HasError(args.Error) && args.Error.GetCode() != S_ALREADY;
+
+    Y_DEFER
+    {
+        if (!needToReleaseDevices) {
+            PendingClientRequests.pop_front();
+            ProcessNextPendingClientRequest(ctx);
+        }
     };
 
     const auto& clientId = args.ClientId;
     const auto& diskId = args.DiskId;
 
-    if (FAILED(args.Error.GetCode())) {
-        auto response = std::make_unique<TEvVolume::TEvRemoveClientResponse>(
-            std::move(args.Error));
-        response->Record.SetDiskId(diskId);
-        response->Record.SetClientId(clientId);
-        response->Record.SetTabletId(TabletID());
-
-        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+    if (HasError(args.Error)) {
+        NCloud::Reply(
+            ctx,
+            *args.RequestInfo,
+            CreateReleaseResponse(args.Error, diskId, clientId, TabletID()));
         return;
     }
 
@@ -243,13 +288,27 @@ void TVolumeActor::CompleteRemoveClient(
         LogTitle.GetWithTime().c_str(),
         clientId.Quote().c_str());
 
-    auto response = std::make_unique<TEvVolume::TEvRemoveClientResponse>();
-    *response->Record.MutableError() = std::move(args.Error);
-    response->Record.SetDiskId(diskId);
-    response->Record.SetClientId(clientId);
-    response->Record.SetTabletId(TabletID());
-
-    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+    if (needToReleaseDevices) {
+        // Release all devices for client.
+        AddAcquireReleaseDiskRequest(
+            ctx,
+            {
+                args.ClientId,
+                std::make_shared<TClientRequest>(
+                    args.RequestInfo,
+                    args.DiskId,
+                    args.PipeServerActorId,
+                    args.ClientId,
+                    args.IsMonRequest),
+                TVector<NProto::TDeviceConfig>{},
+                false   // retryIfTimeoutOrUndelivery
+            });
+    } else {
+        NCloud::Reply(
+            ctx,
+            *args.RequestInfo,
+            CreateReleaseResponse(args.Error, diskId, clientId, TabletID()));
+    }
 
     OnClientListUpdate(ctx);
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -302,17 +302,16 @@ void TVolumeActor::CompleteRemoveClient(
         // Release all devices for client.
         AddAcquireReleaseDiskRequest(
             ctx,
-            TAcquireReleaseDiskRequest::MakeRelease(
-                args.ClientId,
-                std::make_shared<TClientRequest>(
+            TReleaseDiskRequest{
+                .ClientId = args.ClientId,
+                .ClientRequest = std::make_shared<TClientRequest>(
                     args.RequestInfo,
                     args.DiskId,
                     args.PipeServerActorId,
                     args.ClientId,
                     args.IsMonRequest),
-                TVector<NProto::TDeviceConfig>{},
-                false   // retryIfTimeoutOrUndelivery
-                ));
+                .DevicesToRelease = TVector<NProto::TDeviceConfig>{},
+            });
     } else {
         NCloud::Reply(
             ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -254,6 +254,7 @@ struct TTxVolume
         bool WriterChanged = false;
         NProto::TError Error;
         bool ForceTabletRestart = false;
+        TVector<TString> RemovedClientIds;
 
         TAddClient(
                 TRequestInfoPtr requestInfo,

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -2130,7 +2130,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         volumeGeneration = 0;
 
-        volume.RemoveClient(writer.GetClientId());
+        volume.RemoveClient(reader.GetClientId());
         UNIT_ASSERT_VALUES_EQUAL(2, volumeGeneration);
     }
 

--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -55,7 +55,7 @@ def apply_common_params_to_config(cfg, params):
     cfg.files["storage"].NonReplicatedAgentMinTimeout = timeout
     cfg.files["storage"].NonReplicatedAgentMaxTimeout = timeout
 
-    cfg.files["storage"].DoAcquireReleaseDevicesAfterTransaction = True
+    cfg.files["storage"].NonReplicatedVolumeAcquireDiskAfterAddClientEnabled = True
 
     cfg.files["server"].ServerConfig.VhostEnabled = True
     cfg.files["server"].ServerConfig.VhostServerPath = yatest_common.binary_path(


### PR DESCRIPTION
#1345
В этом пре я поменял порядок действий для нрд дисков, сначала мы выполняем транзакцию AddClient\RemoveClient, и уже только после этого делаем все нужные захваты освобождения девайсов. И таким образом когда хост выйдет по питанию и стартанет заного мы придем в волум с новым запросом на монтирование, волум выбьет старого клиента (т.к. он слишком много времени был неактивен) транзакцией AddClient, после нее мы сделаем сначала Release от всех старых клиентов и сделаем Acquire для нового клиента и только после этого ответим, что успешно добавили нового клиента

Для удаления клиента ситуация аналогичная: сначала мы выполняем транзакцию RemoveClient, которое сделает все, что нужно с локальной базой, и только после этого посылаем запросы на освобождение девайссов