### PR TITLE
Describing of secondary disk when primary volume no longer exists (#4…

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -121,6 +121,7 @@ using TValue =
     xxx(UnexpectedCookie)                                                      \
     xxx(MultiAgentRequestAffectsTwoDevices)                                    \
     xxx(ChecksumCalculationError)                                              \
+    xxx(LogicalDiskIdMismatch)                                                 \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/api/stats_service.h
+++ b/cloud/blockstore/libs/storage/api/stats_service.h
@@ -138,6 +138,7 @@ struct TEvStatsService
     struct TVolumeSelfCounters
     {
         const TString DiskId;
+        const bool IsLocalMount;
         const bool HasClients;
         const bool IsPreempted;
         TVolumeSelfCountersPtr VolumeSelfCounters;
@@ -145,11 +146,13 @@ struct TEvStatsService
 
         TVolumeSelfCounters(
                 TString diskId,
+                bool isLocalMount,
                 bool hasClients,
                 bool isPreempted,
                 TVolumeSelfCountersPtr volumeCounters,
                 ui32 failedBoots)
             : DiskId(std::move(diskId))
+            , IsLocalMount(isLocalMount)
             , HasClients(hasClients)
             , IsPreempted(isPreempted)
             , VolumeSelfCounters(std::move(volumeCounters))
@@ -158,11 +161,13 @@ struct TEvStatsService
 
         TVolumeSelfCounters(
                 TString diskId,
+                bool isLocalMount,
                 bool hasClients,
                 bool isPreempted,
                 TVolumeSelfCountersPtr volumeCounters)
             : TVolumeSelfCounters(
                 std::move(diskId),
+                isLocalMount,
                 hasClients,
                 isPreempted,
                 std::move(volumeCounters),

--- a/cloud/blockstore/libs/storage/core/volume_label.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_label.cpp
@@ -126,4 +126,9 @@ TString GetLogicalDiskId(const TString& diskId)
     return diskId;
 }
 
+bool IsSecondaryDiskId(const TString& diskId)
+{
+    return diskId.EndsWith(SecondaryDiskSuffix);
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_label.h
+++ b/cloud/blockstore/libs/storage/core/volume_label.h
@@ -31,4 +31,7 @@ TString GetSecondaryDiskId(const TString& diskId);
 // Remove suffix of secondary disk if needed.
 TString GetLogicalDiskId(const TString& diskId);
 
+// Returns whether the diskId has a secondary disk suffix.
+bool IsSecondaryDiskId(const TString& diskId);
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/volume_label_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/volume_label_ut.cpp
@@ -135,6 +135,8 @@ Y_UNIT_TEST_SUITE(TDiskIdTest)
         UNIT_ASSERT_VALUES_EQUAL("disk-copy", GetSecondaryDiskId("disk"));
         UNIT_ASSERT_VALUES_EQUAL("disk", GetLogicalDiskId("disk"));
         UNIT_ASSERT_VALUES_EQUAL("disk", GetLogicalDiskId("disk-copy"));
+        UNIT_ASSERT_VALUES_EQUAL(false, IsSecondaryDiskId("disk"));
+        UNIT_ASSERT_VALUES_EQUAL(true, IsSecondaryDiskId("disk-copy"));
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_describe.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_describe.cpp
@@ -90,7 +90,7 @@ void TDescribeVolumeActor::DescribeVolume(const TActorContext& ctx)
 void TDescribeVolumeActor::DescribeDiskRegistryVolume(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvDiskRegistry::TEvDescribeDiskRequest>();
-    request->Record.SetDiskId(DiskId);
+    request->Record.SetDiskId(Volume.GetDiskId());
 
     NCloud::Send(
         ctx,

--- a/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
@@ -2,8 +2,7 @@
 
 #include <cloud/blockstore/libs/storage/api/disk_registry.h>
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
-
-#include <chrono>
+#include <cloud/blockstore/libs/storage/core/volume_label.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -13,7 +12,55 @@ using namespace NKikimr;
 
 using namespace std::chrono_literals;
 
+namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
+
+void CreateSimpleSsdDisk(TServiceClient& service, const TString& diskId)
+{
+    service.CreateVolume(
+        diskId,
+        2_GB / DefaultBlockSize,
+        DefaultBlockSize,
+        "",   // folderId
+        "",   // cloudId
+        NCloud::NProto::STORAGE_MEDIA_SSD,
+        NProto::TVolumePerformanceProfile(),
+        TString(),   // placementGroupId
+        0,           // placementPartitionIndex
+        0,           // partitionsCount
+        NProto::TEncryptionSpec());
+}
+
+void CreateSimpleSsdNonreplDisk(TServiceClient& service, const TString& diskId)
+{
+    service.CreateVolume(
+        diskId,
+        1_GB / DefaultBlockSize,
+        DefaultBlockSize,
+        "",   // folderId
+        "",   // cloudId
+        NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+        NProto::TVolumePerformanceProfile(),
+        TString(),   // placementGroupId
+        0,           // placementPartitionIndex
+        0,           // partitionsCount
+        NProto::TEncryptionSpec());
+}
+
+bool IsPathDoesNotExistsError(const NProto::TError& error)
+{
+    if (HasError(error) &&
+        FACILITY_FROM_CODE(error.GetCode()) == FACILITY_SCHEMESHARD)
+    {
+        const auto status = static_cast<NKikimrScheme::EStatus>(
+            STATUS_FROM_CODE(error.GetCode()));
+        return status == NKikimrScheme::StatusPathDoesNotExist;
+    }
+    return false;
+}
+
+}   // namespace
 
 Y_UNIT_TEST_SUITE(TServiceDestroyTest)
 {
@@ -83,23 +130,6 @@ Y_UNIT_TEST_SUITE(TServiceDestroyTest)
                 UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
             }
         }
-    }
-
-    void CreateSimpleSsdDisk(TServiceClient& service, const TString& diskId)
-    {
-        service.CreateVolume(
-            diskId,
-            2_GB / DefaultBlockSize,
-            DefaultBlockSize,
-            "",         // folderId
-            "",    // cloudId
-            NCloud::NProto::STORAGE_MEDIA_SSD,
-            NProto::TVolumePerformanceProfile(),
-            TString(),  // placementGroupId
-            0,          // placementPartitionIndex
-            0,          // partitionsCount
-            NProto::TEncryptionSpec()
-        );
     }
 
     Y_UNIT_TEST(ShouldDestroyAnyDiskByDefault)
@@ -374,6 +404,126 @@ Y_UNIT_TEST_SUITE(TServiceDestroyTest)
                 response->GetStatus(),
                 response->GetError());
         }
