### PR TITLE
issue-4231: populate per-parentNodeId isExhaustive flag for the TInMemoryIndexCache upon single-page lists

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -402,6 +402,7 @@ message TStorageConfig
     optional uint64 InMemoryIndexCacheNodesToNodeAttrsCapacityRatio = 375;
     optional uint64 InMemoryIndexCacheNodeRefsCapacity = 376;
     optional uint64 InMemoryIndexCacheNodesToNodeRefsCapacityRatio = 377;
+    optional uint64 InMemoryIndexCacheNodeRefsExhaustivenessCapacity = 437;
 
     // Used to send non-network metrics as network ones to HIVE,
     // while we use them for load balancing

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -402,6 +402,9 @@ message TStorageConfig
     optional uint64 InMemoryIndexCacheNodesToNodeAttrsCapacityRatio = 375;
     optional uint64 InMemoryIndexCacheNodeRefsCapacity = 376;
     optional uint64 InMemoryIndexCacheNodesToNodeRefsCapacityRatio = 377;
+    // In addition to the per-table isExhaustive flag, it is possible to
+    // per-node isExhaustive flag, which can be set upon exhaustive ListNodes
+    // requests. The number of the per-node flags is limited by this value.
     optional uint64 InMemoryIndexCacheNodeRefsExhaustivenessCapacity = 437;
 
     // Used to send non-network metrics as network ones to HIVE,

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -232,6 +232,9 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(InMemoryIndexCacheNodesToNodeAttrsCapacityRatio,ui64,       0         )\
     xxx(InMemoryIndexCacheNodeRefsCapacity,             ui64,       0         )\
     xxx(InMemoryIndexCacheNodesToNodeRefsCapacityRatio, ui64,       0         )\
