### PR TITLE
[Blockstore] add possibility to override resources limits in hive

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1326,7 +1326,7 @@ message TStorageServiceConfig
 
     // These parameters are used to configure resource limits (CPU, RAM, network)
     // for the local service in the tenant pool.
-    optional uint64 CpuResourceLimit = 456;
-    optional uint64 MemoryResourceLimit = 457;
-    optional uint64 NetworkResourceLimit = 458;
+    optional uint64 HiveLocalServiceCpuResourceLimit = 456;
+    optional uint64 HiveLocalServiceMemoryResourceLimit = 457;
+    optional uint64 HiveLocalServiceNetworkResourceLimit = 458;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -632,9 +632,9 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(TrimFreshLogTimeout,                  TDuration,   Seconds(0)         )\
                                                                                \
-    xxx(CpuResourceLimit,                     ui64,        0                  )\
-    xxx(MemoryResourceLimit,                  ui64,        0                  )\
-    xxx(NetworkResourceLimit,                 ui64,        0                  )\
+    xxx(HiveLocalServiceCpuResourceLimit,     ui64,        0                  )\
+    xxx(HiveLocalServiceMemoryResourceLimit,  ui64,        0                  )\
+    xxx(HiveLocalServiceNetworkResourceLimit, ui64,        0                  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -724,9 +724,9 @@ public:
 
     [[nodiscard]] bool GetEnableDataIntegrityValidationForYdbBasedDisks() const;
 
-    [[nodiscard]] ui64 GetCpuResourceLimit() const;
-    [[nodiscard]] ui64 GetMemoryResourceLimit() const;
-    [[nodiscard]] ui64 GetNetworkResourceLimit() const;
+    [[nodiscard]] ui64 GetHiveLocalServiceCpuResourceLimit() const;
+    [[nodiscard]] ui64 GetHiveLocalServiceMemoryResourceLimit() const;
+    [[nodiscard]] ui64 GetHiveLocalServiceNetworkResourceLimit() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -499,14 +499,17 @@ public:
             auto tenantPoolConfig = MakeIntrusive<TTenantPoolConfig>(localConfig);
 
             NKikimrTabletBase::TMetrics resourceLimit;
-            if (StorageConfig->GetCpuResourceLimit()) {
-                resourceLimit.SetCPU(StorageConfig->GetCpuResourceLimit());
+            if (StorageConfig->GetHiveLocalServiceCpuResourceLimit()) {
+                resourceLimit.SetCPU(
+                    StorageConfig->GetHiveLocalServiceCpuResourceLimit());
             }
-            if (StorageConfig->GetMemoryResourceLimit()) {
-                resourceLimit.SetMemory(StorageConfig->GetMemoryResourceLimit());
+            if (StorageConfig->GetHiveLocalServiceMemoryResourceLimit()) {
+                resourceLimit.SetMemory(
+                    StorageConfig->GetHiveLocalServiceMemoryResourceLimit());
             }
-            if (StorageConfig->GetNetworkResourceLimit()) {
-                resourceLimit.SetNetwork(StorageConfig->GetNetworkResourceLimit());
+            if (StorageConfig->GetHiveLocalServiceNetworkResourceLimit()) {
+                resourceLimit.SetNetwork(
+                    StorageConfig->GetHiveLocalServiceNetworkResourceLimit());
             }
 
             tenantPoolConfig->AddStaticSlot(


### PR DESCRIPTION
- хотим чтобы можно было оверрайдить значения максимумов ресурсов (cpu/ram/net) в hive 
- в итоге их нужно не оверрайдить, а доконфигурировать tenant pool