### PR TITLE
Add debug output for test ShouldForwardRetriedRequestsToSecondaryClientAfterSwitch

### DIFF
--- a/cloud/blockstore/libs/client/switchable_session_ut.cpp
+++ b/cloud/blockstore/libs/client/switchable_session_ut.cpp
@@ -445,7 +445,8 @@ Y_UNIT_TEST_SUITE(TSwitchableSessionTest)
 
         // Check that the session has not switched, as there are requests in
         // flight.
-        drainFuture.Wait(TDuration::Seconds(3));
+        Cerr << "Before drainFuture.Wait\n";
+        drainFuture.Wait(TDuration::Seconds(2.5));
         UNIT_ASSERT_VALUES_EQUAL(false, drainFuture.HasValue());
 
         // Responding with a retriable error to the request from the first disk.
@@ -455,7 +456,9 @@ Y_UNIT_TEST_SUITE(TSwitchableSessionTest)
         {
             NProto::TReadBlocksLocalResponse response;
             *response.MutableError() = MakeError(E_REJECTED, "some error");
+            Cerr << "Before readPromise.SetValue\n";
             readPromise.SetValue(std::move(response));
+            Cerr << "After readPromise.SetValue\n";
         }
 
         // Check that the request was completed successfully.


### PR DESCRIPTION
```
2025-10-17T13:19:37.994768Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:533: [d:disk-1] MountVolume submit request: read-write access, local mount
2025-10-17T13:19:37.994789Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:645: [d:disk-1] MountVolume new disk size: 1024
2025-10-17T13:19:37.994893Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:533: [d:disk-2] MountVolume submit request: read-write access, local mount
2025-10-17T13:19:37.994904Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:645: [d:disk-2] MountVolume new disk size: 1024
2025-10-17T13:19:37.994924Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/switchable_session.cpp:210: Switch #0 session from "disk-1" to "disk-2". Inflight requests:1
2025-10-17T13:19:37.994926Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/switchable_client.cpp:97: Switched from "disk-1" to "disk-2"
Uncaught exception: (TSystemError) (Resource deadlock avoided) util/system/thread.cpp:198: can not join thread
??+0 (0xEE48F9)
std::terminate()+38 (0xFC2456)
??+0 (0xEDE17B)
??+0 (0x1469AE7)
??+0 (0x20390D4)
??+0 (0x203E2A2)
??+0 (0x146A4A0)
??+0 (0x1469E4A)
??+0 (0x10D60BC)
??+0 (0x7F5A5C894AC3)
??+0 (0x7F5A5C9268C0)
```

```
2025-10-10T04:05:56.779916Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:533: [d:disk-1] MountVolume submit request: read-write access, local mount
2025-10-10T04:05:56.779964Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:645: [d:disk-1] MountVolume new disk size: 1024
2025-10-10T04:05:56.780085Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:533: [d:disk-2] MountVolume submit request: read-write access, local mount
2025-10-10T04:05:56.780102Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/session.cpp:645: [d:disk-2] MountVolume new disk size: 1024
2025-10-10T04:05:56.780198Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/switchable_session.cpp:210: Switch #0 session from "disk-1" to "disk-2". Inflight requests:1
2025-10-10T04:05:56.780205Z :BLOCKSTORE_CLIENT INFO: cloud/blockstore/libs/client/switchable_client.cpp:97: Switched from "disk-1" to "disk-2"
Uncaught exception: (TSystemError) (Resource deadlock avoided) util/system/thread.cpp:198: can not join thread
??+0 (0x1F5B331)
std::terminate()+38 (0x21215F6)
??+0 (0x1F5B12E)
??+0 (0x2F84FEF)
std::__y1::__shared_count::__release_shared[abi:v15000]()+183 (0x1F98BE7)
std::__y1::__shared_weak_count::__release_shared[abi:v15000]()+97 (0x1F98AA1)
??+0 (0x524243A)
std::__y1::__shared_count::__release_shared[abi:v15000]()+183 (0x1F98BE7)
std::__y1::__shared_weak_count::__release_shared[abi:v15000]()+97 (0x1F98AA1)
??+0 (0x524F07A)
??+0 (0x2F88031)
??+0 (0x2F864D8)
??+0 (0x23FAB05)
??+0 (0x7FB796C94AC3)
??+0 (0x7FB796D268C0)
```