+    xxx(InMemoryIndexCacheNodeRefsExhaustivenessCapacity,                      \
+        ui64,                                                                  \
+        0                                                                     )\
     xxx(InMemoryIndexCacheLoadOnTabletStart,            bool,       false     )\
     xxx(InMemoryIndexCacheLoadOnTabletStartRowsPerTx,   ui64,       1000      )\
     xxx(InMemoryIndexCacheLoadSchedulePeriod,                                  \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -244,6 +244,7 @@ public:
     ui64 GetInMemoryIndexCacheNodesToNodeAttrsCapacityRatio() const;
     ui64 GetInMemoryIndexCacheNodeRefsCapacity() const;
     ui64 GetInMemoryIndexCacheNodesToNodeRefsCapacityRatio() const;
+    ui64 GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity() const;
     bool GetInMemoryIndexCacheLoadOnTabletStart() const;
     ui64 GetInMemoryIndexCacheLoadOnTabletStartRowsPerTx() const;
     TDuration GetInMemoryIndexCacheLoadSchedulePeriod() const;

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.cpp
@@ -200,8 +200,9 @@ void TMixedBlocks::UnRefRange(ui32 rangeId)
     // offload the range if the capacity is 0
     if (it->second.RefCount == 0) {
         if (Impl->OffloadedRanges.GetMaxSize() != 0) {
-            auto [_, inserted] =
+            auto [_, inserted, evicted] =
                 Impl->OffloadedRanges.emplace(rangeId, Impl->Alloc);
+            Y_UNUSED(evicted);
             Y_DEBUG_ABORT_UNLESS(inserted);
             Impl->OffloadedRanges.at(rangeId).Swap(it->second);
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -126,6 +126,8 @@ private:
         std::atomic<i64> InMemoryIndexStateNodeRefsCapacity;
         std::atomic<i64> InMemoryIndexStateNodeAttrsCount;
         std::atomic<i64> InMemoryIndexStateNodeAttrsCapacity;
+        std::atomic<i64> InMemoryIndexStateNodeRefsExhaustivenessCount;
+        std::atomic<i64> InMemoryIndexStateNodeRefsExhaustivenessCapacity;
         std::atomic<i64> InMemoryIndexStateIsExhaustive;
 
         // Mixed index in-memory stats

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -352,6 +352,12 @@ void TIndexTabletActor::TMetrics::Register(
         InMemoryIndexStateNodeAttrsCapacity,
         EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateNodeRefsExhaustivenessCount,
+        EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        InMemoryIndexStateNodeRefsExhaustivenessCapacity,
+        EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
         InMemoryIndexStateIsExhaustive,
         EMetricType::MT_ABSOLUTE);
 
@@ -609,6 +615,8 @@ void TIndexTabletActor::TMetrics::Update(
     Store(InMemoryIndexStateNodeRefsCapacity, inMemoryIndexStateStats.NodeRefsCapacity);
     Store(InMemoryIndexStateNodeAttrsCount, inMemoryIndexStateStats.NodeAttrsCount);
     Store(InMemoryIndexStateNodeAttrsCapacity, inMemoryIndexStateStats.NodeAttrsCapacity);
+    Store(InMemoryIndexStateNodeRefsExhaustivenessCount, inMemoryIndexStateStats.NodeRefsExhaustivenessCount);
+    Store(InMemoryIndexStateNodeRefsExhaustivenessCapacity, inMemoryIndexStateStats.NodeRefsExhaustivenessCapacity);
     Store(InMemoryIndexStateIsExhaustive, inMemoryIndexStateStats.IsNodeRefsExhaustive);
 
     Store(MixedIndexLoadedRanges, blobMetaMapStats.LoadedRanges);

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -584,7 +584,8 @@ bool TIndexTabletDatabase::ReadNodeRefs(
     const TString& cookie,
     TVector<TNodeRef>& refs,
     ui32 maxBytes,
-    TString* next)
+    TString* next,
+    ui32* skippedRefs)
 {
     using TTable = TIndexTabletSchema::NodeRefs;
 
@@ -598,6 +599,7 @@ bool TIndexTabletDatabase::ReadNodeRefs(
     }
 
     ui32 bytes = 0;
+    ui32 skipped = 0;
     while (it.IsValid()) {
         ui64 minCommitId = it.GetValue<TTable::CommitId>();
         ui64 maxCommitId = InvalidCommitId;
@@ -615,6 +617,8 @@ bool TIndexTabletDatabase::ReadNodeRefs(
 
             // FIXME
             bytes += refs.back().Name.size();
+        } else {
+            ++skipped;
         }
 
         if (!it.Next()) {
@@ -628,6 +632,10 @@ bool TIndexTabletDatabase::ReadNodeRefs(
 
     if (next && it.IsValid()) {
         *next = it.GetValue<TTable::Name>();
+    }
+
+    if (skippedRefs) {
+        *skippedRefs = skipped;
     }
 
     return true;
@@ -2150,15 +2158,41 @@ bool TIndexTabletDatabaseProxy::ReadNodeRefs(
     const TString& cookie,
     TVector<TNodeRef>& refs,
     ui32 maxBytes,
-    TString* next)
+    TString* next,
+    ui32* skippedRefs)
 {
+    ui32 skipped;
+    if (!skippedRefs) {
+        skippedRefs = &skipped;
+    }
     auto result = TIndexTabletDatabase::ReadNodeRefs(
-        nodeId, commitId, cookie, refs, maxBytes, next);
+        nodeId,
+        commitId,
+        cookie,
+        refs,
+        maxBytes,
+        next,
+        skippedRefs);
     if (result) {
         // If ReadNodeRefs was successful, it is reasonable to update the cache
         // with the values that have just been read.
         for (const auto& ref: refs) {
             NodeUpdates.emplace_back(ExtractWriteNodeRefsFromNodeRef(ref));
+        }
+
+        // If the next cookie is empty and cookie is also empty, that means that
+        // we have read all the nodes associated with the given nodeId. This
+        // means that we can mark this nodeId's refs as fully cached after the
+        // WriteNodeRef operations are applied and if and only if following two
+        // conditions are met:
+        //
+        // 1. No nodeRefs were skipped due to commitId filtering
+        // 2. All refs.size() fit into the underlying cache
+        if (next && next->empty() && cookie.empty() && *skippedRefs == 0) {
+            NodeUpdates.emplace_back(
+                TInMemoryIndexState::TMarkNodeRefsAsCachedRequest{
+                    .NodeId = nodeId,
+                    .RefsSize = refs.size()});
         }
     }
     return result;

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -2161,7 +2161,7 @@ bool TIndexTabletDatabaseProxy::ReadNodeRefs(
     TString* next,
     ui32* skippedRefs)
 {
-    ui32 skipped;
+    ui32 skipped = 0;
     if (!skippedRefs) {
         skippedRefs = &skipped;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -211,7 +211,8 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         const TString& cookie,
         TVector<TNodeRef>& refs,
         ui32 maxBytes,
-        TString* next = nullptr) override;
+        TString* next,
+        ui32* skippedRefs) override;
 
     virtual bool ReadNodeRefs(
         ui64 startNodeId,
@@ -629,7 +630,8 @@ public:
         const TString& cookie,
         TVector<TNodeRef>& refs,
         ui32 maxBytes,
-        TString* next = nullptr) override;
+        TString* next = nullptr,
+        ui32* skippedRefs = nullptr) override;
 
     bool ReadNodeRefs(
         ui64 startNodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -159,7 +159,8 @@ void TIndexTabletState::LoadState(
         CalculateInMemoryIndexCacheCapacity(
             config.GetInMemoryIndexCacheNodeRefsCapacity(),
             GetNodesCount(),
-            config.GetInMemoryIndexCacheNodesToNodeRefsCapacityRatio()));
+            config.GetInMemoryIndexCacheNodesToNodeRefsCapacityRatio()),
+        config.GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity());
     Impl->MixedBlocks.Reset(config.GetMixedBlocksOffloadedRangesCapacity());
 
     for (const auto& deletionMarker: largeDeletionMarkers) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -52,6 +52,9 @@ TInMemoryIndexStateStats TInMemoryIndexState::GetStats() const
         .NodeRefsCapacity = NodeRefs.GetMaxSize(),
         .NodeAttrsCount = NodeAttrs.Size(),
         .NodeAttrsCapacity = NodeAttrs.GetMaxSize(),
+        .NodeRefsExhaustivenessCapacity =
+            NodeRefsExhaustivenessInfo.GetMaxSize(),
+        .NodeRefsExhaustivenessCount = NodeRefsExhaustivenessInfo.GetSize(),
         .IsNodeRefsExhaustive = NodeRefsExhaustivenessInfo.IsExhaustive()};
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -347,8 +347,7 @@ void TInMemoryIndexState::WriteNodeRef(
         .ShardNodeName = shardNodeName};
 
     if (it == NodeRefs.end()) {
-        const auto [_, inserted, evicted] =
-            NodeRefs.emplace(key, value);
+        const auto [_, inserted, evicted] = NodeRefs.emplace(key, value);
         if (evicted) {
             NodeRefsExhaustivenessInfo.NodeRefsEvictionObserved(
                 evicted->NodeId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -352,8 +352,7 @@ private:
         void MarkNodeRefsLoadComplete()
         {
             // If during the startup there were no evictions, then the cache
-            // should be
-            // complete upon the load completion.
+            // should be complete upon the load completion.
             IsNodeRefsExhaustive = !IsNodeRefsEvictionObserved;
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -37,7 +37,8 @@ public:
     void Reset(
         ui64 nodesCapacity,
         ui64 nodeAttrsCapacity,
-        ui64 nodeRefsCapacity);
+        ui64 nodeRefsCapacity,
+        ui64 nodeRefsExhaustivenessCapacity);
 
     void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs);
 
@@ -135,7 +136,8 @@ public:
         const TString& cookie,
         TVector<IIndexTabletDatabase::TNodeRef>& refs,
         ui32 maxBytes,
-        TString* next) override;
+        TString* next,
+        ui32* skippedRefs) override;
 
     bool ReadNodeRefs(
         ui64 startNodeId,
@@ -294,14 +296,68 @@ private:
         TMap<TNodeRefsKey, TNodeRefsRow, TLess<TNodeRefsKey>, TStlAllocator>>
         NodeRefs;
 
-    bool IsNodeRefsEvictionObserved = false;
-    bool IsNodeRefsExhaustive = false;
-
-    void NodeRefsEvictionObserved()
+    struct TNodeRefsExhaustivenessInfo
     {
-        IsNodeRefsEvictionObserved = true;
-        IsNodeRefsExhaustive = false;
-    }
+    private:
+        // Indicates whether at least one eviction was observed
+        bool IsNodeRefsEvictionObserved = false;
+        // Can only be set explicitly upone all node refs load completion and in
+        // case zero evictions were observed
+        bool IsNodeRefsExhaustive = false;
+        // Per-nodeId info about several selected nodes
+        ::TLRUCache<ui64, bool> IsExhaustivePerNode;
+
+    public:
+        TNodeRefsExhaustivenessInfo()
+            : IsExhaustivePerNode(0)
+        {}
+
+        void SetMaxSize(size_t size)
+        {
+            IsExhaustivePerNode.SetMaxSize(size);
+        }
+
+        [[nodiscard]] bool IsExhaustiveForNode(ui64 nodeId)
+        {
+            if (Y_UNLIKELY(IsNodeRefsExhaustive)) {
+                return true;
+            }
+            // TInMemoryIndexState is a preemptive cache, thus it is not always
+            // possible to determine, whether the set of stored references is
+            // complete.
+            auto it = IsExhaustivePerNode.Find(nodeId);
+            return it != IsExhaustivePerNode.End() && it.Value();
+        }
+
+        [[nodiscard]] bool IsExhaustive() const
+        {
+            return IsNodeRefsExhaustive;
+        }
+
+        void NodeRefsEvictionObserved(ui64 nodeId)
+        {
+            IsNodeRefsEvictionObserved = true;
+            IsNodeRefsExhaustive = false;
+            auto it = IsExhaustivePerNode.Find(nodeId);
+            if (it != IsExhaustivePerNode.End()) {
+                IsExhaustivePerNode.Erase(it);
+            }
+        }
+
+        void MarkNodeRefsExhaustive(ui64 nodeId)
+        {
+            IsExhaustivePerNode.Insert(nodeId, true);
+        }
+
+        void MarkNodeRefsLoadComplete()
+        {
+            // If during the startup there were no evictions, then the cache
+            // should be
+            // complete upon the load completion.
+            IsNodeRefsExhaustive = !IsNodeRefsEvictionObserved;
+        }
+
+    } NodeRefsExhaustivenessInfo;
 
 public:
     struct TWriteNodeRequest
@@ -331,13 +387,24 @@ public:
 
     using TDeleteNodeRefsRequest = TNodeRefsKey;
 
+    // This request can be interpreted as follow: "last RefsSize added refs were
+    // children of the NodeId and present the entirety of its children", thus if
+    // we see such request, we can mark the NodeRefs cache as exhaustive for
+    // this particular NodeId
+    struct TMarkNodeRefsAsCachedRequest
+    {
+        ui64 NodeId;
+        ui64 RefsSize;
+    };
+
     using TIndexStateRequest = std::variant<
         TWriteNodeRequest,
         TDeleteNodeRequest,
         TWriteNodeAttrsRequest,
         TDeleteNodeAttrsRequest,
         TWriteNodeRefsRequest,
-        TDeleteNodeRefsRequest>;
+        TDeleteNodeRefsRequest,
+        TMarkNodeRefsAsCachedRequest>;
 
     void UpdateState(const TVector<TIndexStateRequest>& nodeUpdates);
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -20,6 +20,8 @@ struct TInMemoryIndexStateStats
     ui64 NodeRefsCapacity;
     ui64 NodeAttrsCount;
     ui64 NodeAttrsCapacity;
+    ui64 NodeRefsExhaustivenessCapacity;
+    ui64 NodeRefsExhaustivenessCount;
     bool IsNodeRefsExhaustive;
 };
 
@@ -354,6 +356,16 @@ private:
             // If during the startup there were no evictions, then the cache
             // should be complete upon the load completion.
             IsNodeRefsExhaustive = !IsNodeRefsEvictionObserved;
+        }
+
+        [[nodiscard]] ui64 GetSize() const
+        {
+            return IsExhaustivePerNode.Size();
+        }
+
+        [[nodiscard]] ui64 GetMaxSize() const
+        {
+            return IsExhaustivePerNode.GetMaxSize();
         }
 
     } NodeRefsExhaustivenessInfo;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -134,7 +134,8 @@ public:
         const TString& cookie,
         TVector<TNodeRef>& refs,
         ui32 maxBytes,
