### PR TITLE
issue-1751: split TWriteDataEntry::IsFinished into IsCorrupted and IsFlushed; rename TWriteDataEntry::Finish to FinishFlush; cleanup comments

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -343,7 +343,7 @@ public:
                     checksum,
                     serializedRequest);
 
-                if (entry->IsFinished()) {
+                if (entry->IsCorrupted()) {
                     // This may happen when a buffer was corrupted.
                     // We should add this entry to a queue like a normal entry
                     // because there is 1-by-1 correspondence between
@@ -1126,11 +1126,11 @@ private:
                 handleState->EntriesWithFlushRequested--;
             }
 
-            entry->Finish(PendingOperations);
+            entry->FinishFlush(PendingOperations);
         }
 
-        // Clear finished entries from the persistent queue
-        while (!CachedEntries.empty() && CachedEntries.front()->IsFinished())
+        // Clear flushed entries from the persistent queue
+        while (!CachedEntries.empty() && CachedEntries.front()->IsFlushed())
         {
             CachedEntries.pop_front();
             CachedEntriesPersistentQueue.PopFront();
@@ -1332,7 +1332,7 @@ void TWriteBackCache::TWriteDataEntry::SerializeAndMoveRequestBuffer(
     }
 }
 
-void TWriteBackCache::TWriteDataEntry::Finish(
+void TWriteBackCache::TWriteDataEntry::FinishFlush(
     TPendingOperations& pendingOperations)
 {
     Y_ABORT_UNLESS(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -56,7 +56,7 @@ public:
     NThreading::TFuture<void> FlushAllData();
 
 private:
-    // only for testing purposes
+    // Only for testing purposes
     friend struct TCalculateDataPartsToReadTestBootstrap;
 
     enum class EWriteDataEntryStatus;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -93,15 +93,19 @@ public:
                Status == EWriteDataEntryStatus::FlushRequested;
     }
 
-    bool IsFinished() const
+    bool IsCorrupted() const
     {
-        return Status == EWriteDataEntryStatus::Flushed ||
-               Status == EWriteDataEntryStatus::Corrupted;
+        return Status == EWriteDataEntryStatus::Corrupted;
     }
 
     bool IsFlushRequested() const
     {
         return Status == EWriteDataEntryStatus::FlushRequested;
+    }
+
+    bool IsFlushed() const
+    {
+        return Status == EWriteDataEntryStatus::Flushed;
     }
 
     size_t GetSerializedSize() const;
@@ -110,7 +114,7 @@ public:
         char* allocationPtr,
         TPendingOperations& pendingOperations);
 
-    void Finish(TPendingOperations& pendingOperations);
+    void FinishFlush(TPendingOperations& pendingOperations);
 
     bool RequestFlush();
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -71,7 +71,7 @@ struct TInFlightRequestTracker
         return res;
     }
 
-    // returns previous in-flight request count in range
+    // Returns previous in-flight request count in range
     ui32 Add(ui64 offset, ui64 length)
     {
         ui32 res = 0;
@@ -80,7 +80,7 @@ struct TInFlightRequestTracker
             std::unique_lock lock(Mutex);
 
             const auto end = offset + length;
-            // append zeroes if needed
+            // Append zeroes if needed
             const auto newSize = Max(InFlightRequests.size(), end);
             InFlightRequests.resize(newSize, 0);
 
@@ -129,19 +129,19 @@ struct TBootstrap
 
     TCallContextPtr CallContext;
 
-    // maps handle to data
+    // Maps handle to data
     THashMap<ui64, TString> ExpectedData;
     std::mutex ExpectedDataMutex;
 
-    // maps handle to data
+    // Maps handle to data
     THashMap<ui64, TString> UnflushedData;
     std::mutex UnflushedDataMutex;
 
-    // maps handle to data
+    // Maps handle to data
     THashMap<ui64, TString> FlushedData;
     std::mutex FlushedDataMutex;
 
-    // ensures that the data is not flushed twice, does not work well with cache
+    // Ensures that the data is not flushed twice, does not work well with cache
     // recreation because after recreation, the data may be flushed again
     bool EraseExpectedUnflushedDataAfterFirstUse = false;
 
@@ -183,7 +183,7 @@ struct TBootstrap
             const auto offset = request->GetOffset();
             const auto length = request->GetLength();
 
-            // overlapping write requests are not allowed
+            // Overlapping write requests are not allowed
             UNIT_ASSERT_VALUES_EQUAL(
                 0,
                 InFlightWriteRequestTracker[handle].Count(offset, length));
@@ -202,7 +202,7 @@ struct TBootstrap
             }
 
             auto data = FlushedData[request->GetHandle()];
-            // append zeroes if needed
+            // Append zeroes if needed
             auto newSize = Max(
                 data.size(),
                 request->GetOffset() + request->GetLength());
@@ -227,12 +227,12 @@ struct TBootstrap
             const auto offset = request->GetOffset();
             const auto length = request->GetBuffer().length();
 
