### PR TITLE
Create SchemeOperationFactory for tenants SS in 25-1

### DIFF
--- a/cloud/blockstore/apps/server/main.cpp
+++ b/cloud/blockstore/apps/server/main.cpp
@@ -32,6 +32,8 @@ int main(int argc, char** argv)
 
     auto moduleFactories = std::make_shared<NKikimr::TModuleFactories>();
     moduleFactories->CreateTicketParser = NKikimr::CreateTicketParser;
+    moduleFactories->SchemeOperationFactory.reset(
+        NKikimr::NSchemeShard::DefaultOperationFactory());
 
     auto serverModuleFactories =
         std::make_shared<NServer::TServerModuleFactories>();

--- a/cloud/filestore/apps/server/main.cpp
+++ b/cloud/filestore/apps/server/main.cpp
@@ -12,6 +12,8 @@ int main(int argc, char** argv)
 
     auto moduleFactories = std::make_shared<NKikimr::TModuleFactories>();
     moduleFactories->CreateTicketParser = NKikimr::CreateTicketParser;
+    moduleFactories->SchemeOperationFactory.reset(
+        NKikimr::NSchemeShard::DefaultOperationFactory());
 
     NDaemon::TBootstrapServer bootstrap(std::move(moduleFactories));
     return NCloud::DoMain(bootstrap, argc, argv);

--- a/cloud/filestore/apps/vhost/main.cpp
+++ b/cloud/filestore/apps/vhost/main.cpp
@@ -14,6 +14,8 @@ int main(int argc, char** argv)
 
     auto moduleFactories = std::make_shared<NKikimr::TModuleFactories>();
     moduleFactories->CreateTicketParser = NKikimr::CreateTicketParser;
+    moduleFactories->SchemeOperationFactory.reset(
+        NKikimr::NSchemeShard::DefaultOperationFactory());
 
     auto vhostFactories = std::make_shared<NDaemon::TVhostModuleFactories>();
     vhostFactories->LoopFactory = NFuse::CreateFuseLoopFactory;


### PR DESCRIPTION
При запуске тенантного SS на железном хосте, он крашится

```
Core was generated by `/usr/bin/blockstore-server --domain testing_klg --ic-port 29015 --mon-port 8766'.
#0 0x000055bac5d7f6e3 in NKikimr::NSchemeShard::TOperation::ConstructParts (this=0x1779b730eb00, tx=..., context=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/core/tx/schemeshard/schemeshard__operation.cpp:1569
[Current thread is 9601 (LWP 3578461)]
```

Создаю дефолтную фабрику в процессе NBS.

