### PR TITLE
Add uptime and restart count for non-replicated partition

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -396,6 +396,7 @@ private:
     // even if the partitions are deleted in a different order.
     TDeque<TPartitionDestroyCallback> WaitForPartitionDestroy;
     ui64 PartitionRestartCounter = 0;
+    std::optional<TInstant> NrdStartTime;
 
     TVector<ui64> GCCompletedPartitions;
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -1761,8 +1761,22 @@ void TVolumeActor::RenderTabletList(IOutputStream& out) const
                         out << State->GetConfig().GetBlocksCount();
                     }
                     TABLED () {
+                        const auto actorId =
+                            State->GetDiskRegistryBasedPartitionActor();
+                        if (actorId && NrdStartTime) {
+                            out << FormatDuration(
+                                TInstant::Now() - *NrdStartTime);
+                        } else if (NrdStartTime) {
+                            out << "Stopped ("
+                                << FormatDuration(
+                                       TInstant::Now() - *NrdStartTime)
+                                << ")";
+                        } else {
+                            out << "Not running";
+                        }
                     }
                     TABLED () {
+                        out << PartitionRestartCounter;
                     }
                 }
             }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -301,6 +301,8 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
     State->SetDiskRegistryBasedPartitionActor(
         std::move(actorStack),
         nonreplicatedConfig);
+
+    NrdStartTime = TInstant::Now();
 }
 
 TActorsStack TVolumeActor::WrapWithShadowDiskActorIfNeeded(


### PR DESCRIPTION
Continue PR:https://github.com/ydb-platform/nbs/pull/4506

Add NRD partition uptime and restart count in monitoring

<img width="1159" height="159" alt="image" src="https://github.com/user-attachments/assets/60ff767f-900f-4f31-a93c-0caa1353ae42" />
