### PR TITLE
[NBS] add "type" field to the StartEndpoint metric

### DIFF
--- a/cloud/blockstore/libs/client/metric.cpp
+++ b/cloud/blockstore/libs/client/metric.cpp
@@ -109,6 +109,14 @@ public:
             }
         };
 
+        if constexpr (requires { request.GetVolumeAccessMode(); }) {
+            MetricRequest.AccessMode = request.GetVolumeAccessMode();
+        }
+
+        if constexpr (requires { request.GetVolumeMountMode(); }) {
+            MetricRequest.MountMode = request.GetVolumeMountMode();
+        }
+
         AppCtx.ServerStats->PrepareMetricRequest(
             MetricRequest,
             GetClientId(request),

--- a/cloud/blockstore/libs/client/throttling_ut.cpp
+++ b/cloud/blockstore/libs/client/throttling_ut.cpp
@@ -155,11 +155,15 @@ struct TRequestStats final
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui64 requestBytes) override
+        ui64 requestBytes,
+        NProto::EVolumeAccessMode accessMode,
+        NProto::EVolumeMountMode mountMode) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
         Y_UNUSED(requestBytes);
+        Y_UNUSED(accessMode);
+        Y_UNUSED(mountMode);
         return 0;
     }
 
@@ -173,7 +177,9 @@ struct TRequestStats final
         ui32 errorFlags,
         bool unaligned,
         ECalcMaxTime calcMaxTime,
-        ui64 responseSent) override
+        ui64 responseSent,
+        NProto::EVolumeAccessMode accessMode,
+        NProto::EVolumeMountMode mountMode) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
@@ -185,6 +191,8 @@ struct TRequestStats final
         Y_UNUSED(unaligned);
         Y_UNUSED(calcMaxTime);
         Y_UNUSED(responseSent);
+        Y_UNUSED(accessMode);
+        Y_UNUSED(mountMode);
         return TDuration::Zero();
     }
 

--- a/cloud/blockstore/libs/diagnostics/request_stats.h
+++ b/cloud/blockstore/libs/diagnostics/request_stats.h
@@ -24,7 +24,9 @@ struct IRequestStats
     virtual ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui64 requestBytes) = 0;
+        ui64 requestBytes,
+        NProto::EVolumeAccessMode accessMode,
+        NProto::EVolumeMountMode mountMode) = 0;
 
     virtual TDuration RequestCompleted(
         NCloud::NProto::EStorageMediaKind mediaKind,
@@ -36,7 +38,9 @@ struct IRequestStats
         ui32 errorFlags,
         bool unaligned,
         ECalcMaxTime calcMaxTime,
-        ui64 responseSent) = 0;
+        ui64 responseSent,
+        NProto::EVolumeAccessMode accessMode,
+        NProto::EVolumeMountMode mountMode) = 0;
 
     virtual void AddIncompleteStats(
         NCloud::NProto::EStorageMediaKind mediaKind,

--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -330,7 +330,9 @@ void TServerStats::RequestStarted(
     auto started = RequestStats->RequestStarted(
         req.MediaKind,
         req.RequestType,
-        req.RequestBytes);
+        req.RequestBytes,
+        req.AccessMode,
+        req.MountMode);
     callContext.SetRequestStartedCycles(started);
 
     if (req.VolumeInfo) {
@@ -436,7 +438,9 @@ void TServerStats::RequestCompleted(
         errorFlags,
         req.Unaligned,
         calcMaxTime,
-        responseSentCycles);
+        responseSentCycles,
+        req.AccessMode,
+        req.MountMode);
 
     ui32 blockSize = DefaultBlockSize;
 

--- a/cloud/blockstore/libs/diagnostics/server_stats.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats.h
@@ -33,6 +33,10 @@ struct TMetricRequest
     TInstant RequestTimestamp;
     bool Unaligned = false;
     bool CellRequest = false;
+    NProto::EVolumeAccessMode AccessMode =
+        NProto::EVolumeAccessMode::VOLUME_ACCESS_READ_WRITE;
+    NProto::EVolumeMountMode MountMode =
+        NProto::EVolumeMountMode::VOLUME_MOUNT_LOCAL;
 
     TMetricRequest(EBlockStoreRequest requestType)
         : RequestType(requestType)

--- a/cloud/blockstore/libs/diagnostics/stats_helpers.cpp
+++ b/cloud/blockstore/libs/diagnostics/stats_helpers.cpp
@@ -26,6 +26,11 @@ TRequestCounters MakeRequestCounters(
             const auto bt = static_cast<EBlockStoreRequest>(t);
             return IsNonLocalReadWriteRequest(bt);
         },
+        [] (TRequestCounters::TRequestType t) {
+            Y_DEBUG_ABORT_UNLESS(t < BlockStoreRequestsCount);
+            const auto bt = static_cast<EBlockStoreRequest>(t);
+            return bt == EBlockStoreRequest::StartEndpoint;
+        },
         options,
         histogramCounterOptions,
         executionTimeSizeClasses);

