### PR TITLE
Add optional message field for device and agent state changes on monitoring page

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -116,6 +116,14 @@ void BuildChangeDeviceStateButton(
                 <option value="%s">Online</option>
                 <option value="%s">Warning</option>
             </select>
+            <br>
+            <label for="stateMessage">State message:</label>
+            <input  type="text"
+                    name="stateMessage"
+                    placeholder="Message"
+                    maxlength="255"
+                    style="width: 150px;">
+            <br>
             <input type="submit" value="Change state">
             <input type='hidden' name='action' value='changeDeviceState'/>
             <input type='hidden' name='DeviceUUID' value='%s'/>
@@ -141,6 +149,14 @@ void BuildChangeAgentStateButton(
                 <option value="%s">Online</option>
                 <option value="%s">Warning</option>
             </select>
+            <br>
+            <label for="stateMessage">State message:</label>
+            <input  type="text"
+                    name="stateMessage"
+                    placeholder="Message"
+                    maxlength="255"
+                    style="width: 150px;">
+            <br>
             <input type="submit" value="Change state">
             <input type='hidden' name='action' value='changeAgentState'/>
             <input type='hidden' name='AgentID' value='%s'/>


### PR DESCRIPTION
This PR adds an optional message field to the device and agent state change form on the monitoring page, allowing to provide context when changing device states.

---

<img width="387" height="444" alt="image" src="https://github.com/user-attachments/assets/94444a0b-9e62-4a23-bb94-b2c70faa1b88" />

<img width="727" height="621" alt="image" src="https://github.com/user-attachments/assets/eb9dde76-5b47-436b-9600-4aeee1124204" />
