### PR TITLE
issue-3988: refactor TReadDataActor to avoid data buffer copy

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -119,7 +119,6 @@ TReadDataActor::TReadDataActor(
         ReadRequest.GetLength(),
         BlockSize)
     , AlignedByteRange(OriginByteRange.AlignedSuperRange())
-    , BlockBuffer(std::make_unique<TString>())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
     , MediaKind(mediaKind)
@@ -132,8 +131,9 @@ void TReadDataActor::Bootstrap(const TActorContext& ctx)
     // a block buffer leads to memory allocation (and initialization) which is
     // heavy and we would like to execute that on a separate thread (instead of
     // this actor's parent thread)
-    BlockBuffer->ReserveAndResize(
-        AlignedByteRange.BlockCount() * AlignedByteRange.BlockSize);
+    BlockBuffer = std::make_unique<TString>(
+        AlignedByteRange.BlockCount() * AlignedByteRange.BlockSize,
+        0);
 
     DescribeData(ctx);
     Become(&TThis::StateWork);

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -131,9 +131,7 @@ void TReadDataActor::Bootstrap(const TActorContext& ctx)
     // a block buffer leads to memory allocation (and initialization) which is
     // heavy and we would like to execute that on a separate thread (instead of
     // this actor's parent thread)
-    BlockBuffer = std::make_unique<TString>(
-        AlignedByteRange.BlockCount() * AlignedByteRange.BlockSize,
-        0);
+    BlockBuffer = std::make_unique<TString>(AlignedByteRange.Length, 0);
 
     DescribeData(ctx);
     Become(&TThis::StateWork);

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3620,20 +3620,36 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 InvalidHandle,
                 256_KB - 1,
                 data.size());
-            UNIT_ASSERT_VALUES_EQUAL(data, response->Record.GetBuffer());
+
+            const auto& buffer = response->Record.GetBuffer();
+            const auto& offset = response->Record.GetBufferOffset();
+            UNIT_ASSERT_VALUES_EQUAL(
+                data.size() + DefaultBlockSize - 1,
+                buffer.size());
+            UNIT_ASSERT_VALUES_EQUAL(DefaultBlockSize - 1, offset);
+            UNIT_ASSERT_VALUES_EQUAL(
+                data,
+                TString(buffer.data() + offset, data.size()));
         }
         {
             // Small unaligned data
             auto data = GenerateValidateData(123, 2);
-            service.WriteData(headers, fs, nodeId, InvalidHandle, 77, data);
+            auto dataOffset = 77;
+            service.WriteData(headers, fs, nodeId, InvalidHandle, dataOffset, data);
             auto response = service.ReadData(
                 headers,
                 fs,
                 nodeId,
                 InvalidHandle,
-                77,
+                dataOffset,
                 data.size());
-            UNIT_ASSERT_VALUES_EQUAL(data, response->Record.GetBuffer());
+            const auto& buffer = response->Record.GetBuffer();
+            const auto& offset = response->Record.GetBufferOffset();
+            UNIT_ASSERT_VALUES_EQUAL(data.size() + dataOffset, buffer.size());
+            UNIT_ASSERT_VALUES_EQUAL(dataOffset, offset);
+            UNIT_ASSERT_EQUAL(
+                data,
+                TString(buffer.data() + offset, data.size()));
         }
         {
             // Multiple blobs

--- a/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
@@ -434,11 +434,17 @@ private:
             CheckResponse(response);
 
             const auto& buffer = response.GetBuffer();
+            const auto& bufferOffset = response.GetBufferOffset();
+            if (buffer.empty()) {
+                Y_ABORT_UNLESS(bufferOffset == 0);
+            } else {
+                Y_ABORT_UNLESS(bufferOffset < buffer.size());
+            }
 
             ui64 segmentId = byteOffset / SEGMENT_SIZE;
             for (ui64 offset = 0; offset < ReadBytes; offset += SEGMENT_SIZE) {
-                const TSegment* segment =
-                    reinterpret_cast<const TSegment*>(buffer.data() + offset);
+                const TSegment* segment = reinterpret_cast<const TSegment*>(
+                    buffer.data() + bufferOffset + offset);
                 if (Spec.GetValidationEnabled()) {
                     Y_ABORT_UNLESS(handleInfo.Segments);
 


### PR DESCRIPTION
issue: https://github.com/ydb-platform/nbs/issues/3988

Move  BlockBuffer to response and use set buffer offset field.