### PR TITLE
Split DR device stats by pool names and pool kinds

### DIFF
--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -558,4 +558,21 @@ TMap<TString, TString> ParseTags(const TString& tags)
     return result;
 }
 
+TString PoolKindToString(const NProto::EDevicePoolKind poolKind)
+{
+    switch (poolKind) {
+        case NProto::DEVICE_POOL_KIND_DEFAULT:
+            return "default";
+        case NProto::DEVICE_POOL_KIND_LOCAL:
+            return "local";
+        case NProto::DEVICE_POOL_KIND_GLOBAL:
+            return "global";
+        case NProto::EDevicePoolKind_INT_MIN_SENTINEL_DO_NOT_USE_:
+        case NProto::EDevicePoolKind_INT_MAX_SENTINEL_DO_NOT_USE_:
+            break;
+    }
+    Y_ABORT("unknown pool kind: %d", static_cast<int>(poolKind));
+    return "unknown";
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -248,4 +248,6 @@ NProto::TVolumePerformanceProfile VolumeConfigToVolumePerformanceProfile(
 
 TMap<TString, TString> ParseTags(const TString& tags);
 
+TString PoolKindToString(const NProto::EDevicePoolKind poolKind);
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.cpp
@@ -1,13 +1,13 @@
 #include "disk_registry_self_counters.h"
 
-#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void TDiskRegistrySelfCounters::Init(
-    const TVector<TString>& poolNames,
+    const TVector<std::pair<TString, NProto::EDevicePoolKind>>& pools,
     NMonitoring::TDynamicCountersPtr counters)
 {
     FreeBytes = counters->GetCounter("FreeBytes");
@@ -63,16 +63,18 @@ void TDiskRegistrySelfCounters::Init(
 
     QueryAvailableStorageErrors.Register(counters, "QueryAvailableStorageErrors");
 
-    for (const auto& poolName: poolNames) {
-        RegisterPool(poolName, counters);
+    for (const auto& [poolName, poolKind]: pools) {
+        RegisterPool(poolName, PoolKindToString(poolKind), counters);
     }
 }
 
 void TDiskRegistrySelfCounters::RegisterPool(
     const TString& poolName,
+    const TString& poolKind,
     NMonitoring::TDynamicCountersPtr counters)
 {
-    PoolName2Counters[poolName].Init(counters->GetSubgroup("pool", poolName));
+    PoolName2Counters[poolName].Init(
+        counters->GetSubgroup("pool", poolName)->GetSubgroup("kind", poolKind));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_self_counters.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+
 #include <cloud/storage/core/libs/diagnostics/solomon_counters.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
@@ -93,11 +95,12 @@ struct TDiskRegistrySelfCounters
     TVector<TNonreplMetricsCounter> NonreplMetricsCounter;
 
     void Init(
-        const TVector<TString>& poolNames,
+        const TVector<std::pair<TString, NProto::EDevicePoolKind>>& pools,
         NMonitoring::TDynamicCountersPtr counters);
 
     void RegisterPool(
         const TString& poolName,
+        const TString& poolKind,
         NMonitoring::TDynamicCountersPtr counters);
 };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -1432,8 +1432,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
         TDiskRegistrySelfCounters::TDevicePoolCounters defaultPool;
         TDiskRegistrySelfCounters::TDevicePoolCounters localPool;
 
-        defaultPool.Init(diskRegistryGroup->GetSubgroup("pool", "default"));
-        localPool.Init(diskRegistryGroup->GetSubgroup("pool", "local"));
+        defaultPool.Init(diskRegistryGroup->GetSubgroup("pool", "default")
+                             ->GetSubgroup("kind", "default"));
+        localPool.Init(diskRegistryGroup->GetSubgroup("pool", "local-ssd")
+                           ->GetSubgroup("kind", "local"));
 
         auto freeBytes = diskRegistryGroup->GetCounter("FreeBytes");
         auto totalBytes = diskRegistryGroup->GetCounter("TotalBytes");

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
@@ -959,6 +959,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         auto freeBytes = diskRegistryGroup
             ->GetSubgroup("pool", "default")
+            ->GetSubgroup("kind", "default")
             ->GetCounter("FreeBytes");
 
         auto agentsInOnlineState = diskRegistryGroup

--- a/cloud/blockstore/tests/infra-cms/test.py
+++ b/cloud/blockstore/tests/infra-cms/test.py
@@ -240,7 +240,7 @@ class _TestCmsPurgeAgentNoUserDisks:
         assert response.ActionResults[0].Result.Code == 0
         assert response.ActionResults[0].Timeout == 0
         nbs.wait_for_stats(UnknownDevices=0)
-        wait_for_secure_erase(nbs.mon_port, pool="local")
+        wait_for_secure_erase(nbs.mon_port, pool="local-ssd", kind="local")
 
         nbs.create_volume("local1", blocks_count=DEFAULT_BLOCK_COUNT_PER_DEVICE,
                           kind="ssd_local")

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -57,6 +57,7 @@ class _TestCase(object):
             allocation_unit_size=1,
             agent_count=1,
             storage_pool_name=None,
+            storage_pool_kind=None,
             dump_block_digests=False,
             reject_late_requests_at_disk_agent=False,
             encryption_at_rest=False):
@@ -71,6 +72,7 @@ class _TestCase(object):
         self.allocation_unit_size = allocation_unit_size
         self.agent_count = agent_count
         self.storage_pool_name = storage_pool_name
+        self.storage_pool_kind = storage_pool_kind
         self.dump_block_digests = dump_block_digests
         self.reject_late_requests_at_disk_agent = reject_late_requests_at_disk_agent
         self.encryption_at_rest = encryption_at_rest
@@ -137,6 +139,7 @@ TESTS = [
         "load-hdd",
         "cloud/blockstore/tests/loadtest/local-nonrepl/local-hdd.txt",
         storage_pool_name="rot",
+        storage_pool_kind="global",
     ),
     _TestCase(
         "load-encryption-at-rest",
@@ -328,7 +331,8 @@ def __run_test(test_case, backend, use_rdma):
 
         wait_for_secure_erase(
             nbs.mon_port,
-            test_case.storage_pool_name or "default")
+            test_case.storage_pool_name or "default",
+            test_case.storage_pool_kind or "default")
 
         if test_case.restart_interval:
             for agent in disk_agents:

--- a/cloud/blockstore/tests/python/lib/test_base.py
+++ b/cloud/blockstore/tests/python/lib/test_base.py
@@ -396,33 +396,35 @@ def get_sensor_by_name(sensors, component, name, def_value=None):
         sensor=name)
 
 
-def __get_free_bytes(sensors, pool, default_value=0):
+def __get_free_bytes(sensors, pool, kind, default_value=0):
     bytes = get_sensor(
         sensors,
         default_value=default_value,
         component='disk_registry',
         sensor='FreeBytes',
-        pool=pool)
+        pool=pool,
+        kind=kind)
 
     return bytes if bytes is not None else default_value
 
 
