### PR TITLE
Add logging to FindFreeAllocationUnit

### DIFF
--- a/contrib/ydb/core/mind/hive/leader_tablet_info.cpp
+++ b/contrib/ydb/core/mind/hive/leader_tablet_info.cpp
@@ -333,6 +333,11 @@ const NKikimrBlobStorage::TEvControllerSelectGroupsResult::TGroupParameters* TLe
             }
         }
     }
+
+    BLOG_I(
+        "TLeaderTabletInfo::FindFreeAllocationUnit, Storage pool is not found "
+        "for channel "
+        << channelId);
     return nullptr;
 }
 

--- a/contrib/ydb/core/mind/hive/storage_pool_info.cpp
+++ b/contrib/ydb/core/mind/hive/storage_pool_info.cpp
@@ -103,6 +103,9 @@ size_t TStoragePoolInfo::SelectGroup<NKikimrConfig::THiveConfig::HIVE_STORAGE_SE
 const TEvControllerSelectGroupsResult::TGroupParameters* TStoragePoolInfo::FindFreeAllocationUnit(std::function<bool(const TStorageGroupInfo&)> filter,
                                                                                                   std::function<double(const TStorageGroupInfo*)> calculateUsage) {
     if (Groups.empty()) {
+        BLOG_I(
+            "TStoragePoolInfo::FindFreeAllocationUnit, Storage pool "
+            << Name << " has empty Groups");
         return nullptr;
     }
     TVector<const TStorageGroupInfo*> groupCandidates;
@@ -113,6 +116,9 @@ const TEvControllerSelectGroupsResult::TGroupParameters* TStoragePoolInfo::FindF
         }
     }
     if (groupCandidates.empty()) {
+        BLOG_I(
+            "TStoragePoolInfo::FindFreeAllocationUnit, Storage pool "
+            << Name << ". There are no groups that satisfy the filter.");
         return nullptr;
     }
     TVector<double> groupCandidateUsages;


### PR DESCRIPTION
Sometimes Y_UNIT_TEST(ShouldReassignTablet) fails because of the

```
                group = tablet->FindFreeAllocationUnit(channelId);
                if (group == nullptr) {
                    BLOG_ERROR("THive::TTxUpdateTabletGroups::Execute{" << (ui64)this << "}: tablet "
                            << tablet->Id
                            << " could not find a group for channel " << channelId
                            << " pool " << tablet->GetChannelStoragePoolName(channelId));

```
In order to get more details logging was added to TLeaderTabletInfo::FindFreeAllocationUnit, TStoragePoolInfo::FindFreeAllocationUnit.