### PR TITLE
[Blobstore] delete obsolete uncofirmed blobs

### DIFF
--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -397,7 +397,7 @@ struct THistogramRequestCounters
         EPublishingPolicy::Repl,
         HistCounterOptions};
     TLowResCounter ConfirmBlobs{EPublishingPolicy::Repl, HistCounterOptions};
-    TLowResCounter DeleteObsoleteUnconfirmedBlobs{
+    TLowResCounter DeleteUnconfirmedBlobs{
         EPublishingPolicy::Repl,
         HistCounterOptions};
 
@@ -426,7 +426,7 @@ struct THistogramRequestCounters
         MakeMeta<&THistogramRequestCounters::AddConfirmedBlobs>(),
         MakeMeta<&THistogramRequestCounters::AddUnconfirmedBlobs>(),
         MakeMeta<&THistogramRequestCounters::ConfirmBlobs>(),
-        MakeMeta<&THistogramRequestCounters::DeleteObsoleteUnconfirmedBlobs>(),
+        MakeMeta<&THistogramRequestCounters::DeleteUnconfirmedBlobs>(),
 
         MakeMeta<&THistogramRequestCounters::WriteBlob>(),
         MakeMeta<&THistogramRequestCounters::ReadBlob>(),

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1033,7 +1033,7 @@ STFUNC(TPartitionActor::StateWork)
         IgnoreFunc(TEvPartitionPrivate::TEvFlushResponse);
         IgnoreFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvAddConfirmedBlobsResponse);
-        IgnoreFunc(TEvPartitionPrivate::TEvDeleteObsoleteUnconfirmedBlobsResponse);
+        IgnoreFunc(TEvPartitionPrivate::TEvDeleteUnconfirmedBlobsResponse);
 
         // Wakeup function should handle wakeup event taking into account that
         // there is wakeup event scheduled during boot stage with
@@ -1095,7 +1095,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvFlushResponse);
         IgnoreFunc(TEvPartitionCommonPrivate::TEvTrimFreshLogResponse);
-        IgnoreFunc(TEvPartitionPrivate::TEvDeleteObsoleteUnconfirmedBlobsResponse);
+        IgnoreFunc(TEvPartitionPrivate::TEvDeleteUnconfirmedBlobsResponse);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
 

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -179,7 +179,7 @@ using TFlushedCommitIds = TVector<TFlushedCommitId>;
     xxx(PatchBlob,                 __VA_ARGS__)                                \
     xxx(AddConfirmedBlobs,         __VA_ARGS__)                                \
     xxx(AddUnconfirmedBlobs,       __VA_ARGS__)                                \
-    xxx(DeleteObsoleteUnconfirmedBlobs, __VA_ARGS__)                           \
+    xxx(DeleteUnconfirmedBlobs,    __VA_ARGS__)                                \
 // BLOCKSTORE_PARTITION_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -676,30 +676,6 @@ struct TEvPartitionPrivate
     };
 
     //
-    // DeleteObsoleteUnconfirmedBlobs
-    //
-
-    struct TDeleteObsoleteUnconfirmedBlobsRequest
-    {
-        ui64 CommitId = 0;
-        TVector<TBlobToConfirm> Blobs;
-
-        TDeleteObsoleteUnconfirmedBlobsRequest() = default;
-
-        TDeleteObsoleteUnconfirmedBlobsRequest(
-            ui64 commitId,
-            TVector<TBlobToConfirm> blobs)
-            : CommitId(commitId)
-            , Blobs(std::move(blobs))
-        {}
-    };
-
-    struct TDeleteObsoleteUnconfirmedBlobsResponse
-    {
-        ui64 ExecCycles = 0;
-    };
-
-    //
     // AddUnconfirmedBlobs
     //
 
@@ -719,6 +695,26 @@ struct TEvPartitionPrivate
     };
 
     struct TAddUnconfirmedBlobsResponse
