### PR TITLE
Introduce new tags for copied disks. Utility function for tags parsing. LogicalDiskId.

### DIFF
--- a/cloud/blockstore/libs/storage/api/public.h
+++ b/cloud/blockstore/libs/storage/api/public.h
@@ -11,6 +11,10 @@ namespace NCloud::NBlockStore::NStorage {
 constexpr TStringBuf IntermediateWriteBufferTagName =
     "use-intermediate-write-buffer";
 
+// If the tag is set, it means that this disk is being copied and the name of
+// the disk from where the copy is being made should be taken from the tag.
+constexpr TStringBuf SourceDiskIdTagName = "source-disk-id";
+
 ////////////////////////////////////////////////////////////////////////////////
 // BackpressureReport event descriptor
 

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -211,14 +211,11 @@ void VolumeConfigToVolume(
     volume.SetIsSystem(volumeConfig.GetIsSystem());
     volume.SetIsFillFinished(volumeConfig.GetIsFillFinished());
 
-    TStringBuf sit(volumeConfig.GetTagsStr());
-    TStringBuf tag;
-    while (sit.NextTok(',', tag)) {
-        if (tag == "use-fastpath") {
-            volume.SetIsFastPathEnabled(true);
-        }
-    }
+    const auto tags = ParseTags(volumeConfig.GetTagsStr());
 
+    if (tags.contains("use-fastpath")) {
+        volume.SetIsFastPathEnabled(true);
+    }
 }
 
 void VolumeConfigToVolumeModel(
@@ -540,6 +537,25 @@ NProto::TVolumePerformanceProfile VolumeConfigToVolumePerformanceProfile(
         volumeConfig,
         performanceProfile);
     return performanceProfile;
+}
+
+TMap<TString, TString> ParseTags(const TString& tags)
+{
+    TMap<TString, TString> result;
+
+    TStringBuf tok;
+    TStringBuf sit(tags);
+    while (sit.NextTok(',', tok)) {
+        TStringBuf key;
+        TStringBuf value;
+        if (tok.TrySplit('=', key, value)) {
+            result.insert({TString(key), TString(value)});
+        } else {
+            result.insert({TString(tok), ""});
+        }
+    }
+
+    return result;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -245,4 +245,7 @@ TString LogDevices(const TVector<NProto::TDeviceConfig>& devices);
 
 NProto::TVolumePerformanceProfile VolumeConfigToVolumePerformanceProfile(
     const NKikimrBlockStore::TVolumeConfig& volumeConfig);
+
+TMap<TString, TString> ParseTags(const TString& tags);
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_label.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_label.cpp
@@ -13,6 +13,10 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+constexpr TStringBuf SecondaryDiskSuffix = "-copy";
+
+////////////////////////////////////////////////////////////////////////////////
+
 TString ComputeFolder(const TString& diskId)
 {
     constexpr ui32 folders = 1 << 10;
@@ -107,6 +111,19 @@ std::tuple<TString, TString> DiskIdToVolumeDirAndName(
 {
     TString path = DiskIdToPath(diskId);
     return ExtractParentDirAndName(rootDir, path);
+}
+
+TString GetSecondaryDiskId(const TString& diskId)
+{
+    return diskId + SecondaryDiskSuffix;
+}
+
+TString GetLogicalDiskId(const TString& diskId)
+{
+    if (diskId.EndsWith(SecondaryDiskSuffix)) {
+        return diskId.substr(0, diskId.size() - SecondaryDiskSuffix.size());
+    }
+    return diskId;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_label.h
+++ b/cloud/blockstore/libs/storage/core/volume_label.h
@@ -24,4 +24,11 @@ std::tuple<TString, TString> DiskIdToVolumeDirAndName(
     const TString& rootDir,
     const TString& diskId);
 
+// Adds a suffix to the disk name so that the disk and its copy always differ in
+// the same way.
+TString GetSecondaryDiskId(const TString& diskId);
+
+// Remove suffix of secondary disk if needed.
+TString GetLogicalDiskId(const TString& diskId);
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_label_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_label_ut.cpp
@@ -129,6 +129,13 @@ Y_UNIT_TEST_SUITE(TDiskIdTest)
             "/local/nbs", "///test///volume",
             "/local/nbs/_1D2", "%2F%2F%2Ftest%2F%2F%2Fvolume");
     }
+
+    Y_UNIT_TEST(TestSecondaryAndLogicalDiskId)
+    {
+        UNIT_ASSERT_VALUES_EQUAL("disk-copy", GetSecondaryDiskId("disk"));
+        UNIT_ASSERT_VALUES_EQUAL("disk", GetLogicalDiskId("disk"));
+        UNIT_ASSERT_VALUES_EQUAL("disk", GetLogicalDiskId("disk-copy"));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -267,6 +267,7 @@ private:
     std::optional<ui64> BlockCountToMigrate;
 
     TCreateFollowerRequests CreateFollowerRequests;
+    TString SourceDiskId;
     TFollowerDisks FollowerDisks;
     TLeaderDisks LeaderDisks;
 


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999
Поведение не меняется.

1. Сделал новый тег "source-disk-id". Нужен чтобы только что созданный диск, в который будет производится копирование знал свой источник и не был случайно использован до того, как данные перенесут.
2. функция для парсинга тегов.
3. Функции для получения имени диска-копии и имени исходного диска
4. Тесты на табличку с лидером