### PR TITLE
[Disk Manager] save state after set estimate in CreateDRBasedDiskCheckpoint task

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/create_dr_based_disk_checkpoint_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_dr_based_disk_checkpoint_task.go
@@ -134,7 +134,7 @@ func (t *createDRBasedDiskCheckpointTask) setEstimate(
 		t.performanceConfig.GetCreateDRBasedDiskCheckpointBandwidthMiBs(),
 	))
 
-	return nil
+	return execCtx.SaveState(ctx)
 }
 
 func (t *createDRBasedDiskCheckpointTask) makeCheckpointID(

--- a/cloud/disk_manager/internal/pkg/dataplane/create_dr_based_disk_checkpoint_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_dr_based_disk_checkpoint_task.go
@@ -134,6 +134,7 @@ func (t *createDRBasedDiskCheckpointTask) setEstimate(
 		t.performanceConfig.GetCreateDRBasedDiskCheckpointBandwidthMiBs(),
 	))
 
+	// Need to save state in order to persist the estimate.
 	return execCtx.SaveState(ctx)
 }
 


### PR DESCRIPTION
Add SaveState call after setting the estimate. Without this call the estimate will be saved to database only after checkpoint is fully created. It might cause false positive hanging task reports.