### PR TITLE
issue-4551: add a custom node ranking function to the device allocation query

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
@@ -3,13 +3,17 @@
 #include "public.h"
 
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/datetime/base.h>
-#include <util/generic/hash_set.h>
 #include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
+
+#include <functional>
+#include <span>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -67,11 +71,13 @@ private:
     const bool AlwaysAllocateLocalDisks;
 
 public:
+    using TNodeRankingFunc = std::function<void (std::span<ui32> nodeIds)>;
+
     struct TAllocationQuery
     {
         THashSet<TString> ForbiddenRacks;
         THashSet<TString> PreferredRacks;
-        THashSet<ui32> DownrankedNodeIds;
+        TNodeRankingFunc NodeRankingFunc;
 
         ui32 LogicalBlockSize = 0;
         ui64 BlockCount = 0;
@@ -181,7 +187,7 @@ private:
         const TAllocationQuery& query,
         const TString& poolName) const;
 
-    [[nodiscard]] TVector<TNodeInfo> RankNodes(
+    [[nodiscard]] TVector<TNodeId> RankNodes(
         const TAllocationQuery& query,
         TVector<TRack> racks) const;
 


### PR DESCRIPTION
#4551

Add a custom node ranking function to the device allocation query to be able to
lower the rank of nodes that already host disks of the user.