### PR TITLE
issue-4231 use per-directory IsExhaustive flag for stats of non-existent files

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -228,7 +228,11 @@ bool TInMemoryIndexState::ReadNodeRef(
 {
     auto it = NodeRefs.find(TNodeRefsKey(nodeId, name));
     if (it == NodeRefs.end()) {
-        return false;
+        // If the cache is exhaustive for the node and we did not find the
+        // entry, then we are sure that the entry does not exist and we can
+        // return true, meaning that cache lookup was successful. But we do not
+        // set the ref, meaning that the entry does not exist.
+        return NodeRefsExhaustivenessInfo.IsExhaustiveForNode(nodeId);
     }
 
     ui64 minCommitId = it->second.CommitId;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -98,7 +98,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         state.UpdateState(
             {TInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId1}});
 
+        node.Clear();
         UNIT_ASSERT(!state.ReadNode(1, commitId1, node));
+        UNIT_ASSERT(node.Empty());
     }
 
     const TString attrName1 = "name1";
@@ -186,7 +188,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         state.UpdateState(
             {TInMemoryIndexState::TDeleteNodeAttrsRequest{nodeId1, attrName1}});
 
+        attr.Clear();
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
+        UNIT_ASSERT(attr.Empty());
     }
 
     const TVector<TString> nodeNames = {"node1", "node2", "node3", "node4"};
@@ -421,9 +425,17 @@ namespace {
         };
 
         state.UpdateState({request});
-        state.MarkNodeRefsLoadComplete();
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        UNIT_ASSERT(state.ReadNodeRef(
+            request.NodeRefsKey.NodeId,
+            request.NodeRefsRow.CommitId,
+            request.NodeRefsKey.Name,
+            ref));
+        UNIT_ASSERT(ref.Defined());
+
+        state.MarkNodeRefsLoadComplete();
+
         UNIT_ASSERT(state.ReadNodeRef(
             request.NodeRefsKey.NodeId,
             request.NodeRefsRow.CommitId,
@@ -435,11 +447,13 @@ namespace {
             request.NodeRefsKey.NodeId,
             request.NodeRefsKey.Name}});
 
-        UNIT_ASSERT(!state.ReadNodeRef(
+        ref.Clear();
+        UNIT_ASSERT(state.ReadNodeRef(
             request.NodeRefsKey.NodeId,
             request.NodeRefsRow.CommitId,
             request.NodeRefsKey.Name,
             ref));
+        UNIT_ASSERT(ref.Empty());
     }
 }
 


### PR DESCRIPTION
#4231

Imagine a situation where we know that all children of a given node are in memory, and a client tries to do stat(node, non-existent-children). In those situations, we should not perform a real transaction, looking up a non-existent row in a NodeRefs table, but we should use only in-memory information. 

This is what this PR does