### PR TITLE
Send PrincipalDiskId in mount response

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/storage/core/libs/common/format.h>
 
+#include <util/digest/multi.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
 
@@ -19,6 +20,15 @@ TString IdForPrint(const TString& diskId, const TString& shardId)
 ////////////////////////////////////////////////////////////////////////////////
 
 }   // namespace
+
+ui64 TLeaderFollowerLink::GetHash() const
+{
+    return MultiHash(
+        LeaderDiskId,
+        LeaderShardId,
+        FollowerDiskId,
+        FollowerShardId);
+}
 
 TString TLeaderFollowerLink::LeaderDiskIdForPrint() const
 {
@@ -67,7 +77,13 @@ bool TLeaderFollowerLink::Match(const TLeaderFollowerLink& rhs) const
 TString TLeaderDiskInfo::Describe() const
 {
     auto builder = TStringBuilder();
-    builder << "{ State:" << ToString(State) << " }";
+    builder << "{ State:" << ToString(State);
+
+    if (ErrorMessage) {
+        builder << ", ErrorMessage: " << ErrorMessage.Quote();
+    }
+
+    builder << " }";
     return builder;
 }
 

--- a/cloud/blockstore/libs/storage/volume/model/follower_disk.h
+++ b/cloud/blockstore/libs/storage/volume/model/follower_disk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cloud/storage/core/libs/common/backoff_delay_provider.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
 #include <contrib/ydb/library/actors/core/actorid.h>
@@ -21,6 +22,7 @@ struct TLeaderFollowerLink
     TString FollowerDiskId;
     TString FollowerShardId;
 
+    ui64 GetHash() const;
     TString LeaderDiskIdForPrint() const;
     TString FollowerDiskIdForPrint() const;
     TString Describe() const;
@@ -40,6 +42,9 @@ struct TLeaderDiskInfo
 
         Leader = 20,   // The link is broken, the disk has become the new
                        // leader. All writes from old leader rejected.
+                       // Need to destroy previous leader.
+
+        Principal = 30,   // Previous leader destroyed.
     };
 
     TLeaderFollowerLink Link;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/storage/core/volume_label.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 
 #include <cloud/storage/core/libs/common/media.h>
@@ -42,10 +43,11 @@ std::unique_ptr<TEvVolume::TEvAddClientResponse> CreateAddClientResponse(
     response->Record.SetClientId(std::move(clientId));
     response->Record.SetForceTabletRestart(forceTabletRestart);
 
-    auto& volumeConfig = state.GetMeta().GetVolumeConfig();
+    const auto& volumeConfig = state.GetMeta().GetVolumeConfig();
     auto* volumeInfo = response->Record.MutableVolume();
     VolumeConfigToVolume(volumeConfig, *volumeInfo);
     volumeInfo->SetInstanceId(std::move(instanceId));
+    volumeInfo->SetPrincipalDiskId(state.GetPrincipalDiskId());
     state.FillDeviceInfo(*volumeInfo);
 
     return response;

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -270,6 +270,7 @@ private:
     TString SourceDiskId;
     TFollowerDisks FollowerDisks;
     TLeaderDisks LeaderDisks;
+    TString PrincipalDiskId;
 
     struct TLaggingAgentMigrationInfo
     {
@@ -823,9 +824,11 @@ public:
 
     std::optional<TLeaderDiskInfo> FindLeader(
         const TLeaderFollowerLink& link) const;
+    std::optional<TLeaderDiskInfo> FindLeaderByHash(ui64 hash) const;
     void AddOrUpdateLeader(TLeaderDiskInfo leader);
     void RemoveLeader(const TLeaderFollowerLink& link);
     const TLeaderDisks& GetAllLeaders() const;
+    TString GetPrincipalDiskId() const;
 
     //
     // Scrubbing
@@ -853,6 +856,8 @@ private:
     THashSet<TString> MakeFilteredDeviceIds() const;
 
     [[nodiscard]] bool ShouldTrackUsedBlocks() const;
+
+    void UpdatePrincipalDiskId();
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -284,6 +284,11 @@ message TVolume
     // Whether volume can use fast data path (external endpoint with direct
     // rdma connection to engine)
     bool IsFastPathEnabled = 36;
+
+    // When a disk is being copied or has already been copied, the
+    // PrincipalDiskId field specifies the name of the disk that the client
+    // should use instead of current.
+    string PrincipalDiskId = 37;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Продолжение https://github.com/ydb-platform/nbs/issues/2999

Новое поле PrincipalDiskId которое возвращаем в ответе на монтирование. Если это поле заполнено, значит клиент подключился к устаревшему или еще не скопированному диску. В этом случае ему нужно переключиться на диск, который указан в PrincipalDiskId.