### PR TITLE
moved TByteRange from cloud/filestore/libs/storage/model to cloud/storage/core/libs/common

### DIFF
--- a/cloud/filestore/libs/storage/model/block_buffer.h
+++ b/cloud/filestore/libs/storage/model/block_buffer.h
@@ -2,7 +2,7 @@
 
 #include "public.h"
 
-#include "range.h"
+#include <cloud/storage/core/libs/common/byte_range.h>
 
 #include <util/generic/strbuf.h>
 #include <util/generic/string.h>

--- a/cloud/filestore/libs/storage/model/range.cpp
+++ b/cloud/filestore/libs/storage/model/range.cpp
@@ -1,1 +1,0 @@
-#include "range.h"

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -4,9 +4,9 @@
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 #include <cloud/filestore/libs/storage/model/block_buffer.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/sparse_segment.h>
 #include <cloud/filestore/libs/storage/tablet/model/verify.h>
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -4,8 +4,8 @@
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 #include <cloud/filestore/libs/storage/core/helpers.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/verify.h>
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 
 #include <library/cpp/iterator/enumerate.h>

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -4,7 +4,6 @@
 #include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/core/model.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/range_locks.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttling_policy.h>
 #include <cloud/filestore/libs/storage/tablet/protos/tablet.pb.h>
@@ -12,6 +11,7 @@
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 #include <cloud/storage/core/libs/tablet/model/partial_blob_id.h>
 

--- a/cloud/filestore/libs/storage/tablet/model/compaction_map.h
+++ b/cloud/filestore/libs/storage/tablet/model/compaction_map.h
@@ -2,8 +2,8 @@
 
 #include "public.h"
 
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/alloc.h>
+#include <cloud/storage/core/libs/common/byte_range.h>
 
 #include <util/generic/vector.h>
 

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -4,7 +4,7 @@
 
 #include "block.h"
 
-#include <cloud/filestore/libs/storage/model/range.h>
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/common/byte_vector.h>
 #include <cloud/storage/core/libs/common/error.h>
 

--- a/cloud/filestore/libs/storage/tablet/model/read_ahead.h
+++ b/cloud/filestore/libs/storage/tablet/model/read_ahead.h
@@ -2,9 +2,9 @@
 
 #include "public.h"
 
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/common/ring_buffer.h>
 
 #include <util/generic/deque.h>

--- a/cloud/filestore/libs/storage/tablet/model/truncate_queue.h
+++ b/cloud/filestore/libs/storage/tablet/model/truncate_queue.h
@@ -2,7 +2,7 @@
 
 #include "public.h"
 
-#include <cloud/filestore/libs/storage/model/range.h>
+#include <cloud/storage/core/libs/common/byte_range.h>
 
 #include <util/generic/hash_set.h>
 #include <util/generic/vector.h>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -16,11 +16,11 @@
 #include <cloud/filestore/libs/storage/core/config.h>
 #include <cloud/filestore/libs/storage/core/tablet.h>
 #include <cloud/filestore/libs/storage/model/public.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
 #include <cloud/filestore/libs/storage/tablet/model/verify.h>
 
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
 #include <cloud/storage/core/libs/diagnostics/busy_idle_calculator.h>
 #include <cloud/storage/core/libs/throttling/public.h>

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -8,11 +8,12 @@
 #include <cloud/filestore/libs/storage/api/events.h>
 #include <cloud/filestore/libs/storage/core/request_info.h>
 #include <cloud/filestore/libs/storage/model/public.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/blob.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
 #include <cloud/filestore/libs/storage/tablet/model/shard_balancer.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
+
+#include <cloud/storage/core/libs/common/byte_range.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -6,7 +6,6 @@
 #include "tablet_state.h"
 #include "tablet_state_cache.h"
 
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/block_list.h>
 #include <cloud/filestore/libs/storage/tablet/model/channels.h>
 #include <cloud/filestore/libs/storage/tablet/model/compaction_map.h>
