### PR TITLE
[Disk Manager] Fix SelectCellForLocalDisk behaviour if config is not set

### DIFF
--- a/cloud/disk_manager/internal/pkg/cells/cells.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells.go
@@ -59,6 +59,10 @@ func (s *cellSelector) SelectCellForLocalDisk(
 	agentIDs []string,
 ) (nbs.Client, error) {
 
+	if s.config == nil {
+		return s.nbsFactory.GetClient(ctx, zoneID)
+	}
+
 	cells := s.getCells(zoneID)
 	if len(cells) == 0 {
 		if s.isCell(zoneID) {

--- a/cloud/disk_manager/internal/pkg/cells/cells_test.go
+++ b/cloud/disk_manager/internal/pkg/cells/cells_test.go
@@ -471,3 +471,25 @@ func TestSelectCellForLocalDiskCellReturnsAnError(t *testing.T) {
 		}
 	}
 }
+
+func TestSelectCellForLocalDiskReturnsCorrectNBSClientIfConfigsIsNotSet(
+	t *testing.T,
+) {
+
+	ctx := context.Background()
+	nbsFactory := nbs_mocks.NewFactoryMock()
+	nbsClient := nbs_mocks.NewClientMock()
+
+	cellSelector := cellSelector{
+		nbsFactory: nbsFactory,
+	}
+
+	nbsFactory.On("GetClient", mock.Anything, "zone-a").Return(nbsClient, nil)
+
+	agentIDs := []string{"agent1"}
+
+	client, err := cellSelector.SelectCellForLocalDisk(ctx, "zone-a", agentIDs)
+	require.NoError(t, err)
+	require.Equal(t, nbsClient, client)
+	mock.AssertExpectationsForObjects(t, nbsFactory, nbsClient)
+}


### PR DESCRIPTION
Fix for https://github.com/ydb-platform/nbs/pull/3779

If config is not set, `SelectCellForLocalDisk` would return an error: `incorrect zone ID provided: 'zone-id'`