### PR TITLE
issue-1751: [Filestore] Get rid of memory allocation in ReadData when there is no cached data

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -838,6 +838,10 @@ private:
                 length);
 
             if (!parts.empty()) {
+                // TODO(nasonov): it is possible to completely get rid of copy
+                // here by referencing the buffer directly in the cache and
+                // adding reference count in order to prevent evicting buffer
+                // from the cache
                 *buffer = TString(length, 0);
                 for (const auto& part: parts) {
                     ReadDataPart(part, startingFromOffset, buffer);


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1751