### PR TITLE
checkrange: removing redundant test. 

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -1852,43 +1852,6 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
 
     Y_UNIT_TEST(ShouldCheckRange)
     {
-        TTestEnv env;
-        NProto::TStorageServiceConfig config;
-        const ui32 nodeIdx = SetupTestEnv(env, std::move(config));
-
-        TServiceClient service(env.GetRuntime(), nodeIdx);
-        service.CreateVolume("vol0");
-
-        const auto sessionId =
-            service.MountVolume("vol0")->Record.GetSessionId();
-
-        service.WriteBlocks(
-            "vol0",
-            TBlockRange64::WithLength(0, 1024),
-            sessionId,
-            char(1));
-
-        {
-            NProto::TCheckRangeRequest request;
-            request.SetDiskId("vol0");
-            request.SetStartIndex(0);
-            request.SetBlocksCount(1000);
-
-            TString buf;
-            google::protobuf::util::MessageToJsonString(request, &buf);
-
-            const auto response = service.ExecuteAction("CheckRange", buf);
-            NProto::TCheckRangeResponse checkRangeResponse;
-
-            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
-                            response->Record.GetOutput(),
-                            &checkRangeResponse)
-                            .ok());
-        }
-    }
-
-    Y_UNIT_TEST(ShouldCalculateCheckSumsWhileCheckRange)
-    {
         constexpr ui32 blockCount = 1000;
 
         TTestEnv env;


### PR DESCRIPTION
CheckRange must calculate checksums always
Future commits will compute checkrange request with "calculate checksums" option with no choice.