### PR TITLE
Fix notify mock after curl upgrade

### DIFF
--- a/cloud/blockstore/tools/testing/notify-mock/__main__.py
+++ b/cloud/blockstore/tools/testing/notify-mock/__main__.py
@@ -58,6 +58,7 @@ def create_api(file):
 
             self.send_response(202)
             self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", "0")
             self.end_headers()
             self.wfile.write('{}'.encode('utf-8'))
 


### PR DESCRIPTION
https://www.w3.org/Protocols/HTTP/1.0/draft-ietf-http-spec.html#Entity-Body

Without this fix, tests fail for curl 8.16.0