### PR TITLE
Fix small linter issue 'unusedwrite: unused write to field Filesystem'

### DIFF
--- a/cloud/disk_manager/internal/pkg/resources/filesystem_snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/filesystem_snapshots_test.go
@@ -198,20 +198,19 @@ func TestDeleteNonexistingFilesystemSnapshot(t *testing.T) {
 	defer db.Close(ctx)
 
 	storage := newStorage(t, ctx, db)
-	filesystemSnapshot := FilesystemSnapshotMeta{
-		ID: "fs-snapshot",
-	}
+
+	filesystemSnapshotID := "fs-snapshot"
 
 	err = storage.FilesystemSnapshotDeleted(
 		ctx,
-		filesystemSnapshot.ID,
+		filesystemSnapshotID,
 		time.Now(),
 	)
 	require.NoError(t, err)
 
 	_, err = storage.DeleteFilesystemSnapshot(
 		ctx,
-		filesystemSnapshot.ID,
+		filesystemSnapshotID,
 		"delete",
 		time.Now(),
 	)
@@ -219,7 +218,7 @@ func TestDeleteNonexistingFilesystemSnapshot(t *testing.T) {
 
 	err = storage.FilesystemSnapshotCreated(
 		ctx,
-		filesystemSnapshot.ID,
+		filesystemSnapshotID,
 		time.Now(),
 		0,
 		0,
@@ -229,7 +228,7 @@ func TestDeleteNonexistingFilesystemSnapshot(t *testing.T) {
 
 	err = storage.FilesystemSnapshotDeleted(
 		ctx,
-		filesystemSnapshot.ID,
+		filesystemSnapshotID,
 		time.Now(),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
We have a problem with internal linter checks
filesystem_snapshots_test.go:203:13: "unusedwrite: unused write to field Filesystem"