### PR TITLE
[Filestore] add logs when writing configs in tests recipe

### DIFF
--- a/cloud/filestore/tests/python/lib/daemon_config.py
+++ b/cloud/filestore/tests/python/lib/daemon_config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import yatest.common as common
@@ -20,6 +21,8 @@ from cloud.filestore.config.storage_pb2 import TStorageConfig
 
 from cloud.storage.core.protos.media_pb2 import STORAGE_MEDIA_HDD
 from cloud.storage.core.tools.testing.access_service.lib import AccessService
+
+logger = logging.getLogger(__name__)
 
 LOG_WARN = 4
 LOG_NOTICE = 5
@@ -275,6 +278,7 @@ class FilestoreDaemonConfigGenerator:
             with open(path, "w") as config_file:
                 config_file.write(MessageToString(proto))
                 config_file.flush()
+                logger.info("written config file: " + path)
 
     def generate_configs(self, domains_txt, names_txt):
         self.__proto_configs = {}


### PR DESCRIPTION
We encountered strange failure of [cloud/filestore/tests/config_dispatcher](https://github.com/ydb-platform/nbs/tree/main/cloud/filestore/tests/config_dispatcher) test - filestore-vhost failed when reading log.txt config file with 'No such file or directory' error

It is not clear why it could have happened because config files are flushed exactly before the service can be started.
Decided to add more logs hoping they might clarify a situation a bit