--- a/cloud/blockstore/libs/service_throttling/throttler_logger_ut.cpp
+++ b/cloud/blockstore/libs/service_throttling/throttler_logger_ut.cpp
@@ -184,11 +184,15 @@ struct TRequestStats final
     ui64 RequestStarted(
         NCloud::NProto::EStorageMediaKind mediaKind,
         EBlockStoreRequest requestType,
-        ui64 requestBytes) override
+        ui64 requestBytes,
+        NProto::EVolumeAccessMode accessMode,
+        NProto::EVolumeMountMode mountMode) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
         Y_UNUSED(requestBytes);
+        Y_UNUSED(accessMode);
+        Y_UNUSED(mountMode);
         return 0;
     }
 
@@ -202,7 +206,9 @@ struct TRequestStats final
         ui32 errorFlags,
         bool unaligned,
         ECalcMaxTime calcMaxTime,
-        ui64 responseSent) override
+        ui64 responseSent,
+        NProto::EVolumeAccessMode accessMode,
+        NProto::EVolumeMountMode mountMode) override
     {
         Y_UNUSED(mediaKind);
         Y_UNUSED(requestType);
@@ -214,6 +220,8 @@ struct TRequestStats final
         Y_UNUSED(unaligned);
         Y_UNUSED(calcMaxTime);
         Y_UNUSED(responseSent);
+        Y_UNUSED(accessMode);
+        Y_UNUSED(mountMode);
         return TDuration::Zero();
     }
 

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -57,6 +57,11 @@ TRequestCountersPtr MakeRequestCounters(
         [] (TRequestCounters::TRequestType t) {
             return IsReadWriteRequest(static_cast<EFileStoreRequest>(t));
         },
+        [] (TRequestCounters::TRequestType t) {
+            Y_DEBUG_ABORT_UNLESS(t < FileStoreRequestCount);
+            const auto bt = static_cast<EFileStoreRequest>(t);
+            return bt == EFileStoreRequest::StartEndpoint;
+        },
         options,
         histogramCounterOptions,
         TVector<TSizeInterval>{}

--- a/cloud/storage/core/libs/diagnostics/request_counters.h
+++ b/cloud/storage/core/libs/diagnostics/request_counters.h
@@ -36,6 +36,7 @@ public:
         ReportControlPlaneHistogram = (1 << 2),
         AddSpecialCounters          = (1 << 3),
         LazyRequestInitialization   = (1 << 4),
+        OnlyStartEndpointRequests   = (1 << 5),
     };
 
     using TRequestType = TDiagnosticsRequestType;
@@ -51,6 +52,7 @@ public:
 private:
     const std::function<TString(TRequestType)> RequestType2Name;
     const std::function<bool(TRequestType)> IsReadWriteRequestType;
+    const std::function<bool(TRequestType)> IsStartEndpointRequestType;
     const EOptions Options;
 
     THolder<TSpecialCounters> SpecialCounters;
@@ -63,6 +65,7 @@ public:
         ui32 requestCount,
         std::function<TString(TRequestType)> requestType2Name,
         std::function<bool(TRequestType)> isReadWriteRequestType,
+        std::function<bool(TRequestType)> isStartEndpointRequestType,
         EOptions options,
         EHistogramCounterOptions histogramCounterOptions,
         const TVector<TSizeInterval>& executionTimeSizeClasses);

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -99,6 +99,12 @@ auto IsReadWriteRequest(TRequestCounters::TRequestType t)
     return true;
 }
 
+auto IsStartEndpointRequest(TRequestCounters::TRequestType t)
+{
+    Y_UNUSED(t);
+    return false;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TRequestCountersOptions
@@ -116,6 +122,7 @@ auto MakeRequestCounters(TRequestCountersOptions options = {})
         2,
         RequestType2Name,
         IsReadWriteRequest,
+        IsStartEndpointRequest,
         options.Options,
         options.HistogramCounterOptions,
         options.ExecutionTimeSizeClasses);
@@ -128,6 +135,7 @@ auto MakeRequestCountersPtr(TRequestCountersOptions options = {})
         2,
         RequestType2Name,
         IsReadWriteRequest,
+        IsStartEndpointRequest,
         options.Options,
         options.HistogramCounterOptions,
         options.ExecutionTimeSizeClasses);


### PR DESCRIPTION
It is useful to see StartEndpoint execution time with different mount and acces modes.
Monitoring request examples:
 ` {project = "nbs", cluster = "cluster", service = "server", host = "cluster", request = "StartEndpoint", sensor = "MaxTime", mount_mode = "local", access_mode = "read_write"}`;

 ` {project = "nbs", cluster = "cluster", service = "server", host = "cluster", request = "StartEndpoint", sensor = "MaxTime", mount_mode = "local", access_mode = "read_only"}`;

 ` {project = "nbs", cluster = "cluster", service = "server", host = "cluster", request = "StartEndpoint", sensor = "MaxTime", mount_mode = "remote"}`;
