### PR TITLE
extending log_title lib for mirror disks

### DIFF
--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -135,6 +135,11 @@ TString ToString(const TLogTitle::TPartitionNonrepl& data)
     return TStringBuilder() << "[nrd:" << data.DiskId;
 }
 
+TString ToString(const TLogTitle::TPartitionMirror& data)
+{
+    return TStringBuilder() << "[md:" << data.DiskId;
+}
+
 TString ToString(const TLogTitle::TDiskRegistry& data)
 {
     return TStringBuilder() << "[dr:" << data.TabletId;

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -48,6 +48,11 @@ public:
         TString DiskId;
     };
 
+    struct TPartitionMirror
+    {
+        TString DiskId;
+    };
+
     struct TSession
     {
         TString SessionId;
@@ -80,7 +85,8 @@ private:
         TPartitionNonrepl,
         TSession,
         TClient,
-        TDiskRegistry>;
+        TDiskRegistry,
+        TPartitionMirror>;
 
     ui64 StartTime = 0;
     TData Data;

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -222,6 +222,19 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
         UNIT_ASSERT_STRING_CONTAINS(logTitle.GetWithTime(), "[nrd:disk1 t:");
     }
 
+    Y_UNIT_TEST(GetForPartitionMirror)
+    {
+        TLogTitle logTitle{
+            GetCycleCount(),
+            TLogTitle::TPartitionMirror{.DiskId = "disk1"}};
+
+        UNIT_ASSERT_STRINGS_EQUAL(
+            "[md:disk1]",
+            logTitle.Get(TLogTitle::EDetails::Brief));
+
+        UNIT_ASSERT_STRING_CONTAINS(logTitle.GetWithTime(), "[md:disk1 t:");
+    }
+
     Y_UNIT_TEST(GetChildLogger)
     {
         const ui64 startTime =


### PR DESCRIPTION
log_title lib is extended for using with mirror disks.
It will be used with checkrange code later