### PR TITLE
[Blockstore] Make "failed to create token for disk" error non-retriable

### DIFF
--- a/cloud/blockstore/libs/kms/iface/key_provider.cpp
+++ b/cloud/blockstore/libs/kms/iface/key_provider.cpp
@@ -84,8 +84,9 @@ private:
         const auto& computeResponse = Executor->WaitFor(computeFuture);
         if (HasError(computeResponse)) {
             const auto& err = computeResponse.GetError();
-            // Disk Manager interprets E_GRPC_NOT_FOUND as retriable error.
-            // See NBS-6176.
+            // Disk Manager interprets E_GRPC_NOT_FOUND as retriable error,
+            // resulting in a retry loop if the disk gets deleted.
+            // See https://github.com/ydb-platform/nbs/issues/4167.
             const ui32 code = err.GetCode() == E_GRPC_NOT_FOUND
                 ? E_NOT_FOUND
                 : err.GetCode();


### PR DESCRIPTION
Closes #4167

If Disk Manager is writing onto encrypted disk thats gets deleted during this process, NBS receives the following errors from KMS: 

```
cloud/blockstore/libs/encryption/encryption_service.cpp:163: MountVolume #<id> finish creating encryption client: E_GRPC_NOT_FOUND failed to create token for disk <id>, error: task "<id>" is finished
```

Disk Manager considers these errors as retriable because they have the E_GRPC_NOT_FOUND code. As a result, DM gets into a retry loop, continuously getting these errors, and a "control plane errors" alert is triggered.

This PR changes the error code to E_NOT_FOUND so this error would be considered silent and non-retriable.