@@ -24,6 +23,8 @@
 #include <cloud/filestore/libs/storage/tablet/model/throttling_policy.h>
 #include <cloud/filestore/libs/storage/tablet/model/truncate_queue.h>
 #include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <cloud/storage/core/libs/common/byte_range.h>
 
 namespace NCloud::NFileStore::NStorage {
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -12,7 +12,6 @@
 #include <cloud/filestore/libs/storage/core/request_info.h>
 #include <cloud/filestore/libs/storage/model/block_buffer.h>
 #include <cloud/filestore/libs/storage/model/public.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
 #include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
 #include <cloud/filestore/libs/storage/tablet/model/range_locks.h>
@@ -20,6 +19,7 @@
 
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
+#include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/folder/pathsplit.h>

--- a/cloud/filestore/tools/analytics/libs/event-log/request_filter.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_filter.cpp
@@ -2,8 +2,9 @@
 
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/service/request.h>
-#include <cloud/filestore/libs/storage/model/range.h>
 #include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
+
+#include <cloud/storage/core/libs/common/byte_range.h>
 
 namespace NCloud::NFileStore {
 
@@ -248,7 +249,7 @@ class TRequestFilterByRange
 private:
     const IRequestFilterPtr NextFilter;
 
-    const NStorage::TByteRange ByteRange;
+    const TByteRange ByteRange;
 
 public:
     TRequestFilterByRange(
@@ -274,7 +275,7 @@ public:
             }
 
             for (const auto& range: profileLogRequest.GetRanges()) {
-                const NStorage::TByteRange reqRange(
+                const TByteRange reqRange(
                     range.GetOffset(),
                     range.GetBytes(),
                     ByteRange.BlockSize);

--- a/cloud/storage/core/libs/common/byte_range.cpp
+++ b/cloud/storage/core/libs/common/byte_range.cpp
@@ -1,0 +1,1 @@
+#include "byte_range.h"

--- a/cloud/storage/core/libs/common/byte_range.h
+++ b/cloud/storage/core/libs/common/byte_range.h
@@ -4,7 +4,7 @@
 #include <util/string/builder.h>
 #include <util/system/align.h>
 
-namespace NCloud::NFileStore::NStorage {
+namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -175,4 +175,4 @@ struct TByteRange
     }
 };
 
-}   // namespace NCloud::NFileStore::NStorage
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/byte_range_ut.cpp
+++ b/cloud/storage/core/libs/common/byte_range_ut.cpp
@@ -1,10 +1,10 @@
-#include "range.h"
+#include "byte_range.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/size_literals.h>
 
-namespace NCloud::NFileStore::NStorage {
+namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -97,4 +97,4 @@ Y_UNIT_TEST_SUITE(TByteRangeTest)
     }
 }
 
-}   // namespace NCloud::NFileStore::NStorage
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/ut/ya.make
+++ b/cloud/storage/core/libs/common/ut/ya.make
@@ -20,6 +20,7 @@ SRCS(
     backoff_delay_provider_ut.cpp
     block_buffer_ut.cpp
     block_data_ref_ut.cpp
+    byte_range_ut.cpp
     concurrent_queue_ut.cpp
     context_ut.cpp
     disjoint_interval_map_ut.cpp

--- a/cloud/storage/core/libs/common/ya.make
+++ b/cloud/storage/core/libs/common/ya.make
@@ -11,6 +11,7 @@ SRCS(
     backoff_delay_provider.cpp
     block_buffer.cpp
     block_data_ref.cpp
+    byte_range.cpp
     byte_vector.cpp
     compressed_bitmap.cpp
     concurrent_queue.cpp


### PR DESCRIPTION
### Notes
Moved TByteRange from cloud/filestore/libs/storage/model to cloud/storage/core/libs/common to reuse it outside of filestore storage. I need TByteRange to implement checksum logging for profile log requests.

### Issue
https://github.com/ydb-platform/nbs/issues/568


