### PR TITLE
[NBS] replaced stats reference with getter functions in TPartitionState

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -748,7 +748,8 @@ public:
 
     ui32 GetUnflushedFreshBlocksCount() const
     {
-        return Stats.GetFreshBlocksCount() + UnflushedFreshBlocksFromChannelCount;
+        return GetStats().GetFreshBlocksCount() +
+               UnflushedFreshBlocksFromChannelCount;
     }
 
     ui32 IncrementUnflushedFreshBlocksFromDbCount(size_t value);
@@ -997,8 +998,8 @@ public:
 
     void UpdateBlocksCountersAfterMetadataRebuild(ui64 mixed, ui64 merged)
     {
-        Stats.SetMixedBlocksCount(mixed);
-        Stats.SetMergedBlocksCount(merged);
+        AccessStats().SetMixedBlocksCount(mixed);
+        AccessStats().SetMergedBlocksCount(merged);
     }
 
     //
@@ -1388,7 +1389,6 @@ public:
     //
 
 private:
-    NProto::TPartitionStats& Stats;
     THashMap<ui32, TDowntimeHistoryHolder> GroupId2Downtimes;
 
 public:
@@ -1402,18 +1402,18 @@ public:
 
     const NProto::TPartitionStats& GetStats() const
     {
-        return Stats;
+        return Meta.GetStats();
     }
 
     NProto::TPartitionStats& AccessStats()
     {
-        return Stats;
+        return *Meta.MutableStats();
     }
 
 #define BLOCKSTORE_PARTITION_DECLARE_COUNTER(name)                             \
     ui64 Get##name() const                                                     \
     {                                                                          \
-        return Stats.Get##name();                                              \
+        return GetStats().Get##name();                                         \
     }                                                                          \
                                                                                \
     ui64 Increment##name(size_t value);                                        \
@@ -1427,7 +1427,7 @@ public:
     template <typename T>
     void UpdateStats(T&& update)
     {
-        update(Stats);
+        update(AccessStats());
     }
 
     void DumpHtml(IOutputStream& out) const;


### PR DESCRIPTION
Запоминать референс на поле Stats не очень безопасно т.к. например может быть вызван метод ClearStats(), после которого референс будет вести в освобожденную память и при попытке обратится к этому полю мы получим краш
```
#0 NCloud::NBlockStore::NStorage::NPartition::TPartitionState::GetMixedBlocksCount (this=0x0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_state.h +1423
#1 NCloud::NBlockStore::NStorage::NPartition::TPartitionActor::ExtractPartCounters (this=0x54e5a21e2500, ctx=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp +62
#2 NCloud::NBlockStore::NStorage::NPartition::TPartitionActor::HandleGetPartCountersRequest (this=0x54e5a21e2500, ev=..., ctx=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp +202
#3 NCloud::NBlockStore::NStorage::NPartition::TPartitionActor::StateInit (this=0x54e5a21e2500, ev=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_actor.cpp +955
#4 NActors::TExecutorThread::Execute (this=0x54e5bf4cbb80, mailbox=0x54e5ad3ec2c0, isTailExecution=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/library/actors/core/executor_thread.cpp +269
#5 NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const (this=0x7f1a325d6570, mailbox=0x54e5ad3ec2c0, isTailExecution=false) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/library/actors/core/executor_thread.cpp +460
#6 NActors::TExecutorThread::ProcessExecutorPool (this=0x54e5bf4cbb80) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/library/actors/core/executor_thread.cpp +512
#7 NActors::TExecutorThread::ThreadProc (this=0x54e5bf4cbb80) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/library/actors/core/executor_thread.cpp +538
#8 (anonymous namespace)::TPosixThread::ThreadProxy (arg=0x54e5bbcc3ab0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/thread.cpp +244
#9 start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#10 clone () from /lib/x86_64-linux-gnu/libc.so.6
```