### PR TITLE
fix: this should prevent runner itself from stopping after childs OOM

### DIFF
--- a/.github/scripts/nebius-manage-vm.py
+++ b/.github/scripts/nebius-manage-vm.py
@@ -208,6 +208,16 @@ until [ $exit_code -eq 0 ] || [ $i -gt 3 ]; do
     [ $exit_code -eq 0 ] || find /actions-runner -name *.log -print -exec cat {{}} \; # noqa: W605
 done
 # true to skip the error and to boot vm correctly
+sed -i \\
+  '/^\[Install\]/i \\
+OOMPolicy=continue \\
+OOMScoreAdjust=-900 \\
+Delegate=yes \\
+TasksMax=infinity \\
+Restart=on-failure \\
+RestartSec=5s \\
+Slice=actions-runner.slice' \
+  ./bin/actions.runner.service.template
 ./svc.sh install || true
 ./svc.sh start || true
 """


### PR DESCRIPTION
I checked why  https://github.com/ydb-platform/nbs/actions/runs/18145885940 cancelled itself. And came to the conclusion that runner's systemd-unit stopped because of the oom kill of the child inside slice.
```Oct 01 05:20:42 computeinstance-e00dkf4nsr3dwrymnr systemd[1]: actions.runner.ydb-platform-nbs.computeinstance-e00dkf4nsr3dwrymnr.service: Failed with result 'oom-kill'.```
And when runner is stopped - task autocancels itself.
This change should:
1. Prevent stopping of the systemd unit
2. Allow, if needed, run ya make in a systemd scope like this
```
JOB_MEMORY_HIGH="${JOB_MEMORY_HIGH:-0}"   # e.g. "240G" (0 = unset)
JOB_MEMORY_MAX="${JOB_MEMORY_MAX:-0}"     # e.g. "270G" hard cap (0 = unset)
JOB_SWAP_MAX="${JOB_SWAP_MAX:-0}"         # e.g. "8G" or "0" to forbid swap for the job
JOB_OOM_SCORE="${JOB_OOM_SCORE:-500}"     # job is more killable than runner
JOB_SLICE="actions-runner.slice"

run_in_scope() {
  local props=(-p "OOMScoreAdjust=${JOB_OOM_SCORE}")
  [ "$JOB_MEMORY_HIGH" != "0" ] && props+=(-p "MemoryHigh=${JOB_MEMORY_HIGH}")
  [ "$JOB_MEMORY_MAX"  != "0" ] && props+=(-p "MemoryMax=${JOB_MEMORY_MAX}")
  [ "$JOB_SWAP_MAX"    != "0" ] && props+=(-p "MemorySwapMax=${JOB_SWAP_MAX}")
  # If available on your systemd, these help kill within the scope under pressure:
  props+=(-p "ManagedOOMMemoryPressure=kill" -p "ManagedOOMMemoryPressureLimit=85%")

  systemd-run --scope --slice="${JOB_SLICE}" "${props[@]}" \
    sudo -E -H -u github bash -lc "$*"
}

(
  run_in_scope \
    "./ya make ${test_size[*]/#/--test-size=} \
               ${test_type[*]/#/--test-type=} \
               ${extra_params[*]} \
               --junit ${JUNIT_REPORT_XML}.${i} \
               --log-file ${RETRY_LOG_DIR}/ya_log.txt \
               --evlog-file ${RETRY_LOG_DIR}/ya_evlog.jsonl \
               ${RETRY_FLAG}"
  echo $? > exit_code
) |& tee "$RETRY_LOG_DIR/ya_make_output.txt"
```