### PR TITLE
[NBS] Limit Mirror disk device replacement per row per reallocation

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1281,4 +1281,8 @@ message TStorageServiceConfig
 
     // If true, describes will be done using SchemeCache instead of TxProxy.
     optional bool UseSchemeCache = 443;
+
+    // if true, disk registry doesn't replace devices of mirrored disks in one row
+    // per reallocation.
+    optional bool LimitMirrorDisksDeviceReplacementsPerRow = 444;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -615,6 +615,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(PartitionBootTimeout,                 TDuration,   Seconds(0)         )\
     xxx(DirectWriteBandwidthQuota,            ui64,        0                  )\
+    xxx(LimitMirrorDisksDeviceReplacementsPerRow,          bool,   false      )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -700,6 +700,8 @@ public:
     [[nodiscard]] TDuration GetPartitionBootTimeout() const;
 
     [[nodiscard]] ui64 GetDirectWriteBandwidthQuota() const;
+
+    [[nodiscard]] bool GetLimitMirrorDisksDeviceReplacementsPerRow() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -320,6 +320,8 @@ private:
 
     void ProcessInitialAgentRejectionPhase(const NActors::TActorContext& ctx);
 
+    void ProcessRecentlyReplaceDevices(const NActors::TActorContext& ctx);
+
 private:
     STFUNC(StateBoot);
     STFUNC(StateInit);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_loadstate.cpp
