### PR TITLE
[DM] Allow overriding EstimatedInflightDuration and EstimatedStallingDuration via tasks config

### DIFF
--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -37,8 +37,8 @@ message TasksConfig {
     // Exception task types for hanging task metric.
     repeated string ExceptHangingTaskTypes = 24;
     optional int64 MaxHangingTaskIDsToReport = 25 [default = 1000];
-    map<string, string> OverrideEstimatedInflightDurationByTaskType = 26;
-    map<string, string> OverrideEstimatedStallingDurationByTaskType = 27;
+    map<string, string> EstimatedInflightDurationOverrideByTaskType = 26;
+    map<string, string> EstimatedStallingDurationOverrideByTaskType = 27;
 
     optional string UpdateTaskTimeout = 28 [default = "1m"];
 

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -37,8 +37,8 @@ message TasksConfig {
     // Exception task types for hanging task metric.
     repeated string ExceptHangingTaskTypes = 24;
     optional int64 MaxHangingTaskIDsToReport = 25 [default = 1000];
-    map<string, string> EstimatedInflightDurationOverrides = 26; // by task type
-    map<string, string> EstimatedStallingDurationOverrides = 27; // by task type
+    map<string, string> OverrideEstimatedInflightDurationByTaskType = 26;
+    map<string, string> OverrideEstimatedStallingDurationByTaskType = 27;
 
     optional string UpdateTaskTimeout = 28 [default = "1m"];
 

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -37,29 +37,31 @@ message TasksConfig {
     // Exception task types for hanging task metric.
     repeated string ExceptHangingTaskTypes = 24;
     optional int64 MaxHangingTaskIDsToReport = 25 [default = 1000];
+    map<string, string> EstimatedInflightDurationOverrides = 26; // by task type
+    map<string, string> EstimatedStallingDurationOverrides = 27; // by task type
 
-    optional string UpdateTaskTimeout = 26 [default = "1m"];
+    optional string UpdateTaskTimeout = 28 [default = "1m"];
 
     // Zonal tasks affinity: zonal tasks from these zones can be executed on
     // current node.
-    repeated string ZoneIds = 27;
+    repeated string ZoneIds = 29;
 
-    optional string HearbeatInterval = 28 [default = "30s"];
+    optional string HearbeatInterval = 30 [default = "30s"];
     // The time window within which the node is considered alive.
-    optional string LivenessWindow = 29 [default = "30s"];
+    optional string LivenessWindow = 31 [default = "30s"];
 
     // Feature flag for enabling node eviction policy based
     // on the health of the node and the number of running nodes.
-    optional bool NodeEvictionEnabled = 30 [default = false];
+    optional bool NodeEvictionEnabled = 32 [default = false];
 
-    map<string, int64> InflightTaskPerNodeLimits = 31; // by task type
+    map<string, int64> InflightTaskPerNodeLimits = 33; // by task type
 
-    optional string CollectListerMetricsTaskScheduleInterval = 32 [default = "10m"];
-    optional string ListerMetricsCollectionInterval = 33 [default = "1m"];
+    optional string CollectListerMetricsTaskScheduleInterval = 34 [default = "10m"];
+    optional string ListerMetricsCollectionInterval = 35 [default = "1m"];
 
     // Needed for tracing.
     // Spans of tasks with greater generation id will not be sampled.
-    optional uint64 MaxSampledTaskGeneration = 34 [default = 100];
+    optional uint64 MaxSampledTaskGeneration = 36 [default = 100];
 
     // System tasks are tasks implemented by `tasks` library, like,
     // tasks.ClearEndedTasks, tasks.CollectListerMetricsTask. If this flag is
@@ -67,16 +69,16 @@ message TasksConfig {
     // execution and scheduled.
     // Warning: if this flag is false, then information about ended tasks
     // will not be cleared from the database.
-    optional bool RegularSystemTasksEnabled = 35 [default = true];
+    optional bool RegularSystemTasksEnabled = 37 [default = true];
 
     // Lister retrieves tasks from the front of the tasks table and sends them
     // to workers if possible.
     // This parameter limits the number of tasks that will be retrieved from the
     // database.
-    optional uint64 TasksToListLimit = 36 [default = 10000];
+    optional uint64 TasksToListLimit = 38 [default = 10000];
 
-    optional string AvailabilityMonitoringSuccessRateReportingPeriod = 37 [default = "15s"];
+    optional string AvailabilityMonitoringSuccessRateReportingPeriod = 39 [default = "15s"];
 
     // Overrides MaxRetriableErrorCount.
-    map<string, uint64> MaxRetriableErrorCountByTaskType = 38;
+    map<string, uint64> MaxRetriableErrorCountByTaskType = 40;
 }

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -82,11 +82,13 @@ type runnerForRun struct {
 	maxRetriableErrorCountByTaskType map[string]uint64
 	maxPanicCount                    uint64
 
-	hangingTaskTimeout                time.Duration
-	inflightHangingTaskTimeout        time.Duration
-	stallingHangingTaskTimeout        time.Duration
-	missedEstimatesUntilTaskIsHanging uint64
-	maxSampledTaskGeneration          uint64
+	hangingTaskTimeout                 time.Duration
+	inflightHangingTaskTimeout         time.Duration
+	stallingHangingTaskTimeout         time.Duration
+	missedEstimatesUntilTaskIsHanging  uint64
+	estimatedInflightDurationOverrides map[string]time.Duration
+	estimatedStallingDurationOverrides map[string]time.Duration
+	maxSampledTaskGeneration           uint64
 }
 
 func (r *runnerForRun) receiveTask(
@@ -337,6 +339,8 @@ func (r *runnerForRun) lockAndExecuteTask(
 		r.inflightHangingTaskTimeout,
 		r.stallingHangingTaskTimeout,
 		r.missedEstimatesUntilTaskIsHanging,
+		r.estimatedInflightDurationOverrides,
+		r.estimatedStallingDurationOverrides,
 		r.maxSampledTaskGeneration,
 	)
 }
@@ -353,11 +357,13 @@ type runnerForCancel struct {
 	host        string
 	id          string
 
-	hangingTaskTimeout                time.Duration
-	inflightHangingTaskTimeout        time.Duration
-	stallingHangingTaskTimeout        time.Duration
-	missedEstimatesUntilTaskIsHanging uint64
-	maxSampledTaskGeneration          uint64
+	hangingTaskTimeout                 time.Duration
+	inflightHangingTaskTimeout         time.Duration
+	stallingHangingTaskTimeout         time.Duration
+	missedEstimatesUntilTaskIsHanging  uint64
+	estimatedInflightDurationOverrides map[string]time.Duration
+	estimatedStallingDurationOverrides map[string]time.Duration
+	maxSampledTaskGeneration           uint64
 }
 
 func (r *runnerForCancel) receiveTask(
@@ -470,6 +476,8 @@ func (r *runnerForCancel) lockAndExecuteTask(
 		r.inflightHangingTaskTimeout,
 		r.stallingHangingTaskTimeout,
 		r.missedEstimatesUntilTaskIsHanging,
+		r.estimatedInflightDurationOverrides,
+		r.estimatedStallingDurationOverrides,
 		r.maxSampledTaskGeneration,
 	)
 }
@@ -540,6 +548,8 @@ func lockAndExecuteTask(
 	inflightHangingTaskTimeout time.Duration,
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
+	estimatedInflightDurationOverrides map[string]time.Duration,
+	estimatedStallingDurationOverrides map[string]time.Duration,
 	maxSampledTaskGeneration uint64,
 ) error {
 
@@ -616,6 +626,16 @@ func lockAndExecuteTask(
 		missedEstimatesUntilTaskIsHanging,
 	)
 
+	estimatedInflightDurationOverride, ok := estimatedInflightDurationOverrides[taskState.TaskType]
+	if ok {
+		execCtx.SetEstimatedInflightDuration(estimatedInflightDurationOverride)
+	}
+
+	estimatedStallingDurationOverride, ok := estimatedStallingDurationOverrides[taskState.TaskType]
+	if ok {
+		execCtx.SetEstimatedStallingDuration(estimatedStallingDurationOverride)
+	}
+
 	pingCtx, cancelPing := context.WithCancel(ctx)
 	go taskPinger(pingCtx, execCtx, pingPeriod, pingTimeout, cancelRun)
 	defer cancelPing()
@@ -673,6 +693,8 @@ func startRunner(
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
 	exceptHangingTaskTypes []string,
+	estimatedInflightDurationOverrides map[string]time.Duration,
+	estimatedStallingDurationOverrides map[string]time.Duration,
 	host string,
 	idForRun string,
 	idForCancel string,
@@ -703,11 +725,13 @@ func startRunner(
 		maxRetriableErrorCountByTaskType: maxRetriableErrorCountByTaskType,
 		maxPanicCount:                    maxPanicCount,
 
-		hangingTaskTimeout:                hangingTaskTimeout,
-		inflightHangingTaskTimeout:        inflightHangingTaskTimeout,
-		stallingHangingTaskTimeout:        stallingHangingTaskTimeout,
-		missedEstimatesUntilTaskIsHanging: missedEstimatesUntilTaskIsHanging,
-		maxSampledTaskGeneration:          maxSampledTaskGeneration,
+		hangingTaskTimeout:                 hangingTaskTimeout,
+		inflightHangingTaskTimeout:         inflightHangingTaskTimeout,
+		stallingHangingTaskTimeout:         stallingHangingTaskTimeout,
+		missedEstimatesUntilTaskIsHanging:  missedEstimatesUntilTaskIsHanging,
+		estimatedInflightDurationOverrides: estimatedInflightDurationOverrides,
+		estimatedStallingDurationOverrides: estimatedStallingDurationOverrides,
+		maxSampledTaskGeneration:           maxSampledTaskGeneration,
 	})
 
 	runnerForCancelMetrics := newRunnerMetrics(
@@ -726,11 +750,13 @@ func startRunner(
 		host:        host,
 		id:          idForCancel,
 
-		hangingTaskTimeout:                hangingTaskTimeout,
-		inflightHangingTaskTimeout:        inflightHangingTaskTimeout,
-		stallingHangingTaskTimeout:        stallingHangingTaskTimeout,
-		missedEstimatesUntilTaskIsHanging: missedEstimatesUntilTaskIsHanging,
-		maxSampledTaskGeneration:          maxSampledTaskGeneration,
+		hangingTaskTimeout:                 hangingTaskTimeout,
+		inflightHangingTaskTimeout:         inflightHangingTaskTimeout,
+		stallingHangingTaskTimeout:         stallingHangingTaskTimeout,
+		missedEstimatesUntilTaskIsHanging:  missedEstimatesUntilTaskIsHanging,
+		estimatedInflightDurationOverrides: estimatedInflightDurationOverrides,
+		estimatedStallingDurationOverrides: estimatedStallingDurationOverrides,
+		maxSampledTaskGeneration:           maxSampledTaskGeneration,
 	})
 
 	return nil
@@ -751,6 +777,8 @@ func startRunners(
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
 	exceptHangingTaskTypes []string,
+	estimatedInflightDurationOverrides map[string]time.Duration,
+	estimatedStallingDurationOverrides map[string]time.Duration,
 	host string,
 	maxRetriableErrorCountDefault uint64,
 	maxRetriableErrorCountByTaskType map[string]uint64,
@@ -773,6 +801,8 @@ func startRunners(
 			stallingHangingTaskTimeout,
 			missedEstimatesUntilTaskIsHanging,
 			exceptHangingTaskTypes,
+			estimatedInflightDurationOverrides,
+			estimatedStallingDurationOverrides,
 			host,
 			fmt.Sprintf("run_%v", i),
 			fmt.Sprintf("cancel_%v", i),
@@ -804,6 +834,8 @@ func startStalkingRunners(
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
 	exceptHangingTaskTypes []string,
+	estimatedInflightDurationOverrides map[string]time.Duration,
+	estimatedStallingDurationOverrides map[string]time.Duration,
 	host string,
 	maxRetriableErrorCountDefault uint64,
 	maxRetriableErrorCountByTaskType map[string]uint64,
@@ -826,6 +858,8 @@ func startStalkingRunners(
 			stallingHangingTaskTimeout,
 			missedEstimatesUntilTaskIsHanging,
 			exceptHangingTaskTypes,
+			estimatedInflightDurationOverrides,
+			estimatedStallingDurationOverrides,
 			host,
 			fmt.Sprintf("stalker_run_%v", i),
 			fmt.Sprintf("stalker_cancel_%v", i),
@@ -876,6 +910,21 @@ func startHeartbeats(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+func parseEstimatedDurationOverrides(overrides map[string]string) (map[string]time.Duration, error) {
+	parsedOverrides := make(map[string]time.Duration, len(overrides))
+
+	for taskType, durationStr := range overrides {
+		duration, err := time.ParseDuration(durationStr)
+		if err != nil {
+			return nil, err
+		}
+
+		parsedOverrides[taskType] = duration
+	}
+
+	return parsedOverrides, nil
+}
 
 func StartRunners(
 	ctx context.Context,
@@ -945,6 +994,20 @@ func StartRunners(
 		return err
 	}
 
+	estimatedInflightDurationOverrides, err := parseEstimatedDurationOverrides(
+		config.GetEstimatedInflightDurationOverrides(),
+	)
+	if err != nil {
+		return err
+	}
+
+	estimatedStallingDurationOverrides, err := parseEstimatedDurationOverrides(
+		config.GetEstimatedStallingDurationOverrides(),
+	)
+	if err != nil {
+		return err
+	}
+
 	inflightTaskLimits := config.GetInflightTaskPerNodeLimits()
 
 	taskTypesForExecution := registry.TaskTypesForExecution()
@@ -995,6 +1058,8 @@ func StartRunners(
 		stallingHangingTaskTimeout,
 		config.GetMissedEstimatesUntilTaskIsHanging(),
 		config.GetExceptHangingTaskTypes(),
+		estimatedInflightDurationOverrides,
+		estimatedStallingDurationOverrides,
 		host,
 		config.GetMaxRetriableErrorCount(),
 		config.GetMaxRetriableErrorCountByTaskType(),
@@ -1053,6 +1118,8 @@ func StartRunners(
 		stallingHangingTaskTimeout,
 		config.GetMissedEstimatesUntilTaskIsHanging(),
 		config.GetExceptHangingTaskTypes(),
+		estimatedInflightDurationOverrides,
+		estimatedStallingDurationOverrides,
 		host,
 		config.GetMaxRetriableErrorCount(),
 		config.GetMaxRetriableErrorCountByTaskType(),

--- a/cloud/tasks/runner.go
+++ b/cloud/tasks/runner.go
@@ -86,8 +86,8 @@ type runnerForRun struct {
 	inflightHangingTaskTimeout                  time.Duration
 	stallingHangingTaskTimeout                  time.Duration
 	missedEstimatesUntilTaskIsHanging           uint64
-	overrideEstimatedInflightDurationByTaskType map[string]time.Duration
-	overrideEstimatedStallingDurationByTaskType map[string]time.Duration
+	estimatedInflightDurationOverrideByTaskType map[string]time.Duration
+	estimatedStallingDurationOverrideByTaskType map[string]time.Duration
 	maxSampledTaskGeneration                    uint64
 }
 
@@ -339,8 +339,8 @@ func (r *runnerForRun) lockAndExecuteTask(
 		r.inflightHangingTaskTimeout,
 		r.stallingHangingTaskTimeout,
 		r.missedEstimatesUntilTaskIsHanging,
-		r.overrideEstimatedInflightDurationByTaskType,
-		r.overrideEstimatedStallingDurationByTaskType,
+		r.estimatedInflightDurationOverrideByTaskType,
+		r.estimatedStallingDurationOverrideByTaskType,
 		r.maxSampledTaskGeneration,
 	)
 }
@@ -361,8 +361,8 @@ type runnerForCancel struct {
 	inflightHangingTaskTimeout                  time.Duration
 	stallingHangingTaskTimeout                  time.Duration
 	missedEstimatesUntilTaskIsHanging           uint64
-	overrideEstimatedInflightDurationByTaskType map[string]time.Duration
-	overrideEstimatedStallingDurationByTaskType map[string]time.Duration
+	estimatedInflightDurationOverrideByTaskType map[string]time.Duration
+	estimatedStallingDurationOverrideByTaskType map[string]time.Duration
 	maxSampledTaskGeneration                    uint64
 }
 
@@ -476,8 +476,8 @@ func (r *runnerForCancel) lockAndExecuteTask(
 		r.inflightHangingTaskTimeout,
 		r.stallingHangingTaskTimeout,
 		r.missedEstimatesUntilTaskIsHanging,
-		r.overrideEstimatedInflightDurationByTaskType,
-		r.overrideEstimatedStallingDurationByTaskType,
+		r.estimatedInflightDurationOverrideByTaskType,
+		r.estimatedStallingDurationOverrideByTaskType,
 		r.maxSampledTaskGeneration,
 	)
 }
@@ -548,8 +548,8 @@ func lockAndExecuteTask(
 	inflightHangingTaskTimeout time.Duration,
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
-	overrideEstimatedInflightDurationByTaskType map[string]time.Duration,
-	overrideEstimatedStallingDurationByTaskType map[string]time.Duration,
+	estimatedInflightDurationOverrideByTaskType map[string]time.Duration,
+	estimatedStallingDurationOverrideByTaskType map[string]time.Duration,
 	maxSampledTaskGeneration uint64,
 ) error {
 
@@ -626,12 +626,12 @@ func lockAndExecuteTask(
 		missedEstimatesUntilTaskIsHanging,
 	)
 
-	estimatedInflightDurationOverride, ok := overrideEstimatedInflightDurationByTaskType[taskState.TaskType]
+	estimatedInflightDurationOverride, ok := estimatedInflightDurationOverrideByTaskType[taskState.TaskType]
 	if ok {
 		execCtx.SetEstimatedInflightDuration(estimatedInflightDurationOverride)
 	}
 
-	estimatedStallingDurationOverride, ok := overrideEstimatedStallingDurationByTaskType[taskState.TaskType]
+	estimatedStallingDurationOverride, ok := estimatedStallingDurationOverrideByTaskType[taskState.TaskType]
 	if ok {
 		execCtx.SetEstimatedStallingDuration(estimatedStallingDurationOverride)
 	}
@@ -693,8 +693,8 @@ func startRunner(
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
 	exceptHangingTaskTypes []string,
-	overrideEstimatedInflightDurationByTaskType map[string]time.Duration,
-	overrideEstimatedStallingDurationByTaskType map[string]time.Duration,
+	estimatedInflightDurationOverrideByTaskType map[string]time.Duration,
+	estimatedStallingDurationOverrideByTaskType map[string]time.Duration,
 	host string,
 	idForRun string,
 	idForCancel string,
@@ -729,8 +729,8 @@ func startRunner(
 		inflightHangingTaskTimeout:                  inflightHangingTaskTimeout,
 		stallingHangingTaskTimeout:                  stallingHangingTaskTimeout,
 		missedEstimatesUntilTaskIsHanging:           missedEstimatesUntilTaskIsHanging,
-		overrideEstimatedInflightDurationByTaskType: overrideEstimatedInflightDurationByTaskType,
-		overrideEstimatedStallingDurationByTaskType: overrideEstimatedStallingDurationByTaskType,
+		estimatedInflightDurationOverrideByTaskType: estimatedInflightDurationOverrideByTaskType,
+		estimatedStallingDurationOverrideByTaskType: estimatedStallingDurationOverrideByTaskType,
 		maxSampledTaskGeneration:                    maxSampledTaskGeneration,
 	})
 
@@ -754,8 +754,8 @@ func startRunner(
 		inflightHangingTaskTimeout:                  inflightHangingTaskTimeout,
 		stallingHangingTaskTimeout:                  stallingHangingTaskTimeout,
 		missedEstimatesUntilTaskIsHanging:           missedEstimatesUntilTaskIsHanging,
-		overrideEstimatedInflightDurationByTaskType: overrideEstimatedInflightDurationByTaskType,
-		overrideEstimatedStallingDurationByTaskType: overrideEstimatedStallingDurationByTaskType,
+		estimatedInflightDurationOverrideByTaskType: estimatedInflightDurationOverrideByTaskType,
+		estimatedStallingDurationOverrideByTaskType: estimatedStallingDurationOverrideByTaskType,
 		maxSampledTaskGeneration:                    maxSampledTaskGeneration,
 	})
 
@@ -777,8 +777,8 @@ func startRunners(
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
 	exceptHangingTaskTypes []string,
-	overrideEstimatedInflightDurationByTaskType map[string]time.Duration,
-	overrideEstimatedStallingDurationByTaskType map[string]time.Duration,
+	estimatedInflightDurationOverrideByTaskType map[string]time.Duration,
+	estimatedStallingDurationOverrideByTaskType map[string]time.Duration,
 	host string,
 	maxRetriableErrorCountDefault uint64,
 	maxRetriableErrorCountByTaskType map[string]uint64,
@@ -801,8 +801,8 @@ func startRunners(
 			stallingHangingTaskTimeout,
 			missedEstimatesUntilTaskIsHanging,
 			exceptHangingTaskTypes,
-			overrideEstimatedInflightDurationByTaskType,
-			overrideEstimatedStallingDurationByTaskType,
+			estimatedInflightDurationOverrideByTaskType,
+			estimatedStallingDurationOverrideByTaskType,
 			host,
 			fmt.Sprintf("run_%v", i),
 			fmt.Sprintf("cancel_%v", i),
@@ -834,8 +834,8 @@ func startStalkingRunners(
 	stallingHangingTaskTimeout time.Duration,
 	missedEstimatesUntilTaskIsHanging uint64,
 	exceptHangingTaskTypes []string,
-	overrideEstimatedInflightDurationByTaskType map[string]time.Duration,
-	overrideEstimatedStallingDurationByTaskType map[string]time.Duration,
+	estimatedInflightDurationOverrideByTaskType map[string]time.Duration,
+	estimatedStallingDurationOverrideByTaskType map[string]time.Duration,
 	host string,
 	maxRetriableErrorCountDefault uint64,
 	maxRetriableErrorCountByTaskType map[string]uint64,
@@ -858,8 +858,8 @@ func startStalkingRunners(
 			stallingHangingTaskTimeout,
 			missedEstimatesUntilTaskIsHanging,
 			exceptHangingTaskTypes,
-			overrideEstimatedInflightDurationByTaskType,
-			overrideEstimatedStallingDurationByTaskType,
+			estimatedInflightDurationOverrideByTaskType,
+			estimatedStallingDurationOverrideByTaskType,
 			host,
 			fmt.Sprintf("stalker_run_%v", i),
 			fmt.Sprintf("stalker_cancel_%v", i),
@@ -994,15 +994,15 @@ func StartRunners(
 		return err
 	}
 
-	overrideEstimatedInflightDurationByTaskType, err := parseEstimatedDurationOverrides(
-		config.GetOverrideEstimatedInflightDurationByTaskType(),
+	estimatedInflightDurationOverrideByTaskType, err := parseEstimatedDurationOverrides(
+		config.GetEstimatedInflightDurationOverrideByTaskType(),
 	)
 	if err != nil {
 		return err
 	}
 
-	overrideEstimatedStallingDurationByTaskType, err := parseEstimatedDurationOverrides(
-		config.GetOverrideEstimatedStallingDurationByTaskType(),
+	estimatedStallingDurationOverrideByTaskType, err := parseEstimatedDurationOverrides(
+		config.GetEstimatedStallingDurationOverrideByTaskType(),
 	)
 	if err != nil {
 		return err
@@ -1058,8 +1058,8 @@ func StartRunners(
 		stallingHangingTaskTimeout,
 		config.GetMissedEstimatesUntilTaskIsHanging(),
 		config.GetExceptHangingTaskTypes(),
-		overrideEstimatedInflightDurationByTaskType,
-		overrideEstimatedStallingDurationByTaskType,
+		estimatedInflightDurationOverrideByTaskType,
+		estimatedStallingDurationOverrideByTaskType,
 		host,
 		config.GetMaxRetriableErrorCount(),
 		config.GetMaxRetriableErrorCountByTaskType(),
@@ -1118,8 +1118,8 @@ func StartRunners(
 		stallingHangingTaskTimeout,
 		config.GetMissedEstimatesUntilTaskIsHanging(),
 		config.GetExceptHangingTaskTypes(),
-		overrideEstimatedInflightDurationByTaskType,
-		overrideEstimatedStallingDurationByTaskType,
+		estimatedInflightDurationOverrideByTaskType,
+		estimatedStallingDurationOverrideByTaskType,
 		host,
 		config.GetMaxRetriableErrorCount(),
 		config.GetMaxRetriableErrorCountByTaskType(),

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1507,8 +1507,8 @@ func TestTryExecutingTask(t *testing.T) {
 		time.Hour,      // inflightHangingTaskTimeout
 		30*time.Minute, // stallingHangingTaskTimeout
 		2,              // missedEstimatesUntilTaskIsHanging,
-		nil,            // overrideEstimatedInflightDurationByTaskType
-		nil,            // overrideEstimatedStallingDurationByTaskType
+		nil,            // estimatedInflightDurationOverrideByTaskType
+		nil,            // estimatedStallingDurationOverrideByTaskType
 		100,            // maxSampledTaskGeneration
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
@@ -1569,12 +1569,13 @@ func TestTryExecutingTaskFailToPing(t *testing.T) {
 		time.Hour,      // inflightHangingTaskTimeout
 		30*time.Minute, // stallingHangingTaskTimeout
 		2,              // missedEstimatesUntilTaskIsHanging
-		nil,            // overrideEstimatedInflightDurationByTaskType
-		nil,            // overrideEstimatedStallingDurationByTaskType
+		nil,            // estimatedInflightDurationOverrideByTaskType
+		nil,            // estimatedStallingDurationOverrideByTaskType
 		100,            // maxSampledTaskGeneration
 	)
-	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)
+
+	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 }
 
 func testTryExecutingTaskWithEstimatedDurationOverride(
@@ -1629,14 +1630,14 @@ func testTryExecutingTaskWithEstimatedDurationOverride(
 	).Run(waitForContextCancelCallback(t))
 	runnerMetrics.On("OnExecutionStopped")
 
-	overrideEstimatedInflightDurationByTaskType := map[string]time.Duration{}
+	estimatedInflightDurationOverrideByTaskType := map[string]time.Duration{}
 	if overrideEstimatedInflightDuration {
-		overrideEstimatedInflightDurationByTaskType["task"] = estimatedInflightDuration
+		estimatedInflightDurationOverrideByTaskType["task"] = estimatedInflightDuration
 	}
 
-	overrideEstimatedStallingDurationByTaskType := map[string]time.Duration{}
+	estimatedStallingDurationOverrideByTaskType := map[string]time.Duration{}
 	if overrideEstimatedStallingDuration {
-		overrideEstimatedStallingDurationByTaskType["task"] = estimatedStallingDuration
+		estimatedStallingDurationOverrideByTaskType["task"] = estimatedStallingDuration
 	}
 
 	err = lockAndExecuteTask(
@@ -1652,12 +1653,13 @@ func testTryExecutingTaskWithEstimatedDurationOverride(
 		time.Hour,      // inflightHangingTaskTimeout
 		30*time.Minute, // stallingHangingTaskTimeout
 		2,              // missedEstimatesUntilTaskIsHanging
-		overrideEstimatedInflightDurationByTaskType,
-		overrideEstimatedStallingDurationByTaskType,
+		estimatedInflightDurationOverrideByTaskType,
+		estimatedStallingDurationOverrideByTaskType,
 		100, // maxSampledTaskGeneration
 	)
-	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)
+
+	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 }
 
 func TestTryExecutingTaskWithEstimatedDurationOverride(t *testing.T) {

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1652,8 +1652,8 @@ func testTryExecutingTaskWithEstimatedDurationOverride(
 		time.Hour,      // inflightHangingTaskTimeout
 		30*time.Minute, // stallingHangingTaskTimeout
 		2,              // missedEstimatesUntilTaskIsHanging
-		overrideEstimatedInflightDurationByTaskType, // overrideEstimatedInflightDurationByTaskType
-		overrideEstimatedStallingDurationByTaskType, // overrideEstimatedStallingDurationByTaskType
+		overrideEstimatedInflightDurationByTaskType,
+		overrideEstimatedStallingDurationByTaskType,
 		100, // maxSampledTaskGeneration
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1582,6 +1582,7 @@ func testTryExecutingTaskWithEstimatedDurationOverride(
 	overrideEstimatedInflightDuration bool,
 	overrideEstimatedStallingDuration bool,
 ) {
+
 	pingPeriod := 100 * time.Millisecond
 	pingTimeout := 100 * time.Second
 	ctx, cancel := context.WithCancel(newContext())

--- a/cloud/tasks/runner_test.go
+++ b/cloud/tasks/runner_test.go
@@ -1507,8 +1507,8 @@ func TestTryExecutingTask(t *testing.T) {
 		time.Hour,      // inflightHangingTaskTimeout
 		30*time.Minute, // stallingHangingTaskTimeout
 		2,              // missedEstimatesUntilTaskIsHanging,
-		nil,            // estimatedInflightDurationOverrides
-		nil,            // estimatedStallingDurationOverrides
+		nil,            // overrideEstimatedInflightDurationByTaskType
+		nil,            // overrideEstimatedStallingDurationByTaskType
 		100,            // maxSampledTaskGeneration
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
@@ -1569,8 +1569,8 @@ func TestTryExecutingTaskFailToPing(t *testing.T) {
 		time.Hour,      // inflightHangingTaskTimeout
 		30*time.Minute, // stallingHangingTaskTimeout
 		2,              // missedEstimatesUntilTaskIsHanging
-		nil,            // estimatedInflightDurationOverrides
-		nil,            // estimatedStallingDurationOverrides
+		nil,            // overrideEstimatedInflightDurationByTaskType
+		nil,            // overrideEstimatedStallingDurationByTaskType
 		100,            // maxSampledTaskGeneration
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
@@ -1628,14 +1628,14 @@ func testTryExecutingTaskWithEstimatedDurationOverride(
 	).Run(waitForContextCancelCallback(t))
 	runnerMetrics.On("OnExecutionStopped")
 
-	estimatedInflightDurationOverrides := map[string]time.Duration{}
+	overrideEstimatedInflightDurationByTaskType := map[string]time.Duration{}
 	if overrideEstimatedInflightDuration {
-		estimatedInflightDurationOverrides["task"] = estimatedInflightDuration
+		overrideEstimatedInflightDurationByTaskType["task"] = estimatedInflightDuration
 	}
 
-	estimatedStallingDurationOverrides := map[string]time.Duration{}
+	overrideEstimatedStallingDurationByTaskType := map[string]time.Duration{}
 	if overrideEstimatedStallingDuration {
-		estimatedStallingDurationOverrides["task"] = estimatedStallingDuration
+		overrideEstimatedStallingDurationByTaskType["task"] = estimatedStallingDuration
 	}
 
 	err = lockAndExecuteTask(
@@ -1647,13 +1647,13 @@ func testTryExecutingTaskWithEstimatedDurationOverride(
 		pingTimeout,
 		runner,
 		taskInfo,
-		24*time.Hour,                       // hangingTaskTimeout
-		time.Hour,                          // inflightHangingTaskTimeout
-		30*time.Minute,                     // stallingHangingTaskTimeout
-		2,                                  // missedEstimatesUntilTaskIsHanging
-		estimatedInflightDurationOverrides, // estimatedInflightDurationOverrides
-		estimatedStallingDurationOverrides, // estimatedStallingDurationOverrides
-		100,                                // maxSampledTaskGeneration
+		24*time.Hour,   // hangingTaskTimeout
+		time.Hour,      // inflightHangingTaskTimeout
+		30*time.Minute, // stallingHangingTaskTimeout
+		2,              // missedEstimatesUntilTaskIsHanging
+		overrideEstimatedInflightDurationByTaskType, // overrideEstimatedInflightDurationByTaskType
+		overrideEstimatedStallingDurationByTaskType, // overrideEstimatedStallingDurationByTaskType
+		100, // maxSampledTaskGeneration
 	)
 	mock.AssertExpectationsForObjects(t, taskStorage, runner, runnerMetrics, task)
 	require.NoError(t, err)

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1955,6 +1955,7 @@ func testTaskWithEstimatedDurationOverride(
 	overrideEstimatedInflightDuration bool,
 	overrideEstimatedStallingDuration bool,
 ) {
+
 	ctx, cancel := context.WithCancel(newContext())
 	defer cancel()
 

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1966,12 +1966,12 @@ func testTaskWithEstimatedDurationOverride(
 	config := newDefaultConfig()
 	config.RunnersCount = &runnersCount
 	if overrideEstimatedInflightDuration {
-		config.EstimatedInflightDurationOverrides = map[string]string{
+		config.OverrideEstimatedInflightDurationByTaskType = map[string]string{
 			"long": "42h",
 		}
 	}
 	if overrideEstimatedStallingDuration {
-		config.EstimatedStallingDurationOverrides = map[string]string{
+		config.OverrideEstimatedStallingDurationByTaskType = map[string]string{
 			"long": "42s",
 		}
 	}

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1963,23 +1963,26 @@ func testTaskWithEstimatedDurationOverride(
 	defer db.Close(ctx)
 
 	runnersCount := uint64(2)
+	// Schedule long task so pinger will have time to update tasks state in storage.
+	overrideTaskType := "long"
 
 	config := newDefaultConfig()
 	config.RunnersCount = &runnersCount
+
 	if overrideEstimatedInflightDuration {
 		config.OverrideEstimatedInflightDurationByTaskType = map[string]string{
-			"long": "42h",
+			overrideTaskType: "42h",
 		}
 	}
+
 	if overrideEstimatedStallingDuration {
 		config.OverrideEstimatedStallingDurationByTaskType = map[string]string{
-			"long": "42s",
+			overrideTaskType: "42s",
 		}
 	}
 
 	s := createServicesWithConfig(t, ctx, db, config, metrics_empty.NewRegistry())
 
-	// Schedule long task so pinger will have time to update tasks state in storage.
 	err := registerLongTask(s.registry)
 	require.NoError(t, err)
 

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1970,13 +1970,13 @@ func testTaskWithEstimatedDurationOverride(
 	config.RunnersCount = &runnersCount
 
 	if overrideEstimatedInflightDuration {
-		config.OverrideEstimatedInflightDurationByTaskType = map[string]string{
+		config.EstimatedInflightDurationOverrideByTaskType = map[string]string{
 			overrideTaskType: "42h",
 		}
 	}
 
 	if overrideEstimatedStallingDuration {
-		config.OverrideEstimatedStallingDurationByTaskType = map[string]string{
+		config.EstimatedStallingDurationOverrideByTaskType = map[string]string{
 			overrideTaskType: "42s",
 		}
 	}


### PR DESCRIPTION
Part of #3738 

Add `EstimatedInflightDurationOverrideByTaskType` and `EstimatedStallingDurationOverrideByTaskType` fields to config which handles keys as task types and values as estimated durations.

If set, estimates for selected task types will be automatically set in `lockTaskToExecute`. As SetEstimatedInflightDuration and SetEstimatedStallingDuration allows to set estimate only once, this estimate won't be overrided by the task.

This allows temporarily changing estimates for tasks without needing to change the code and deploying new release.