### PR TITLE
fix printf linter errors in arcadia ci

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nbs/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/ya.make
@@ -1,5 +1,10 @@
 GO_LIBRARY()
 
+SET(
+    GO_VET_FLAGS
+    -printf=false
+)
+
 SRCS(
     client.go
     factory.go

--- a/cloud/disk_manager/internal/pkg/clients/nfs/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/ya.make
@@ -1,5 +1,10 @@
 GO_LIBRARY()
 
+SET(
+    GO_VET_FLAGS
+    -printf=false
+)
+
 SRCS(
     client.go
     endpoint_picker.go

--- a/cloud/disk_manager/internal/pkg/common/ya.make
+++ b/cloud/disk_manager/internal/pkg/common/ya.make
@@ -1,5 +1,10 @@
 GO_LIBRARY()
 
+SET(
+    GO_VET_FLAGS
+    -printf=false
+)
+
 SRCS(
     assert.go
     channel_with_cancellation.go

--- a/cloud/disk_manager/internal/pkg/dataplane/url/common/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/common/ya.make
@@ -1,5 +1,10 @@
 GO_LIBRARY()
 
+SET(
+    GO_VET_FLAGS
+    -printf=false
+)
+
 SRCS(
     errors.go
     http_client.go

--- a/cloud/disk_manager/internal/pkg/facade/interceptor.go
+++ b/cloud/disk_manager/internal/pkg/facade/interceptor.go
@@ -86,7 +86,7 @@ var (
 
 func convertError(err error) error {
 	if errors.CanRetry(err) {
-		return grpc_status.Errorf(grpc_codes.Unavailable, err.Error())
+		return grpc_status.Errorf(grpc_codes.Unavailable, "%s", err.Error())
 	}
 
 	return err

--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
@@ -108,7 +108,7 @@ func (t *deleteDiskTask) deleteDisk(
 	}
 
 	// Only overlay disks (created from image) should be released.
-	if diskMeta != nil && len(diskMeta.SrcImageID) != 0 {
+	if len(diskMeta.SrcImageID) != 0 {
 		taskID, err = t.poolService.ReleaseBaseDisk(
 			headers.SetIncomingIdempotencyKey(
 				ctx,

--- a/cloud/tasks/errors/ya.make
+++ b/cloud/tasks/errors/ya.make
@@ -1,5 +1,10 @@
 GO_LIBRARY()
 
+SET(
+    GO_VET_FLAGS
+    -printf=false
+)
+
 SRCS(
     errors.go
 )

--- a/cloud/tasks/persistence/ydb_logger.go
+++ b/cloud/tasks/persistence/ydb_logger.go
@@ -65,17 +65,17 @@ func (l *logger) Log(ctx context.Context, msg string, fields ...ydb_log.Field) {
 
 	switch ydb_log.LevelFromContext(ctx) {
 	case ydb_log.TRACE:
-		logging.Trace(ctx, msg)
+		logging.Trace(ctx, "%s", msg)
 	case ydb_log.DEBUG:
-		logging.Debug(ctx, msg)
+		logging.Debug(ctx, "%s", msg)
 	case ydb_log.INFO:
-		logging.Info(ctx, msg)
+		logging.Info(ctx, "%s", msg)
 	case ydb_log.WARN:
-		logging.Warn(ctx, msg)
+		logging.Warn(ctx, "%s", msg)
 	case ydb_log.ERROR:
-		logging.Error(ctx, msg)
+		logging.Error(ctx, "%s", msg)
 	case ydb_log.FATAL:
-		logging.Fatal(ctx, msg)
+		logging.Fatal(ctx, "%s", msg)
 	default:
 	}
 }

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -592,7 +592,7 @@ func lockAndExecuteTask(
 
 	runCtx, span := tracing.StartSpanWithSampling(
 		runCtx,
-		fmt.Sprintf(taskInfo.TaskType),
+		taskInfo.TaskType,
 		taskInfo.GenerationID <= maxSampledTaskGeneration, // sampled
 		tracing.WithAttributes(
 			tracing.AttributeString("task_id", taskInfo.ID),


### PR DESCRIPTION
добавил в ya.make
```
SET(
    GO_VET_FLAGS
    -printf=false
)
```

т.к. аркадийный ci ругается подобным образом 
```
$S/cloud/disk_manager/internal/pkg/facade/interceptor.go:89:53: "printf: non-constant format string in call to google.golang.org/grpc/status.Errorf"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:28:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Error"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:33:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Error"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:43:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Warn"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:48:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Warn"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:58:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Info"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:63:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Info"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:73:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Debug"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:78:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Debug"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:28:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Error"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:33:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Error"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:43:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Warn"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:48:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Warn"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:58:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Info"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:63:20: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Info"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:73:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Debug"
$S/cloud/disk_manager/internal/pkg/clients/nbs/factory.go:78:21: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/logging.Debug"
$S/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_image_task.go:128:46: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/errors.NewSilentNonRetriableErrorf"
$S/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_image_task.go:130:39: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/errors.NewNonRetriableErrorf"
$S/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_snapshot_task.go:128:46: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/errors.NewSilentNonRetriableErrorf"
$S/cloud/disk_manager/internal/pkg/services/disks/create_disk_from_snapshot_task.go:130:39: "printf: non-constant format string in call to a.yandex-team.ru/cloud/tasks/errors.NewNonRetriableErrorf"
```

при этом то что в этих местах не константная format строка совершенно нормально, т.к. это просто обертки над printf, отключить точечно в выбранных строчках с помощью директив `//nolint` не получилось т.к. используется голый govet, который их не поддерживает. В итоге в пакетах где возникала эта проблема отключил printf линтер