### PR TITLE
issue-4602: add more logging upon the NodeNotFoundInShard critical event

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -497,6 +497,17 @@ void TListNodesActor::HandleGetNodeAttrResponseCheck(
 
     if (exists) {
         ++LostNodeCount;
+        LOG_WARN(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "Node found in leader but missing in shard. Node observed in "
+            "leader: (name: %s, node proto: %s). Listing request proto: %s. "
+            "Validation response proto: %s",
+            name.Quote().c_str(),
+            node.ShortDebugString().Quote().c_str(),
+            ListNodesRequest.ShortDebugString().Quote().c_str(),
+            msg->Record.ShortDebugString().Quote().c_str());
+
         ReportNodeNotFoundInShard();
     }
 


### PR DESCRIPTION
Added logging for nodes found in the leader but missing in the shard upon listing.

Will help in debugging #4602