### PR TITLE
dump more information about unhandled exceptions

### DIFF
--- a/cloud/blockstore/apps/client/ya.make
+++ b/cloud/blockstore/apps/client/ya.make
@@ -8,6 +8,7 @@ SRCS(
 
 PEERDIR(
     library/cpp/getopt
+    library/cpp/terminate_handler
     cloud/blockstore/apps/client/lib
     cloud/storage/core/libs/iam/iface
 )

--- a/cloud/blockstore/apps/disk_agent/ya.make
+++ b/cloud/blockstore/apps/disk_agent/ya.make
@@ -21,6 +21,10 @@ PEERDIR(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG" AND BUILD_TYPE != "RELWITHDEBINFO")
     SPLIT_DWARF()
+ELSE()
+    PEERDIR(
+        library/cpp/terminate_handler
+    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/blockstore/apps/server/ya.make
+++ b/cloud/blockstore/apps/server/ya.make
@@ -29,6 +29,10 @@ PEERDIR(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG" AND BUILD_TYPE != "RELWITHDEBINFO")
     SPLIT_DWARF()
+ELSE()
+    PEERDIR(
+        library/cpp/terminate_handler
+    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -8,6 +8,10 @@ SRCS(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
+ELSE()
+    PEERDIR(
+        library/cpp/terminate_handler
+    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/filestore/apps/client/ya.make
+++ b/cloud/filestore/apps/client/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     cloud/filestore/apps/client/lib
     cloud/storage/core/libs/iam/iface
     library/cpp/getopt
+    library/cpp/terminate_handler
 )
 
 END()

--- a/cloud/filestore/apps/server/ya.make
+++ b/cloud/filestore/apps/server/ya.make
@@ -4,6 +4,10 @@ ALLOCATOR(TCMALLOC_TC)
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
+ELSE()
+    PEERDIR(
+        library/cpp/terminate_handler
+    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/filestore/apps/vhost/ya.make
+++ b/cloud/filestore/apps/vhost/ya.make
@@ -8,6 +8,10 @@ ENDIF()
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
+ELSE()
+    PEERDIR(
+        library/cpp/terminate_handler
+    )
 ENDIF()
 
 IF (SANITIZER_TYPE)


### PR DESCRIPTION
Sometimes we see the following messages in our integration tests where is not completely clear where in the code such exception was raised
```
uncaught exception:
    address -> 0x51a00000be90
    what() -> "library/cpp/json/writer/json_value.cpp:457: Not a string"
    type -> NJson::TJsonException
```
There is a library located in library/cpp/terminated_handler which allows to collect stack trace during unwinding and dump this information upon call to std::terminate.

So far library is enabled for non-release builds since we see such crashes usually in integration tests
