### PR TITLE
[NBS] Make request to VolumeThrottlingManager fail fast

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor_update_volume_throttling_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_update_volume_throttling_config.cpp
@@ -149,7 +149,9 @@ void TServiceActor::HandleUpdateVolumeThrottlingConfig(
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
     if (!Config->GetVolumeThrottlingManagerEnabled()) {
-        auto error = MakeError(E_FAIL, "VolumeThrottlingManager is disabled");
+        auto error = MakeError(
+            E_PRECONDITION_FAILED,
+            "VolumeThrottlingManager is disabled");
         auto response = std::make_unique<
             TEvService::TEvUpdateVolumeThrottlingConfigResponse>(
             std::move(error));


### PR DESCRIPTION
- If VolumeThrottlingManager is disabled (`VolumeThrottlingManagerEnabled` is `false`) we don't get response. Send it immediatly 
- Add timeout to `VolumeThrottlingManager` response