### PR TITLE
Unification of the disk registry logs. Logging counters of inflight transactions. Part 1

### DIFF
--- a/cloud/blockstore/libs/storage/core/transaction_time_tracker.cpp
+++ b/cloud/blockstore/libs/storage/core/transaction_time_tracker.cpp
@@ -211,4 +211,37 @@ TTransactionTimeTracker::GetInflightOperations() const
     return Inflight;
 }
 
+TString TTransactionTimeTracker::GetInflightInfo(ui64 nowCycles) const
+{
+    if (Inflight.empty()) {
+        return {};
+    }
+
+    struct TInflight
+    {
+        ui64 FirstStartTime = Max<ui64>();
+        size_t Count = 0;
+    };
+    THashMap<TString, TInflight> inflightTransactions;
+    for (const auto& [transactionId, transaction]: Inflight) {
+        TInflight& inflight = inflightTransactions[transaction.TransactionName];
+        inflight.FirstStartTime =
+            Min(inflight.FirstStartTime, transaction.StartTime);
+        ++inflight.Count;
+    }
+
+    TStringBuilder builder;
+    for (const auto& [transactionName, inflight]: inflightTransactions) {
+        if (!builder.empty()) {
+            builder << ", ";
+        }
+        const TDuration duration =
+            CyclesToDurationSafe(nowCycles - inflight.FirstStartTime);
+        builder << transactionName << "(" << inflight.Count << ", "
+                << FormatDuration(duration) << ")";
+    }
+
+    return "Inflight: " + builder + "";
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/transaction_time_tracker.h
+++ b/cloud/blockstore/libs/storage/core/transaction_time_tracker.h
@@ -91,6 +91,7 @@ public:
     void ResetStats();
 
     [[nodiscard]] const TInflightMap& GetInflightOperations() const;
+    [[nodiscard]] TString GetInflightInfo(ui64 nowCycles) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/transaction_time_tracker_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/transaction_time_tracker_ut.cpp
@@ -135,6 +135,30 @@ Y_UNIT_TEST_SUITE(TTransactionTimeTrackerTest)
         UNIT_ASSERT_VALUES_EQUAL("+ 1", get("ReadBlocks_inflight_Total"));
         UNIT_ASSERT_VALUES_EQUAL("0", get("WriteBlocks_finished_Total"));
     }
+
+    Y_UNIT_TEST(ShouldMakeInflightInfo)
+    {
+        TTransactionTimeTracker timeTracker(TransactionNames);
+
+        timeTracker.OnStarted(
+            1,
+            "ReadBlocks",
+            1000 * GetCyclesPerMillisecond());
+        timeTracker.OnStarted(
+            2,
+            "ReadBlocks",
+            2000 * GetCyclesPerMillisecond());
+        timeTracker.OnStarted(
+            3,
+            "WriteBlocks",
+            2000 * GetCyclesPerMillisecond());
+
+        const TString inflightInfo =
+            timeTracker.GetInflightInfo(4000 * GetCyclesPerMillisecond());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "Inflight: ReadBlocks(2, 3.000s), WriteBlocks(1, 2.000s)",
+            inflightInfo);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -51,6 +51,9 @@ TDiskRegistryActor::TDiskRegistryActor(
     , TTabletBase(owner, std::move(storage), &TransactionTimeTracker)
     , Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
+    , LogTitle(
+          GetCycleCount(),
+          TLogTitle::TDiskRegistry{.TabletId = TabletID()})
     , LogbrokerService(std::move(logbrokerService))
     , NotifyService(std::move(notifyService))
     , Logging(std::move(logging))

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -21,11 +21,11 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/core/tablet.h>
 #include <cloud/blockstore/libs/storage/model/composite_task_waiter.h>
+#include <cloud/blockstore/libs/storage/model/log_title.h>
 
 #include <cloud/storage/core/libs/common/backoff_delay_provider.h>
 
 #include <contrib/ydb/core/base/tablet_pipe.h>
-
 #include <contrib/ydb/library/actors/core/actor.h>
 #include <contrib/ydb/library/actors/core/events.h>
 #include <contrib/ydb/library/actors/core/hfunc.h>
@@ -72,6 +72,7 @@ class TDiskRegistryActor final
 private:
     const TStorageConfigPtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
+    TLogTitle LogTitle;
 
     static const TStateInfo States[];
     EState CurrentState = STATE_BOOT;
@@ -139,7 +140,7 @@ public:
         NNotify::IServicePtr notifyService,
         ILoggingServicePtr logging);
 
