### PR TITLE
[NBS] treat EREMOTEIO as fatal; convert system IO errors to E_IO in DeviceAdaptor; set the silent flag for EREMOTEIO in the partition

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -185,6 +185,7 @@ auto CreateDiskAgentStateSpdk(TDiskAgentConfigPtr config)
 struct TTestStorageState: TAtomicRefCount<TTestStorageState>
 {
     bool DropRequests = false;
+    NProto::TError Error;
 };
 
 using TTestStorageStatePtr = TIntrusivePtr<TTestStorageState>;
@@ -209,7 +210,10 @@ struct TTestStorage: IStorage
             return NewPromise<NProto::TReadBlocksLocalResponse>();
         }
 
-        return MakeFuture<NProto::TReadBlocksLocalResponse>();
+        NProto::TReadBlocksLocalResponse response;
+        *response.MutableError() = StorageState->Error;
+
+        return MakeFuture(std::move(response));
     }
 
     TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
@@ -223,7 +227,10 @@ struct TTestStorage: IStorage
             return NewPromise<NProto::TWriteBlocksLocalResponse>();
         }
 
-        return MakeFuture<NProto::TWriteBlocksLocalResponse>();
+        NProto::TWriteBlocksLocalResponse response;
+        *response.MutableError() = StorageState->Error;
+
+        return MakeFuture(std::move(response));
     }
 
     TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
@@ -237,7 +244,10 @@ struct TTestStorage: IStorage
             return NewPromise<NProto::TZeroBlocksResponse>();
         }
 
