### PR TITLE
Add feature toggle to disable write buffers copying in the volume actor

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1353,6 +1353,6 @@ message TStorageServiceConfig
     // Enables force calculation of the checksums for all compaction blocks.
     optional bool ComputeDigestForEveryBlockOnCompaction = 465;
 
-    // Enables the use of intermediate write buffers in volume actor.
-    optional bool EnableUsingIntermediateWriteBuffer = 466;
+    // Disables the use of intermediate write buffers in volume actor.
+    optional bool DisableUsingIntermediateWriteBuffer = 466;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -566,7 +566,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MaxScrubbingBandwidth,                          ui64,      50            )\
     xxx(MinScrubbingBandwidth,                          ui64,      5             )\
     xxx(AutomaticallyEnableBufferCopyingAfterChecksumMismatch, bool, false       )\
-    xxx(EnableUsingIntermediateWriteBuffer,                    bool, true        )\
+    xxx(DisableUsingIntermediateWriteBuffer,                   bool, false       )\
     xxx(ScrubbingResyncPolicy,                                                    \
         NProto::EResyncPolicy,                                                    \
         NProto::EResyncPolicy::RESYNC_POLICY_MINOR_4MB                           )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -627,7 +627,7 @@ public:
     ui64 GetMaxScrubbingBandwidth() const;
     ui64 GetMinScrubbingBandwidth() const;
     bool GetAutomaticallyEnableBufferCopyingAfterChecksumMismatch() const;
-    bool GetEnableUsingIntermediateWriteBuffer() const;
+    bool GetDisableUsingIntermediateWriteBuffer() const;
     NProto::EResyncPolicy GetScrubbingResyncPolicy() const;
 
     bool GetOptimizeVoidBuffersTransferForReadsEnabled() const;

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -393,8 +393,8 @@ void TVolumeState::Reset()
     if (tags.contains(UseFastPathTagName)) {
         UseFastPath = true;
     }
-    if (tags.contains(IntermediateWriteBufferTagName) &&
-        StorageConfig->GetEnableUsingIntermediateWriteBuffer())
+    if (!StorageConfig->GetDisableUsingIntermediateWriteBuffer() &&
+        tags.contains(IntermediateWriteBufferTagName))
     {
         UseIntermediateWriteBuffer = true;
     }

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9486,12 +9486,12 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         NCloud::NProto::EStorageMediaKind mediaKind,
         ui32 writeNumberToIntercept,
         const TString& tags,
-        bool enableUsingIntermediateWriteBuffer = true)
+        bool disableUsingIntermediateWriteBuffer = false)
     {
         NProto::TStorageServiceConfig config;
         config.SetAcquireNonReplicatedDevices(true);
-        config.SetEnableUsingIntermediateWriteBuffer(
-            enableUsingIntermediateWriteBuffer);
+        config.SetDisableUsingIntermediateWriteBuffer(
+            disableUsingIntermediateWriteBuffer);
         auto state = MakeIntrusive<TDiskRegistryState>();
         auto runtime = PrepareTestActorRuntime(config, state);
 
@@ -9617,7 +9617,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             // 3 - to 3 replicas
             1 + 1 + 3,
             "use-intermediate-write-buffer",
-            /*enableUsingIntermediateWriteBuffer=*/false);
+            /*disableUsingIntermediateWriteBuffer=*/true);
         const TString adata(4_KB, 'a');
 
         const bool replica1Match = (adata == results[0]);


### PR DESCRIPTION
#2988
Added a toggle that allows to disable buffer copying even if the tag is set. This change does not modify the current behavior.