### PR TITLE
issue-4503: [Filestore] Automatic flush should be triggered in WriteBackCache without waiting for the completion of the previous FlushAll

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -389,14 +389,17 @@ public:
             Timer->Now() + FlushConfig.AutomaticFlushPeriod,
             [ptr = weak_from_this()] () {
                 if (auto self = ptr.lock()) {
-                    self->FlushAllData().Subscribe(
-                        [ptr = self->weak_from_this()] (auto) {
-                            if (auto self = ptr.lock()) {
-                                self->ScheduleAutomaticFlushIfNeeded();
-                            }
-                        });
+                    self->RequestAutomaticFlush();
                 }
             });
+    }
+
+    void RequestAutomaticFlush()
+    {
+        auto guard = Guard(Lock);
+        RequestFlushAll();
+        ExecutePendingOperations(guard);
+        ScheduleAutomaticFlushIfNeeded();
     }
 
     // should be protected by |Lock|


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/4503