### PR TITLE
Fix NonReplicatedVolumeMigrationDisabled param behaviour

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.cpp
@@ -50,6 +50,11 @@ bool TProcessingBlocks::IsProcessing() const
     return !!BlockMap;
 }
 
+bool TProcessingBlocks::IsProcessingDone() const
+{
+    return !BlockMap && CurrentProcessingIndex == BlockCount;
+}
+
 bool TProcessingBlocks::IsProcessed(TBlockRange64 range) const
 {
     return BlockMap->Count(range.Start, range.End + 1) == range.Size();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h
@@ -38,6 +38,7 @@ public:
 public:
     void AbortProcessing();
     bool IsProcessing() const;
+    bool IsProcessingDone() const;
     bool IsProcessed(TBlockRange64 range) const;
     void MarkProcessed(TBlockRange64 range);
     bool SkipProcessedRanges();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -147,8 +147,8 @@ bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationAllowed() const
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsMigrationFinished() const
 {
-    return !ProcessingBlocks.IsProcessing() && MigrationsInProgress.Empty() &&
-           DeferredMigrations.Empty();
+    return ProcessingBlocks.IsProcessingDone() &&
+           MigrationsInProgress.Empty() && DeferredMigrations.Empty();
 }
 
 bool TNonreplicatedPartitionMigrationCommonActor::IsIoDepthLimitReached() const


### PR DESCRIPTION
Сейчас параметр `NonReplicatedVolumeMigrationDisabled` работает не как ожидается.
При включении `NonReplicatedVolumeMigrationDisabled` в `TNonreplicatedPartitionMigrationCommonActor::InitWork()` передаётся пустой `DstActorId`. При этом в `TNonreplicatedPartitionMigrationCommonActor::StartWork()` вызовется событие `OnMigrationFinished()`, т.к. NBS посчитает что всё было смигрировано. 

В этом ПРе добавил проверку на то что индекс миграции проитерирован до конца. 