### PR TITLE
Fix arcadia sync. Restore dependency to  directory_handles_test

### DIFF
--- a/cloud/filestore/tools/testing/ya.make
+++ b/cloud/filestore/tools/testing/ya.make
@@ -1,7 +1,7 @@
 RECURSE(
+    directory_handles_test
     fs_posix_compliance
     loadtest
     open_close_bench
-    directory_handles_state_test
     profile_log
 )


### PR DESCRIPTION
```
RECURSE to missing directory: $S/cloud/filestore/tools/testing/directory_handles_state_test
```