+    }
+
+    Y_UNIT_TEST(ShouldDestroyPrimaryAndSecondary)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        config.SetAllocationUnitNonReplicatedSSD(1);
+        ui32 nodeIdx = SetupTestEnv(env, config);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        const TString diskId = "disk1";
+
+        // Create secondary volume
+        CreateSimpleSsdNonreplDisk(service, GetSecondaryDiskId(diskId));
+
+        // Primary and secondary volume should be described as secondary
+        auto response = service.DescribeVolume(diskId);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        response = service.DescribeVolume(GetSecondaryDiskId(diskId));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        // Create primary volume
+        CreateSimpleSsdDisk(service, diskId);
+
+        // Primary and secondary volume should be described as-as
+        response = service.DescribeVolume(diskId);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            diskId,
+            response->Record.GetVolume().GetDiskId());
+
+        response = service.DescribeVolume(GetSecondaryDiskId(diskId));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        // Destroy primary volume
+        service.DestroyVolume(
+            diskId,
+            false,   // destroyIfBroken
+            false,   // sync
+            0,       // fillGeneration
+            false    // exactDiskIdMatch
+        );
+
+        // adjust time to trigger pipe connection destroy
+        env.GetRuntime().AdvanceCurrentTime(TDuration::Minutes(1));
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+        // Primary and secondary volume should be described as secondary
+        response = service.DescribeVolume(diskId);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        response = service.DescribeVolume(GetSecondaryDiskId(diskId));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        // Destroying primary volume should't touch secondary volume when
+        // exactDiskIdMatch is set
+        service.DestroyVolume(
+            diskId,
+            false,   // destroyIfBroken
+            false,   // sync
+            0,       // fillGeneration
+            true     // exactDiskIdMatch
+        );
+
+        // Primary and secondary volume should be described as secondary since
+        // secondary alive
+        response = service.DescribeVolume(diskId);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        response = service.DescribeVolume(GetSecondaryDiskId(diskId));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetSecondaryDiskId(diskId),
+            response->Record.GetVolume().GetDiskId());
+
+        // Destroy secondary volume using primary diskId (exactDiskIdMatch is
+        // not set)
+        service.DestroyVolume(
+            diskId,
+            false,   // destroyIfBroken
+            false,   // sync
+            0,       // fillGeneration
+            false    // exactDiskIdMatch
+        );
+
+        // Both volumes should be deleted and described as
+        // StatusPathDoesNotExist
+        service.SendDescribeVolumeRequest(diskId);
+        response = service.RecvDescribeVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            true,
+            IsPathDoesNotExistsError(response->GetError()),
+            FormatError(response->GetError()));
+
+        service.SendDescribeVolumeRequest(GetSecondaryDiskId(diskId));
+        response = service.RecvDescribeVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            true,
+            IsPathDoesNotExistsError(response->GetError()),
+            FormatError(response->GetError()));
     }
 }
 

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
@@ -7,7 +7,6 @@
 #include <cloud/storage/core/libs/common/helpers.h>
 
 #include <contrib/ydb/core/tx/tx_proxy/proxy.h>
