### PR TITLE
eternal-load: dump actual state on break or failure

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -72,6 +72,7 @@ int TTest::Run()
                 Options->RequestBlockCount,
                 Options->WriteParts,
                 Options->AlternatingPhase);
+            DumpConfiguration();
             break;
         case ECommand::ReadConfigCmd:
             Y_ENSURE(Options->RestorePath.Defined(), "You need to specify the restore path");
@@ -82,15 +83,13 @@ int TTest::Run()
             return 2;
     }
 
-    DumpConfiguration();
-
     return RunTest();
 }
 
 void TTest::DumpConfiguration()
 {
     ConfigHolder->DumpConfig(Options->DumpPath);
-    STORAGE_INFO("Load configuration has been generated. See file "
+    STORAGE_INFO("Test configuration and actual state have been stored to file "
         << Options->DumpPath.Quote());
 }
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -44,12 +44,12 @@ ui64 CalculateInverse(ui64 step, ui64 len)
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TRange {
-    TRangeConfig Config;
+    TRangeConfig& Config;
     ui64 Size;
     std::shared_ptr<char[]> Buf;
     ui64 StepInversion;
 
-    TRange(const TRangeConfig& config, ui64 size)
+    TRange(TRangeConfig& config, ui64 size)
         : Config{config}
         , Size{size}
         , Buf{static_cast<char*>(std::aligned_alloc(NSystemInfo::GetPageSize(), Size)), std::free}
@@ -158,7 +158,7 @@ public:
     {
         auto& config = ConfigHolder->GetConfig();
         for (ui16 i = 0; i < config.GetIoDepth(); ++i) {
-            auto rangeConfig = config.GetRanges(i);
+            auto& rangeConfig = *config.MutableRanges(i);
             Ranges.emplace_back(
                 rangeConfig,
                 rangeConfig.GetRequestBlockCount() * config.GetBlockSize());


### PR DESCRIPTION
When the eternal test is crashed, the dumped configuration doesn't contain the actual state.
This PR resolves the problem and makes it to store the actual state.

Crash example:
```
2025-08-14T06:31:43.379225Z :ETERNAL_EXECUTOR ERROR: cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:289: [26] Wrong data in block 56573536 expected RequestNumber 1234 actual TBlockData { RequestNumber 1317154 PartNumber 0 BlockIndex 56573536 RangeIdx 26 RequestTimestamp 2025-08-14T06:11:17.421977Z TestTimestamp 2025-08-13T18:45:57.473308Z TestId 8009441898669853898 Checksum 2883400439}
```