### PR TITLE
Fix clang-20 compilation error

### DIFF
--- a/cloud/blockstore/libs/client/client.cpp
+++ b/cloud/blockstore/libs/client/client.cpp
@@ -846,7 +846,7 @@ protected:
         }
         auto request = requestOrError.ExtractResult();
 
-        return Client->ExecuteRequest<TWriteBlocksMethod>(
+        return Client->template ExecuteRequest<TWriteBlocksMethod>(
             *Service,
             std::move(callContext),
             std::move(request));
@@ -857,7 +857,7 @@ protected:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
     {
-        auto future = Client->ExecuteRequest<TReadBlocksMethod>(
+        auto future = Client->template ExecuteRequest<TReadBlocksMethod>(
             *Service,
             std::move(callContext),
             request);


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/blockstore/libs/client/client.cpp:849:24: error: use 'template' keyword to treat 'ExecuteRequest' as a dependent template name
  849 |         return Client->ExecuteRequest<TWriteBlocksMethod>(
      |                        ^
      |                        template 
$(SOURCE_ROOT)/cloud/blockstore/libs/client/client.cpp:860:31: error: use 'template' keyword to treat 'ExecuteRequest' as a dependent template name
  860 |         auto future = Client->ExecuteRequest<TReadBlocksMethod>(
      |                               ^
      |                               template 
2 errors generated.
```