### PR TITLE
Use FormatError instead of TError::GetMessage in logs

### DIFF
--- a/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
@@ -157,12 +157,12 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
             blocks,
             updates);
 
-        if (FAILED(error.GetCode())) {
+        if (HasError(error)) {
             LOG_ERROR_S(ctx, TBlockStoreComponents::PARTITION,
                 "[" << TabletID() << "]"
                 << " Failed to parse fresh blob "
                 << "(blob commitId: " << blob.CommitId << "): "
-                << error.GetMessage());
+                << FormatError(error));
 
             ReportInitFreshBlocksError(
                 TStringBuilder()

--- a/cloud/blockstore/libs/storage/partition_common/actor_loadfreshblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_loadfreshblobs.cpp
@@ -190,11 +190,12 @@ void TLoadFreshBlobsActor::HandleRangeResult(
 
     auto error = MakeKikimrError(msg->Status, msg->ErrorReason);
     if (HasError(error)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::PARTITION,
-            "[%lu] Fresh blobs range request failed: %u reason: %s",
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "[%lu] Fresh blobs range request failed: %s",
             TabletInfo->TabletID,
-            error.GetCode(),
-            error.GetMessage().Quote().c_str());
+            FormatError(error).c_str());
 
         Error = std::move(error);
     } else {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor.h
@@ -251,7 +251,7 @@ void TMigrationRequestActor<TMethod>::HandleUndelivery(
         TBlockStoreComponents::PARTITION_WORKER,
         "[%s] %s",
         DiskId.c_str(),
-        error.GetMessage().c_str());
+        FormatError(error).c_str());
 
     TResponseProto response;
     *response.MutableError() = std::move(error);

--- a/cloud/blockstore/libs/storage/service/service_actor_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_create.cpp
@@ -340,17 +340,18 @@ void TCreateVolumeActor::HandleDescribeVolumeResponse(
     const auto& msg = ev->Get();
     const auto& error = msg->GetError();
 
-    if (FAILED(error.GetCode())) {
-        LOG_ERROR_S(ctx, TBlockStoreComponents::VOLUME,
+    if (HasError(error)) {
+        LOG_ERROR_S(
+            ctx,
+            TBlockStoreComponents::VOLUME,
             "Could not resolve path for base volume "
-            << baseDiskId.Quote() << ": " << FormatError(error));
+                << baseDiskId.Quote() << ": " << FormatError(error));
 
         ReplyAndDie(
             ctx,
             std::make_unique<TEvService::TEvCreateVolumeResponse>(error));
 
         return;
-
     }
 
     const auto& pathDescr = msg->PathDescription;
@@ -373,10 +374,12 @@ void TCreateVolumeActor::HandleCreateVolumeResponse(
     const auto& error = msg->GetError();
 
     if (HasError(error)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::SERVICE,
             "Creation of volume %s failed: %s",
             Request.GetDiskId().Quote().c_str(),
-            msg->GetErrorReason().c_str());
+            FormatError(error).c_str());
 
         ReplyAndDie(
             ctx,
@@ -407,12 +410,16 @@ void TCreateVolumeActor::HandleWaitReadyResponse(
     auto error = msg->GetError();
 
     if (HasError(error)) {
-        LOG_WARN(ctx, TBlockStoreComponents::SERVICE,
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::SERVICE,
             "Volume %s creation failed with error: %s",
             Request.GetDiskId().Quote().c_str(),
-            error.GetMessage().Quote().c_str());
+            FormatError(error).c_str());
     } else {
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
             "Successfully created volume %s",
             Request.GetDiskId().Quote().c_str());
     }
@@ -457,8 +464,6 @@ NProto::TError ValidateCreateVolumeRequest(
     const TStorageConfig& config,
     const NProto::TCreateVolumeRequest& request)
 {
-    TString errorMessage;
-
     if (!request.GetDiskId()) {
         return MakeError(E_ARGUMENT, "DiskId cannot be empty");
     }

--- a/cloud/blockstore/libs/storage/stats_fetcher/stats_fetcher.cpp
+++ b/cloud/blockstore/libs/storage/stats_fetcher/stats_fetcher.cpp
@@ -56,7 +56,7 @@ void TStatsFetcherActor::HandleWakeup(
 
     auto [cpuWait, error] = StatsFetcher->GetCpuWait();
     if (HasError(error)) {
-        auto errorMessage = ReportCpuWaitCounterReadError(error.GetMessage());
+        auto errorMessage = ReportCpuWaitCounterReadError(FormatError(error));
         LOG_WARN_S(
             ctx,
             TBlockStoreComponents::STATS_SERVICE,

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -250,7 +250,7 @@ void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
         auto [cpuWait, error] = StatsFetcher->GetCpuWait();
         if (HasError(error)) {
             auto errorMessage =
-                ReportCpuWaitCounterReadError(error.GetMessage());
+                ReportCpuWaitCounterReadError(FormatError(error));
                 LOG_WARN_S(
                     ctx,
                     TBlockStoreComponents::VOLUME_BALANCER,


### PR DESCRIPTION
Заменил вывод ошибки через `TError::GetMessage()` на `FormatError()`