### PR TITLE
[NBS] Added waiting for volume notification completion in direct acquire integration tests

### DIFF
--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -191,6 +191,15 @@ def restart_volume(client, disk_id):
     restart_tablet(client, tablet_id)
 
 
+def wait_for_all_volumes_to_be_notified(client):
+    while True:
+        bkp = client.backup_disk_registry_state()
+        print(bkp)
+        if not ("DisksToNotify" in bkp):
+            break
+        time.sleep(1)
+
+
 def test_should_mount_volume_with_unknown_devices(
         nbs_with_dr,
         nbs,
@@ -260,7 +269,7 @@ def test_should_mount_volume_with_unknown_devices(
     assert len(r.ActionResults) == 1
     assert r.ActionResults[0].Result.Code == 0
 
-    time.sleep(1)
+    wait_for_all_volumes_to_be_notified(client)
 
     nbs_with_dr.kill()
     restart_volume(client, "vol1")
@@ -389,6 +398,8 @@ def test_should_mount_volume_with_unavailable_agents(
     agents[0].kill()
 
     client.wait_agent_state(agent_ids[0], "AGENT_STATE_UNAVAILABLE")
+
+    wait_for_all_volumes_to_be_notified(client)
 
     nbs_with_dr.kill()
     restart_volume(client, "vol1")


### PR DESCRIPTION
иногда тест https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/tests/direct_device_acquire/test.py#L338 таймаутится по причине того, что DR не успевает реалоцировать диск и мы его прибиваем

Добавил ожидание того что все нотификации пройдут перед убийством NBSа на котором живет DR