### PR TITLE
issue-4138: [Filestore] Fix resize with creating a new shard for old fs with strict in config

### DIFF
--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -521,8 +521,7 @@ TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
     const TStorageConfig& config,
     const NKikimrFileStore::TConfig& fileStore,
     const NProto::TFileStorePerformanceProfile& clientProfile,
-    const ui32 explicitShardCount,
-    const ui32 maxShardCount)
+    const ui32 explicitShardCount)
 {
     TMultiShardFileStoreConfig result;
     result.MainFileSystemConfig = fileStore;
@@ -538,7 +537,7 @@ TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
             fileStore.GetBlocksCount(),
             fileStore.GetBlockSize(),
             config.GetShardAllocationUnit(),
-            maxShardCount);
+            config.GetMaxShardCount());
     result.ShardConfigs.resize(shardCount);
     for (ui32 i = 0; i < shardCount; ++i) {
         result.ShardConfigs[i] = fileStore;

--- a/cloud/filestore/libs/storage/core/model.h
+++ b/cloud/filestore/libs/storage/core/model.h
@@ -28,8 +28,7 @@ TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
     const TStorageConfig& config,
     const NKikimrFileStore::TConfig& fileStore,
     const NProto::TFileStorePerformanceProfile& clientProfile,
-    const ui32 explicitShardCount,
-    const ui32 maxShardCount);
+    const ui32 explicitShardCount);
 
 void SetupFileStorePerformanceAndChannels(
     bool allocateMixed0Channel,

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -2254,8 +2254,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            0,
-            StorageConfig.GetMaxShardCount());
+            0);
         UNIT_ASSERT_VALUES_EQUAL(1, fs.ShardConfigs.size());
         // MaxWriteIops per allocation unit is 1000, so (4096 GiB / 32 GiB) *
         // 1000 = 128000
@@ -2270,8 +2269,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            0,
-            StorageConfig.GetMaxShardCount());
+            0);
         UNIT_ASSERT_VALUES_EQUAL(2, fs.ShardConfigs.size());
 
         KikimrConfig.SetBlocksCount(5_TB / 4_KB);
@@ -2279,8 +2277,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            0,
-            StorageConfig.GetMaxShardCount());
+            0);
         UNIT_ASSERT_VALUES_EQUAL(2, fs.ShardConfigs.size());
 
         KikimrConfig.SetBlocksCount(16_TB / 4_KB);
@@ -2288,8 +2285,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            0,
-            StorageConfig.GetMaxShardCount());
+            0);
         UNIT_ASSERT_VALUES_EQUAL(4, fs.ShardConfigs.size());
 
         KikimrConfig.SetBlocksCount(512_TB / 4_KB);
@@ -2297,8 +2293,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            0,
-            StorageConfig.GetMaxShardCount());
+            0);
         UNIT_ASSERT_VALUES_EQUAL(128, fs.ShardConfigs.size());
 
         KikimrConfig.SetBlocksCount(1_PB / 4_KB);
@@ -2306,8 +2301,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            0,
-            StorageConfig.GetMaxShardCount());
+            0);
         UNIT_ASSERT_VALUES_EQUAL(254, fs.ShardConfigs.size());
 
         for (const auto& sc: fs.ShardConfigs) {
@@ -2336,8 +2330,7 @@ Y_UNIT_TEST_SUITE(TModel)
             StorageConfig,
             KikimrConfig,
             ClientPerformanceProfile,
-            10,
-            StorageConfig.GetMaxShardCount());
+            10);
         UNIT_ASSERT_VALUES_EQUAL(10, fs.ShardConfigs.size());
 
         for (const auto& sc: fs.ShardConfigs) {

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -42,7 +42,7 @@ class TAlterFileStoreActor final
     : public TActorBootstrapped<TAlterFileStoreActor>
 {
 private:
-    const TStorageConfigPtr StorageConfig;
+    TStorageConfigPtr StorageConfig;
     const TRequestInfoPtr RequestInfo;
     const TString FileSystemId;
     const NProto::TFileStorePerformanceProfile PerformanceProfile;
@@ -95,6 +95,7 @@ private:
     void ConfigureShards(const TActorContext& ctx);
     void ConfigureMainFileStore(const TActorContext& ctx);
 
+    void PatchStorageConfig();
     void FillMultiShardFileStoreConfig(const TActorContext& ctx);
 
     void HandleDescribeFileStoreForAlterResponse(
@@ -303,7 +304,17 @@ void TAlterFileStoreActor::HandleDescribeFileStoreResponse(
     GetFileSystemTopology(ctx);
 }
 
-void TAlterFileStoreActor::FillMultiShardFileStoreConfig(const TActorContext& ctx)
+void TAlterFileStoreActor::PatchStorageConfig()
+{
+    NProto::TStorageConfig protoConfig;
+    protoConfig.SetStrictFileSystemSizeEnforcementEnabled(
+        StrictFileSystemSizeEnforcementEnabled);
+    protoConfig.SetMaxShardCount(MaxShardCount);
+    StorageConfig->Merge(protoConfig);
+}
+
+void TAlterFileStoreActor::FillMultiShardFileStoreConfig(
+    const TActorContext& ctx)
 {
     NKikimrFileStore::TConfig currentConfig = MainFileStoreOriginalConfig;
 
@@ -337,8 +348,7 @@ void TAlterFileStoreActor::FillMultiShardFileStoreConfig(const TActorContext& ct
             *StorageConfig,
             currentConfig,
             PerformanceProfile,
-            ExplicitShardCount,
-            MaxShardCount);
+            ExplicitShardCount);
     } else {
         SetupFileStorePerformanceAndChannels(
             allocateMixed0,
@@ -462,6 +472,7 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
         msg->Record.GetStrictFileSystemSizeEnforcementEnabled();
     MaxShardCount = msg->Record.GetMaxShardCount();
 
+    PatchStorageConfig();
     FillMultiShardFileStoreConfig(ctx);
 
     for (auto& shardId: *msg->Record.MutableShardFileSystemIds()) {
@@ -484,8 +495,7 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
                 *StorageConfig,
                 FileStoreConfig.MainFileSystemConfig,
                 PerformanceProfile,
-                ExistingShardIds.size(),
-                MaxShardCount);
+                ExistingShardIds.size());
         }
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -152,8 +152,7 @@ void TCreateFileStoreActor::CreateMainFileStore(const TActorContext& ctx)
             *StorageConfig,
             config,
             Request.GetPerformanceProfile(),
-            Request.GetShardCount(),
-            StorageConfig->GetMaxShardCount());
+            Request.GetShardCount());
         ShardsToCreate = FileStoreConfig.ShardConfigs.size();
         ShardsToConfigure = ShardsToCreate;
         config = FileStoreConfig.MainFileSystemConfig;


### PR DESCRIPTION
If StrictFileSystemSizeEnforcementEnable == true  in the config and an old filesystem with 
StrictFileSystemSizeEnforcementEnable == false is resized in such a way that new shards are created,
a new shard was created with the size equal to the filesystem size.
The fix uses always uses the flag value from a filesystem.

#4138

