### PR TITLE
Fix division by zero in ValidateTest::ValidateRange

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -561,6 +561,10 @@ public:
         if (config.HasAlternatingPhase()) {
             PhaseDuration =
                 TDuration::Parse(config.GetAlternatingPhase()).SecondsFloat();
+
+            Y_ENSURE(
+                PhaseDuration > 0,
+                "Alternating phase duration should be positive non-zero value");
         }
 
         WriteRate = config.GetWriteRate();

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -564,7 +564,7 @@ public:
 
             Y_ENSURE(
                 PhaseDuration > 0,
-                "Alternating phase duration should be positive non-zero value");
+                "Alternating phase duration should be a positive non-zero value");
         }
 
         WriteRate = config.GetWriteRate();

--- a/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(ValidateTest)
             100,  // writeRage
             1,    // requestBlockCount
             1,    // writeParts
-            "0",    // alternatingPhase
+            "",   // alternatingPhase
             maxWriteRequestCount);
 
         auto executor = NTesting::CreateTestExecutor(


### PR DESCRIPTION
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(ubsan)/17847114373/1/nebius-x86-64-ubsan/test_data/1/actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/ut/test-results/unittest/chunk0/testing_out_stuff/ut.err

```
###subtest-started:ValidateTest::ValidateRange
2025-09-19T04:25:34.533077Z :ETERNAL_EXECUTOR INFO: cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:124: Started TTestExecutor
/actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:590:31: runtime error: inf is outside the range of representable values of type 'unsigned long'
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0xf0 has a premature terminator entry at offset 0x100
warning: address range table at offset 0x120 has a premature terminator entry at offset 0x130
    #0 0x3dbf15d in NCloud::NBlockStore::NTesting::(anonymous namespace)::TAlignedBlockTestScenario::DoRequest /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:590:31
    #1 0x3dbf15d in NCloud::NBlockStore::NTesting::(anonymous namespace)::TAlignedBlockTestScenario::TWorker::Run(double, NCloud::NBlockStore::NTesting::ITestExecutorIOService&) /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:540:23
    #2 0x3dc8e97 in NCloud::NBlockStore::NTesting::(anonymous namespace)::TTestExecutor::TWorkerService::Run() /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:198:12
    #3 0x3dc526d in NCloud::NBlockStore::NTesting::(anonymous namespace)::TTestExecutor::Run() /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:129:18
    #4 0x185871f in NCloud::NBlockStore::NTestSuiteValidateTest::ValidateRange(unsigned long) /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp:44:9
    #5 0x185a23d in NCloud::NBlockStore::NTestSuiteValidateTest::TTestCaseValidateRange::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp:53:13
    #6 0x185c71e in NCloud::NBlockStore::NTestSuiteValidateTest::TCurrentTest::Execute()::'lambda'()::operator()() const /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp:20:1
    #7 0x1b8f5e9 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18
    #8 0x185ab26 in NCloud::NBlockStore::NTestSuiteValidateTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp:20:1
    #9 0x1b90f0c in NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19
    #10 0x1bb330c in NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44
    #11 0x7fc263629d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)
    #12 0x7fc263629e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)
    #13 0x1823028 in _start (/home/github/.ya/build/build_root/4o8q/001392/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/ut/range-validator-lib-ut+0x1823028) (BuildId: 88b1b5b696ea31c30ca6eb4c8ea216e58c786873)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /actions-runner/_work/nbs/nbs/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:590:31 in 
```