### PR TITLE
eternal-load: Fix aio-errors logging

### DIFF
--- a/cloud/storage/core/libs/common/error.h
+++ b/cloud/storage/core/libs/common/error.h
@@ -460,6 +460,14 @@ T ExtractResponse(NThreading::TFuture<T>& future)
 }
 
 template <typename T>
+TResultOrError<T> ResultOrError(const NThreading::TFuture<T>& future)
+{
+    return SafeExecute<TResultOrError<T>>([&] {
+        return future.GetValue();
+    });
+}
+
+template <typename T>
 TResultOrError<T> ResultOrError(NThreading::TFuture<T>& future)
 {
     return SafeExecute<TResultOrError<T>>([&] {
@@ -467,12 +475,18 @@ TResultOrError<T> ResultOrError(NThreading::TFuture<T>& future)
     });
 }
 
-inline TResultOrError<void> ResultOrError(NThreading::TFuture<void>& future)
+inline TResultOrError<void> ResultOrError(
+    const NThreading::TFuture<void>& future)
 {
     return SafeExecute<TResultOrError<void>>([&] {
         future.TryRethrow();
         return NProto::TError();
     });
+}
+
+inline TResultOrError<void> ResultOrError(NThreading::TFuture<void>& future)
+{
+    return ResultOrError(std::as_const(future));
 }
 
 NProto::TError MakeTabletIsDeadError(


### PR DESCRIPTION
For now there is no error info in logs if async operation fails in `eternal-load`. This PR propagates exception message up to `TTestExecutor`

Before:
```VERIFY failed (2025-12-04T13:29:23.713748+0100): 
  cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:442
  RunCompletion(): requirement future.HasValue() failed
```

After:
```
2025-12-04T12:29:29.162259Z :ETERNAL_EXECUTOR ERROR: cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp:193: Can't write to file: (yexception) (No space left on device) async IO operation failed
```