### PR TITLE
copy data to proper variables in dynamic persistent table tests

### DIFF
--- a/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
@@ -61,14 +61,15 @@ struct TTestData
         if (size < sizeof(ui64)) {
             return result;
         }
-        result.Id = *reinterpret_cast<const ui64*>(ptr);
+        std::memcpy(&result.Id, ptr, sizeof(ui64));
         ptr += sizeof(ui64);
         size -= sizeof(ui64);
 
         if (size < sizeof(ui32)) {
             return result;
         }
-        ui32 nameLen = *reinterpret_cast<const ui32*>(ptr);
+        ui32 nameLen;
+        std::memcpy(&nameLen, ptr, sizeof(ui32));
         ptr += sizeof(ui32);
         size -= sizeof(ui32);
 
@@ -82,7 +83,8 @@ struct TTestData
         if (size < sizeof(ui32)) {
             return result;
         }
-        ui32 valuesCount = *reinterpret_cast<const ui32*>(ptr);
+        ui32 valuesCount;
+        std::memcpy(&valuesCount, ptr, sizeof(ui32));
         ptr += sizeof(ui32);
         size -= sizeof(ui32);
 


### PR DESCRIPTION
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build-(ubsan)/17964890345/1/nebius-x86-64-ubsan/logs/1/cloud/storage/core/libs/common/ut/test-results/unittest/testing_out_stuff/TDynamicPersistentTableTest.ShouldAllocAndStoreVariableSizeRecords.err