### PR TITLE
Fix broken build for "cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/ut/unittest" after PR 4341

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
@@ -37,10 +37,15 @@ Y_UNIT_TEST_SUITE(ValidateTest)
             "",   // alternatingPhase
             maxWriteRequestCount);
 
+        auto log = logging->CreateLog("ETERNAL_EXECUTOR");
+
         auto executor = NTesting::CreateTestExecutor(
-            configHolder,
-            logging->CreateLog("ETERNAL_EXECUTOR")
-        );
+            {.TestScenario =
+                 NTesting::CreateAlignedBlockTestScenario(configHolder, log),
+             .FileService = NTesting::ETestExecutorFileService::AsyncIo,
+             .FilePath = filePath,
+             .Log = log});
+
         UNIT_ASSERT(executor->Run());
 
         TFile file(filePath, EOpenModeFlag::RdOnly | EOpenModeFlag::DirectAligned);


### PR DESCRIPTION
PR https://github.com/ydb-platform/nbs/pull/4341 broke the build of `cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/ut/unittest`

