### PR TITLE
increase restart_interval for load tests from 15s to 12s

### DIFF
--- a/cloud/blockstore/tests/python/lib/test_base.py
+++ b/cloud/blockstore/tests/python/lib/test_base.py
@@ -31,7 +31,7 @@ from google.protobuf import text_format
 def get_restart_interval():
     if common.context.sanitize is not None:
         return 30
-    return 15
+    return 20
 
 
 def thread_count():


### PR DESCRIPTION
After enabling O_DIRECT, some tests involving restarting disk agents sometimes end in a timeout. This happens because the disk agents do not have enough time to clear the devices. Therefore, I increased restart_timeout from 15 to 20 seconds to fix this problem.