### PR TITLE
Fix tsan failure in TFileSystemTest::ShouldFlushAllRequestsBeforeSessonIsDestroyed

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -2890,7 +2890,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         auto requestInProgressSensor = counters->GetCounter("InProgress");
         i64 requestCount = 0;
 
-        while (requestInProgressSensor->GetAtomic() < MaxPendingRequestCount) {
+        while (requestInProgressSensor->Val() < MaxPendingRequestCount) {
             UNIT_ASSERT_GT(MaxRequestCount, requestCount);
 
             ui64 nodeId = RandomNumber(NodeCount) + 123;
@@ -2915,8 +2915,8 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 [&]()
                 {
                     const bool requestIsProcessed =
-                        requestCount == requestInProgressSensor->GetAtomic() +
-                                            requestCountSensor->GetAtomic();
+                        requestCount == requestInProgressSensor->Val() +
+                                            requestCountSensor->Val();
 
                     // A pending request will eventually become completed if the
                     // cache is not full. We don't want to count these requests
@@ -2927,7 +2927,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                     // space to store the request
 
                     const bool nonZeroPendingIsExpected =
-                        requestInProgressSensor->GetAtomic() == 0 ||
+                        requestInProgressSensor->Val() == 0 ||
                         writeDataCalledCount > 0;
 
                     return requestIsProcessed && nonZeroPendingIsExpected;
@@ -2943,14 +2943,14 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         UNIT_ASSERT_VALUES_EQUAL(
             MaxPendingRequestCount,
-            requestInProgressSensor->GetAtomic());
+            requestInProgressSensor->Val());
 
         // Enable progression of WriteData requests - this will enable flushing
         writeDataPromise.SetValue();
         UNIT_ASSERT(stopFuture.Wait(Timeout));
 
-        UNIT_ASSERT_VALUES_EQUAL(0, requestInProgressSensor->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(requestCount, requestCountSensor->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(0, requestInProgressSensor->Val());
+        UNIT_ASSERT_VALUES_EQUAL(requestCount, requestCountSensor->Val());
         UNIT_ASSERT(!path.Exists());
     }
 }


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=632431)
  Atomic write of size 8 at 0x7b0c000bfec8 by thread T80 (mutexes: read M0):
    #0 AtomicIncrement /actions-runner/_work/nbs/nbs/library/cpp/deprecated/atomic/atomic_gcc.h:35:12 (cloud-filestore-libs-vfs_fuse-ut+0x23f72b9) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #1 NMonitoring::TDeprecatedCounter::Inc /actions-runner/_work/nbs/nbs/library/cpp/monlib/counters/counters.h:71:20 (cloud-filestore-libs-vfs_fuse-ut+0x23f72b9)
    #2 NCloud::TRequestCounters::TStatCounters::Started /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/request_counters.cpp:610:43 (cloud-filestore-libs-vfs_fuse-ut+0x23f72b9)
    #3 NCloud::TRequestCounters::RequestStartedImpl(unsigned int, unsigned long) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/request_counters.cpp:1119:41 (cloud-filestore-libs-vfs_fuse-ut+0x23f72b9)
    #4 NCloud::TRequestCounters::RequestStarted(unsigned int, unsigned long) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/request_counters.cpp:950:5 (cloud-filestore-libs-vfs_fuse-ut+0x23f7139) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #5 NCloud::NFileStore::(anonymous namespace)::TFileSystemStats::RequestStarted /actions-runner/_work/nbs/nbs/cloud/filestore/libs/diagnostics/request_stats.cpp:474:55 (cloud-filestore-libs-vfs_fuse-ut+0x23dd089) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #6 NCloud::NFileStore::(anonymous namespace)::TFileSystemStats::RequestStarted(TLog&, NCloud::NFileStore::TCallContext&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/diagnostics/request_stats.cpp:494:9 (cloud-filestore-libs-vfs_fuse-ut+0x23dd089)
    #7 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::Call<void (NCloud::NFileStore::NFuse::IFileSystem::*)(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, fuse_req *, unsigned long, fuse_bufvec *, long, fuse_file_info *), unsigned long &, fuse_bufvec *&, long &, fuse_file_info *&> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1373:30 (cloud-filestore-libs-vfs_fuse-ut+0x24d9af3) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #8 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::InitOps(fuse_lowlevel_ops &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1543:13 (cloud-filestore-libs-vfs_fuse-ut+0x24d9af3)
    #9 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::InitOps(fuse_lowlevel_ops&)::'lambda'(fuse_req*, unsigned long, fuse_bufvec*, long, fuse_file_info*)::__invoke(fuse_req*, unsigned long, fuse_bufvec*, long, fuse_file_info*) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1542:25 (cloud-filestore-libs-vfs_fuse-ut+0x24d9af3)
    #10 do_write_buf /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:1214:5 (libvirtiofsd.so+0xae4f) (BuildId: bdc1a4aa0877ef4aac85df21fea14f855c709e0e)
    #11 fuse_session_process_buf_int /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:2508:9 (libvirtiofsd.so+0xae4f)
    #12 process_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:315:5 (cloud-filestore-libs-vfs_fuse-ut+0x25c5e01) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #13 virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:532:19 (cloud-filestore-libs-vfs_fuse-ut+0x25c5e01)
    #14 fuse_session_loop /actions-runner/_work/nbs/nbs/contrib/libs/virtiofsd/fuse_lowlevel.c:2701:12 (libvirtiofsd.so+0xb67e) (BuildId: bdc1a4aa0877ef4aac85df21fea14f855c709e0e)
    #15 NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:533:9 (cloud-filestore-libs-vfs_fuse-ut+0x24e00d1) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #16 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (cloud-filestore-libs-vfs_fuse-ut+0x11a0d52) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #17 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (cloud-filestore-libs-vfs_fuse-ut+0x11a48ac) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
  Previous read of size 8 at 0x7b0c000bfec8 by main thread:
    #0 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TTestCaseShouldFlushAllRequestsBeforeSessionIsDestroyed::Execute_(NUnitTest::TTestContext &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:2913:13 (cloud-filestore-libs-vfs_fuse-ut+0xe9b781) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #1 NCloud::NFileStore::NFuse::(anonymous namespace)::WaitForCondition<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:2913:13)> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:81:13 (cloud-filestore-libs-vfs_fuse-ut+0xe9b781)
    #2 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TTestCaseShouldFlushAllRequestsBeforeSessionIsDestroyed::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:2913:13 (cloud-filestore-libs-vfs_fuse-ut+0xe9b781)
    #3 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1 (cloud-filestore-libs-vfs_fuse-ut+0xea2934) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #4 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #5 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #6 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #7 std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #8 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-filestore-libs-vfs_fuse-ut+0x11e4e9f) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #9 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-filestore-libs-vfs_fuse-ut+0x11e4e9f)
    #10 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-filestore-libs-vfs_fuse-ut+0x11e4e9f)
    #11 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-filestore-libs-vfs_fuse-ut+0x11cc48a) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #12 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1 (cloud-filestore-libs-vfs_fuse-ut+0xea1c56) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #13 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-filestore-libs-vfs_fuse-ut+0x11cd293) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #14 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-filestore-libs-vfs_fuse-ut+0x11e123c) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #15 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-filestore-libs-vfs_fuse-ut+0x11e01b0) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
  Location is heap block of size 40 at 0x7b0c000bfeb0 allocated by main thread:
    #0 operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (cloud-filestore-libs-vfs_fuse-ut+0xfe4ab7) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #1 MakeIntrusive<NMonitoring::TCounterForPtr, TDefaultIntrusivePtrOps<NMonitoring::TCounterForPtr>, bool &, NMonitoring::TCountableBase::EVisibility &> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:785:12 (cloud-filestore-libs-vfs_fuse-ut+0x18feed1) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #2 TIntrusivePtr<NMonitoring::TCountableBase, TDefaultIntrusivePtrOps<NMonitoring::TCountableBase>> NMonitoring::TDynamicCounters::GetNamedCounterImpl<false, NMonitoring::TCounterForPtr, bool&, NMonitoring::TCountableBase::EVisibility&>(TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool&, NMonitoring::TCountableBase::EVisibility&) /actions-runner/_work/nbs/nbs/library/cpp/monlib/dynamic_counters/counters.cpp:307:22 (cloud-filestore-libs-vfs_fuse-ut+0x18feed1)
    #3 NMonitoring::TDynamicCounters::GetNamedCounter /actions-runner/_work/nbs/nbs/library/cpp/monlib/dynamic_counters/counters.cpp:70:25 (cloud-filestore-libs-vfs_fuse-ut+0x18fe6f4) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #4 NMonitoring::TDynamicCounters::GetCounter(TBasicString<char, std::__y1::char_traits<char>> const&, bool, NMonitoring::TCountableBase::EVisibility) /actions-runner/_work/nbs/nbs/library/cpp/monlib/dynamic_counters/counters.cpp:66:12 (cloud-filestore-libs-vfs_fuse-ut+0x18fe6f4)
    #5 NCloud::TRequestCounters::TStatCounters::FullInitIfNeeded() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/request_counters.cpp:526:31 (cloud-filestore-libs-vfs_fuse-ut+0x23f2695) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #6 NCloud::TRequestCounters::Register(NMonitoring::TDynamicCounters&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/request_counters.cpp:935:38 (cloud-filestore-libs-vfs_fuse-ut+0x23f672b) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #7 NCloud::NFileStore::(anonymous namespace)::MakeRequestCounters(std::__y1::shared_ptr<NCloud::ITimer>, NMonitoring::TDynamicCounters&, TFlags<NCloud::TRequestCounters::EOption>, TFlags<NCloud::EHistogramCounterOption>) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/diagnostics/request_stats.cpp:64:22 (cloud-filestore-libs-vfs_fuse-ut+0x23d830d) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #8 NCloud::NFileStore::(anonymous namespace)::TFileSystemStats::TFileSystemStats /actions-runner/_work/nbs/nbs/cloud/filestore/libs/diagnostics/request_stats.cpp:447:20 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #9 std::__y1::allocator<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats>::construct<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, std::__y1::shared_ptr<NCloud::ITimer>, TIntrusivePtr<NMonitoring::TDynamicCounters, TDefaultIntrusivePtrOps<NMonitoring::TDynamicCounters> >, std::__y1::shared_ptr<NCloud::IPostponeTimePredictor>, TDuration &, TDuration &, TFlags<NCloud::EHistogramCounterOption> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:165:28 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #10 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats> >::construct<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, std::__y1::shared_ptr<NCloud::ITimer>, TIntrusivePtr<NMonitoring::TDynamicCounters, TDefaultIntrusivePtrOps<NMonitoring::TDynamicCounters> >, std::__y1::shared_ptr<NCloud::IPostponeTimePredictor>, TDuration &, TDuration &, TFlags<NCloud::EHistogramCounterOption> &, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:290:13 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #11 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats, std::__y1::allocator<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats> >::__shared_ptr_emplace<TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, std::__y1::shared_ptr<NCloud::ITimer>, TIntrusivePtr<NMonitoring::TDynamicCounters, TDefaultIntrusivePtrOps<NMonitoring::TDynamicCounters> >, std::__y1::shared_ptr<NCloud::IPostponeTimePredictor>, TDuration &, TDuration &, TFlags<NCloud::EHistogramCounterOption> &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:318:9 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #12 std::__y1::allocate_shared<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats, std::__y1::allocator<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats>, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, std::__y1::shared_ptr<NCloud::ITimer>, TIntrusivePtr<NMonitoring::TDynamicCounters, TDefaultIntrusivePtrOps<NMonitoring::TDynamicCounters> >, std::__y1::shared_ptr<NCloud::IPostponeTimePredictor>, TDuration &, TDuration &, TFlags<NCloud::EHistogramCounterOption> &, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:979:55 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #13 std::__y1::make_shared<NCloud::NFileStore::(anonymous namespace)::TFileSystemStats, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, TBasicString<char, std::__y1::char_traits<char> >, std::__y1::shared_ptr<NCloud::ITimer>, TIntrusivePtr<NMonitoring::TDynamicCounters, TDefaultIntrusivePtrOps<NMonitoring::TDynamicCounters> >, std::__y1::shared_ptr<NCloud::IPostponeTimePredictor>, TDuration &, TDuration &, TFlags<NCloud::EHistogramCounterOption> &, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:988:12 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #14 NCloud::NFileStore::(anonymous namespace)::TRequestStatsRegistry::CreateRequestStats /actions-runner/_work/nbs/nbs/cloud/filestore/libs/diagnostics/request_stats.cpp:918:16 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #15 NCloud::NFileStore::(anonymous namespace)::TRequestStatsRegistry::GetFileSystemStats(TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/diagnostics/request_stats.cpp:754:26 (cloud-filestore-libs-vfs_fuse-ut+0x23d4dc8)
    #16 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StartAsync() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:675:39 (cloud-filestore-libs-vfs_fuse-ut+0x24b499e) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #17 NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrap::StartAsync /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:238:29 (cloud-filestore-libs-vfs_fuse-ut+0xe11d8d) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #18 NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrap::Start(bool) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:217:25 (cloud-filestore-libs-vfs_fuse-ut+0xe11d8d)
    #19 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TTestCaseShouldFlushAllRequestsBeforeSessionIsDestroyed::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:2874:19 (cloud-filestore-libs-vfs_fuse-ut+0xe99fdf) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #20 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1 (cloud-filestore-libs-vfs_fuse-ut+0xea2934) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #21 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #22 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #23 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #24 std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12 (cloud-filestore-libs-vfs_fuse-ut+0xea2934)
    #25 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16 (cloud-filestore-libs-vfs_fuse-ut+0x11e4e9f) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #26 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12 (cloud-filestore-libs-vfs_fuse-ut+0x11e4e9f)
    #27 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-filestore-libs-vfs_fuse-ut+0x11e4e9f)
    #28 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-filestore-libs-vfs_fuse-ut+0x11cc48a) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #29 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:299:1 (cloud-filestore-libs-vfs_fuse-ut+0xea1c56) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #30 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-filestore-libs-vfs_fuse-ut+0x11cd293) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #31 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-filestore-libs-vfs_fuse-ut+0x11e123c) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
    #32 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-filestore-libs-vfs_fuse-ut+0x11e01b0) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
  Mutex M0 (0x7b6000002738) created at:
    #0 pthread_rwlock_init /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1484:3 (cloud-filestore-libs-vfs_fuse-ut+0xf5e77e) (BuildId: af475cb515b6e3b3c574616549b594b9ae0df523)
```