### PR TITLE
Fix TStatsAggregator

### DIFF
--- a/cloud/blockstore/libs/diagnostics/stats_aggregator.cpp
+++ b/cloud/blockstore/libs/diagnostics/stats_aggregator.cpp
@@ -111,8 +111,22 @@ struct TRequestPercentiles
         if (!counters) {
             return;
         }
-        Time.Update(Log, counters->FindSubgroup("histogram", "Time"), counters, "Time");
-        Size.Update(Log, counters->FindSubgroup("histogram", "Size"), counters, "Size");
+
+        auto timeCounters = counters->FindSubgroup("histogram", "Time");
+        if (timeCounters) {
+            if (auto counters = timeCounters->FindSubgroup("units", "usec")) {
+                timeCounters = counters;
+            }
+            Time.Update(Log, timeCounters, counters, "Time");
+        }
+
+        auto sizeCounters = counters->FindSubgroup("histogram", "Size");
+        if (sizeCounters) {
+            if (auto counters = sizeCounters->FindSubgroup("units", "KB")) {
+                sizeCounters = counters;
+            }
+            Size.Update(Log, sizeCounters, counters, "Size");
+        }
     }
 };
 

--- a/cloud/blockstore/libs/diagnostics/stats_aggregator_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/stats_aggregator_ut.cpp
@@ -94,6 +94,7 @@ TDynamicCounterPtr SetupTestClientCounters(
             *inProgressCounter = sum * WriteBlocksInProgress;
 
             auto timeGroup = writeBlocksGroup->GetSubgroup("histogram", "Time");
+            timeGroup = timeGroup->GetSubgroup("units", "usec");
 
             for (auto bucket : TimeBuckets) {
                 auto bucketCounter = timeGroup->GetCounter(ToString(bucket)+"ms", true);

--- a/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
@@ -244,7 +244,9 @@ public:
             if (Units) {
                 subgroup = subgroup->FindSubgroup("units", Units);
             }
-            Counters.push_back(subgroup);
+            if (subgroup) {
+                Counters.push_back(subgroup);
+            }
         }
     }
 


### PR DESCRIPTION
**Summary**

Update TStatsAggregator to be compatible with the recent changes introduced in [ydb-platform/nbs#4029](https://github.com/ydb-platform/nbs/pull/4029)

**Motivation**

Recent changes in [PR #4029](https://github.com/ydb-platform/nbs/pull/4029) modified the way counters are handled. As a result, TStatsAggregator was no longer compatible, causing several load test to fail (`cloud/blockstore/tests/loadtest/local*`). This PR aligns TStatsAggregator with the new behavior and restores the affected tests.