### PR TITLE
Fix `example/2-init_storage.sh` script

### DIFF
--- a/example/ydb/config.yaml
+++ b/example/ydb/config.yaml
@@ -19,4 +19,4 @@ selector_config:
     nbs: true
   config:
     blockstore_config: !inherit
-      volume_preemption_type: VOLUME_PREEMPTION_NONE
+      volume_preemption_type: PREEMPTION_NONE


### PR DESCRIPTION
The problem was that there's invalid enum name

https://github.com/ydb-platform/nbs/blob/7b3654f1ab252ceb34d1e02ed91608d4836cfff0/contrib/ydb/core/protos/nbs/blockstore.proto#L7 