-
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -25,16 +24,30 @@ constexpr TDuration Timeout = TDuration::Seconds(20);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Finds a disk in the SchemaShard by DiskId. The search starts with the
+// deprecated path naming scheme and then performed with the actual path naming
+// scheme. If a disk is not found, a disk with a "-copy" suffix in its name is
+// searched for.
 class TDescribeVolumeActor final
     : public TActorBootstrapped<TDescribeVolumeActor>
 {
 private:
-    const TRequestInfoPtr RequestInfo;
+    enum class EState
+    {
+        DescribePrimaryDeprecated,   // Search in SchemeShard with an deprecated
+                                     // path
 
+        DescribePrimary,   // Search in SchemeShard with an actual path
+
+        DescribeSecondary,   // Describe SchemeShard for a disk with an actual
+                             // path and name with suffix "-copy"
+    };
+
+    const TRequestInfoPtr RequestInfo;
     const TStorageConfigPtr Config;
     const TString DiskId;
 
-    bool FallbackRequest = false;
+    EState State = EState::DescribePrimaryDeprecated;
 
 public:
     TDescribeVolumeActor(
@@ -111,10 +124,16 @@ TString TDescribeVolumeActor::GetFullPath() const
     TStringBuilder fullPath;
     fullPath << Config->GetSchemeShardDir() << '/';
 
-    if (!FallbackRequest) {
-        fullPath << DiskIdToPathDeprecated(DiskId);
-    } else {
-        fullPath << DiskIdToPath(DiskId);
+    switch (State) {
+        case EState::DescribePrimaryDeprecated:
+            fullPath << DiskIdToPathDeprecated(DiskId);
+            break;
+        case EState::DescribePrimary:
+            fullPath << DiskIdToPath(DiskId);
+            break;
+        case EState::DescribeSecondary:
+            fullPath << DiskIdToPath(GetSecondaryDiskId(DiskId));
+            break;
     }
 
     return fullPath;
@@ -150,11 +169,32 @@ void TDescribeVolumeActor::HandleDescribeSchemeResponse(
             auto status =
                 static_cast<NKikimrScheme::EStatus>(STATUS_FROM_CODE(error.GetCode()));
             // TODO: return E_NOT_FOUND instead of StatusPathDoesNotExist
+
+            LOG_TRACE(
+                ctx,
+                TBlockStoreComponents::SS_PROXY,
+                "Describe request error for volume %s %s %s",
+                DiskId.c_str(),
+                GetFullPath().Quote().data(),
+                FormatError(error).c_str());
+
             if (status == NKikimrScheme::StatusPathDoesNotExist) {
-                if (!FallbackRequest) {
-                    FallbackRequest = true;
-                    DescribeVolume(ctx);
-                    return;
+                switch (State) {
+                    case EState::DescribePrimaryDeprecated: {
+                        State = EState::DescribePrimary;
+                        DescribeVolume(ctx);
+                        return;
+                    }
+                    case EState::DescribePrimary: {
+                        if (IsSecondaryDiskId(DiskId)) {
+                            break;
+                        }
+                        State = EState::DescribeSecondary;
+                        DescribeVolume(ctx);
+                        return;
+                    }
+                    case EState::DescribeSecondary:
+                        break;
                 }
             }
         }

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -130,6 +130,11 @@ struct TVolumeStatsInfo
     NProto::TVolume VolumeInfo;
     ui64 VolumeTabletId = 0;
 
+    NMonitoring::TDynamicCounters::TCounterPtr IsStartedCounter;
+
+    bool IsLocalMount;
+    NMonitoring::TDynamicCounters::TCounterPtr IsLocalMountCounter;
+
     TDiskPerfData PerfCounters;
     NBlobMetrics::TBlobLoadMetrics OffsetBlobMetrics;
     TInstant ApproximateStartTs;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -12,6 +12,8 @@
 #include <cloud/blockstore/libs/ydbstats/ydbrow.h>
 #include <cloud/blockstore/libs/ydbstats/ydbstats.h>
 
+#include <cloud/blockstore/libs/diagnostics/hostname.h>
+
 #include <cloud/storage/core/config/features.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -92,7 +94,7 @@ NMonitoring::TDynamicCounters::TCounterPtr GetCounterToCheck(
 {
     auto volumeCounters = counters.GetSubgroup("counters", "blockstore")
         ->GetSubgroup("component", "service_volume")
-        ->GetSubgroup("host", "cluster")
+        ->GetSubgroup("host", GetShortHostName())
         ->GetSubgroup("volume", DefaultDiskId)
         ->GetSubgroup("cloud", DefaultCloudId)
         ->GetSubgroup("folder", DefaultFolderId);
@@ -103,7 +105,7 @@ bool VolumeMetricsExists(NMonitoring::TDynamicCounters& counters)
 {
     auto volumeCounters = counters.GetSubgroup("counters", "blockstore")
         ->GetSubgroup("component", "service_volume")
-        ->GetSubgroup("host", "cluster");
+        ->GetSubgroup("host", GetShortHostName());
 
     return (bool)volumeCounters->FindSubgroup("volume", DefaultDiskId);
 }
@@ -208,6 +210,7 @@ void SendDiskStats(
 
     auto volumeMsg = std::make_unique<TEvStatsService::TEvVolumeSelfCounters>(
         diskId,
+        true, // isLocalMount
         volumeOptions & EVolumeTestOptions::VOLUME_HASCLIENTS,
         false,
         std::move(volumeCounters));
@@ -1347,7 +1350,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             ui64 actual = *runtime.GetAppData(0).Counters
                 ->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service_volume")
-                ->GetSubgroup("host", "cluster")
+                ->GetSubgroup("host", GetShortHostName())
                 ->GetSubgroup("volume", "vol0")
                 ->GetSubgroup("cloud", DefaultCloudId)
                 ->GetSubgroup("folder", DefaultFolderId)
@@ -1360,7 +1363,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             ui64 actual = *runtime.GetAppData(0).Counters
                 ->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service_volume")
-                ->GetSubgroup("host", "cluster")
+                ->GetSubgroup("host", GetShortHostName())
                 ->GetSubgroup("volume", "vol0")
                 ->GetSubgroup("cloud", DefaultCloudId)
                 ->GetSubgroup("folder", DefaultFolderId)

--- a/cloud/blockstore/libs/storage/testlib/service_client.cpp
+++ b/cloud/blockstore/libs/storage/testlib/service_client.cpp
@@ -83,14 +83,17 @@ std::unique_ptr<TEvService::TEvDestroyVolumeRequest> TServiceClient::CreateDestr
     const TString& diskId,
     bool destroyIfBroken,
     bool sync,
-    ui64 fillGeneration)
+    ui64 fillGeneration,
+    bool exactDiskIdMatch)
 {
     auto request = std::make_unique<TEvService::TEvDestroyVolumeRequest>();
     PrepareRequestHeaders(*request);
+    request->Record.MutableHeaders()->SetExactDiskIdMatch(exactDiskIdMatch);
     request->Record.SetDiskId(diskId);
     request->Record.SetDestroyIfBroken(destroyIfBroken);
     request->Record.SetSync(sync);
     request->Record.SetFillGeneration(fillGeneration);
+
     return request;
 }
 

--- a/cloud/blockstore/libs/storage/testlib/service_client.h
+++ b/cloud/blockstore/libs/storage/testlib/service_client.h
@@ -105,7 +105,8 @@ public:
         const TString& diskId = DefaultDiskId,
         bool destroyIfBroken = false,
         bool sync = false,
-        ui64 fillGeneration = 0);
+        ui64 fillGeneration = 0,
+        bool exactDiskIdMatch = false);
 
     std::unique_ptr<TEvService::TEvAssignVolumeRequest> CreateAssignVolumeRequest(
         const TString& diskId = DefaultDiskId,

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -535,6 +535,7 @@ void TVolumeActor::SendVolumeSelfCounters(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvStatsService::TEvVolumeSelfCounters>(
         State->GetConfig().GetDiskId(),
+        !State->GetLocalMountClientId().empty(),
         State->HasActiveClients(ctx.Now()),
         State->IsPreempted(SelfId()),
         std::move(VolumeSelfCounters),

--- a/cloud/blockstore/public/api/protos/headers.proto
+++ b/cloud/blockstore/public/api/protos/headers.proto
@@ -96,4 +96,9 @@ message THeaders
 
     // Id of the cell request came from
     string CellId = 15;
+
+    // It requires an exact match of the DiskId.
+    // When set it does not allow the execution of request on a disk that is a
+    // copy with a mangled name with an additional suffix.
+    bool ExactDiskIdMatch = 16;
 }


### PR DESCRIPTION
…321)

Продолжение https://github.com/ydb-platform/nbs/issues/2999

1. Теперь если основной диск уже удален, то мы находим второй вместо него
2. При удалении диска, если существует исходник и копия, то удаляется сначала исходник
3. Если исходника нет, но есть копия, то при удалении диска с именем исходника смотрим на флаг UseStrictDiskId, если флаг задан, то копия не удалится, так как по факту у него другое имя. Но если флаг не задан, то копия удалится, это чтобы диск менеджер имел возможность удалить копию, используя имя исходника.
4. Если нужно удалить именно копию, то тут проблем нет, так как поиск не транзитивен - по имени исходника находим и исходник и копию, а вот по имени копии исходник уже не находим.