### PR TITLE
Add ability to force data integrity validation in tests for DR-based disks

### DIFF
--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 import "cloud/blockstore/config/rdma.proto";
 import "cloud/blockstore/config/spdk.proto";
+import "cloud/blockstore/public/api/protos/disk.proto";
 
 package NCloud.NBlockStore.NProto;
 
@@ -347,10 +348,14 @@ message TDiskAgentConfig
 
     // Enables data integrity validation for the DR-based disks.
     // See "EnableDataIntegrityClient" in server.proto for more details.
+    // Deprecated. Use "DataIntegrityValidationPolicyForDrBasedDisks" instead.
     optional bool EnableDataIntegrityValidationForDrBasedDisks = 44;
 
     // DANGER! It is used to generate errors during chaos testing.
     optional TChaosConfig ChaosConfig = 45;
+
+    // Allows to control data integrity validation for DR-based disks.
+    optional EDataIntegrityValidationPolicy DataIntegrityValidationPolicyForDrBasedDisks = 46;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -790,9 +790,9 @@ void TBootstrapBase::InitLocalService()
             NvmeManager,
             {.DirectIO = false,
              .UseSubmissionThread = false,
-             .EnableDataIntegrityValidation =
+             .DataIntegrityValidationPolicy =
                  Configs->DiskAgentConfig
-                     ->GetEnableDataIntegrityValidationForDrBasedDisks()}));
+                     ->GetDataIntegrityValidationPolicyForDrBasedDisks()}));
 }
 
 void TBootstrapBase::InitNullService()

--- a/cloud/blockstore/libs/disk_agent/config_initializer.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.cpp
@@ -343,7 +343,8 @@ void TConfigInitializer::SetupLogConfig(NKikimrConfig::TLogConfig& logConfig) co
     }
 }
 
-void TConfigInitializer::SetupDiskAgentConfig(NProto::TDiskAgentConfig& config) const
+void TConfigInitializer::SetupDiskAgentConfig(
+    NProto::TDiskAgentConfig& config) const
 {
     if (!config.GetDedicatedDiskAgent()) {
         config.SetEnabled(false);
@@ -360,6 +361,13 @@ void TConfigInitializer::SetupDiskAgentConfig(NProto::TDiskAgentConfig& config) 
     if (Options->RdmaTargetPort != 0) {
         config.MutableRdmaTarget()->MutableEndpoint()->SetPort(
             Options->RdmaTargetPort);
+    }
+
+    if (!config.HasDataIntegrityValidationPolicyForDrBasedDisks() &&
+        config.GetEnableDataIntegrityValidationForDrBasedDisks())
+    {
+        config.SetDataIntegrityValidationPolicyForDrBasedDisks(
+            NProto::DIVP_ENABLED);
     }
 }
 

--- a/cloud/blockstore/libs/service_local/storage_local.h
+++ b/cloud/blockstore/libs/service_local/storage_local.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/nvme/public.h>
 #include <cloud/blockstore/libs/service/public.h>
+#include <cloud/blockstore/public/api/protos/disk.pb.h>
 
 #include <cloud/storage/core/libs/common/public.h>
 
@@ -15,7 +16,8 @@ struct TLocalStorageProviderParams
 {
     bool DirectIO = false;
     bool UseSubmissionThread = false;
-    bool EnableDataIntegrityValidation = false;
+    NProto::EDataIntegrityValidationPolicy DataIntegrityValidationPolicy =
+        NProto::DIVP_DISABLED;
     TString SubmissionThreadName = "AIO.SQ";
 };
 

--- a/cloud/blockstore/libs/storage/disk_agent/model/bootstrap.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/bootstrap.cpp
@@ -123,8 +123,9 @@ IStorageProviderPtr CreateStorageProvider(
                     .DirectIO = !config.GetDirectIoFlagDisabled(),
                     .UseSubmissionThread =
                         config.GetUseLocalStorageSubmissionThread(),
-                    .EnableDataIntegrityValidation =
-                        config.GetEnableDataIntegrityValidationForDrBasedDisks(),
+                    .DataIntegrityValidationPolicy =
+                        config
+                            .GetDataIntegrityValidationPolicyForDrBasedDisks(),
                 });
             break;
         }
@@ -142,8 +143,9 @@ IStorageProviderPtr CreateStorageProvider(
                     // Each io_uring service already has its own submission
                     // thread, so we don't need one here
                     .UseSubmissionThread = false,
-                    .EnableDataIntegrityValidation =
-                        config.GetEnableDataIntegrityValidationForDrBasedDisks(),
+                    .DataIntegrityValidationPolicy =
+                        config
+                            .GetDataIntegrityValidationPolicyForDrBasedDisks(),
                 });
             break;
         }

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.cpp
@@ -51,6 +51,9 @@ namespace {
     xxx(OffloadAllIORequestsParsingEnabled, bool,       false                 )\
     xxx(DisableNodeBrokerRegistrationOnDevicelessAgent, bool,          false  )\
     xxx(EnableDataIntegrityValidationForDrBasedDisks,   bool,          false  )\
+    xxx(DataIntegrityValidationPolicyForDrBasedDisks,                          \
+        NProto::EDataIntegrityValidationPolicy,                                \
+        NProto::DIVP_DISABLED                                                 )\
     xxx(MaxAIOContextEvents,                ui32,       1024                  )\
     xxx(PathsPerFileIOService,              ui32,       0                     )\
     xxx(DisableBrokenDevices,               bool,       false                 )\
@@ -103,6 +106,20 @@ IOutputStream& operator<<(IOutputStream& out, NProto::EDeviceEraseMethod pt)
     if (s.empty()) {
         return out << "(Unknown EDeviceEraseMethod value "
                    << static_cast<int>(pt) << ")";
+    }
+
+    return out << s;
+}
+
+IOutputStream& operator<<(
+    IOutputStream& out,
+    NProto::EDataIntegrityValidationPolicy policy)
+{
+    const TString& s = NProto::EDataIntegrityValidationPolicy_Name(policy);
+
+    if (s.empty()) {
+        return out << "(Unknown EDataIntegrityValidationPolicy value "
+                   << static_cast<int>(policy) << ")";
     }
 
     return out << s;

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -142,6 +142,8 @@ public:
     [[nodiscard]] bool GetKickOutOldClientsEnabled() const;
 
     bool GetEnableDataIntegrityValidationForDrBasedDisks() const;
+    NProto::EDataIntegrityValidationPolicy
+    GetDataIntegrityValidationPolicyForDrBasedDisks() const;
 
     [[nodiscard]] bool HasChaosConfig() const;
     [[nodiscard]] const NProto::TChaosConfig& GetChaosConfig() const;

--- a/cloud/blockstore/public/api/protos/disk.proto
+++ b/cloud/blockstore/public/api/protos/disk.proto
@@ -52,6 +52,19 @@ enum EDevicePoolKind
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Allows to control data integrity validation
+
+enum EDataIntegrityValidationPolicy
+{
+    // Data integrity validation is disabled.
+    DIVP_DISABLED = 0;
+    // Data integrity validation is enabled.
+    DIVP_ENABLED = 1;
+    // Non-present checksums will be treated as validation errors.
+    DIVP_ENABLED_FORCED = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Device Override
 
 message TDeviceOverride


### PR DESCRIPTION
#2988

For testing purposes, we want to make sure that no code is dropping checksums. We add a special policy here that treats missing checksum as an error.
Loadtest with this feature is coming next.