### PR TITLE
Fix DiskRegistry-based devices request tracking

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -89,8 +89,6 @@ private:
         GetCycleCount(),
         TLogTitle::TPartitionNonrepl{.DiskId = PartConfig->GetName()}};
 
-    ui64 DeviceOperationIdGenerator = 1;
-
 public:
     TNonreplicatedPartitionActor(
         TStorageConfigPtr config,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_base_request.h
@@ -84,9 +84,11 @@ protected:
         const NActors::TActorContext& ctx,
         const TString& deviceUUID,
         TDeviceOperationTracker::ERequestType requestType,
-        ui32 cookie);
+        size_t requestIndex);
 
-    void OnRequestFinished(const NActors::TActorContext& ctx, ui32 cookie);
+    void OnRequestFinished(
+        const NActors::TActorContext& ctx,
+        size_t requestIndex);
 
 private:
     void StateWork(TAutoPtr<NActors::IEventHandle>& ev);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_checksumblocks.cpp
@@ -146,6 +146,8 @@ void TDiskAgentChecksumActor::HandleChecksumDeviceBlocksUndelivery(
     const TEvDiskAgent::TEvChecksumDeviceBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    OnRequestFinished(ctx, ev->Cookie);
+
     const auto& device = DeviceRequests[ev->Cookie].Device;
     LOG_WARN(
         ctx,
@@ -164,6 +166,8 @@ void TDiskAgentChecksumActor::HandleChecksumDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
+    OnRequestFinished(ctx, ev->Cookie);
+
     if (HasError(msg->GetError())) {
         HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
@@ -173,8 +177,6 @@ void TDiskAgentChecksumActor::HandleChecksumDeviceBlocksResponse(
     const auto rangeStart = deviceRequest.BlockRange.Start;
     const auto rangeSize = deviceRequest.DeviceBlockRange.Size() * PartConfig->GetBlockSize();
     Checksums[rangeStart] = {msg->Record.GetChecksum(), rangeSize};
-
-    OnRequestFinished(ctx, ev->Cookie);
 
     if (++RequestsCompleted < DeviceRequests.size()) {
         return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks.cpp
@@ -168,6 +168,8 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksUndelivery(
     const TEvDiskAgent::TEvReadDeviceBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    OnRequestFinished(ctx, ev->Cookie);
+
     const auto& device = DeviceRequests[ev->Cookie].Device;
     LOG_WARN(
         ctx,
@@ -185,6 +187,8 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksResponse(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
+
+    OnRequestFinished(ctx, ev->Cookie);
 
     if (HasError(msg->GetError())) {
         HandleError(ctx, msg->GetError(), EStatus::Fail);
@@ -211,8 +215,6 @@ void TDiskAgentReadActor::HandleReadDeviceBlocksResponse(
             ++NonVoidBlockCount;
         }
     }
-
-    OnRequestFinished(ctx, ev->Cookie);
 
     if (++RequestsCompleted < DeviceRequests.size()) {
         return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_readblocks_local.cpp
@@ -170,6 +170,8 @@ void TDiskAgentReadLocalActor::HandleReadDeviceBlocksUndelivery(
     const TEvDiskAgent::TEvReadDeviceBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    OnRequestFinished(ctx, ev->Cookie);
+
     const auto& device = DeviceRequests[ev->Cookie].Device;
     LOG_WARN(
         ctx,
@@ -187,6 +189,8 @@ void TDiskAgentReadLocalActor::HandleReadDeviceBlocksResponse(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
+
+    OnRequestFinished(ctx, ev->Cookie);
 
     if (HasError(msg->GetError())) {
         HandleError(ctx, msg->GetError(), EStatus::Fail);
@@ -224,8 +228,6 @@ void TDiskAgentReadLocalActor::HandleReadDeviceBlocksResponse(
             STORAGE_CHECK_PRECONDITION(voidBlockStat.VoidBlockCount == 0);
         }
     }
-
-    OnRequestFinished(ctx, ev->Cookie);
 
     if (++RequestsCompleted < DeviceRequests.size()) {
         return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks.cpp
@@ -179,6 +179,8 @@ void TDiskAgentWriteActor::HandleWriteDeviceBlocksUndelivery(
     const TEvDiskAgent::TEvWriteDeviceBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    OnRequestFinished(ctx, ev->Cookie);
+
     const auto& device = DeviceRequests[ev->Cookie].Device;
     LOG_WARN(
         ctx,
@@ -197,12 +199,12 @@ void TDiskAgentWriteActor::HandleWriteDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
+    OnRequestFinished(ctx, ev->Cookie);
+
     if (HasError(msg->GetError())) {
         HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
-
-    OnRequestFinished(ctx, ev->Cookie);
 
     if (++RequestsCompleted < DeviceRequests.size()) {
         return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -182,6 +182,8 @@ void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksUndelivery(
 {
     Y_UNUSED(ev);
 
+    OnRequestFinished(ctx, ev->Cookie);
+
     LOG_WARN(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
@@ -198,6 +200,8 @@ void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksResponse(
     const TActorContext& ctx)
 {
     const auto* msg = ev->Get();
+
+    OnRequestFinished(ctx, ev->Cookie);
 
     auto replyInconsistentError = [&]()
     {
@@ -239,8 +243,6 @@ void TDiskAgentMultiWriteActor::HandleWriteDeviceBlocksResponse(
         replyInconsistentError();
         return;
     }
-
-    OnRequestFinished(ctx, 0);
 
     Y_DEBUG_ABORT_UNLESS(error.GetCode() == S_OK);
     Done(ctx, MakeResponse(std::move(error)), EStatus::Success);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_zeroblocks.cpp
@@ -144,6 +144,8 @@ void TDiskAgentZeroActor::HandleZeroDeviceBlocksUndelivery(
     const TEvDiskAgent::TEvZeroDeviceBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    OnRequestFinished(ctx, ev->Cookie);
+
     const auto& device = DeviceRequests[ev->Cookie].Device;
     LOG_WARN(
         ctx,
@@ -162,12 +164,12 @@ void TDiskAgentZeroActor::HandleZeroDeviceBlocksResponse(
 {
     auto* msg = ev->Get();
 
+    OnRequestFinished(ctx, ev->Cookie);
+
     if (HasError(msg->GetError())) {
         HandleError(ctx, msg->GetError(), EStatus::Fail);
         return;
     }
-
-    OnRequestFinished(ctx, ev->Cookie);
 
     if (++RequestsCompleted < DeviceRequests.size()) {
         return;


### PR DESCRIPTION
continue https://github.com/ydb-platform/nbs/pull/4381
1. Fixed operationId reusing
2. Fixed missed OnRequestFinished() when operation finished with error
