### PR TITLE
hide inter-cell error from metrics

### DIFF
--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -414,7 +414,9 @@ void TServerStats::RequestCompleted(
     }
 
     if (errorKind != EDiagnosticsErrorKind::Success && req.CellRequest) {
-        // Hide inter-cell errors here to prevent them from showing in error metrics.
+        // We want to exclude from our metrics errors resulting from requests
+        // coming from other cells, since those errors will already appear
+        // in the metrics of the host that sent the request
         errorKind = EDiagnosticsErrorKind::Success;
     }
 

--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -413,6 +413,11 @@ void TServerStats::RequestCompleted(
         errorKind = EDiagnosticsErrorKind::ErrorSilent;
     }
 
+    if (errorKind != EDiagnosticsErrorKind::Success && req.CellRequest) {
+        // Hide inter-cell errors here to prevent them from showing in error metrics.
+        errorKind = EDiagnosticsErrorKind::Success;
+    }
+
     auto calcMaxTime = callContext.GetHasUncountableRejects()
                            ? ECalcMaxTime::DISABLE
                            : ECalcMaxTime::ENABLE;

--- a/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
@@ -376,6 +376,74 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
         DoTestShouldCountHwProblems(
             NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD_NONREPLICATED);
     }
+
+    Y_UNIT_TEST(ShouldNotReportErrorsForCellRequests)
+    {
+        TLog log;
+
+        auto timer = std::make_shared<TTestTimer>();
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto serverStats = CreateServerStats(
+            std::make_shared<TTestDumpable>(),
+            std::make_shared<TDiagnosticsConfig>(),
+            monitoring,
+            CreateProfileLogStub(),
+            CreateServerRequestStats(
+                monitoring->GetCounters(),
+                timer,
+                EHistogramCounterOption::ReportMultipleCounters),
+            CreateVolumeStatsStub()
+        );
+
+        TMetricRequest request {EBlockStoreRequest::DescribeVolume};
+        request.CellRequest = true;
+        serverStats->PrepareMetricRequest(
+            request,
+            "",
+            "",
+            0,
+            0,
+            false);
+
+        auto callContext = MakeIntrusive<TCallContext>();
+
+        serverStats->RequestStarted(
+            log,
+            request,
+            *callContext,
+            "");
+
+        serverStats->RequestCompleted(
+            log,
+            request,
+            *callContext,
+            MakeError(S_OK, "not found")
+        );
+
+        serverStats->UpdateStats(false);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "DescribeVolume")
+            ->GetCounter("Count", true)->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "DescribeVolume")
+            ->GetCounter("Errors/Fatal")->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            monitoring
+            ->GetCounters()
+            ->GetSubgroup("request", "DescribeVolume")
+            ->GetCounter("Errors")->Val());
+    }
 }
 
 }   // namespace NCloud::NBlockStore


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/3783

We don't want to see errors for inter-cell requests in target host metrics. For instance we send describe volume request to all cells and only one of the replies with success. In this case other cells should not report errors in metrics