### PR TITLE
Fix mirror disks device replacement without 'fresh' tag

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -124,6 +124,7 @@ using TCritEventParams = TVector<std::pair<TStringBuf, TValue>>;
     xxx(MultiAgentRequestAffectsTwoDevices)                                    \
     xxx(ChecksumCalculationError)                                              \
     xxx(LogicalDiskIdMismatch)                                                 \
+    xxx(DeviceReplacementContractBroken)                                       \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
@@ -1,7 +1,10 @@
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+
 #include <cloud/storage/core/libs/common/media.h>
+
+#include <util/string/join.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -202,12 +205,13 @@ void TDiskRegistryActor::CompleteAddDisk(
 
         LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
             "[%lu] AddDisk success. DiskId=%s Devices=%s Replicas=%s"
-            " Migrations=%s",
+            " Migrations=%s DeviceReplacementUUIDs=[%s]",
             TabletID(),
             args.DiskId.Quote().c_str(),
             devices.c_str(),
             replicas.c_str(),
-            migrations.c_str()
+            migrations.c_str(),
+            JoinSeq(", ", args.DeviceReplacementUUIDs).c_str()
         );
 
         auto onDevice = [&] (NProto::TDeviceConfig& d, ui32 blockSize) {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1469,17 +1469,16 @@ NProto::TError TDiskRegistryState::ReplaceDeviceWithoutDiskStateUpdate(
             Y_DEBUG_ABORT_UNLESS(masterDisk);
             if (masterDisk) {
                 *historyItem.MutableMessage() += TStringBuilder()
-                    << ", replica=" << diskId;
+                                                 << ", replica=" << diskId;
                 masterDisk->History.push_back(historyItem);
-
-                db.UpdateDisk(BuildDiskConfig(disk.MasterDiskId, *masterDisk));
 
                 const bool replaced = ReplicaTable.ReplaceDevice(
                     disk.MasterDiskId,
                     deviceId,
                     targetDevice.GetDeviceUUID());
-
                 Y_DEBUG_ABORT_UNLESS(replaced);
+
+                db.UpdateDisk(BuildDiskConfig(disk.MasterDiskId, *masterDisk));
             }
         }
 
@@ -6458,11 +6457,11 @@ NProto::TError TDiskRegistryState::AbortMigrationAndReplaceDevice(
     Y_DEBUG_ABORT_UNLESS(masterDiskState);
     if (masterDiskState) {
         masterDiskState->History.push_back(std::move(historyItem));
-        db.UpdateDisk(BuildDiskConfig(diskId, disk));
         db.UpdateDisk(BuildDiskConfig(disk.MasterDiskId, *masterDiskState));
-        UpdatePlacementGroup(db, diskId, disk, "AbortMigrationAndReplaceDevice");
     }
 
+    db.UpdateDisk(BuildDiskConfig(diskId, disk));
+    UpdatePlacementGroup(db, diskId, disk, "AbortMigrationAndReplaceDevice");
     return {};
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -1808,7 +1808,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         });
     }
 
-    Y_UNIT_TEST(ShouldKek)
+    Y_UNIT_TEST(ShouldUpdateDiskInDBAfterDeviceReplacement)
     {
         TTestExecutor executor;
         executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });

--- a/cloud/blockstore/libs/storage/testlib/test_env_state.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env_state.cpp
@@ -67,6 +67,7 @@ bool TDiskRegistryState::ReplaceDevice(
     }
 
     *device = *newDevice;
+    DeviceReplacementUUIDs.insert(newDevice->GetDeviceUUID());
     return true;
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -636,7 +636,8 @@ private:
     bool CheckAllocationResult(
         const NActors::TActorContext& ctx,
         const TDevices& devices,
-        const TVector<TDevices>& replicas);
+        const TVector<TDevices>& replicas,
+        const TVector<TString>& freshDeviceIds);
 
     void CopyCachedStatsToPartCounters(
         const NProto::TCachedPartStats& src,

--- a/cloud/blockstore/libs/storage/volume/volume_ut_session.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_session.cpp
@@ -883,8 +883,8 @@ Y_UNIT_TEST_SUITE(TVolumeAcquireReleaseTest)
         auto stat = volume.StatVolume();
         const auto& volumeConfig = stat->Record.GetVolume();
         TVector<TString> replacedDevices = {
-            volumeConfig.GetDevices(0).GetDeviceUUID(),
-            volumeConfig.GetReplicas(0).GetDevices(0).GetDeviceUUID()};
+            volumeConfig.GetReplicas(0).GetDevices(0).GetDeviceUUID(),
+            volumeConfig.GetReplicas(1).GetDevices(0).GetDeviceUUID()};
         UNIT_ASSERT(
             diskRegistryState->ReplaceDevice("vol0", replacedDevices[0]));
         UNIT_ASSERT(


### PR DESCRIPTION
ПР состоит из двух частей: 
1) В DR чиню баг, из-за которого не сохранялось в базу назначение девайса fresh'ом при замене. 
2) Правки в Volume, которые добавляют предохранитель на такие случаи. То есть если девайс был заменён, но он не fresh и не цель миграции, значит что-то пошло не так. 