### PR TITLE
issue-1751: Optimize CalculateDataPartsToRead in TWriteBackCache using disjoint interval tree

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/disjoint_interval_map.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/disjoint_interval_map.cpp
@@ -1,0 +1,1 @@
+#include "disjoint_interval_map.h"

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/disjoint_interval_map.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/disjoint_interval_map.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <util/generic/map.h>
+#include <util/generic/yexception.h>
+
+#include <functional>
+
+namespace NCloud::NFileStore::NFuse {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class TKey, class TValue>
+class TDisjointIntervalMap
+{
+public:
+    struct TItem
+    {
+        const TKey Begin;
+        const TKey End;
+        const TValue Value;
+    };
+
+    using TData = TMap<TKey, TItem>;
+    using TConstIterator = typename TData::const_iterator;
+    using TVisitor = std::function<void(TConstIterator it)>;
+
+private:
+    TData Data;
+
+public:
+    // Add a new interval [begin, end) -> value into the map
+    // An exception is thrown if it intersects with any of the existing
+    // intervals
+    void Add(TKey begin, TKey end, TValue value)
+    {
+        Y_ENSURE(
+            begin < end,
+            "Input argument [" << begin << ", " << end
+                               << ") is invalid interval");
+
+        // Find first TItem with .End > begin
+        auto it = Data.upper_bound(begin);
+
+        Y_ENSURE(
+            it == Data.end() || it->second.Begin >= end,
+            "Adding interval ["
+                << begin << ", " << end
+                << ") failed because it overlaps with the existing interval ["
+                << it->second.Begin << ", " << it->second.End << ")");
+
+        Data.emplace_hint(it, end, TItem{
+            .Begin = begin,
+            .End = end,
+            .Value = std::move(value)});
+    }
+
+    void Remove(TConstIterator iterator)
+    {
+        Data.erase(iterator);
+    }
+
+    // Visit each interval that intersects with [begin, end)
+    // Note: it is allowed to remove the current element from the visitor
+    void VisitOverlapping(TKey begin, TKey end, const TVisitor& visitor) const
+    {
+        // Find first TItem with .End > begin
+        auto it = Data.upper_bound(begin);
+
+        while (it != Data.end() && it->second.Begin < end) {
+            auto next = std::next(it);
+            visitor(it);
+            it = next;
+        }
+    }
+
+    TConstIterator begin() const
+    {
+        return Data.begin();
+    }
+
+    TConstIterator end() const
+    {
+        return Data.end();
+    }
+};
+
+}   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/disjoint_interval_map_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/disjoint_interval_map_ut.cpp
@@ -1,0 +1,117 @@
+#include "disjoint_interval_map.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NFileStore::NFuse {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template<class TKey, class TValue>
+TString Print(const TDisjointIntervalMap<TKey, TValue>& map)
+{
+    TStringBuilder sb;
+    sb << "[";
+
+    bool first = true;
+    for (const auto& [_, value]: map) {
+        if (first) {
+            first = false;
+        } else {
+            sb << ", ";
+        }
+        sb << "(" << value.Begin << ", " << value.End << "): " << value.Value;
+    }
+    sb << "]";
+
+    return sb;
+}
+
+template <class TKey, class TValue>
+TString PrintOverlapping(
+    TDisjointIntervalMap<TKey, TValue>& map,
+    TKey begin,
+    TKey end)
+{
+    TDisjointIntervalMap<TKey, TValue> tmp;
+
+    map.VisitOverlapping(begin, end, [&](auto it) {
+        tmp.Add(it->second.Begin, it->second.End, it->second.Value);
+    });
+
+    return Print(tmp);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TMap = TDisjointIntervalMap<ui64, TString>;
+
+Y_UNIT_TEST_SUITE(TDisjointIntervalMapTest)
+{
+    Y_UNIT_TEST(SimpleAdd)
+    {
+        TMap map;
+        map.Add(3, 5, "petya");
+        map.Add(1, 3, "vasya");
+
+        UNIT_ASSERT_VALUES_EQUAL("[(1, 3): vasya, (3, 5): petya]", Print(map));
+    }
+
+    Y_UNIT_TEST(VisitOverlapping)
+    {
+        TMap map;
+        map.Add(3, 5, "petya");
+        map.Add(1, 3, "vasya");
+        map.Add(9, 12, "ben");
+        map.Add(6, 7, "igor");
+
+        for (ui64 l = 0; l <= 14; l++) {
+            for (ui64 r = l + 1; r <= 15; r++) {
+                TMap expected;
+                if (l < 3 && r > 1) {
+                    expected.Add(1, 3, "vasya");
+                }
+                if (l < 5 && r > 3) {
+                    expected.Add(3, 5, "petya");
+                }
+                if (l < 7 && r > 6) {
+                    expected.Add(6, 7, "igor");
+                }
+                if (l < 12 && r > 9) {
+                    expected.Add(9, 12, "ben");
+                }
+
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    Print(expected),
+                    PrintOverlapping(map, l, r),
+                    "Failed for l=" << l << ", r=" << r);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(DeleteWhileVisitOverlapping)
+    {
+        TMap map;
+        map.Add(3, 5, "petya");
+        map.Add(1, 3, "vasya");
+        map.Add(9, 12, "ben");
+        map.Add(6, 7, "igor");
+
+        map.VisitOverlapping(4UL, 13UL, [&](auto it) {
+            if (it->second.Value == "igor") {
+                map.Remove(it);
+            }
+        });
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[(1, 3): vasya, (3, 5): petya, (9, 12): ben]",
+            Print(map));
+    }
+}
+
+}   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/ut/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
 SRCDIR(cloud/filestore/libs/vfs_fuse/write_back_cache)
 
 SRCS(
+    disjoint_interval_map_ut.cpp
     overlapping_interval_set_ut.cpp
     read_write_range_lock_ut.cpp
     write_back_cache_ut.cpp

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -67,6 +67,7 @@ private:
     class TUtil;
     struct TPendingOperations;
     class TContiguousWriteDataEntryPartsReader;
+    class TWriteDataEntryIntervalMap;
 };
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util.cpp
@@ -128,14 +128,14 @@ auto TWriteBackCache::TUtil::CalculateDataPartsToRead(
         [&res, offset = startingFromOffset, end = startingFromOffset + length](
             auto it)
         {
-            auto ioffset = Max(offset, it->second.Begin);
-            auto iend = Min(end, it->second.End);
+            auto partOffset = Max(offset, it->second.Begin);
+            auto partEnd = Min(end, it->second.End);
             auto* entry = it->second.Value;
             res.emplace_back(
                 it->second.Value,
-                ioffset - entry->Offset(),
-                ioffset,
-                iend - ioffset);
+                partOffset - entry->Offset(),
+                partOffset,
+                partEnd - partOffset);
         });
 
     return res;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util_ut.cpp
@@ -1,5 +1,7 @@
 #include "write_back_cache_impl.h"
 
+#include "disjoint_interval_map.h"
+
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -137,6 +139,7 @@ struct TCalculateDataPartsToReadTestBootstrap
 {
     using TWriteDataEntry = TWriteBackCache::TWriteDataEntry;
     using TWriteDataEntryPart = TWriteBackCache::TWriteDataEntryPart;
+    using TCachedIntervalsMap = TWriteBackCache::TWriteDataEntryIntervalMap;
 
     ILoggingServicePtr Logging;
     TLog Log;
@@ -155,8 +158,13 @@ struct TCalculateDataPartsToReadTestBootstrap
         ui64 startingFromOffset,
         ui64 length)
     {
+        TCachedIntervalsMap map;
+        for (auto* entry: entries) {
+            map.Add(entry);
+        }
+
         return TWriteBackCache::TUtil::CalculateDataPartsToRead(
-            entries,
+            map,
             startingFromOffset,
             length);
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    disjoint_interval_map.cpp
     overlapping_interval_set.cpp
     read_write_range_lock.cpp
     write_back_cache.cpp


### PR DESCRIPTION
Switch from long running linear search (in about ~250k elements) to O(log n) algorithm.