### PR TITLE
issue-1751: Make behavior for read/write requests with O_DIRECT consistent with Linux behavior for write-back cache

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -353,8 +353,10 @@ void TFileSystem::Read(
     request->SetOffset(offset);
     request->SetLength(size);
 
+    const bool useWriteBackCache = ShouldUseServerWriteBackCache(fi);
+
     TFuture<NProto::TReadDataResponse> future;
-    if (WriteBackCache) {
+    if (useWriteBackCache) {
         future = WriteBackCache.ReadData(callContext, std::move(request));
     } else {
         future = Session->ReadData(callContext, std::move(request));

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -2342,6 +2342,80 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT_VALUES_EQUAL(3, writeDataCalled.load());
     }
 
+    Y_UNIT_TEST(ShouldNotUseWriteBackCacheForDirectReads)
+    {
+        NProto::TFileStoreFeatures features;
+        features.SetServerWriteBackCacheEnabled(true);
+
+        TBootstrap bootstrap(
+            CreateWallClockTimer(),
+            CreateScheduler(),
+            features);
+
+        const ui64 nodeId = 123;
+        const ui64 handleId = 456;
+
+        bootstrap.Service->ReadDataHandler = [&] (auto, auto) {
+            NProto::TReadDataResponse result;
+            *result.MutableBuffer() = TString("direct_data");
+            return MakeFuture(result);
+        };
+
+        bootstrap.Service->WriteDataHandler = [&] (auto, auto) {
+            NProto::TWriteDataResponse result;
+            return MakeFuture(result);
+        };
+
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        {
+            // write request without O_DIRECT should go to write-back cache
+            auto reqWrite = std::make_shared<TWriteRequest>(
+                nodeId,
+                handleId,
+                0,
+                "cached_data");
+            reqWrite->In->Body.flags |= O_WRONLY;
+            UNIT_ASSERT(
+                bootstrap.Fuse->SendRequest<TWriteRequest>(reqWrite).Wait(
+                    WaitTimeout));
+        }
+
+        {
+            // read request without O_DIRECT should go to cache
+            auto reqRead =
+                std::make_shared<TReadRequest>(nodeId, handleId, 0, 11);
+
+            auto rspRead = bootstrap.Fuse->SendRequest<TReadRequest>(reqRead);
+            UNIT_ASSERT(rspRead.Wait(WaitTimeout));
+
+            auto readData = TStringBuf(
+                reinterpret_cast<const char*>(reqRead->Out->Data()),
+                rspRead.GetValue());
+
+            UNIT_ASSERT_VALUES_EQUAL("cached_data", readData);
+        }
+
+        {
+            // read request with O_DIRECT should bypass cache
+            auto reqRead =
+                std::make_shared<TReadRequest>(nodeId, handleId, 0, 11);
+            reqRead->In->Body.flags |= O_DIRECT;
+
+            auto rspRead = bootstrap.Fuse->SendRequest<TReadRequest>(reqRead);
+            UNIT_ASSERT(rspRead.Wait(WaitTimeout));
+
+            auto readData = TStringBuf(
+                reinterpret_cast<const char*>(reqRead->Out->Data()),
+                rspRead.GetValue());
+
+            UNIT_ASSERT_VALUES_EQUAL("direct_data", readData);
+        }
+    }
+
     Y_UNIT_TEST(ShouldFsyncDirWithServerWriteBackCacheEnabled)
     {
         NProto::TFileStoreFeatures features;

--- a/cloud/filestore/libs/vhost/request.h
+++ b/cloud/filestore/libs/vhost/request.h
@@ -64,6 +64,11 @@ struct TRequestBuffer<THeader, TBody, true>
         Header.len = len;
     }
 
+    [[nodiscard]] void* Data() const
+    {
+        return const_cast<void*>(reinterpret_cast<const void*>(this + 1));
+    }
+
     static auto Create(size_t dataSize = 0)
     {
         size_t len = sizeof(TSelf) + dataSize;
@@ -248,7 +253,7 @@ struct TWriteRequest
 };
 
 struct TReadRequest
-    : public TRequestBase<fuse_read_in, ui32, ui32>
+    : public TRequestBase<fuse_read_in, void, ui32>
 {
     TReadRequest(ui64 nodeId, ui64 handle, ui64 offset, ui64 size)
     {


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1751

## Linux behavior

1. All read/write requests are sequenced, newest requests should observe the effects of completed previous requests no matter of whether O_DIRECT flag is set or not.
2. Flag O_DIRECT only instructs that the data cannot be read from or written to a cache:
* Direct read: the cached data is flushed then the request is processed:
https://github.com/torvalds/linux/blob/30f09200cc4aefbd8385b01e41bde2e4565a6f0e/mm/filemap.c#L2907
* Direct write: the cache is invalidated then the request is processed:
https://github.com/torvalds/linux/blob/30f09200cc4aefbd8385b01e41bde2e4565a6f0e/mm/filemap.c#L4181
3. For FUSE:
* Direct reads trigger flushing write-back cache:
https://github.com/torvalds/linux/blob/c875a6c3246713a018d8b7b143deb3ebaeecaf1c/fs/fuse/file.c#L1677

Note: O_DIRECT flag is a non-POSIX feature so we should follow Linux behavior.

## Current behavior in filestore

* Direct read: ignore O_DIRECT flag and read from cache. The read data is consistent but this breaks rule 2.
* Direct write: bypass cache. This breaks rule 1 as the data in the cache is not invalidated nor updated and subsequent reads may return wrong data.

## Proposed behavior

### WriteData

Call `FlushNodeData` then call `WriteData` (directly to the Session) if flush was successful.

Note: it is guaranteed by an RW lock that no cached WriteData request can be received while there are direct writes in progress.

https://github.com/torvalds/linux/blob/c537e12daeecaecdcd322c56a5f70659d2de7bde/fs/fuse/file.c#L1494

### ReadData

Call `FlushNodeData` then call `ReadData` (directly to the Session) if flush was successful.

Note: the kernel does not guarantee mutual exclusion or coherence between overlapping direct reads and writes.
A client making writes while a read operation is in progress may observe partially written data (and this is POSIX-compliant).