### PR TITLE
[Filestore] enable directory handles in local setup

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-server.txt
+++ b/cloud/filestore/bin/nfs/nfs-server.txt
@@ -5,4 +5,3 @@ ServerConfig {
 }
 KikimrServiceConfig {
 }
-

--- a/cloud/filestore/bin/nfs/nfs-storage.txt
+++ b/cloud/filestore/bin/nfs/nfs-storage.txt
@@ -5,3 +5,5 @@ AutomaticShardCreationEnabled: true
 AutomaticallyCreatedShardSize: 1073741824
 ThreeStageWriteEnabled: true
 UnalignedThreeStageWriteEnabled: true
+DirectoryHandlesStorageEnabled: true
+DirectoryHandlesTableSize: 10000

--- a/cloud/filestore/bin/nfs/nfs-vhost.txt
+++ b/cloud/filestore/bin/nfs/nfs-vhost.txt
@@ -10,5 +10,7 @@ VhostServiceConfig {
   EndpointStorageDir: "./data/endpoints"
   HandleOpsQueuePath: "/run/qemu/filestore-vhost"
   WriteBackCachePath: "/run/qemu/filestore-vhost"
+  DirectoryHandlesStoragePath: "/run/qemu/filestore-vhost"
+  DirectoryHandlesInitialDataSize: 10485760
 }
 


### PR DESCRIPTION
Directory handles cache will be enabled soon in real clusters, so it makes sense to add them to local setup as well. 