### PR TITLE
introduce timeout for trimfreshlog operation

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1315,4 +1315,7 @@ message TStorageServiceConfig
     // Min percentage of reassignable fresh channels after which reassign requests
     // are sent.
     optional uint32 ReassignFreshChannelsPercentageThreshold = 453;
+
+    // Timeout for trim fresh log (in milliseconds).
+    optional uint32 TrimFreshLogTimeout = 454;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -74,6 +74,7 @@ using TValue =
     xxx(DiskAgentInconsistentMultiWriteResponse)                               \
     xxx(ReleaseShadowDiskError)                                                \
     xxx(WrongCellIdInDescribeVolume)                                           \
+    xxx(TrimFreshLogTimeout)                                                   \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(xxx)                             \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -628,6 +628,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(RetryAcquireReleaseDiskMaxDelay,      TDuration,   Seconds(5)         )\
                                                                                \
     xxx(NonReplicatedVolumeAcquireDiskAfterAddClientEnabled, bool,   false    )\
+                                                                               \
+    xxx(TrimFreshLogTimeout,                  TDuration,   Seconds(0)          )
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -717,6 +717,8 @@ public:
 
     [[nodiscard]] bool
     GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() const;
+
+    [[nodiscard]] TDuration GetTrimFreshLogTimeout() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1090,6 +1090,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildUsedBlocksResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvFlushResponse);
+        IgnoreFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogResponse);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
@@ -140,7 +140,8 @@ void TPartitionActor::HandleTrimFreshLog(
         Executor()->Generation(),
         nextPerGenerationCounter,
         std::move(freshChannels),
-        PartitionConfig.GetDiskId());
+        PartitionConfig.GetDiskId(),
+        Config->GetTrimFreshLogTimeout());
 
     Actors.Insert(actor);
 }
@@ -159,6 +160,11 @@ void TPartitionActor::HandleTrimFreshLogCompleted(
             LogTitle.GetWithTime().c_str(),
             msg->GetStatus(),
             FormatError(msg->GetError()).c_str());
+
+        if (msg->GetStatus() == E_TIMEOUT) {
+            Suicide(ctx);
+            return;
+        }
 
         State->RegisterTrimFreshLogError();
     } else {

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13128,6 +13128,70 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         // Check that partition sent statistics
         UNIT_ASSERT(partitionStatisticsSent);
     }
+
+    Y_UNIT_TEST(ShouldRaiseCriticalEventIfTrimFreshLogTimesOut)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelCount(1);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetTrimFreshLogTimeout(TDuration::Seconds(1).MilliSeconds());
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        NMonitoring::TDynamicCountersPtr counters
+            = new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto trimCounter =
+            counters->GetCounter("AppCriticalEvents/TrimFreshLogTimeout", true);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+        }
+
+        bool trimSeen = false;
+        bool trimCompletedSeen = false;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->Channel == 4) {
+                            trimSeen = true;
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvTrimFreshLogCompleted: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted>();
+                        UNIT_ASSERT(FAILED(msg->GetStatus()));
+                        trimCompletedSeen = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+
+        // wait for tablet to reboot
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(NActors::TEvents::TSystem::Poison);
+        runtime->DispatchEvents(options, TDuration::Seconds(2));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
+        UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
+        UNIT_ASSERT_VALUES_EQUAL(1, trimCounter->Val());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -994,6 +994,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvCompactionResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvUpdateIndexStructuresResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvFlushResponse);
+        IgnoreFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogResponse);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
@@ -131,7 +131,8 @@ void TPartitionActor::HandleTrimFreshLog(
         ParseCommitId(State->GetLastCommitId()).first,
         nextPerGenerationCounter,
         std::move(freshChannels),
-        "");
+        "",
+        Config->GetTrimFreshLogTimeout());
 
     Actors.insert(actor);
 }
@@ -147,6 +148,11 @@ void TPartitionActor::HandleTrimFreshLogCompleted(
             "[" << TabletID() << "]"
                 << " TrimFreshLog failed: " << msg->GetStatus()
                 << " reason: " << msg->GetError().GetMessage().Quote());
