### PR TITLE
Add strace to rm for posix compliance test (mknod)

### DIFF
--- a/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t
+++ b/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t
@@ -31,4 +31,4 @@ expect char stat ${nx} type
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} c 0644 1 2
 
-rm -rf "${nx%%/*}"
+strace -v rm -rf "${nx%%/*}"


### PR DESCRIPTION
Add strace to investigate test failure
```
2025-11-24 06:28:49,263 - INFO - root - __run_test_suite: executing (mknod, 03.t)
2025-11-24 06:28:51,766 - ERROR - root - __run_test_suite: test (mknod, 03.t) failed: b'1..12\nok 1 (line: 19)\nok 2 (line: 20)\nok 3 (line: 21)\nok 4 (line: 22)\nok 5 (line: 24)\nok 6 (line: 25)\nok 7 (line: 26)\nok 8 (line: 27)\nok 9 (line: 29)\nok 10 (line: 30)\nok 11 (line: 31)\nok 12 (line: 32)\n'
2025-11-24 06:28:51,989 - ERROR - ya.test - logreport: cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-nemesis-test/test.py:15: in test_posix_compliance
    out = compliance.run_compliance_suite(get_filestore_mount_path(), suite, __suites[suite])
cloud/filestore/tools/testing/fs_posix_compliance/pylib/test.py:79: in run_compliance_suite
    return __run_test_suite(tmp_dir, suite, tests)
cloud/filestore/tools/testing/fs_posix_compliance/pylib/test.py:65: in __run_test_suite
    p.check_returncode()
contrib/tools/python3/src/Lib/subprocess.py:502: in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
E   subprocess.CalledProcessError: Command '/home/nbsci/nbs/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t' returned non-zero exit status 1.

rm: cannot remove 'c5b514f04b2bad6f0a6c4a824f02da2b7cf9395db217a4f440214aa0523245000d7d8c1a1a4140223460da8554236a1e0f03367342aa20ef6f59bacd2d457d0/f15e9b39ccfbbf986c679a61c0a2b9485e3cde0a0802202e7e6286c5261ed51bcd5c9e313f56418fb133cfe39f5f5adceec571a6af9121c202b2e0e9332b5ee/15f7a8d58aac1eff1c944c37edefbdf4f9f6e7c6b072f3f3d26e9ddaabceddc3eca7568fe8b41664b69bab00443a35573d5137af7029237563ce0490f492078/55b38a1a9c74020128651bb5384fc9229f8b793076b2dde305b89c6091e691e126c0d2348cf7cf914e8ebb7b44d2444f45508adae4648a06e5a7492ccc591be/79bed80fc0ea33245d973f370936dc022b17ec9b77dc692af407f0d670c10c052f550bb85de93ce5e34bc97b6e29e8f6b5490e3d0ae10f2634ce01296fd459b/ed1edf8e6d82060914849746e1cec6393d1037c01251dfb1caf2bf4e69bf013f15b04336de2971daee7162c660a4095cfe6cd570b4ecfab53453c5a81fbf74a/838c73693647b4b88c381c0aaa85acf20c98e6f3a948f2cfda8b14bb102e9cedc87cbbc3c5cdb28f56dea326a8fd6d3964bdc362cfcef0e9fb91f2dfa635767/40f26b19d24e12679dde20058a018f898b30ed5b4c6be9a380c65b39a4972b37efd9afa5fbc2e2a7fd637855a08656b85a658fa41e9e0400079da5ae621e086/2f342f5fc05c0b96f507a9de15cb3b2d1eb3e760f97bb76699c151c3e9ff4cfdf423218168c5a1071c470c4c23cabdd57958b7d4b8e83647d01f89774ec18f5/58a5912ebbb45bf08ac7426747a22abcbb032515b7bab0c0a62bc7e5a79d02953287c7c057dd1cffe27eb4138067fa82b7b0b98459cb34ea12450d0dd3b2323/1a5d847ca5957d111e3ddce15f57ff97bc375aa9c14f1cfa780f44ba868abfae036df0e5cca1d822949d3c76e63384b597b8e761da9f2105b5334442d008629/8967ac90f010066e9152b4fe4ba9f519735801796610d7d92e7b51a7b250d36195cafecbf11fcece14038a07f46351dffffaf0e01f8a1dafe5e3bd4e44de934/24079b03fe66e2ab439040f652795154135ca330cc9f07691e3acb044f59c3a37a2f5815ce63b7be3236307d3046f2315963437a94e6953564758ddea79a0df/31f259164822261debf0d7fc37149e336b9ac734007aaefa3e8d20edac3a545050bcb1915efd1629916b4ee4d8840212ecf1f3bc3bd670373896a7d0dc238d7/224cfdd2658535b5229157ff768fa7e2a67373a356d25ed0c5f16ea9d2d3a8f6a83f2de58011d2e0ac3e0d53e6da73f1a17eabb8651a72758d240b31445e81a/080e0bd3f866f952ff114b1ba6ede4dfcdbf7a8cb4e8d2e12940783e4b84f014fcc35c6fe51c9f0a367e3fb7d3402facc879b299a4a0a95010d04aaa4fd5756/ce741683f098215e947ef9d43f58ff0ea0bec65a9f968c345f1a3fdc52ef38ee35d2be0d1e22749b9289f45c302bc2dd22bde7c1c3362c24f48e00db1872838/322db727581fb7b414fbc5c736471143be435323ba429949743792352c2eceded4be9011454d641f16af49986018af2db7cb23445103697ed02acc05b7eb4bd/b974511ac96fc7c739285d03001588035075b222ebe91eae57cdb43596ddd0c6cbc9b5bc8ac9a43aa5cffec3bafcd90ba0f7d518a7f1cae62a848b52deec28e/dd41e315f609d94c6fabcdb9b39b379f09cc5ae7ba8eb506c2b91678db286335d199bafef09ba30d2f3fbe31ec618ebf959df8f5e33d4e9ac162c0f40f9d123/6a6751ea09d8b02af1822e1749d4eeb57fd55b422b8aa21b085796342a541ab4408f13d54284b53897e3ba0464fe258b48e343f365e96a0c4d78e2fb967b3d1/4901ddf5d4a050f8fd03ccbc3ae580b4b6300dc53005418d3f6e428fe346a2856d740863ae99110586a5eae70853ffea72034860bfffc483884c531c1317822/51ddae92cb30249799d543a85e7477770bcad11949f0203328e6617d77d549fe1d1bc7ff0bd0d577a4ab6ca35dcc316bb0f4c8b18d76627b76e74f564b3a35e/44c27e3ec0beb0ab827c3d18792ed143badc5b4d3cd8c42552d7108feac1bc8ab5f1c57816ccd0337869d68a321e2b994e42128661fd697eb7db8e6248da89a/a0382d8d4b9cd7c4bce38d36d76d3c705c1f254896147c19d50c46d7b3fae79b33f472e067370e077d261f152584efaa3c42376e7f010f83af071c89f0d357c/5f8e387ec69cb15ef62dad1f440bb7a3c395b7f4d4dedc130e960d2346762ec5e77c67eb6aa7f7f75b796bf007a1f88eaa59ed41e4ce69cf28aa68e282ed61d': Directory not empty
```