-    ~TDiskRegistryActor();
+    ~TDiskRegistryActor() override;
 
     static constexpr ui32 LogComponent = TBlockStoreComponents::DISK_REGISTRY;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
@@ -23,13 +23,16 @@ void TDiskRegistryActor::HandleUpdateCmsHostDeviceState(
         ev->Cookie,
         msg->CallContext);
 
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received UpdateCmsHostDeviceState request"
-        ": host=%s, path=%s, State=%u",
-        TabletID(),
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received UpdateCmsHostDeviceState request: host=%s, path=%s, "
+        "State=%s %s",
+        LogTitle.GetWithTime().c_str(),
         msg->Host.c_str(),
         msg->Path.c_str(),
-        static_cast<ui32>(msg->State));
+        NProto::EDeviceState_Name(msg->State).c_str(),
+        TransactionTimeTracker.GetInflightInfo(GetCycleCount()).c_str());
 
     ExecuteTx<TUpdateCmsHostDeviceState>(
         ctx,
@@ -86,8 +89,11 @@ void TDiskRegistryActor::CompleteUpdateCmsHostDeviceState(
     const TActorContext& ctx,
     TTxDiskRegistry::TUpdateCmsHostDeviceState& args)
 {
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "UpdateCmsDeviceState result: %s %u",
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s UpdateCmsDeviceState result: %s %u",
+        LogTitle.GetWithTime().c_str(),
         FormatError(args.Error).c_str(),
         args.Timeout.Seconds());
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_device_state.cpp
@@ -21,11 +21,13 @@ void TDiskRegistryActor::HandleChangeDeviceState(
         ev->Cookie,
         msg->CallContext);
 
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received ChangeDeviceState request: UUID=%s, State=%u",
-        TabletID(),
-        msg->Record.GetDeviceUUID().c_str(),
-        static_cast<ui32>(msg->Record.GetDeviceState()));
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received ChangeDeviceState request: %s %s",
+        LogTitle.GetWithTime().c_str(),
+        msg->Record.ShortDebugString().c_str(),
+        TransactionTimeTracker.GetInflightInfo(GetCycleCount()).c_str());
 
     ExecuteTx<TUpdateDeviceState>(
         ctx,
@@ -73,8 +75,11 @@ void TDiskRegistryActor::CompleteUpdateDeviceState(
     TTxDiskRegistry::TUpdateDeviceState& args)
 {
     if (HasError(args.Error)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::DISK_REGISTRY,
-            "UpdateDeviceState error: %s, affected disk: %s",
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "%s UpdateDeviceState error: %s, affected disk: %s",
+            LogTitle.GetWithTime().c_str(),
             FormatError(args.Error).c_str(),
             args.AffectedDisk.c_str());
     }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_disk_block_size.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_disk_block_size.cpp
@@ -28,13 +28,6 @@ TString CreateInputDescription(
     return CreateInputDescription(args.DiskId, args.BlockSize, args.Force);
 }
 
-TString CreateInputDescription(
-    const NProto::TUpdateDiskBlockSizeRequest& request)
-{
-    return CreateInputDescription(request.GetDiskId(), request.GetBlockSize(),
-        request.GetForce());
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -47,10 +40,13 @@ void TDiskRegistryActor::HandleUpdateDiskBlockSize(
 
     const auto& record = ev->Get()->Record;
 
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received UpdateDiskBlockSize request: %s",
-        TabletID(),
-        CreateInputDescription(record).c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received UpdateDiskBlockSize request: %s %s",
+        LogTitle.GetWithTime().c_str(),
+        record.ShortDebugString().c_str(),
+        TransactionTimeTracker.GetInflightInfo(GetCycleCount()).c_str());
 
     ExecuteTx<TUpdateDiskBlockSize>(
         ctx,
@@ -91,15 +87,21 @@ void TDiskRegistryActor::ExecuteUpdateDiskBlockSize(
         args.Force);
 
     if (HasError(args.Error)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::DISK_REGISTRY,
-            "UpdateDiskBlockSize execution errored: %s. %s",
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "%s UpdateDiskBlockSize execution errored: %s. %s",
+            LogTitle.GetWithTime().c_str(),
             FormatError(args.Error).c_str(),
             CreateInputDescription(args).c_str());
         return;
     }
 
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "UpdateDiskBlockSize execution succeeded. %s",
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s UpdateDiskBlockSize execution succeeded. %s",
+        LogTitle.GetWithTime().c_str(),
         CreateInputDescription(args).c_str());
 }
 