+
+        if (msg->GetStatus() == E_TIMEOUT) {
+            Suicide(ctx);
+            return;
+        }
 
         State->RegisterTrimFreshLogError();
     } else {

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -7642,6 +7642,70 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
         // Check that partition sent statistics
         UNIT_ASSERT(partitionStatisticsSent);
     }
+
+    Y_UNIT_TEST(ShouldRaiseCriticalEventIfTrimFreshLogTimesOut)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelCount(1);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetTrimFreshLogTimeout(TDuration::Seconds(1).MilliSeconds());
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        NMonitoring::TDynamicCountersPtr counters
+            = new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto trimCounter =
+            counters->GetCounter("AppCriticalEvents/TrimFreshLogTimeout", true);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+        }
+
+        bool trimSeen = false;
+        bool trimCompletedSeen = false;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->Channel == 4) {
+                            trimSeen = true;
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvTrimFreshLogCompleted: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted>();
+                        UNIT_ASSERT(FAILED(msg->GetStatus()));
+                        trimCompletedSeen = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+
+        // wait for tablet to reboot
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(NActors::TEvents::TSystem::Poison);
+        runtime->DispatchEvents(options, TDuration::Seconds(2));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
+        UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
+        UNIT_ASSERT_VALUES_EQUAL(1, trimCounter->Val());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition2

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -26,7 +26,8 @@ TTrimFreshLogActor::TTrimFreshLogActor(
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
-        TString diskId)
+        TString diskId,
+        TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , PartitionActorId(partitionActorId)
     , TabletInfo(std::move(tabletInfo))
@@ -35,6 +36,7 @@ TTrimFreshLogActor::TTrimFreshLogActor(
     , PerGenerationCounter(perGenerationCounter)
     , FreshChannels(std::move(freshChannels))
     , DiskId(std::move(diskId))
+    , Timeout(timeout)
 {}
 
 void TTrimFreshLogActor::Bootstrap(const TActorContext& ctx)
@@ -50,6 +52,10 @@ void TTrimFreshLogActor::Bootstrap(const TActorContext& ctx)
         RequestInfo->CallContext->RequestId);
 
     TrimFreshLog(ctx);
+
+    if (Timeout) {
+        ctx.Schedule(Timeout, new TEvents::TEvWakeup());
+    }
 }
 
 void TTrimFreshLogActor::TrimFreshLog(const TActorContext& ctx)
@@ -157,12 +163,29 @@ void TTrimFreshLogActor::HandlePoisonPill(
     Die(ctx);
 }
 
+void TTrimFreshLogActor::HandleWakeup(
+    const NActors::TEvents::TEvWakeup::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    Error = MakeError(E_TIMEOUT, "TrimFreshLog timeout timer hit");
+
+    ReportTrimFreshLogTimeout(
+        FormatError(Error),
+        {{"disk", DiskId}, {"TabletId", TabletInfo->TabletID}});
+
+    NotifyCompleted(ctx);
+    ReplyAndDie(ctx);
+}
+
 STFUNC(TTrimFreshLogActor::StateWork)
 {
     TRequestScope timer(*RequestInfo);
 
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         HFunc(TEvBlobStorage::TEvCollectGarbageResult, HandleCollectGarbageResult);
 

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -27,6 +27,7 @@ private:
     const ui32 PerGenerationCounter;
     const TVector<ui32> FreshChannels;
     const TString DiskId;
+    const TDuration Timeout;
 
     ui32 RequestsInFlight = 0;
     NProto::TError Error;
@@ -40,7 +41,8 @@ public:
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
-        TString diskId);
+        TString diskId,
+        TDuration timeout);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
@@ -59,6 +61,10 @@ private:
 
     void HandlePoisonPill(
         const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleWakeup(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 


### PR DESCRIPTION
It turned out the sometimes CollectGarbage requests from TrimFreshLog operation hang somewhere in blob storage. The problem is that in such situation fresh channel is not trimmed and keeps collecting garbage. If tablet restarts, during LoadState transaction we load all the blobs from fresh including all the garbage from previous generation. It was observed that amount of data loaded could reach hundreds of gigabytes.

Solution so far is simple, implement configurable timeout for TrimFreshLog operation and if timeout occurs, raise CriticalEvent and reboot tablet. After restart we load data from fresh and run Flush followed by TrimFreshLog again. 