### PR TITLE
[NBS] dont extract partition counters if there is no state

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp
@@ -162,7 +162,7 @@ TPartitionStatisticsCounters TPartitionActor::ExtractPartCounters(
 
 void TPartitionActor::SendStatsToService(const TActorContext& ctx)
 {
-    if (!PartCounters) {
+    if (!PartCounters || !State) {
         return;
     }
 
@@ -186,7 +186,7 @@ void TPartitionActor::HandleGetPartCountersRequest(
     const TEvPartitionCommonPrivate::TEvGetPartCountersRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    if (!PartCounters) {
+    if (!PartCounters || !State) {
         NCloud::Reply(
             ctx,
             *ev,

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_stats.cpp
@@ -140,7 +140,7 @@ TPartitionStatisticsCounters TPartitionActor::ExtractPartCounters(
 
 void TPartitionActor::SendStatsToService(const TActorContext& ctx)
 {
-    if (!PartCounters) {
+    if (!PartCounters || !State) {
         return;
     }
 
@@ -164,7 +164,7 @@ void TPartitionActor::HandleGetPartCountersRequest(
     const TEvPartitionCommonPrivate::TEvGetPartCountersRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    if (!PartCounters) {
+    if (!PartCounters || !State) {
         NCloud::Reply(
             ctx,
             *ev,


### PR DESCRIPTION
Если сообщение TEvPartitionCommonPrivate::TEvGetPartCountersRequest придет слишком рано когда мы не инициализировали состояние то будет краш
```
#0 NCloud::NBlockStore::NProto::TPartitionMeta::_internal_stats (this=0x0) at /-B/cloud/blockstore/libs/storage/protos/part.pb.h +5066
#1 NCloud::NBlockStore::NProto::TPartitionMeta::stats (this=0x0) at /-B/cloud/blockstore/libs/storage/protos/part.pb.h +5072
#2 NCloud::NBlockStore::NProto::TPartitionMeta::GetStats (this=0x0) at /-B/cloud/blockstore/libs/storage/protos/part.pb.h +1650
#3 NCloud::NBlockStore::NStorage::NPartition::TPartitionState::GetStats (this=0x0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_state.h +1405
#4 NCloud::NBlockStore::NStorage::NPartition::TPartitionState::GetMixedBlocksCount (this=0x0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_state.h +1423
#5 NCloud::NBlockStore::NStorage::NPartition::TPartitionActor::ExtractPartCounters (this=0x451af07c2880, ctx=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp +62
#6 NCloud::NBlockStore::NStorage::NPartition::TPartitionActor::HandleGetPartCountersRequest (this=0x451af07c2880, ev=..., ctx=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp +202
#7 NCloud::NBlockStore::NStorage::NPartition::TPartitionActor::StateInit (this=0x451af07c2880, ev=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition/part_actor.cpp +955
#8 NActors::TExecutorThread::Execute (this=0x451aff2ced80, mailbox=0x451ae8dc1e40, isTailExecution=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/library/actors/core/executor_thread.cpp +269
```
