### PR TITLE
Fix missing events during tablet reboot

### DIFF
--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -27,13 +27,11 @@ private:
     TTestActorRuntime& Runtime;
     TTestActorRuntime::TEventObserver PrevObserverFunc;
     TTestActorRuntime::TScheduledEventFilter PrevScheduledFilterFunc;
-    TTestActorRuntime::TScheduledEventsSelector PrevScheduledEventsSelector;
     TTestActorRuntime::TRegistrationObserver PrevRegistrationObserverFunc;
 
     std::unique_ptr<ITabletScheduledEventsGuard> Guard;
     TTestActorRuntime::TEventObserver GuardObserverFunc;
     TTestActorRuntime::TScheduledEventFilter GuardScheduledFilterFunc;
-    TTestActorRuntime::TScheduledEventsSelector GuardScheduledEventsSelector;
     TTestActorRuntime::TRegistrationObserver GuardRegistrationObserverFunc;
 
 public:
@@ -44,8 +42,6 @@ public:
         : Runtime(runtime)
         , PrevObserverFunc(runtime.SetObserverFunc({}))
         , PrevScheduledFilterFunc(runtime.SetScheduledEventFilter({}))
-        , PrevScheduledEventsSelector(
-              runtime.SetScheduledEventsSelectorFunc({}))
         , PrevRegistrationObserverFunc(runtime.SetRegistrationObserverFunc({}))
         , Guard(CreateTabletScheduledEventsGuard(tablets, runtime, sender)
                     .Release())
@@ -97,20 +93,6 @@ public:
                 }
                 return result;
             });
-
-        GuardScheduledEventsSelector = Runtime.SetScheduledEventsSelectorFunc(
-            [&](TTestActorRuntimeBase& runtime,
-                TScheduledEventsList& scheduledEvents,
-                TEventsList& queue)
-            {
-                GuardScheduledEventsSelector(runtime, scheduledEvents, queue);
-                if (PrevScheduledEventsSelector) {
-                    PrevScheduledEventsSelector(
-                        runtime,
-                        scheduledEvents,
-                        queue);
-                }
-            });
     }
 
     ~TTabletScheduledEventsGuard()
@@ -118,7 +100,6 @@ public:
         Guard.reset();
         Runtime.SetObserverFunc(PrevObserverFunc);
         Runtime.SetScheduledEventFilter(PrevScheduledFilterFunc);
-        Runtime.SetScheduledEventsSelectorFunc(PrevScheduledEventsSelector);
         Runtime.SetRegistrationObserverFunc(PrevRegistrationObserverFunc);
     }
 };

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.h
@@ -291,7 +291,7 @@ public:
         TAutoPtr<IEventHandle> handle;
         Runtime.GrabEdgeEventRethrow<TResponse>(handle, WaitTimeout);
 
-        UNIT_ASSERT(handle);
+        Y_ABORT_UNLESS(handle);
         return std::unique_ptr<TResponse>(handle->Release<TResponse>().Release());
     }
 
@@ -593,7 +593,8 @@ std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
     TDiskRegistryStatePtr diskRegistryState = {},
     NProto::TFeaturesConfig featuresConfig = {},
     NRdma::IClientPtr rdmaClient = {},
-    TVector<TDiskAgentStatePtr> diskAgentStates = {});
+    TVector<TDiskAgentStatePtr> diskAgentStates = {},
+    bool debugActorRegistration = false);
 
 struct TTestRuntimeBuilder
 {

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1259,7 +1259,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         state->MigrationMode = EMigrationMode::InProgress;
         TBlockRange64 migratedRange;
 
-        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+        auto original = runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
                 const auto migratedEvent =
                     TEvNonreplPartitionPrivate::EvRangeMigrated;
                 using TMigratedEvent =
@@ -1283,6 +1283,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT(migratedRange.Size() == 1024);
         UNIT_ASSERT_VALUES_EQUAL(0, state->FinishMigrationRequests);
 
+        runtime->SetObserverFunc(original);
         // rebooting volume to stop partition actors
         volume.RebootTablet();
 
@@ -1415,7 +1416,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         ui32 migrationProgressCounter = 0;
 
         bool drop = false;
-        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+        auto original = runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
                 const auto migratedEvent =
                     TEvNonreplPartitionPrivate::EvRangeMigrated;
                 using TMigratedEvent =
@@ -1458,6 +1459,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(1, migrationStartedCounter);
         UNIT_ASSERT_VALUES_EQUAL(60, migrationProgressCounter);
 
+        runtime->SetObserverFunc(original);
         volume.RebootTablet();
         volume.AddClient(clientInfo);
 
@@ -7710,7 +7712,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
             return TTestActorRuntime::DefaultObserverFunc(event);
         };
-        runtime->SetObserverFunc(obs);
+        auto original = runtime->SetObserverFunc(obs);
 
         volume.AddClient(clientInfo);
         volume.ReconnectPipe();
@@ -7723,6 +7725,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             UNIT_ASSERT(v.GetResyncInProgress());
         }
 
+        runtime->SetObserverFunc(original);
         volume.RebootTablet();
         volume.AddClient(clientInfo);
         volume.WaitReady();


### PR DESCRIPTION
Наступил в проблему, что когда происходит рестарт таблетки, то тестовая акторная система НЕ вызывает установленные фильтры и обработчики. Все потому, что на это время создается TTabletScheduledEventsGuard, который временно заменяет все обработчики на свой, и НЕ вызывает по цепочке старые.
Это приводит к забавным спецэффектам, что акторы, созданные во время RebootTablet, не видны нашему обработчику, который делает EnableScheduleForActor(), также сообщения не видны фильтру сообщений в самом тесте. 