### PR TITLE
[Blockstore] blockstore-client: make ignore unknown nbs-client.txt config params

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -581,8 +581,15 @@ TString TCommand::GetIamTokenFromClient()
 void TCommand::InitClientConfig()
 {
     NProto::TClientAppConfig appConfig;
+
     if (NFs::Exists(ConfigFile)) {
-        ParseFromTextFormat(ConfigFile, appConfig);
+        TStringStream errmsg;
+        ParseFromTextFormat(ConfigFile, appConfig,
+            EParseFromTextFormatOption::AllowUnknownField, &errmsg);
+        if (errmsg) {
+            GetErrorStream() << "Some unknown parameters ignored in config file"
+                << " '" << ConfigFile << "': " << errmsg.Str() << Endl;
+        }
     }
 
     auto& clientConfig = *appConfig.MutableClientConfig();

--- a/cloud/blockstore/tests/client/test_ignore_unknown_conf_params/data/nbs-client-unknown-params.txt
+++ b/cloud/blockstore/tests/client/test_ignore_unknown_conf_params/data/nbs-client-unknown-params.txt
@@ -1,0 +1,32 @@
+ClientConfig {
+  SOME_UNKNOWN_PARAM: 1
+  Host: "localhost"
+  Port: 9767
+  RetryTimeout: 86400000
+  SecurePort: 9768
+  RootCertsFile: "certs/server.crt"
+  ThrottlingConfig {
+    SOME_UNKNOWN_PARAM: 1
+    NonreplThrottlingConfig {
+      SOME_UNKNOWN_PARAM: "abc"
+      ReadBandwidthPerCpuUnit: 1
+      ReadIopsPerCpuUnit: 100
+      WriteBandwidthPerCpuUnit: 1
+      WriteIopsPerCpuUnit: 100
+      MaxReadBandwidth: 1000
+      MaxReadIops: 100000
+      MaxWriteBandwidth: 1000
+      MaxWriteIops: 100000
+    }
+  }
+  InsecurePort: 9766
+}
+LogConfig {
+  SysLogService: "NBS_CLIENT"
+  LogLevel: 6
+  SOME_UNKNOWN_PARAM: 1
+}
+SOME_UNKNOWN_CONFIG {
+  SOME_UNKNOWN_PARAM_1: "abc"
+  SOME_UNKNOWN_PARAM_2: 1
+}

--- a/cloud/blockstore/tests/client/test_ignore_unknown_conf_params/test_ignore_unknown_conf_params.py
+++ b/cloud/blockstore/tests/client/test_ignore_unknown_conf_params/test_ignore_unknown_conf_params.py
@@ -1,0 +1,52 @@
+import logging
+import os
+import subprocess
+import yatest.common
+
+
+def test_ignore_unknown_conf_params():
+
+    BINARY_PATH = yatest.common.binary_path(
+        "cloud/blockstore/apps/client/blockstore-client")
+
+    CONF = yatest.common.test_source_path(
+        "data/nbs-client-unknown-params.txt")
+
+    # blockstore-client silently ignores unexisting --config file,
+    # so make sure file exists at test path
+    assert os.path.exists(CONF)
+
+    WAIT_TIMEOUT = 5
+
+    # use most simple 'ping' commant, wich parses --config file and can be run
+    # without additional environment preparations
+    args = [BINARY_PATH] + [
+        "ping",
+        "--config", CONF,
+        "--timeout", "1",
+        "--skip-cert-verification"]
+
+    logging.info(f"""run: {args}""")
+
+    process = subprocess.Popen(
+        args,
+        stdin=None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+
+    try:
+        outs, errs = process.communicate(timeout=WAIT_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        assert False, "blockstore-client reasonable timeout expired"
+
+    # - yexception is thrown by protobuf parser ang logged in case of unknown
+    #   params found
+    # - E_CANCELLED logged expected in case of correct config and exit by
+    #   --timeout option
+
+    for stream in [outs, errs]:
+        assert not ("yexception" in stream.decode("utf-8"))
+
+    assert "Some unknown parameters ignored in config file" in errs.decode("utf-8")
+    assert "E_CANCELLED" in outs.decode("utf-8")

--- a/cloud/blockstore/tests/client/test_ignore_unknown_conf_params/ya.make
+++ b/cloud/blockstore/tests/client/test_ignore_unknown_conf_params/ya.make
@@ -1,0 +1,17 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+TEST_SRCS(
+    test_ignore_unknown_conf_params.py
+)
+
+DEPENDS(
+    cloud/blockstore/apps/client
+)
+
+PEERDIR(
+    cloud/blockstore/tests/python/lib
+)
+
+END()

--- a/cloud/blockstore/tests/client/ya.make
+++ b/cloud/blockstore/tests/client/ya.make
@@ -29,3 +29,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE(
+    test_ignore_unknown_conf_params
+)


### PR DESCRIPTION
Now blockstore-client ignores unknown params in nbs-client.txt config file.