### PR TITLE
[Blockstore] should not report service_volume metrics if volume is not mounted or doesn't have a checkpoint; add host label only to isLoclMount counter

### DIFF
--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -229,7 +229,4 @@ message TDiagnosticsConfig
     optional bool SkipReportingZeroBlocksMetricsForYDBBasedDisks = 53;
 
     optional NCloud.NProto.TOpentelemetryTraceConfig OpentelemetryTraceConfig = 54;
-
-    // Add host label in service volume metrics.
-    optional bool AddHostLabelInServiceVolumeMetrics = 55;
 }

--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -84,6 +84,8 @@ message TMonitoringUrlData
 
 message TDiagnosticsConfig
 {
+    reserved 55;
+
     // How NBS generates name for external resources.
     optional EHostNameScheme HostNameScheme = 1;
 

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -60,7 +60,6 @@ namespace {
                                                                                                          \
     xxx(SkipReportingZeroBlocksMetricsForYDBBasedDisks, bool, false                                     )\
     xxx(OpentelemetryTraceConfig,           ::NCloud::NProto::TOpentelemetryTraceConfig, {}             )\
-    xxx(AddHostLabelInServiceVolumeMetrics,             bool, false                                     )\
 // BLOCKSTORE_DIAGNOSTICS_CONFIG
 
 #define BLOCKSTORE_DIAGNOSTICS_DECLARE_CONFIG(name, type, value)               \

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -166,8 +166,6 @@ public:
     [[nodiscard]] NCloud::NProto::TOpentelemetryTraceConfig
     GetOpentelemetryTraceConfig() const;
 
-    [[nodiscard]] bool GetAddHostLabelInServiceVolumeMetrics() const;
-
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor.h
@@ -94,6 +94,14 @@ public:
 private:
     void RegisterCounters(const NActors::TActorContext& ctx);
 
+    void RegisterIsLocalMountCounter(
+        NMonitoring::TDynamicCounterPtr& counters,
+        TVolumeStatsInfo& volume);
+
+    void UnregisterIsLocalMountCounter(
+        NMonitoring::TDynamicCounterPtr& counters,
+        TVolumeStatsInfo& volume);
+
     void RegisterVolumeSelfCounters(
         std::shared_ptr<NUserCounter::IUserCounterSupplier> userCounters,
         NMonitoring::TDynamicCounterPtr& counters,

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -97,7 +97,7 @@ void TStatsServiceActor::RegisterVolumeSelfCounters(
             volume.VolumeInfo.GetDiskId(),
             volumeCounters);
 
-        volume.CountersRegistered = true;
+        volume.SelfCountersRegistered = true;
     }
 }
 
@@ -123,7 +123,7 @@ void TStatsServiceActor::UnregisterVolumeSelfCounters(
         volume.VolumeInfo.GetFolderId(),
         volume.VolumeInfo.GetDiskId());
 
-    volume.CountersRegistered = false;
+    volume.SelfCountersRegistered = false;
 }
 
 void TStatsServiceActor::UpdateVolumeSelfCounters(const TActorContext& ctx)
