### PR TITLE
adds UntrimmedFreshByteCountHardLimit to reject writes by untrimmed fresh byte count

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1333,4 +1333,7 @@ message TStorageServiceConfig
     // Timeout for dynamic node registration via discovery service
     // (in milliseconds).
     optional uint32 DynamicNodeRegistrationTimeout = 459;
+
+    // Maximum allowed untrimmed fresh byte count after which we start to reject writes.
+    optional uint32 UntrimmedFreshByteCountHardLimit = 460;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -355,6 +355,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(FreshByteCountThresholdForBackpressure,         ui32,   40_MB         )\
     xxx(FreshByteCountFeatureMaxValue,                  ui32,   10            )\
     xxx(FreshByteCountHardLimit,                        ui32,   256_MB        )\
+    xxx(UntrimmedFreshByteCountHardLimit,               ui32,   256_MB        )\
                                                                                \
     xxx(CleanupQueueBytesLimitForBackpressure,            ui64,   4_TB        )\
     xxx(CleanupQueueBytesThresholdForBackpressure,        ui64,   1_TB        )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -252,6 +252,7 @@ public:
     ui32 GetCleanupQueueBytesFeatureMaxValue() const;
     ui32 GetMaxWriteCostMultiplier() const;
     ui32 GetFreshByteCountHardLimit() const;
+    [[nodiscard]] ui32 GetUntrimmedFreshByteCountHardLimit() const;
     bool GetDiskSpaceScoreThrottlingEnabled() const;
 
     TDuration GetStatsUploadInterval() const;


### PR DESCRIPTION
Дополнительная защита на случай неполучения ответа при выставлении барьера для фрэш канала.