-            // overlapping read requests are not allowed
+            // Overlapping read requests are not allowed
             UNIT_ASSERT_VALUES_EQUAL(
                 0,
                 InFlightReadRequestTracker[handle].Count(offset, length));
 
-            // overlapping write requests are not allowed
+            // Overlapping write requests are not allowed
             UNIT_ASSERT_VALUES_EQUAL(
                 0,
                 InFlightWriteRequestTracker[handle].Add(offset, length));
@@ -260,7 +260,7 @@ struct TBootstrap
             UNIT_ASSERT_VALUES_EQUAL(from, request->GetBuffer());
 
             auto& to = FlushedData[request->GetHandle()];
-            // append zeroes if needed
+            // Append zeroes if needed
             auto newSize = Max(to.size(), request->GetOffset() + from.size());
             to.resize(newSize, 0);
             to.replace(request->GetOffset(), from.size(), from);
@@ -528,7 +528,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         };
 
         NProto::TReadDataResponse response;
-        // return empty buffer in response
+        // Return empty buffer in response
         readPromise.SetValue(response);
 
         auto readFuture = b.ReadFromCache(1, 0, 1);
@@ -686,12 +686,12 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         TBootstrap b;
 
         b.WriteToCacheSync(1, 0, "abc");
-        // additional check for test correctness
+        // Additional check for test correctness
         UNIT_ASSERT_VALUES_EQUAL("abc", b.ExpectedData[1]);
         b.ValidateCache();
 
         b.WriteToCacheSync(2, 2, "bcde");
-        // additional check for test correctness
+        // Additional check for test correctness
         UNIT_ASSERT_VALUES_EQUAL(TString("\0\0bcde", 6), b.ExpectedData[2]);
         b.ValidateCache();
 
@@ -707,7 +707,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         b.ValidateCache();
 
         b.WriteToCacheSync(1, 0, "defgh");
-        // additional check for test correctness
+        // Additional check for test correctness
         UNIT_ASSERT_VALUES_EQUAL("defghfghijklmnde", b.ExpectedData[1]);
         b.ValidateCache();
 
@@ -743,7 +743,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
     void TestShouldReadAfterWriteRandomized(bool withRecreation = false) {
         TBootstrap b;
-        // ensures that the data is not flushed twice, does not work well with
+        // Ensures that the data is not flushed twice, does not work well with
         // cache recreation because after recreation, the data may be flushed
         // again
         b.EraseExpectedUnflushedDataAfterFirstUse = !withRecreation;
@@ -885,7 +885,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
             });
         }
 
-        // read-only threads for "smoke" testing
+        // Read-only threads for "smoke" testing
         for (ui32 i = 0; i < roThreadCount; i++) {
             threads.emplace_back([&] {
                 start.arrive_and_wait();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util.cpp
@@ -42,7 +42,7 @@ TVector<TResult> CalculateDataParts(TVector<TPoint<TEntry>> points)
     const auto cutTop = [&res, &heap] (auto lastOffset, auto currOffset)
     {
         if (currOffset <= lastOffset) {
-            // ignore
+            // Ignore
             return lastOffset;
         }
 
@@ -56,7 +56,7 @@ TVector<TResult> CalculateDataParts(TVector<TPoint<TEntry>> points)
             res.back().Source == top.Entry &&
             res.back().End() == lastOffset)
         {
-            // extend last entry
+            // Extend last entry
             res.back().Length += partLength;
         } else {
             res.emplace_back(
@@ -66,7 +66,7 @@ TVector<TResult> CalculateDataParts(TVector<TPoint<TEntry>> points)
                 partLength);
         }
 
-        // cut part of the top
+        // Cut part of the top
         lastOffset += partLength;
         return lastOffset;
     };
@@ -74,32 +74,32 @@ TVector<TResult> CalculateDataParts(TVector<TPoint<TEntry>> points)
     ui64 cutEnd = 0;
     for (const auto& point: points) {
         if (point.IsEnd) {
-            // cut at every interval's end
+            // Cut at every interval's end
             cutEnd = cutTop(cutEnd, point.Offset);
         } else {
             if (heap.empty()) {
-                // no intervals before, start from scratch
+                // No intervals before, start from scratch
                 cutEnd = point.Offset;
             } else {
                 if (point.Order > heap.front().Order) {
-                    // new interval is now on top
+                    // New interval is now on top
                     cutEnd = cutTop(cutEnd, point.Offset);
                 }
             }
 
-            // add to heap
+            // Add to heap
             heap.push_back(point);
             std::push_heap(heap.begin(), heap.end(), heapComparator);
         }
 
-        // remove affected (cut) entries
+        // Remove affected (cut) entries
         while (!heap.empty()) {
             const auto& top = heap.front();
             if (cutEnd < top.Entry->End()) {
                 break;
             }
 
-            // remove from heap
+            // Remove from heap
             std::pop_heap(heap.begin(), heap.end(), heapComparator);
             heap.pop_back();
         }


### PR DESCRIPTION
#1751 