### PR TITLE
[NBS] disable O_DIRECT & O_SYNC for local-nonrepl/mirror tests (because of tmpfs)

### DIFF
--- a/cloud/blockstore/tests/python/lib/nonreplicated_setup.py
+++ b/cloud/blockstore/tests/python/lib/nonreplicated_setup.py
@@ -214,7 +214,7 @@ def setup_disk_agent_config(
     config.Enabled = True
     config.DedicatedDiskAgent = False
     config.Backend = DISK_AGENT_BACKEND_AIO
-    config.DirectIoFlagDisabled = False
+    config.DirectIoFlagDisabled = True
     config.AgentId = agent_id
     config.AcquireRequired = True
     config.RegisterRetryTimeout = 1000  # 1 second


### PR DESCRIPTION
```
(TFileError) (Invalid argument) util/system/file.cpp:918: can't open "/mnt/ya_make_tmpfs/tmp10b1qfuo.nonrepl" with mode RdWr|Sync|DirectAligned (0x00003018)
```