### PR TITLE
Logtitle refactoring, partition nonrepl remake.

### DIFF
--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -330,7 +330,7 @@ void TLogTitle::RebuildForPartitionNonrepl()
     auto builder = TStringBuilder();
 
     builder << "[";
-    builder << "nr:";
+    builder << "nrd:";
     builder << " d:" << DiskId;
 
     CachedPrefix = builder;

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -82,7 +82,7 @@ TLogTitle::TLogTitle(EType type, ui64 startTime)
     , StartTime(startTime)
 {}
 
-TLogTitle TLogTitle::CreatePartitionNonreplLog(TString diskId, ui64 startTime)
+TLogTitle TLogTitle::MakeForPartitionNonrepl(TString diskId, ui64 startTime)
 {
     auto log = TLogTitle(EType::PartitionNonrepl, startTime);
     log.DiskId = std::move(diskId);
@@ -332,10 +332,7 @@ void TLogTitle::RebuildForVolumeProxy()
 
 void TLogTitle::RebuildForPartitionNonrepl()
 {
-    auto builder = TStringBuilder();
-
-    builder << "[";
-    builder << "nrd:" << DiskId;
+    auto builder = TStringBuilder() << "[nrd:" << DiskId;
 
     CachedPrefix = builder;
 }

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -77,6 +77,14 @@ TLogTitle::TLogTitle(TString diskId, bool temporaryServer, ui64 startTime)
     Rebuild();
 }
 
+TLogTitle::TLogTitle(TString diskId, ui64 startTime)
+    : Type(EType::PartitionNonrepl)
+    , StartTime(startTime)
+    , DiskId(std::move(diskId))
+{
+    Rebuild();
+}
+
 // static
 TString TLogTitle::GetPartitionPrefix(
     ui64 tabletId,
@@ -201,6 +209,10 @@ void TLogTitle::Rebuild()
             RebuildForVolumeProxy();
             break;
         }
+        case EType::PartitionNonrepl: {
+            RebuildForPartitionNonrepl();
+            break;
+        }
     }
 }
 
@@ -309,6 +321,17 @@ void TLogTitle::RebuildForVolumeProxy()
     }
     builder << " d:" << DiskId;
     builder << " pg:" << Generation;
+
+    CachedPrefix = builder;
+}
+
+void TLogTitle::RebuildForPartitionNonrepl()
+{
+    auto builder = TStringBuilder();
+
+    builder << "[";
+    builder << "nr:";
+    builder << " d:" << DiskId;
 
     CachedPrefix = builder;
 }

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -6,6 +6,8 @@
 #include <util/string/builder.h>
 #include <util/system/datetime.h>
 
+#include <utility>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,12 +79,17 @@ TLogTitle::TLogTitle(TString diskId, bool temporaryServer, ui64 startTime)
     Rebuild();
 }
 
-TLogTitle::TLogTitle(TString diskId, ui64 startTime)
-    : Type(EType::PartitionNonrepl)
+TLogTitle::TLogTitle(EType type, ui64 startTime)
+    : Type(type)
     , StartTime(startTime)
-    , DiskId(std::move(diskId))
+{}
+
+TLogTitle TLogTitle::CreatePartitionNonreplLog(TString diskId, ui64 startTime)
 {
-    Rebuild();
+    auto log = TLogTitle(EType::PartitionNonrepl, startTime);
+    log.DiskId = std::move(diskId);
+    log.Rebuild();
+    return log;
 }
 
 // static
@@ -330,8 +337,7 @@ void TLogTitle::RebuildForPartitionNonrepl()
     auto builder = TStringBuilder();
 
     builder << "[";
-    builder << "nrd:";
-    builder << " d:" << DiskId;
+    builder << "nrd:" << DiskId;
 
     CachedPrefix = builder;
 }

--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -6,8 +6,6 @@
 #include <util/string/builder.h>
 #include <util/system/datetime.h>
 
-#include <utility>
-
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -76,7 +76,7 @@ public:
     TLogTitle(TString diskId, bool temporaryServer, ui64 startTime);
 
     // fabric for PartitionNonrepl
-    static TLogTitle CreatePartitionNonreplLog(TString diskId, ui64 startTime);
+    static TLogTitle MakeForPartitionNonrepl(TString diskId, ui64 startTime);
 
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
@@ -102,7 +102,7 @@ public:
     void SetTabletId(ui64 tabletId);
 
 private:
-    explicit TLogTitle(EType type, ui64 startTime);
+    TLogTitle(EType type, ui64 startTime);
     void Rebuild();
     void RebuildForVolume();
     void RebuildForPartition();

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -75,8 +75,8 @@ public:
     // Constructor for VolumeProxy
     TLogTitle(TString diskId, bool temporaryServer, ui64 startTime);
 
