### PR TITLE
Enable symbolizing for ASAN errors in examples

### DIFF
--- a/example/3-start_nbs.sh
+++ b/example/3-start_nbs.sh
@@ -8,6 +8,8 @@ SECURE_SERVER_PORT=${SECURE_SERVER_PORT:-9768}
 MON_PORT=${MON_PORT:-8766}
 source ./prepare_binaries.sh || exit 1
 
+export ASAN_SYMBOLIZER_PATH=$(../ya tool llvm-symbolizer --print-path)
+
 echo "First NBS http://localhost:$MON_PORT/blockstore/service"
 
 nbsd \

--- a/example/3-start_nbs2.sh
+++ b/example/3-start_nbs2.sh
@@ -8,6 +8,8 @@ SECURE_SERVER_PORT=${SECURE_SERVER_PORT:-9788}
 MON_PORT=${MON_PORT:-8786}
 source ./prepare_binaries.sh || exit 1
 
+export ASAN_SYMBOLIZER_PATH=$(../ya tool llvm-symbolizer --print-path)
+
 echo "Second NBS http://localhost:$MON_PORT/blockstore/service"
 
 nbsd \

--- a/example/4-start_disk_agent.sh
+++ b/example/4-start_disk_agent.sh
@@ -10,6 +10,8 @@ find_bin_dir() {
 BIN_DIR=`find_bin_dir`
 source ./prepare_binaries.sh || exit 1
 
+export ASAN_SYMBOLIZER_PATH=$(../ya tool llvm-symbolizer --print-path)
+
 blockstore-client ExecuteAction --action DiskRegistrySetWritableState --verbose error --input-bytes '{"State":true}'
 if [ $? -ne 0 ]; then
     echo "Can't set writable state for disk registry"


### PR DESCRIPTION
Теперь символифицируются краши ASAN.
Для сборки добавил себе с ~/.ya/ya.conf
```
[flags]
SANITIZER_TYPE="address"

[[target_platform]]
platform_name = "default-linux-x86_64"
build_type = "relwithdebinfo"

[target_platform.flags]
FORCE_STATIC_LINKING="yes"
SKIP_JUNK="yes"
USE_EAT_MY_DATA="yes"
DEBUGINFO_LINES_ONLY="yes"
```