@@ -209,6 +209,10 @@ void TDiskRegistryActor::CompleteLoadState(
 
     ScheduleDiskRegistryAgentListExpiredParamsCleanup(ctx);
 
+    if (Config->GetLimitMirrorDisksDeviceReplacementsPerRow()) {
+        ProcessRecentlyReplaceDevices(ctx);
+    }
+
     if (auto orphanDevices = State->FindOrphanDevices()) {
         LOG_INFO(
             ctx,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -1177,7 +1177,7 @@ void TDiskRegistryActor::RenderDisksToNotify(IOutputStream& out) const
                 TABLER() {
                     TABLED() {
                         DumpDiskLink(out, TabletID(), p.first);
-                        out << " <font color=gray>" << p.second << "</font>";
+                        out << " <font color=gray>" << p.second.SeqNo << "</font>";
                     }
 
                     auto it = FindIf(DisksBeingNotified, [&] (auto& x) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_notify.cpp
@@ -111,7 +111,7 @@ void TNotifyActor::ReallocateDisks(const TActorContext& ctx)
     PendingOperations = DiskNotifications.size();
 
     ui64 cookie = 0;
-    for (const auto& [diskId, seqNo]: DiskNotifications) {
+    for (const auto& [diskId, seqNo, _] : DiskNotifications) {
         LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY_WORKER,
             "[%lu] Notifying volume: DiskId=%s",
             TabletID,
@@ -224,7 +224,7 @@ void TDiskRegistryActor::HandleListDisksToNotify(
     const auto& disksToReallocate = State->GetDisksToReallocate();
 
     TVector<TString> diskIds(Reserve(disksToReallocate.size()));
-    for (const auto& [diskId, seqNo]: disksToReallocate) {
+    for (const auto& [diskId, notifyDiskInfo]: disksToReallocate) {
         diskIds.push_back(diskId);
     }
 
@@ -276,8 +276,11 @@ void TDiskRegistryActor::HandleNotifyDisks(
     DisksNotificationStartTs = ctx.Now();
 
     DisksBeingNotified.reserve(State->GetDisksToReallocate().size());
-    for (const auto& [diskId, seqNo]: State->GetDisksToReallocate()) {
-        DisksBeingNotified.emplace_back(diskId, seqNo);
+    for (const auto& [diskId, notifyDiskInfo]: State->GetDisksToReallocate()) {
+        DisksBeingNotified.emplace_back(
+            diskId,
+            notifyDiskInfo.SeqNo,
+            State->GetAndDeleteRowToSeqNo(diskId));
     }
 
     auto actor = NCloud::Register<TNotifyActor>(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_replace_devices.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_replace_devices.cpp
@@ -1,0 +1,50 @@
+#include "disk_registry_actor.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::ProcessRecentlyReplaceDevices(const TActorContext& ctx)
+{
+    ExecuteTx<TProcessRecentlyReplaceDevices>(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TDiskRegistryActor::PrepareProcessRecentlyReplaceDevices(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxDiskRegistry::TProcessRecentlyReplaceDevices& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+
+    return true;
+}
+
+void TDiskRegistryActor::ExecuteProcessRecentlyReplaceDevices(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxDiskRegistry::TProcessRecentlyReplaceDevices& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(args);
+
+    TDiskRegistryDatabase db(tx.DB);
+    State->ReplaceNextDevicesAfterRestart(ctx.Now(), db);
+}
+
+void TDiskRegistryActor::CompleteProcessRecentlyReplaceDevices(
+    const TActorContext& ctx,
+    TTxDiskRegistry::TProcessRecentlyReplaceDevices& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(args);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -31,12 +31,17 @@ struct TDiskNotification
 {
     TString DiskId;
     ui64 SeqNo = 0;
+    THashMap<ui32, ui64> RowToSeqNo;
 
     TDiskNotification() = default;
 
-    TDiskNotification(TString diskId, ui64 seqNo)
+    TDiskNotification(
+            TString diskId,
+            ui64 seqNo,
+            THashMap<ui32, ui64> rowToSeqNo)
         : DiskId(std::move(diskId))
         , SeqNo(seqNo)
+        , RowToSeqNo(std::move(rowToSeqNo))
     {}
 };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -423,6 +423,11 @@ TDiskRegistryState::TDiskRegistryState(
     ProcessDirtyDevices(std::move(dirtyDevices));
     // fills Migrations and uses both Disks and DeviceList
     FillMigrations();
+    // fills information about the master disks on which some devices are being
+    // reallocated
+    if (StorageConfig->GetLimitMirrorDisksDeviceReplacementsPerRow()) {
+        ProcessDisksToReallocate();
+    }
 
     if (Counters) {
         TVector<TString> poolNames;
@@ -783,6 +788,26 @@ void TDiskRegistryState::ProcessDirtyDevices(TVector<TDirtyDevice> dirtyDevices)
             }
         }
     }
+}
+
+void TDiskRegistryState::ProcessDisksToReallocate()
+{
+    THashMap<TDiskId, ui64> masterDiskToSeqNo;
+    for (const auto& [diskId, notifyDiskInfo]: GetDisksToReallocate()) {
+        const TDiskState* disk = FindDiskState(diskId);
+        if (!disk || (disk->MediaKind != NProto::STORAGE_MEDIA_SSD_MIRROR2 &&
+                      disk->MediaKind != NProto::STORAGE_MEDIA_SSD_MIRROR3))
+        {
+            continue;
+        }
+        auto it = masterDiskToSeqNo.find(diskId);
+        if (it == masterDiskToSeqNo.end()) {
+            masterDiskToSeqNo.emplace(diskId, notifyDiskInfo.SeqNo);
+            continue;
+        }
+        it->second = std::max(it->second, notifyDiskInfo.SeqNo);
+    }
+    ReplicaTable.SetMasterDiskToSeqNo(std::move(masterDiskToSeqNo));
 }
 
 const TVector<NProto::TAgentConfig>& TDiskRegistryState::GetAgents() const
@@ -1524,7 +1549,18 @@ NProto::TError TDiskRegistryState::ReplaceDeviceWithoutDiskStateUpdate(
         UpdateAgent(db, *agentPtr);
 
         UpdatePlacementGroup(db, diskId, disk, "ReplaceDevice");
-        UpdateAndReallocateDisk(db, diskId, disk);
+
+        if (disk.MasterDiskId) {
+            UpdateAndReallocateDisk(
+                db,
+                diskId,
+                disk,
+                ReplicaTable.GetDeviceRow(
+                    disk.MasterDiskId,
+                    targetDevice.GetDeviceUUID()));
+        } else {
+            UpdateAndReallocateDisk(db, diskId, disk);
+        }
 
         error = AddDevicesToPendingCleanup(diskId, {deviceId});
         if (HasError(error)) {
@@ -4918,6 +4954,21 @@ void TDiskRegistryState::UpdateAndReallocateDisk(
     AddReallocateRequest(db, diskId);
 }
 
+void TDiskRegistryState::UpdateAndReallocateDisk(
+    TDiskRegistryDatabase& db,
+    const TString& diskId,
+    TDiskState& disk,
+    ui32 deviceRow)
+{
+    db.UpdateDisk(BuildDiskConfig(diskId, disk));
+    ui64 seqNo = AddReallocateRequest(db, diskId, deviceRow);
+    ReplicaTable.SetRecentlyReplacedDevice(
+        disk.MasterDiskId,
+        deviceRow,
+        seqNo,
+        /*isRecentlyReplaced*/ true);
+}
+
 ui64 TDiskRegistryState::AddReallocateRequest(
     TDiskRegistryDatabase& db,
     const TString& diskId)
@@ -4927,7 +4978,19 @@ ui64 TDiskRegistryState::AddReallocateRequest(
         GetDiskIdToNotify(diskId));
 }
 
-const THashMap<TString, ui64>& TDiskRegistryState::GetDisksToReallocate() const
+ui64 TDiskRegistryState::AddReallocateRequest(
+    TDiskRegistryDatabase& db,
+    const TString& diskId,
+    ui32 deviceRow)
+{
+    return NotificationSystem.AddReallocateRequest(
+        db,
+        GetDiskIdToNotify(diskId),
+        deviceRow);
+}
+
+const THashMap<TString, NDiskRegistry::TNotificationSystem::TNotifyDiskInfo>&
+TDiskRegistryState::GetDisksToReallocate() const
 {
     return NotificationSystem.GetDisksToReallocate();
 }
@@ -5054,6 +5117,26 @@ void TDiskRegistryState::DeleteDiskToReallocate(
                 << FormatError(error));
             ReportDiskRegistryCouldNotAddOutdatedLaggingDevice(diskId);
         }
+    }
+
+    const TDiskState* disk = FindDiskState(diskId);
+    if (StorageConfig->GetLimitMirrorDisksDeviceReplacementsPerRow() && disk &&
+        (disk->MediaKind == NProto::STORAGE_MEDIA_SSD_MIRROR2 ||
+         disk->MediaKind == NProto::STORAGE_MEDIA_SSD_MIRROR3))
+    {
+        ReplicaTable.DeleteItemFromMasterDiskToSeqNo(diskId, seqNo);
+        auto rowToSeqNo = std::move(notification.DiskNotification.RowToSeqNo);
+        for (auto [row, oldSeqNo]: rowToSeqNo) {
+            if (oldSeqNo < ReplicaTable.GetSeqNo(diskId, row)) {
+                continue;
+            }
+            ReplicaTable.SetRecentlyReplacedDevice(
+                diskId,
+                row,
+                seqNo,
+                /*isRecentlyReplaced*/ false);
+        }
+        ReplaceNextDevices(now, db, diskId);
     }
 }
 
@@ -7711,6 +7794,20 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         return false;
     }
 
+    const bool isRecentlyReplacedDevice =
+        ReplicaTable.IsRecentlyReplacedDevice(masterDiskId, deviceId);
+    if (StorageConfig->GetLimitMirrorDisksDeviceReplacementsPerRow() &&
+        isRecentlyReplacedDevice)
+    {
+        STORAGE_WARN(
+            "DiskId=%s, DeviceId=%s, automatic device replacement is postponed "
+            "due to replacements in "
+            "other replicas.",
+            masterDiskId.c_str(),
+            deviceId.c_str());
+        return false;
+    }
+
     return true;
 }
 
@@ -8119,6 +8216,66 @@ bool TDiskRegistryState::MigrationCanBeStarted(
     }
 
     return true;
+}
+
+void TDiskRegistryState::ReplaceNextDevices(
+    TInstant now,
+    TDiskRegistryDatabase& db,
+    const TString& masterDiskId)
+{
+    const TDiskState* masterDisk = FindDiskState(masterDiskId);
+    if (!masterDisk) {
+        return;
+    }
+
+    for (ui32 i = 0; i < masterDisk->ReplicaCount + 1; ++i) {
+        const auto replicaId = GetReplicaDiskId(masterDiskId, i);
+        TDiskState* replicaState = AccessDiskState(replicaId);
+        if (!replicaState) {
+            return;
+        }
+
+        for (const auto& deviceId: replicaState->Devices) {
+            const auto* device = DeviceList.FindDevice(deviceId);
+            if (!device) {
+                continue;
+            }
+
+            const auto* agent = AgentList.FindAgent(device->GetAgentId());
+            if (!agent) {
+                continue;
+            }
+
+            if (device->GetState() == NProto::DEVICE_STATE_ERROR ||
+                agent->GetState() == NProto::AGENT_STATE_UNAVAILABLE)
+            {
+                TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
+                    db,
+                    *replicaState,
+                    replicaId,
+                    deviceId,
+                    now,
+                    "postponed replacement");
+
+                TryUpdateDiskState(db, replicaId, *replicaState, now);
+            }
+        }
+    }
+}
+
+THashMap<ui32, ui64> TDiskRegistryState::GetAndDeleteRowToSeqNo(
+    const TDiskId& diskId)
+{
+    return NotificationSystem.GetAndDeleteRowToSeqNo(diskId);
+}
+
+void TDiskRegistryState::ReplaceNextDevicesAfterRestart(
+    TInstant now,
+    TDiskRegistryDatabase& db)
+{
+    for (const auto& masterDiskId: GetMasterDiskIds()) {
+        ReplaceNextDevices(now, db, masterDiskId);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -568,8 +568,15 @@ public:
         TDiskRegistryDatabase& db,
         TVector<TDiskId> ids);
 
-    const THashMap<TString, ui64>& GetDisksToReallocate() const;
+    const THashMap<
+        TString,
+        NDiskRegistry::TNotificationSystem::TNotifyDiskInfo>&
+    GetDisksToReallocate() const;
     ui64 AddReallocateRequest(TDiskRegistryDatabase& db, const TString& diskId);
+    ui64 AddReallocateRequest(
+        TDiskRegistryDatabase& db,
+        const TString& diskId,
+        ui32 deviceRow);
 
     void DeleteDiskToReallocate(
         TInstant now,
@@ -847,6 +854,8 @@ public:
         const TDeviceId& sourceDeviceId,
         const TDeviceId& targetDeviceId);
 
+    THashMap<ui32, ui64> GetAndDeleteRowToSeqNo(const TDiskId& diskId);
+
     // for tests and monpages
     const TReplicaTable& GetReplicaTable() const
     {
@@ -882,6 +891,10 @@ public:
         TDiskRegistryDatabase& db,
         TInstant now);
 
+    void ReplaceNextDevicesAfterRestart(
+        TInstant now,
+        TDiskRegistryDatabase& db);
+
     TVector<TString> GetPoolNames() const;
 
     const NProto::TDeviceConfig* FindDevice(const TDeviceId& uuid) const;
@@ -910,6 +923,7 @@ private:
     void ProcessAgents();
     void ProcessDisksToCleanup(TVector<TString> diskIds);
     void ProcessDirtyDevices(TVector<TDirtyDevice> dirtyDevices);
+    void ProcessDisksToReallocate();
 
     void AddMigration(
         const TDiskState& disk,
@@ -1096,6 +1110,12 @@ private:
         TDiskRegistryDatabase& db,
         const TString& diskId,
         TDiskState& disk);
+
+    void UpdateAndReallocateDisk(
+        TDiskRegistryDatabase& db,
+        const TString& diskId,
+        TDiskState& disk,
+        ui32 deviceRow);
 
     void AdjustDeviceIfNeeded(
         NProto::TDeviceConfig& device,
@@ -1372,6 +1392,11 @@ private:
     void ReallocateDisksWithLostOrReappearedDevices(
         const TAgentList::TAgentRegistrationResult& r,
         THashSet<TDiskId>& disksToReallocate);
+
+    void ReplaceNextDevices(
+        TInstant now,
+        TDiskRegistryDatabase& db,
+        const TString& masterDiskId);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_notification.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_notification.cpp
@@ -224,30 +224,52 @@ auto TNotificationSystem::GetUserNotifications() const
 
 ui64 TNotificationSystem::AddReallocateRequest(
     TDiskRegistryDatabase& db,
+    const TDiskId& diskId,
+    ui32 deviceRow)
+{
+    db.AddDiskToReallocate(diskId);
+    return AddReallocateRequest(diskId, deviceRow);
+}
+
+ui64 TNotificationSystem::AddReallocateRequest(
+    TDiskRegistryDatabase& db,
     const TDiskId& diskId)
 {
     db.AddDiskToReallocate(diskId);
     return AddReallocateRequest(diskId);
 }
 
+ui64 TNotificationSystem::AddReallocateRequest(
+    const TDiskId& diskId,
+    ui32 deviceRow)
+{
+    const auto seqNo = DisksToReallocateSeqNo++;
+    auto& notifyInfo = DisksToReallocate[diskId];
+
+    notifyInfo.SeqNo = seqNo;
+    notifyInfo.RowToSeqNo[deviceRow] = seqNo;
+
+    return seqNo;
+}
+
 ui64 TNotificationSystem::AddReallocateRequest(const TDiskId& diskId)
 {
     const auto seqNo = DisksToReallocateSeqNo++;
 
-    DisksToReallocate[diskId] = seqNo;
+    DisksToReallocate[diskId].SeqNo = seqNo;
 
     return seqNo;
 }
 
 ui64 TNotificationSystem::GetDiskSeqNo(const TDiskId& diskId) const
 {
-    const ui64* seqNo = DisksToReallocate.FindPtr(diskId);
+    const TNotifyDiskInfo* notifyDiskInfo = DisksToReallocate.FindPtr(diskId);
 
-    return seqNo ? *seqNo : 0;
+    return notifyDiskInfo ? notifyDiskInfo->SeqNo : 0;
 }
 
 auto TNotificationSystem::GetDisksToReallocate() const
-    -> const THashMap<TDiskId, ui64>&
+    -> const THashMap<TDiskId, TNotifyDiskInfo>&
 {
     return DisksToReallocate;
 }
@@ -258,7 +280,7 @@ void TNotificationSystem::DeleteDiskToReallocate(
     ui64 seqNo)
 {
     auto it = DisksToReallocate.find(diskId);
-    if (it != DisksToReallocate.end() && it->second == seqNo) {
+    if (it != DisksToReallocate.end() && it->second.SeqNo == seqNo) {
         DisksToReallocate.erase(it);
         db.DeleteDiskToReallocate(diskId);
     }
@@ -368,6 +390,19 @@ void TNotificationSystem::AddOutdatedVolumeConfig(
 {
     OutdatedVolumeConfigs[diskId] = VolumeConfigSeqNo++;
     db.AddOutdatedVolumeConfig(diskId);
+}
+
+THashMap<ui32, ui64> TNotificationSystem::GetAndDeleteRowToSeqNo(
+    const TDiskId& diskId)
+{
+    auto it = DisksToReallocate.find(diskId);
+    if (it == DisksToReallocate.end()) {
+        return {};
+    }
+    auto rowToSeqNo = std::move(it->second.RowToSeqNo);
+    it->second.RowToSeqNo.clear();
+
+    return rowToSeqNo;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NDiskRegistry

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_notification.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_notification.h
@@ -30,6 +30,19 @@ class TNotificationSystem
         {}
     };
 
+public:
+    struct TNotifyDiskInfo
+    {
+        ui64 SeqNo = 0;
+        THashMap<ui32, ui64> RowToSeqNo;
+
+        TNotifyDiskInfo() = default;
+
+        explicit TNotifyDiskInfo(ui64 seqNo)
+            : SeqNo(seqNo)
+        {}
+    };
+
 private:
     const TStorageConfigPtr StorageConfig;
 
@@ -39,7 +52,7 @@ private:
     TUserNotifications UserNotifications;
 
     // notify volumes (reallocate)
-    THashMap<TDiskId, ui64> DisksToReallocate;
+    THashMap<TDiskId, TNotifyDiskInfo> DisksToReallocate;
     ui64 DisksToReallocateSeqNo = 1;
 
     // notify Compute (write events to Logbroker)
@@ -81,12 +94,18 @@ public:
 
     auto GetUserNotifications() const -> const TUserNotifications&;
 
+    ui64 AddReallocateRequest(
+        TDiskRegistryDatabase& db,
+        const TDiskId& diskId,
+        ui32 deviceRow);
     ui64 AddReallocateRequest(TDiskRegistryDatabase& db, const TDiskId& diskId);
+    ui64 AddReallocateRequest(const TDiskId& diskId, ui32 deviceRow);
     ui64 AddReallocateRequest(const TDiskId& diskId);
 
     ui64 GetDiskSeqNo(const TDiskId& diskId) const;
 
-    auto GetDisksToReallocate() const -> const THashMap<TDiskId, ui64>&;
+    auto GetDisksToReallocate() const
+        -> const THashMap<TDiskId, TNotifyDiskInfo>&;
 
     void DeleteDiskToReallocate(
         TDiskRegistryDatabase& db,
@@ -117,6 +136,8 @@ public:
     void DeleteOutdatedVolumeConfig(
         TDiskRegistryDatabase& db,
         const TDiskId& diskId);
+
+    THashMap<ui32, ui64> GetAndDeleteRowToSeqNo(const TDiskId& diskId);
 
 private:
     void PullInUserNotifications(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -5787,12 +5787,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
         ui64 seqNo1 = 0;
         ui64 seqNo2 = 0;
+        THashMap<ui32, ui64> rowToSeqNo1;
+        THashMap<ui32, ui64> rowToSeqNo2;
 
         {
             const auto& disks = state.GetDisksToReallocate();
             UNIT_ASSERT_VALUES_EQUAL(1, disks.size());
 
-            seqNo1 = disks.at("disk-1");
+            seqNo1 = disks.at("disk-1").SeqNo;
+            rowToSeqNo1 = state.GetAndDeleteRowToSeqNo("disk-1");
             UNIT_ASSERT_VALUES_UNEQUAL(0, seqNo1);
         }
 
@@ -5804,7 +5807,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(1, r.DisksToReallocate.size());
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetDisksToReallocate().size());
 
-            seqNo2 = state.GetDisksToReallocate().at("disk-1");
+            seqNo2 = state.GetDisksToReallocate().at("disk-1").SeqNo;
+            rowToSeqNo2 = state.GetAndDeleteRowToSeqNo("disk-1");
 
             UNIT_ASSERT_VALUES_UNEQUAL(0, seqNo2);
             UNIT_ASSERT_VALUES_UNEQUAL(seqNo1, seqNo2);
@@ -5813,7 +5817,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         {
             const auto& disks = state.GetDisksToReallocate();
             UNIT_ASSERT_VALUES_EQUAL(1, disks.size());
-            UNIT_ASSERT_VALUES_EQUAL(seqNo2, disks.at("disk-1"));
+            UNIT_ASSERT_VALUES_EQUAL(seqNo2, disks.at("disk-1").SeqNo);
         }
 
         executor.WriteTx(
@@ -5823,7 +5827,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                     Now(),
                     db,
                     TDiskNotificationResult{
-                        TDiskNotification{"disk-1", seqNo1},
+                        TDiskNotification{
+                            "disk-1",
+                            seqNo1,
+                            std::move(rowToSeqNo1)},
                         {},
                     });
             });
@@ -5831,18 +5838,23 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         {
             const auto& disks = state.GetDisksToReallocate();
             UNIT_ASSERT_VALUES_EQUAL(1, disks.size());
-            UNIT_ASSERT_VALUES_EQUAL(seqNo2, disks.at("disk-1"));
+            UNIT_ASSERT_VALUES_EQUAL(seqNo2, disks.at("disk-1").SeqNo);
         }
 
-        executor.WriteTx([&] (TDiskRegistryDatabase db) {
-            state.DeleteDiskToReallocate(
-                Now(),
-                db,
-                TDiskNotificationResult{
-                    TDiskNotification{"disk-1", seqNo2},
-                    {},
-                });
-        });
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                state.DeleteDiskToReallocate(
+                    Now(),
+                    db,
+                    TDiskNotificationResult{
+                        TDiskNotification{
+                            "disk-1",
+                            seqNo2,
+                            std::move(rowToSeqNo2)},
+                        {},
+                    });
+            });
 
         {
             const auto& disks = state.GetDisksToReallocate();
@@ -9012,12 +9024,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             {
                 auto disksToReallocate = state.GetDisksToReallocate();
                 UNIT_ASSERT_VALUES_EQUAL(1, disksToReallocate.size());
-                for (auto& [diskId, seqNo]: disksToReallocate) {
+                for (auto& [diskId, notifyDiskInfo]: disksToReallocate) {
                     state.DeleteDiskToReallocate(
                         Now(),
                         db,
                         TDiskNotificationResult{
-                            TDiskNotification{diskId, seqNo},
+                            TDiskNotification{
+                                diskId,
+                                notifyDiskInfo.SeqNo,
+                                state.GetAndDeleteRowToSeqNo(diskId)},
                             {},
                         });
                 }
@@ -9779,7 +9794,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         TDiskRegistryState& state = *statePtr;
 
         UNIT_ASSERT_VALUES_EQUAL(1, state.GetDisksToReallocate().size());
-        UNIT_ASSERT_GT(state.GetDisksToReallocate().at("disk-1"), 0);
+        UNIT_ASSERT_GT(state.GetDisksToReallocate().at("disk-1").SeqNo, 0);
         UNIT_ASSERT_VALUES_EQUAL(0, state.GetDiskStateUpdates().size());
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -9963,12 +9978,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             {
                 auto disksToReallocate = state.GetDisksToReallocate();
                 UNIT_ASSERT_VALUES_EQUAL(1, disksToReallocate.size());
-                for (auto& [diskId, seqNo]: disksToReallocate) {
+                for (auto& [diskId, notifyDiskInfo]: disksToReallocate) {
                     state.DeleteDiskToReallocate(
                         Now(),
                         db,
                         TDiskNotificationResult{
-                            TDiskNotification{diskId, seqNo},
+                            TDiskNotification{
+                                diskId,
+                                notifyDiskInfo.SeqNo,
+                                state.GetAndDeleteRowToSeqNo(diskId)},
                             {},
                         });
                 }
@@ -10062,12 +10080,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             {
                 auto disksToReallocate = state.GetDisksToReallocate();
                 UNIT_ASSERT_VALUES_EQUAL(1, disksToReallocate.size());
-                for (auto& [diskId, seqNo]: disksToReallocate) {
+                for (auto& [diskId, notifyDiskInfo]: disksToReallocate) {
                     state.DeleteDiskToReallocate(
                         Now(),
                         db,
                         TDiskNotificationResult{
-                            TDiskNotification{diskId, seqNo},
+                            TDiskNotification{
+                                diskId,
+                                notifyDiskInfo.SeqNo,
+                                state.GetAndDeleteRowToSeqNo(diskId)},
                             {},
                         });
                 }
@@ -10645,12 +10666,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             [&](TDiskRegistryDatabase db) mutable
             {
                 auto notifications = state.GetDisksToReallocate();
-                for (const auto& [diskId, seqNo]: notifications) {
+                for (const auto& [diskId, notifyDiskInfo]: notifications) {
                     state.DeleteDiskToReallocate(
                         Now(),
                         db,
                         TDiskNotificationResult{
-                            TDiskNotification{diskId, seqNo},
+                            TDiskNotification{
+                                diskId,
+                                notifyDiskInfo.SeqNo,
+                                state.GetAndDeleteRowToSeqNo(diskId)},
                             {},
                         });
                 }
@@ -11917,12 +11941,15 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             {
                 auto disksToReallocate = state.GetDisksToReallocate();
                 UNIT_ASSERT_VALUES_EQUAL(2, disksToReallocate.size());
-                for (auto& [diskId, seqNo]: disksToReallocate) {
+                for (auto& [diskId, notifyDiskInfo]: disksToReallocate) {
                     state.DeleteDiskToReallocate(
                         Now(),
                         db,
                         TDiskNotificationResult{
-                            TDiskNotification{diskId, seqNo},
+                            TDiskNotification{
+                                diskId,
+                                notifyDiskInfo.SeqNo,
+                                state.GetAndDeleteRowToSeqNo(diskId)},
                             {},
                         });
                 }
@@ -12224,14 +12251,17 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 const auto& disks = state.GetDisksToReallocate();
                 UNIT_ASSERT_VALUES_EQUAL(1, disks.size());
 
-                const auto seqNo = disks.at("vol1");
+                const auto seqNo = disks.at("vol1").SeqNo;
                 UNIT_ASSERT_VALUES_UNEQUAL(0, seqNo);
 
                 state.DeleteDiskToReallocate(
                     Now(),
                     db,
                     TDiskNotificationResult{
-                        TDiskNotification{"vol1", seqNo},
+                        TDiskNotification{
+                            "vol1",
+                            seqNo,
+                            state.GetAndDeleteRowToSeqNo("vol1")},
                         {},
                     });
             });

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -1085,7 +1085,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     Now(),
                     db,
                     TDiskNotificationResult{
-                        TDiskNotification{"nrd0", notification->second},
+                        TDiskNotification{
+                            "nrd0",
+                            notification->second.SeqNo,
+                            state.GetAndDeleteRowToSeqNo("nrd0")},
                         {},
                     });
             });

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_lagging_agents.cpp
@@ -111,7 +111,10 @@ void DeleteDisksToNotify(
                     Now(),
                     db,
                     TDiskNotificationResult{
-                        TDiskNotification{x.first, x.second},
+                        TDiskNotification{
+                            x.first,
+                            x.second.SeqNo,
+                            state.GetAndDeleteRowToSeqNo(x.first)},
                         {},
                     });
             }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -705,7 +705,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     Now(),
                     db,
                     TDiskNotificationResult{
-                        TDiskNotification{"disk-1", notification->second},
+                        TDiskNotification{
+                            "disk-1",
+                            notification->second.SeqNo,
+                            state.GetAndDeleteRowToSeqNo("disk-1")},
                         {},
                     });
             });
@@ -858,7 +861,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                 Now(),
                 db,
                 TDiskNotificationResult{
-                    TDiskNotification{"disk-1", notification->second},
+                    TDiskNotification{
+                        "disk-1",
+                        notification->second.SeqNo,
+                        state.GetAndDeleteRowToSeqNo("disk-1")},
                     {},
                 });
         });
@@ -970,7 +976,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                 Now(),
                 db,
                 TDiskNotificationResult{
-                    TDiskNotification{"disk-1", notification->second},
+                    TDiskNotification{
+                        "disk-1",
+                        notification->second.SeqNo,
+                        state.GetAndDeleteRowToSeqNo("disk-1")},
                     {},
                 });
         });

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -18,6 +18,33 @@
 
 namespace NCloud::NBlockStore::NStorage {
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void NotifyDisks(
+    TDiskRegistryState& state,
+    TDiskRegistryDatabase& db,
+    TInstant now)
+{
+    TVector<TDiskNotificationResult> diskBeingNotify;
+    for (const auto& [disk, notifyDiskInfo]: state.GetDisksToReallocate()) {
+        TDiskNotification diskNotification(
+            disk,
+            notifyDiskInfo.SeqNo,
+            state.GetAndDeleteRowToSeqNo(disk));
+        TDiskNotificationResult notification(diskNotification, {});
+        diskBeingNotify.push_back(notification);
+    }
+    for (auto& notification: diskBeingNotify) {
+        state.DeleteDiskToReallocate(now, db, notification);
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 using namespace NDiskRegistryStateTest;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -950,7 +977,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                             Now(),
                             db,
                             TDiskNotificationResult{
-                                TDiskNotification{x.first, x.second},
+                                TDiskNotification{
+                                    x.first,
+                                    x.second.SeqNo,
+                                    state.GetAndDeleteRowToSeqNo(x.first)},
                                 {},
                             });
                     }
@@ -1303,7 +1333,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                             Now(),
                             db,
                             TDiskNotificationResult{
-                                TDiskNotification{x.first, x.second},
+                                TDiskNotification{
+                                    x.first,
+                                    x.second.SeqNo,
+                                    state.GetAndDeleteRowToSeqNo(x.first)},
                                 {},
                             });
                     }
@@ -1633,6 +1666,214 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             state.DeallocateDisk(db, "disk-1");
         });
+    }
+
+    // With enable LimitMirrorDisksDeviceReplacementsPerRow
+    Y_UNIT_TEST(
+        ShouldRemoveReplacementDeviceIdsUponReplacementDeviceReplacement2)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        auto agentConfig1 = AgentConfig(
+            1,
+            {
+                Device("dev-1", "uuid-1", "rack-1"),
+                Device("dev-2", "uuid-2", "rack-1"),
+                Device("dev-3", "uuid-3", "rack-1"),
+            });
+
+        auto agentConfig2 = AgentConfig(
+            2,
+            {
+                Device("dev-4", "uuid-4", "rack-2"),
+                Device("dev-5", "uuid-5", "rack-2"),
+                Device("dev-6", "uuid-6", "rack-2"),
+            });
+
+        auto agentConfig3 = AgentConfig(
+            3,
+            {
+                Device("dev-7", "uuid-7", "rack-3"),
+                Device("dev-8", "uuid-8", "rack-3"),
+                Device("dev-9", "uuid-9", "rack-3"),
+            });
+
+        auto agentConfig4 = AgentConfig(
+            4,
+            {
+                Device("dev-10", "uuid-10", "rack-4"),
+                Device("dev-11", "uuid-11", "rack-4"),
+                Device("dev-12", "uuid-12", "rack-4"),
+            });
+
+        auto agentConfig5 = AgentConfig(
+            5,
+            {
+                Device("dev-13", "uuid-13", "rack-5"),
+                Device("dev-14", "uuid-14", "rack-5"),
+                Device("dev-15", "uuid-15", "rack-5"),
+            });
+
+        auto storageConfig = CreateDefaultStorageConfigProto();
+        storageConfig.SetLimitMirrorDisksDeviceReplacementsPerRow(true);
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                                agentConfig5,
+                            })
+                            .WithStorageConfig(std::move(storageConfig))
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TVector<TDeviceConfig> devices;
+                TVector<TVector<TDeviceConfig>> replicas;
+                TVector<NProto::TDeviceMigration> migrations;
+                TVector<TString> deviceReplacementIds;
+                auto error = AllocateMirroredDisk(
+                    db,
+                    state,
+                    "disk-1",
+                    10_GB,
+                    2,
+                    devices,
+                    replicas,
+                    migrations,
+                    deviceReplacementIds);
+                UNIT_ASSERT_SUCCESS(error);
+                UNIT_ASSERT_VALUES_EQUAL(1, devices.size());
+                UNIT_ASSERT_VALUES_EQUAL("dev-1", devices[0].GetDeviceName());
+                UNIT_ASSERT_VALUES_EQUAL(2, replicas.size());
+                UNIT_ASSERT_VALUES_EQUAL(1, replicas[0].size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "dev-4",
+                    replicas[0][0].GetDeviceName());
+                UNIT_ASSERT_VALUES_EQUAL(1, replicas[1].size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "dev-7",
+                    replicas[1][0].GetDeviceName());
+                ASSERT_VECTORS_EQUAL(TVector<TString>{}, deviceReplacementIds);
+            });
+
+        const auto changeStateTs = Now();
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db) mutable
+            {
+                TVector<TString> affectedDisks;
+                TDuration timeout;
+                auto error = state.UpdateAgentState(
+                    db,
+                    agentConfig1.GetAgentId(),
+                    NProto::AGENT_STATE_UNAVAILABLE,
+                    changeStateTs,
+                    "unreachable",
+                    affectedDisks);
+
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+                UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            });
+
+        TDiskInfo diskInfo;
+        auto error = state.GetDiskInfo("disk-1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Devices.size());
+        UNIT_ASSERT_VALUES_EQUAL("dev-10", diskInfo.Devices[0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(0, diskInfo.Migrations.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, diskInfo.Replicas.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas[0].size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dev-4",
+            diskInfo.Replicas[0][0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas[1].size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dev-7",
+            diskInfo.Replicas[1][0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            NProto::EDiskState_Name(NProto::DISK_STATE_ONLINE),
+            NProto::EDiskState_Name(diskInfo.State));
+        ASSERT_VECTORS_EQUAL(
+            TVector<TString>{"uuid-10"},
+            diskInfo.DeviceReplacementIds);
+
+        auto dirtyDevices = state.GetDirtyDevices();
+        UNIT_ASSERT_VALUES_EQUAL(1, dirtyDevices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", dirtyDevices[0].GetDeviceUUID());
+
+        auto replaced = state.GetAutomaticallyReplacedDevices();
+        UNIT_ASSERT_VALUES_EQUAL(1, replaced.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", replaced[0].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs, replaced[0].ReplacementTs);
+
+        const auto changeStateTs2 = Now();
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db) mutable
+            {
+                TVector<TString> affectedDisks;
+                TDuration timeout;
+                auto error = state.UpdateAgentState(
+                    db,
+                    agentConfig4.GetAgentId(),
+                    NProto::AGENT_STATE_UNAVAILABLE,
+                    changeStateTs2,
+                    "unreachable",
+                    affectedDisks);
+
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+
+                // Check that we postponed device replacement
+                UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
+
+                NotifyDisks(state, db, changeStateTs2);
+            });
+
+        diskInfo = {};
+        error = state.GetDiskInfo("disk-1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Devices.size());
+        UNIT_ASSERT_VALUES_EQUAL("dev-13", diskInfo.Devices[0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(0, diskInfo.Migrations.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, diskInfo.Replicas.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas[0].size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dev-4",
+            diskInfo.Replicas[0][0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas[1].size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dev-7",
+            diskInfo.Replicas[1][0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            NProto::EDiskState_Name(NProto::DISK_STATE_ONLINE),
+            NProto::EDiskState_Name(diskInfo.State));
+
+        // Check that we replacement device after postponing
+        ASSERT_VECTORS_EQUAL(
+            TVector<TString>{"uuid-13"},
+            diskInfo.DeviceReplacementIds);
+
+        dirtyDevices = state.GetDirtyDevices();
+        SortBy(dirtyDevices, [](const auto& d) { return d.GetDeviceUUID(); });
+        UNIT_ASSERT_VALUES_EQUAL(2, dirtyDevices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", dirtyDevices[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-10", dirtyDevices[1].GetDeviceUUID());
+
+        replaced = state.GetAutomaticallyReplacedDevices();
+        UNIT_ASSERT_VALUES_EQUAL(2, replaced.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", replaced[0].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-10", replaced[1].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs, replaced[0].ReplacementTs);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs2, replaced[1].ReplacementTs);
+
+        executor.WriteTx([&](TDiskRegistryDatabase db)
+                         { state.DeallocateDisk(db, "disk-1"); });
     }
 
     Y_UNIT_TEST(ShouldTakeReplicaAvailabilityIntoAccount)
@@ -2251,6 +2492,295 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         });
     }
 
+    // With enable LimitMirrorDisksDeviceReplacementsPerRow
+    Y_UNIT_TEST(ShouldProperlyCleanupAutomaticallyReplacedDevices2)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        auto agentConfig1 = AgentConfig(
+            1,
+            {
+                Device("dev-1", "uuid-1", "rack-1"),
+                Device("dev-2", "uuid-2", "rack-1"),
+                Device("dev-3", "uuid-3", "rack-1"),
+            });
+
+        auto agentConfig2 = AgentConfig(
+            2,
+            {
+                Device("dev-4", "uuid-4", "rack-2"),
+                Device("dev-5", "uuid-5", "rack-2"),
+                Device("dev-6", "uuid-6", "rack-2"),
+            });
+
+        auto agentConfig3 = AgentConfig(
+            3,
+            {
+                Device("dev-7", "uuid-7", "rack-3"),
+                Device("dev-8", "uuid-8", "rack-3"),
+                Device("dev-9", "uuid-9", "rack-3"),
+            });
+
+        auto agentConfig4 = AgentConfig(
+            4,
+            {
+                Device("dev-10", "uuid-10", "rack-4"),
+                Device("dev-11", "uuid-11", "rack-4"),
+                Device("dev-12", "uuid-12", "rack-4"),
+            });
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto diskRegistryGroup =
+            monitoring->GetCounters()
+                ->GetSubgroup("counters", "blockstore")
+                ->GetSubgroup("component", "disk_registry");
+
+        auto storageConfig = CreateDefaultStorageConfigProto();
+        storageConfig.SetLimitMirrorDisksDeviceReplacementsPerRow(true);
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(diskRegistryGroup)
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                            })
+                            .WithStorageConfig(std::move(storageConfig))
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TVector<TDeviceConfig> devices;
+                TVector<TVector<TDeviceConfig>> replicas;
+                TVector<NProto::TDeviceMigration> migrations;
+                TVector<TString> deviceReplacementIds;
+                auto error = AllocateMirroredDisk(
+                    db,
+                    state,
+                    "disk-1",
+                    30_GB,
+                    1,
+                    devices,
+                    replicas,
+                    migrations,
+                    deviceReplacementIds);
+                UNIT_ASSERT_SUCCESS(error);
+                UNIT_ASSERT_VALUES_EQUAL(3, devices.size());
+                UNIT_ASSERT_VALUES_EQUAL("uuid-1", devices[0].GetDeviceUUID());
+                UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[1].GetDeviceUUID());
+                UNIT_ASSERT_VALUES_EQUAL("uuid-3", devices[2].GetDeviceUUID());
+                UNIT_ASSERT_VALUES_EQUAL(1, replicas.size());
+                UNIT_ASSERT_VALUES_EQUAL(3, replicas[0].size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "uuid-4",
+                    replicas[0][0].GetDeviceUUID());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "uuid-5",
+                    replicas[0][1].GetDeviceUUID());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "uuid-6",
+                    replicas[0][2].GetDeviceUUID());
+                ASSERT_VECTORS_EQUAL(TVector<TString>{}, deviceReplacementIds);
+            });
+
+        const auto changeStateTs1 = Now();
+        const auto changeStateTs2 = changeStateTs1 + TDuration::Hours(1);
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db) mutable
+            {
+                TVector<TString> affectedDisks;
+                TDuration timeout;
+                auto error = state.UpdateAgentState(
+                    db,
+                    agentConfig1.GetAgentId(),
+                    NProto::AGENT_STATE_UNAVAILABLE,
+                    changeStateTs1,
+                    "unreachable",
+                    affectedDisks);
+
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+                UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+
+                error = state.MarkReplacementDevice(
+                    changeStateTs1,
+                    db,
+                    "disk-1",
+                    "uuid-7",
+                    false);
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                error = state.MarkReplacementDevice(
+                    changeStateTs1,
+                    db,
+                    "disk-1",
+                    "uuid-8",
+                    false);
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                error = state.MarkReplacementDevice(
+                    changeStateTs1,
+                    db,
+                    "disk-1",
+                    "uuid-9",
+                    false);
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+
+                error = state.UpdateAgentState(
+                    db,
+                    agentConfig2.GetAgentId(),
+                    NProto::AGENT_STATE_UNAVAILABLE,
+                    changeStateTs2,
+                    "unreachable",
+                    affectedDisks);
+
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+
+                // Check that we postponed device replacement
+                UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
+
+                NotifyDisks(state, db, changeStateTs2);
+
+                error = state.MarkReplacementDevice(
+                    changeStateTs2,
+                    db,
+                    "disk-1",
+                    "uuid-10",
+                    false);
+                // Check that we replace device after postponing
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                error = state.MarkReplacementDevice(
+                    changeStateTs2,
+                    db,
+                    "disk-1",
+                    "uuid-11",
+                    false);
+                // Check that we replace device after postponing
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                error = state.MarkReplacementDevice(
+                    changeStateTs2,
+                    db,
+                    "disk-1",
+                    "uuid-12",
+                    false);
+                // Check that we replace device after postponing
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+            });
+
+        TDiskInfo diskInfo;
+        auto error = state.GetDiskInfo("disk-1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(3, diskInfo.Devices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-7", diskInfo.Devices[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-8", diskInfo.Devices[1].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-9", diskInfo.Devices[2].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(0, diskInfo.Migrations.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas.size());
+        UNIT_ASSERT_VALUES_EQUAL(3, diskInfo.Replicas[0].size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-10",
+            diskInfo.Replicas[0][0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-11",
+            diskInfo.Replicas[0][1].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "uuid-12",
+            diskInfo.Replicas[0][2].GetDeviceUUID());
+        ASSERT_VECTORS_EQUAL(TVector<TString>(), diskInfo.DeviceReplacementIds);
+
+        diskInfo = {};
+        error = state.GetDiskInfo("disk-1/0", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        // 3 x replacement
+        UNIT_ASSERT_VALUES_EQUAL(3, diskInfo.History.size());
+
+        diskInfo = {};
+        error = state.GetDiskInfo("disk-1/1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        // 3 x postponed replacement + 2 disk state changed
+        UNIT_ASSERT_VALUES_EQUAL(5, diskInfo.History.size());
+
+        auto dirtyDevices = state.GetDirtyDevices();
+        UNIT_ASSERT_VALUES_EQUAL(6, dirtyDevices.size());
+        SortBy(dirtyDevices, [](const auto& d) { return d.GetDeviceUUID(); });
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", dirtyDevices[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-2", dirtyDevices[1].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-3", dirtyDevices[2].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-4", dirtyDevices[3].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-5", dirtyDevices[4].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-6", dirtyDevices[5].GetDeviceUUID());
+
+        auto device = state.GetDevice("uuid-1");
+        UNIT_ASSERT_EQUAL(NProto::DEVICE_STATE_ONLINE, device.GetState());
+        device = state.GetDevice("uuid-2");
+        UNIT_ASSERT_EQUAL(NProto::DEVICE_STATE_ONLINE, device.GetState());
+        device = state.GetDevice("uuid-3");
+        UNIT_ASSERT_EQUAL(NProto::DEVICE_STATE_ONLINE, device.GetState());
+        device = state.GetDevice("uuid-4");
+        UNIT_ASSERT_EQUAL(NProto::DEVICE_STATE_ONLINE, device.GetState());
+        device = state.GetDevice("uuid-5");
+        UNIT_ASSERT_EQUAL(NProto::DEVICE_STATE_ONLINE, device.GetState());
+        device = state.GetDevice("uuid-6");
+        UNIT_ASSERT_EQUAL(NProto::DEVICE_STATE_ONLINE, device.GetState());
+
+        auto replaced = state.GetAutomaticallyReplacedDevices();
+        UNIT_ASSERT_VALUES_EQUAL(6, replaced.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", replaced[0].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-2", replaced[1].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-3", replaced[2].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-4", replaced[3].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-5", replaced[4].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-6", replaced[5].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs1, replaced[0].ReplacementTs);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs1, replaced[1].ReplacementTs);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs1, replaced[2].ReplacementTs);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs2, replaced[3].ReplacementTs);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs2, replaced[4].ReplacementTs);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs2, replaced[5].ReplacementTs);
+
+        auto deviceCounter =
+            diskRegistryGroup->GetCounter("AutomaticallyReplacedDevices");
+
+        state.PublishCounters(Now());
+        UNIT_ASSERT_VALUES_EQUAL(deviceCounter->Val(), 6);
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                state.DeleteAutomaticallyReplacedDevices(db, changeStateTs1);
+                replaced = state.GetAutomaticallyReplacedDevices();
+                UNIT_ASSERT_VALUES_EQUAL(3, replaced.size());
+                UNIT_ASSERT_VALUES_EQUAL("uuid-4", replaced[0].DeviceId);
+                UNIT_ASSERT_VALUES_EQUAL("uuid-5", replaced[1].DeviceId);
+                UNIT_ASSERT_VALUES_EQUAL("uuid-6", replaced[2].DeviceId);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    changeStateTs2,
+                    replaced[0].ReplacementTs);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    changeStateTs2,
+                    replaced[1].ReplacementTs);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    changeStateTs2,
+                    replaced[2].ReplacementTs);
+
+                state.PublishCounters(Now());
+                UNIT_ASSERT_VALUES_EQUAL(deviceCounter->Val(), 3);
+
+                state.DeleteAutomaticallyReplacedDevices(db, changeStateTs2);
+                replaced = state.GetAutomaticallyReplacedDevices();
+                UNIT_ASSERT_VALUES_EQUAL(0, replaced.size());
+
+                state.PublishCounters(Now());
+                UNIT_ASSERT_VALUES_EQUAL(deviceCounter->Val(), 0);
+            });
+
+        executor.WriteTx([&](TDiskRegistryDatabase db)
+                         { state.DeallocateDisk(db, "disk-1"); });
+    }
+
     void DoTestShouldWaitForReplicaMigrationUponCmsRemoveRequest(
         bool isAgent)
     {
@@ -2435,7 +2965,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                 Now(),
                 db,
                 TDiskNotificationResult{
-                    TDiskNotification{"disk-1", 4},
+                    TDiskNotification{
+                        "disk-1",
+                        4,
+                        state.GetAndDeleteRowToSeqNo("disk-1")},
                     {},
                 });
         });
