### PR TITLE
add quote for string in critical events

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -30,7 +30,13 @@ TString FormatKeyValueList(
         if (!first) {
             sb << "; ";
         }
-        sb << key << "=" << value;
+        sb << key << "=";
+        if (std::holds_alternative<TString>(value)) {
+            sb << std::get<TString>(value).Quote();
+        } else {
+            sb << value;
+        }
+
         first = false;
     }
     return sb;


### PR DESCRIPTION
`CRITICAL_EVENT:AppCriticalEvents/TrimFreshLogTimeout:E_TIMEOUT TrimFreshLog timed out; disk="test"; TabletId=17592186044417`