### PR TITLE
Increase delay for eternal-load test_load_fails test from 10 to 20 seconds

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
@@ -51,7 +51,7 @@ def test_load_fails(scenario, engine, direct):
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(__run_load_test, tmp_file.name, scenario, engine, direct)
-        time.sleep(10)
+        time.sleep(20)
 
         cnt = 0
         while future.running():


### PR DESCRIPTION
Resolve test fail
```
cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py.test_load_fails[aligned-sync-False]

2025-11-07 07:06:39,880 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2025-11-07 07:06:39,880 - INFO - ya.test - pytest_runtest_setup: test_load_fails[aligned-sync-False]
2025-11-07 07:06:39,880 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2025-11-07 07:06:39,880 - INFO - ya.test - pytest_runtest_setup: Test setup
2025-11-07 07:06:39,882 - INFO - ya.test - pytest_runtest_call: Test call (class_name: test.py, test_name: test_load_fails[aligned-sync-False])
2025-11-07 07:06:39,884 - DEBUG - ya.test - get_binary: Binary was found by /home/github/.ya/build/build_root/08ga/000770/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load
2025-11-07 07:06:50,482 - ERROR - ya.test - logreport: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py:65: in test_load_fails
    assert (result.returncode == 1) and (result.stderr.find('Wrong') != -1) and (result.stderr.find('MiB/s') != -1)
E   assert (1 == 1 and 1786 != -1 and -1 != -1)
E    +  where 1 = CompletedProcess(args=['/home/github/.ya/build/build_root/08ga/000770/cloud/blockstore/tools/testing/eternal_tests/ete...ests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n').returncode
E    +  and   1786 = <built-in method find of str object at 0x61e000200480>('Wrong')
E    +    where <built-in method find of str object at 0x61e000200480> = '2025-11-07T07:06:46.918978Z :ETERNAL_MAIN INFO: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cp...tests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n'.find
E    +      where '2025-11-07T07:06:46.918978Z :ETERNAL_MAIN INFO: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cp...tests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n' = CompletedProcess(args=['/home/github/.ya/build/build_root/08ga/000770/cloud/blockstore/tools/testing/eternal_tests/ete...ests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n').stderr
E    +  and   -1 = <built-in method find of str object at 0x61e000200480>('MiB/s')
E    +    where <built-in method find of str object at 0x61e000200480> = '2025-11-07T07:06:46.918978Z :ETERNAL_MAIN INFO: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cp...tests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n'.find
E    +      where '2025-11-07T07:06:46.918978Z :ETERNAL_MAIN INFO: cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cp...tests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n' = CompletedProcess(args=['/home/github/.ya/build/build_root/08ga/000770/cloud/blockstore/tools/testing/eternal_tests/ete...ests/eternal-load/bin/test.cpp:112: Test configuration and actual state have been stored to file "load-config.json"\n').stderr
2025-11-07 07:06:50,485 - INFO - ya.test - pytest_runtest_teardown: Test teardown
```

Test failure reason: eternal-load should write a message to the log in 5 seconds after start. We waited 10 seconds for it but the message didn't appear. This is likely to be caused by running under asan with heavy load. Increasing the wait time should resolve the issue.