### PR TITLE
[NBS] fix "disk.{read,write}_throttler_delay" user counter

### DIFF
--- a/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
@@ -243,7 +243,10 @@ public:
                 continue;
             }
             if (Units) {
-                subgroup = subgroup->FindSubgroup("units", Units);
+                if (auto unitsSubgroup = subgroup->FindSubgroup("units", Units))
+                {
+                    subgroup = unitsSubgroup;
+                }
             }
             if (subgroup) {
                 BaseCounters.emplace_back(subgroup, name);


### PR DESCRIPTION
**Motivation**

The user counters `disk.read_throttler_delay` and `disk.write_throttler_delay` are currently broken (after https://github.com/ydb-platform/nbs/pull/4217). They rely on the `units=usec` label, but the underlying `ThrottlerDelay` counter (calculated via `volume_service`) does not provide this label. As a result, these counters do not work as intended.

**Summary**

This PR updates the implementation of the user counters so that they function correctly regardless of the presence or absence of the units label. In addition, proper tests are introduced to cover this behavior and prevent regressions.