### PR TITLE
Fix flaky test by enabling endpoint storage

### DIFF
--- a/cloud/blockstore/tests/loadtest/local-mirror-lagging/local-mirror2-restart-nbs.txt
+++ b/cloud/blockstore/tests/loadtest/local-mirror-lagging/local-mirror2-restart-nbs.txt
@@ -5,6 +5,9 @@ Vertices {
             BlockSize: 4096
             StorageMediaKind: STORAGE_MEDIA_SSD_MIRROR2
         }
+        StartEndpointRequest {
+            IpcType: IPC_GRPC
+        }
         ArtificialLoadSpec {
             Ranges {
                 Start: 250000


### PR DESCRIPTION
Починка после падения в nightly: https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/17566623421/1/nebius-x86-64/summary/1/ya-test.html#FAIL

Если рестарт NBS происходит в момент, когда нагрузка от load теста уже не идет, то таблетка Volume не будет переподнята и тест зависнет, т.к. не сможет удалить диск. В ПРе включаю хранилище эндпоитов для автоподнятия таблетки