### PR TITLE
[NBS] add possibility to calculate checksums for all blocks in compaction

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1349,4 +1349,7 @@ message TStorageServiceConfig
     // schemeshard, etc.) and the DR tablet. Lower value means lower priority.
     // NOTE: can be negative.
     optional int32 SystemTabletsPriority = 464;
+
+    // Enables force calculation of the checksums for all compaction blocks.
+    optional bool ComputeDigestForEveryBlockOnCompaction = 465;
 }

--- a/cloud/blockstore/libs/diagnostics/block_digest.cpp
+++ b/cloud/blockstore/libs/diagnostics/block_digest.cpp
@@ -50,6 +50,12 @@ struct TExt4BlockDigestGenerator final
             return Nothing();
         }
 
+        return ComputeDigestForce(blockContent);
+    }
+
+    TMaybe<ui32> ComputeDigestForce(
+        TBlockDataRef blockContent) const override
+    {
         if (blockContent.Data() != nullptr) {
             return ComputeDefaultDigest(blockContent);
         }
@@ -109,6 +115,12 @@ struct TTestBlockDigestGenerator final
     {
         Y_UNUSED(blockIndex);
 
+        return ComputeDigestForce(blockContent);
+    }
+
+    TMaybe<ui32> ComputeDigestForce(
+        TBlockDataRef blockContent) const override
+    {
         if (blockContent.Data() == nullptr) {
             return 0;
         }
@@ -139,8 +151,20 @@ struct TTestBlockDigestGenerator final
 struct TBlockDigestGeneratorStub final
     : IBlockDigestGenerator
 {
-    TMaybe<ui32> ComputeDigest(ui64, TBlockDataRef) const override
+    TMaybe<ui32> ComputeDigest(
+        ui64 blockIndex,
+        TBlockDataRef blockContent) const override
     {
+        Y_UNUSED(blockIndex);
+
+        return ComputeDigestForce(blockContent);
+    }
+
+    TMaybe<ui32> ComputeDigestForce(
+        TBlockDataRef blockContent) const override
+    {
+        Y_UNUSED(blockContent);
+
         return Nothing();
     }
 

--- a/cloud/blockstore/libs/diagnostics/block_digest.h
+++ b/cloud/blockstore/libs/diagnostics/block_digest.h
@@ -16,6 +16,10 @@ struct IBlockDigestGenerator
         ui64 blockIndex,
         TBlockDataRef blockContent) const = 0;
 
+    // calculate checksum independently of ShouldProcess result
+    virtual TMaybe<ui32> ComputeDigestForce(
+        TBlockDataRef blockContent) const = 0;
+
     virtual bool ShouldProcess(
         ui64 blockIndex,
         ui32 blockCount,

--- a/cloud/blockstore/libs/diagnostics/block_digest_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/block_digest_ut.cpp
@@ -18,10 +18,15 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
         auto offset = 256;
 
         UNIT_ASSERT(!gen->ComputeDigest(0, TBlockDataRef::CreateZeroBlock(2_KB)));
+        UNIT_ASSERT(!gen->ComputeDigestForce(TBlockDataRef::CreateZeroBlock(2_KB)));
         UNIT_ASSERT(!gen->ComputeDigest(0, TBlockDataRef::CreateZeroBlock(256_KB)));
+        UNIT_ASSERT(!gen->ComputeDigestForce(TBlockDataRef::CreateZeroBlock(256_KB)));
         UNIT_ASSERT(!gen->ComputeDigest(0, TBlockDataRef::CreateZeroBlock(5_KB)));
+        UNIT_ASSERT(!gen->ComputeDigestForce(TBlockDataRef::CreateZeroBlock(5_KB)));
         UNIT_ASSERT(gen->ComputeDigest(0, TBlockDataRef::CreateZeroBlock(4_KB)));
+        UNIT_ASSERT(gen->ComputeDigestForce(TBlockDataRef::CreateZeroBlock(4_KB)));
         UNIT_ASSERT(gen->ComputeDigest(0, TBlockDataRef::CreateZeroBlock(128_KB)));
+        UNIT_ASSERT(gen->ComputeDigestForce(TBlockDataRef::CreateZeroBlock(128_KB)));
 
         TString str("asd");
         str.resize(4_KB);
@@ -32,8 +37,10 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
         UNIT_ASSERT(gen->ComputeDigest(offset + 300, blockData));
         UNIT_ASSERT(!gen->ShouldProcess(offset + 400, 1, 4_KB));
         UNIT_ASSERT(!gen->ComputeDigest(offset + 400, blockData));
+        UNIT_ASSERT(gen->ComputeDigestForce(blockData));
         UNIT_ASSERT(!gen->ShouldProcess(offset + 20000, 1, 4_KB));
         UNIT_ASSERT(!gen->ComputeDigest(offset + 20000, blockData));
+        UNIT_ASSERT(gen->ComputeDigestForce(blockData));
 
         offset += 128_MB / 4_KB;
         UNIT_ASSERT(gen->ShouldProcess(offset, 1, 4_KB));
@@ -42,8 +49,10 @@ Y_UNIT_TEST_SUITE(TBlockDigestGeneratorTest)
         UNIT_ASSERT(gen->ComputeDigest(offset + 300, blockData));
         UNIT_ASSERT(!gen->ShouldProcess(offset + 400, 1, 4_KB));
         UNIT_ASSERT(!gen->ComputeDigest(offset + 400, blockData));
+        UNIT_ASSERT(gen->ComputeDigestForce(blockData));
         UNIT_ASSERT(!gen->ShouldProcess(offset + 20000, 1, 4_KB));
         UNIT_ASSERT(!gen->ComputeDigest(offset + 20000, blockData));
+        UNIT_ASSERT(gen->ComputeDigestForce(blockData));
     }
 
     Y_UNIT_TEST(TestTest)

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -164,6 +164,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(LinkedDiskFillBandwidth,                                               \
         TVector<NProto::TLinkedDiskFillBandwidth>,                             \
         {}                                                                    )\
+    xxx(ComputeDigestForEveryBlockOnCompaction,     bool,            false    )\
 // BLOCKSTORE_STORAGE_CONFIG_RO
 
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -732,6 +732,8 @@ public:
     [[nodiscard]] ui64 GetHiveLocalServiceNetworkResourceLimit() const;
 
     [[nodiscard]] TDuration GetDynamicNodeRegistrationTimeout() const;
+
+    [[nodiscard]] bool GetComputeDigestForEveryBlockOnCompaction() const;
 };
 
 ui64 GetAllocationUnit(


### PR DESCRIPTION
To exclude the possibility of Compact being responsible for corruption of user data, we require checksums for all data written by Compact.

This PR adds the ability to enable forced checksum calculation during compaction (without checking any conditions).