### PR TITLE
Fix crash

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -555,7 +555,7 @@ public:
 
     ~TRdmaDataEndpoint() override
     {
-        Stop();
+        DoStopEndpoint();
     }
 
     void Init(NRdma::IClientEndpointPtr endpoint)
@@ -636,6 +636,8 @@ private:
         NRdma::TClientRequestPtr req,
         ui32 status,
         size_t responseBytes) override;
+
+    void DoStopEndpoint();
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -697,7 +699,7 @@ void TRdmaDataEndpoint::Start()
 
 void TRdmaDataEndpoint::Stop()
 {
-    Endpoint->Stop().Wait();
+    DoStopEndpoint();
 }
 
 TStorageBuffer TRdmaDataEndpoint::AllocateBuffer(size_t bytesCount)
@@ -765,6 +767,12 @@ void TRdmaDataEndpoint::HandleResponse(
     });
 }
 
+void TRdmaDataEndpoint::DoStopEndpoint()
+{
+    if (Endpoint) {
+        Endpoint->Stop().Wait();
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
```
Thread 8113 (LWP 26546):
#0 NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaDataEndpoint::Stop (this=0x570bb50d7a20) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/client_rdma/rdma_client.cpp +704
#1 NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaDataEndpoint::~TRdmaDataEndpoint (this=0x570bb50d7a20) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/client_rdma/rdma_client.cpp +562
#2 NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint::~TRdmaEndpoint (this=0x570bb50d7a20) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/client_rdma/rdma_client.cpp +647
#3 std::__y1::default_delete<NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint>::operator()[abi:ne190000](NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint*) const (__ptr=0x570bb50d7a20, this=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h +68
#4 std::__y1::__shared_ptr_pointer<NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint*, std::__y1::shared_ptr<NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint>::__shared_ptr_default_delete<NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint, NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint>, std::__y1::allocator<NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint> >::__on_zero_shared (this=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +259
#5 std::__y1::__shared_count::__release_shared[abi:ne190000]() (this=0x570bb0bd5140) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +171
#6 std::__y1::__shared_weak_count::__release_shared[abi:ne190000]() (this=0x570bb0bd5140) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +217
#7 std::__y1::shared_ptr<NCloud::NBlockStore::NClient::(anonymous namespace)::TRdmaEndpoint>::~shared_ptr[abi:ne190000]() (this=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +682
#8 NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0::~$_0() (this=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/client_rdma/rdma_client.cpp +838
#9 NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::Apply<NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0>(NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0&&) const::{lambda(NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)#1}::~Apply() (this=0x5
 70bb1283f38) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/library/cpp/threading/future/core/future-inl.h +637
#10 std::__y1::__compressed_pair_elem<NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::Apply<NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0>(NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0&&) const::{lambda(NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint
 > > const&)#1}, 0, false>::~__compressed_pair_elem() (this=0x570bb1283f38) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/compressed_pair.h +43
#11 std::__y1::__function::__alloc_func<NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::Apply<NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0>(NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0&&) const::{lambda(NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoi
 nt> > const&)#1}, std::__y1::allocator<{lambda(NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)#1}>, void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>::destroy[abi:ne190000]() (this=0x570bb1283f38) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__functional/function.h +182
#12 std::__y1::__function::__func<NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::Apply<NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0>(NCloud::NBlockStore::NClient::CreateRdmaEndpointClientAsync(std::__y1::shared_ptr<NCloud::ILoggingService>, std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClient>, std::__y1::shared_ptr<NCloud::NBlockStore::IBlockStore>, std::__y1::shared_ptr<NCloud::ITraceSerializer>, std::__y1::shared_ptr<NCloud::ITaskQueue>, NCloud::NBlockStore::NClient::TRdmaEndpointConfig const&)::$_0&&) const::{lambda(NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >
 const&)#1}, std::__y1::allocator<{lambda(NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)#1}>, void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>::destroy() (this=0x570bb1283f30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__functional/function.h +297
#13 std::__y1::__function::__value_func<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>::~__value_func[abi:ne190000]() (this=0x570bb1283f30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/vector +938
#14 std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>::~function() (this=0x570bb1283f30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__functional/function.h +978
#15 std::__y1::allocator<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)> >::destroy[abi:ne190000](std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>*) (this=0x7f1e92831500, __p=0x570bb1283f30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h +170
#16 _ZNSt4__y116allocator_traitsINS_9allocatorINS_8functionIFvRKN10NThreading7TFutureINS_10shared_ptrIN6NCloud11NBlockStore5NRdma15IClientEndpointEEEEEEEEEEE7destroyB8ne190000ISF_TnNS_9enable_ifIXsr13__has_destroyISG_PT_EE5valueEiE4typeELi0EEEvRSG_SL_ (__a=..., __p=0x570bb1283f30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h +334
#17 std::__y1::vector<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>, std::__y1::allocator<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)> > >::__base_destruct_at_end[abi:ne190000](std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>*) (this=0x7f1e928314f0, __new_last=0x570bb1283f30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/vector +939
#18 std::__y1::vector<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>, std::__y1::allocator<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)> > >::__clear[abi:ne190000]() (this=0x7f1e928314f0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/vector +933
#19 std::__y1::vector<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>, std::__y1::allocator<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)> > >::__destroy_vector::operator()[abi:ne190000]() (this=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/vector +497
#20 std::__y1::vector<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)>, std::__y1::allocator<std::__y1::function<void (NThreading::TFuture<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> > const&)> > >::~vector[abi:ne190000]() (this=0x7f1e928314f0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/vector +508
#21 NThreading::NImpl::TFutureState<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::TrySetException (this=0x570bb10793f0, e=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/library/cpp/threading/future/core/future-inl.h +212
#22 NThreading::NImpl::TFutureState<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::SetException (this=0x570bb10793f0, e=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/library/cpp/threading/future/core/future-inl.h +176
#23 NThreading::TPromise<std::__y1::shared_ptr<NCloud::NBlockStore::NRdma::IClientEndpoint> >::SetException (this=<optimized out>, e=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/library/cpp/threading/future/core/future-inl.h +854
#24 NCloud::NBlockStore::NRdma::(anonymous namespace)::TClient::Reconnect (this=0x570bbfb3b300, endpoint=0x570bb1183820) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/rdma/impl/client.cpp +2039
#25 NCloud::NBlockStore::NRdma::(anonymous namespace)::TConnectionPoller::ThreadProc (this=0x570bb1182c00) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/rdma/impl/client.cpp +1477
#26 non-virtual thunk to NCloud::NBlockStore::NRdma::(anonymous namespace)::TConnectionPoller::ThreadProc() () at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/yield.cpp +12
#27 (anonymous namespace)::TPosixThread::ThreadProxy (arg=0x570bb0fbab30) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/thread.cpp +244
#28 start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#29 clone () from /lib/x86_64-linux-gnu/libc.so.6
```