### PR TITLE
[Filestore] wait compaction events properly in ShouldRunForcedOperation test

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -768,7 +768,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         {
             return compactionCounter == 4;
         };
-        env.GetRuntime().DispatchEvents(options, TDuration::Seconds(5));
+        env.GetRuntime().DispatchEvents(options);
 
         UNIT_ASSERT_VALUES_EQUAL(4, compactionCounter);
 


### PR DESCRIPTION
- real delay around 1 sec, instead of guessing we wait for events