### PR TITLE
Use disk agent checksums for read2 if present

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -30,6 +30,12 @@ ui32 CalculateChecksum(
 {
     Y_UNUSED(request);
 
+    // If checksum is already calculated by the disk agent, we can use it instead
+    // of calculating it again.
+    if (response.HasChecksum() && response.GetChecksum().GetByteCount() > 0) {
+        return response.GetChecksum().GetChecksum();
+    }
+
     TBlockChecksum checksum;
     for (const auto& buffer: response.GetBlocks().GetBuffers()) {
         checksum.Extend(buffer.data(), buffer.size());
@@ -41,7 +47,11 @@ ui32 CalculateChecksum(
     const TEvService::TEvReadBlocksLocalRequest::ProtoRecordType& request,
     const TEvService::TEvReadBlocksLocalResponse::ProtoRecordType& response)
 {
-    Y_UNUSED(response);
+    // If checksum is already calculated by the disk agent, we can use it instead
+    // of calculating it again.
+    if (response.HasChecksum() && response.GetChecksum().GetByteCount() > 0) {
+        return response.GetChecksum().GetChecksum();
+    }
 
     auto g = request.Sglist.Acquire();
     if (!g) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -2026,7 +2026,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(1, mirroredDiskMinorityChecksumMismatch->Val());
     }
 
-    Y_UNIT_TEST(ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled)
+    void ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled(
+        bool diskAgentChecksumCalculation)
     {
         using namespace NMonitoring;
 
@@ -2064,6 +2065,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         NProto::TStorageServiceConfig config;
         config.SetMirrorReadReplicaCount(2);
         TTestEnv env(runtime, config);
+        env.DiskAgentState->EnableDataIntegrityValidation =
+            diskAgentChecksumCalculation;
 
         // Write different data to all replicas.
         const auto range = TBlockRange64::WithLength(2049, 50);
@@ -2150,6 +2153,16 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(
             2,
             mirroredDiskChecksumMismatchUponRead->Val());
+    }
+
+    Y_UNIT_TEST(ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled_NBSChecksumCalculation)
+    {
+        ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled(false);
+    }
+
+    Y_UNIT_TEST(ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled_DiskAgentChecksumCalculation)
+    {
+        ShouldRejectReadUponChecksumMismatchIfRead2IsEnabled(true);
     }
 
     Y_UNIT_TEST(ShouldNotFireMismatchUponReadErrorWhenThereAreOverlappingWritesAndRead2IsEnabled)


### PR DESCRIPTION
#2988
Если включена фича подсчёта контрольных сумм на диск агенте, то можем им доверять и не считать их в NBS на read2 операции mirror дисков.