-        return MakeFuture<NProto::TZeroBlocksResponse>();
+        NProto::TZeroBlocksResponse response;
+        *response.MutableError() = StorageState->Error;
+
+        return MakeFuture(std::move(response));
     }
 
     TFuture<NProto::TError> EraseDevice(
@@ -2123,6 +2133,87 @@ Y_UNIT_TEST_SUITE(TDiskAgentStateTest)
             UNIT_ASSERT_VALUES_EQUAL("uuid-1", devices[0].GetDeviceUUID());
             UNIT_ASSERT_VALUES_EQUAL("uuid-2", devices[1].GetDeviceUUID());
             UNIT_ASSERT_VALUES_EQUAL("uuid-3", devices[2].GetDeviceUUID());
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldConvertSystemIoErrorsToE_IO, TFiles)
+    {
+        auto config = CreateNullConfig({ .Files = Nvme3s });
+
+        TTestStorageStatePtr storageState = MakeIntrusive<TTestStorageState>();
+
+        TDiskAgentState state(
+            CreateStorageConfig(),
+            config,
+            nullptr,   // spdk
+            CreateTestAllocator(),
+            std::make_shared<TTestStorageProvider>(storageState),
+            CreateProfileLogStub(),
+            CreateBlockDigestGeneratorStub(),
+            CreateLoggingService("console"),
+            nullptr,   // rdmaServer
+            NvmeManager,
+            nullptr,   // rdmaTargetConfig
+            TOldRequestCounters(),
+            nullptr   // multiAgentWriteHandler
+        );
+
+        auto future = state.Initialize();
+        const auto& r = future.GetValue(WaitTimeout);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, r.Errors.size());
+        UNIT_ASSERT_VALUES_EQUAL(3, r.Configs.size());
+
+        auto stats = state.CollectStats().GetValue(WaitTimeout);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetInitErrorsCount());
+        UNIT_ASSERT_VALUES_EQUAL(3, stats.GetDeviceStats().size());
+
+        NProto::TReadDeviceBlocksRequest readRequest;
+        readRequest.SetDeviceUUID("uuid-1");
+        readRequest.SetStartIndex(1);
+        readRequest.SetBlockSize(4_KB);
+        readRequest.SetBlocksCount(10);
+
+        NProto::TWriteDeviceBlocksRequest writeRequest;
+        writeRequest.SetDeviceUUID("uuid-1");
+        writeRequest.SetStartIndex(1);
+        writeRequest.SetBlockSize(4_KB);
+        ResizeIOVector(*writeRequest.MutableBlocks(), 10, 4_KB);
+
+        NProto::TZeroDeviceBlocksRequest zeroRequest;
+        zeroRequest.SetDeviceUUID("uuid-1");
+        zeroRequest.SetStartIndex(1);
+        zeroRequest.SetBlockSize(4_KB);
+        zeroRequest.SetBlocksCount(10);
+
+        for (int ec: {EIO, EREMOTEIO}) {
+            storageState->Error = MakeError(MAKE_SYSTEM_ERROR(ec), "Error");
+
+            {
+                auto future = state.Read(Now(), readRequest);
+                const auto& response = future.GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    E_IO,
+                    response.GetError().GetCode(),
+                    FormatError(response.GetError()));
+            }
+            {
+                auto future = state.Write(Now(), writeRequest);
+                const auto& response = future.GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    E_IO,
+                    response.GetError().GetCode(),
+                    FormatError(response.GetError()));
+            }
+            {
+                auto future = state.WriteZeroes(Now(), zeroRequest);
+                const auto& response = future.GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    E_IO,
+                    response.GetError().GetCode(),
+                    FormatError(response.GetError()));
+            }
         }
     }
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.cpp
@@ -25,6 +25,20 @@ void SendEvReacquireDisk(
     system.Send(event.release());
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+bool IsIOError(const NProto::TError& error)
+{
+    switch (error.GetCode()) {
+        case E_IO:
+        case MAKE_SYSTEM_ERROR(EIO):
+        case MAKE_SYSTEM_ERROR(EREMOTEIO):
+            return true;
+        default:
+            return false;
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,7 +58,7 @@ void ProcessError(
         error.SetCode(E_IO);
     }
 
-    if (error.GetCode() == E_IO || error.GetCode() == MAKE_SYSTEM_ERROR(EIO)) {
+    if (IsIOError(error)) {
         error = config.MakeIOError(std::move(*error.MutableMessage()));
     } else {
         config.AugmentErrorFlags(error);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -1359,41 +1359,46 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
 
         TPartitionClient client(runtime, env.ActorId);
 
-        runtime.SetEventFilter(
-            [&](auto&, TAutoPtr<IEventHandle>& event)
-            {
-                if (event->GetTypeRewrite() ==
-                    TEvDiskAgent::EvReadDeviceBlocksResponse)
+        for (int ec: {EIO, EREMOTEIO}) {
+            runtime.SetEventFilter(
+                [&](auto&, TAutoPtr<IEventHandle>& event)
                 {
-                    auto response = std::make_unique<
-                        TEvDiskAgent::TEvReadDeviceBlocksResponse>(MakeError(
-                        MAKE_SYSTEM_ERROR(EIO),
-                        "async IO operation failed"));
+                    if (event->GetTypeRewrite() ==
+                        TEvDiskAgent::EvReadDeviceBlocksResponse)
+                    {
+                        auto response = std::make_unique<
+                            TEvDiskAgent::TEvReadDeviceBlocksResponse>(
+                            MakeError(
+                                MAKE_SYSTEM_ERROR(ec),
+                                "async IO operation failed"));
 
-                    std::unique_ptr<IEventHandle> handle{new IEventHandle(
-                        event->Recipient,
-                        event->Sender,
-                        response.release(),
-                        0,
-                        event->Cookie)};
-                    event.Reset(handle.release());
-                }
+                        std::unique_ptr<IEventHandle> handle{new IEventHandle(
+                            event->Recipient,
+                            event->Sender,
+                            response.release(),
+                            0,
+                            event->Cookie)};
+                        event.Reset(handle.release());
+                    }
 
-                return false;
-            });
+                    return false;
+                });
 
-        client.SendReadBlocksRequest(
-            TBlockRange64::MakeClosedInterval(0, 1024));
+            client.SendReadBlocksRequest(
+                TBlockRange64::MakeClosedInterval(0, 1024));
 
-        auto response = client.RecvReadBlocksResponse();
-        UNIT_ASSERT_C(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT),
-            FormatError(response->GetError()));
-        UNIT_ASSERT_C(
-            HasProtoFlag(
-                response->GetError().GetFlags(),
-                NProto::EF_HW_PROBLEMS_DETECTED),
-            FormatError(response->GetError()));
+            auto response = client.RecvReadBlocksResponse();
+            UNIT_ASSERT_C(
+                HasProtoFlag(
+                    response->GetError().GetFlags(),
+                    NProto::EF_SILENT),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_C(
+                HasProtoFlag(
+                    response->GetError().GetFlags(),
+                    NProto::EF_HW_PROBLEMS_DETECTED),
+                FormatError(response->GetError()));
+        }
     }
 
     Y_UNIT_TEST(ShouldHandleLostDevice)

--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -73,11 +73,13 @@ EErrorKind GetErrorKind(const NProto::TError& e)
     }
 
     // FACILITY_SYSTEM error codes are obtained from "errno". The list of all
-    // possible errors: contrib/libs/linux-headers/asm-generic/errno-base.h
+    // possible errors: contrib/libs/linux-headers/asm-generic/errno-base.h and
+    //                  contrib/libs/linux-headers/asm-generic/errno.h
     if (FACILITY_FROM_CODE(code) == FACILITY_SYSTEM) {
         switch (STATUS_FROM_CODE(code)) {
             case EIO:
             case ENODATA:
+            case EREMOTEIO:
                 return EErrorKind::ErrorFatal;
             default:
                 // system/network errors should be retriable

--- a/cloud/storage/core/libs/common/error_ut.cpp
+++ b/cloud/storage/core/libs/common/error_ut.cpp
@@ -157,7 +157,7 @@ Y_UNIT_TEST_SUITE(GetDiagnosticsErrorKindTest)
 
     Y_UNIT_TEST(ShouldCorrectlyInterpretErrorKindForSystemErrors)
     {
-        constexpr std::array FatalSystemErrors = {EIO, ENODATA};
+        constexpr std::array FatalSystemErrors = {EIO, EREMOTEIO, ENODATA};
 
         for (ui32 i = 0; i < 1000; i++) {
             NProto::TError e = MakeError(MAKE_SYSTEM_ERROR(i));


### PR DESCRIPTION
Since EREMOTEIO is not a fatal error and treated as a retriable error, Disk Registry does not mark devices as broken.