### PR TITLE
[Blockstore] fix backups load

### DIFF
--- a/cloud/blockstore/libs/storage/ss_proxy/path_description_backup.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/path_description_backup.cpp
@@ -45,7 +45,7 @@ void TPathDescriptionBackup::Bootstrap(const TActorContext& ctx)
     Become(&TThis::StateWork);
 
     if (ReadOnlyMode) {
-        if (!LoadFromTextFormat(ctx) && !LoadFromBinaryFormat(ctx)) {
+        if (!LoadFromBinaryFormat(ctx) && !LoadFromTextFormat(ctx)) {
             LOG_WARN_S(
                 ctx,
                 LogComponent,

--- a/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
+++ b/cloud/storage/core/libs/hive_proxy/tablet_boot_info_backup.cpp
@@ -46,7 +46,7 @@ void TTabletBootInfoBackup::Bootstrap(const TActorContext& ctx)
     Become(&TThis::StateWork);
 
     // Load backup even if in read-only mode to warm up BS group connections.
-    if (!LoadFromTextFormat(ctx) && !LoadFromBinaryFormat(ctx)) {
+    if (!LoadFromBinaryFormat(ctx) && !LoadFromTextFormat(ctx)) {
         LOG_WARN_S(
             ctx,
             LogComponent,


### PR DESCRIPTION
Текстовый парсинг из файлика работает только с текстовыми данными, а не бинарными 

Поэтому меняю их местами, чтобы избежать крешей 
- Сначала идет бинарный парсинг, который читает все что угодно
- Потом текстовый, который читает только текст