### PR TITLE
[loadtest] use the test name and action name for clientId to improve logs

### DIFF
--- a/cloud/blockstore/tests/python/lib/test_base.py
+++ b/cloud/blockstore/tests/python/lib/test_base.py
@@ -126,7 +126,8 @@ class LoadTest(Daemon):
             "--secure-port" if enable_tls else "--port", str(nbs_port),
             "--config", config_path,
             "--results", self.__results_path,
-            "--verbose", "info"
+            "--verbose", "info",
+            "--test-name", self.__test_name,
         ]
 
         if client_config is not None:

--- a/cloud/blockstore/tools/testing/loadtest/lib/aliased_volumes.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/aliased_volumes.cpp
@@ -62,7 +62,8 @@ void TAliasedVolumes::DestroyAliasedVolumesUnsafe(IClientFactory& clientFactory)
 
             const auto requestId = GetRequestId(*request);
 
-            auto client = clientFactory.CreateClient({});
+            auto client =
+                clientFactory.CreateClient({}, "destroy-aliased-volumes");
             client->Start();
 
             STORAGE_INFO("Destroy volume: " << volume.Name);

--- a/cloud/blockstore/tools/testing/loadtest/lib/app.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/app.cpp
@@ -136,7 +136,7 @@ int TApp::Run(TBootstrap& bootstrap)
     }
 
     auto& out = options->GetOutputStream();
