### PR TITLE
[NBS, Filestore] Add "units" label to request counters

### DIFF
--- a/cloud/blockstore/libs/diagnostics/user_counter_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/user_counter_ut.cpp
@@ -93,8 +93,8 @@ Y_UNIT_TEST_SUITE(TUserWrapperTest)
             request->GetCounter("InProgressBytes")->Set(5);
             request->GetCounter("MaxInProgressBytes")->Set(50);
 
-            auto requestTimeHist =
-                request->GetSubgroup("histogram", "Time");
+            auto requestTimeHist = request->GetSubgroup("histogram", "Time")
+                                       ->GetSubgroup("units", "msec");
             requestTimeHist->GetCounter("0.001ms")->Set(1);
             requestTimeHist->GetCounter("0.1ms")->Set(2);
             requestTimeHist->GetCounter("0.2ms")->Set(3);
@@ -173,7 +173,8 @@ Y_UNIT_TEST_SUITE(TUserWrapperTest)
 
             auto request = stats->GetSubgroup("request", name);
             auto requestTimeHist =
-                request->GetSubgroup("histogram", "ThrottlerDelay");
+                request->GetSubgroup("histogram", "ThrottlerDelay")
+                    ->GetSubgroup("units", "usec");
             requestTimeHist->GetCounter("1")->Set(1);
             requestTimeHist->GetCounter("100")->Set(2);
             requestTimeHist->GetCounter("200")->Set(3);

--- a/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
@@ -287,8 +287,11 @@ Y_UNIT_TEST_SUITE(TEndpointStatsTest)
 
         auto sizes = writeBlocks->FindSubgroup("histogram", "Size");
         UNIT_ASSERT(sizes);
+        sizes = sizes->FindSubgroup("units", "KB");
+        UNIT_ASSERT(sizes);
 
         auto times = writeBlocks->FindSubgroup("histogram", "Time");
+        times = times->FindSubgroup("units", "msec");
         UNIT_ASSERT(times);
 
         {

--- a/cloud/filestore/libs/diagnostics/user_counter_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/user_counter_ut.cpp
@@ -124,7 +124,8 @@ void SetTimeHistogramCountersMs(
     const TIntrusivePtr<NMonitoring::TDynamicCounters>& counters,
     const TString& histName)
 {
-    auto subgroup = counters->GetSubgroup("histogram", histName);
+    auto subgroup = counters->GetSubgroup("histogram", histName)
+                        ->GetSubgroup("units", "msec");
     subgroup->GetCounter("0.001ms")->Set(1);
     subgroup->GetCounter("0.1ms")->Set(2);
     subgroup->GetCounter("0.2ms")->Set(3);

--- a/cloud/storage/core/libs/diagnostics/histogram_types.h
+++ b/cloud/storage/core/libs/diagnostics/histogram_types.h
@@ -27,6 +27,8 @@ struct TRequestUsTimeBuckets
         10000000, 35000000, Max<double>()
     }};
 
+    static constexpr TStringBuf Units = "usec";
+
     static TVector<TString> MakeNames();
 };
 
@@ -43,6 +45,8 @@ struct TRequestUsTimeBucketsLowResolution
         1000000, 2000000, 5000000,
         10000000, 35000000, Max<double>()
     }};
+
+    static constexpr TStringBuf Units = "usec";
 
     static TVector<TString> MakeNames();
 };
@@ -68,6 +72,8 @@ struct TRequestMsTimeBuckets
     static constexpr std::array<double, BUCKETS_COUNT> Buckets =
         MakeArray(TRequestUsTimeBuckets::Buckets);
 
+    static constexpr TStringBuf Units = "msec";
+
     static TVector<TString> MakeNames();
 };
 
@@ -85,6 +91,8 @@ struct TQueueSizeBuckets
         10000, 35000, Max<double>()
     }};
 
+    static constexpr TStringBuf Units = "";
+
     static TVector<TString> MakeNames();
 };
 
@@ -98,6 +106,8 @@ struct TKbSizeBuckets
         4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, Max<double>()
     }};
 
+    static constexpr TStringBuf Units = "KB";
+
     static TVector<TString> MakeNames();
 };
 
@@ -107,4 +117,3 @@ inline TVector<double> ConvertToHistBounds(const TBucketsType& buckets) {
 }
 
 }   // namespace NCloud