+    {
+        ui64 ExecCycles = 0;
+    };
+
+    //
+    // DeleteUnconfirmedBlobs
+    //
+
+    struct TDeleteUnconfirmedBlobsRequest
+    {
+        ui64 CommitId = 0;
+
+        TDeleteUnconfirmedBlobsRequest() = default;
+
+        explicit TDeleteUnconfirmedBlobsRequest(ui64 commitId)
+            : CommitId(commitId)
+        {}
+    };
+
+    struct TDeleteUnconfirmedBlobsResponse
     {
         ui64 ExecCycles = 0;
     };

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -708,17 +708,17 @@ void TPartitionState::WriteUnconfirmedBlob(
 
 void TPartitionState::DeleteUnconfirmedBlobs(
     TPartitionDatabase& db,
-    ui64 commitId,
-    const TVector<TBlobToConfirm>& blobs)
+    ui64 commitId)
 {
-    for (const auto& blob: blobs) {
-        auto blobId = MakePartialBlobId(commitId, blob.UniqueId);
-        db.DeleteUnconfirmedBlob(blobId);
-    }
-
     auto it = UnconfirmedBlobs.find(commitId);
     if (it != UnconfirmedBlobs.end()) {
-        const auto blobCount = it->second.size();
+        const auto& blobs = it->second;
+        for (const auto& blob: blobs) {
+            auto blobId = MakePartialBlobId(commitId, blob.UniqueId);
+            db.DeleteUnconfirmedBlob(blobId);
+        }
+
+        const auto blobCount = blobs.size();
         UnconfirmedBlobs.erase(it);
         Y_DEBUG_ABORT_UNLESS(UnconfirmedBlobCount >= blobCount);
         UnconfirmedBlobCount -= blobCount;

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -1372,8 +1372,7 @@ public:
 
     void DeleteUnconfirmedBlobs(
         TPartitionDatabase& db,
-        ui64 commitId,
-        const TVector<TBlobToConfirm>& blobs);
+        ui64 commitId);
 
     void ConfirmedBlobsAdded(TPartitionDatabase& db, ui64 commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -62,7 +62,7 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
     xxx(ScanDiskBatch,              __VA_ARGS__)                               \
     xxx(AddUnconfirmedBlobs,        __VA_ARGS__)                               \
     xxx(ConfirmBlobs,               __VA_ARGS__)                               \
-    xxx(DeleteObsoleteUnconfirmedBlobs, __VA_ARGS__)                           \
+    xxx(DeleteUnconfirmedBlobs,     __VA_ARGS__)                               \
     xxx(LoadCompactionMapChunk,     __VA_ARGS__)                               \
 // BLOCKSTORE_PARTITION_TRANSACTIONS
 
@@ -680,22 +680,19 @@ struct TTxPartition
     };
 
     //
-    // DeleteObsoleteUnconfirmedBlobs
+    // DeleteUnconfirmedBlobs
     //
 
-    struct TDeleteObsoleteUnconfirmedBlobs
+    struct TDeleteUnconfirmedBlobs
     {
         const TRequestInfoPtr RequestInfo;
         const ui64 CommitId;
-        const TVector<TBlobToConfirm> Blobs;
 
-        TDeleteObsoleteUnconfirmedBlobs(
+        TDeleteUnconfirmedBlobs(
             TRequestInfoPtr requestInfo,
-            ui64 commitId,
-            TVector<TBlobToConfirm> blobs)
+            ui64 commitId)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
-            , Blobs(std::move(blobs))
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -12927,7 +12927,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT(!barriers.empty());
     }
 
-    Y_UNIT_TEST(ShouldCleanupUnconfirmedBlobsAfterErrorsInWriteBlocks)
+    Y_UNIT_TEST(ShouldCleanupUnconfirmedBlobsAfterErrorOnWriteBlob)
     {
         auto config = DefaultConfig();
         config.SetWriteBlobThreshold(1);
@@ -12938,7 +12938,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             {},
             {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
 
-        bool shouldRejectDeleteObsoleteUnconfirmedBlobsRequest = true;
+        bool shouldRejectDeleteUnconfirmedBlobsRequest = true;
         // Create event filter for WriteBlobResponse rejection
         TTestActorRuntimeBase::TEventFilter rejectionFilter =
             [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
@@ -12952,8 +12952,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                     return false;
                 }
                 case TEvPartitionPrivate::
-                    EvDeleteObsoleteUnconfirmedBlobsRequest: {
-                    return shouldRejectDeleteObsoleteUnconfirmedBlobsRequest;
+                    EvDeleteUnconfirmedBlobsRequest: {
+                    return shouldRejectDeleteUnconfirmedBlobsRequest;
                 }
             };
             return false;
@@ -13010,7 +13010,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
         }
 
-        shouldRejectDeleteObsoleteUnconfirmedBlobsRequest = false;
+        shouldRejectDeleteUnconfirmedBlobsRequest = false;
 
         partition.SendWriteBlocksRequest(TBlockRange32::WithLength(12, 1), 1);
 

--- a/cloud/blockstore/libs/storage/partition/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ya.make
@@ -16,7 +16,7 @@ SRCS(
     part_actor_compactrange.cpp
     part_actor_confirmblobs.cpp
     part_actor_deletegarbage.cpp
-    part_actor_deleteobsoleteunconfirmedblobs.cpp
+    part_actor_deleteunconfirmedblobs.cpp
     part_actor_describeblocks.cpp
     part_actor_flush.cpp
     part_actor_getusedblocks.cpp


### PR DESCRIPTION
Currently, if we receive error during WriteMergedBlocks, unconfirmed blobs left in the table until next restart. 
This PR resolves this problem by cleaning table from unwanted blobs.
On restart we will have less amount of blobs to confirm with BS