### PR TITLE
issue-1751: [Filestore] TWriteBackCache::ReadData should not read beyond end of file

### DIFF
--- a/cloud/storage/core/libs/common/disjoint_interval_map.h
+++ b/cloud/storage/core/libs/common/disjoint_interval_map.h
@@ -22,8 +22,10 @@ public:
 
     using TData = TMap<TKey, TItem>;
     using TIterator = typename TData::iterator;
+    using TReverseIterator = typename TData::reverse_iterator;
     using TVisitor = std::function<void(TIterator it)>;
     using TConstIterator = typename TData::const_iterator;
+    using TConstReverseIterator = typename TData::const_reverse_iterator;
     using TConstVisitor = std::function<void(TConstIterator it)>;
 
 private:
@@ -89,6 +91,11 @@ public:
         }
     }
 
+    bool empty() const
+    {
+        return Data.empty();
+    }
+
     TIterator begin()
     {
         return Data.begin();
@@ -107,6 +114,26 @@ public:
     TConstIterator end() const
     {
         return Data.end();
+    }
+
+    TReverseIterator rbegin()
+    {
+        return Data.rbegin();
+    }
+
+    TReverseIterator rend()
+    {
+        return Data.rend();
+    }
+
+    TConstReverseIterator rbegin() const
+    {
+        return Data.rbegin();
+    }
+
+    TConstReverseIterator rend() const
+    {
+        return Data.rend();
     }
 };
 


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/1751

Actual behavior:
`WriteBackCache::ReadData` always reads the requested amount of bytes extending the buffer by zeros.

Expected behavior:
`WriteBackCache::ReadData` should truncate the response according to the file size.

Proposal:
* No cached WriteData requests — return the response send to the session as is.
* There are cached WriteData requests — resize the returned buffer is needed.
