### PR TITLE
fix: LOGS ARE EMPTY are wrong in case of dot in test arguments

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -293,6 +293,7 @@ runs:
             MUTED_CONFIG=".github/config/muted_ya.txt"
             echo "::endgroup::"
             echo "::group::postprocess-junit-${i}"
+            sudo -E -H -u github gzip -c "${JUNIT_REPORT_XML}.${i}" > "$REPORTS_ARTIFACTS_DIR/orig_junit.${i}.xml.gz"
             sudo -E -H -u github .github/scripts/tests/transform-ya-junit.py -i \
               -m "${MUTED_CONFIG}" \
               --ya-out "$OUT_DIR" \
@@ -368,7 +369,7 @@ runs:
             echo "::endgroup::"
           fi
           # shellcheck disable=SC2024
-          sudo -E -H -u github gzip -c "${JUNIT_REPORT_XML}.${i}" > "$REPORTS_ARTIFACTS_DIR/orig_junit.${i}.xml.gz"
+          sudo -E -H -u github gzip -c "${JUNIT_REPORT_XML}.${i}" > "$REPORTS_ARTIFACTS_DIR/transformed_junit.${i}.xml.gz"
           sudo -E -H -u github tar -C "$JUNIT_REPORT_PARTS/.." -czf "${REPORTS_ARTIFACTS_DIR}/junit_parts.${i}.xml.tar.gz" "$(basename $JUNIT_REPORT_PARTS)/${i}" "${JUNIT_REPORT_XML}.${i}"*
 
 

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -66,8 +66,8 @@ class TestResult:
     @classmethod
     def from_junit(cls, testcase):
         classname, name = testcase.get("classname"), testcase.get("name")
-
         is_timed_out = False
+
         if testcase.find("failure") is not None:
             status = TestStatus.FAIL
             text = testcase.find("failure").text

--- a/.github/scripts/tests/transform-ya-junit.py
+++ b/.github/scripts/tests/transform-ya-junit.py
@@ -271,7 +271,11 @@ def transform(
 
             if is_fail:
                 if "." in test_name:
+                    # we need this hack because the test name format is not consistent
+                    test_name = test_name.replace("kubernetes.io", "kubernetes::io")
                     test_cls, test_method = test_name.rsplit(".", maxsplit=1)
+                    test_method = test_method.replace("kubernetes::io", "kubernetes.io")
+                    print(f"test class: {test_cls}, test method: {test_method}")
                     logs = filter_empty_logs(traces.get_logs(test_cls, test_method))
                     logs_directory = traces.get_log_dir(test_cls, test_method)
                 elif "chunk" in test_name:


### PR DESCRIPTION
fixes few problems:
* orig_junit.xml was not original, it was after transform-ya-junit.py
* in case of `test.py.test_csi_sanity_nbs_backend[/var/lib/kubelet/pods/123/volumes/kubernetes.io~csi/456/mount-mount-True-skip_tests2]` LOGS ARE EMTPY message was wrong, because it was identified incorrectly because of `kubernetes.io` string in test parameters