### PR TITLE
release the trim fresh log barriers in case of write blocks error

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
@@ -100,6 +100,9 @@ void TPartitionActor::HandleStatPartition(
     response->Record.MutableStats()->SetConfirmedBlobCount(
         State->GetConfirmedBlobCount());
 
+    response->Record.MutableStats()->SetTrimFreshLogToCommitId(
+        State->GetTrimFreshLogToCommitId());
+
     LWTRACK(
         ResponseSent_Partition,
         requestInfo->CallContext->LWOrbit,

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
@@ -366,6 +366,12 @@ void TPartitionActor::HandleWriteBlocksCompleted(
         if (msg->CollectGarbageBarrierAcquired) {
             State->GetGarbageQueue().ReleaseBarrier(commitId);
         }
+
+        if (msg->TrimFreshLogBarrierAcquired && HasError(msg->GetError())) {
+            State->GetTrimFreshLogBarriers().ReleaseBarrierN(
+                commitId,
+                blocksCount);
+        }
     }
 
     Actors.Erase(ev->Sender);

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -250,12 +250,10 @@ void TWriteFreshBlocksActor::NotifyCompleted(
     const NProto::TError& error)
 {
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
+    using TCompleted = TEvPartitionPrivate::TWriteBlocksCompleted;
     auto ev = std::make_unique<TEvent>(
         error,
-        false,                      // collectGarbageBarrierAcquired
-        false,                      // unconfirmedBlobsAdded
-        TVector<TBlobToConfirm>{}   // blobsToConfirm
-    );
+        TCompleted::CreateFreshBlocksCompleted());
 
     ev->ExecCycles = Requests.front().RequestInfo->GetExecCycles();
     ev->TotalCycles = Requests.front().RequestInfo->GetTotalCycles();

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemergedblocks.cpp
@@ -278,6 +278,7 @@ void TWriteMergedBlocksActor::NotifyCompleted(
     const NProto::TError& error)
 {
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
+    using TCompleted = TEvPartitionPrivate::TWriteBlocksCompleted;
     if (!BlockSizeForChecksums) {
         // this structure is needed only to transfer block checksums to
         // PartState - passing it without checksums will trigger a couple
@@ -287,9 +288,9 @@ void TWriteMergedBlocksActor::NotifyCompleted(
     }
     auto ev = std::make_unique<TEvent>(
         error,
-        true,   // collectGarbageBarrierAcquired
-        UnconfirmedBlobsAdded,
-        std::move(BlobsToConfirm));
+        TCompleted::CreateMergedBlocksCompleted(
+            UnconfirmedBlobsAdded,
+            std::move(BlobsToConfirm)));
 
     ev->ExecCycles = RequestInfo->GetExecCycles();
     ev->TotalCycles = RequestInfo->GetTotalCycles();

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
@@ -303,12 +303,10 @@ void TWriteMixedBlocksActor::NotifyCompleted(
     const NProto::TError& error)
 {
     using TEvent = TEvPartitionPrivate::TEvWriteBlocksCompleted;
+    using TCompleted = TEvPartitionPrivate::TWriteBlocksCompleted;
     auto ev = std::make_unique<TEvent>(
         error,
-        true,                       // collectGarbageBarrierAcquired
-        false,                      // unconfirmedBlobsAdded
-        TVector<TBlobToConfirm>{}   // blobsToConfirm
-    );
+        TCompleted::CreateMixedBlocksCompleted());
 
     ui32 blocksCount = 0;
     ui64 waitCycles = 0;

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -396,6 +396,9 @@ message TVolumeStats
 
     uint32 UnconfirmedBlobCount = 27;
     uint32 ConfirmedBlobCount = 28;
+
+    // Current trim fresh log as commit id
+    uint64 TrimFreshLogToCommitId = 29;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
В случае ошибок записи фрэш блоков не освобождаются барьеры, что приводит к тому, что мы не двигаем LastTrimFreshLogToCommitId, и при следующем ребуте таблетки можем не загрузить огромный кусок фрэша в память и получить OOM.  