### PR TITLE
[DM] Fix ChangedStateAt not being changed on dependency add

### DIFF
--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -422,21 +422,21 @@ func scheduleHangingTask(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type waitingTask struct {
+type waitingTaskWithSleep struct {
 	request   *wrappers.StringValue
 	scheduler tasks.Scheduler
 }
 
-func (t *waitingTask) Save() ([]byte, error) {
+func (t *waitingTaskWithSleep) Save() ([]byte, error) {
 	return proto.Marshal(t.request)
 }
 
-func (t *waitingTask) Load(request, state []byte) error {
+func (t *waitingTaskWithSleep) Load(request, state []byte) error {
 	t.request = &wrappers.StringValue{}
 	return proto.Unmarshal(request, t.request)
 }
 
-func (t *waitingTask) Run(ctx context.Context, execCtx tasks.ExecutionContext) error {
+func (t *waitingTaskWithSleep) Run(ctx context.Context, execCtx tasks.ExecutionContext) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -456,30 +456,30 @@ func (t *waitingTask) Run(ctx context.Context, execCtx tasks.ExecutionContext) e
 	}
 }
 
-func (t *waitingTask) Cancel(ctx context.Context, execCtx tasks.ExecutionContext) error {
+func (t *waitingTaskWithSleep) Cancel(ctx context.Context, execCtx tasks.ExecutionContext) error {
 	return nil
 }
 
-func (t *waitingTask) GetMetadata(ctx context.Context) (proto.Message, error) {
+func (t *waitingTaskWithSleep) GetMetadata(ctx context.Context) (proto.Message, error) {
 	return &empty.Empty{}, nil
 }
 
-func (t *waitingTask) GetResponse() proto.Message {
+func (t *waitingTaskWithSleep) GetResponse() proto.Message {
 	return &wrappers.UInt64Value{
 		Value: 1,
 	}
 }
 
-func registerWaitingTask(registry *tasks.Registry, scheduler tasks.Scheduler) error {
+func registerWaitingTaskWithSleep(registry *tasks.Registry, scheduler tasks.Scheduler) error {
 	return registry.RegisterForExecution(
 		"waiting",
 		func() tasks.Task {
-			return &waitingTask{scheduler: scheduler}
+			return &waitingTaskWithSleep{scheduler: scheduler}
 		},
 	)
 }
 
-func scheduleWaitingTask(
+func scheduleWaitingTaskWithSleep(
 	ctx context.Context,
 	scheduler tasks.Scheduler,
 	depTaskId string,
@@ -1830,14 +1830,14 @@ func TestTaskInflightDurationDoesNotCountWaitingStatus(t *testing.T) {
 	defer db.Close(ctx)
 
 	// runnersCount must be at least the count of tasks + 1 (for CollectListerMetrics).
-	// Otherwise, a race condition can occur where longTask is picked up before waitingTask.
+	// Otherwise, a race condition can occur where longTask is picked up before waitingTaskWithSleep.
 	// https://github.com/ydb-platform/nbs/pull/4002
 	s := createServices(t, ctx, db, 3 /* runnersCount */)
 
 	err := registerLongTask(s.registry)
 	require.NoError(t, err)
 
-	err = registerWaitingTask(s.registry, s.scheduler)
+	err = registerWaitingTaskWithSleep(s.registry, s.scheduler)
 	require.NoError(t, err)
 
 	err = s.startRunners(ctx)
@@ -1848,17 +1848,17 @@ func TestTaskInflightDurationDoesNotCountWaitingStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	reqCtx = getRequestContext(t, ctx)
-	waitingTaskID, err := scheduleWaitingTask(reqCtx, s.scheduler, depTaskID)
+	waitingTaskWithSleepID, err := scheduleWaitingTaskWithSleep(reqCtx, s.scheduler, depTaskID)
 	require.NoError(t, err)
 
 	timeout := 30 * time.Second
 
-	_, err = waitTaskWithTimeout(ctx, s.scheduler, waitingTaskID, timeout)
+	_, err = waitTaskWithTimeout(ctx, s.scheduler, waitingTaskWithSleepID, timeout)
 	require.NoError(t, err)
 	_, err = waitTaskWithTimeout(ctx, s.scheduler, depTaskID, timeout)
 	require.NoError(t, err)
 
-	waitingState, err := s.storage.GetTask(ctx, waitingTaskID)
+	waitingState, err := s.storage.GetTask(ctx, waitingTaskWithSleepID)
 	require.NoError(t, err)
 
 	inflightDuration := waitingState.InflightDuration
@@ -1869,9 +1869,9 @@ func TestTaskInflightDurationDoesNotCountWaitingStatus(t *testing.T) {
 	// in WaitingDuration, so it can be less than expected.
 	waitingThreshold := 2 * time.Second
 
-	// First waitingTask iteration: it waits for 2 seconds, then
+	// First waitingTaskWithSleep iteration: it waits for 2 seconds, then
 	// adds a dependency and interrupts.
-	// Second waitingTask iteration: it waits for 2 seconds, then
+	// Second waitingTaskWithSleep iteration: it waits for 2 seconds, then
 	// skips WaitTask (as the dependency is finished) and waits for 5 seconds.
 	// Total: 2+2+5 = 9 seconds.
 	require.GreaterOrEqual(t, inflightDuration, 9*time.Second)
@@ -1893,7 +1893,7 @@ func TestTaskWaitingDurationInChain(t *testing.T) {
 	err := registerLongTask(s.registry)
 	require.NoError(t, err)
 
-	err = registerWaitingTask(s.registry, s.scheduler)
+	err = registerWaitingTaskWithSleep(s.registry, s.scheduler)
 	require.NoError(t, err)
 
 	err = s.startRunners(ctx)
@@ -1904,11 +1904,11 @@ func TestTaskWaitingDurationInChain(t *testing.T) {
 	require.NoError(t, err)
 
 	reqCtx = getRequestContext(t, ctx)
-	task2ID, err := scheduleWaitingTask(reqCtx, s.scheduler, task1ID)
+	task2ID, err := scheduleWaitingTaskWithSleep(reqCtx, s.scheduler, task1ID)
 	require.NoError(t, err)
 
 	reqCtx = getRequestContext(t, ctx)
-	task3ID, err := scheduleWaitingTask(reqCtx, s.scheduler, task2ID)
+	task3ID, err := scheduleWaitingTaskWithSleep(reqCtx, s.scheduler, task2ID)
 	require.NoError(t, err)
 
 	timeout := 30 * time.Second


### PR DESCRIPTION
Part of #3738

Current `updateTaskTx` implementation has a bug: when the task dependency is added, ChangedStateAt was not modified (even with actual status transitioning).

This resulted to incorrect WaitingDuration calculating when the task was running inflight for some time before `WaitTask` call - InflightDuration was duplicated to WaitingDuration, thus leading to incorrect tasks with `inflight_duration + waiting_duration > (ended_at - created_at)` being true (sum of inflight_duration, waiting_duration and stalling_duration cannot be less than total duration in any case).

This PR fixes it by moving corresponding code block with ChangeStateAt updating after dependency adding and enhances tests for `WaitingDuration` to handle this case.