### PR TITLE
[Disk Manager] Stabilize tasks tests

### DIFF
--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -308,7 +308,7 @@ func scheduleDoublerTask(
 ////////////////////////////////////////////////////////////////////////////////
 
 // DurableWait waits for the waitDuration, saving state every 100ms.
-// To wait many times within a single task, add already waited duration from 
+// To wait many times within a single task, add already waited duration from
 // previous calls to the duration you want to wait for in current DurableWait().
 // For instance, to wait 2 seconds, then 5 seconds, we will run the following code
 // DurableWait(ctx, execCtx, 2 * time.Second, t.state)


### PR DESCRIPTION
Make "long" test task save passed time to its state to avoid longer than expected run time due to restarts and timeouts.
(long tasks sometimes get restarted because task pings are too slow due to a lack of resources and the lister decides that the task is stalling).