-    // Constructor for PartitionNonrepl
-    TLogTitle(TString diskId, ui64 startTime);
+    // fabric for PartitionNonrepl
+    static TLogTitle CreatePartitionNonreplLog(TString diskId, ui64 startTime);
 
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
@@ -102,6 +102,7 @@ public:
     void SetTabletId(ui64 tabletId);
 
 private:
+    explicit TLogTitle(EType type, ui64 startTime);
     void Rebuild();
     void RebuildForVolume();
     void RebuildForPartition();

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -26,6 +26,7 @@ public:
         Session,
         Client,
         VolumeProxy,
+        PartitionNonrepl,
     };
 
 private:
@@ -74,6 +75,9 @@ public:
     // Constructor for VolumeProxy
     TLogTitle(TString diskId, bool temporaryServer, ui64 startTime);
 
+    // Constructor for PartitionNonrepl
+    TLogTitle(TString diskId, ui64 startTime);
+
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
 
@@ -104,6 +108,7 @@ private:
     void RebuildForSession();
     void RebuildForClient();
     void RebuildForVolumeProxy();
+    void RebuildForPartitionNonrepl();
     TString GetPartitionPrefix() const;
 };
 

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -19,64 +19,75 @@ public:
         WithTime,
     };
 
-    enum class EType
+    struct TVolume
     {
-        Volume,
-        Partition,
-        Session,
-        Client,
-        VolumeProxy,
-        PartitionNonrepl,
+        ui64 TabletId;
+        TString DiskId;
+        ui32 Generation = 0;
+    };
+
+    struct TVolumeProxy
+    {
+        TString DiskId;
+        bool TemporaryServer = false;
+        ui32 Generation = 0;
+        ui64 TabletId = 0;
+    };
+
+    struct TPartition
+    {
+        ui64 TabletId = 0;
+        TString DiskId;
+        ui32 PartitionIndex = 0;
+        ui32 PartitionCount = 0;
+        ui32 Generation = 0;
+    };
+
+    struct TPartitionNonrepl
+    {
+        TString DiskId;
+    };
+
+    struct TSession
+    {
+        TString SessionId;
+        TString DiskId;
+        ui64 TabletId = 0;
+        bool TemporaryServer = false;
+    };
+
+    struct TClient
+    {
+        ui64 TabletId = 0;
+        TString SessionId;
+        TString ClientId;
+        TString DiskId;
+        bool TemporaryServer = false;
+        ui32 Generation = 0;
     };
 
 private:
-    const EType Type;
-    const TString SessionId;
-    const TString ClientId;
-    const ui64 StartTime;
-    const ui32 PartitionIndex = 0;
-    const ui32 PartitionCount = 0;
-    const bool TemporaryServer = false;
+    using TData = std::variant<
+        TVolume,
+        TVolumeProxy,
+        TPartition,
+        TPartitionNonrepl,
+        TSession,
+        TClient>;
 
-    ui64 TabletId = 0;
-    ui32 Generation = 0;
-    TString DiskId;
+    ui64 StartTime = 0;
+    TData Data;
+
     TString CachedPrefix;
 
 public:
-    // Constructor for Volume
-    TLogTitle(ui64 tabletId, TString diskId, ui64 startTime);
-
-    // Constructor for Partition
-    TLogTitle(
-        ui64 tabletId,
-        TString diskId,
-        ui64 startTime,
-        ui32 partitionIndex,
-        ui32 partitionCount);
-
-    // Constructor for Session
-    TLogTitle(
-        EType type,
-        TString sessionId,
-        TString diskId,
-        bool temporaryServer,
-        ui64 startTime);
-
-    // Constructor for Client
-    TLogTitle(
-        ui64 tabletId,
-        TString sessionId,
-        TString clientId,
-        TString diskId,
-        bool temporaryServer,
-        ui64 startTime);
-
-    // Constructor for VolumeProxy
-    TLogTitle(TString diskId, bool temporaryServer, ui64 startTime);
-
-    // fabric for PartitionNonrepl
-    static TLogTitle MakeForPartitionNonrepl(TString diskId, ui64 startTime);
+    template <typename T>
+    TLogTitle(ui64 startTime, T&& data)
+        : StartTime(startTime)
+        , Data(std::forward<T>(data))
+    {
+        Rebuild();
+    }
 
     static TString
     GetPartitionPrefix(ui64 tabletId, ui32 partitionIndex, ui32 partitionCount);
@@ -102,15 +113,7 @@ public:
     void SetTabletId(ui64 tabletId);
 
 private:
-    TLogTitle(EType type, ui64 startTime);
     void Rebuild();