@@ -107,8 +109,11 @@ void TDiskRegistryActor::CompleteUpdateDiskBlockSize(
     const TActorContext& ctx,
     TTxDiskRegistry::TUpdateDiskBlockSize& args)
 {
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "UpdateDiskBlockSize complete. %s",
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s UpdateDiskBlockSize complete. %s",
+        LogTitle.GetWithTime().c_str(),
         CreateInputDescription(args).c_str());
 
     ReallocateDisks(ctx);
@@ -121,4 +126,3 @@ void TDiskRegistryActor::CompleteUpdateDiskBlockSize(
 }
 
 }   // namespace NCloud::NBlockStore::NStorage
-

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_placement_group_settings.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_placement_group_settings.cpp
@@ -18,13 +18,13 @@ void TDiskRegistryActor::HandleUpdatePlacementGroupSettings(
     auto* msg = ev->Get();
     auto& record = msg->Record;
 
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received UpdatePlacementGroupSettings request."
-        " GroupId=%s, ConfigVersion=%u, Settings=%s",
-        TabletID(),
-        record.GetGroupId().c_str(),
-        record.GetConfigVersion(),
-        record.GetSettings().DebugString().Quote().c_str());
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received UpdatePlacementGroupSettings request: %s %s",
+        LogTitle.GetWithTime().c_str(),
+        record.ShortDebugString().c_str(),
+        TransactionTimeTracker.GetInflightInfo(GetCycleCount()).c_str());
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_stats.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_stats.cpp
@@ -15,16 +15,21 @@ void TDiskRegistryActor::HandleUpdateAgentStats(
     auto* msg = ev->Get();
     auto& stats = *msg->Record.MutableAgentStats();
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received UpdateAgentStats request: NodeId=%u",
-        TabletID(),
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received UpdateAgentStats request: NodeId=%u",
+        LogTitle.GetWithTime().c_str(),
         stats.GetNodeId());
 
     auto error = State->UpdateAgentCounters(stats);
 
     if (HasError(error)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::DISK_REGISTRY,
-            "UpdateAgentCounters error: %s",
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "%s UpdateAgentCounters error: %s",
+            LogTitle.GetWithTime().c_str(),
             FormatError(error).c_str());
     }
 