@@ -2641,7 +3174,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                             Now(),
                             db,
                             TDiskNotificationResult{
-                                TDiskNotification{x.first, x.second},
+                                TDiskNotification{
+                                    x.first,
+                                    x.second.SeqNo,
+                                    state.GetAndDeleteRowToSeqNo(x.first)},
                                 {},
                             });
                     }
@@ -2974,6 +3510,195 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         ASSERT_VECTORS_EQUAL(expectedReplacedDeviceIds, replacedDeviceIds);
     }
 
+    // With enable LimitMirrorDisksDeviceReplacementsPerRow
+    Y_UNIT_TEST(ShouldStopAutomaticReplacementIfReplacementRateIsTooHigh2)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        /*
+         *  Configuring many agents to be able to break many agents and cause
+         *  many device replacements.
+         */
+
+        TVector<NProto::TAgentConfig> agents;
+        for (ui32 i = 1; i <= 20; ++i) {
+            agents.push_back(AgentConfig(
+                i,
+                {Device(
+                    Sprintf("dev-%u", i),
+                    Sprintf("uuid-%u", i),
+                    Sprintf("rack-%u", i))}));
+        }
+
+        NProto::TStorageServiceConfig proto;
+        proto.SetMaxAutomaticDeviceReplacementsPerHour(10);
+        proto.SetAllocationUnitNonReplicatedSSD(10);
+        proto.SetLimitMirrorDisksDeviceReplacementsPerRow(true);
+        auto storageConfig = CreateStorageConfig(proto);
+
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .With(storageConfig)
+                            .WithKnownAgents(agents)
+                            .Build();
+        TDiskRegistryState& state = *statePtr;
+
+        /*
+         *  Creating a small mirror-2 disk that will use 2 agents.
+         */
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TVector<TDeviceConfig> devices;
+                TVector<TVector<TDeviceConfig>> replicas;
+                TVector<NProto::TDeviceMigration> migrations;
+                TVector<TString> deviceReplacementIds;
+                auto error = AllocateMirroredDisk(
+                    db,
+                    state,
+                    "disk-1",
+                    10_GB,
+                    1,
+                    devices,
+                    replicas,
+                    migrations,
+                    deviceReplacementIds);
+                UNIT_ASSERT_SUCCESS(error);
+                UNIT_ASSERT_VALUES_EQUAL(1, devices.size());
+                UNIT_ASSERT_VALUES_EQUAL(1, replicas.size());
+                UNIT_ASSERT_VALUES_EQUAL(1, replicas[0].size());
+                ASSERT_VECTORS_EQUAL(TVector<TString>{}, deviceReplacementIds);
+            });
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto rootGroup =
+            monitoring->GetCounters()->GetSubgroup("counters", "blockstore");
+
+        auto serverGroup = rootGroup->GetSubgroup("component", "server");
+        InitCriticalEventsCounter(serverGroup);
+
+        auto criticalEvents = serverGroup->FindCounter(
+            "AppCriticalEvents/MirroredDiskDeviceReplacementRateLimitExceeded");
+
+        UNIT_ASSERT_VALUES_EQUAL(0, criticalEvents->Val());
+
+        /*
+         *  10 agent failures should cause 10 replacements which should work
+         *  just fine.
+         */
+
+        auto changeStateTs = Now();
+
+        TVector<TString> expectedReplacedDeviceIds;
+
+        auto breakAgent = [&](const TString& agentId)
+        {
+            executor.WriteTx(
+                [&](TDiskRegistryDatabase db) mutable
+                {
+                    TVector<TString> affectedDisks;
+                    TDuration timeout;
+                    auto error = state.UpdateAgentState(
+                        db,
+                        agentId,
+                        NProto::AGENT_STATE_UNAVAILABLE,
+                        changeStateTs,
+                        "unreachable",
+                        affectedDisks);
+
+                    NotifyDisks(state, db, changeStateTs);
+
+                    UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                    UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+                });
+        };
+
+        auto fixAgent = [&](const TString& agentId)
+        {
+            executor.WriteTx(
+                [&](TDiskRegistryDatabase db) mutable
+                {
+                    TVector<TString> affectedDisks;
+                    TDuration timeout;
+                    auto error = state.UpdateAgentState(
+                        db,
+                        agentId,
+                        NProto::AGENT_STATE_ONLINE,
+                        changeStateTs,
+                        "fixed",
+                        affectedDisks);
+
+                    UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                    UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+                });
+        };
+
+        for (ui32 i = 2; i <= 11; ++i) {
+            TDiskInfo diskInfo;
+            auto error = state.GetDiskInfo("disk-1", diskInfo);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas.size());
+            UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas[0].size());
+            const auto deviceId = diskInfo.Replicas[0][0].GetDeviceUUID();
+            const auto agentId = diskInfo.Replicas[0][0].GetAgentId();
+
+            changeStateTs += TDuration::Minutes(5);
+
+            breakAgent(agentId);
+
+            expectedReplacedDeviceIds.push_back(deviceId);
+            TVector<TString> replacedDeviceIds;
+            for (const auto& d: state.GetAutomaticallyReplacedDevices()) {
+                replacedDeviceIds.push_back(d.DeviceId);
+            }
+            ASSERT_VECTORS_EQUAL(expectedReplacedDeviceIds, replacedDeviceIds);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, criticalEvents->Val());
+
+        /*
+         *  11th agent failure within the same hour should cause a critical
+         *  event. Replacement should not happen.
+         */
+
+        TDiskInfo diskInfo;
+        const auto error = state.GetDiskInfo("disk-1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, diskInfo.Replicas[0].size());
+        const auto agentId = diskInfo.Replicas[0][0].GetAgentId();
+        const auto deviceId = diskInfo.Replicas[0][0].GetDeviceUUID();
+
+        breakAgent(agentId);
+
+        // 1 after first try and 1 after postponed try
+        UNIT_ASSERT_VALUES_EQUAL(2, criticalEvents->Val());
+
+        TVector<TString> replacedDeviceIds;
+        for (const auto& d: state.GetAutomaticallyReplacedDevices()) {
+            replacedDeviceIds.push_back(d.DeviceId);
+        }
+        ASSERT_VECTORS_EQUAL(expectedReplacedDeviceIds, replacedDeviceIds);
+
+        /*
+         *  After a while automatic replacements should be enabled again.
+         */
+
+        changeStateTs += TDuration::Minutes(15);
+
+        fixAgent(agentId);
+        breakAgent(agentId);
+        UNIT_ASSERT_VALUES_EQUAL(2, criticalEvents->Val());
+
+        expectedReplacedDeviceIds.push_back(deviceId);
+        replacedDeviceIds.clear();
+        for (const auto& d: state.GetAutomaticallyReplacedDevices()) {
+            replacedDeviceIds.push_back(d.DeviceId);
+        }
+        ASSERT_VECTORS_EQUAL(expectedReplacedDeviceIds, replacedDeviceIds);
+    }
+
     Y_UNIT_TEST(ShouldReportRateLimitExceededCritEventUponDeviceFailure)
     {
         TTestExecutor executor;
@@ -3242,6 +3967,295 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             state.DeallocateDisk(db, "disk-1");
         });
