### PR TITLE
Do not trigger fatal errors alert on local disks creation

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
@@ -140,8 +140,9 @@ void TDiskRegistryActor::ExecuteAddDisk(
             args.PoolName,
             args.BlocksCount * args.BlockSize))
     {
-        // Note: DM uses this specific error message to identify this case.
-        // Update createEmptyDiskTask simultaneously if you change it.
+        // Note: DM and NBS uses this specific error message to identify this
+        // case. Update "createEmptyDiskTask()" and "GetDiagnosticsErrorKind()"
+        // simultaneously if you change it.
         args.Error = MakeError(
             E_TRY_AGAIN,
             "Unable to allocate local disk: secure erase has not finished yet");

--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -145,6 +145,13 @@ EDiagnosticsErrorKind GetDiagnosticsErrorKind(const NProto::TError& e)
         return EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint;
     }
 
+    if (code == E_TRY_AGAIN &&
+        e.GetMessage().StartsWith(
+            "Unable to allocate local disk: secure erase has not finished yet"))
+    {
+        return EDiagnosticsErrorKind::ErrorSilent;
+    }
+
     if (HasProtoFlag(e.GetFlags(), NProto::EF_SILENT)
         || code == E_IO_SILENT) // TODO: NBS-3124#622886b937bf95501db66aad
     {

--- a/cloud/storage/core/libs/common/error_ut.cpp
+++ b/cloud/storage/core/libs/common/error_ut.cpp
@@ -65,6 +65,24 @@ Y_UNIT_TEST_SUITE(GetDiagnosticsErrorKindTest)
             GetDiagnosticsErrorKind(e));
     }
 
+    Y_UNIT_TEST(ShouldRetrieveErrorKindSilentOnLocalDiskAllocation)
+    {
+        NProto::TError e;
+        e.SetCode(E_TRY_AGAIN);
+        e.SetMessage(
+            "Unable to allocate local disk: secure erase has not finished yet");
+
+        UNIT_ASSERT_EQUAL(
+            EDiagnosticsErrorKind::ErrorSilent,
+            GetDiagnosticsErrorKind(e));
+
+        e.SetCode(E_FAIL);
+
+        UNIT_ASSERT_EQUAL(
+            EDiagnosticsErrorKind::ErrorFatal,
+            GetDiagnosticsErrorKind(e));
+    }
+
     Y_UNIT_TEST(ShouldWrapExceptionInResponse)
     {
         auto response = SafeExecute<TTestResponse>(


### PR DESCRIPTION
#2945
An attempt to create a volume while devices are in secure erase should not increase fatal errors counter. This PR changes the kind of local disks errors to `ErrorSilent`