### PR TITLE
[NBS] remove obsolete PlacementGroupWith*Disk counters

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.cpp
@@ -47,14 +47,6 @@ void TDiskRegistrySelfCounters::Init(
     Mirror3DisksMinus1 = counters->GetCounter("Mirror3DisksMinus1");
     Mirror3DisksMinus2 = counters->GetCounter("Mirror3DisksMinus2");
     Mirror3DisksMinus3 = counters->GetCounter("Mirror3DisksMinus3");
-    PlacementGroupsWithRecentlyBrokenSingleDisk =
-        counters->GetCounter("PlacementGroupsWithRecentlyBrokenSingleDisk");
-    PlacementGroupsWithRecentlyBrokenTwoOrMoreDisks =
-        counters->GetCounter("PlacementGroupsWithRecentlyBrokenTwoOrMoreDisks");
-    PlacementGroupsWithBrokenSingleDisk =
-        counters->GetCounter("PlacementGroupsWithBrokenSingleDisk");
-    PlacementGroupsWithBrokenTwoOrMoreDisks =
-        counters->GetCounter("PlacementGroupsWithBrokenTwoOrMoreDisks");
     PlacementGroupsWithRecentlyBrokenSinglePartition =
         counters->GetCounter("PlacementGroupsWithRecentlyBrokenSinglePartition");
     PlacementGroupsWithRecentlyBrokenTwoOrMorePartitions =

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.h
@@ -78,13 +78,6 @@ struct TDiskRegistrySelfCounters
     TCounterPtr Mirror3DisksMinus1;
     TCounterPtr Mirror3DisksMinus2;
     TCounterPtr Mirror3DisksMinus3;
-    // TODO(dvrazumov): "*Disk*" counters are replaced with "*Partitions" counters.
-    // They are left for compatibility and should be removed later (NBSNEBIUS-26)
-    TCounterPtr PlacementGroupsWithRecentlyBrokenSingleDisk;
-    TCounterPtr PlacementGroupsWithRecentlyBrokenTwoOrMoreDisks;
-    TCounterPtr PlacementGroupsWithBrokenSingleDisk;
-    TCounterPtr PlacementGroupsWithBrokenTwoOrMoreDisks;
-    // remove above ^^^
     TCounterPtr PlacementGroupsWithRecentlyBrokenSinglePartition;
     TCounterPtr PlacementGroupsWithRecentlyBrokenTwoOrMorePartitions;
     TCounterPtr PlacementGroupsWithBrokenSinglePartition;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4518,20 +4518,6 @@ void TDiskRegistryState::PublishCounters(TInstant now)
         placementGroupsWithBrokenTwoOrMorePartitions += total > 1;
     }
 
-    // TODO(dvrazumov): left for compatibility (NBSNEBIUS-26)
-    SelfCounters.PlacementGroupsWithRecentlyBrokenSingleDisk->Set(
-        placementGroupsWithRecentlyBrokenSinglePartition);
-
-    SelfCounters.PlacementGroupsWithRecentlyBrokenTwoOrMoreDisks->Set(
-        placementGroupsWithRecentlyBrokenTwoOrMorePartitions);
-
-    SelfCounters.PlacementGroupsWithBrokenSingleDisk->Set(
-        placementGroupsWithBrokenSinglePartition);
-
-    SelfCounters.PlacementGroupsWithBrokenTwoOrMoreDisks->Set(
-        placementGroupsWithBrokenTwoOrMorePartitions);
-    // remove above ^^^^
-
     SelfCounters.PlacementGroupsWithRecentlyBrokenSinglePartition->Set(
         placementGroupsWithRecentlyBrokenSinglePartition);
 


### PR DESCRIPTION
Cleaning obsolete counters (more info in commit https://github.com/ydb-platform/nbs/commit/c18bfdf04b8a5b189d6abb0dd87a7bf6567330c8)

The counters should be replaced to the new ones:
```
PlacementGroupsWithRecentlyBrokenSingleDisk -> PlacementGroupsWithRecentlyBrokenSinglePartition
PlacementGroupsWithRecentlyBrokenTwoOrMoreDisks -> PlacementGroupsWithRecentlyBrokenTwoOrMorePartitions
PlacementGroupsWithBrokenSingleDisk -> PlacementGroupsWithBrokenSinglePartition
PlacementGroupsWithBrokenTwoOrMoreDisks -> PlacementGroupsWithBrokenTwoOrMorePartitions
```
