### PR TITLE
Revert "use max timeout as default value for DynamicNodeRegistrationTimeout"

### DIFF
--- a/cloud/storage/core/libs/kikimr/node_registration_settings.h
+++ b/cloud/storage/core/libs/kikimr/node_registration_settings.h
@@ -20,7 +20,7 @@ struct TNodeRegistrationSettings
     TDuration LegacyRegistrationTimeout;
 
     // Timeout for dynamic node registration via discovery service
-    TDuration DynamicNodeRegistrationTimeout = TDuration::Max();
+    TDuration DynamicNodeRegistrationTimeout;
 
     TDuration LoadConfigsFromCmsRetryMinDelay;
     TDuration LoadConfigsFromCmsRetryMaxDelay;


### PR DESCRIPTION
Reverts ydb-platform/nbs#4720 because of `cloud/filestore/tests/registration/test.py.test_server_registration` tests being failed since then 

https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/Nightly-build/19790584012/1/nebius-x86-64/summary/1/ya-test.html#FAIL

