### PR TITLE
[Filestore] fix double-free while stopping filestore-vhost when 'Forget' request is in-flight

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -2354,6 +2354,24 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, static_cast<int>(*writeBackCacheError));
     }
+
+    Y_UNIT_TEST(ShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight)
+    {
+        auto scheduler = std::make_shared<TTestScheduler>();
+        TBootstrap bootstrap(CreateWallClockTimer(), scheduler);
+
+        bootstrap.Start();
+
+        const ui64 nodeId = 123;
+        const ui64 refCount = 10;
+
+        auto future = bootstrap.Fuse->SendRequest<TForgetRequest>(nodeId, refCount);
+        bootstrap.Stop();
+
+        scheduler->RunAllScheduledTasks();
+
+        UNIT_ASSERT_EXCEPTION(future.GetValue(WaitTimeout), yexception);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse


### PR DESCRIPTION
ASAN report:
```
: heap-use-after-free on address 0x60c0002d92c8 at pc 0x0000464d5cbc bp 0x7f18a446f990 sp 0x7f18a446f988\nWRITE of size 1 at 0x60c0002d92c8 thread T142 (file.FUSE0.0)\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\n    #0 0x464d5cbb in complete_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:159:24\n    #1 0x464d5cbb in process_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:295:9\n    #2 0x464d5cbb in virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:492:19\n    #3 0x4634b739 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:525:9\n    #4 0x15b77a43 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20\n    #5 0x7f18fd694ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)\n    #6 0x7f18fd72684f  (/lib/x86_64-linux-gnu/libc.so.6+0x12684f) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)\n\n0x60c0002d92c8 is located 72 bytes inside of 128-byte region [0x60c0002d9280,0x60c0002d9300)\nfreed by thread T142 (file.FUSE0.0) here:\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\n    #0 0x157cc4e6 in __interceptor_free /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_malloc_linux.cpp:52:3\n    #1 0x464d3785 in vhd_free /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/platform.h:179:5\n    #2 0x464d3785 in complete_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:164:5\n    #3 0x464d3785 in fuse_cancel_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:380:13\n    #4 0x463f53c2 in NCloud::NFileStore::NFuse::CancelRequest(TLog&, NCloud::NFileStore::IRequestStats&, NCloud::NFileStore::TCallContext&, fuse_req*) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs.cpp:406:15\n    #5 0x4631a671 in void NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::Call<void (NCloud::NFileStore::NFuse::IFileSystem::*)(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, fuse_req*, unsigned long, unsigned long), unsigned long&, unsigned long&>(void (NCloud::NFileStore::NFuse::IFileSystem::*&&)(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, fuse_req*, unsigned long, unsigned long), char const*, NCloud::NFileStore::EFileStoreRequest, unsigned int, fuse_req*, unsigned long&, unsigned long&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1227:13\n    #6 0x46319f47 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::InitOps(fuse_lowlevel_ops &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1308:13\n    #7 0x46319f47 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::InitOps(fuse_lowlevel_ops&)::\'lambda\'(fuse_req*, unsigned long, unsigned long)::__invoke(fuse_req*, unsigned long, unsigned long) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1307:22\n    #8 0x7f18fd9bd4ba in fuse_session_process_buf_int /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:2503:9\n    #9 0x464d577e in process_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:282:5\n    #10 0x464d577e in virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:492:19\n    #11 0x4634b739 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:525:9\n    #12 0x15b77a43 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20\n    #13 0x7f18fd694ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)\n\npreviously allocated by thread T142 (file.FUSE0.0) here:\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\n    #0 0x157cc978 in __interceptor_calloc /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_malloc_linux.cpp:77:3\n    #1 0x464d491f in vhd_zalloc /actions-runner/_work/nbs/nbs/cloud/contrib/vhost/platform.h:161:15\n    #2 0x464d491f in process_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:212:39\n    #3 0x464d491f in virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:492:19\n    #4 0x4634b739 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:525:9\n    #5 0x15b77a43 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20\n    #6 0x7f18fd694ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)\n\nThread T142 (file.FUSE0.0) created by T86 (filestor.User) here:\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\n    #0 0x157b4a2a in __interceptor_pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_interceptors.cpp:208:3\n    #1 0x15b66072 in (anonymous namespace)::TPosixThread::Start /actions-runner/_work/nbs/nbs/util/system/thread.cpp:229:27\n    #2 0x15b66072 in TThread::Start() /actions-runner/_work/nbs/nbs/util/system/thread.cpp:314:34\n    #3 0x463071e6 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoop::Start /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:569:21\n    #4 0x463071e6 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartWithSessionState(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1059:23\n    #5 0x462fc1e7 in NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> > /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:694:31\n    #6 0x462fc1e7 in NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:679:48) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53\n    #7 0x462fc1e7 in NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39\n    #8 0x462fc1e7 in NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TCreateSessionResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>::Apply<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync()::\'lambda\'(auto const&)>(auto&&) const::\'lambda\'(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&)::operator()(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13\n    #9 0x46b00efa in std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16\n    #10 0x46b00efa in std::__y1::function<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12\n    #11 0x46b00efa in bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::TrySetValue<NCloud::NFileStore::NProto::TCreateSessionResponse>(NCloud::NFileStore::NProto::TCreateSessionResponse&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25\n    #12 0x47092c80 in NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue<NCloud::NFileStore::NProto::TCreateSessionResponse> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32\n    #13 0x47092c80 in NThreading::TPromise<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16\n    #14 0x47092c80 in NCloud::NFileStore::NClient::(anonymous namespace)::TSession::HandleResponse /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:480:25\n    #15 0x47092c80 in auto void NCloud::NFileStore::NClient::(anonymous namespace)::TSession::ExecuteRequestWithSession<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>>>)::\'lambda\'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>>(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:728:27\n    #16 0x46b00efa in std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16\n    #17 0x46b00efa in std::__y1::function<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12\n    #18 0x46b00efa in bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::TrySetValue<NCloud::NFileStore::NProto::TCreateSessionResponse>(NCloud::NFileStore::NProto::TCreateSessionResponse&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25\n    #19 0x46ff6e7a in NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue<NCloud::NFileStore::NProto::TCreateSessionResponse> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32\n    #20 0x46ff6e7a in NThreading::TPromise<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16\n    #21 0x46ff6e7a in NCloud::NFileStore::NClient::(anonymous namespace)::TDurableClientBase<NCloud::NFileStore::IFileStoreService>::HandleResponse<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:219:29\n    #22 0x46ff6e7a in auto void NCloud::NFileStore::NClient::(anonymous namespace)::TDurableClientBase<NCloud::NFileStore::IFileStoreService>::ExecuteRequest<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>>>)::\'lambda\'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>>(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:155:27\n    #23 0x46b00efa in std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16\n    #24 0x46b00efa in std::__y1::function<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12\n    #25 0x46b00efa in bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::TrySetValue<NCloud::NFileStore::NProto::TCreateSessionResponse>(NCloud::NFileStore::NProto::TCreateSessionResponse&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25\n    #26 0x46c18fd5 in NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue<NCloud::NFileStore::NProto::TCreateSessionResponse> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32\n    #27 0x46c18fd5 in NThreading::TPromise<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16\n    #28 0x46c18fd5 in NCloud::NFileStore::(anonymous namespace)::TRequestActor<NCloud::NFileStore::(anonymous namespace)::TCreateSessionMethod>::HandleResponse /actions-runner/_work/nbs/nbs/cloud/filestore/libs/service_kikimr/service.cpp:119:22\n    #29 0x46c18fd5 in NCloud::NFileStore::(anonymous namespace)::TRequestActor<NCloud::NFileStore::(anonymous namespace)::TCreateSessionMethod>::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/service_kikimr/service.cpp:132:13\n    #30 0x16b1daa3 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.h:530:23\n    #31 0x16aeec4d in NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TSimpleMailbox>(NActors::TMailboxTable::TSimpleMailbox*, unsigned int, bool) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:251:28\n    #32 0x16ae6330 in NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:437:25\n    #33 0x16ae4eec in NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:492:13\n    #34 0x16ae813b in NActors::TExecutorThread::ThreadProc() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:523:9\n    #35 0x15b77a43 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20\n    #36 0x7f18fd694ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)\n\nThread T86 (filestor.User) created by T0 (filestor.Main) here:\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\n    #0 0x157b4a2a in __interceptor_pthread_create /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_interceptors.cpp:208:3\n    #1 0x15b66072 in (anonymous namespace)::TPosixThread::Start /actions-runner/_work/nbs/nbs/util/system/thread.cpp:229:27\n    #2 0x15b66072 in TThread::Start() /actions-runner/_work/nbs/nbs/util/system/thread.cpp:314:34\n    #3 0x16ab596c in NActors::TBasicExecutorPool::Start() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_pool_basic.cpp:409:32\n    #4 0x16a8fb1b in NActors::TCpuManager::Start() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/cpu_manager.cpp:72:32\n    #5 0x16a83b45 in NActors::TActorSystem::Start() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actorsystem.cpp:294:21\n    #6 0x344f5414 in NKikimr::TKikimrRunner::KikimrStart() /actions-runner/_work/nbs/nbs/contrib/ydb/core/driver_lib/run/run.cpp:1631:22\n    #7 0x340c8a6b in NCloud::NFileStore::NDaemon::TBootstrapCommon::Start() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/common/bootstrap.cpp:85:5\n    #8 0x157341bf in int NCloud::DoMain<NCloud::NFileStore::NDaemon::TBootstrapVhost>(NCloud::NFileStore::NDaemon::TBootstrapVhost&, int, char**) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/daemon/app.h:37:23\n    #9 0x15733c1c in main /actions-runner/_work/nbs/nbs/cloud/filestore/apps/vhost/main.cpp:22:12\n    #10 0x7f18fd629d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)\n\nwarning: address range table at offset 0x0 has a premature terminator entry at offset 0x10\nwarning: address range table at offset 0x30 has a premature terminator entry at offset 0x40\nwarning: address range table at offset 0x60 has a premature terminator entry at offset 0x70\nwarning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0\nwarning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0\nwarning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30\nwarning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60\nwarning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010\nwarning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040\nwarning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070\nwarning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0\nwarning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0\nwarning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100\nwarning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130\nwarning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160\nwarning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190\nwarning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0\nwarning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0\nwarning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220\nwarning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250\nwarning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280\nwarning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0\nwarning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0\nwarning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400\nwarning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430\nwarning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460\nwarning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490\nwarning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0\nwarning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520\nwarning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550\nwarning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580\nSUMMARY: Address
```

When stopping `filestore-vhost`, each in-flight request is cancelled which implies underlying virtio request to be destroyed. Cancellation (`fuse_cancel_request `) may be called while handling virtio operation in `fuse_session_process_buf_int` on stack of `process_request` function: 
https://github.com/ydb-platform/nbs/blob/3b323d8779d3c70ec61df98dbdaccf330b429d61/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c#L282 ->
https://github.com/ydb-platform/nbs/blob/3b323d8779d3c70ec61df98dbdaccf330b429d61/contrib/libs/virtiofsd/fuse_lowlevel.c#L2503 -> https://github.com/ydb-platform/nbs/blob/c6d2257e61a6eba4787316aac02dfaabbc8638d7/cloud/filestore/libs/vfs_fuse/loop.cpp#L1227 -> https://github.com/ydb-platform/nbs/blob/6fa79575f5b797f40729da1b56061e714f8ba943/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c#L369

`complete_request` may be mistakenly called second time (after cancellation) at the end of `process_request`: https://github.com/ydb-platform/nbs/blob/3b323d8779d3c70ec61df98dbdaccf330b429d61/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c#L295 which causing double-free