@@ -206,18 +206,18 @@ void TStatsServiceActor::UpdateVolumeSelfCounters(const TActorContext& ctx)
         *vol.IsLocalMountCounter = vol.IsLocalMount;
 
         if (vol.PerfCounters.HasCheckpoint || vol.PerfCounters.HasClients) {
-            if (!vol.CountersRegistered) {
+            if (!vol.SelfCountersRegistered) {
                 RegisterVolumeSelfCounters(
                     UserCounters,
                     AppData(ctx)->Counters,
                     vol);
             }
 
-            Y_ABORT_UNLESS(vol.CountersRegistered);
+            Y_ABORT_UNLESS(vol.SelfCountersRegistered);
             vol.PerfCounters.DiskCounters.Publish(ctx.Now());
             vol.PerfCounters.VolumeSelfCounters.Publish(ctx.Now());
             *vol.PerfCounters.VolumeBindingCounter = !vol.PerfCounters.IsPreempted;
-        } else if (vol.CountersRegistered) {
+        } else if (vol.SelfCountersRegistered) {
             UnregisterVolumeSelfCounters(
                 UserCounters,
                 AppData(ctx)->Counters,

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -40,14 +40,16 @@ void TStatsServiceActor::RegisterVolumeSelfCounters(
         auto volumeCounters =
             counters
             ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "service_volume")
-            ->GetSubgroup("volume", volume.VolumeInfo.GetDiskId())
-            ->GetSubgroup("cloud", volume.VolumeInfo.GetCloudId())
-            ->GetSubgroup("folder", volume.VolumeInfo.GetFolderId());
+            ->GetSubgroup("component", "service_volume");
 
         if (!DiagnosticsConfig->GetAddHostLabelInServiceVolumeMetrics()) {
             volumeCounters = volumeCounters->GetSubgroup("host", "cluster");
         }
+
+        volumeCounters =
+            volumeCounters->GetSubgroup("volume", volume.VolumeInfo.GetDiskId())
+                ->GetSubgroup("cloud", volume.VolumeInfo.GetCloudId())
+                ->GetSubgroup("folder", volume.VolumeInfo.GetFolderId());
 
         volume.IsLocalMountCounter =
             volumeCounters->GetCounter("IsLocalMount", false);

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -129,6 +129,7 @@ struct TVolumeStatsInfo
     NProto::TVolume VolumeInfo;
     ui64 VolumeTabletId = 0;
 
+    bool IsLocalMountCounterRegistered = false;
     bool CountersRegistered = false;
 
     bool IsLocalMount = false;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -130,7 +130,7 @@ struct TVolumeStatsInfo
     ui64 VolumeTabletId = 0;
 
     bool IsLocalMountCounterRegistered = false;
-    bool CountersRegistered = false;
+    bool SelfCountersRegistered = false;
 
     bool IsLocalMount = false;
     NMonitoring::TDynamicCounters::TCounterPtr IsLocalMountCounter;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -503,14 +503,15 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
         auto counters = BroadcastVolumeCounters(runtime, {0}, {});
         UNIT_ASSERT(counters[0]== 0);
 
-        ui64 actual = *runtime.GetAppData(0).Counters
+        auto isLocalMountCounter = runtime.GetAppData(0).Counters
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "service_volume")
             ->GetSubgroup("volume", DefaultDiskId)
             ->GetSubgroup("cloud", DefaultCloudId)
             ->GetSubgroup("folder", DefaultFolderId)
-            ->GetCounter("IsLocalMount");
-        UNIT_ASSERT_VALUES_EQUAL(0, actual);
+            ->FindCounter("IsLocalMount");
+        UNIT_ASSERT(isLocalMountCounter);
+        UNIT_ASSERT_VALUES_EQUAL(0, isLocalMountCounter->Val());
     }
 
     Y_UNIT_TEST(ShouldReportSolomonMetricsIfVolumeRunsLocallyAndMounted)

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -92,10 +92,10 @@ NMonitoring::TDynamicCounters::TCounterPtr GetCounterToCheck(
 {
     auto volumeCounters = counters.GetSubgroup("counters", "blockstore")
         ->GetSubgroup("component", "service_volume")
+        ->GetSubgroup("host", "cluster")
         ->GetSubgroup("volume", DefaultDiskId)
         ->GetSubgroup("cloud", DefaultCloudId)
-        ->GetSubgroup("folder", DefaultFolderId)
-        ->GetSubgroup("host", "cluster");
+        ->GetSubgroup("folder", DefaultFolderId);
     return volumeCounters->GetCounter("MixedBytesCount");
 }
 
@@ -587,10 +587,10 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             ui64 actual = *runtime.GetAppData(0).Counters
                 ->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service_volume")
+                ->GetSubgroup("host", "cluster")
                 ->GetSubgroup("volume", DefaultDiskId)
                 ->GetSubgroup("cloud", DefaultCloudId)
                 ->GetSubgroup("folder", DefaultFolderId)
-                ->GetSubgroup("host", "cluster")
                 ->GetCounter("IsLocalMount");
             UNIT_ASSERT_VALUES_EQUAL(0, actual);
         }
@@ -626,10 +626,10 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             ui64 actual = *runtime.GetAppData(0).Counters
                 ->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service_volume")
+                ->GetSubgroup("host", "cluster")
                 ->GetSubgroup("volume", DefaultDiskId)
                 ->GetSubgroup("cloud", DefaultCloudId)
                 ->GetSubgroup("folder", DefaultFolderId)
-                ->GetSubgroup("host", "cluster")
                 ->GetCounter("IsLocalMount");
             UNIT_ASSERT_VALUES_EQUAL(1, actual);
         }
@@ -1423,10 +1423,10 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             ui64 actual = *runtime.GetAppData(0).Counters
                 ->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service_volume")
+                ->GetSubgroup("host", "cluster")
                 ->GetSubgroup("volume", "vol0")
                 ->GetSubgroup("cloud", DefaultCloudId)
                 ->GetSubgroup("folder", DefaultFolderId)
-                ->GetSubgroup("host", "cluster")
                 ->GetSubgroup("request", "ReadBlocks")
                 ->GetCounter("Count");
             UNIT_ASSERT_VALUES_EQUAL(42, actual);
@@ -1436,10 +1436,10 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             ui64 actual = *runtime.GetAppData(0).Counters
                 ->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service_volume")
+                ->GetSubgroup("host", "cluster")
                 ->GetSubgroup("volume", "vol0")
                 ->GetSubgroup("cloud", DefaultCloudId)
                 ->GetSubgroup("folder", DefaultFolderId)
-                ->GetSubgroup("host", "cluster")
                 ->GetSubgroup("request", "ReadBlocks")
                 ->GetCounter("RequestBytes");
             UNIT_ASSERT_VALUES_EQUAL(100500, actual);


### PR DESCRIPTION
оказался важен порядок лейблов

меняю порядок, чтобы было удобно удалять метрики

https://github.com/ydb-platform/nbs/pull/4369/files#diff-fea65bbfa84009091d30905bd75573aa02ff0110474869ad37c93255ce44c903R84