### PR TITLE
feat: add flag to disable vm removal if task is cancelled

### DIFF
--- a/.github/workflows/build_and_test_on_demand.yaml
+++ b/.github/workflows/build_and_test_on_demand.yaml
@@ -265,7 +265,7 @@ jobs:
           sparse-checkout: '.github'
       - name: Stop runner
         uses: ./.github/actions/nebius_runner_remove
-        if: always()
+        if: ${{ always() && ( vars.NEBIUS_REMOVE_CANCELLED_VMS == 'yes' || !contains(needs.*.result, 'cancelled') ) }}
         timeout-minutes: 60
         with:
           service_account_key: ${{ secrets.NEW_NEBIUS_SA_JSON_CREDENTIALS }}


### PR DESCRIPTION
It may be helpful in case when runner app is stopped due to OOM