### PR TITLE
Removing redundant checkrange .proto interface

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -1906,7 +1906,7 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             char(1));
 
         {
-            NPrivateProto::TCheckRangeRequest request;
+            NProto::TCheckRangeRequest request;
             request.SetDiskId(DefaultDiskId);
             request.SetStartIndex(0);
             request.SetBlocksCount(blockCount);
@@ -1916,7 +1916,7 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             google::protobuf::util::MessageToJsonString(request, &buf);
 
             const auto response = service.ExecuteAction("CheckRange", buf);
-            NPrivateProto::TCheckRangeResponse checkRangeResponse;
+            NProto::TCheckRangeResponse checkRangeResponse;
 
             UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
                             response->Record.GetOutput(),

--- a/cloud/blockstore/private/api/protos/volume.proto
+++ b/cloud/blockstore/private/api/protos/volume.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package NCloud.NBlockStore.NPrivateProto;
 
 import "cloud/blockstore/private/api/protos/blob.proto";
-import "cloud/storage/core/protos/error.proto";
 
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/private/api/protos";
 
@@ -294,33 +293,4 @@ message TFinishFillDiskRequest
 
 message TFinishFillDiskResponse
 {
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// CheckRange request/response.
-
-message TCheckRangeRequest
-{
-    string DiskId = 1;
-
-    // First block index.
-    uint32 StartIndex = 2;
-
-    // Number of blobs per batch.
-    uint32 BlocksCount = 3;
-
-    // Is it necessary to calculate and include checksums in the response
-    bool CalculateChecksums = 4;
-
-    // Number of replicas to read from m3 disks.
-    uint64 ReplicaCount = 5;
-}
-
-message TCheckRangeResponse
-{
-    // Status of ReadBlocks operation.
-    NCloud.NProto.TError Status = 1;
-
-    // checksum of blocks
-    repeated uint32 Checksums = 2;
 }


### PR DESCRIPTION
This .proto interface is not needed. For example, neighbour unittest `ShouldCheckRange` does not use this .proto from the beginning.