### PR TITLE
[NBS] Add volatile throttling info to volume monpage

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -506,6 +506,7 @@ private:
     void RenderMigrationStatus(IOutputStream& out) const;
     void RenderResyncStatus(IOutputStream& out) const;
     void RenderLaggingStatus(IOutputStream& out) const;
+    void RenderAppliedVolumeThrottlingRule(IOutputStream& out) const;
     void RenderLaggingStateForDevice(
         IOutputStream& out,
         const NProto::TDeviceConfig& d);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -2410,8 +2410,8 @@ void TVolumeActor::RenderAppliedVolumeThrottlingRule(IOutputStream& out) const
     }
 
     if (!rule.HasCoefficients() &&
-        rule.GetSelectorCase() == NCloud::NBlockStore::NProto::
-                                      TVolumeThrottlingRule::SELECTOR_NOT_SET)
+        rule.GetSelectorCase() ==
+            NProto::TVolumeThrottlingRule::SELECTOR_NOT_SET)
     {
         HTML (out) {
             DIV () {


### PR DESCRIPTION
## If no rule applied to volume:

<img width="744" height="870" alt="image" src="https://github.com/user-attachments/assets/1105ebd1-18c3-406b-8a8b-0aa4c25d9ced" />

## If specific disk rule applied:

You can achieve that by running (after setup, disk creation (`vol0` in this example) and mount):
```shell
./blockstore-client.sh updatevolumethrottlingconfig --proto --input nbs/nbs-volume-throttling.txt
```

<img width="744" height="870" alt="image" src="https://github.com/user-attachments/assets/bc647442-4712-48c2-a98b-fb5ba52040ea" />


Though there're two rules...
https://github.com/ydb-platform/nbs/blob/a8a30c1a4dd3d2d393681e905cf948e4666fb019/example/nbs/nbs-volume-throttling.txt#L1-L22
...specific disk rule (one that target disks by their ID) prevails

## If filter disk rule applied:

You can achieve that by running the same command from the previous step, but changing Version to 2 and deleting the second rule:

<img width="744" height="870" alt="image" src="https://github.com/user-attachments/assets/dfe414c4-32f9-4af2-b104-62860dc3f3b6" />