### PR TITLE
issue-4336: Refactoring allowing extensibility for using different file IO services and test scenarios in eternal-load

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -2,6 +2,7 @@
 
 #include "options.h"
 
+#include <cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h>
 #include <cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -9,6 +10,8 @@
 #include <util/system/file.h>
 
 namespace NCloud::NBlockStore {
+
+using namespace NTesting;
 
 namespace {
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/public.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/public.h
@@ -48,9 +48,6 @@ inline IOutputStream& operator<<(IOutputStream& out, const TBlockData& data)
 struct IRequestGenerator;
 using IRequestGeneratorPtr = std::shared_ptr<IRequestGenerator>;
 
-struct ITestExecutor;
-using ITestExecutorPtr = std::shared_ptr<ITestExecutor>;
-
 struct IConfigHolder;
 using IConfigHolderPtr = std::shared_ptr<IConfigHolder>;
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -1,5 +1,12 @@
 #include "test_executor.h"
 
+#include <atomic>
+
+#include <cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h>
+
+#include <cloud/storage/core/libs/common/file_io_service.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
 #include <library/cpp/aio/aio.h>
 #include <library/cpp/digest/crc32c/crc32c.h>
 
@@ -11,11 +18,379 @@
 #include <util/system/info.h>
 #include <util/thread/lfstack.h>
 
-namespace NCloud::NBlockStore {
+namespace NCloud::NBlockStore::NTesting {
 
 namespace {
 
 using namespace NThreading;
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestExecutor: public ITestExecutor
+{
+private:
+    class TContext;
+
+    const TInstant TestStartTimestamp;
+    ITestScenarioPtr TestScenario;
+    IFileIOServicePtr FileService;
+    TFileHandle File;
+
+    std::atomic_bool ShouldStop = false;
+    std::atomic_bool Failed = false;
+    TPromise<void> StopPromise = NewPromise();
+
+    TVector<std::unique_ptr<TContext>> Contexts;
+    TLockFreeStack<TContext*> ReadyContexts;
+
+    const TLog Log;
+
+public:
+    TTestExecutor(TTestExecutorSettings settings, IFileIOServicePtr service);
+    bool Run() override;
+    void Stop() override;
+    void Fail(TStringBuf message);
+
+private:
+    void RunMainThread();
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestExecutor::TContext: public ITestThreadContext
+{
+private:
+    TTestExecutor& TestExecutor;
+    ITestScenarioThread& TestThread;
+    TPromise<void> StopPromise = NewPromise();
+    std::atomic_int PendingRequestCount = 0;
+    int RequestCount = 0;
+
+public:
+    TContext(TTestExecutor& testExecutor, ITestScenarioThread& testThread);
+
+    void Run();
+    void Wait();
+
+private:
+    void HandleRequest();
+
+    void Read(
+        void* buffer,
+        ui32 count,
+        ui64 offset,
+        TCallback callback) override;
+
+    void Write(
+        const void* buffer,
+        ui32 count,
+        ui64 offset,
+        TCallback callback) override;
+
+    void Stop() override;
+
+    void Fail(TStringBuf message) override;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTestExecutor::TTestExecutor(
+        TTestExecutorSettings settings,
+        IFileIOServicePtr service)
+    : TestStartTimestamp(Now())
+    , TestScenario(std::move(settings.TestScenario))
+    , FileService(std::move(service))
+    , File(
+        settings.FilePath,
+        EOpenModeFlag::DirectAligned | EOpenModeFlag::RdWr)
+    , Log(settings.Log)
+{
+    File.Resize(static_cast<i64>(settings.FileSize));
+
+    for (ui32 i = 0; i < TestScenario->GetThreadCount(); i++) {
+        Contexts.push_back(
+            std::make_unique<TContext>(*this, TestScenario->GetThread(i)));
+    }
+}
+
+bool TTestExecutor::Run()
+{
+    if (!TestScenario->Initialize(File)) {
+        return false;
+    }
+
+    STORAGE_INFO("Started TTestExecutor");
+
+    FileService->Start();
+
+    for (auto& context: Contexts) {
+        context->Run();
+    }
+
+    RunMainThread();
+
+    FileService->Stop();
+    File.Close();
+
+    STORAGE_INFO("Stopped TTestExecutor");
+    return !Failed.load();
+}
+
+void TTestExecutor::Stop()
+{
+    ShouldStop.store(true);
+    if (StopPromise.TrySetValue()) {
+        STORAGE_INFO("Stop has been requested");
+    }
+}
+
+void TTestExecutor::Fail(TStringBuf message)
+{
+    Stop();
+    Failed.store(true);
+    STORAGE_ERROR(message);
+}
+
+void TTestExecutor::RunMainThread()
+{
+    TVector<TContext*> contextsToRun;
+
+    while (!ShouldStop) {
+        contextsToRun.clear();
+        ReadyContexts.DequeueAllSingleConsumer(&contextsToRun);
+        for (auto* context: contextsToRun) {
+            context->Run();
+        }
+    }
+
+    while (contextsToRun.size() < Contexts.size()) {
+        ReadyContexts.DequeueAllSingleConsumer(&contextsToRun);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTestExecutor::TContext::TContext(
+        TTestExecutor& testExecutor,
+        ITestScenarioThread& testThread)
+    : TestExecutor(testExecutor)
+    , TestThread(testThread)
+{}
+
+void TTestExecutor::TContext::Run()
+{
+    if (TestExecutor.ShouldStop) {
+        StopPromise.SetValue();
+        return;
+    }
+
+    Y_ABORT_UNLESS(
+        PendingRequestCount == 0,
+        "New iteration can be run only after requests from the previous "
+        "iteration are handled");
+
+    RequestCount = 0;
+    PendingRequestCount = 1;
+
+    auto testDuration = Now() - TestExecutor.TestStartTimestamp;
+    TestThread.Run(testDuration.SecondsFloat(), *this);
+
+    Y_ABORT_UNLESS(
+        RequestCount > 0,
+        "Test thread should make at least one request");
+
+    HandleRequest();
+}
+
+void TTestExecutor::TContext::Wait()
+{
+    StopPromise.GetFuture().Wait();
+}
+
+void TTestExecutor::TContext::HandleRequest()
+{
+    auto prev = PendingRequestCount--;
+    Y_ABORT_UNLESS(prev > 0, "There are no unhandled requests");
+
+    if (prev > 1) {
+        return;
+    }
+
+    TestExecutor.ReadyContexts.Enqueue(this);
+}
+
+void TTestExecutor::TContext::Stop()
+{
+    TestExecutor.Stop();
+}
+
+void TTestExecutor::TContext::Fail(TStringBuf message)
+{
+    TestExecutor.Fail(message);
+}
+
+void TTestExecutor::TContext::Read(
+    void* buffer,
+    ui32 count,
+    ui64 offset,
+    TCallback callback)
+{
+    RequestCount++;
+    PendingRequestCount++;
+
+    TestExecutor.FileService->AsyncRead(
+        TestExecutor.File,
+        static_cast<i64>(offset),
+        TArrayRef(static_cast<char*>(buffer), count),
+        [this, count, callback = std::move(callback)](
+            const NProto::TError& error,
+            ui32 value)
+        {
+            if (HasError(error)) {
+                TestExecutor.Fail(
+                    "Can't read from file: " + error.GetMessage());
+            } else if (value < count) {
+                TestExecutor.Fail(
+                    TStringBuilder() << "Read less than expected: " << value
+                                     << " < " << count);
+            } else {
+                callback();
+            }
+            HandleRequest();
+        });
+}
+
+void TTestExecutor::TContext::Write(
+    const void* buffer,
+    ui32 count,
+    ui64 offset,
+    TCallback callback)
+{
+    RequestCount++;
+    PendingRequestCount++;
+
+    TestExecutor.FileService->AsyncWrite(
+        TestExecutor.File,
+        static_cast<i64>(offset),
+        TArrayRef(static_cast<const char*>(buffer), count),
+        [this, count, callback = std::move(callback)](
+            const NProto::TError& error,
+            ui32 value)
+        {
+            if (HasError(error)) {
+                TestExecutor.Fail(
+                    "Can't write to file: " + error.GetMessage());
+            } else if (value < count) {
+                TestExecutor.Fail(
+                    TStringBuilder() << "Written less than expected: " << value
+                                     << " < " << count);
+            } else {
+                callback();
+            }
+            HandleRequest();
+        });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TAsyncIoFileService
+    : public IFileIOService
+    , private NAsyncIO::TAsyncIOService
+{
+public:
+    using TAsyncIOService::TAsyncIOService;
+
+    void Start() override
+    {
+        TAsyncIOService::Start();
+    }
+
+    void Stop() override
+    {
+        TAsyncIOService::Stop();
+    }
+
+    void AsyncRead(
+        TFileHandle& file,
+        i64 offset,
+        TArrayRef<char> buffer,
+        TFileIOCompletion* completion) override
+    {
+        auto future = TAsyncIOService::Read(
+            file,
+            buffer.data(),
+            static_cast<ui32>(buffer.size()),
+            static_cast<ui64>(offset));
+
+        future.Subscribe([completion](const auto& f) {
+            RunCompletion(f, completion);
+        });
+    }
+
+    void AsyncWrite(
+        TFileHandle& file,
+        i64 offset,
+        TArrayRef<const char> buffer,
+        TFileIOCompletion* completion) override
+    {
+        auto future = TAsyncIOService::Write(
+            file,
+            buffer.data(),
+            static_cast<ui32>(buffer.size()),
+            static_cast<ui64>(offset));
+
+        future.Subscribe([completion](const auto& f) {
+            RunCompletion(f, completion);
+        });
+    }
+
+    void AsyncReadV(
+        TFileHandle& file,
+        i64 offset,
+        const TVector<TArrayRef<char>>& buffers,
+        TFileIOCompletion* completion) override
+    {
+        Y_UNUSED(file);
+        Y_UNUSED(offset);
+        Y_UNUSED(buffers);
+        Y_UNUSED(completion);
+        Y_ABORT("Not used");
+    }
+
+    void AsyncWriteV(
+        TFileHandle& file,
+        i64 offset,
+        const TVector<TArrayRef<const char>>& buffers,
+        TFileIOCompletion* completion) override
+    {
+        Y_UNUSED(file);
+        Y_UNUSED(offset);
+        Y_UNUSED(buffers);
+        Y_UNUSED(completion);
+        Y_ABORT("Not used");
+    }
+
+    static void RunCompletion(
+        const NThreading::TFuture<ui32>& future,
+        TFileIOCompletion* completion)
+    {
+        Y_ABORT_UNLESS(future.HasValue());
+
+        try {
+            auto value = future.GetValue();
+            if (value >= 0) {
+                completion->Func(completion, {}, value);
+            } else {
+                completion->Func(completion, MakeError(E_FAIL), value);
+            }
+        } catch (...) {
+            completion->Func(
+                completion,
+                MakeError(E_FAIL, CurrentExceptionMessage()),
+                0);
+        }
+    }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -115,45 +490,59 @@ struct TRange {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TTestExecutor final
-   : public ITestExecutor
+class TAlignedBlockTestScenario: public ITestScenario
 {
 private:
+    using IContext = ITestThreadContext;
+
     const TInstant TestStartTimestamp;
     IConfigHolderPtr ConfigHolder;
     TDuration SlowRequestThreshold;
+    std::optional<double> PhaseDuration;
+    ui32 WriteRate;
 
     TVector<TRange> Ranges;
-
-    TFileHandle File;
-    NAsyncIO::TAsyncIOService AsyncIO;
-
-    TLockFreeStack<ui16> RangesQueue;
-
-    TVector<NThreading::TFuture<void>> Futures;
-
-    TAtomic ShouldStop = 0;
-    TAtomic Failed = 0;
+    TVector<std::unique_ptr<ITestScenarioThread>> Threads;
 
     TLog Log;
 
     TAtomic WriteRequestsCompleted = 0;
 
 private:
-    void DoWriteRequest(ui16 rangeIdx);
-    void DoReadRequest(ui16 rangeIdx);
+    void DoRequest(
+        ui16 rangeIdx,
+        double secondsSinceTestStart,
+        IContext& context);
 
-    void OnResponse(TInstant startTs, ui16 rangeIdx, TStringBuf reqType);
+    void DoWriteRequest(ui16 rangeIdx, IContext& context);
+    void DoReadRequest(ui16 rangeIdx, IContext& context);
+
+    void OnResponse(
+        TInstant startTs,
+        ui16 rangeIdx,
+        TStringBuf reqType,
+        IContext& context);
+
+    struct TThread: public ITestScenarioThread
+    {
+        TAlignedBlockTestScenario* Scenario;
+        ui32 Index;
+
+        TThread(TAlignedBlockTestScenario* testExecutor, ui32 index)
+            : Scenario(testExecutor)
+            , Index(index)
+        {}
+
+        void Run(double secondsSinceTestStart, IContext& context) final
+        {
+            Scenario->DoRequest(Index, secondsSinceTestStart, context);
+        }
+    };
 
 public:
-    TTestExecutor(IConfigHolderPtr configHolder, const TLog& log)
+    TAlignedBlockTestScenario(IConfigHolderPtr configHolder, const TLog& log)
         : TestStartTimestamp(Now())
         , ConfigHolder(configHolder)
-        , File(
-            TString(ConfigHolder->GetConfig().GetFilePath()),
-            EOpenModeFlag::DirectAligned | EOpenModeFlag::RdWr)
-        , AsyncIO(0, ConfigHolder->GetConfig().GetIoDepth())
-        , Futures(ConfigHolder->GetConfig().GetIoDepth())
         , Log(log)
     {
         auto& config = ConfigHolder->GetConfig();
@@ -162,61 +551,57 @@ public:
             Ranges.emplace_back(
                 rangeConfig,
                 rangeConfig.GetRequestBlockCount() * config.GetBlockSize());
-            RangesQueue.Enqueue(i);
+            Threads.push_back(std::make_unique<TThread>(this, i));
         }
 
         SlowRequestThreshold = TDuration::Parse(config.GetSlowRequestThreshold());
+
+        if (config.HasAlternatingPhase()) {
+            PhaseDuration =
+                TDuration::Parse(config.GetAlternatingPhase()).SecondsFloat();
+        }
+
+        WriteRate = config.GetWriteRate();
     }
 
-    bool Run() override;
-    void Stop() override;
+    ui32 GetThreadCount() const final
+    {
+        return static_cast<ui32>(Threads.size());
+    }
+
+    ITestScenarioThread& GetThread(ui32 index) const final
+    {
+        return *Threads[index];
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TTestExecutor::Run()
+void TAlignedBlockTestScenario::DoRequest(
+    ui16 rangeIdx,
+    double secondsSinceTestStart,
+    IContext& context)
 {
-    STORAGE_INFO("Running load");
-
-    AsyncIO.Start();
-    TVector<ui16> buf;
-
-    TDuration phaseDuration = TDuration::Max();
-    if (ConfigHolder->GetConfig().HasAlternatingPhase()) {
-        phaseDuration = TDuration::Parse(ConfigHolder->GetConfig().GetAlternatingPhase());
-    }
-    TInstant phaseStartTs = Now();
-    ui16 writeRate = ConfigHolder->GetConfig().GetWriteRate();
-
-    while (!AtomicGet(ShouldStop)) {
-        buf.clear();
-        if (phaseStartTs + phaseDuration < Now()) {
+    auto writeRate = WriteRate;
+    if (PhaseDuration) {
+        auto iter = secondsSinceTestStart / PhaseDuration.value();
+        if (static_cast<ui64>(iter) % 2 == 1) {
             writeRate = 100 - writeRate;
-            phaseStartTs = Now();
-        }
-        RangesQueue.DequeueAllSingleConsumer(&buf);
-        for (auto rangeIdx: buf) {
-            if (RandomNumber(100u) >= writeRate) {
-                DoReadRequest(rangeIdx);
-            } else {
-                DoWriteRequest(rangeIdx);
-            }
         }
     }
 
-    for (auto future: Futures) {
-        future.GetValueSync();
+    if (RandomNumber(100u) >= writeRate) {
+        DoReadRequest(rangeIdx, context);
+    } else {
+        DoWriteRequest(rangeIdx, context);
     }
-    AsyncIO.Stop();
-    File.Close();
-    STORAGE_INFO("Stopped");
-    return !AtomicGet(Failed);
 }
 
-void TTestExecutor::OnResponse(
+void TAlignedBlockTestScenario::OnResponse(
     TInstant startTs,
     ui16 rangeIdx,
-    TStringBuf reqType)
+    TStringBuf reqType,
+    IContext& context)
 {
     if (reqType == "write") {
         const i64 maxRequestCount =
@@ -224,7 +609,7 @@ void TTestExecutor::OnResponse(
         if (maxRequestCount &&
             AtomicIncrement(WriteRequestsCompleted) >= maxRequestCount)
         {
-            Stop();
+            context.Stop();
         }
     }
 
@@ -232,11 +617,13 @@ void TTestExecutor::OnResponse(
     const auto d = now - startTs;
     if (d > SlowRequestThreshold) {
         STORAGE_WARN("Slow " << reqType << " request: "
-            << "range=" << rangeIdx << ", duration=" << d);
+                    << "range=" << rangeIdx << ", duration=" << d);
     }
 }
 
-void TTestExecutor::DoReadRequest(ui16 rangeIdx)
+void TAlignedBlockTestScenario::DoReadRequest(
+    ui16 rangeIdx,
+    IContext& context)
 {
     auto& range = Ranges[rangeIdx];
     // https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding
@@ -247,30 +634,13 @@ void TTestExecutor::DoReadRequest(ui16 rangeIdx)
     ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
 
     const auto startTs = Now();
-    auto future = AsyncIO.Read(
-        File,
-        range.Data(),
-        range.DataSize(),
-        blockIdx * blockSize);
 
-    future.Subscribe([=, this] (const auto& f) mutable {
-        OnResponse(startTs, rangeIdx, "read");
-
-        try {
-            if (f.GetValue() && f.GetValue() < range.DataSize()) {
-                throw yexception() << "read less than expected: "
-                    << f.GetValue() << " < " << range.DataSize();
-            }
-        } catch (...) {
-            STORAGE_ERROR("Can't read from file: "
-                << CurrentExceptionMessage());
-            AtomicSet(Failed, 1);
-            Stop();
-            return;
-        }
+    auto readHandler =
+        [this, startTs, blockIdx, rangeIdx, expected, &context]() mutable
+    {
+        OnResponse(startTs, rangeIdx, "read", context);
 
         if (!expected) {
-            RangesQueue.Enqueue(rangeIdx);
             return;
         }
 
@@ -281,24 +651,30 @@ void TTestExecutor::DoReadRequest(ui16 rangeIdx)
             TBlockData blockData;
             memcpy(&blockData, range.Data(part * partSize), sizeof(blockData));
 
-            if (blockData.RequestNumber != *expected || blockData.PartNumber != part) {
-                STORAGE_ERROR(
-                    "[" << rangeIdx << "] Wrong data in block "
+            if (blockData.RequestNumber != *expected ||
+                blockData.PartNumber != part)
+            {
+                context.Fail(
+                    TStringBuilder()
+                    << "[" << rangeIdx << "] Wrong data in block "
                     << blockIdx
                     << " expected RequestNumber " << expected
                     << " actual TBlockData " << blockData);
-                AtomicSet(Failed, 1);
-                Stop();
                 return;
             }
         }
-        RangesQueue.Enqueue(rangeIdx);
-    });
+    };
 
-    Futures[rangeIdx] = future.IgnoreResult();
+    context.Read(
+        range.Data(),
+        range.DataSize(),
+        blockIdx * blockSize,
+        readHandler);
 }
 
-void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
+void TAlignedBlockTestScenario::DoWriteRequest(
+    ui16 rangeIdx,
+    IContext& context)
 {
     auto& range = Ranges[rangeIdx];
 
@@ -314,7 +690,6 @@ void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
         .Checksum = 0
     };
 
-    TVector<TFuture<void>> futures;
     ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
     ui64 partSize = range.DataSize() / range.Config.GetWriteParts();
     for (ui32 part = 0; part < range.Config.GetWriteParts(); ++part) {
@@ -323,51 +698,44 @@ void TTestExecutor::DoWriteRequest(ui16 rangeIdx)
         blockData.Checksum = Crc32c(&blockData, sizeof(blockData));
         ui64 partOffset = part * partSize;
         memcpy(range.Data(partOffset), &blockData, sizeof(blockData));
-        auto future = AsyncIO.Write(
-            File,
+        context.Write(
             range.Data(partOffset),
             partSize,
-            blockIdx * blockSize + partOffset);
-
-        future.Subscribe([=, this] (const auto& f) mutable {
-            OnResponse(startTs, rangeIdx, "write");
-
-            try {
-                if (f.GetValue() && f.GetValue() < range.DataSize()) {
-                    throw yexception() << "written less than expected: "
-                        << f.GetValue() << " < " << partSize;
-                }
-            } catch (...) {
-                STORAGE_ERROR("Can't write to file: "
-                    << CurrentExceptionMessage());
-                AtomicSet(Failed, 1);
-                Stop();
-                return;
-            }
-        });
-        futures.push_back(future.IgnoreResult());
+            blockIdx * blockSize + partOffset,
+            [this, startTs, rangeIdx, &context]() mutable
+            {
+                OnResponse(startTs, rangeIdx, "write", context);
+            });
     }
-
-    Futures[rangeIdx] = WaitAll(futures);
-    Futures[rangeIdx].Subscribe([=, this] (auto) {
-        RangesQueue.Enqueue(rangeIdx);
-    });
-}
-
-void TTestExecutor::Stop()
-{
-    AtomicSet(ShouldStop, 1);
 }
 
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ITestScenarioPtr CreateAlignedBlockTestScenario(
+    IConfigHolderPtr configHolder,
+    const TLog& log)
+{
+    return ITestScenarioPtr(
+        new TAlignedBlockTestScenario(std::move(configHolder), log));
+}
+
 ITestExecutorPtr CreateTestExecutor(
     IConfigHolderPtr configHolder,
     const TLog& log)
 {
-    return std::make_shared<TTestExecutor>(std::move(configHolder), log);
+    TTestExecutorSettings settings;
+    settings.FilePath = configHolder->GetConfig().GetFilePath();
+    settings.FileSize = configHolder->GetConfig().GetFileSize();
+    settings.Log = log;
+    settings.TestScenario = CreateAlignedBlockTestScenario(configHolder, log);
+
+    return std::make_shared<TTestExecutor>(
+        std::move(settings),
+        std::make_shared<TAsyncIoFileService>(
+            0,
+            settings.TestScenario->GetThreadCount()));
 }
 
-}   // namespace NCloud::NBlockStore
+}   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -49,7 +49,7 @@ public:
     TTestExecutor(TTestExecutorSettings settings, IFileIOServicePtr service);
     bool Run() override;
     void Stop() override;
-    void Fail(TStringBuf message);
+    void Fail(const TString& message);
 
 private:
     void RunMainThread();
@@ -89,7 +89,7 @@ private:
 
     void Stop() override;
 
-    void Fail(TStringBuf message) override;
+    void Fail(const TString& message) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,7 +146,7 @@ void TTestExecutor::Stop()
     }
 }
 
-void TTestExecutor::Fail(TStringBuf message)
+void TTestExecutor::Fail(const TString& message)
 {
     Stop();
     Failed.store(true);
@@ -226,7 +226,7 @@ void TTestExecutor::TWorkerService::Stop()
     Executor.Stop();
 }
 
-void TTestExecutor::TWorkerService::Fail(TStringBuf message)
+void TTestExecutor::TWorkerService::Fail(const TString& message)
 {
     Executor.Fail(message);
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
@@ -68,7 +68,7 @@ struct ITestExecutorIOService
     virtual void Stop() = 0;
 
     // Stop and write the error message
-    virtual void Fail(TStringBuf message) = 0;
+    virtual void Fail(const TString& message) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
@@ -2,34 +2,123 @@
 
 #include "public.h"
 
-#include <cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h>
-#include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <functional>
 
-#include <library/cpp/config/config.h>
-#include <library/cpp/config/domscheme.h>
+#include <library/cpp/logger/log.h>
 
-#include <util/datetime/base.h>
 #include <util/generic/string.h>
-#include <library/cpp/deprecated/atomic/atomic.h>
-#include <util/system/event.h>
+#include <util/system/file.h>
+#include <util/system/types.h>
 
-namespace NCloud::NBlockStore {
+namespace NCloud::NBlockStore::NTesting {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+* Runs a test scenario until Stop is requested.
+*
+* A test scenario is represented by a collection of concurrently executed
+* logical threads.
+*
+* Each thread is executed repeatedly by calling ITestThread::Run.
+* It should initiate one or several read or write requests via the provided
+* context object.
+* Next call of ITestThread::Run is made when all the requests are handled.
+*/
 struct ITestExecutor
 {
     virtual ~ITestExecutor() = default;
 
+    // The function returns when the test is finished (true) or failed (false)
     virtual bool Run() = 0;
 
+    // Requests the test to stop and returns immediately
     virtual void Stop() = 0;
 };
 
+using ITestExecutorPtr = std::shared_ptr<ITestExecutor>;
+
 ////////////////////////////////////////////////////////////////////////////////
+
+struct ITestThreadContext
+{
+    using TCallback = std::function<void()>;
+
+    virtual ~ITestThreadContext() = default;
+
+    // Initiates an asynchronous read operation and calls the callback when
+    // the operation is completed successfully.
+    // If it fails, the test is stopped and the error is reported.
+    virtual void Read(
+        void* buffer,
+        ui32 count,
+        ui64 offset,
+        TCallback callback) = 0;
+
+    // Initiates an asynchronous write operation and calls the callback when
+    // the operation is completed successfully.
+    // If it fails, the test is stopped and the error is reported.
+    virtual void Write(
+        const void* buffer,
+        ui32 count,
+        ui64 offset,
+        TCallback callback) = 0;
+
+    virtual void Stop() = 0;
+
+    virtual void Fail(TStringBuf message) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// It doesn't necessary correspond to a real thread and instead is considered
+// as a logical thread. The Run method can be called from any thread.
+struct ITestScenarioThread
+{
+    virtual ~ITestScenarioThread() = default;
+
+    virtual void Run(
+        double secondsSinceTestStart,
+        ITestThreadContext& context) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ITestScenario
+{
+    virtual ~ITestScenario() = default;
+
+    virtual bool Initialize(TFileHandle& fileHandle)
+    {
+        Y_UNUSED(fileHandle);
+        return true;
+    }
+
+    virtual ui32 GetThreadCount() const = 0;
+
+    virtual ITestScenarioThread& GetThread(ui32 index) const = 0;
+};
+
+using ITestScenarioPtr = std::shared_ptr<ITestScenario>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestExecutorSettings
+{
+    ITestScenarioPtr TestScenario;
+    TString FilePath;
+    ui64 FileSize = 0;
+    TLog Log;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITestScenarioPtr CreateAlignedBlockTestScenario(
+    IConfigHolderPtr configHolder,
+    const TLog& log);
 
 ITestExecutorPtr CreateTestExecutor(
     IConfigHolderPtr configHolder,
     const TLog& log);
 
-}   // namespace NCloud::NBlockStore
+}   // namespace NCloud::NBlockStore::NTesting


### PR DESCRIPTION
Issue https://github.com/ydb-platform/nbs/issues/4336
Extracted from https://github.com/ydb-platform/nbs/pull/4234

Split `TTestExecutor` into two parts: the test logic itself and an executor proving file IO service for the test.

Also this PR fixes a data race where the read operation could start before the callback for the previous write operation had finished. This could result in a false-positive data verification error (the behavior is well-observed when lowering the alternate phase duration to 1s and file size to 1GiB).