### PR TITLE
[Disk Manager] Fix TestPrivateServiceOptimizeBaseDisks test

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/private_service_test/private_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/private_service_test/private_service_test.go
@@ -353,8 +353,8 @@ func TestPrivateServiceOptimizeBaseDisks(t *testing.T) {
 
 	// Should wait for first disk creation in order to ensure that pool is
 	// created.
-	firstCreateDiskOperationId := operations[0].Id
-	err = internal_client.WaitOperation(ctx, client, firstCreateDiskOperationId)
+	firstCreateDiskOperationID := operations[0].Id
+	err = internal_client.WaitOperation(ctx, client, firstCreateDiskOperationID)
 	require.NoError(t, err)
 
 	privateClient, err := testcommon.NewPrivateClient(ctx)
@@ -376,7 +376,7 @@ func TestPrivateServiceOptimizeBaseDisks(t *testing.T) {
 		diskID := fmt.Sprintf("%v%v", t.Name(), i)
 		errGroup.Go(
 			func() error {
-				if operationID != firstCreateDiskOperationId {
+				if operationID != firstCreateDiskOperationID {
 					err := internal_client.WaitOperation(
 						ctx,
 						client,


### PR DESCRIPTION
If some AcquireBaseDisks tasks work slowly (they need to create a new disk, it might be slow), and the first image is quickly created - the first task can expire and be removed and re-accessed afterwards, which causes an error. 