### PR TITLE
[Filestore] use TAdaptiveLock instead of TMutex in TFSyncQueue

### DIFF
--- a/cloud/filestore/libs/vfs/fsync_queue.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue.cpp
@@ -228,7 +228,7 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
 
     STORAGE_TRACE(LogTag << " Request was started " << request);
 
-    with_lock (StateMutex) {
+    with_lock (StateLock) {
         CurrentState.AddRequest(request);
     }
 }
@@ -246,7 +246,7 @@ void TFSyncQueue::Dequeue(
 
     STORAGE_TRACE(LogTag << " Request was finished " << request);
 
-    with_lock (StateMutex) {
+    with_lock (StateLock) {
         CurrentState.RemoveRequest(request);
     }
 }
@@ -260,7 +260,7 @@ TFuture<NProto::TError> TFSyncQueue::WaitForRequests(
     STORAGE_TRACE(LogTag
         << " FSync request was received " << request << " meta");
 
-    with_lock (StateMutex) {
+    with_lock (StateLock) {
         return CurrentState.AddFSyncRequest(request);
     }
 }
@@ -281,7 +281,7 @@ TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
     STORAGE_TRACE(LogTag
         << " FSync request was received " << request << " data");
 
-    with_lock (StateMutex) {
+    with_lock (StateLock) {
         return CurrentState.AddFSyncRequest(request);
     }
 }

--- a/cloud/filestore/libs/vfs/fsync_queue.h
+++ b/cloud/filestore/libs/vfs/fsync_queue.h
@@ -88,7 +88,7 @@ private:
     TLog Log;
 
     TFSyncCache CurrentState;
-    TMutex StateMutex;
+    TAdaptiveLock StateLock;
 
 public:
     TFSyncQueue(const TString& fileSystemId, ILoggingServicePtr logging);


### PR DESCRIPTION
<img width="2386" height="1328" alt="image" src="https://github.com/user-attachments/assets/6072420a-d7c3-467c-9593-a42ee2315902" />


Improves WriteData iops in high-parallelism with small-sized requests  scenario by 50 percent:
```
  | 66.5k | write numjobs=32 bs=4k iodepth=32 |
  | 93.5k | TMutex changed to TAdaptiveLock   |
```