-        TString* next) = 0;
+        TString* next = nullptr,
+        ui32* skippedRefs = nullptr) = 0;
 
     /**
      * @brief read at most maxCount node refs starting from key

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache_stress.cpp
@@ -27,6 +27,7 @@ class TRequestGenerator
         SET_NODE_XATTR,
         CREATE_NODE,
         UNLINK_NODE,
+        LIST_NODES,
         CREATE_HANDLE,
         DESTROY_HANDLE,
         REBOOT_TABLET,
@@ -97,6 +98,9 @@ public:
                     break;
                 case UNLINK_NODE:
                     response = DoUnlinkNode();
+                    break;
+                case LIST_NODES:
+                    response = DoListNodes();
                     break;
                 case CREATE_HANDLE:
                     response = DoCreateHandle();
@@ -258,6 +262,18 @@ private:
                 [node](const TNode& n) { return n.NodeId == node.NodeId; });
             Y_ASSERT(it != ObservedNodes.end());
             ObservedNodes.erase(it);
+        }
+
+        return response->Record.DebugString();
+    }
+
+    TString DoListNodes()
+    {
+        const TNode node = PickRandomNode();
+        auto response = Tablet->SendAndRecvListNodes(node.NodeId);
+
+        for (auto& n: *response->Record.MutableNodes()) {
+            RectifyTimes(&n);
         }
 
         return response->Record.DebugString();

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache_stress.cpp
@@ -457,6 +457,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Cache_Stress)
         storageConfig.SetInMemoryIndexCacheNodesCapacity(100);
         storageConfig.SetInMemoryIndexCacheNodeAttrsCapacity(100);
         storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(100);
+        storageConfig.SetInMemoryIndexCacheNodeRefsExhaustivenessCapacity(2);
 
         ui64 seed = Now().GetValue();
         auto responses1 =

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -24,7 +24,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     Y_UNIT_TEST(ShouldPopulateNodes)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0);
+        state.Reset(1, 0, 0, 0);
 
         TMaybe<IIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
@@ -57,7 +57,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     Y_UNIT_TEST(ShouldEvictNodes)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0);
+        state.Reset(1, 0, 0, 0);
 
         state.UpdateState(
             {TInMemoryIndexState::TWriteNodeRequest{
@@ -82,7 +82,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     Y_UNIT_TEST(ShouldDeleteNodes)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0);
+        state.Reset(1, 0, 0, 0);
 
         state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
@@ -116,7 +116,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     Y_UNIT_TEST(ShouldPopulateNodeAttrs)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 1, 0);
+        state.Reset(0, 1, 0, 0);
 
         TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId2, attrName1, attr));
@@ -152,7 +152,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     Y_UNIT_TEST(ShouldEvictNodeAttrs)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 1, 0);
+        state.Reset(0, 1, 0, 0);
 
         state.UpdateState(
             {TInMemoryIndexState::TWriteNodeAttrsRequest{
@@ -172,7 +172,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     Y_UNIT_TEST(ShouldDeleteNodeAttrs)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 1, 0);
+        state.Reset(0, 1, 0, 0);
 
         state.UpdateState({TInMemoryIndexState::TWriteNodeAttrsRequest{
             .NodeAttrsKey = {nodeId1, attrName1},
@@ -251,7 +251,7 @@ namespace {
     Y_UNIT_TEST(ShouldPopulateNodeRefs)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 0, 1);
+        state.Reset(0, 0, 1, 0);
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
         UNIT_ASSERT(
@@ -280,7 +280,8 @@ namespace {
             "",
             refs,
             Max<ui32>(),
-            &next));
+            &next,
+            nullptr));
         UNIT_ASSERT(refs.empty());
         UNIT_ASSERT(next.empty());
 
@@ -299,7 +300,7 @@ namespace {
     Y_UNIT_TEST(ShouldEvictNodeRefs)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 0, 3);
+        state.Reset(0, 0, 3, 0);
 
         const TVector<TInMemoryIndexState::TWriteNodeRefsRequest> requests = {
             {
@@ -347,7 +348,8 @@ namespace {
             requests[0].NodeRefsKey.Name,
             refs,
             Max<ui32>(),
-            &nextName));
+            &nextName,
+            nullptr));
         UNIT_ASSERT(refs.size() == 2);
         UNIT_ASSERT(nextName.empty());
 
@@ -386,9 +388,10 @@ namespace {
             requests[0].NodeRefsKey.Name,
             refs,
             Max<ui32>(),
-            &nextName));
+            &nextName,
+            nullptr));
 
-        // write a ref with the same key bu different value
+        // write a ref with the same key but different value
         TInMemoryIndexState::TWriteNodeRefsRequest request4 = {
             .NodeRefsKey = {rootNodeIds[3], nodeNames[3]},
             .NodeRefsRow = {
@@ -406,7 +409,7 @@ namespace {
     Y_UNIT_TEST(ShouldDeleteNodeRefs)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 0, 1);
+        state.Reset(0, 0, 1, 0);
 
         TInMemoryIndexState::TWriteNodeRefsRequest request = {
             .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -14,6 +14,7 @@ InMemoryIndexCacheNodeRefsCapacity: 10
 InMemoryIndexCacheNodeAttrsCapacity: 10
 InMemoryIndexCacheLoadOnTabletStart: true
 InMemoryIndexCacheLoadOnTabletStartRowsPerTx: 1
+GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity: 3
 UseMixedBlocksInsteadOfAliveBlocksInCompaction: true
 MixedBlocksOffloadedRangesCapacity: 1024
 CalculateCleanupScoreBasedOnUsedBlocksCount: true

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -14,7 +14,7 @@ InMemoryIndexCacheNodeRefsCapacity: 10
 InMemoryIndexCacheNodeAttrsCapacity: 10
 InMemoryIndexCacheLoadOnTabletStart: true
 InMemoryIndexCacheLoadOnTabletStartRowsPerTx: 1
-GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity: 3
+InMemoryIndexCacheNodeRefsExhaustivenessCapacity: 3
 UseMixedBlocksInsteadOfAliveBlocksInCompaction: true
 MixedBlocksOffloadedRangesCapacity: 1024
 CalculateCleanupScoreBasedOnUsedBlocksCount: true

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/nfs-storage.txt
@@ -14,5 +14,6 @@ InMemoryIndexCacheNodeRefsCapacity: 10
 InMemoryIndexCacheNodeAttrsCapacity: 10
 InMemoryIndexCacheLoadOnTabletStart: true
 InMemoryIndexCacheLoadOnTabletStartRowsPerTx: 1
+InMemoryIndexCacheNodeRefsExhaustivenessCapacity: 2
 UseMixedBlocksInsteadOfAliveBlocksInCompaction: true
 MixedBlocksOffloadedRangesCapacity: 1024

--- a/cloud/storage/core/libs/common/lru_cache.h
+++ b/cloud/storage/core/libs/common/lru_cache.h
@@ -77,8 +77,8 @@ class TLRUCache: public TMapOps<TLRUCache<TKey, TValue, THashFunc, TBase>>
             auto& key = OrderList.back();
             Base.erase(key);
             OrderPositions.erase(key);
-            OrderList.pop_back();
             evictedKeys.emplace_back(key);
+            OrderList.pop_back();
         }
         return evictedKeys;
     }

--- a/cloud/storage/core/libs/common/lru_cache.h
+++ b/cloud/storage/core/libs/common/lru_cache.h
@@ -115,7 +115,7 @@ public:
         OrderPositions.reserve(hint);
     }
 
-    // Movesd the key to the front of the order list; used upon any access
+    // Moves the key to the front of the order list; used upon any access
     void TouchKey(const TKey& key)
     {
         auto it = OrderPositions.find(key);
@@ -167,6 +167,18 @@ public:
         return Base.lower_bound(key);
     }
 
+    /**
+     * @brief Inserts a new element into the cache, evicting the least recently
+     * used item if necessary.
+     *
+     * @return std::tuple<iterator, bool, std::optional<TKey>>
+     *         - iterator: Iterator to the inserted or existing element.
+     *         - bool: True if the element was inserted, false if it already
+     *           existed.
+     *         - std::optional<TKey>: The key of the evicted element, if any;
+     *           std::nullopt otherwise. Note that it is assumed that at most
+     *           one element is evicted per insertion.
+     */
     template <typename... Args>
     std::tuple<iterator, bool, std::optional<TKey>> emplace(Args&&... args)
     {

--- a/cloud/storage/core/libs/common/lru_cache_ut.cpp
+++ b/cloud/storage/core/libs/common/lru_cache_ut.cpp
@@ -25,7 +25,10 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);
         UNIT_ASSERT_VALUES_EQUAL("value2", hashMap.find("key2")->second);
 