@@ -34,8 +39,12 @@ void TDiskRegistryActor::HandleUpdateAgentStats(
     NCloud::Reply(ctx, *ev, std::move(response));
 
     for (const auto& uuid: State->CollectBrokenDevices(stats)) {
-        LOG_ERROR(ctx, TBlockStoreComponents::DISK_REGISTRY,
-            "Device with IO errors detected: %s", uuid.c_str());
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "%s Device with IO errors detected: %s",
+            LogTitle.GetWithTime().c_str(),
+            uuid.c_str());
 
         auto request = std::make_unique<TEvDiskRegistry::TEvChangeDeviceStateRequest>();
         request->Record.SetDeviceUUID(uuid);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_waitready.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_waitready.cpp
@@ -15,9 +15,11 @@ void TDiskRegistryActor::HandleWaitReady(
     if (CurrentState != STATE_WORK &&
         CurrentState != STATE_READ_ONLY)
     {
-        LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-            "[%lu] WaitReady request delayed until DiskRegistry is ready",
-            TabletID());
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "%s WaitReady request delayed until DiskRegistry is ready",
+            LogTitle.GetWithTime().c_str());
 
         auto requestInfo = CreateRequestInfo<TEvDiskRegistry::TWaitReadyMethod>(
             ev->Sender,
@@ -30,9 +32,11 @@ void TDiskRegistryActor::HandleWaitReady(
 
     BLOCKSTORE_DISK_REGISTRY_COUNTER(WaitReady);
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received WaitReady request",
-        TabletID());
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received WaitReady request",
+        LogTitle.GetWithTime().c_str());
 
     auto response = std::make_unique<TEvDiskRegistry::TEvWaitReadyResponse>();
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
@@ -18,10 +18,13 @@ void TDiskRegistryActor::HandleSetWritableState(
     const auto* msg = ev->Get();
     const bool writableState = msg->Record.GetState();
 
-    LOG_INFO(ctx, TBlockStoreComponents::DISK_REGISTRY,
-        "[%lu] Received SetWritableState request: State=%s",
-        TabletID(),
-        writableState ? "true" : "false");
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "%s Received SetWritableState request: %s %s",
+        LogTitle.GetWithTime().c_str(),
+        msg->Record.ShortDebugString().c_str(),
+        TransactionTimeTracker.GetInflightInfo(GetCycleCount()).c_str());
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,
@@ -35,8 +38,11 @@ void TDiskRegistryActor::HandleSetWritableState(
             << "Can't change state in "
             << States[CurrentState].Name
             << " state";
-        LOG_ERROR(ctx, TBlockStoreComponents::DISK_REGISTRY,
-            "SetWritableState error: %s",
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "%s SetWritableState error: %s",
+            LogTitle.GetWithTime().c_str(),
             errorMsg.c_str());
         auto response =
             std::make_unique<TEvDiskRegistry::TEvSetWritableStateResponse>(

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -66,6 +66,12 @@ public:
         ui32 Generation = 0;
     };
 
+    struct TDiskRegistry
+    {
+        ui64 TabletId = 0;
+        ui32 Generation = 0;
+    };
+
 private:
     using TData = std::variant<
         TVolume,
@@ -73,7 +79,8 @@ private:
         TPartition,
         TPartitionNonrepl,
         TSession,
-        TClient>;
+        TClient,
+        TDiskRegistry>;
 
     ui64 StartTime = 0;
     TData Data;

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -258,6 +258,19 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             childLogTitle.GetWithTime(),
             "[v:12345 g:5 d:disk1 cp:123 t:1.001s + 1.");
     }
+
+    Y_UNIT_TEST(GetForDiskRegistry)
+    {
+        TLogTitle logTitle{
+            GetCycleCount(),
+            TLogTitle::TDiskRegistry{.TabletId = 10}};
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[dr:10]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(logTitle.GetWithTime(), "[dr:10 t:");
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
Started unification logs for DiskRegistry. Part 1.

```
[dr:72075186224037888 t:127.792ms] Received ChangeAgentState request: AgentId: "remote1.cloud-example.net" AgentState: AGENT_STATE_WARNING Reason: "private api: XXX" Inflight: AddAgent(4, 2.456ms), ChangeAgentState(2, 4.456ms)
```
1. dr:tabletId
2. t:127.792ms - time from disk registry actor start
3. Printed proto debug string.
4. Printed information about running transactions