### PR TITLE
User histograms now select the source accroding to config; do not increment throttler percentiles with zeros

### DIFF
--- a/cloud/blockstore/libs/diagnostics/user_counter.cpp
+++ b/cloud/blockstore/libs/diagnostics/user_counter.cpp
@@ -95,20 +95,22 @@ void RegisterServiceVolume(
 
     auto readSub = src->FindSubgroup("request", "ReadBlocks");
     AddHistogramUserMetric(
-        GetTimeBuckets(histogramCounterOptions),
+        GetUsBuckets(),
         dsc,
         commonLabels,
         {{readSub, "ThrottlerDelay"}},
-        DISK_READ_THROTTLER_DELAY);
+        DISK_READ_THROTTLER_DELAY,
+        histogramCounterOptions);
 
     auto writeSub = src->FindSubgroup("request", "WriteBlocks");
     auto zeroSub = src->FindSubgroup("request", "ZeroBlocks");
     AddHistogramUserMetric(
-        GetTimeBuckets(histogramCounterOptions),
+        GetUsBuckets(),
         dsc,
         commonLabels,
         {{writeSub, "ThrottlerDelay"}, {zeroSub, "ThrottlerDelay"}},
-        DISK_WRITE_THROTTLER_DELAY);
+        DISK_WRITE_THROTTLER_DELAY,
+        histogramCounterOptions);
 }
 
 void UnregisterServiceVolume(
@@ -190,7 +192,8 @@ void RegisterServerVolumeInstance(
         dsc,
         commonLabels,
         {{readSub, "Time"}},
-        DISK_READ_LATENCY);
+        DISK_READ_LATENCY,
+        histogramCounterOptions);
 
     auto writeSubgroup = src->FindSubgroup("request", "WriteBlocks");
     auto zeroSubgroup = src->FindSubgroup("request", "ZeroBlocks");
@@ -248,7 +251,8 @@ void RegisterServerVolumeInstance(
         dsc,
         commonLabels,
         getWriteCounters("Time"),
-        DISK_WRITE_LATENCY);
+        DISK_WRITE_LATENCY,
+        histogramCounterOptions);
 }
 
 void UnregisterServerVolumeInstance(

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -1023,7 +1023,7 @@ NProto::TVolumeClientInfo CreateVolumeClientInfo(
     ui64 mountSeqNumber)
 {
     NProto::TVolumeClientInfo info;
-    info.SetClientId();
+    info.SetClientId(clientId);
     info.SetVolumeAccessMode(accessMode);
     info.SetMountSeqNumber(mountSeqNumber);
     info.SetVolumeMountMode(mountMode);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -118,7 +118,7 @@ void TVolumeActor::UpdateDelayCounter(
     TVolumeThrottlingPolicy::EOpType opType,
     TDuration time)
 {
-    if (!VolumeSelfCounters) {
+    if (!VolumeSelfCounters || time == TDuration::Zero()) {
         return;
     }
     switch (opType) {

--- a/cloud/filestore/libs/diagnostics/user_counter.cpp
+++ b/cloud/filestore/libs/diagnostics/user_counter.cpp
@@ -134,7 +134,8 @@ void RegisterFilestore(
         dsc,
         commonLabels,
         { { readSub, "Time" } },
-        FILESTORE_READ_LATENCY);
+        FILESTORE_READ_LATENCY,
+        histogramCounterOptions);
 
     auto writeSub = src->FindSubgroup("request", "WriteData");
     AddUserMetric(
@@ -167,7 +168,8 @@ void RegisterFilestore(
         dsc,
         commonLabels,
         { { writeSub, "Time" } },
-        FILESTORE_WRITE_LATENCY);
+        FILESTORE_WRITE_LATENCY,
+        histogramCounterOptions);
 
     TVector<TBaseDynamicCounters> indexOpsCounters;
     TVector<TBaseDynamicCounters> indexErrorCounters;
@@ -209,7 +211,8 @@ void RegisterFilestore(
                     dsc,
                     labels,
                     {{ indexSubgroup, "Time" }},
-                    FILESTORE_INDEX_LATENCY);
+                    FILESTORE_INDEX_LATENCY,
+                    histogramCounterOptions);
                 AddUserMetric(
                     dsc,
                     labels,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -93,6 +93,9 @@ void TIndexTabletActor::UpdateDelayCounter(
     TThrottlingPolicy::EOpType opType,
     TDuration time)
 {
+    if (time == TDuration::Zero()) {
+        return;
+    }
     switch (opType) {
         case TThrottlingPolicy::EOpType::Read: {
             Metrics.ReadDataPostponed.Record(time.MicroSeconds());

--- a/cloud/storage/core/libs/user_stats/counter/user_counter.h
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.h
@@ -69,6 +69,8 @@ static constexpr size_t BUCKETS_COUNT = 25;
 using TBuckets = std::array<TBucket, BUCKETS_COUNT>;
 using TBucketsWithUnits = std::pair<TBuckets, TString>;
 
+TBucketsWithUnits GetMsBuckets();
+TBucketsWithUnits GetUsBuckets();
 TBucketsWithUnits GetTimeBuckets(EHistogramCounterOptions options);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,6 +89,7 @@ void AddHistogramUserMetric(
     IUserCounterSupplier& dsc,
     const NMonitoring::TLabels& commonLabels,
     const TVector<TBaseDynamicCounters>& baseCounters,
-    TStringBuf newName);
+    TStringBuf newName,
+    EHistogramCounterOptions histogramCounterOptions);
 
 }   // namespace NCloud::NStorage::NUserStats


### PR DESCRIPTION
Fixing ThrottlerDelay user percentiles that were reporting non-zero values even when the throttler was inactive. It looked like this:
<img width="1396" height="948" alt="Screenshot 2025-12-11 at 01 52 59" src="https://github.com/user-attachments/assets/0bc814b9-5782-4473-82c5-1aa32166b97c" />

Last couple of "dots" in the graph were reported with this fix.