### PR TITLE
Make using for NYdb::ICredentialsProviderFactory

### DIFF
--- a/cloud/blockstore/libs/logbroker/iface/credentials_provider.cpp
+++ b/cloud/blockstore/libs/logbroker/iface/credentials_provider.cpp
@@ -5,12 +5,13 @@
 #include <contrib/ydb/public/sdk/cpp/client/iam/common/iam.h>
 
 #include <util/generic/overloaded.h>
+#include <util/string/cast.h>
 
 namespace NCloud::NBlockStore::NLogbroker {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::shared_ptr<NYdb::ICredentialsProviderFactory>
+std::shared_ptr<NYdbICredentialsProviderFactory>
 CreateCredentialsProviderFactory(const TLogbrokerConfig& config)
 {
     return std::visit(TOverloaded(
@@ -33,7 +34,7 @@ CreateCredentialsProviderFactory(const TLogbrokerConfig& config)
             });
 
         }, [] (std::monostate) {
-            return std::shared_ptr<NYdb::ICredentialsProviderFactory>();
+            return std::shared_ptr<NYdbICredentialsProviderFactory>();
         }), config.GetAuthConfig());
 }
 

--- a/cloud/blockstore/libs/logbroker/iface/credentials_provider.h
+++ b/cloud/blockstore/libs/logbroker/iface/credentials_provider.h
@@ -12,11 +12,13 @@ namespace NYdb {
 
 namespace NCloud::NBlockStore::NLogbroker {
 
+using NYdbICredentialsProviderFactory = NYdb::ICredentialsProviderFactory;
+
 class TLogbrokerConfig;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::shared_ptr<NYdb::ICredentialsProviderFactory>
+std::shared_ptr<NYdbICredentialsProviderFactory>
 CreateCredentialsProviderFactory(const TLogbrokerConfig& config);
 
 }   // namespace NCloud::NBlockStore::NLogbroker

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.cpp
@@ -89,14 +89,14 @@ private:
     std::unique_ptr<TBatch> Batch;
     std::optional<TContinuationToken> ContinuationToken;
 
-    std::shared_ptr<NYdb::ICredentialsProviderFactory>
+    std::shared_ptr<NYdbICredentialsProviderFactory>
         CredentialsProviderFactory;
 
 public:
     TService(
             TLogbrokerConfigPtr config,
             ILoggingServicePtr logging,
-            std::shared_ptr<NYdb::ICredentialsProviderFactory>
+            std::shared_ptr<NYdbICredentialsProviderFactory>
             credentialsProviderFactory)
         : Config(std::move(config))
         , Logging(std::move(logging))
@@ -306,7 +306,7 @@ private:
 IServicePtr CreateTopicAPIService(
     TLogbrokerConfigPtr config,
     ILoggingServicePtr logging,
-    std::shared_ptr<NYdb::ICredentialsProviderFactory>
+    std::shared_ptr<NYdbICredentialsProviderFactory>
         credentialsProviderFactory)
 {
     return std::make_shared<TService>(

--- a/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.h
+++ b/cloud/blockstore/libs/logbroker/topic_api_impl/topic_api.h
@@ -1,16 +1,9 @@
 #pragma once
 
+#include <cloud/blockstore/libs/logbroker/iface/credentials_provider.h>
 #include <cloud/blockstore/libs/logbroker/iface/public.h>
 
 #include <cloud/storage/core/libs/diagnostics/public.h>
-
-////////////////////////////////////////////////////////////////////////////////
-
-namespace NYdb {
-    class ICredentialsProviderFactory;
-}   // namespace NYdb
-
-////////////////////////////////////////////////////////////////////////////////
 
 namespace NCloud::NBlockStore::NLogbroker {
 
@@ -19,7 +12,7 @@ namespace NCloud::NBlockStore::NLogbroker {
 IServicePtr CreateTopicAPIService(
     TLogbrokerConfigPtr config,
     ILoggingServicePtr logging,
-    std::shared_ptr<NYdb::ICredentialsProviderFactory>
+    std::shared_ptr<NYdbICredentialsProviderFactory>
         credentialsProviderFactory);
 
 IServicePtr CreateTopicAPIService(


### PR DESCRIPTION
В аркадии ICredentialsProviderFactory лежит в другом неймспейсе и чтобы  патч был небольшой сделал using на NYdb::ICredentialsProviderFactory