### PR TITLE
Fixed a bug where writing to the source disk was blocked due to shadow disk acquire errors when the shadow disk was already fully filled.

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -911,6 +911,7 @@ void TShadowDiskActor::SetErrorState(const NActors::TActorContext& ctx)
 bool TShadowDiskActor::CanJustForwardWritesToSrcDisk() const
 {
     return State == EActorState::CheckpointReady ||
+           State == EActorState::WaitAcquireForRead ||
            State == EActorState::Error ||
            State == EActorState::WaitAcquireForPrepareStart;
 }

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.h
@@ -65,6 +65,7 @@ private:
 
         // Waiting for the acquire of the shadow disk devices. The disk is
         // already completely filled and we will only read checkpoint data from it.
+        // We do not block writes to the source disk.
         WaitAcquireForRead,
 
         // The devices of the shadow disk have been successfully acquired and we
@@ -73,11 +74,13 @@ private:
 
         // The devices of the shadow disk have been successfully acquired and we
         // are ready to read the checkpoint data.
+        // We do not block writes to the source disk.
         CheckpointReady,
 
         // Something went wrong and we stopped filling the shadow disk.
         // At the same time, we do not interfere with the operation of the
         // source disk.
+        // We do not block writes to the source disk.
         Error,
     };
 


### PR DESCRIPTION
1. Shadow disk filled.
2. The host under the shadow disk is breaking down.
3. DiskRegistry send to volume reacquire messgae since volume depends on this host.
4. TShadowDiskActor failed to acquire shadow disk 
5. TShadowDiskActor blocks the client's writes, although it should not do this, since the shadow disk is completely filled.
6. Since the shadow disk is acquired for reading, a long 10-minute timeout is enabled, and the user's writes freeze for these 10 minutes.