### PR TITLE
issue-4664: copy only origin blobs range

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -129,7 +129,7 @@ TReadDataActor::TReadDataActor(
         BlockSize)
     , AlignedByteRange(OriginByteRange.AlignedSuperRange())
     , BlockBuffer(std::make_unique<TString>())
-    , ZeroIntervals(TDefaultAllocator::Instance(), 0, AlignedByteRange.Length)
+    , ZeroIntervals(TDefaultAllocator::Instance(), 0, OriginByteRange.Length)
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
     , MediaKind(mediaKind)
@@ -143,7 +143,7 @@ void TReadDataActor::Bootstrap(const TActorContext& ctx)
     // a block buffer leads to memory allocation (and initialization) which is
     // heavy and we would like to execute that on a separate thread (instead of
     // this actor's parent thread)
-    BlockBuffer->ReserveAndResize(AlignedByteRange.Length);
+    BlockBuffer->ReserveAndResize(ReadRequest.GetLength());
 
     if (UseTwoStageRead) {
         DescribeData(ctx);
@@ -218,7 +218,7 @@ void ApplyFreshDataRange(
     const TActorContext& ctx,
     const NProtoPrivate::TFreshDataRange& sourceFreshData,
     TString& targetBuffer,
-    TByteRange alignedTargetByteRange,
+    TByteRange targetByteRange,
     ui32 blockSize,
     ui64 offset,
     ui64 length,
@@ -239,25 +239,24 @@ void ApplyFreshDataRange(
         "common byte range found: source: %s, target: %s, original request: "
         "[%lu, %lu), response: %s",
         sourceByteRange.Describe().c_str(),
-        alignedTargetByteRange.Describe().c_str(),
+        targetByteRange.Describe().c_str(),
         offset,
         length,
         DescribeResponseDebugString(describeResponse).Quote().c_str());
 
-    auto commonRange = sourceByteRange.Intersect(alignedTargetByteRange);
+    auto commonRange = sourceByteRange.Intersect(targetByteRange);
 
-    Y_ABORT_UNLESS(sourceByteRange == commonRange);
     if (commonRange.Length == 0) {
         LOG_WARN(
             ctx,
             TFileStoreComponents::SERVICE,
             "common range is empty: source: %s, target: %s",
             sourceByteRange.Describe().c_str(),
-            alignedTargetByteRange.Describe().c_str());
+            targetByteRange.Describe().c_str());
         return;
     }
 
-    const ui64 relOffset = commonRange.Offset - alignedTargetByteRange.Offset;
+    const ui64 relOffset = commonRange.Offset - targetByteRange.Offset;
     memcpy(
         &targetBuffer[relOffset],
         sourceFreshData.GetContent().data() +
@@ -467,7 +466,6 @@ void TReadDataActor::HandleReadBlobResponse(
             return;
         }
 
-        auto dataIter = response.Buffer.begin();
         LOG_DEBUG(
             ctx,
             TFileStoreComponents::SERVICE,
@@ -487,11 +485,27 @@ void TReadDataActor::HandleReadBlobResponse(
             response.Buffer.size());
         TABLET_VERIFY(blobRange.GetOffset() >= AlignedByteRange.Offset);
 
-        const ui64 relOffset = blobRange.GetOffset() - AlignedByteRange.Offset;
-        dataIter.ExtractPlainDataAndAdvance(
-            &(*BlockBuffer)[relOffset],
-            blobRange.GetLength());
-        ZeroIntervals.PunchHole(relOffset, relOffset + blobRange.GetLength());
+        const auto blobByteRange =
+            TByteRange{blobRange.GetOffset(), blobRange.GetLength(), BlockSize};
+        const auto commonRange = OriginByteRange.Intersect(blobByteRange);
+        if (commonRange.Length != 0) {
+            const auto relOffset = commonRange.Offset - OriginByteRange.Offset;
+            auto dataIter = response.Buffer.begin();
+            dataIter += commonRange.Offset - blobByteRange.Offset;
+            dataIter.ExtractPlainDataAndAdvance(
+                &(*BlockBuffer)[relOffset],
+                commonRange.Length);
+            ZeroIntervals.PunchHole(
+                relOffset,
+                relOffset + commonRange.Length);
+        } else {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "common range is empty: origin range: %s, blob range: %s",
+                OriginByteRange.Describe().c_str(),
+                blobByteRange.Describe().c_str());
+        }
     }
 
     --RemainingBlobsToRead;
@@ -637,7 +651,7 @@ void TReadDataActor::ReplyAndDie(const TActorContext& ctx)
             ctx,
             freshDataRange,
             *BlockBuffer,
-            AlignedByteRange,
+            OriginByteRange,
             BlockSize,
             ReadRequest.GetOffset(),
             ReadRequest.GetLength(),
@@ -664,11 +678,8 @@ void TReadDataActor::ReplyAndDie(const TActorContext& ctx)
     if (end <= OriginByteRange.Offset) {
         BlockBuffer->clear();
     } else {
-        BlockBuffer->ReserveAndResize(end - AlignedByteRange.Offset);
-        const auto bufferOffset =
-            OriginByteRange.Offset - AlignedByteRange.Offset;
+        BlockBuffer->ReserveAndResize(end - OriginByteRange.Offset);
         response->Record.set_allocated_buffer(BlockBuffer.release());
-        response->Record.SetBufferOffset(bufferOffset);
     }
 
     MoveBufferToIovecsIfNeeded(ctx, response->Record);

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3791,14 +3791,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 data.size());
 
             const auto& buffer = response->Record.GetBuffer();
-            const auto& offset = response->Record.GetBufferOffset();
-            UNIT_ASSERT_VALUES_EQUAL(
-                data.size() + DefaultBlockSize - 1,
-                buffer.size());
-            UNIT_ASSERT_VALUES_EQUAL(DefaultBlockSize - 1, offset);
-            UNIT_ASSERT_VALUES_EQUAL(
-                data,
-                TString(buffer.data() + offset, data.size()));
+            UNIT_ASSERT_VALUES_EQUAL(data.size(), buffer.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetBufferOffset());
+            UNIT_ASSERT_VALUES_EQUAL(data, buffer);
         }
         {
             // Small unaligned data
@@ -3813,12 +3808,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 dataOffset,
                 data.size());
             const auto& buffer = response->Record.GetBuffer();
-            const auto& offset = response->Record.GetBufferOffset();
-            UNIT_ASSERT_VALUES_EQUAL(data.size() + dataOffset, buffer.size());
-            UNIT_ASSERT_VALUES_EQUAL(dataOffset, offset);
-            UNIT_ASSERT_EQUAL(
-                data,
-                TString(buffer.data() + offset, data.size()));
+            UNIT_ASSERT_VALUES_EQUAL(data.size(), buffer.size());
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetBufferOffset());
+            UNIT_ASSERT_EQUAL(data, buffer);
         }
         {
             // Multiple blobs


### PR DESCRIPTION
issue: #4664

This refactoring(prefactoring) is required to remove unnecessary buffer copy in TReadDataActor for zero-copy read https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/libs/storage/service/service_actor_readdata.cpp#L674 as it's not possible to copy data from aligned super range directly to iovecs with unaligned origin range.

BufferOffset is always 0 in the response.


[Here](https://github.com/ydb-platform/nbs/pull/4790/commits/1bc7e40f6a134b91934fc6fd46fb41a8660e20df#diff-24b44c319c6982823d902343c7ea19cc99303e62f2ace02206de81dceaf7f6e9R152) is the pr with elimination of buffer copy for iovecs over the current branch