### PR TITLE
Yet another flaky test fix

### DIFF
--- a/cloud/blockstore/tools/testing/loadtest/lib/load_test_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/load_test_runner.cpp
@@ -535,18 +535,18 @@ void TLoadTestRunner::TeardownTest(
         STORAGE_INFO("Stop endpoint"
             << ", socket: " << request->GetUnixSocketPath());
 
-        if (EndpointStorage) {
-            auto error = EndpointStorage->RemoveEndpoint(EndpointSocketPath);
-            Y_ABORT_UNLESS(!HasError(error));
-            EndpointsDir.reset();
-        }
-
         WaitForCompletion(
             "StopEndpoint",
             TestContext.Client->StopEndpoint(
                 MakeIntrusive<TCallContext>(),
                 request),
             successOnError);
+
+        if (EndpointStorage) {
+            auto error = EndpointStorage->RemoveEndpoint(EndpointSocketPath);
+            Y_ABORT_UNLESS(!HasError(error));
+            EndpointsDir.reset();
+        }
     }
 
     auto isAliased = AliasedVolumes.IsAliased(diskId);


### PR DESCRIPTION
Опять починка cloud/blockstore/tests/loadtest/local-mirror-lagging/test.py.test_load[mirror2-restart-nbs-interconnect]

https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/17659584617/1/nebius-x86-64/summary/1/ya-test.html#FAIL

В тесте воспроизвелась гонка, в которой эндпоинт не стопнулся, nbs рестартанул, а ретрай запроса StopEndpoint привёл к ответу S_FALSE, т.к. в хранилище уже не было эндпоинта