### PR TITLE
issue-4231: do not use per-node exhaustive flag if the corresponding cache is not configured to be non-empty

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -402,7 +402,7 @@ message TStorageConfig
     optional uint64 InMemoryIndexCacheNodesToNodeAttrsCapacityRatio = 375;
     optional uint64 InMemoryIndexCacheNodeRefsCapacity = 376;
     optional uint64 InMemoryIndexCacheNodesToNodeRefsCapacityRatio = 377;
-    // In addition to the per-table isExhaustive flag, it is possible to
+    // In addition to the per-table isExhaustive flag, it is possible to have a
     // per-node isExhaustive flag, which can be set upon exhaustive ListNodes
     // requests. The number of the per-node flags is limited by this value.
     optional uint64 InMemoryIndexCacheNodeRefsExhaustivenessCapacity = 437;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -356,7 +356,6 @@ void TInMemoryIndexState::WriteNodeRef(
             NodeRefsExhaustivenessInfo.NodeRefsEvictionObserved(
                 evicted->NodeId);
         }
-
     } else {
         it->second = value;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -349,7 +349,9 @@ private:
 
         void MarkNodeRefsExhaustive(ui64 nodeId)
         {
-            IsExhaustivePerNode.Insert(nodeId, true);
+            if (IsExhaustivePerNode.GetMaxSize()) {
+                IsExhaustivePerNode.Insert(nodeId, true);
+            }
         }
 
         void MarkNodeRefsLoadComplete()


### PR DESCRIPTION
References #4231
Follow-up after #4232