### PR TITLE
Dynamically disable VolumeBalancer via ConfigDispatcher

### DIFF
--- a/cloud/blockstore/buildall/ya.make
+++ b/cloud/blockstore/buildall/ya.make
@@ -1,6 +1,7 @@
 PACKAGE()
 
 PEERDIR(
+    contrib/ydb/apps/ydb
     contrib/ydb/apps/ydbd
     cloud/blockstore/apps/client
     cloud/blockstore/apps/disk_agent

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -38,6 +38,7 @@ enum ECompactionType
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Keep consistent with copy from contrib/ydb/core/protos/nbs/blockstore.proto
 enum EVolumePreemptionType
 {
     // Do not preempt volumes when host is overloaded
@@ -1297,6 +1298,4 @@ message TStorageServiceConfig
     optional bool VolumeThrottlingManagerEnabled = 447;
     // Duration between VolumeThrottlingManager notifications to volumes
     optional uint32 VolumeThrottlingManagerNotificationPeriodSeconds = 448;
-
-    optional bool VolumeBalancerEnabled = 449;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1297,4 +1297,6 @@ message TStorageServiceConfig
     optional bool VolumeThrottlingManagerEnabled = 447;
     // Duration between VolumeThrottlingManager notifications to volumes
     optional uint32 VolumeThrottlingManagerNotificationPeriodSeconds = 448;
+
+    optional bool VolumeBalancerEnabled = 449;
 }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -66,6 +66,7 @@
 #include <cloud/storage/core/libs/iam/iface/config.h>
 #include <cloud/storage/core/libs/io_uring/service.h>
 #include <cloud/storage/core/libs/kikimr/actorsystem.h>
+#include <cloud/storage/core/libs/kikimr/config_dispatcher_helpers.h>
 #include <cloud/storage/core/libs/kikimr/node.h>
 #include <cloud/storage/core/libs/kikimr/node_registration_settings.h>
 #include <cloud/storage/core/libs/kikimr/proxy.h>
@@ -520,17 +521,22 @@ void TBootstrapYdb::InitKikimrService()
         .NodeType = Configs->StorageConfig->GetNodeType(),
     };
 
-    NCloud::NStorage::TRegisterDynamicNodeOptions registerOpts {
+    auto nodeLabels = GetLabels(
+        Configs->StorageConfig->GetConfigDispatcherSettings(),
+        Configs->StorageConfig->GetSchemeShardDir(),
+        Configs->StorageConfig->GetNodeType());
+    NCloud::NStorage::TRegisterDynamicNodeOptions registerOpts{
         .Domain = Configs->Options->Domain,
         .SchemeShardDir = Configs->StorageConfig->GetSchemeShardDir(),
         .NodeBrokerAddress = Configs->Options->NodeBrokerAddress,
         .NodeBrokerPort = Configs->Options->NodeBrokerPort,
         .NodeBrokerSecurePort = Configs->Options->NodeBrokerSecurePort,
-        .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl
-            || Configs->StorageConfig->GetNodeRegistrationUseSsl(),
+        .UseNodeBrokerSsl = Configs->Options->UseNodeBrokerSsl ||
+                            Configs->StorageConfig->GetNodeRegistrationUseSsl(),
         .InterconnectPort = Configs->Options->InterconnectPort,
         .LoadCmsConfigs = Configs->Options->LoadCmsConfigs,
-        .Settings = std::move(settings)
+        .Settings = std::move(settings),
+        .Labels = std::move(nodeLabels),
     };
 
     const bool emergencyMode =

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -437,8 +437,9 @@ void TConfigInitializerYdb::ApplyBlockstoreConfig(
 
     const auto& blockstoreConfig = config.GetBlockstoreConfig();
 
-    StorageConfig->SetVolumeBalancerEnabled(
-        blockstoreConfig.GetVolumeBalancerEnabled());
+    auto volumePreemptionType = static_cast<NProto::EVolumePreemptionType>(
+        blockstoreConfig.GetVolumePreemptionType());
+    StorageConfig->SetVolumePreemptionType(volumePreemptionType);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -372,7 +372,10 @@ void TConfigInitializerYdb::ApplyComputeClientConfig(const TString& text)
     ComputeClientConfig = std::move(config);
 }
 
-void TConfigInitializerYdb::ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config)
+////////////////////////////////////////////////////////////////////////////////
+
+void TConfigInitializerYdb::ApplyNamedConfigs(
+    const NKikimrConfig::TAppConfig& config)
 {
     THashMap<TString, ui32> configs;
 
@@ -423,6 +426,28 @@ void TConfigInitializerYdb::ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfi
             this,
             config.GetNamedConfigs(it->second).GetConfig());
     }
