### PR TITLE
Fix arcadia build

### DIFF
--- a/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp
+++ b/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp
@@ -177,7 +177,7 @@ std::unique_ptr<TDiskRegistryState> GenerateAll(ui64 seed)
                 case EDevicePool::Nrd: {
                     device->SetBlockSize(NrdBlockSize);
                     device->SetBlocksCount(
-                        AllocationUnit[""] / DefaultBlockSize);
+                        AllocationUnit[""] / NCloud::DefaultBlockSize);
                 } break;
                 case EDevicePool::V1: {
                     device->SetBlockSize(LocalBlockSize);
@@ -311,7 +311,7 @@ std::unique_ptr<TDiskRegistryState> GenerateAll(ui64 seed)
 
         auto mediaKind = NProto::STORAGE_MEDIA_SSD_NONREPLICATED;
         TString poolName;
-        ui32 blockSize = DefaultBlockSize;
+        ui32 blockSize = NCloud::DefaultBlockSize;
         switch (tag) {
             case EVolumeType::V1:
                 poolName = "standard-v1";


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp:180:46: error: use of undeclared identifier 'DefaultBlockSize'; did you mean 'NCloud::DefaultBlockSize'?
  180 |                         AllocationUnit[""] / DefaultBlockSize);
      |                                              ^~~~~~~~~~~~~~~~
      |                                              NCloud::DefaultBlockSize
$(SOURCE_ROOT)/cloud/storage/core/libs/common/public.h:50:16: note: 'NCloud::DefaultBlockSize' declared here
   50 | constexpr ui32 DefaultBlockSize = 4_KB;
      |                ^
$(SOURCE_ROOT)/cloud/blockstore/tools/testing/disk-registry-state-generator/main.cpp:314:26: error: use of undeclared identifier 'DefaultBlockSize'; did you mean 'NCloud::DefaultBlockSize'?
  314 |         ui32 blockSize = DefaultBlockSize;
      |                          ^~~~~~~~~~~~~~~~
      |                          NCloud::DefaultBlockSize
$(SOURCE_ROOT)/cloud/storage/core/libs/common/public.h:50:16: note: 'NCloud::DefaultBlockSize' declared here
   50 | constexpr ui32 DefaultBlockSize = 4_KB;
      |                ^
2 errors generated.
```