### PR TITLE
[Filestore local] issue-4612: add missing config parameters to allow setting timeouts for dentry, and attributes caches

### DIFF
--- a/cloud/filestore/config/server.proto
+++ b/cloud/filestore/config/server.proto
@@ -171,6 +171,20 @@ message TLocalServiceConfig
 
     // Disable fsync queue which is used to synchronize data/metadata ops during fsync
     optional bool FSyncQueueDisabled = 29;
+
+    // Inode entry timeout.
+    optional uint32 EntryTimeout = 30;
+
+    // Inode entry timeout for negative responses (responses with errors).
+    // The most notable one is ENOENT for getattr.
+    optional uint32 NegativeEntryTimeout = 31;
+
+    // Node attributes timeout.
+    optional uint32 AttrTimeout = 32;
+
+    // X Attrs cache timeout
+    optional uint32 XAttrCacheTimeout = 33;
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -42,6 +42,10 @@ namespace {
     xxx(MaxFuseLoopThreads,          ui32,          1                         )\
     xxx(ZeroCopyWriteEnabled,        bool,          false                     )\
     xxx(FSyncQueueDisabled,          bool,          false                     )\
+    xxx(EntryTimeout,                TDuration,     TDuration::Seconds(15)    )\
+    xxx(NegativeEntryTimeout,        TDuration,     TDuration::Zero()         )\
+    xxx(AttrTimeout,                 TDuration,     TDuration::Seconds(15)    )\
+    xxx(XAttrCacheTimeout,           TDuration,     TDuration::Seconds(15)    )\
 // FILESTORE_SERVICE_CONFIG
 
 #define FILESTORE_SERVICE_NULL_FILE_IO_CONFIG(xxx)                             \

--- a/cloud/filestore/libs/service_local/config.h
+++ b/cloud/filestore/libs/service_local/config.h
@@ -116,6 +116,14 @@ public:
     bool GetZeroCopyWriteEnabled() const;
 
     bool GetFSyncQueueDisabled() const;
+
+    TDuration GetEntryTimeout() const;
+
+    TDuration GetNegativeEntryTimeout() const;
+
+    TDuration GetAttrTimeout() const;
+
+    TDuration GetXAttrCacheTimeout() const;
 };
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -46,6 +46,13 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         features->SetMaxFuseLoopThreads(
             Config->GetMaxFuseLoopThreads());
         features->SetFSyncQueueDisabled(Config->GetFSyncQueueDisabled());
+        features->SetEntryTimeout(Config->GetEntryTimeout().MilliSeconds());
+        features->SetNegativeEntryTimeout(
+            Config->GetNegativeEntryTimeout().MilliSeconds());
+        features->SetAttrTimeout(Config->GetAttrTimeout().MilliSeconds());
+        features->SetXAttrCacheTimeout(
+            Config->GetXAttrCacheTimeout().MilliSeconds());
+
         return response;
     };
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1110,6 +1110,9 @@ private:
         if (features.GetAttrTimeout()) {
             config.SetAttrTimeout(features.GetAttrTimeout());
         }
+        if (features.GetXAttrCacheTimeout()) {
+            config.SetXAttrCacheTimeout(features.GetXAttrCacheTimeout());
+        }
         config.SetAsyncDestroyHandleEnabled(
             features.GetAsyncDestroyHandleEnabled());
         config.SetAsyncHandleOperationPeriod(

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -40,6 +40,7 @@ message TFileStoreFeatures
     uint32 MaxFuseLoopThreads = 25;
     bool ZeroCopyWriteEnabled = 26;
     bool FSyncQueueDisabled = 27;
+    uint32 XAttrCacheTimeout = 28;
 }
 
 message TFileStore


### PR DESCRIPTION
#4612