+}
+
+void TConfigInitializerYdb::ApplyBlockstoreConfig(
+    const NKikimrConfig::TAppConfig& config)
+{
+    if (!config.HasBlockstoreConfig()) {
+        return;
+    }
+
+    const auto& blockstoreConfig = config.GetBlockstoreConfig();
+
+    StorageConfig->SetVolumeBalancerEnabled(
+        blockstoreConfig.GetVolumeBalancerEnabled());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TConfigInitializerYdb::ApplyCustomCMSConfigs(
+    const NKikimrConfig::TAppConfig& config)
+{
+    ApplyNamedConfigs(config);
+    ApplyBlockstoreConfig(config);
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.h
@@ -100,6 +100,9 @@ private:
     void ApplyKmsClientConfig(const TString& text);
     void ApplyRootKmsConfig(const TString& text);
     void ApplyComputeClientConfig(const TString& text);
+
+    void ApplyNamedConfigs(const NKikimrConfig::TAppConfig& config);
+    void ApplyBlockstoreConfig(const NKikimrConfig::TAppConfig& config);
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -622,7 +622,6 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(VolumeThrottlingManagerNotificationPeriodSeconds,                      \
         TDuration,                                                             \
         Seconds(5)                                                            )\
-    xxx(VolumeBalancerEnabled,                             bool,   true       )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
@@ -857,9 +856,10 @@ struct TStorageConfig::TImpl
         FeaturesConfig = std::move(featuresConfig);
     }
 
-    void SetVolumeBalancerEnabled(bool volumeBalancerEnabled)
+    void SetVolumePreemptionType(
+        NProto::EVolumePreemptionType volumePreemptionType)
     {
-        StorageServiceConfig.SetVolumeBalancerEnabled(volumeBalancerEnabled);
+        StorageServiceConfig.SetVolumePreemptionType(volumePreemptionType);
     }
 
     NProto::TStorageServiceConfig GetStorageConfigProto() const
@@ -900,9 +900,10 @@ void TStorageConfig::SetFeaturesConfig(
     Impl->SetFeaturesConfig(std::move(featuresConfig));
 }
 
-void TStorageConfig::SetVolumeBalancerEnabled(bool volumeBalancerEnabled)
+void TStorageConfig::SetVolumePreemptionType(
+    NProto::EVolumePreemptionType volumePreemptionType)
 {
-    Impl->SetVolumeBalancerEnabled(volumeBalancerEnabled);
+    Impl->SetVolumePreemptionType(volumePreemptionType);
 }
 
 void TStorageConfig::Register(TControlBoard& controlBoard){

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -622,6 +622,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(VolumeThrottlingManagerNotificationPeriodSeconds,                      \
         TDuration,                                                             \
         Seconds(5)                                                            )\
+    xxx(VolumeBalancerEnabled,                             bool,   true       )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 
@@ -856,6 +857,11 @@ struct TStorageConfig::TImpl
         FeaturesConfig = std::move(featuresConfig);
     }
 
+    void SetVolumeBalancerEnabled(bool volumeBalancerEnabled)
+    {
+        StorageServiceConfig.SetVolumeBalancerEnabled(volumeBalancerEnabled);
+    }
+
     NProto::TStorageServiceConfig GetStorageConfigProto() const
     {
         NProto::TStorageServiceConfig proto = StorageServiceConfig;
@@ -892,6 +898,11 @@ void TStorageConfig::SetFeaturesConfig(
     NFeatures::TFeaturesConfigPtr featuresConfig)
 {
     Impl->SetFeaturesConfig(std::move(featuresConfig));
+}
+
+void TStorageConfig::SetVolumeBalancerEnabled(bool volumeBalancerEnabled)
+{
+    Impl->SetVolumeBalancerEnabled(volumeBalancerEnabled);
 }
 
 void TStorageConfig::Register(TControlBoard& controlBoard){

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -43,7 +43,7 @@ public:
 
     void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig);
 
-    void SetVolumeBalancerEnabled(bool volumeBalancerEnabled);
+    void SetVolumePreemptionType(NProto::EVolumePreemptionType volumePreemptionType);
 
     void Register(NKikimr::TControlBoard& controlBoard);
 
@@ -711,8 +711,6 @@ public:
     [[nodiscard]] bool GetVolumeThrottlingManagerEnabled() const;
     [[nodiscard]] TDuration
     GetVolumeThrottlingManagerNotificationPeriodSeconds() const;
-
-    [[nodiscard]] bool GetVolumeBalancerEnabled() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -43,6 +43,8 @@ public:
 
     void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig);
 
+    void SetVolumeBalancerEnabled(bool volumeBalancerEnabled);
+
     void Register(NKikimr::TControlBoard& controlBoard);
 
     static TStorageConfigPtr Merge(
@@ -709,6 +711,8 @@ public:
     [[nodiscard]] bool GetVolumeThrottlingManagerEnabled() const;
     [[nodiscard]] TDuration
     GetVolumeThrottlingManagerNotificationPeriodSeconds() const;
+
+    [[nodiscard]] bool GetVolumeBalancerEnabled() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -431,7 +431,7 @@ void TVolumeBalancerActor::HandleConfigNotificationRequest(
     auto volumePreemptionType = static_cast<NProto::EVolumePreemptionType>(
         config.GetBlockstoreConfig().GetVolumePreemptionType());
 
-    State->SetVolumePreemptionType(volumePreemptionType);
+    State->OverrideVolumePreemptionTypeIfPossible(volumePreemptionType);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -196,9 +196,7 @@ void TVolumeBalancerActor::RegisterCounters(const TActorContext& ctx)
 
 bool TVolumeBalancerActor::IsBalancerEnabled() const
 {
-    return State->GetEnabled()
-        && VolumeBalancerSwitch->IsBalancerEnabled()
-        && StorageConfig->GetVolumePreemptionType() != NProto::PREEMPTION_NONE;
+    return State->GetEnabled() && VolumeBalancerSwitch->IsBalancerEnabled();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -420,16 +418,20 @@ void TVolumeBalancerActor::HandleConfigNotificationRequest(
     const auto& config = record.GetConfig();
 
     if (!config.HasBlockstoreConfig() ||
-        !config.GetBlockstoreConfig().HasVolumeBalancerEnabled())
+        !config.GetBlockstoreConfig().HasVolumePreemptionType())
     {
         LOG_INFO(
             ctx,
             TBlockStoreComponents::VOLUME_BALANCER,
-            "VolumeBalancerEnabled is not present in ConfigDispatcher "
+            "VolumePreemptionType is not present in ConfigDispatcher "
             "notification");
         return;
     }
-    State->SetEnabled(config.GetBlockstoreConfig().GetVolumeBalancerEnabled());
+
+    auto volumePreemptionType = static_cast<NProto::EVolumePreemptionType>(
+        config.GetBlockstoreConfig().GetVolumePreemptionType());
+
+    State->SetVolumePreemptionType(volumePreemptionType);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -159,9 +159,63 @@ void TVolumeBalancerActor::Bootstrap(const TActorContext& ctx)
 {
     LastCpuWaitTs = ctx.Monotonic();
 
+    SendConfigSubscriptionRequest(ctx);
     RegisterPages(ctx);
     RegisterCounters(ctx);
     Become(&TThis::StateWork);
+}
+
+void TVolumeBalancerActor::SendConfigSubscriptionRequest(
+    const TActorContext& ctx)
+{
+    auto req = std::make_unique<
+        NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest>();
+    auto blockstoreConfig =
+        static_cast<ui32>(NKikimrConsole::TConfigItem::BlockstoreConfigItem);
+    req->ConfigItemKinds = {
+        blockstoreConfig,
+    };
+    NCloud::Send(
+        ctx,
+        NConsole::MakeConfigsDispatcherID(ctx.SelfID.NodeId()),
+        std::move(req));
+}
+
+void TVolumeBalancerActor::HandleConfigSubscriptionResponse(
+    const NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::
+        TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME_BALANCER,
+        "Subscribed to config changes");
+}
+
+void TVolumeBalancerActor::HandleConfigNotificationRequest(
+    const NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto& record = ev->Get()->Record;
+    auto response =
+        std::make_unique<NConsole::TEvConsole::TEvConfigNotificationResponse>(
+            record);
+    NCloud::Reply(ctx, *ev, std::move(response));
+
+    const auto& config = record.GetConfig();
+
+    if (!config.HasBlockstoreConfig() ||
+        !config.GetBlockstoreConfig().HasVolumeBalancerEnabled())
+    {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME_BALANCER,
+            "VolumeBalancerEnabled is not present in ConfigDispatcher "
+            "notification");
+        return;
+    }
+    State->SetEnabled(config.GetBlockstoreConfig().GetVolumeBalancerEnabled());
 }
 
 void TVolumeBalancerActor::RegisterPages(const TActorContext& ctx)
@@ -392,6 +446,9 @@ STFUNC(TVolumeBalancerActor::StateWork)
         HFunc(TEvVolumeBalancer::TEvConfigureVolumeBalancerRequest, HandleConfigureVolumeBalancerRequest);
 
         HFunc(NMon::TEvHttpInfo, HandleHttpInfo);
+
+        HFunc(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse, HandleConfigSubscriptionResponse);
+        HFunc(NConsole::TEvConsole::TEvConfigNotificationRequest, HandleConfigNotificationRequest);
 
         default:
             HandleUnexpectedEvent(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
@@ -28,6 +28,9 @@ namespace NCloud::NBlockStore::NStorage {
 class TVolumeBalancerActor final
     : public NActors::TActorBootstrapped<TVolumeBalancerActor>
 {
+    using TEvConfigsDispatcher = NKikimr::NConsole::TEvConfigsDispatcher;
+    using TEvConsole = NKikimr::NConsole::TEvConsole;
+
 private:
     const TStorageConfigPtr StorageConfig;
     const IVolumeStatsPtr VolumeStats;
@@ -99,13 +102,11 @@ private:
         const NActors::TActorContext& ctx);
 
     void HandleConfigSubscriptionResponse(
-        const NKikimr::NConsole::TEvConfigsDispatcher::
-            TEvSetConfigSubscriptionResponse::TPtr& ev,
+        const TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleConfigNotificationRequest(
-        const NKikimr::NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr&
-            ev,
+        const TEvConsole::TEvConfigNotificationRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
@@ -13,6 +13,8 @@
 
 #include <cloud/storage/core/libs/diagnostics/public.h>
 
+#include <contrib/ydb/core/cms/console/configs_dispatcher.h>
+#include <contrib/ydb/core/cms/console/console.h>
 #include <contrib/ydb/core/tablet/tablet_metrics.h>
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/mon.h>
@@ -72,6 +74,8 @@ private:
         const NActors::TActorContext& ctx,
         TString volume);
 
+    void SendConfigSubscriptionRequest(const NActors::TActorContext& ctx);
+
     STFUNC(StateWork);
 
     void HandleWakeup(
@@ -92,6 +96,16 @@ private:
 
     void HandleConfigureVolumeBalancerRequest(
         const TEvVolumeBalancer::TEvConfigureVolumeBalancerRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleConfigSubscriptionResponse(
+        const NKikimr::NConsole::TEvConfigsDispatcher::
+            TEvSetConfigSubscriptionResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleConfigNotificationRequest(
+        const NKikimr::NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr&
+            ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -22,7 +22,8 @@ constexpr TDuration MaxPullDelay = TDuration::Hours(24);
 
 TVolumeBalancerState::TVolumeBalancerState(TStorageConfigPtr storageConfig)
     : StorageConfig(std::move(storageConfig))
-    , IsEnabled(StorageConfig->GetVolumeBalancerEnabled())
+    , InitialVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
+    , CurrentVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
 {}
 
 void TVolumeBalancerState::UpdateVolumeStats(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -23,7 +23,7 @@ constexpr TDuration MaxPullDelay = TDuration::Hours(24);
 TVolumeBalancerState::TVolumeBalancerState(TStorageConfigPtr storageConfig)
     : StorageConfig(std::move(storageConfig))
     , InitialVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
-    , CurrentVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
+    , OverrideVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
 {}
 
 void TVolumeBalancerState::UpdateVolumeStats(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -22,6 +22,7 @@ constexpr TDuration MaxPullDelay = TDuration::Hours(24);
 
 TVolumeBalancerState::TVolumeBalancerState(TStorageConfigPtr storageConfig)
     : StorageConfig(std::move(storageConfig))
+    , IsEnabled(StorageConfig->GetVolumeBalancerEnabled())
 {}
 
 void TVolumeBalancerState::UpdateVolumeStats(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -23,7 +23,7 @@ constexpr TDuration MaxPullDelay = TDuration::Hours(24);
 TVolumeBalancerState::TVolumeBalancerState(TStorageConfigPtr storageConfig)
     : StorageConfig(std::move(storageConfig))
     , InitialVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
-    , OverrideVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
+    , OverridenVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
 {}
 
 void TVolumeBalancerState::UpdateVolumeStats(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -60,7 +60,7 @@ private:
     bool IsEnabled = true;
 
     const NProto::EVolumePreemptionType InitialVolumePreemptionType;
-    NProto::EVolumePreemptionType OverrideVolumePreemptionType;
+    NProto::EVolumePreemptionType OverridenVolumePreemptionType;
 
 public:
     TVolumeBalancerState(TStorageConfigPtr storageConfig);
@@ -90,7 +90,7 @@ public:
     void OverrideVolumePreemptionTypeIfPossible(
         NProto::EVolumePreemptionType volumePreemptionType)
     {
-        OverrideVolumePreemptionType = volumePreemptionType;
+        OverridenVolumePreemptionType = volumePreemptionType;
     }
 
     NProto::EVolumePreemptionType GetVolumePreemptionType() const
@@ -99,7 +99,7 @@ public:
         // Config Dispatcher ones
         return StorageConfig->GetVolumePreemptionType() ==
                        InitialVolumePreemptionType
-                   ? OverrideVolumePreemptionType
+                   ? OverridenVolumePreemptionType
                    : StorageConfig->GetVolumePreemptionType();
     }
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -60,7 +60,7 @@ private:
     bool IsEnabled = true;
 
     const NProto::EVolumePreemptionType InitialVolumePreemptionType;
-    NProto::EVolumePreemptionType CurrentVolumePreemptionType;
+    NProto::EVolumePreemptionType OverrideVolumePreemptionType;
 
 public:
     TVolumeBalancerState(TStorageConfigPtr storageConfig);
@@ -87,18 +87,19 @@ public:
                IsEnabled;
     }
 
-    void SetVolumePreemptionType(
+    void OverrideVolumePreemptionTypeIfPossible(
         NProto::EVolumePreemptionType volumePreemptionType)
     {
-        CurrentVolumePreemptionType = volumePreemptionType;
+        OverrideVolumePreemptionType = volumePreemptionType;
     }
 
     NProto::EVolumePreemptionType GetVolumePreemptionType() const
     {
-        // We prioritize ICB overriden configs over CD ones
+        // We prioritize Immediate Control Board overriden configs over
+        // Config Dispatcher ones
         return StorageConfig->GetVolumePreemptionType() ==
                        InitialVolumePreemptionType
-                   ? CurrentVolumePreemptionType
+                   ? OverrideVolumePreemptionType
                    : StorageConfig->GetVolumePreemptionType();
     }
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -59,6 +59,9 @@ private:
 
     bool IsEnabled = true;
 
+    const NProto::EVolumePreemptionType InitialVolumePreemptionType;
+    NProto::EVolumePreemptionType CurrentVolumePreemptionType;
+
 public:
     TVolumeBalancerState(TStorageConfigPtr storageConfig);
 
@@ -80,9 +83,23 @@ public:
 
     bool GetEnabled() const
     {
-        return
-            StorageConfig->GetVolumePreemptionType() != NProto::PREEMPTION_NONE &&
-            IsEnabled;
+        return GetVolumePreemptionType() != NProto::PREEMPTION_NONE &&
+               IsEnabled;
+    }
+
+    void SetVolumePreemptionType(
+        NProto::EVolumePreemptionType volumePreemptionType)
+    {
+        CurrentVolumePreemptionType = volumePreemptionType;
+    }
+
+    NProto::EVolumePreemptionType GetVolumePreemptionType() const
+    {
+        // We prioritize ICB overriden configs over CD ones
+        return StorageConfig->GetVolumePreemptionType() ==
+                       InitialVolumePreemptionType
+                   ? CurrentVolumePreemptionType
+                   : StorageConfig->GetVolumePreemptionType();
     }
 
     void SetVolumeInProgress(TString volume)

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -95,12 +95,6 @@ public:
         return *this;
     }
 
-    TVolumeBalancerConfigBuilder& WithVolumeBalancerEnabled(bool enabled)
-    {
-        StorageConfig.SetVolumeBalancerEnabled(enabled);
-        return *this;
-    }
-
     NProto::TStorageServiceConfig Build()
     {
         return StorageConfig;
@@ -739,7 +733,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
             std::make_unique<TEvConsole::TEvConfigNotificationRequest>();
         request->Record.MutableConfig()
             ->MutableBlockstoreConfig()
-            ->SetVolumeBalancerEnabled(false);
+            ->SetVolumePreemptionType(NKikimrConfig::PREEMPTION_NONE);
 
         testEnv.Send(volumeBalancerActorId, std::move(request));
 
@@ -758,14 +752,14 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
             TDuration::Seconds(15));
     }
 
-    Y_UNIT_TEST(ShouldNotDoAnythingIfBalancerIsDisabledViaStorageConfig)
+    Y_UNIT_TEST(ShouldNotDoAnythingIfPreemptionTypeNone)
     {
         TVolumeBalancerTestEnv testEnv;
         TVolumeBalancerConfigBuilder config;
-        config.WithVolumeBalancerEnabled(false);
+        config.WithType(NProto::PREEMPTION_NONE);
 
         auto volumeBalancerActorId = testEnv.Register(CreateVolumeBalancerActor(
-            config.WithType(NProto::PREEMPTION_MOVE_MOST_HEAVY),
+            config.WithType(NProto::PREEMPTION_NONE),
             testEnv.VolumeStats,
             testEnv.Fetcher,
             testEnv.GetEdgeActor()));

--- a/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.cpp
+++ b/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.cpp
@@ -11,14 +11,28 @@ using namespace NKikimr::NConfig;
 static const TString tenantLabel = "tenant";
 static const TString nodeNameLabel = "node_type";
 
+auto GetLabels(
+    const NCloud::NProto::TConfigDispatcherSettings& settings,
+    const TString& tenantName,
+    const TString& nodeType) -> TMap<TString, TString>
+{
+    TMap<TString, TString> result{
+        {tenantLabel, tenantName},
+        {nodeNameLabel, nodeType},
+    };
+    for (const auto& label: settings.GetAdditionalNodeLabels()) {
+        result.emplace(label.GetKey(), label.GetValue());
+    }
+    return result;
+}
+
 void SetupConfigDispatcher(
     const NProto::TConfigDispatcherSettings& settings,
     const TString& tenantName,
     const TString& nodeType,
     NKikimr::NConfig::TConfigsDispatcherInitInfo* config)
 {
-    config->Labels.emplace(tenantLabel, tenantName);
-    config->Labels.emplace(nodeNameLabel, nodeType);
+    config->Labels = GetLabels(settings, tenantName, nodeType);
 
     if (!settings.HasAllowList() && !settings.HasDenyList()) {
         return;

--- a/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.cpp
+++ b/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.cpp
@@ -11,12 +11,12 @@ using namespace NKikimr::NConfig;
 static const TString tenantLabel = "tenant";
 static const TString nodeNameLabel = "node_type";
 
-auto GetLabels(
+TRegisterDynamicNodeOptions::TNodeLabels GetLabels(
     const NCloud::NProto::TConfigDispatcherSettings& settings,
     const TString& tenantName,
-    const TString& nodeType) -> TMap<TString, TString>
+    const TString& nodeType)
 {
-    TMap<TString, TString> result{
+    TRegisterDynamicNodeOptions::TNodeLabels result{
         {tenantLabel, tenantName},
         {nodeNameLabel, nodeType},
     };

--- a/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.h
+++ b/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "node.h"
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
@@ -14,10 +16,10 @@ namespace NCloud::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-auto GetLabels(
+TRegisterDynamicNodeOptions::TNodeLabels GetLabels(
     const NCloud::NProto::TConfigDispatcherSettings& settings,
     const TString& tenantName,
-    const TString& nodeType) -> TMap<TString, TString>;
+    const TString& nodeType);
 
 void SetupConfigDispatcher(
     const NProto::TConfigDispatcherSettings& settings,

--- a/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.h
+++ b/cloud/storage/core/libs/kikimr/config_dispatcher_helpers.h
@@ -14,6 +14,11 @@ namespace NCloud::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+auto GetLabels(
+    const NCloud::NProto::TConfigDispatcherSettings& settings,
+    const TString& tenantName,
+    const TString& nodeType) -> TMap<TString, TString>;
+
 void SetupConfigDispatcher(
     const NProto::TConfigDispatcherSettings& settings,
     const TString& tenantName,

--- a/cloud/storage/core/libs/kikimr/config_initializer.h
+++ b/cloud/storage/core/libs/kikimr/config_initializer.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "node.h"
+
 #include <cloud/storage/core/libs/daemon/config_initializer.h>
 
 #include <contrib/ydb/core/protos/config.pb.h>

--- a/cloud/storage/core/libs/kikimr/config_initializer.h
+++ b/cloud/storage/core/libs/kikimr/config_initializer.h
@@ -2,8 +2,6 @@
 
 #include "public.h"
 
-#include "node.h"
-
 #include <cloud/storage/core/libs/daemon/config_initializer.h>
 
 #include <contrib/ydb/core/protos/config.pb.h>

--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -136,16 +136,17 @@ TResultOrError<NKikimrConfig::TAppConfig> GetConfigsFromCms(
     NKikimrConfig::TStaticNameserviceConfig& nsConfig)
 {
     auto configurator = kikimr.GetNodeConfigurator();
-    // version is YamlApiVersion, token is a rudimentary parameter
+    // Token is a rudimentary parameter
+    // Version is YamlApiVersion. Only version 1 can serve YAML
     auto configResult = configurator.SyncGetNodeConfig(
-        nodeId,
-        hostName,
-        options.SchemeShardDir,
-        options.Settings.NodeType,
-        options.Domain,
-        "",
-        true,
-        1);
+        /*nodeId=*/nodeId,
+        /*host=*/hostName,
+        /*tenant=*/options.SchemeShardDir,
+        /*nodeType=*/options.Settings.NodeType,
+        /*domain=*/options.Domain,
+        /*token=*/"",
+        /*serveYaml=*/true,
+        /*version=*/1);
 
     if (!configResult.IsSuccess()) {
         return MakeError(

--- a/cloud/storage/core/libs/kikimr/node.h
+++ b/cloud/storage/core/libs/kikimr/node.h
@@ -8,10 +8,13 @@
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
+#include <cloud/storage/core/protos/config_dispatcher_settings.pb.h>
+
 #include <contrib/ydb/core/protos/config.pb.h>
 #include <contrib/ydb/core/protos/node_broker.pb.h>
 #include <contrib/ydb/library/actors/core/defs.h>
 
+#include <util/generic/map.h>
 #include <util/generic/maybe.h>
 #include <util/generic/string.h>
 
@@ -39,6 +42,8 @@ using INodeRegistrantPtr = std::unique_ptr<INodeRegistrant>;
 
 struct TRegisterDynamicNodeOptions
 {
+    using TNodeLabels = TMap<TString, TString>;
+
     TString Domain;
     TString SchemeShardDir;
 
@@ -56,6 +61,8 @@ struct TRegisterDynamicNodeOptions
     bool LoadCmsConfigs = false;
 
     TNodeRegistrationSettings Settings;
+
+    TNodeLabels Labels;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/protos/config_dispatcher_settings.proto
+++ b/cloud/storage/core/protos/config_dispatcher_settings.proto
@@ -14,8 +14,15 @@ message TConfigNames
 
 message TConfigDispatcherSettings
 {
+    message TLabel {
+        string Key = 1;
+        string Value = 2;
+    }
+
     oneof AllowDenySettings {
         TConfigNames AllowList = 1;
         TConfigNames DenyList = 2;
     };
+
+    repeated TLabel AdditionalNodeLabels = 3;
 };

--- a/contrib/ydb/core/protos/nbs/blockstore.proto
+++ b/contrib/ydb/core/protos/nbs/blockstore.proto
@@ -1,4 +1,6 @@
 package NKikimrConfig;
 
-// This is a message that is used for config overrides in Console for https://github.com/ydb-platform/nbs, where it's not empty
-message TBlockstoreConfig {}
+message TBlockstoreConfig {
+    // TStorageServiceConfig (447)
+    optional bool VolumeBalancerEnabled = 1;
+}

--- a/contrib/ydb/core/protos/nbs/blockstore.proto
+++ b/contrib/ydb/core/protos/nbs/blockstore.proto
@@ -1,6 +1,17 @@
 package NKikimrConfig;
 
+// Copy of the message from cloud/blockstore/config/storage.proto
+enum EVolumePreemptionType
+{
+    // Do not preempt volumes when host is overloaded
+    PREEMPTION_NONE = 0;
+    // Move most resource consuming disk
+    PREEMPTION_MOVE_MOST_HEAVY = 1;
+    // Move least resource consumig disk
+    PREEMPTION_MOVE_LEAST_HEAVY = 2;
+}
+
 message TBlockstoreConfig {
-    // TStorageServiceConfig (447)
-    optional bool VolumeBalancerEnabled = 1;
+    // TStorageServiceConfig (134)
+    optional EVolumePreemptionType VolumePreemptionType = 1;
 }

--- a/example/2-init_storage.sh
+++ b/example/2-init_storage.sh
@@ -30,3 +30,5 @@ echo "AllowNamedConfigs"
 ydbd -s grpc://localhost:$GRPC_PORT admin console config set --merge "$ALLOW_NAMED_CONFIGS_REQ"
 echo "SetUserAttributes(set unlimited for nonrepl disks)"
 ydbd -s grpc://localhost:$GRPC_PORT db schema user-attribute set /Root/NBS __volume_space_limit_ssd_nonrepl=$(( 999 * 1024**5 ))
+echo "Set Console Config"
+ydb -e grpc://localhost:$GRPC_PORT -d /Root admin config replace -f ydb/config.yaml --allow-unknown-fields

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -60,3 +60,15 @@ TabletBootInfoBackupFilePath: "backups/nbs-tablet-boot-info-backup.txt"
 
 # Volume Throttling Manager
 VolumeThrottlingManagerEnabled: true
+
+# YDB Config Dispatcher Support
+ConfigsDispatcherServiceEnabled: true
+ConfigDispatcherSettings {
+  AllowList {
+    Names: "BlockstoreConfigItem"
+  }
+  AdditionalNodeLabels {
+    Key: "nbs"
+    Value: "true"
+  }
+}

--- a/example/prepare_binaries.sh
+++ b/example/prepare_binaries.sh
@@ -1,5 +1,6 @@
 BUILD_ROOT="../cloud/blockstore/buildall"
 YDBD_BIN="$BUILD_ROOT/contrib/ydb/apps/ydbd/ydbd"
+YDB_BIN="$BUILD_ROOT/contrib/ydb/apps/ydb/ydb"
 NBSD_BIN="$BUILD_ROOT/cloud/blockstore/apps/server/nbsd"
 BLOCKSTORE_CLIENT_BIN="$BUILD_ROOT/cloud/blockstore/apps/client/blockstore-client"
 BLOCKSTORE_VHOST_SERVER_BIN="$BUILD_ROOT/cloud/blockstore/vhost-server/blockstore-vhost-server"
@@ -14,6 +15,10 @@ do
     return 1
   fi
 done
+
+function ydb {
+  LD_LIBRARY_PATH=$(dirname $YDB_BIN) $YDB_BIN "$@"
+}
 
 function ydbd {
   LD_LIBRARY_PATH=$(dirname $YDBD_BIN) $YDBD_BIN "$@"

--- a/example/ydb/config.yaml
+++ b/example/ydb/config.yaml
@@ -19,4 +19,4 @@ selector_config:
     nbs: true
   config:
     blockstore_config: !inherit
-      volume_balancer_enabled: true
+      volume_preemption_type: VOLUME_PREEMPTION_NONE

--- a/example/ydb/config.yaml
+++ b/example/ydb/config.yaml
@@ -1,0 +1,22 @@
+metadata:
+  kind: MainConfig
+  cluster: "local"
+  version: 0
+config:
+  yaml_config_enabled: true
+allowed_labels:
+  nbs:
+    type: string
+  node_id:
+    type: string
+  host:
+    type: string
+  tenant:
+    type: string
+selector_config:
+- description: dummy
+  selector:
+    nbs: true
+  config:
+    blockstore_config: !inherit
+      volume_balancer_enabled: true


### PR DESCRIPTION
Introduce Configs Dispatcher over NBS config

1. Load them on start from Console (this includes using correct node labels that are consistent with the ones used later)
1. Map configs that we receive on boot to our `StorageConfig`
1. Subscribe our actor (in this example -- `VolumeBalancer`) to changes in this config and allow him to react to them