### PR TITLE
use max timeout as default value for DynamicNodeRegistrationTimeout

### DIFF
--- a/cloud/storage/core/libs/kikimr/node_registration_settings.h
+++ b/cloud/storage/core/libs/kikimr/node_registration_settings.h
@@ -20,7 +20,7 @@ struct TNodeRegistrationSettings
     TDuration LegacyRegistrationTimeout;
 
     // Timeout for dynamic node registration via discovery service
-    TDuration DynamicNodeRegistrationTimeout;
+    TDuration DynamicNodeRegistrationTimeout = TDuration::Max();
 
     TDuration LoadConfigsFromCmsRetryMinDelay;
     TDuration LoadConfigsFromCmsRetryMaxDelay;


### PR DESCRIPTION
Use max timeout explicitly instead of 0 timeout.

Needed for non-backwards comaptible changes in ydb C++ sdk: ClientTimeout = 0 does not mean max timeout since ydb-cpp-sdk v3.13.0-rc1.