### PR TITLE
Make rotation time of ydbstats tables configurable

### DIFF
--- a/cloud/blockstore/config/ydbstats.proto
+++ b/cloud/blockstore/config/ydbstats.proto
@@ -52,4 +52,7 @@ message TYdbStatsConfig
 
     // Refresh time before IAM token expiration (in milliseconds).
     optional uint32 IamTokenRefreshTimeBeforeExpiration = 15;
+
+    // Rotate history table at a given time instead of midnight UTC.
+    optional uint32 StatsTableRotationHour = 16;
 }

--- a/cloud/blockstore/libs/ydbstats/config.cpp
+++ b/cloud/blockstore/libs/ydbstats/config.cpp
@@ -23,6 +23,7 @@ TDuration Seconds(ui32 value)
     xxx(ServerAddress,                    TString,          ""                )\
     xxx(HistoryTableLifetimeDays,         ui32,             3                 )\
     xxx(StatsTableRotationAfterDays,      ui32,             1                 )\
+    xxx(StatsTableRotationHour,           ui32,             0                 )\
     xxx(ArchiveStatsTableName,            TString,          ""                )\
     xxx(BlobLoadMetricsTableName,         TString,          ""                )\
     xxx(GroupsTableName,                  TString,          ""                )\

--- a/cloud/blockstore/libs/ydbstats/config.h
+++ b/cloud/blockstore/libs/ydbstats/config.h
@@ -33,6 +33,7 @@ public:
     TString GetServerAddress() const;
     ui32 GetHistoryTableLifetimeDays() const;
     ui32 GetStatsTableRotationAfterDays() const;
+    ui32 GetStatsTableRotationHour() const;
     bool GetUseSsl() const;
     TDuration GetStatsTableTtl() const;
     TDuration GetArchiveStatsTableTtl() const;

--- a/cloud/blockstore/libs/ydbstats/ydbstats.cpp
+++ b/cloud/blockstore/libs/ydbstats/ydbstats.cpp
@@ -825,9 +825,17 @@ TFuture<NProto::TError> TYdbStatsUploader::AlterTable(
 
 bool TYdbStatsUploader::IsRotationRequired(TInstant ts) const
 {
-    auto configValue = Config->GetStatsTableRotationAfterDays();
-    auto currentDay = TInstant::Now().Days();
-    return currentDay - ts.Days() >= configValue;
+    auto configRotationAfterDays = Config->GetStatsTableRotationAfterDays();
+    auto configRotationHour = Config->GetStatsTableRotationHour();
+
+    auto now = TInstant::Now();
+    auto daysPassed = now.Days() - ts.Days();
+    auto currentHour = now.Hours() % 24;
+
+    if (daysPassed == configRotationAfterDays) {
+        return currentHour >= configRotationHour;
+    }
+    return daysPassed > configRotationAfterDays;
 }
 
 TString TYdbStatsUploader::FormatHistoryTableName(TInstant ts) const


### PR DESCRIPTION
Now ydbstats tables rotation happeps only at midnight UTC. Therefore, all hosts in the cluster attempt to create a new table in the ydbstats database all at once. This might be too intensive query rate for a single database.

We add a new parameter to ydbstats config that regulates the rotation time. For example, with this parameter the cluster can be configurered like this:
zone 1 -> rotate at 00:00 UTC
zone 2 -> rotate at 01:00 UTC
zone 3 -> rotate at 02:00 UTC