### PR TITLE
issue-1345: added releasing devices after RemoveClient transactions, even if client have already been removed

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -270,8 +270,7 @@ void TVolumeActor::CompleteRemoveClient(
     const bool needToReleaseDevices =
         State->IsDiskRegistryMediaKind() &&
         Config->GetAcquireNonReplicatedDevices() &&
-        Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() &&
-        args.Error.GetCode() == S_OK;
+        Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled();
 
     Y_DEFER
     {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -270,7 +270,8 @@ void TVolumeActor::CompleteRemoveClient(
     const bool needToReleaseDevices =
         State->IsDiskRegistryMediaKind() &&
         Config->GetAcquireNonReplicatedDevices() &&
-        Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled();
+        Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() &&
+        !HasError(args.Error);
 
     Y_DEFER
     {

--- a/cloud/blockstore/tests/direct_device_acquire/test.py
+++ b/cloud/blockstore/tests/direct_device_acquire/test.py
@@ -213,6 +213,10 @@ def wait_for_all_volumes_to_be_notified(client, timeout=60):
         time.sleep(1)
 
 
+@pytest.mark.parametrize("nbs", [
+    ({"NonReplicatedVolumeAcquireDiskAfterAddClientEnabled": True}),
+    ({})
+], indirect=["nbs"])
 def test_should_mount_volume_with_unknown_devices(
         nbs_with_dr,
         nbs,
@@ -299,6 +303,10 @@ def test_should_mount_volume_with_unknown_devices(
     session.unmount_volume()
 
 
+@pytest.mark.parametrize("nbs", [
+    ({"NonReplicatedVolumeAcquireDiskAfterAddClientEnabled": True}),
+    ({})
+], indirect=["nbs"])
 def test_should_mount_volume_without_dr(nbs_with_dr, nbs, agent_ids, disk_agent_configurators):
 
     logger = logging.getLogger("client")
@@ -358,6 +366,10 @@ def test_should_mount_volume_without_dr(nbs_with_dr, nbs, agent_ids, disk_agent_
 
 @pytest.mark.parametrize("should_break_device", [True, False])
 @pytest.mark.parametrize("nbs_with_dr", [{"NonReplicatedAgentTimeout": 6000}], indirect=["nbs_with_dr"])
+@pytest.mark.parametrize("nbs", [
+    ({"NonReplicatedVolumeAcquireDiskAfterAddClientEnabled": True}),
+    ({})
+], indirect=["nbs"])
 def test_should_mount_volume_with_unavailable_agents(
         nbs_with_dr,
         nbs,
@@ -515,6 +527,10 @@ def test_should_stop_not_restored_endpoint(nbs_with_dr,
     assert not Path(another_socket.name).exists()
 
 
+@pytest.mark.parametrize("nbs", [
+    ({"NonReplicatedVolumeAcquireDiskAfterAddClientEnabled": True}),
+    ({})
+], indirect=["nbs"])
 def test_should_stop_not_restored_endpoint_when_volume_was_deleted(nbs_with_dr,
                                                                    nbs,
                                                                    agent_ids,


### PR DESCRIPTION
#1345
Возможно следующее залипание:

- Пусть у диска есть клиент client-1 и включена фича NonReplicatedVolumeAcquireDiskAfterAddClientEnabled
- Делаем RemoveClient для client-1:
    - Выполняется транзакция и удаляет client-1 из бд
    - Посылаем ReleaseDevice и по какой-то причине это сообщение теряется
    - Отдаем в ответе ошибку
- Ретраим RemoveClient для client-1:
    - Не находим client-1 в локальной бд и отвечаем S_ALREADY
- Сообщения снова начинают доходить до DA
- Посылаем AddClient для client-2:
    - Запрос приходит в DA И фейлится, т.к. мы не зарелизили девайс от client-1

и так мы нге сможем примонтировать диск пока  client-1 в DA не протухнет