+    }
+
+    Y_UNIT_TEST(
+        ShouldDiskRegistryCorrectLimitMirrorDiskDeviceReplacementAfterRestart)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        auto agentConfig1 = AgentConfig(
+            1,
+            {
+                Device("dev-1", "uuid-1", "rack-1"),
+                Device("dev-2", "uuid-2", "rack-1"),
+                Device("dev-3", "uuid-3", "rack-1"),
+            });
+
+        auto agentConfig2 = AgentConfig(
+            2,
+            {
+                Device("dev-4", "uuid-4", "rack-2"),
+                Device("dev-5", "uuid-5", "rack-2"),
+                Device("dev-6", "uuid-6", "rack-2"),
+            });
+
+        auto agentConfig3 = AgentConfig(
+            3,
+            {
+                Device("dev-7", "uuid-7", "rack-3"),
+                Device("dev-8", "uuid-8", "rack-3"),
+                Device("dev-9", "uuid-9", "rack-3"),
+            });
+
+        auto agentConfig4 = AgentConfig(
+            4,
+            {
+                Device("dev-10", "uuid-10", "rack-4"),
+                Device("dev-11", "uuid-11", "rack-4"),
+                Device("dev-12", "uuid-12", "rack-4"),
+            });
+
+        auto agentConfig5 = AgentConfig(
+            5,
+            {
+                Device("dev-13", "uuid-13", "rack-5"),
+                Device("dev-14", "uuid-14", "rack-5"),
+                Device("dev-15", "uuid-15", "rack-5"),
+            });
+
+        auto agentConfig6 = AgentConfig(
+            6,
+            {
+                Device("dev-16", "uuid-16", "rack-6"),
+                Device("dev-17", "uuid-17", "rack-6"),
+                Device("dev-18", "uuid-18", "rack-6"),
+            });
+
+        TVector<NProto::TDiskConfig> disks = {
+            Disk("disk-1/0", {"uuid-1", "uuid-18"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-1/1", {"uuid-4", "uuid-5"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-1/2", {"uuid-7", "uuid-8"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-2/0", {"uuid-3", "uuid-11"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-2/1", {"uuid-13", "uuid-14"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-2/2", {"uuid-16", "uuid-17"}, NProto::DISK_STATE_ONLINE),
+        };
+
+        ui32 count = 0;
+        for (auto& disk: disks) {
+            if (count++ < 3) {
+                disk.SetMasterDiskId("disk-1");
+                continue;
+            }
+            disk.SetMasterDiskId("disk-2");
+        }
+
+        disks.push_back(Disk("disk-1", {}, NProto::DISK_STATE_ONLINE));
+        disks.back().SetReplicaCount(2);
+
+        disks.push_back(Disk("disk-2", {}, NProto::DISK_STATE_ONLINE));
+        disks.back().SetReplicaCount(2);
+
+        auto storageConfig = CreateDefaultStorageConfigProto();
+        storageConfig.SetLimitMirrorDisksDeviceReplacementsPerRow(true);
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                                agentConfig5,
+                                agentConfig6,
+                            })
+                            .WithStorageConfig(std::move(storageConfig))
+                            .WithDisks(std::move(disks))
+                            .WithDisksToReallocate({"disk-1"})
+                            .Build();
+
+        TDiskRegistryState& state = *statePtr;
+
+        const auto changeStateTs = Now();
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db) mutable
+            {
+                TVector<TString> affectedDisks;
+                TDuration timeout;
+                auto error = state.UpdateAgentState(
+                    db,
+                    agentConfig1.GetAgentId(),
+                    NProto::AGENT_STATE_UNAVAILABLE,
+                    changeStateTs,
+                    "unreachable",
+                    affectedDisks);
+
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+
+                // Check that we postponed device replacement of disk-1
+                UNIT_ASSERT_VALUES_EQUAL(1, affectedDisks.size());
+                UNIT_ASSERT_VALUES_EQUAL("disk-1/0", affectedDisks[0]);
+            });
+
+        // Check that we replaced device of disk-2
+
+        TDiskInfo diskInfo;
+        auto error = state.GetDiskInfo("disk-2", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(2, diskInfo.Devices.size());
+        UNIT_ASSERT_VALUES_EQUAL("dev-6", diskInfo.Devices[0].GetDeviceName());
+        ASSERT_VECTORS_EQUAL(
+            TVector<TString>{"uuid-6"},
+            diskInfo.DeviceReplacementIds);
+
+        auto dirtyDevices = state.GetDirtyDevices();
+        UNIT_ASSERT_VALUES_EQUAL(1, dirtyDevices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-3", dirtyDevices[0].GetDeviceUUID());
+
+        auto replaced = state.GetAutomaticallyReplacedDevices();
+        UNIT_ASSERT_VALUES_EQUAL(1, replaced.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-3", replaced[0].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs, replaced[0].ReplacementTs);
+
+        // Notify disks
+        executor.WriteTx([&](TDiskRegistryDatabase db) mutable
+                         { NotifyDisks(state, db, changeStateTs); });
+
+        // Check that we replaced device of disk-1 after postponing
+
+        diskInfo = {};
+        error = state.GetDiskInfo("disk-1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(2, diskInfo.Devices.size());
+
+        UNIT_ASSERT_VALUES_EQUAL("dev-9", diskInfo.Devices[0].GetDeviceName());
+        ASSERT_VECTORS_EQUAL(
+            TVector<TString>{"uuid-9"},
+            diskInfo.DeviceReplacementIds);
+
+        dirtyDevices = state.GetDirtyDevices();
+        UNIT_ASSERT_VALUES_EQUAL(2, dirtyDevices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", dirtyDevices[1].GetDeviceUUID());
+
+        replaced = state.GetAutomaticallyReplacedDevices();
+        UNIT_ASSERT_VALUES_EQUAL(2, replaced.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", replaced[1].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs, replaced[1].ReplacementTs);
+
+         executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            state.DeallocateDisk(db, "disk-1");
+            state.DeallocateDisk(db, "disk-2");
+        });
+    }
+
+    Y_UNIT_TEST(
+        ShouldDiskRegistryDontLimitMirrorDiskDeviceReplacementInDifferentRows)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        auto agentConfig1 = AgentConfig(
+            1,
+            {
+                Device("dev-1", "uuid-1", "rack-1"),
+                Device("dev-2", "uuid-2", "rack-1"),
+                Device("dev-3", "uuid-3", "rack-1"),
+            });
+
+        auto agentConfig2 = AgentConfig(
+            2,
+            {
+                Device("dev-4", "uuid-4", "rack-2"),
+                Device("dev-5", "uuid-5", "rack-2"),
+                Device("dev-6", "uuid-6", "rack-2"),
+            });
+
+        auto agentConfig3 = AgentConfig(
+            3,
+            {
+                Device("dev-7", "uuid-7", "rack-3"),
+                Device("dev-8", "uuid-8", "rack-3"),
+                Device("dev-9", "uuid-9", "rack-3"),
+            });
+
+        auto agentConfig4 = AgentConfig(
+            4,
+            {
+                Device("dev-10", "uuid-10", "rack-4"),
+                Device("dev-11", "uuid-11", "rack-4"),
+                Device("dev-12", "uuid-12", "rack-4"),
+            });
+
+        TVector<NProto::TDiskConfig> disks = {
+            Disk("disk-1/0", {"uuid-1", "uuid-10"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-1/1", {"uuid-4", "uuid-2"}, NProto::DISK_STATE_ONLINE),
+            Disk("disk-1/2", {"uuid-7", "uuid-6"}, NProto::DISK_STATE_ONLINE),
+        };
+
+        for (auto& disk: disks) {
+            disk.SetMasterDiskId("disk-1");
+        }
+
+        disks.push_back(Disk("disk-1", {}, NProto::DISK_STATE_ONLINE));
+        disks.back().SetReplicaCount(2);
+
+        auto storageConfig = CreateDefaultStorageConfigProto();
+        storageConfig.SetLimitMirrorDisksDeviceReplacementsPerRow(true);
+        auto statePtr = TDiskRegistryStateBuilder()
+                            .WithKnownAgents({
+                                agentConfig1,
+                                agentConfig2,
+                                agentConfig3,
+                                agentConfig4,
+                            })
+                            .WithStorageConfig(std::move(storageConfig))
+                            .WithDisks(std::move(disks))
+                            .Build();
+
+        TDiskRegistryState& state = *statePtr;
+
+        const auto changeStateTs = Now();
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db) mutable
+            {
+                TVector<TString> affectedDisks;
+                TDuration timeout;
+                auto error = state.UpdateAgentState(
+                    db,
+                    agentConfig1.GetAgentId(),
+                    NProto::AGENT_STATE_UNAVAILABLE,
+                    changeStateTs,
+                    "unreachable",
+                    affectedDisks);
+
+                UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+                UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), timeout);
+
+                // Check that we didn't postponed device replacement
+                UNIT_ASSERT_VALUES_EQUAL(0, affectedDisks.size());
+            });
+
+        // Check that we replaced devices
+
+        TDiskInfo diskInfo;
+        auto error = state.GetDiskInfo("disk-1", diskInfo);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(2, diskInfo.Devices.size());
+        UNIT_ASSERT_VALUES_EQUAL("dev-5", diskInfo.Devices[0].GetDeviceName());
+        UNIT_ASSERT_VALUES_EQUAL(2, diskInfo.Replicas[0].size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dev-8",
+            diskInfo.Replicas[0][1].GetDeviceName());
+        TVector<TString> expectedDeviceReplacementIds = {"uuid-5", "uuid-8"};
+        ASSERT_VECTORS_EQUAL(
+            expectedDeviceReplacementIds,
+            diskInfo.DeviceReplacementIds);
+
+        auto dirtyDevices = state.GetDirtyDevices();
+        UNIT_ASSERT_VALUES_EQUAL(2, dirtyDevices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", dirtyDevices[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-2", dirtyDevices[1].GetDeviceUUID());
+
+        auto replaced = state.GetAutomaticallyReplacedDevices();
+        UNIT_ASSERT_VALUES_EQUAL(2, replaced.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", replaced[0].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-2", replaced[1].DeviceId);
+        UNIT_ASSERT_VALUES_EQUAL(changeStateTs, replaced[0].ReplacementTs);
+
+        executor.WriteTx([&](TDiskRegistryDatabase db)
+                         { state.DeallocateDisk(db, "disk-1"); });
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -63,6 +63,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(PurgeHostCms,                       __VA_ARGS__)                       \
     xxx(RemoveOrphanDevices,                __VA_ARGS__)                       \
     xxx(AddOutdatedLaggingDevices,          __VA_ARGS__)                       \
+    xxx(ProcessRecentlyReplaceDevices,      __VA_ARGS__)                       \
 // BLOCKSTORE_DISK_REGISTRY_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1478,6 +1479,18 @@ struct TTxDiskRegistry
         {
             Error.Clear();
         }
+    };
+
+    //
+    // ProcessRecentlyReplaceDevices
+    //
+
+    struct TProcessRecentlyReplaceDevices
+    {
+        TProcessRecentlyReplaceDevices() = default;
+
+        void Clear()
+        {}
     };
 };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_mirrored_disk_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_mirrored_disk_migration.cpp