-    void RebuildForVolume();
-    void RebuildForPartition();
-    void RebuildForSession();
-    void RebuildForClient();
-    void RebuildForVolumeProxy();
-    void RebuildForPartitionNonrepl();
-    TString GetPartitionPrefix() const;
 };
 
 class TChildLogTitle

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -193,13 +193,14 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
 
     Y_UNIT_TEST(GetForPartitionNonrepl)
     {
-        TLogTitle logTitle("disk1", GetCycleCount());
+        TLogTitle logTitle =
+            TLogTitle::CreatePartitionNonreplLog("disk1", GetCycleCount());
 
         UNIT_ASSERT_STRINGS_EQUAL(
-            "[nrd: d:disk1]",
+            "[nrd:disk1]",
             logTitle.Get(TLogTitle::EDetails::Brief));
 
-        UNIT_ASSERT_STRING_CONTAINS(logTitle.GetWithTime(), "[nrd: d:disk1 t:");
+        UNIT_ASSERT_STRING_CONTAINS(logTitle.GetWithTime(), "[nrd:disk1 t:");
     }
 
     Y_UNIT_TEST(GetChildLogger)

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -191,6 +191,17 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             temporayLogTitle.Get(TLogTitle::EDetails::Brief));
     }
 
+    Y_UNIT_TEST(GetForPartitionNonrepl)
+    {
+        TLogTitle logTitle("disk1", GetCycleCount());
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[nrd: d:disk1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(logTitle.GetWithTime(), "[nrd: d:disk1 t:");
+    }
+
     Y_UNIT_TEST(GetChildLogger)
     {
         const ui64 startTime =

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -47,7 +47,9 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
 
     Y_UNIT_TEST(GetForVolume)
     {
-        TLogTitle logTitle1(12345, "", GetCycleCount());
+        TLogTitle logTitle1(
+            GetCycleCount(),
+            TLogTitle::TVolume{.TabletId = 12345, .DiskId = ""});
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[v:12345 g:? d:???]",
@@ -70,7 +72,13 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
 
     Y_UNIT_TEST(GetForPartition)
     {
-        TLogTitle logTitle1(12345, "disk1", GetCycleCount(), 1, 2);
+        TLogTitle logTitle1(
+            GetCycleCount(),
+            TLogTitle::TPartition{
+                .TabletId = 12345,
+                .DiskId = "disk1",
+                .PartitionIndex = 1,
+                .PartitionCount = 2});
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[p1:12345 g:? d:disk1]",
@@ -89,11 +97,11 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
     Y_UNIT_TEST(GetForSession)
     {
         TLogTitle logTitle(
-            TLogTitle::EType::Session,
-            "session-1",
-            "disk1",
-            false,
-            GetCycleCount());
+            GetCycleCount(),
+            TLogTitle::TSession{
+                .SessionId = "session-1",
+                .DiskId = "disk1",
+                .TemporaryServer = false});
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[vs:? d:disk1 s:session-1]",
@@ -112,11 +120,11 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
     Y_UNIT_TEST(GetForSessionOnTemporaryServer)
     {
         TLogTitle logTitle(
-            TLogTitle::EType::Session,
-            "session-1",
-            "disk1",
-            true,
-            GetCycleCount());
+            GetCycleCount(),
+            TLogTitle::TSession{
+                .SessionId = "session-1",
+                .DiskId = "disk1",
+                .TemporaryServer = true});
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[~vs:? d:disk1 s:session-1]",
@@ -135,12 +143,13 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
     Y_UNIT_TEST(GetForClient)
     {
         TLogTitle logTitle(
-            12345,
-            "session-1",
-            "client-1",
-            "disk1",
-            false,
-            GetCycleCount());
+            GetCycleCount(),
+            TLogTitle::TClient{
+                .TabletId = 12345,
+                .SessionId = "session-1",
+                .ClientId = "client-1",
+                .DiskId = "disk1",
+                .TemporaryServer = false});
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[vc:12345 d:disk1 s:session-1 c:client-1 pg:?]",
@@ -156,12 +165,13 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             "[vc:12345 d:disk1 s:session-1 c:client-1 pg:1 t:");
 
         TLogTitle temporayLogTitle(
-            12345,
-            "session-1",
-            "client-1",
-            "disk1",
-            true,
-            GetCycleCount());
+            GetCycleCount(),
+            TLogTitle::TClient{
+                .TabletId = 12345,
+                .SessionId = "session-1",
+                .ClientId = "client-1",
+                .DiskId = "disk1",
+                .TemporaryServer = true});
         UNIT_ASSERT_STRINGS_EQUAL(
             "[~vc:12345 d:disk1 s:session-1 c:client-1 pg:?]",
             temporayLogTitle.Get(TLogTitle::EDetails::Brief));
@@ -169,7 +179,11 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
 
     Y_UNIT_TEST(GetForVolumeProxy)
     {
-        TLogTitle logTitle("disk1", false, GetCycleCount());
+        TLogTitle logTitle(
+            GetCycleCount(),
+            TLogTitle::TVolumeProxy{
+                .DiskId = "disk1",
+                .TemporaryServer = false});
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[vp:? d:disk1 pg:0]",
@@ -185,7 +199,11 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             "[vp:12345 d:disk1 pg:5]",
             logTitle.Get(TLogTitle::EDetails::Brief));
 
-        TLogTitle temporayLogTitle("disk1", true, GetCycleCount());
+        TLogTitle temporayLogTitle(
+            GetCycleCount(),
+            TLogTitle::TVolumeProxy{
+                .DiskId = "disk1",
+                .TemporaryServer = true});
         UNIT_ASSERT_STRINGS_EQUAL(
             "[~vp:? d:disk1 pg:0]",
             temporayLogTitle.Get(TLogTitle::EDetails::Brief));
@@ -193,8 +211,9 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
 
     Y_UNIT_TEST(GetForPartitionNonrepl)
     {
-        TLogTitle logTitle =
-            TLogTitle::MakeForPartitionNonrepl("disk1", GetCycleCount());
+        TLogTitle logTitle{
+            GetCycleCount(),
+            TLogTitle::TPartitionNonrepl{.DiskId = "disk1"}};
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[nrd:disk1]",
@@ -207,7 +226,9 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
     {
         const ui64 startTime =
             GetCycleCount() - GetCyclesPerMillisecond() * 2001;
-        TLogTitle logTitle1(12345, "disk1", startTime);
+        TLogTitle logTitle1(
+            startTime,
+            TLogTitle::TVolume{.TabletId = 12345, .DiskId = "disk1"});
         logTitle1.SetGeneration(5);
 
         auto childLogTitle =
@@ -222,10 +243,12 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
     {
         const ui64 startTime =
             GetCycleCount() - GetCyclesPerMillisecond() * 2001;
-        TLogTitle logTitle1(12345, "disk1", startTime);
+        TLogTitle logTitle1(
+            startTime,
+            TLogTitle::TVolume{.TabletId = 12345, .DiskId = "disk1"});
         logTitle1.SetGeneration(5);
 
-        std::vector<std::pair<TString, TString>> tags = {{"cp", "123"}};
+        std::pair<TString, TString> tags[] = {{"cp", "123"}};
 
         auto childLogTitle = logTitle1.GetChildWithTags(
             startTime + GetCyclesPerMillisecond() * 1001,

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -194,7 +194,7 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
     Y_UNIT_TEST(GetForPartitionNonrepl)
     {
         TLogTitle logTitle =
-            TLogTitle::CreatePartitionNonreplLog("disk1", GetCycleCount());
+            TLogTitle::MakeForPartitionNonrepl("disk1", GetCycleCount());
 
         UNIT_ASSERT_STRINGS_EQUAL(
             "[nrd:disk1]",

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -48,18 +48,18 @@ const TString PartitionTransactions[] = {
 };
 
 TPartitionActor::TPartitionActor(
-        const TActorId& owner,
-        TTabletStorageInfoPtr storage,
-        TStorageConfigPtr config,
-        TDiagnosticsConfigPtr diagnosticsConfig,
-        IProfileLogPtr profileLog,
-        IBlockDigestGeneratorPtr blockDigestGenerator,
-        NProto::TPartitionConfig partitionConfig,
-        EStorageAccessMode storageAccessMode,
-        ui32 partitionIndex,
-        ui32 siblingCount,
-        const TActorId& volumeActorId,
-        ui64 volumeTabletId)
+    const TActorId& owner,
+    TTabletStorageInfoPtr storage,
+    TStorageConfigPtr config,
+    TDiagnosticsConfigPtr diagnosticsConfig,
+    IProfileLogPtr profileLog,
+    IBlockDigestGeneratorPtr blockDigestGenerator,
+    NProto::TPartitionConfig partitionConfig,
+    EStorageAccessMode storageAccessMode,
+    ui32 partitionIndex,
+    ui32 siblingCount,
+    const TActorId& volumeActorId,
+    ui64 volumeTabletId)
     : TActor(&TThis::StateBoot)
     , TTabletBase(owner, std::move(storage), &TransactionTimeTracker)
     , Config(std::move(config))
@@ -74,11 +74,12 @@ TPartitionActor::TPartitionActor(
     , BlobCodec(NBlockCodecs::Codec(Config->GetBlobCompressionCodec()))
     , VolumeTabletId(volumeTabletId)
     , LogTitle(
-          TabletID(),
-          PartitionConfig.GetDiskId(),
           StartTime,
-          partitionIndex,
-          siblingCount)
+          TLogTitle::TPartition{
+              .TabletId = TabletID(),
+              .DiskId = PartitionConfig.GetDiskId(),
+              .PartitionIndex = partitionIndex,
+              .PartitionCount = siblingCount})
     , TransactionTimeTracker(PartitionTransactions)
 {}
 

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -36,17 +36,17 @@ const TPartitionActor::TStateInfo TPartitionActor::States[STATE_MAX] = {
 };
 
 TPartitionActor::TPartitionActor(
-        const TActorId& owner,
-        TTabletStorageInfoPtr storage,
-        TStorageConfigPtr config,
-        TDiagnosticsConfigPtr diagnosticsConfig,
-        IProfileLogPtr profileLog,
-        IBlockDigestGeneratorPtr blockDigestGenerator,
-        NProto::TPartitionConfig partitionConfig,
-        EStorageAccessMode storageAccessMode,
-        ui32 siblingCount,
-        const TActorId& volumeActorId,
-        ui64 volumeTabletId)
+    const TActorId& owner,
+    TTabletStorageInfoPtr storage,
+    TStorageConfigPtr config,
+    TDiagnosticsConfigPtr diagnosticsConfig,
+    IProfileLogPtr profileLog,
+    IBlockDigestGeneratorPtr blockDigestGenerator,
+    NProto::TPartitionConfig partitionConfig,
+    EStorageAccessMode storageAccessMode,
+    ui32 siblingCount,
+    const TActorId& volumeActorId,
+    ui64 volumeTabletId)
     : TActor(&TThis::StateBoot)
     , TTabletBase(owner, std::move(storage), nullptr)
     , Config(std::move(config))
@@ -60,11 +60,12 @@ TPartitionActor::TPartitionActor(
     , ChannelHistorySize(CalcChannelHistorySize())
     , VolumeTabletId(volumeTabletId)
     , LogTitle(
-          TabletID(),
-          PartitionConfig.GetDiskId(),
           StartTime,
-          0,
-          siblingCount)
+          TLogTitle::TPartition{
+              .TabletId = TabletID(),
+              .DiskId = PartitionConfig.GetDiskId(),
+              .PartitionIndex = 0,
+              .PartitionCount = siblingCount})
 {}
 
 TPartitionActor::~TPartitionActor()

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -36,9 +36,6 @@ TNonreplicatedPartitionActor::TNonreplicatedPartitionActor(
     , PartCounters(CreatePartitionDiskCounters(
           EPublishingPolicy::DiskRegistryBased,
           DiagnosticsConfig->GetHistogramCounterOptions()))
-    , LogTitle(TLogTitle::CreatePartitionNonreplLog(
-          PartConfig->GetName(),
-          GetCycleCount()))
 {}
 
 TNonreplicatedPartitionActor::~TNonreplicatedPartitionActor() = default;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -36,7 +36,9 @@ TNonreplicatedPartitionActor::TNonreplicatedPartitionActor(
     , PartCounters(CreatePartitionDiskCounters(
           EPublishingPolicy::DiskRegistryBased,
           DiagnosticsConfig->GetHistogramCounterOptions()))
-    , LogTitle(PartConfig->GetName(), GetCycleCount())
+    , LogTitle(TLogTitle::CreatePartitionNonreplLog(
+          PartConfig->GetName(),
+          GetCycleCount()))
 {}
 
 TNonreplicatedPartitionActor::~TNonreplicatedPartitionActor() = default;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -36,6 +36,7 @@ TNonreplicatedPartitionActor::TNonreplicatedPartitionActor(
     , PartCounters(CreatePartitionDiskCounters(
           EPublishingPolicy::DiskRegistryBased,
           DiagnosticsConfig->GetHistogramCounterOptions()))
+    , LogTitle(PartConfig->GetName(), GetCycleCount())
 {}
 
 TNonreplicatedPartitionActor::~TNonreplicatedPartitionActor() = default;
@@ -530,8 +531,8 @@ void TNonreplicatedPartitionActor::HandleDeviceTimedOutResponse(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Attempted to deem device %s as lagging. Result: %s",
-        PartConfig->GetName().c_str(),
+        "%s Attempted to deem device %s as lagging. Result: %s",
+        LogTitle.GetWithTime().c_str(),
         PartConfig->GetDevices()[ev->Cookie].GetDeviceUUID().c_str(),
         FormatError(msg->GetError()).c_str());
 }
@@ -547,8 +548,8 @@ void TNonreplicatedPartitionActor::HandleAgentIsUnavailable(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Agent %s has become unavailable",
-        PartConfig->GetName().c_str(),
+        "%s Agent %s has become unavailable",
+        LogTitle.GetWithTime().c_str(),
         laggingAgentId.Quote().c_str());
 
     if (!PartConfig->GetLaggingDevicesAllowed()) {
@@ -605,8 +606,8 @@ void TNonreplicatedPartitionActor::HandleAgentIsBackOnline(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Agent %s is back online",
-        PartConfig->GetName().c_str(),
+        "%s Agent %s is back online",
+        LogTitle.GetWithTime().c_str(),
         msg->AgentId.Quote().c_str());
 
     for (int i = 0; i < PartConfig->GetDevices().size(); ++i) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -84,7 +84,9 @@ private:
 
     TRequestInfoPtr Poisoner;
 
-    TLogTitle LogTitle;
+    TLogTitle LogTitle{TLogTitle::MakeForPartitionNonrepl(
+        PartConfig->GetName(),
+        GetCycleCount())};
 
 public:
     TNonreplicatedPartitionActor(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/model/requests_in_progress.h>
 #include <cloud/blockstore/libs/storage/partition_common/drain_actor_companion.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/get_device_for_range_companion.h>
@@ -82,6 +83,8 @@ private:
     TDuration CpuUsage;
 
     TRequestInfoPtr Poisoner;
+
+    TLogTitle LogTitle;
 
 public:
     TNonreplicatedPartitionActor(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -84,9 +84,9 @@ private:
 
     TRequestInfoPtr Poisoner;
 
-    TLogTitle LogTitle{TLogTitle::MakeForPartitionNonrepl(
-        PartConfig->GetName(),
-        GetCycleCount())};
+    TLogTitle LogTitle{
+        GetCycleCount(),
+        TLogTitle::TPartitionNonrepl{.DiskId = PartConfig->GetName()}};
 
 public:
     TNonreplicatedPartitionActor(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -249,8 +249,11 @@ void TNonreplicatedPartitionActor::HandleChecksumBlocksCompleted(
 {
     const auto* msg = ev->Get();
 
-    LOG_TRACE(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Complete checksum blocks", SelfId().ToString().c_str());
+    LOG_TRACE(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Complete checksum blocks",
+        LogTitle.GetWithTime().c_str());
 
     const auto requestBytes = msg->Stats.GetSysChecksumCounters().GetBlocksCount()
         * PartConfig->GetBlockSize();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -281,8 +281,11 @@ void TNonreplicatedPartitionActor::HandleReadBlocksCompleted(
 {
     const auto* msg = ev->Get();
 
-    LOG_TRACE(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Complete read blocks", SelfId().ToString().c_str());
+    LOG_TRACE(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Complete read blocks",
+        LogTitle.GetWithTime().c_str());
 
     UpdateStats(msg->Stats);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -393,8 +393,11 @@ void TNonreplicatedPartitionActor::HandleWriteBlocksCompleted(
 {
     const auto* msg = ev->Get();
 
-    LOG_TRACE(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Complete write blocks", SelfId().ToString().c_str());
+    LOG_TRACE(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Complete write blocks",
+        LogTitle.GetWithTime().c_str());
 
     UpdateStats(msg->Stats);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -324,8 +324,8 @@ void TNonreplicatedPartitionActor::HandleMultiAgentWriteBlocksCompleted(
     LOG_TRACE(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Complete multi agent write blocks",
-        SelfId().ToString().c_str());
+        "%s Complete multi agent write blocks",
+        LogTitle.GetWithTime().c_str());
 
     UpdateStats(msg->Stats);
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -238,8 +238,11 @@ void TNonreplicatedPartitionActor::HandleZeroBlocksCompleted(
 {
     const auto* msg = ev->Get();
 
-    LOG_TRACE(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Complete zero blocks", SelfId().ToString().c_str());
+    LOG_TRACE(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Complete zero blocks",
+        LogTitle.GetWithTime().c_str());
 
     UpdateStats(msg->Stats);
 

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
@@ -144,15 +144,15 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TVolumeClientActor::TVolumeClientActor(
-        TStorageConfigPtr config,
-        ITraceSerializerPtr traceSerializer,
-        NServer::IEndpointEventHandlerPtr endpointEventHandler,
-        const TActorId& sessionActorId,
-        TString sessionId,
-        TString clientId,
-        bool temporaryServer,
-        TString diskId,
-        ui64 tabletId)
+    TStorageConfigPtr config,
+    ITraceSerializerPtr traceSerializer,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
+    const TActorId& sessionActorId,
+    TString sessionId,
+    TString clientId,
+    bool temporaryServer,
+    TString diskId,
+    ui64 tabletId)
     : TActor(&TThis::StateWork)
     , TraceSerializer(std::move(traceSerializer))
     , EndpointEventHandler(std::move(endpointEventHandler))
@@ -161,12 +161,13 @@ TVolumeClientActor::TVolumeClientActor(
     , TabletId(tabletId)
     , ClientConfig(CreateTabletPipeClientConfig(*config))
     , LogTitle(
-          TabletId,
-          std::move(sessionId),
-          std::move(clientId),
-          DiskId,
-          temporaryServer,
-          GetCycleCount())
+          GetCycleCount(),
+          TLogTitle::TClient{
+              .TabletId = TabletId,
+              .SessionId = std::move(sessionId),
+              .ClientId = std::move(clientId),
+              .DiskId = DiskId,
+              .TemporaryServer = temporaryServer})
 {}
 
 void TVolumeClientActor::OnConnectionError(

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -59,11 +59,11 @@ private:
     const bool TemporaryServer;
 
     TLogTitle LogTitle{
-        TLogTitle::EType::Session,
-        VolumeInfo->SessionId,
-        VolumeInfo->DiskId,
-        TemporaryServer,
-        GetCycleCount()};
+        GetCycleCount(),
+        TLogTitle::TSession{
+            .SessionId = VolumeInfo->SessionId,
+            .DiskId = VolumeInfo->DiskId,
+            .TemporaryServer = TemporaryServer}};
 
     TQueue<NActors::IEventHandlePtr> MountUnmountRequests;
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -79,7 +79,9 @@ private:
     // Duration between reboot attempts
     TDuration RebootSleepDuration;
 
-    TLogTitle LogTitle{VolumeTabletId, DiskId, GetCycleCount()};
+    TLogTitle LogTitle{
+        GetCycleCount(),
+        TLogTitle::TVolume{.TabletId = VolumeTabletId, .DiskId = DiskId}};
 
 public:
     TStartVolumeActor(

--- a/cloud/blockstore/libs/storage/volume/actors/forward_write_and_mark_used_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/forward_write_and_mark_used_ut.cpp
@@ -57,7 +57,9 @@ Y_UNIT_TEST_SUITE(TForwardWriteAndMarkUsedTests)
                     EdgeActor,
                     0,
                     EdgeActor,
-                    TLogTitle(0, TString("test"), GetCycleCount())
+                    TLogTitle(
+                        GetCycleCount(),
+                        TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                         .GetChild(GetCycleCount())});
         }
     };
@@ -83,7 +85,9 @@ Y_UNIT_TEST_SUITE(TForwardWriteAndMarkUsedTests)
                     EdgeActor,
                     0,
                     EdgeActor,
-                    TLogTitle(0, TString("test"), GetCycleCount())
+                    TLogTitle(
+                        GetCycleCount(),
+                        TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                         .GetChild(GetCycleCount())});
         }
     };

--- a/cloud/blockstore/libs/storage/volume/actors/read_and_clear_empty_blocks_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_and_clear_empty_blocks_actor_ut.cpp
@@ -61,7 +61,9 @@ Y_UNIT_TEST_SUITE(TForwardReadTests)
                 EdgeActor,
                 0,
                 EdgeActor,
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         ActorSystem.GrabEdgeEvent<TEvService::TReadBlocksMethod::TRequest>();

--- a/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay_ut.cpp
@@ -57,8 +57,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
         request.SetBlocksCount(10);
 
         const ui32 blockSize = 512;
-        auto readActor = ActorSystem.Register(
-            new TReadDiskRegistryBasedOverlayActor<TEvService::TReadBlocksMethod>{
+        auto readActor =
+            ActorSystem.Register(new TReadDiskRegistryBasedOverlayActor<
+                                 TEvService::TReadBlocksMethod>{
                 MakeIntrusive<TRequestInfo>(
                     EdgeActor,
                     0ull,
@@ -73,7 +74,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
                 blockSize,
                 EStorageAccessMode::Default,
                 TDuration(),
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         auto requestToPartition = ActorSystem.GrabEdgeEvent<
@@ -125,8 +128,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
         request.SetBlocksCount(10);
 
         const ui32 blockSize = 512;
-        auto readActor = ActorSystem.Register(
-            new TReadDiskRegistryBasedOverlayActor<TEvService::TReadBlocksMethod>{
+        auto readActor =
+            ActorSystem.Register(new TReadDiskRegistryBasedOverlayActor<
+                                 TEvService::TReadBlocksMethod>{
                 MakeIntrusive<TRequestInfo>(
                     EdgeActor,
                     0ull,
@@ -141,7 +145,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
                 blockSize,
                 EStorageAccessMode::Default,
                 TDuration(),
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         ActorSystem.GrabEdgeEvent<
@@ -196,7 +202,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
                 blockSize,
                 EStorageAccessMode::Default,
                 TDuration(),
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         TAutoPtr<NActors::IEventHandle> handle;
@@ -383,7 +391,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
                 blockSize,
                 EStorageAccessMode::Default,
                 TDuration(),
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         TAutoPtr<NActors::IEventHandle> handle;
@@ -439,7 +449,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
                 blockSize,
                 EStorageAccessMode::Default,
                 TDuration(),
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         TAutoPtr<NActors::IEventHandle> handle;
@@ -532,7 +544,9 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
                 blockSize,
                 EStorageAccessMode::Default,
                 TDuration(),
-                TLogTitle(0, TString("test"), GetCycleCount())
+                TLogTitle(
+                    GetCycleCount(),
+                    TLogTitle::TVolume{.TabletId = 0, .DiskId = "test"})
                     .GetChild(GetCycleCount())});
 
         // read from overlay disk

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
@@ -125,7 +125,9 @@ Y_UNIT_TEST_SUITE(TVolumeAsPartitionActorTests)
         const ui64 FollowerBlockCount = 256;
         const TString LeaderDiskId = "leader-disk";
         const TString FollowerDiskId = "follower-disk";
-        TLogTitle LogTitle{10, LeaderDiskId, GetCycleCount()};
+        TLogTitle LogTitle{
+            GetCycleCount(),
+            TLogTitle::TVolume{.TabletId = 10, .DiskId = LeaderDiskId}};
 
         TActorSystem ActorSystem;
         NActors::TActorId EdgeActor;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -60,17 +60,17 @@ const TString VolumeTransactions[] = {
 };
 
 TVolumeActor::TVolumeActor(
-        const TActorId& owner,
-        TTabletStorageInfoPtr storage,
-        TStorageConfigPtr config,
-        TDiagnosticsConfigPtr diagnosticsConfig,
-        IProfileLogPtr profileLog,
-        IBlockDigestGeneratorPtr blockDigestGenerator,
-        ITraceSerializerPtr traceSerializer,
-        NRdma::IClientPtr rdmaClient,
-        NServer::IEndpointEventHandlerPtr endpointEventHandler,
-        EVolumeStartMode startMode,
-        TString diskId)
+    const TActorId& owner,
+    TTabletStorageInfoPtr storage,
+    TStorageConfigPtr config,
+    TDiagnosticsConfigPtr diagnosticsConfig,
+    IProfileLogPtr profileLog,
+    IBlockDigestGeneratorPtr blockDigestGenerator,
+    ITraceSerializerPtr traceSerializer,
+    NRdma::IClientPtr rdmaClient,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler,
+    EVolumeStartMode startMode,
+    TString diskId)
     : TActor(&TThis::StateBoot)
     , TTabletBase(owner, std::move(storage), &TransactionTimeTracker)
     , GlobalStorageConfig(config)
@@ -82,7 +82,11 @@ TVolumeActor::TVolumeActor(
     , RdmaClient(std::move(rdmaClient))
     , EndpointEventHandler(std::move(endpointEventHandler))
     , StartMode(startMode)
-    , LogTitle(TabletID(), std::move(diskId), StartTime)
+    , LogTitle(
+          StartTime,
+          TLogTitle::TVolume{
+              .TabletId = TabletID(),
+              .DiskId = std::move(diskId)})
     , ThrottlerLogger(
           TabletID(),
           [this](ui32 opType, TDuration time)

--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
@@ -84,7 +84,11 @@ class TVolumeProxyActor final
         TConnection(ui64 id, TString diskId, bool temporaryServer)
             : Id(id)
             , DiskId(std::move(diskId))
-            , LogTitle(DiskId, temporaryServer, GetCycleCount())
+            , LogTitle(
+                  GetCycleCount(),
+                  TLogTitle::TVolumeProxy{
+                      .DiskId = DiskId,
+                      .TemporaryServer = temporaryServer})
         {}
 
         void AdvanceGeneration()


### PR DESCRIPTION
before
`2025-08-11T10:30:26.571690Z node 39 :BLOCKSTORE_PARTITION INFO: [vol0] Agent "agent-2" has become unavailable`

after
`2025-08-11T10:25:41.210592Z node 39 :BLOCKSTORE_PARTITION INFO: [nrd:vol0 t:27.482ms] Agent "agent-2" has become unavailable`

также было решено переделать процесс создания TLogTitle , чтобы избежать путаницы 