### PR TITLE
Ignore time tracking events for DiskRegistry-based in zombie state

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1206,6 +1206,9 @@ STFUNC(TVolumeActor::StateZombie)
 
         IgnoreFunc(TEvService::TEvDestroyVolumeResponse);
 
+        IgnoreFunc(TEvVolumePrivate::TEvDiskRegistryDeviceOperationStarted);
+        IgnoreFunc(TEvVolumePrivate::TEvDiskRegistryDeviceOperationFinished);
+
         default:
             if (!RejectRequests(ev)) {
                 HandleUnexpectedEvent(


### PR DESCRIPTION
```
CRITICAL_EVENT:AppImpossibleEvents/UnexpectedEvent:[BLOCKSTORE_VOLUME] Unexpected event: (0x10620159) NCloud::NBlockStore::TRequestEvent<NCloud::NBlockStore::NStorage::TEvVolumePrivate::TDiskRegistryDeviceOperationFinished, 274858329u>, void NCloud::NBlockStore::NStorage::TVolumeActor::StateZombie(TAutoPtr< ::NActors::IEventHandle> &)
```