@@ -3,6 +3,7 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h>
+#include <cloud/blockstore/libs/storage/testlib/ss_proxy_client.h>
 
 #include <contrib/ydb/core/testlib/basics/runtime.h>
 
@@ -415,6 +416,142 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
     Y_UNIT_TEST(ShouldFinishMigrationForMirroredDiskAfterReboot)
     {
         ShouldFinishMigrationForMirroredDiskImpl(true);
+    }
+
+    Y_UNIT_TEST(ShouldReplaceBrokenDevicesAfterRestart)
+    {
+        const auto agent1 = CreateAgentConfig(
+            "agent-1",
+            {
+                Device("dev-1", "uuid-1", "rack-1", 10_GB),
+                Device("dev-2", "uuid-2", "rack-1", 10_GB),
+            });
+
+        const auto agent2 = CreateAgentConfig(
+            "agent-2",
+            {
+                Device("dev-1", "uuid-3", "rack-2", 10_GB),
+                Device("dev-2", "uuid-4", "rack-2", 10_GB),
+            });
+
+        const auto agent3 = CreateAgentConfig(
+            "agent-3",
+            {
+                Device("dev-1", "uuid-5", "rack-3", 10_GB),
+                Device("dev-2", "uuid-6", "rack-3", 10_GB),
+            });
+
+        NProto::TStorageServiceConfig config = CreateDefaultStorageConfig();
+        config.SetLimitMirrorDisksDeviceReplacementsPerRow(true);
+        auto runtime = TTestRuntimeBuilder()
+                           .With(config)
+                           .WithAgents({agent1, agent2, agent3})
+                           .Build();
+
+        TDiskRegistryClient diskRegistry(*runtime);
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+
+        diskRegistry.UpdateConfig(
+            CreateRegistryConfig(0, {agent1, agent2, agent3}));
+
+        RegisterAgents(*runtime, 3);
+        WaitForAgents(*runtime, 3);
+        WaitForSecureErase(*runtime, {agent1, agent2, agent3});
+
+        TSSProxyClient ss(*runtime);
+        ss.CreateVolume("mirrored-vol");
+        diskRegistry.AllocateDisk(
+            "mirrored-vol",
+            10_GB,
+            DefaultLogicalBlockSize,
+            "",   // placementGroupId
+            0,    // placementPartitionIndex
+            "",   // cloudId
+            "",   // folderId
+            2,    // replicaCount
+            NProto::STORAGE_MEDIA_SSD_MIRROR3);
+
+        // Send volume reallocations.
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+
+        IEventHandle* notifyEvent;
+
+        runtime->SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistryPrivate::EvNotifyDisksResponse)
+                {
+                    notifyEvent = new IEventHandle(
+                        event->Recipient,
+                        event->Sender,
+                        new TEvDiskRegistryPrivate::TEvNotifyDisksResponse(
+                            MakeIntrusive<TCallContext>(),
+                            TVector<TDiskNotificationResult>{}));
+                    return true;
+                }
+
+                return false;
+            });
+
+        diskRegistry.ChangeDeviceState("uuid-1", NProto::DEVICE_STATE_ERROR);
+        diskRegistry.ChangeDeviceState("uuid-3", NProto::DEVICE_STATE_ERROR);
+
+        // Check that "mirrored-vol" has broken device "uuid-3"
+        {
+            auto response = diskRegistry.DescribeDisk("mirrored-vol");
+            auto& r = response->Record;
+            UNIT_ASSERT_VALUES_EQUAL(1, r.DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", r.GetDevices(0).GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(2, r.ReplicasSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, r.GetReplicas(0).DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-3",
+                r.GetReplicas(0).GetDevices(0).GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(1, r.GetReplicas(1).DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-5",
+                r.GetReplicas(1).GetDevices(0).GetDeviceUUID());
+
+            UNIT_ASSERT_VALUES_EQUAL(1, r.GetDeviceReplacementUUIDs().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-2",
+                r.GetDeviceReplacementUUIDs()[0]);
+        }
+
+        runtime->SetEventFilter([](auto&, auto&) { return false; });
+
+        runtime->Send(notifyEvent);
+
+        // Restart disk registry
+        diskRegistry.RebootTablet();
+        diskRegistry.WaitReady();
+
+        // "uuid-3" should be replaced with "uuid-4".
+        {
+            auto response = diskRegistry.DescribeDisk("mirrored-vol");
+            auto& r = response->Record;
+            UNIT_ASSERT_VALUES_EQUAL(1, r.DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL("uuid-2", r.GetDevices(0).GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(2, r.ReplicasSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, r.GetReplicas(0).DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-4",
+                r.GetReplicas(0).GetDevices(0).GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(1, r.GetReplicas(1).DevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-5",
+                r.GetReplicas(1).GetDevices(0).GetDeviceUUID());
+
+            UNIT_ASSERT_VALUES_EQUAL(2, r.GetDeviceReplacementUUIDs().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-2",
+                r.GetDeviceReplacementUUIDs()[0]);
+            UNIT_ASSERT_VALUES_EQUAL(
+                "uuid-4",
+                r.GetDeviceReplacementUUIDs()[1]);
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/model/replica_table.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/replica_table.cpp
@@ -17,7 +17,7 @@ void TReplicaTable::AddReplica(
     auto& diskState = Disks[diskId];
     UpdateReplica(
         diskId,
-        diskState.Cells.empty() ? 0 : diskState.Cells[0].size(),
+        diskState.Cells.empty() ? 0 : diskState.Cells[0].DeviceInfos.size(),
         devices);
 }
 
@@ -37,19 +37,21 @@ void TReplicaTable::UpdateReplica(
         diskState.Cells.resize(devices.size());
     }
 
-    if (diskState.Cells[0].size() < replicaNo + 1) {
-        diskState.Cells[0].resize(replicaNo + 1);
+    if (diskState.Cells[0].DeviceInfos.size() < replicaNo + 1) {
+        diskState.Cells[0].DeviceInfos.resize(replicaNo + 1);
     }
     for (ui32 i = 1; i < diskState.Cells.size(); ++i) {
-        diskState.Cells[i].resize(diskState.Cells[0].size());
+        diskState.Cells[i].DeviceInfos.resize(
+            diskState.Cells[0].DeviceInfos.size());
     }
 
     for (ui32 j = 0; j < devices.size(); ++j) {
-        diskState.Cells[j][replicaNo] = {devices[j], false};
+        diskState.Cells[j].DeviceInfos[replicaNo] = {devices[j], false};
+        diskState.Cells[j].Row = j;
     }
 
     for (auto& cell: diskState.Cells) {
-        diskState.DeviceId2Cell[cell[replicaNo].Id] = &cell;
+        diskState.DeviceId2Cell[cell.DeviceInfos[replicaNo].Id] = &cell;
     }
 }
 
@@ -73,7 +75,7 @@ bool TReplicaTable::IsReplacementAllowed(
     }
 
     ui32 readyDeviceCount = 0;
-    for (auto& device: **cell) {
+    for (auto& device: (*cell)->DeviceInfos) {
         const bool canUseDevice = device.Id && device.Id != deviceId;
         const bool deviceOK =
             !device.IsReplacement &&
@@ -119,7 +121,7 @@ bool TReplicaTable::ChangeDevice(
     }
 
     TDeviceInfo* unit = nullptr;
-    for (auto& device: **cell) {
+    for (auto& device: (*cell)->DeviceInfos) {
         if (device.Id == oldDeviceId) {
             unit = &device;
             break;
@@ -151,7 +153,7 @@ TVector<TVector<TReplicaTable::TDeviceInfo>> TReplicaTable::AsMatrix(
     }
 
     for (const auto& cell: disk->Cells) {
-        matrix.push_back(cell);
+        matrix.push_back(cell.DeviceInfos);
     }
 
     return matrix;
@@ -197,11 +199,11 @@ TMirroredDisksStat TReplicaTable::CalculateReplicaCountStats() const
             continue;
         }
 
-        ui32 replicaCount = diskState.Cells.front().size();
+        ui32 replicaCount = diskState.Cells.front().DeviceInfos.size();
         ui32 incompleteCount = 0;
         for (const auto& cell: diskState.Cells) {
             ui32 incompleteCountInCell = 0;
-            for (const auto& device: cell) {
+            for (const auto& device: cell.DeviceInfos) {
                 incompleteCountInCell +=
                     device.IsReplacement ||
                     DeviceList->GetDeviceState(device.Id) ==
@@ -232,7 +234,7 @@ TMirroredDiskDevicesStat TReplicaTable::CalculateDiskStats(
         ui32 incompleteCountInCell = 0;
         ui32 cellReplacementCount = 0;
         ui32 cellErrorCount = 0;
-        for (const auto& deviceInfo: cell) {
+        for (const auto& deviceInfo: cell.DeviceInfos) {
             if (DeviceList->GetDeviceState(deviceInfo.Id) ==
                 NProto::EDeviceState::DEVICE_STATE_ERROR)
             {
@@ -248,13 +250,92 @@ TMirroredDiskDevicesStat TReplicaTable::CalculateDiskStats(
         }
         ++result.CellsByState[replacementAndErrorCount];
 
-        result.DeviceReadyCount += cell.size() - replacementAndErrorCount;
+        result.DeviceReadyCount += cell.DeviceInfos.size() - replacementAndErrorCount;
         result.DeviceReplacementCount += cellReplacementCount;
         result.DeviceErrorCount += cellErrorCount;
         result.MaxIncompleteness =
             Max(result.MaxIncompleteness, incompleteCountInCell);
     }
     return result;
+}
+
+bool TReplicaTable::IsRecentlyReplacedDevice(
+    const TDiskId& diskId,
+    const TDeviceId& deviceId)
+{
+    const auto* diskState = Disks.FindPtr(diskId);
+    if (diskState == nullptr ||
+        MasterDiskToSeqNo.find(diskId) != MasterDiskToSeqNo.end())
+    {
+        return true;
+    }
+
+    const auto* cell = diskState->DeviceId2Cell.FindPtr(deviceId);
+    if (!cell || !*cell) {
+        return true;
+    }
+
+    return (*cell)->IsRecentlyReplacedDevice;
+}
+
+void TReplicaTable::SetRecentlyReplacedDevice(
+    const TDiskId& diskId,
+    ui32 deviceRow,
+    ui64 seqNo,
+    bool isRecentlyReplaced)
+{
+    auto* diskState = Disks.FindPtr(diskId);
+    if (!diskState || deviceRow >= diskState->Cells.size()) {
+        return;
+    }
+
+    diskState->Cells[deviceRow].IsRecentlyReplacedDevice = isRecentlyReplaced;
+    diskState->Cells[deviceRow].SeqNo = seqNo;
+}
+
+ui32 TReplicaTable::GetDeviceRow(
+    const TDiskId& diskId,
+    const TDeviceId& deviceId)
+{
+    auto* diskState = Disks.FindPtr(diskId);
+    if (!diskState) {
+        return EmptyRow;
+    }
+
+    auto* cell = diskState->DeviceId2Cell.FindPtr(deviceId);
+    if (!cell || !*cell) {
+        return EmptyRow;
+    }
+
+    return (*cell)->Row;
+}
+
+ui64 TReplicaTable::GetSeqNo(const TDiskId& diskId, ui32 row)
+{
+    auto* diskState = Disks.FindPtr(diskId);
+    if (!diskState || row >= diskState->Cells.size()) {
+        return Max<ui64>();
+    }
+
+    return diskState->Cells[row].SeqNo;
+}
+
+void TReplicaTable::SetMasterDiskToSeqNo(
+    THashMap<TDiskId, ui64> masterDiskToSeqNo)
+{
+    MasterDiskToSeqNo = std::move(masterDiskToSeqNo);
+}
+
+void TReplicaTable::DeleteItemFromMasterDiskToSeqNo(
+    const TDiskId& diskId,
+    ui64 seqNo)
+{
+    auto it = MasterDiskToSeqNo.find(diskId);
+    if (it == MasterDiskToSeqNo.end() || it->second > seqNo) {
+        return;
+    }
+
+    MasterDiskToSeqNo.erase(it);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/model/replica_table.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/replica_table.h
@@ -13,6 +13,10 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+constexpr ui32 EmptyRow = Max<ui32>();
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TDeviceList;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,6 +79,18 @@ public:
         const TDiskId& diskId,
         const TDeviceId& deviceId,
         bool isReplacement);
+    bool IsRecentlyReplacedDevice(
+        const TDiskId& diskId,
+        const TDeviceId& deviceId);
+    void SetRecentlyReplacedDevice(
+        const TDiskId& diskId,
+        ui32 deviceRow,
+        ui64 seqNo,
+        bool isRecentlyReplaced);
+    void SetMasterDiskToSeqNo(THashMap<TDiskId, ui64> masterDiskToSeqNo);
+    void DeleteItemFromMasterDiskToSeqNo(const TDiskId& diskId, ui64 seqNo);
+    ui32 GetDeviceRow(const TDiskId& diskId, const TDeviceId& deviceId);
+    ui64 GetSeqNo(const TDiskId& diskId, ui32 row);
 
     // for tests and monpages
     TVector<TVector<TDeviceInfo>> AsMatrix(const TString& diskId) const;
@@ -94,7 +110,17 @@ private:
 private:
     // a transposed view of disk config
 
-    using TCell = TVector<TDeviceInfo>;
+    struct TCell
+    {
+        // Set to true when some device is replacing now.
+        bool IsRecentlyReplacedDevice = false;
+
+        ui32 Row = EmptyRow;
+
+        ui64 SeqNo = 0;
+
+        TVector<TDeviceInfo> DeviceInfos;
+    };
 
     struct TDiskState
     {
@@ -104,6 +130,8 @@ private:
 
     THashMap<TDiskId, TDiskState> Disks;
     const TDeviceList* const DeviceList = nullptr;
+
+    THashMap<TDiskId, ui64> MasterDiskToSeqNo;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -38,6 +38,7 @@ SRCS(
     disk_registry_actor_register.cpp
     disk_registry_actor_regular.cpp
     disk_registry_actor_release.cpp
+    disk_registry_actor_replace_devices.cpp
     disk_registry_actor_replace.cpp
     disk_registry_actor_restore_state.cpp
     disk_registry_actor_resume_device.cpp


### PR DESCRIPTION
Этот пулл реквест решает проблему https://github.com/ydb-platform/nbs/issues/3505.

Для решения проблемы TCell
https://github.com/ydb-platform/nbs/blob/311fc3f624251779e31a0a26d1749838aa18f2fa/cloud/blockstore/libs/storage/disk_registry/model/replica_table.h#L97

переделанна в структуру и в нее добавлена булка IsRecentlyReplacedDevice, которая равна true, если сейчас в этой ячейке есть девайсы, которые перемещаются.

Для того, чтобы запретить одновременное перемещение двух и более девайсов в одной строке
в функцию 
https://github.com/ydb-platform/nbs/blob/311fc3f624251779e31a0a26d1749838aa18f2fa/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp#L7676

добавленна дополнительная проверка,
по мастер диску и девайсу определяем нужную строку и смотрим значение IsRecentlyReplacedDevice,
если оно равно true, то запрещаем replacement.

Чтобы не оставлять сломанные девайсы, в функции
https://github.com/ydb-platform/nbs/blob/311fc3f624251779e31a0a26d1749838aa18f2fa/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp#L5025

проверяем есть ли в этом диске сломанные девайсы, если есть, пытаемся их заменить.
(также в этой функции, выставляем булку обратно в false при определенных условиях)

Поскольку disk registry может рестартануть, то при конструировании disk registry state,
проверяем есть ли сломанные девайсы и если есть, то пытаемся их заменить.
Однако диски:
https://github.com/ydb-platform/nbs/blob/311fc3f624251779e31a0a26d1749838aa18f2fa/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp#L366

не трогаем, и запрещаем  замену для них, пока не получим нотификацию для этих дисков в
https://github.com/ydb-platform/nbs/blob/311fc3f624251779e31a0a26d1749838aa18f2fa/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp#L5025

