### PR TITLE
Fix arcadia build

### DIFF
--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -213,7 +213,7 @@ void VolumeConfigToVolume(
     volume.SetIsFillFinished(volumeConfig.GetIsFillFinished());
     const auto tags = ParseTags(volumeConfig.GetTagsStr());
     for (const auto& [key, value]: tags) {
-        volume.MutableTags()->insert(google::protobuf::MapPair(key, value));
+        volume.MutableTags()->insert({key, value});
     }
 }
 


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/blockstore/libs/storage/core/proto_helpers.cpp:216:38: error: alias template 'MapPair' requires template arguments; argument deduction only allowed for class templates
  216 |         volume.MutableTags()->insert(google::protobuf::MapPair(key, value));
      |                                      ^
$(SOURCE_ROOT)/contrib/libs/protobuf/src/google/protobuf/map.h:1002:1: note: template is declared here
 1002 | using MapPair = std::pair<const Key, T>;
      | ^
1 error generated.
```