### PR TITLE
[Filestore] fix empty file error in test_zero_range_read_rand_data

### DIFF
--- a/cloud/filestore/tests/client_two_stage_read/test.py
+++ b/cloud/filestore/tests/client_two_stage_read/test.py
@@ -1,7 +1,9 @@
 import filecmp
+import logging
 import os
 import random
 import string
+import time
 
 import yatest.common as common
 
@@ -61,6 +63,10 @@ def test_zero_range_read():
 def test_zero_range_read_rand_data():
 
     file_size = 1024 * 1024
+
+    seed = time.time()
+    random.seed(seed)
+    logging.info(f"Run test with seed: {seed}")
     num_writes = random.randint(1, 10)
 
     client, results_path = __init_test()
@@ -68,7 +74,7 @@ def test_zero_range_read_rand_data():
     expected_file = os.path.join(common.output_path(), "expected_data.txt")
     with open(expected_file, "w") as expected_file_handle:
         for i in range(num_writes):
-            write_size = random.randint(1, 1000) // 2 * 2
+            write_size = random.randint(2, 1000) // 2 * 2
             offset = random.randint(0, file_size - write_size) // 2 * 2
             data = ''.join(random.choices(string.ascii_letters, k=write_size))
             expected_file_handle.seek(offset)

--- a/cloud/filestore/tests/client_two_stage_read/test.py
+++ b/cloud/filestore/tests/client_two_stage_read/test.py
@@ -89,6 +89,9 @@ def test_zero_range_read_rand_data():
 
     client.destroy("fs0")
 
+    with open(results_path, "wb") as results_file:
+        results_file.write(result)
+
     with open(expected_file, mode='rb') as expected_file_handle:
         expected_file_content = expected_file_handle.read()
         assert expected_file_content == result

--- a/cloud/filestore/tests/client_two_stage_read/test.py
+++ b/cloud/filestore/tests/client_two_stage_read/test.py
@@ -76,6 +76,7 @@ def test_zero_range_read_rand_data():
         for i in range(num_writes):
             write_size = random.randint(2, 1000) // 2 * 2
             offset = random.randint(0, file_size - write_size) // 2 * 2
+            logging.info(f"Write data with size {write_size} and offset {offset}")
             data = ''.join(random.choices(string.ascii_letters, k=write_size))
             expected_file_handle.seek(offset)
             expected_file_handle.write(data)

--- a/cloud/filestore/tests/client_two_stage_read/ya.make
+++ b/cloud/filestore/tests/client_two_stage_read/ya.make
@@ -19,6 +19,8 @@ SET(
     cloud/filestore/tests/client_two_stage_read/nfs-storage.txt
 )
 
+SET(NFS_FORCE_VERBOSE 1)
+
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 
 END()


### PR DESCRIPTION
1. fix bug with write_size equal 0
2. write/read data as binary string
3. log seed/write_size/offset
4. increase nfs logs verbosity