### PR TITLE
switch to deadlines in collect garbage request

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1333,4 +1333,10 @@ message TStorageServiceConfig
     // Timeout for dynamic node registration via discovery service
     // (in milliseconds).
     optional uint32 DynamicNodeRegistrationTimeout = 459;
+
+    // Timeout for collect garbage on SSD (in milliseconds).
+    optional uint32 CollectGarbageTimeoutSSD = 460;
+
+    // Timeout for collect garbage on HDD (in milliseconds).
+    optional uint32 CollectGarbageTimeoutHDD = 461;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -11,6 +11,8 @@ namespace NCloud::NBlockStore {
 using TValue =
     std::variant<TString, int, ui16, ui32, ui64, TBlockRange64, TStringBuf>;
 
+using TCritEventParams = TVector<std::pair<TStringBuf, TValue>>;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_CRITICAL_EVENTS(xxx)                                        \
@@ -132,9 +134,9 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+        const TCritEventParams& keyValues);                                    \
     TString Report##name(                                                      \
-        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+        const TCritEventParams& keyValues);                                    \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 
@@ -145,9 +147,9 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+        const TCritEventParams& keyValues);                                    \
     TString Report##name(                                                      \
-        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+        const TCritEventParams& keyValues);                                    \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE
 
@@ -159,9 +161,9 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \
         const TString& message,                                                \
-        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+        const TCritEventParams& keyValues);                                    \
     TString Report##name(                                                      \
-        const TVector<std::pair<TStringBuf, TValue>>& keyValues);              \
+        const TCritEventParams& keyValues);                                    \
     const TString GetCriticalEventFor##name();                                 \
 // BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -631,6 +631,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(EnableDataIntegrityValidationForYdbBasedDisks,       bool,   false    )\
                                                                                \
     xxx(TrimFreshLogTimeout,                  TDuration,   Seconds(0)         )\
+    xxx(CollectGarbageTimeoutSSD,             TDuration,   Seconds(0)         )\
+    xxx(CollectGarbageTimeoutHDD,             TDuration,   Seconds(0)         )\
                                                                                \
     xxx(DynamicNodeRegistrationTimeout,       TDuration,   Seconds(5)         )\
     xxx(HiveLocalServiceCpuResourceLimit,     ui64,        0                  )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -721,6 +721,8 @@ public:
     GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() const;
 
     [[nodiscard]] TDuration GetTrimFreshLogTimeout() const;
+    [[nodiscard]] TDuration GetCollectGarbageTimeoutSSD() const;
+    [[nodiscard]] TDuration GetCollectGarbageTimeoutHDD() const;
 
     [[nodiscard]] bool GetEnableDataIntegrityValidationForYdbBasedDisks() const;
 

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -281,9 +281,9 @@ std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
         TBlockStoreComponents::END,
         GetComponentName);
 
-    for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
-        runtime->SetLogPriority(i, NLog::PRI_DEBUG);
-    }
+    // for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
+    //     runtime->SetLogPriority(i, NLog::PRI_DEBUG);
+    // }
     // runtime->SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
     runtime->SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_ERROR);
 

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -7710,7 +7710,6 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
         runtime->DispatchEvents(options);
 
         UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
-        UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
         UNIT_ASSERT_VALUES_UNEQUAL(0, trimCounter->Val());
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -281,9 +281,9 @@ std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
         TBlockStoreComponents::END,
         GetComponentName);
 
-    // for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
-    //     runtime->SetLogPriority(i, NLog::PRI_DEBUG);
-    // }
+    for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
+        runtime->SetLogPriority(i, NLog::PRI_DEBUG);
+    }
     // runtime->SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
     runtime->SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_ERROR);
 
@@ -7645,9 +7645,12 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
 
     Y_UNIT_TEST(ShouldRaiseCriticalEventIfTrimFreshLogTimesOut)
     {
+        constexpr ui32 FreshChannelId = 4;
+
         auto config = DefaultConfig();
         config.SetFreshChannelCount(1);
         config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFlushThreshold(4_MB);
         config.SetTrimFreshLogTimeout(TDuration::Seconds(1).MilliSeconds());
 
         auto runtime = PrepareTestActorRuntime(config);
@@ -7674,13 +7677,15 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
         bool trimSeen = false;
         bool trimCompletedSeen = false;
 
-        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
                 switch (event->GetTypeRewrite()) {
-                    case TEvBlobStorage::EvCollectGarbage: {
-                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
-                        if (msg->Channel == 4) {
+                    case TEvBlobStorage::EvCollectGarbageResult: {
+                        auto* msg =
+                            event->Get<TEvBlobStorage::TEvCollectGarbageResult>();
+                        if (msg->Channel == FreshChannelId) {
                             trimSeen = true;
-                            return TTestActorRuntime::EEventAction::DROP;
+                            msg->Status = NKikimrProto::EReplyStatus::DEADLINE;
                         }
                         break;
                     }
@@ -7691,7 +7696,7 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
                         break;
                     }
                 }
-                return TTestActorRuntime::DefaultObserverFunc(event);
+                return false;
             }
         );
 
@@ -7699,13 +7704,14 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
 
         // wait for trimfreshlog to complete
         TDispatchOptions options;
-        options.FinalEvents.emplace_back(
-            TEvPartitionCommonPrivate::EvTrimFreshLogCompleted);
+        options.CustomFinalCondition = [&] {
+            return trimCompletedSeen;
+        };
         runtime->DispatchEvents(options);
 
         UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
         UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
-        UNIT_ASSERT_VALUES_EQUAL(1, trimCounter->Val());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, trimCounter->Val());
     }
 }
 


### PR DESCRIPTION
This is a follow up for https://github.com/ydb-platform/nbs/pull/4266

We finally decided to support and use the deadline parameter in TEvBlobStorage::EvCollectGarbage.

According to the YDB team, this functionality has been available since 24-1, and in 25-1 tests for deadlines in the BS proxy were implemented. These tests are green, and since the functionality has not changed since 24-1, we may assume that it also works in 24-1.

Deadlines are now supported in both CollectGarbage and TrimFreshLog operations.