-        hashMap.emplace("key3", "value3");   // Should evict "key1"
+        auto [_, inserted, evicted] =
+            hashMap.emplace("key3", "value3");   // Should evict "key1"
+        UNIT_ASSERT_VALUES_EQUAL(true, inserted);
+        UNIT_ASSERT(evicted.has_value());
 
         UNIT_ASSERT_VALUES_EQUAL(2, hashMap.size());
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
@@ -131,7 +134,9 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         hashMap.emplace("key3", "value3");
         hashMap.find("key1");
         // Now the order is key1, key3, key2
-        hashMap.SetMaxSize(2);
+        auto evicted4 = hashMap.SetMaxSize(2);
+        UNIT_ASSERT_VALUES_EQUAL(1, evicted4.size());
+        UNIT_ASSERT_VALUES_EQUAL("key2", evicted4[0]);
         // Should evict key2
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key2"));
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);

--- a/cloud/storage/core/libs/common/lru_cache_ut.cpp
+++ b/cloud/storage/core/libs/common/lru_cache_ut.cpp
@@ -100,8 +100,9 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         hashMap.SetMaxSize(0);
 
         // Test capacity 0
-        auto [it, inserted1] = hashMap.emplace("key1", "value1");
+        auto [it, inserted1, evicted] = hashMap.emplace("key1", "value1");
         UNIT_ASSERT_VALUES_EQUAL(false, inserted1);
+        UNIT_ASSERT(!evicted.has_value());
         UNIT_ASSERT_EQUAL(hashMap.end(), it);
         UNIT_ASSERT_VALUES_EQUAL(0, hashMap.size());
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
@@ -112,10 +113,12 @@ Y_UNIT_TEST_SUITE(TLRUCache)
 
         // Test inserting duplicate keys - emplace should not overwrite the
         // value
-        auto [it1, inserted2] = hashMap.emplace("key1", "value1");
+        auto [it1, inserted2, evicted2] = hashMap.emplace("key1", "value1");
         UNIT_ASSERT_VALUES_EQUAL(true, inserted2);
-        auto [it2, inserted3] = hashMap.emplace("key1", "value2");
+        UNIT_ASSERT(!evicted2.has_value());
+        auto [it2, inserted3, evicted3] = hashMap.emplace("key1", "value2");
         UNIT_ASSERT_VALUES_EQUAL(false, inserted3);
+        UNIT_ASSERT(!evicted3.has_value());
 
         UNIT_ASSERT_VALUES_EQUAL(1, hashMap.size());
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);


### PR DESCRIPTION
References #4231