### PR TITLE
issue-4165: add separate iam token client for ydb stats

### DIFF
--- a/cloud/blockstore/config/ydbstats.proto
+++ b/cloud/blockstore/config/ydbstats.proto
@@ -4,6 +4,8 @@ package NCloud.NBlockStore.NProto;
 
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
 
+import "cloud/storage/core/config/iam.proto";
+
 ////////////////////////////////////////////////////////////////////////////////
 
 message TYdbStatsConfig
@@ -49,4 +51,7 @@ message TYdbStatsConfig
 
     // Table to report correspondence between partition tablets and volume tablets.
     optional string PartitionsTableName = 14;
+
+    // Iam client config for ydb stats uploader.
+    optional NCloud.NProto.TIamClientConfig IamClientConfig = 15;
 }

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -941,6 +941,7 @@ void TBootstrapBase::Start()
     START_KIKIMR_COMPONENT(ClientPercentiles);
     START_KIKIMR_COMPONENT(StatsAggregator);
     START_KIKIMR_COMPONENT(IamTokenClient);
+    START_KIKIMR_COMPONENT(SyncIamTokenClient);
     START_KIKIMR_COMPONENT(ComputeClient);
     START_KIKIMR_COMPONENT(KmsClient);
     START_KIKIMR_COMPONENT(RootKmsClient);
@@ -960,7 +961,7 @@ void TBootstrapBase::Start()
     START_COMMON_COMPONENT(ServerStatsUpdater);
     START_COMMON_COMPONENT(BackgroundThreadPool);
     START_COMMON_COMPONENT(RdmaClient);
-    START_COMMON_COMPONENT(GetTraceServiceClient());
+    START_KIKIMR_COMPONENT(TraceServiceClient);
     START_COMMON_COMPONENT(RdmaRequestServer);
     START_COMMON_COMPONENT(RdmaTarget);
     START_COMMON_COMPONENT(CellManager);
@@ -1019,7 +1020,7 @@ void TBootstrapBase::Stop()
     STOP_COMMON_COMPONENT(CellManager);
     STOP_COMMON_COMPONENT(RdmaTarget);
     STOP_COMMON_COMPONENT(RdmaRequestServer);
-    STOP_COMMON_COMPONENT(GetTraceServiceClient());
+    STOP_KIKIMR_COMPONENT(TraceServiceClient);
     STOP_COMMON_COMPONENT(RdmaClient);
     STOP_COMMON_COMPONENT(BackgroundThreadPool);
     STOP_COMMON_COMPONENT(ServerStatsUpdater);
@@ -1045,6 +1046,7 @@ void TBootstrapBase::Stop()
     STOP_KIKIMR_COMPONENT(RootKmsClient);
     STOP_KIKIMR_COMPONENT(KmsClient);
     STOP_KIKIMR_COMPONENT(ComputeClient);
+    STOP_KIKIMR_COMPONENT(SyncIamTokenClient);
     STOP_KIKIMR_COMPONENT(IamTokenClient);
     STOP_KIKIMR_COMPONENT(StatsAggregator);
     STOP_KIKIMR_COMPONENT(ClientPercentiles);

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -971,10 +971,10 @@ void TBootstrapBase::Start()
     // order
     START_COMMON_COMPONENT(Scheduler);
 
-    // We need to start ydb stats uploader after scheduler because ydb driver
-    // synchronously waiting for IAM token and if IAM token agent is down our
-    // client will retry request and schedule tasks. If scheduler is not started
-    // yet we will block main thread.
+    // We need to start the YDB stats uploader after the scheduler, as the YDB
+    // driver waits for an IAM token synchronously. If the IAM token service is
+    // down, our client will retry the request and schedule the task. If the
+    // scheduler has not started yet, it will block the main thread.
     START_KIKIMR_COMPONENT(YdbStorage);
     START_KIKIMR_COMPONENT(StatsUploader);
 

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -117,6 +117,7 @@ protected:
     virtual IStartable* GetNotifyService() = 0;
     virtual IStartable* GetStatsFetcher() = 0;
     virtual IStartable* GetIamTokenClient() = 0;