-

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -7,6 +7,7 @@
 #include "cloud/storage/core/libs/diagnostics/histogram_types.h"
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/testing/hook/hook.h>
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -297,7 +298,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         requestCounters.UpdateStats(true);
 
         {
-            auto percentiles = writeBlocks->GetSubgroup("percentiles", "Time");
+            auto percentiles = writeBlocks->GetSubgroup("percentiles", "Time")
+                                   ->GetSubgroup("units", "msec");
 
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
@@ -307,7 +309,9 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = writeBlocks->GetSubgroup("percentiles", "ExecutionTime");
+            auto percentiles =
+                writeBlocks->GetSubgroup("percentiles", "ExecutionTime")
+                    ->GetSubgroup("units", "msec");
 
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
@@ -317,7 +321,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = readBlocks->GetSubgroup("percentiles", "Time");
+            auto percentiles = readBlocks->GetSubgroup("percentiles", "Time")
+                                   ->GetSubgroup("units", "msec");
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
@@ -326,7 +331,9 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = readBlocks->GetSubgroup("percentiles", "ExecutionTime");
+            auto percentiles =
+                readBlocks->GetSubgroup("percentiles", "ExecutionTime")
+                    ->GetSubgroup("units", "msec");
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
@@ -359,7 +366,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         requestCounters.UpdateStats(true);
 
         {
-            auto percentiles = writeBlocks->GetSubgroup("percentiles", "Time");
+            auto percentiles = writeBlocks->GetSubgroup("percentiles", "Time")
+                                   ->GetSubgroup("units", "msec");
 
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
@@ -369,7 +377,9 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = writeBlocks->GetSubgroup("percentiles", "ExecutionTime");
+            auto percentiles =
+                writeBlocks->GetSubgroup("percentiles", "ExecutionTime")
+                    ->GetSubgroup("units", "msec");
 
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
@@ -379,7 +389,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = readBlocks->GetSubgroup("percentiles", "Time");
+            auto percentiles = readBlocks->GetSubgroup("percentiles", "Time")
+                                   ->GetSubgroup("units", "msec");
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
@@ -388,7 +399,9 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = readBlocks->GetSubgroup("percentiles", "ExecutionTime");
+            auto percentiles =
+                readBlocks->GetSubgroup("percentiles", "ExecutionTime")
+                    ->GetSubgroup("units", "msec");
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
@@ -397,7 +410,9 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         }
 
         {
-            auto percentiles = readBlocks->GetSubgroup("percentiles", "RequestCompletionTime");
+            auto percentiles =
+                readBlocks->GetSubgroup("percentiles", "RequestCompletionTime")
+                    ->GetSubgroup("units", "msec");
             auto p100 = percentiles->GetCounter("100");
             auto p50 = percentiles->GetCounter("50");
 
@@ -425,7 +440,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
 
         requestCounters.UpdateStats(true);
 
-        auto percentiles = counters->GetSubgroup("percentiles", "Size");
+        auto percentiles = counters->GetSubgroup("percentiles", "Size")
+                               ->GetSubgroup("units", "KB");
         auto p100 = percentiles->GetCounter("100");
         auto p50 = percentiles->GetCounter("50");
 
@@ -680,6 +696,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
                 ->GetSubgroup("request", "WriteBlocks")
                 ->GetSubgroup("sizeclass", "Unaligned")
                 ->GetSubgroup("histogram", "Time")
+                ->GetSubgroup("units", "msec")
                 ->GetCounter("Inf");
 
             UNIT_ASSERT_VALUES_EQUAL(time->Val(), 2);
@@ -715,11 +732,12 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         const auto group = monitoring
             ->GetCounters()
             ->GetSubgroup("request", "WriteBlocks")
-            ->GetSubgroup("histogram", "Time");
+            ->GetSubgroup("histogram", "Time")
+            ->GetSubgroup("units", "msec");
 
         for (const auto& [name, value]: expectedHistogramValues) {
             const auto counter = group->FindCounter(name);
-            UNIT_ASSERT(counter);
+            UNIT_ASSERT_C(counter, "Counter " + name.Quote() + " not found");
             UNIT_ASSERT_VALUES_EQUAL(counter->Val(), value);
         }
     }
@@ -753,6 +771,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
             ->GetCounters()
             ->GetSubgroup("request", "WriteBlocks")
             ->GetSubgroup("histogram", "Time")
+            ->GetSubgroup("units", "msec")
             ->FindHistogram("Time");
         UNIT_ASSERT(histogram);
 
@@ -786,6 +805,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
             ->GetCounters()
             ->GetSubgroup("request", "WriteBlocks")
             ->GetSubgroup("histogram", "Time")
+            ->GetSubgroup("units", "msec")
             ->FindCounter("1ms");
 
         UNIT_ASSERT(!counter);
@@ -794,6 +814,7 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
             ->GetCounters()
             ->GetSubgroup("request", "WriteBlocks")
             ->GetSubgroup("histogram", "Time")
+            ->GetSubgroup("units", "msec")
             ->FindHistogram("Time");
 
         UNIT_ASSERT(!histogram);

--- a/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
@@ -146,20 +146,20 @@ std::shared_ptr<IUserCounterSupplier> CreateUserCounterSupplierStub()
 
 ///////////////////////////////////////////////////////////////////////////////
 
-TBuckets GetMsBuckets()
+TBucketsWithUnits GetMsBuckets()
 {
     constexpr auto Identity = [](double data) { return data; };
     static const auto Buckets = MakeBuckets<TRequestMsTimeBuckets>(Identity);
-    return Buckets;
+    return {Buckets, "msec"};
 }
 
-TBuckets GetUsBuckets()
+TBucketsWithUnits GetUsBuckets()
 {
     constexpr auto UsToMs = [](double data) {
         return data == std::numeric_limits<double>::max() ? data : data / 1000.;
     };
     static const auto Buckets = MakeBuckets<TRequestUsTimeBuckets>(UsToMs);
-    return Buckets;
+    return {Buckets, "usec"};
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -221,17 +221,19 @@ private:
     static constexpr size_t IgnoreBucketCount = 10;
 
     TVector<TIntrusivePtr<NMonitoring::TDynamicCounters>> Counters;
-    TIntrusivePtr<TExplicitHistogramSnapshot> Histogram;
     const TBuckets Buckets;
+    const TString Units;
+    TIntrusivePtr<TExplicitHistogramSnapshot> Histogram;
     EMetricType Type = EMetricType::UNKNOWN;
 
 public:
     TUserSumHistogramWrapper(
-        const TBuckets& buckets,
+        const TBucketsWithUnits& buckets,
         const TVector<TBaseDynamicCounters>& baseCounters)
-        : Histogram(TExplicitHistogramSnapshot::New(
-              buckets.size() - IgnoreBucketCount))
-        , Buckets(buckets)
+        : Buckets(buckets.first)
+        , Units(buckets.second)
+        , Histogram(TExplicitHistogramSnapshot::New(
+              Buckets.size() - IgnoreBucketCount))
         , Type(EMetricType::HIST_RATE)
     {
         for (size_t i = IgnoreBucketCount; i < Buckets.size(); ++i) {
@@ -239,11 +241,18 @@ public:
         }
 
         for (const auto& [baseCounter, name]: baseCounters) {
-            if (baseCounter) {
-                if (auto hist = baseCounter->FindSubgroup("histogram", name)) {
-                    Counters.push_back(hist);
-                }
+            if (!baseCounter) {
+                continue;
             }
+            auto histSubgroup = baseCounter->FindSubgroup("histogram", name);
+            if (!histSubgroup) {
+                continue;
+            }
+            auto unitsSubgroup = histSubgroup->FindSubgroup("units", Units);
+            if (!unitsSubgroup) {
+                continue;
+            }
+            Counters.push_back(unitsSubgroup);
         }
     }
 
@@ -294,7 +303,7 @@ void AddUserMetric(
 }
 
 void AddHistogramUserMetric(
-    const TBuckets& buckets,
+    const TBucketsWithUnits& buckets,
     IUserCounterSupplier& dsc,
     const TLabels& commonLabels,
     const TVector<TBaseDynamicCounters>& baseCounters,

--- a/cloud/storage/core/libs/user_stats/counter/user_counter.h
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.h
@@ -64,9 +64,10 @@ struct TBucket
 static constexpr size_t BUCKETS_COUNT = 25;
 
 using TBuckets = std::array<TBucket, BUCKETS_COUNT>;
+using TBucketsWithUnits = std::pair<TBuckets, TString>;
 
-TBuckets GetMsBuckets();
-TBuckets GetUsBuckets();
+TBucketsWithUnits GetMsBuckets();
+TBucketsWithUnits GetUsBuckets();
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -80,7 +81,7 @@ void AddUserMetric(
     TStringBuf newName);
 
 void AddHistogramUserMetric(
-    const TBuckets& buckets,
+    const TBucketsWithUnits& buckets,
     IUserCounterSupplier& dsc,
     const NMonitoring::TLabels& commonLabels,
     const TVector<TBaseDynamicCounters>& baseCounters,


### PR DESCRIPTION
**Summary**
This PR introduces a units label for request counters to ensure seamless visualization in dashboards.

**Motivation**
The label will be required when transitioning histogram/percentile metrics from milliseconds to microseconds, allowing graphs to remain consistent across unit changes.

**Additional Changes**
A minor refactoring was performed as part of this update. `TRequestPercentiles` should be consistent with THistBase in order to:
* inherit the same name as the source histogram
* inherit the same units as the source histogram
* update its values from the source histogram