-def __get_dirty_devices(sensors, pool, default_value=0):
+def __get_dirty_devices(sensors, pool, kind, default_value=0):
     return get_sensor(
         sensors,
         default_value=default_value,
         component='disk_registry',
         sensor='DirtyDevices',
-        pool=pool)
+        pool=pool,
+        kind=kind)
 
 
 # wait for DiskAgent registration & secure erase
-def wait_for_free_bytes(mon_port, pool='default'):
+def wait_for_free_bytes(mon_port, pool='default', kind='default'):
     while True:
         logging.info("Wait for agents...")
         time.sleep(1)
         sensors = get_nbs_counters(mon_port)['sensors']
-        bytes = __get_free_bytes(sensors, pool)
+        bytes = __get_free_bytes(sensors, pool, kind)
 
         if bytes > 0:
             logging.info("Bytes: {}".format(bytes))
@@ -430,7 +432,7 @@ def wait_for_free_bytes(mon_port, pool='default'):
 
 
 # wait for DA & secure erase of all available devices
-def wait_for_secure_erase(mon_port, pool='default', expectedAgents=1):
+def wait_for_secure_erase(mon_port, pool='default', kind='default', expectedAgents=1):
     if expectedAgents == 0:
         return
 
@@ -445,13 +447,13 @@ def wait_for_secure_erase(mon_port, pool='default', expectedAgents=1):
 
         logging.info("Agents: {}".format(agents))
 
-        dd = __get_dirty_devices(sensors, pool)
+        dd = __get_dirty_devices(sensors, pool, kind)
         logging.info("Dirty devices: {}".format(dd))
 
         if dd:
             continue
 
-        bytes = __get_free_bytes(sensors, pool)
+        bytes = __get_free_bytes(sensors, pool, kind)
         logging.info("Bytes: {}".format(bytes))
 
         if not bytes:


### PR DESCRIPTION
Меняю агрегацию метрик `FreeBytes`, `TotalBytes` и прочих.
Теперь `pool` содержит реальное имя пула, вместо агрегатов (local/default). Плюс, добавлен новый лэйбл `kind`, который как раз содержит агрегаты: `default`, `local`, `global`