+    virtual IStartable* GetSyncIamTokenClient() = 0;
     virtual IStartable* GetComputeClient() = 0;
     virtual IStartable* GetKmsClient() = 0;
     virtual IStartable* GetRootKmsClient() = 0;

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -117,7 +117,7 @@ protected:
     virtual IStartable* GetNotifyService() = 0;
     virtual IStartable* GetStatsFetcher() = 0;
     virtual IStartable* GetIamTokenClient() = 0;
-    virtual IStartable* GetSyncIamTokenClient() = 0;
+    virtual IStartable* GetYdbStatsIamTokenClient() = 0;
     virtual IStartable* GetComputeClient() = 0;
     virtual IStartable* GetKmsClient() = 0;
     virtual IStartable* GetRootKmsClient() = 0;

--- a/cloud/blockstore/libs/daemon/local/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.h
@@ -33,7 +33,12 @@ protected:
     IStartable* GetNotifyService() override      { return nullptr; }
     IStartable* GetStatsFetcher() override       { return nullptr; }
     IStartable* GetIamTokenClient() override     { return nullptr; }
-    IStartable* GetSyncIamTokenClient() override { return nullptr; }
+
+    IStartable* GetYdbStatsIamTokenClient() override
+    {
+        return nullptr;
+    }
+
     IStartable* GetComputeClient() override      { return nullptr; }
     IStartable* GetKmsClient() override          { return nullptr; }
     IStartable* GetRootKmsClient() override      { return nullptr; }

--- a/cloud/blockstore/libs/daemon/local/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/local/bootstrap.h
@@ -33,6 +33,7 @@ protected:
     IStartable* GetNotifyService() override      { return nullptr; }
     IStartable* GetStatsFetcher() override       { return nullptr; }
     IStartable* GetIamTokenClient() override     { return nullptr; }
