### PR TITLE
Fix inability to increase iops and bandwidth

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -2666,10 +2666,10 @@ void TVolumeActor::HandleHttpInfo_ChangeThrottlingPolicy(
     const auto maxReadBandwidth = getParam64("MaxReadBandwidth");
     const auto maxWriteBandwidth = getParam64("MaxWriteBandwidth");
 
-    pp.SetMaxReadIops(Min(pp.GetMaxReadIops(), maxReadIops));
-    pp.SetMaxWriteIops(Min(pp.GetMaxWriteIops(), maxWriteIops));
-    pp.SetMaxReadBandwidth(Min(pp.GetMaxReadBandwidth(), maxReadBandwidth));
-    pp.SetMaxWriteBandwidth(Min(pp.GetMaxWriteBandwidth(), maxWriteBandwidth));
+    pp.SetMaxReadIops(maxReadIops);
+    pp.SetMaxWriteIops(maxWriteIops);
+    pp.SetMaxReadBandwidth(maxReadBandwidth);
+    pp.SetMaxWriteBandwidth(maxWriteBandwidth);
 
     State->ResetThrottlingPolicy(pp);
 


### PR DESCRIPTION
Now, it is not possible to set iops and bandwidth above the default values