### PR TITLE
[DM] Add Size() method to Source interface and use it for estimating

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/common/transfer.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/common/transfer.go
@@ -52,7 +52,11 @@ type Source interface {
 	baseSource
 
 	Read(ctx context.Context, chunk *Chunk) error
+	// Represents total chunk count in the source.
 	ChunkCount(ctx context.Context) (uint32, error)
+	// Represents the actual data size to read. May be less
+	// than ChunkCount * chunkSize. Useful for estimating.
+	Size(ctx context.Context) (uint64, error)
 }
 
 type ShallowSource interface {

--- a/cloud/disk_manager/internal/pkg/dataplane/common/transfer_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/common/transfer_test.go
@@ -52,6 +52,11 @@ func (m *sourceMock) ChunkCount(ctx context.Context) (uint32, error) {
 	return args.Get(0).(uint32), args.Error(1)
 }
 
+func (m *sourceMock) Size(ctx context.Context) (uint64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
 func (m *sourceMock) Close(ctx context.Context) {
 	m.Called(ctx)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
@@ -420,7 +420,7 @@ func (t *createSnapshotFromDiskTask) setEstimate(
 	diskSource common.Source,
 ) error {
 
-	bytesToTransfer, err := nbs.GetDiskSourceBytesToRead(ctx, diskSource)
+	bytesToTransfer, err := diskSource.Size(ctx)
 	if err != nil {
 		return err
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_url_task.go
@@ -90,8 +90,13 @@ func (t *createSnapshotFromURLTask) Run(
 
 		t.state.ChunkCount = chunkCount
 
+		sourceSize, err := source.Size(ctx)
+		if err != nil {
+			return err
+		}
+
 		execCtx.SetEstimatedInflightDuration(performance.Estimate(
-			uint64(chunkCount)*chunkSize,
+			sourceSize,
 			t.performanceConfig.GetTransferFromURLToSnapshotBandwidthMiBs(),
 		))
 

--- a/cloud/disk_manager/internal/pkg/dataplane/nbs/source.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/nbs/source.go
@@ -225,6 +225,16 @@ func (s *diskSource) ChunkCount(ctx context.Context) (uint32, error) {
 	return s.chunkCount, nil
 }
 
+func (s *diskSource) Size(ctx context.Context) (uint64, error) {
+	return s.client.GetChangedBytes(
+		ctx,
+		s.diskID,
+		s.baseCheckpointID,
+		s.checkpointID,
+		s.ignoreBaseDisk,
+	)
+}
+
 func (s *diskSource) Close(ctx context.Context) {
 	s.session.Close(ctx)
 }
@@ -309,27 +319,4 @@ func NewDiskSource(
 		ignoreBaseDisk:         ignoreBaseDisk,
 		dontReadFromCheckpoint: dontReadFromCheckpoint,
 	}, nil
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-func GetDiskSourceBytesToRead(
-	ctx context.Context,
-	source dataplane_common.Source,
-) (uint64, error) {
-
-	diskSource, ok := source.(*diskSource)
-	if !ok {
-		return 0, task_errors.NewNonRetriableErrorf(
-			"GetDiskSourceBytesToRead argument must be of type diskSource",
-		)
-	}
-
-	return diskSource.client.GetChangedBytes(
-		ctx,
-		diskSource.diskID,
-		diskSource.baseCheckpointID,
-		diskSource.checkpointID,
-		diskSource.ignoreBaseDisk,
-	)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/replicate_disk_task.go
@@ -415,7 +415,7 @@ func (t *replicateDiskTask) setEstimate(
 	diskSource common.Source,
 ) error {
 
-	bytesToReplicate, err := nbs.GetDiskSourceBytesToRead(ctx, diskSource)
+	bytesToReplicate, err := diskSource.Size(ctx)
 	if err != nil {
 		return err
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/source.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/source.go
@@ -151,6 +151,16 @@ func (s *snapshotSource) ChunkCount(ctx context.Context) (uint32, error) {
 	return meta.ChunkCount, nil
 }
 
+// Not thread-safe.
+func (s *snapshotSource) Size(ctx context.Context) (uint64, error) {
+	meta, err := s.getSnapshotMeta(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return meta.StorageSize, nil
+}
+
 func (s *snapshotSource) Close(ctx context.Context) {
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/transfer_from_disk_to_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/transfer_from_disk_to_disk_task.go
@@ -160,7 +160,7 @@ func (t *transferFromDiskToDiskTask) setEstimate(
 	diskSource common.Source,
 ) error {
 
-	bytesToTransfer, err := nbs.GetDiskSourceBytesToRead(ctx, diskSource)
+	bytesToTransfer, err := diskSource.Size(ctx)
 	if err != nil {
 		return err
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/url/chunk_map_reader.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/chunk_map_reader.go
@@ -34,8 +34,12 @@ func newChunkMapReader(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+func (r *chunkMapReader) size() uint64 {
+	return r.imageMapReader.Size()
+}
+
 func (r *chunkMapReader) chunkCount() uint32 {
-	size := r.imageMapReader.Size()
+	size := r.size()
 
 	if size%r.chunkSize == 0 {
 		return uint32(size / r.chunkSize)

--- a/cloud/disk_manager/internal/pkg/dataplane/url/source.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/source.go
@@ -150,6 +150,10 @@ func (s *urlSource) ChunkCount(ctx context.Context) (uint32, error) {
 	return s.chunkMapReader.chunkCount(), nil
 }
 
+func (s *urlSource) Size(ctx context.Context) (uint64, error) {
+	return s.chunkMapReader.size(), nil
+}
+
 func (s *urlSource) Close(ctx context.Context) {
 }
 


### PR DESCRIPTION
Part of #3738 

Add `(Source).Size(ctx context.Context)` method that represents the size of the data would be read.