+    IStartable* GetSyncIamTokenClient() override { return nullptr; }
     IStartable* GetComputeClient() override      { return nullptr; }
     IStartable* GetKmsClient() override          { return nullptr; }
     IStartable* GetRootKmsClient() override      { return nullptr; }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -379,7 +379,12 @@ IStartable* TBootstrapYdb::GetLogbrokerService()   { return LogbrokerService.get
 IStartable* TBootstrapYdb::GetNotifyService()      { return NotifyService.get(); }
 IStartable* TBootstrapYdb::GetStatsFetcher()       { return StatsFetcher.get(); }
 IStartable* TBootstrapYdb::GetIamTokenClient()     { return IamTokenClient.get(); }
-IStartable* TBootstrapYdb::GetSyncIamTokenClient() { return SyncIamTokenClient.get(); }
+
+IStartable* TBootstrapYdb::GetYdbStatsIamTokenClient()
+{
+    return YdbStatsIamTokenClient.get();
+}
+
 IStartable* TBootstrapYdb::GetComputeClient()      { return ComputeClient.get(); }
 IStartable* TBootstrapYdb::GetKmsClient()          { return KmsClient.get(); }
 IStartable* TBootstrapYdb::GetRootKmsClient()      { return RootKmsClient.get(); }
@@ -638,7 +643,7 @@ void TBootstrapYdb::InitKikimrService()
 
     auto statsConfig = Configs->StatsConfig;
 
-    SyncIamTokenClient = ServerModuleFactories->IamClientFactory(
+    YdbStatsIamTokenClient = ServerModuleFactories->IamClientFactory(
         statsConfig->GetIamClientConfig(),
         logging,
         Scheduler,
@@ -646,7 +651,7 @@ void TBootstrapYdb::InitKikimrService()
 
     if (statsConfig->IsValid() && !Configs->Options->TemporaryServer) {
         auto iamTokenClient = statsConfig->GetIamClientConfig()->IsValid()
-                                  ? SyncIamTokenClient
+                                  ? YdbStatsIamTokenClient
                                   : IamTokenClient;
         YdbStorage =
             NYdbStats::CreateYdbStorage(statsConfig, logging, iamTokenClient);

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -104,7 +104,7 @@ private:
     NNotify::IServicePtr NotifyService;
     NCloud::NStorage::IStatsFetcherPtr StatsFetcher;
     NIamClient::IIamTokenClientPtr IamTokenClient;
-    NIamClient::IIamTokenClientPtr SyncIamTokenClient;
+    NIamClient::IIamTokenClientPtr YdbStatsIamTokenClient;
     IComputeClientPtr ComputeClient;
     IKmsClientPtr KmsClient;
     IRootKmsClientPtr RootKmsClient;
@@ -134,7 +134,7 @@ protected:
     IStartable* GetNotifyService() override;
     IStartable* GetStatsFetcher() override;
     IStartable* GetIamTokenClient() override;
-    IStartable* GetSyncIamTokenClient() override;
+    IStartable* GetYdbStatsIamTokenClient() override;
     IStartable* GetComputeClient() override;
     IStartable* GetKmsClient() override;
     IStartable* GetRootKmsClient() override;

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -104,6 +104,7 @@ private:
     NNotify::IServicePtr NotifyService;
     NCloud::NStorage::IStatsFetcherPtr StatsFetcher;
     NIamClient::IIamTokenClientPtr IamTokenClient;
+    NIamClient::IIamTokenClientPtr SyncIamTokenClient;
     IComputeClientPtr ComputeClient;
     IKmsClientPtr KmsClient;
     IRootKmsClientPtr RootKmsClient;
@@ -133,6 +134,7 @@ protected:
     IStartable* GetNotifyService() override;
     IStartable* GetStatsFetcher() override;
     IStartable* GetIamTokenClient() override;
+    IStartable* GetSyncIamTokenClient() override;
     IStartable* GetComputeClient() override;
     IStartable* GetKmsClient() override;
     IStartable* GetRootKmsClient() override;

--- a/cloud/blockstore/libs/ydbstats/config.cpp
+++ b/cloud/blockstore/libs/ydbstats/config.cpp
@@ -61,6 +61,8 @@ TDuration ConvertValue<TDuration, ui32>(ui32 value)
 
 TYdbStatsConfig::TYdbStatsConfig(NProto::TYdbStatsConfig ydbStatsConfig)
     : YdbStatsConfig(std::move(ydbStatsConfig))
+    , IamClientConfig(std::make_shared<NIamClient::TIamClientConfig>(
+          YdbStatsConfig.GetIamClientConfig()))
 {}
 
 bool TYdbStatsConfig::IsValid() const
@@ -83,5 +85,10 @@ type TYdbStatsConfig::Get##name() const                                        \
 BLOCKSTORE_YDBSTATS_CONFIG(BLOCKSTORE_CONFIG_GETTER);
 
 #undef BLOCKSTORE_CONFIG_GETTER
+
+NIamClient::TIamClientConfigPtr TYdbStatsConfig::GetIamClientConfig() const
+{
+    return IamClientConfig;
+}
 
 }   // namespace NCloud::NBlockStore::NYdbStats

--- a/cloud/blockstore/libs/ydbstats/config.h
+++ b/cloud/blockstore/libs/ydbstats/config.h
@@ -4,6 +4,9 @@
 
 #include <cloud/blockstore/config/ydbstats.pb.h>
 
+#include <cloud/storage/core/libs/iam/iface/config.h>
+#include <cloud/storage/core/libs/iam/iface/public.h>
+
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
 #include <util/stream/output.h>
@@ -16,6 +19,7 @@ class TYdbStatsConfig
 {
 private:
     NProto::TYdbStatsConfig YdbStatsConfig;
+    NIamClient::TIamClientConfigPtr IamClientConfig;
 
 public:
     TYdbStatsConfig(NProto::TYdbStatsConfig statsUploadConfig = {});
@@ -36,6 +40,7 @@ public:
     bool GetUseSsl() const;
     TDuration GetStatsTableTtl() const;
     TDuration GetArchiveStatsTableTtl() const;
+    NIamClient::TIamClientConfigPtr GetIamClientConfig() const;
 };
 
 }   // namespace NCloud::NBlockStore::NYdbStats


### PR DESCRIPTION
#4165 В этом пре добавляю отдельного IAM clientа который будет использоваться для синхронноговыписывания IAM токена для YDB stats. Отдельный клиент нужен чтобы понизить политику ретраев, чтобы если IAM не работает мы быстро зафейлились, а не залипли на синхронном выписывании токена для YDB stats