### PR TITLE
Backport https://github.com/ydb-platform/ydb/pull/30354

### DIFF
--- a/contrib/ydb/core/protos/blockstore_config.proto
+++ b/contrib/ydb/core/protos/blockstore_config.proto
@@ -140,6 +140,10 @@ message TVolumeConfig {
 
     // Mount requests with incorrect FillGeneration will be rejected unless filling is finished.
     optional uint64 FillGeneration = 51;
+
+    // Enables discard (ZeroBlocks) requests for the volume.
+    // If this flag is set, it should never be unset anymore!
+    optional bool VhostDiscardEnabled = 52;
 }
 
 message TUpdateVolumeConfig {


### PR DESCRIPTION
issue #4823

This change was already done in ydb repo: https://github.com/ydb-platform/ydb/pull/30354. Now we do it in nbs repo.

Description:

We (NBS) are going to enable the discard feature for NBS disks. To deploy it safely, we need to be able to turn on this feature at the volume level. To do this, we need to add the corresponding flag to the VolumeConfig.
