### PR TITLE
[NBS, Filestore] Make user counter able to work with both single and multiple counter histograms

### DIFF
--- a/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
@@ -265,8 +265,7 @@ public:
 
     void IncrementHistogram(ui64 value, size_t baseBucketId) const
     {
-        // Since the base histogram uses usec bounds while the user histogram
-        // uses msec boundaries, we need to merge several first buckets into one
+        // Base histogram in usec vs user histogram in msec, merge first buckets
         size_t id = baseBucketId < MergeFirstBucketsCount
                         ? 0
                         : baseBucketId - MergeFirstBucketsCount;


### PR DESCRIPTION
Currently user counters work only through multiple-counter histogram:
```
histogram=Time:
    sensor=0.001ms: 248
    sensor=0.1ms: 15
    sensor=0.2ms: 23
    ...
    sensor=10000ms: 7
    sensor=35000ms: 6
    sensor=Inf: 0
```

This PR make it possible to calculate `users_stats` with single-counter histogram as well:
```
sensor=Time:
    bin=0.001: 248
    bin=0.1: 15
    bin=0.2: 23
    ...
    bin=10000: 7
    bin=35000: 6
    bin=inf: 0
```

