### PR TITLE
[CSI] Pass context to blockdev/blkid command execution

### DIFF
--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -868,7 +868,7 @@ func (s *nodeService) nodeStageDiskAsFilesystem(
 
 	// startNbsEndpointForNBD is async function. Kubelet will retry
 	// NodeStageVolume request if nbd device is not available yet.
-	hasBlockDevice, err := s.mounter.HasBlockDevice(resp.NbdDeviceFile)
+	hasBlockDevice, err := s.mounter.HasBlockDevice(ctx, resp.NbdDeviceFile)
 	if !hasBlockDevice {
 		return s.statusErrorf(codes.Unavailable,
 			"Nbd device is not available: %w", err)
@@ -1703,31 +1703,6 @@ func (s *nodeService) formatAndMount(
 	logVolume(nbsId, "mount source %q to target %q, fsType: %q, options: %v",
 		source, target, fsType, options)
 	return s.mounter.FormatAndMount(source, target, fsType, options)
-}
-
-func (s *nodeService) makeFilesystemIfNeeded(
-	diskId string,
-	deviceName string,
-	fsType string) error {
-
-	existed, err := s.mounter.IsFilesystemExisted(deviceName)
-	if err != nil {
-		return err
-	}
-
-	if existed {
-		logVolume(diskId, "filesystem exists on device: %q", deviceName)
-		return nil
-	}
-
-	logVolume(diskId, "making filesystem %q on device %q", fsType, deviceName)
-	out, err := s.mounter.MakeFilesystem(deviceName, fsType)
-	if err != nil {
-		return fmt.Errorf("failed to make filesystem: %w, output %q", err, out)
-	}
-
-	logVolume(diskId, "succeeded making filesystem: %q", out)
-	return nil
 }
 
 func (s *nodeService) getPodId(req *csi.NodePublishVolumeRequest) string {

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/iface.go
@@ -1,5 +1,7 @@
 package mounter
 
+import "context"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type Interface interface {
@@ -9,9 +11,9 @@ type Interface interface {
 	IsMountPoint(file string) (bool, error)
 	CleanupMountPoint(target string) error
 
-	HasBlockDevice(device string) (bool, error)
+	HasBlockDevice(context context.Context, device string) (bool, error)
 
-	IsFilesystemExisted(device string) (bool, error)
+	IsFilesystemExisted(ctx context.Context, device string) (bool, error)
 	IsFilesystemRemountedAsReadonly(mountPoint string) (bool, error)
 	MakeFilesystem(device string, fsType string) ([]byte, error)
 

--- a/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
+++ b/cloud/blockstore/tools/csi_driver/internal/mounter/mock.go
@@ -1,6 +1,8 @@
 package mounter
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -30,12 +32,12 @@ func (c *Mock) CleanupMountPoint(target string) error {
 	return args.Error(0)
 }
 
-func (c *Mock) HasBlockDevice(device string) (bool, error) {
+func (c *Mock) HasBlockDevice(ctx context.Context, device string) (bool, error) {
 	args := c.Called(device)
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (c *Mock) IsFilesystemExisted(device string) (bool, error) {
+func (c *Mock) IsFilesystemExisted(ctx context.Context, device string) (bool, error) {
 	args := c.Called(device)
 	return args.Get(0).(bool), args.Error(1)
 }


### PR DESCRIPTION
The caller of NodeStageVolume can cancel the context to terminate execution if blockdev or blkid hangs