### PR TITLE
Remove obsolete paths in build script

### DIFF
--- a/build/sysincl/stl-to-libcxx.yml
+++ b/build/sysincl/stl-to-libcxx.yml
@@ -71,7 +71,6 @@
   - complex:                   contrib/libs/cxxsupp/libcxx/include/complex
   - concepts:                  contrib/libs/cxxsupp/libcxx/include/concepts
   - condition_variable:        contrib/libs/cxxsupp/libcxx/include/condition_variable
-  - coroutine:                 contrib/libs/cxxsupp/libcxx/include/coroutine
   - csetjmp:                   contrib/libs/cxxsupp/libcxx/include/csetjmp
   - csignal:                   contrib/libs/cxxsupp/libcxx/include/csignal
   - cstdarg:                   contrib/libs/cxxsupp/libcxx/include/cstdarg


### PR DESCRIPTION
Remove obsolete paths in build script to get rid of ya ide warnings.