-    for (const auto& testContext : TestContexts) {
+    for (const auto& testContext: TestContexts) {
         out << testContext.Result.Str() << Endl;
     }
 
@@ -337,7 +337,7 @@ void TApp::RunGraph(const NProto::TActionGraph& graph, TBootstrap& bootstrap)
 
                 case NProto::TActionGraph::TVertex::kControlPlaneAction: {
                     const auto& cpa = vertex.GetControlPlaneAction();
-                    auto client = bootstrap.CreateClient({});
+                    auto client = bootstrap.CreateClient({}, cpa.GetName());
                     for (ui32 j = 0; j < Max(1u, cpa.GetRepetitions()); ++j) {
                         if (j) {
                             testContext.Result << Endl;

--- a/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.h
@@ -60,7 +60,7 @@ public:
     TBootstrap(
         TOptionsPtr options,
         std::shared_ptr<TModuleFactories> moduleFactories);
-    ~TBootstrap();
+    ~TBootstrap() final;
 
     void Init();
 
@@ -110,7 +110,9 @@ public:
 
     IBlockDigestCalculatorPtr CreateDigestCalculator();
 
-    IBlockStorePtr CreateClient(TVector<ui32> nonretriableErrorCodes) override;
+    IBlockStorePtr CreateClient(
+        TVector<ui32> nonretriableErrorCodes,
+        const TString& clientId) override;
 
     IBlockStorePtr CreateAndStartFilesystemClient() override;
 
@@ -138,6 +140,9 @@ private:
     IBlockStorePtr CreateDurableDataClient(
         IBlockStorePtr dataClient,
         TVector<ui32> nonretriableErrorCodes);
+    NClient::TClientAppConfigPtr CreateClientConfig(
+        const NClient::TClientAppConfigPtr& config,
+        TString clientId);
 };
 
 }   // namespace NCloud::NBlockStore::NLoadTest

--- a/cloud/blockstore/tools/testing/loadtest/lib/client_factory.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/client_factory.h
@@ -13,9 +13,11 @@ namespace NCloud::NBlockStore::NLoadTest {
 
 struct IClientFactory
 {
-    virtual ~IClientFactory() {}
+    virtual ~IClientFactory() = default;
 
-    virtual IBlockStorePtr CreateClient(TVector<ui32> nonretriableErrorCodes) = 0;
+    virtual IBlockStorePtr CreateClient(
+        TVector<ui32> nonretriableErrorCodes,
+        const TString& clientId) = 0;
 
     virtual IBlockStorePtr CreateEndpointDataClient(
         NProto::EClientIpcType ipcType,

--- a/cloud/blockstore/tools/testing/loadtest/lib/compare_data_action_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/compare_data_action_runner.cpp
@@ -49,7 +49,7 @@ int TCompareDataActionRunner::Run(
     int code = 0;
 
     try {
-        TestContext.Client = ClientFactory.CreateClient({});
+        TestContext.Client = ClientFactory.CreateClient({}, action.GetName());
         TestContext.Client->Start();
 
         Y_ENSURE(

--- a/cloud/blockstore/tools/testing/loadtest/lib/load_test_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/load_test_runner.cpp
@@ -171,7 +171,8 @@ void TLoadTestRunner::SetupTest(
         TestContext.Client = ClientFactory.CreateAndStartFilesystemClient();
         volumeName = std::move(volumeFile);
     } else {
-        TestContext.Client = ClientFactory.CreateClient(successOnError);
+        TestContext.Client =
+            ClientFactory.CreateClient(successOnError, test.GetName());
         TestContext.Client->Start();
     }
 

--- a/cloud/blockstore/tools/testing/loadtest/lib/options.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/options.cpp
@@ -15,6 +15,10 @@ void TOptions::Parse(int argc, char** argv)
     TOpts opts;
     opts.AddHelpOption();
 
+    opts.AddLongOption("test-name")
+        .RequiredArgument("STR")
+        .StoreResult(&TestName);
+
     opts.AddLongOption("client-config")
         .RequiredArgument("STR")
         .StoreResult(&ClientConfig);

--- a/cloud/blockstore/tools/testing/loadtest/lib/options.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/options.h
@@ -12,6 +12,7 @@ namespace NCloud::NBlockStore::NLoadTest {
 
 struct TOptions
 {
+    TString TestName;
     TString ClientConfig;
     TString Host;
     ui32 InsecurePort = 0;

--- a/cloud/blockstore/tools/testing/loadtest/lib/suite_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/suite_runner.cpp
@@ -43,19 +43,20 @@ TSuiteRunner::TSuiteRunner(
         const TString& checkpointId,
         const TString& testName,
         TTestContext& testContext)
-    : AppContext(appContext)
+    : TestName(testName)
+    , AppContext(appContext)
     , Logging(std::move(logging))
     , SuccessOnError(successOnError)
     , CheckpointId(checkpointId)
     , LoggingTag(MakeLoggingTag(testName))
     , TestContext(testContext)
     , StartTime(Now())
-{
-}
+{}
 
 void TSuiteRunner::StartSubtest(const NProto::TRangeTest& range)
 {
     auto runner = CreateTestRunner(
+        TestName,
         Logging,
         TestContext.Session,
         TestContext.Volume,
@@ -84,6 +85,7 @@ void TSuiteRunner::StartReplay(
     ui64 maxRequestsInMemory)
 {
     auto runner = CreateTestRunner(
+        TestName,
         Logging,
         TestContext.Session,
         TestContext.Volume,

--- a/cloud/blockstore/tools/testing/loadtest/lib/suite_runner.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/suite_runner.h
@@ -16,6 +16,7 @@ namespace NCloud::NBlockStore::NLoadTest {
 class TSuiteRunner
 {
 private:
+    const TString TestName;
     TAppContext& AppContext;
     ILoggingServicePtr Logging;
     const TVector<ui32>& SuccessOnError;

--- a/cloud/blockstore/tools/testing/loadtest/lib/test_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/test_runner.cpp
@@ -89,6 +89,7 @@ class TTestRunner final
     , public std::enable_shared_from_this<TTestRunner>
 {
 private:
+    const TString TestName;
     TLog Log;
     NProto::TVolume Volume;
     TString LoggingTag;
@@ -120,6 +121,7 @@ private:
 
 public:
     TTestRunner(
+            TString testName,
             ILoggingServicePtr loggingService,
             ISessionPtr session,
             NProto::TVolume volume,
@@ -130,7 +132,8 @@ public:
             TVector<ui32> successOnError,
             IBlockDigestCalculatorPtr digestCalculator,
             std::atomic<bool>& shouldStop)
-        : Log(loggingService->CreateLog(requests->Describe()))
+        : TestName(std::move(testName))
+        , Log(loggingService->CreateLog(requests->Describe()))
         , Volume(std::move(volume))
         , LoggingTag(std::move(loggingTag))
         , Requests(std::move(requests))
@@ -178,7 +181,7 @@ private:
 
 void* TTestRunner::ThreadProc()
 {
-    SetCurrentThreadName("Test");
+    SetCurrentThreadName(TestName.c_str());
     StartTs = Now();
     LastReportTs = Now();
 
@@ -487,6 +490,7 @@ void TTestRunner::ReportProgress()
 ////////////////////////////////////////////////////////////////////////////////
 
 ITestRunnerPtr CreateTestRunner(
+    TString testName,
     ILoggingServicePtr loggingService,
     ISessionPtr session,
     NProto::TVolume volume,
@@ -499,6 +503,7 @@ ITestRunnerPtr CreateTestRunner(
     std::atomic<bool>& shouldStop)
 {
     return std::make_shared<TTestRunner>(
+        std::move(testName),
         std::move(loggingService),
         std::move(session),
         std::move(volume),

--- a/cloud/blockstore/tools/testing/loadtest/lib/test_runner.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/test_runner.h
@@ -44,6 +44,7 @@ struct ITestRunner
 ////////////////////////////////////////////////////////////////////////////////
 
 ITestRunnerPtr CreateTestRunner(
+    TString testName,
     ILoggingServicePtr loggingService,
     NClient::ISessionPtr session,
     NProto::TVolume volume,

--- a/cloud/blockstore/tools/testing/loadtest/lib/wait_for_fresh_devices_action.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/wait_for_fresh_devices_action.cpp
@@ -30,7 +30,7 @@ int TWaitForFreshDevicesActionRunner::Run(
 {
     const TDuration waitDuration = TDuration::Seconds(5);
 
-    TestContext.Client = ClientFactory.CreateClient({});
+    TestContext.Client = ClientFactory.CreateClient({}, action.GetName());
     TestContext.Client->Start();
 
     const TString& volumeName =


### PR DESCRIPTION
Tweak ClientId:
```
... Mounting volume: "vol0" (client: "mirror2-agent-removal--shoot1" ...
... Received AcquireDisk request: DiskId=vol0, ClientId=mirror2-agent-removal--shoot1 ...

```