### PR TITLE
[Filestore] fix data race when writing to 'fuse_session::exited' flag in 'virtio_session_loop' from several threads

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -5,7 +5,6 @@
 #include "fuse.h"
 #include "handle_ops_queue.h"
 #include "log.h"
-#include "util/system/file_lock.h"
 
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
@@ -31,6 +30,7 @@
 #include <util/folder/path.h>
 #include <util/generic/string.h>
 #include <util/generic/yexception.h>
+#include "util/system/file_lock.h"
 #include <util/system/fs.h>
 #include <util/system/info.h>
 #include <util/system/rwlock.h>

--- a/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
+++ b/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
@@ -470,6 +470,8 @@ void virtio_session_exit(struct fuse_session* se)
         sched_yield();
     }
 
+    se->exited = 1;
+
     VHD_LOG_INFO("finished unregister device");
 }
 
@@ -496,7 +498,6 @@ int virtio_session_loop(struct fuse_session* se, int queue_index)
         }
     }
 
-    se->exited = 1;
     return res;
 }
 


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=613793)
  Write of size 4 at 0x7b6000080008 by thread T147:
    #0 virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:499:16 (filestore-vhost+0x2793f74d) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #1 fuse_session_loop /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:2694:12 (libvirtiofsd.so+0xb67e) (BuildId: d669c68e288fc6da51483d7bfbbc6b4af5a8ba09)
    #2 NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:531:9 (filestore-vhost+0x2787de91) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #3 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-vhost+0xfbdbea2) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #4 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-vhost+0xfbdf37c) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)

  Previous write of size 4 at 0x7b6000080008 by thread T146:
    #0 virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:499:16 (filestore-vhost+0x2793f74d) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #1 fuse_session_loop /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:2694:12 (libvirtiofsd.so+0xb67e) (BuildId: d669c68e288fc6da51483d7bfbbc6b4af5a8ba09)
    #2 NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:531:9 (filestore-vhost+0x2787de91) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #3 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-vhost+0xfbdbea2) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #4 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-vhost+0xfbdf37c) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)

  Location is heap block of size 984 at 0x7b6000080000 allocated by thread T88:
    #0 calloc /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:712:5 (filestore-vhost+0xf98fb66) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #1 fuse_session_new /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:2621:33 (libvirtiofsd.so+0xb279) (BuildId: d669c68e288fc6da51483d7bfbbc6b4af5a8ba09)
    #2 NCloud::NFileStore::NFuse::(anonymous namespace)::TSession::TSession /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:321:19 (filestore-vhost+0x2785d5ae) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #3 NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoop::TFuseLoop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:557:11 (filestore-vhost+0x2785d5ae)
    #4 std::__y1::make_unique<NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoop, TLog &, NCloud::NFileStore::NVFS::TVFSConfig &, unsigned int &, fuse_lowlevel_ops &, TBasicString<char, std::__y1::char_traits<char> > &, NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop *> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:715:32 (filestore-vhost+0x2785d5ae)
    #5 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartWithSessionState(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1060:24 (filestore-vhost+0x2785d5ae)
    #6 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync()::(anonymous class)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> > /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:700:31 (filestore-vhost+0x27857761) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #7 NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>::Apply((lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:685:48) &&)::(anonymous class)::operator()(const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:53 (filestore-vhost+0x27857761)
    #8 NThreading::NImpl::SetValue<NCloud::NProto::TError, (lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:38)> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:486:39 (filestore-vhost+0x27857761)
    #9 NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TCreateSessionResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>::Apply<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&)::operator()(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:627:13 (filestore-vhost+0x27857761)
    #10 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (filestore-vhost+0x27858284) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #11 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19) &, const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (filestore-vhost+0x27858284)
    #12 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:626:19)>, void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (filestore-vhost+0x27858284)
    #13 std::__y1::__function::__func<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TCreateSessionResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>::Apply<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&), std::__y1::allocator<NThreading::TFuture<NThreading::NImpl::TFutureType<NThreading::NImpl::TFutureCallResult<auto, NCloud::NFileStore::NProto::TCreateSessionResponse>::TType>::TType> NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>::Apply<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync()::'lambda'(auto const&)>(auto&&) const::'lambda'(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&)>, void (NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&)>::operator()(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (filestore-vhost+0x27858284)
    #14 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (filestore-vhost+0x27c4dba7) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #15 std::__y1::function<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (filestore-vhost+0x27c4dba7)
    #16 bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::TrySetValue<NCloud::NFileStore::NProto::TCreateSessionResponse>(NCloud::NFileStore::NProto::TCreateSessionResponse&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (filestore-vhost+0x27c4dba7)
    #17 NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue<NCloud::NFileStore::NProto::TCreateSessionResponse> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (filestore-vhost+0x27f1f207) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #18 NThreading::TPromise<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (filestore-vhost+0x27f1f207)
    #19 NCloud::NFileStore::NClient::(anonymous namespace)::TSession::HandleResponse /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:480:25 (filestore-vhost+0x27f1f207)
    #20 auto void NCloud::NFileStore::NClient::(anonymous namespace)::TSession::ExecuteRequestWithSession<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>>>)::'lambda'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>>(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:728:27 (filestore-vhost+0x27f1f207)
    #21 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:724:13) &, const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (filestore-vhost+0x27f1fae4) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #22 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:724:13) &, const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (filestore-vhost+0x27f1fae4)
    #23 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:724:13), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:724:13)>, void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (filestore-vhost+0x27f1fae4)
    #24 std::__y1::__function::__func<void NCloud::NFileStore::NClient::(anonymous namespace)::TSession::ExecuteRequestWithSession<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>>>)::'lambda'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod const&), std::__y1::allocator<void NCloud::NFileStore::NClient::(anonymous namespace)::TSession::ExecuteRequestWithSession<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod>>>)::'lambda'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionMethod const&)>, void (NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&)>::operator()(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (filestore-vhost+0x27f1fae4)
    #25 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (filestore-vhost+0x27c4dba7) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #26 std::__y1::function<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (filestore-vhost+0x27c4dba7)
    #27 bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::TrySetValue<NCloud::NFileStore::NProto::TCreateSessionResponse>(NCloud::NFileStore::NProto::TCreateSessionResponse&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (filestore-vhost+0x27c4dba7)
    #28 NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue<NCloud::NFileStore::NProto::TCreateSessionResponse> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (filestore-vhost+0x27ed0428) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #29 NThreading::TPromise<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (filestore-vhost+0x27ed0428)
    #30 NCloud::NFileStore::NClient::(anonymous namespace)::TDurableClientBase<NCloud::NFileStore::IFileStoreService>::HandleResponse<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:219:29 (filestore-vhost+0x27ed0428)
    #31 auto void NCloud::NFileStore::NClient::(anonymous namespace)::TDurableClientBase<NCloud::NFileStore::IFileStoreService>::ExecuteRequest<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>>>)::'lambda'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse>>(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:155:27 (filestore-vhost+0x27ed0428)
    #32 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:150:13) &, const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (filestore-vhost+0x27ed19a4) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #33 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:150:13) &, const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (filestore-vhost+0x27ed19a4)
    #34 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:150:13), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/durable.cpp:150:13)>, void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (filestore-vhost+0x27ed19a4)
    #35 std::__y1::__function::__func<void NCloud::NFileStore::NClient::(anonymous namespace)::TDurableClientBase<NCloud::NFileStore::IFileStoreService>::ExecuteRequest<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>>>)::'lambda'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod const&), std::__y1::allocator<void NCloud::NFileStore::NClient::(anonymous namespace)::TDurableClientBase<NCloud::NFileStore::IFileStoreService>::ExecuteRequest<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod>>>)::'lambda'(NCloud::NFileStore::NClient::(anonymous namespace)::TCreateSessionFsMethod const&)>, void (NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&)>::operator()(NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> const&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (filestore-vhost+0x27ed19a4)
    #36 std::__y1::__function::__value_func<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (filestore-vhost+0x27c4dba7) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #37 std::__y1::function<void (const NThreading::TFuture<NCloud::NFileStore::NProto::TCreateSessionResponse> &)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (filestore-vhost+0x27c4dba7)
    #38 bool NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::TrySetValue<NCloud::NFileStore::NProto::TCreateSessionResponse>(NCloud::NFileStore::NProto::TCreateSessionResponse&&) /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:164:25 (filestore-vhost+0x27c4dba7)
    #39 NThreading::NImpl::TFutureState<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue<NCloud::NFileStore::NProto::TCreateSessionResponse> /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:132:32 (filestore-vhost+0x27cd4c32) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #40 NThreading::TPromise<NCloud::NFileStore::NProto::TCreateSessionResponse>::SetValue /actions-runner/_work/nbs/nbs/library/cpp/threading/future/core/future-inl.h:799:16 (filestore-vhost+0x27cd4c32)
    #41 NCloud::NFileStore::(anonymous namespace)::TRequestActor<NCloud::NFileStore::(anonymous namespace)::TCreateSessionMethod>::HandleResponse /actions-runner/_work/nbs/nbs/cloud/filestore/libs/service_kikimr/service.cpp:119:22 (filestore-vhost+0x27cd4c32)
    #42 NCloud::NFileStore::(anonymous namespace)::TRequestActor<NCloud::NFileStore::(anonymous namespace)::TCreateSessionMethod>::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/service_kikimr/service.cpp:132:13 (filestore-vhost+0x27cd4c32)
    #43 NActors::TActorCallbackBehaviour::Receive(NActors::IActor*, TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.cpp:244:9 (filestore-vhost+0x102cb7b3) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #44 NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/actor.h:530:23 (filestore-vhost+0x1031d4d2) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #45 NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TSimpleMailbox>(NActors::TMailboxTable::TSimpleMailbox*, unsigned int, bool) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:251:28 (filestore-vhost+0x10304d18) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #46 NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:437:25 (filestore-vhost+0x103011fe) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #47 NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:492:13 (filestore-vhost+0x10300804) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #48 NActors::TExecutorThread::ThreadProc() /actions-runner/_work/nbs/nbs/contrib/ydb/library/actors/core/executor_thread.cpp:523:9 (filestore-vhost+0x10301f7a) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #49 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (filestore-vhost+0xfbdbea2) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
    #50 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (filestore-vhost+0xfbdf37c) (BuildId: f39855eab050464179fd7ca54128547df84de6cb)
...
```