### PR TITLE
release fresh barrier in add blobs not at flush completion

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -90,8 +90,7 @@ public:
         , DeletionCommitId(deletionCommitId)
         , MaxBlocksInBlob(maxBlocksInBlob)
         , LogTitle(std::move(logTitle))
-    {
-    }
+    {}
 
     void Execute(const TActorContext& ctx, TPartitionDatabase& db)
     {

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -751,7 +751,6 @@ bool TPartitionActor::PrepareAddBlobs(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(tx);
-    Y_UNUSED(args);
 
     args.FlushedCommitIdsFromChannel = BuildFlushedCommitIdsFromChannel(
         args.FreshBlobs);

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -154,6 +154,12 @@ public:
         for (const auto& blob: Args.FreshBlobs) {
             ProcessNewBlob(ctx, db, blob);
             UpdateCompactionCounters(blob);
+
+            for (const auto& block: blob.Blocks) {
+                if (!block.IsStoredInDb) {
+                    State.GetTrimFreshLogBarriers().ReleaseBarrier(block.CommitId);
+                }
+            }
         }
 
         if (Args.Mode == ADD_COMPACTION_RESULT) {

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -148,21 +148,6 @@ struct TBlobCompactionInfo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TFlushedCommitId
-{
-    ui64 CommitId;
-    ui32 BlockCount;
-
-    TFlushedCommitId(ui64 commitId, ui32 blockCount)
-        : CommitId(commitId)
-        , BlockCount(blockCount)
-    {}
-};
-
-using TFlushedCommitIds = TVector<TFlushedCommitId>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 #define BLOCKSTORE_PARTITION_REQUESTS_PRIVATE(xxx, ...)                        \
     xxx(WriteBlob,                 __VA_ARGS__)                                \
     xxx(AddBlobs,                  __VA_ARGS__)                                \
@@ -774,15 +759,12 @@ struct TEvPartitionPrivate
     {
         ui32 FlushedFreshBlobCount;
         ui64 FlushedFreshBlobByteCount;
-        TFlushedCommitIds FlushedCommitIdsFromChannel;
 
         TFlushCompleted(
                 ui32 flushedFreshBlobCount,
-                ui64 flushedFreshBlobByteCount,
-                TFlushedCommitIds flushedCommitIdsFromChannel)
+                ui64 flushedFreshBlobByteCount)
             : FlushedFreshBlobCount(flushedFreshBlobCount)
             , FlushedFreshBlobByteCount(flushedFreshBlobByteCount)
-            , FlushedCommitIdsFromChannel(std::move(flushedCommitIdsFromChannel))
         {
         }
     };

--- a/cloud/blockstore/libs/storage/partition/part_tx.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_tx.cpp
@@ -1,0 +1,41 @@
+#include "part_tx.h"
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTxPartition::TAddBlobs::BuildFlushedCommitIdsFromChannel()
+{
+    TVector<ui64> commitIds;
+
+    for (const auto& blob: FreshBlobs) {
+        for (const auto& block: blob.Blocks) {
+            if (!block.IsStoredInDb) {
+                commitIds.push_back(block.CommitId);
+            }
+        }
+    }
+
+    if (!commitIds) {
+        return;
+    }
+
+    Sort(commitIds);
+
+    ui64 cur = commitIds.front();
+    ui32 cnt = 0;
+
+    for (const auto commitId: commitIds) {
+        if (commitId == cur) {
+            ++cnt;
+        } else {
+            FlushedCommitIdsFromChannel.emplace_back(cur, cnt);
+            cur = commitId;
+            cnt = 1;
+        }
+    }
+
+    FlushedCommitIdsFromChannel.emplace_back(cur, cnt);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -67,21 +67,6 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TFlushedCommitId
-{
-    ui64 CommitId;
-    ui32 BlockCount;
-
-    TFlushedCommitId(ui64 commitId, ui32 blockCount)
-        : CommitId(commitId)
-        , BlockCount(blockCount)
-    {}
-};
-
-using TFlushedCommitIds = TVector<TFlushedCommitId>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TTxPartition
 {
     using TBlockMark = NBlobMarkers::TBlockMark;
@@ -317,6 +302,17 @@ struct TTxPartition
 
     struct TAddBlobs
     {
+        struct TFlushedCommitId
+        {
+            ui64 CommitId;
+            ui32 BlockCount;
+
+            TFlushedCommitId(ui64 commitId, ui32 blockCount)
+                : CommitId(commitId)
+                , BlockCount(blockCount)
+            {}
+        };
+
         const TRequestInfoPtr RequestInfo;
 
         const ui64 CommitId;
@@ -332,7 +328,7 @@ struct TTxPartition
         const TVector<TBlobCompactionInfo> MergedBlobCompactionInfos;
 
         // fresh
-        TFlushedCommitIds FlushedCommitIdsFromChannel;
+        TVector<TFlushedCommitId> FlushedCommitIdsFromChannel;
 
         ui64 DeletionCommitId = 0;
 
@@ -357,12 +353,17 @@ struct TTxPartition
             , AffectedBlocks(std::move(affectedBlocks))
             , MixedBlobCompactionInfos(std::move(mixedBlobCompactionInfos))
             , MergedBlobCompactionInfos(std::move(mergedBlobCompactionInfos))
-        {}
+        {
+            BuildFlushedCommitIdsFromChannel();
+        }
 
         void Clear()
         {
             // nothing to do
         }
+
+    private:
+        void BuildFlushedCommitIdsFromChannel();
     };
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -67,6 +67,21 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TFlushedCommitId
+{
+    ui64 CommitId;
+    ui32 BlockCount;
+
+    TFlushedCommitId(ui64 commitId, ui32 blockCount)
+        : CommitId(commitId)
+        , BlockCount(blockCount)
+    {}
+};
+
+using TFlushedCommitIds = TVector<TFlushedCommitId>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TTxPartition
 {
     using TBlockMark = NBlobMarkers::TBlockMark;
@@ -315,6 +330,9 @@ struct TTxPartition
         const TAffectedBlocks AffectedBlocks;
         const TVector<TBlobCompactionInfo> MixedBlobCompactionInfos;
         const TVector<TBlobCompactionInfo> MergedBlobCompactionInfos;
+
+        // fresh
+        TFlushedCommitIds FlushedCommitIdsFromChannel;
 
         ui64 DeletionCommitId = 0;
 

--- a/cloud/blockstore/libs/storage/partition/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ya.make
@@ -50,6 +50,7 @@ SRCS(
     part_database.cpp
     part_schema.cpp
     part_state.cpp
+    part_tx.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
This is a follow up for https://github.com/ydb-platform/nbs/pull/4266

Currently, fresh blob barriers are released at flush completion. This is fine, but we calculate TrimFreshLogToCommitId for saving in meta during AddBlobs handling. This means that TrimFreshLogToCommitId is lower than the commit ID of the recently flushed data. If the tablet restarts before trimming the fresh log, it will reload all the fresh blobs from the recent flush again.

To solve this inefficiency, we can release fresh blob barriers during the execute phase of the AddBlobs transaction. This way, the TrimFreshLogToCommitId saved in meta will match the volatile TrimFreshLogToCommitId in state