### PR TITLE
Fix broken build for "cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/ut/unittest"

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
@@ -37,7 +37,7 @@ Y_UNIT_TEST_SUITE(ValidateTest)
             "0",    // alternatingPhase
             maxWriteRequestCount);
 
-        auto executor = CreateTestExecutor(
+        auto executor = NTesting::CreateTestExecutor(
             configHolder,
             logging->CreateLog("ETERNAL_EXECUTOR")
         );


### PR DESCRIPTION
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/17813006975/1/nebius-x86-64/summary/1/ya-test.html#FAIL_BUILD

```
test name                                                                    | elapsed | status
---------------------------------------------------------------------------- | ------- | ----------
cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/ut/unittest | 0.000s  | FAIL BUILD
```