### PR TITLE
issue-4782: support for tablet-level TwoStageReadThreshold

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -775,8 +775,12 @@ void TStorageServiceActor::HandleReadData(
         }
     }
 
+    const ui32 twoStageReadThreshold =
+        filestore.GetFeatures().GetTwoStageReadThreshold()
+        ? filestore.GetFeatures().GetTwoStageReadThreshold()
+        : StorageConfig->GetTwoStageReadThreshold();
     const bool useTwoStageRead = IsTwoStageReadEnabled(filestore)
-        && msg->Record.GetLength() >= StorageConfig->GetTwoStageReadThreshold();
+        && msg->Record.GetLength() >= twoStageReadThreshold;
 
     LOG_DEBUG(
         ctx,

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -2232,12 +2232,14 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         CheckTwoStageReads(NProto::STORAGE_MEDIA_SSD, false);
     }
 
-    Y_UNIT_TEST(ShouldUseTwoStageReadThreshold)
+    void DoTestShouldUseTwoStageReadThreshold(bool setUpForTablet)
     {
         NProto::TStorageConfig storageConfig;
-        storageConfig.SetTwoStageReadEnabled(true);
         storageConfig.SetFlushThreshold(1); // disabling fresh blocks
-        storageConfig.SetTwoStageReadThreshold(8_KB);
+        if (!setUpForTablet) {
+            storageConfig.SetTwoStageReadEnabled(true);
+            storageConfig.SetTwoStageReadThreshold(8_KB);
+        }
 
         TTestEnv env({}, storageConfig);
         env.CreateSubDomain("nfs");
@@ -2251,6 +2253,23 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             1000,
             DefaultBlockSize,
             NProto::STORAGE_MEDIA_SSD);
+
+        if (setUpForTablet) {
+            NProto::TStorageConfig newConfig;
+            newConfig.SetTwoStageReadEnabled(true);
+            newConfig.SetTwoStageReadThreshold(8_KB);
+            const auto response =
+                ExecuteChangeStorageConfig(std::move(newConfig), service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                response.GetStorageConfig().GetTwoStageReadEnabled());
+            UNIT_ASSERT_VALUES_EQUAL(
+                8_KB,
+                response.GetStorageConfig().GetTwoStageReadThreshold());
+
+            TDispatchOptions options;
+            env.GetRuntime().DispatchEvents(options, TDuration::Seconds(1));
+        }
 
         auto headers = service.InitSession(fs, "client");
 
@@ -2307,6 +2326,16 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                 1,
                 subgroup->GetCounter("Count")->GetAtomic());
         }
+    }
+
+    Y_UNIT_TEST(ShouldUseGlobalTwoStageReadThreshold)
+    {
+        DoTestShouldUseTwoStageReadThreshold(false /* setUpForTablet */);
+    }
+
+    Y_UNIT_TEST(ShouldUseTabletLevelTwoStageReadThreshold)
+    {
+        DoTestShouldUseTwoStageReadThreshold(true /* setUpForTablet */);
     }
 
     Y_UNIT_TEST(ShouldFallbackToReadDataIfDescribeDataFails)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -24,6 +24,7 @@ void FillFeatures(
 {
     auto* features = fileStore.MutableFeatures();
     features->SetTwoStageReadEnabled(config.GetTwoStageReadEnabled());
+    features->SetTwoStageReadThreshold(config.GetTwoStageReadThreshold());
     features->SetThreeStageWriteEnabled(config.GetThreeStageWriteEnabled());
     features->SetTwoStageReadDisabledForHDD(
         config.GetTwoStageReadDisabledForHDD());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -834,6 +834,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
 
         config.SetTwoStageReadEnabled(true);
+        config.SetTwoStageReadThreshold(64_KB);
         config.SetThreeStageWriteEnabled(true);
         config.SetThreeStageWriteThreshold(10_MB);
         config.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
@@ -853,6 +854,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetZeroCopyReadEnabled(true);
 
         features.SetTwoStageReadEnabled(true);
+        features.SetTwoStageReadThreshold(64_KB);
         features.SetEntryTimeout(TDuration::Seconds(10).MilliSeconds());
         features.SetNegativeEntryTimeout(TDuration::Seconds(1).MilliSeconds());
         features.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -45,6 +45,7 @@ message TFileStoreFeatures
     uint64 DirectoryHandlesTableSize = 30;
     bool GuestHandleKillPrivV2Enabled = 31;
     bool ZeroCopyReadEnabled = 32;
+    uint32 TwoStageReadThreshold = 33;
 }
 
 message TFileStore


### PR DESCRIPTION
### Notes
Just made it possible to set up per-fs TwoStageReadThresholds

### Issue
https://github.com/ydb-platform/nbs/issues/4782