### PR TITLE
[Filestore] add support for binary features to service_local

### DIFF
--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -135,7 +135,43 @@ FILESTORE_SERVICE_CONFIG(FILESTORE_CONFIG_GETTER)
 
 #undef FILESTORE_CONFIG_GETTER
 
-#define DURATION_FEATURE_GETTER(name)                                          \
+#define FILESTORE_BINARY_FEATURES(xxx)                                         \
+    xxx(DirectoryHandlesStorageEnabled)                                        \
+
+// FILESTORE_BINARY_FEATURES
+
+#define FILESTORE_DURATION_FEATURES(xxx)                                       \
+    xxx(EntryTimeout)                                                          \
+    xxx(NegativeEntryTimeout)                                                  \
+    xxx(AttrTimeout)                                                           \
+    xxx(XAttrCacheTimeout)                                                     \
+
+// FILESTORE_DURATION_FEATURES
+
+#define FILESTORE_BINARY_FEATURE_GETTER(name)                                  \
+bool TLocalFileStoreConfig::Get##name(                                         \
+    const TString& cloudId,                                                    \
+    const TString& folderId,                                                   \
+    const TString& fsId) const                                                 \
+{                                                                              \
+    if (!FeaturesConfig) {                                                     \
+        return Get##name();                                                    \
+    }                                                                          \
+                                                                               \
+    return FeaturesConfig->IsFeatureEnabled(                                   \
+        cloudId,                                                               \
+        folderId,                                                              \
+        fsId,                                                                  \
+        #name);                                                                \
+}                                                                              \
+
+// FILESTORE_BINARY_FEATURE_GETTER
+
+FILESTORE_BINARY_FEATURES(FILESTORE_BINARY_FEATURE_GETTER)
+
+#undef FILESTORE_BINARY_FEATURE_GETTER
+
+#define FILESTORE_DURATION_FEATURE_GETTER(name)                                \
 TDuration TLocalFileStoreConfig::Get##name(                                    \
     const TString& cloudId,                                                    \
     const TString& folderId,                                                   \
@@ -158,14 +194,11 @@ TDuration TLocalFileStoreConfig::Get##name(                                    \
     return res;                                                                \
 }                                                                              \
 
-// DURATION_FEATURE_GETTER
+// FILESTORE_DURATION_FEATURE_GETTER
 
-DURATION_FEATURE_GETTER(EntryTimeout)
-DURATION_FEATURE_GETTER(NegativeEntryTimeout)
-DURATION_FEATURE_GETTER(AttrTimeout)
-DURATION_FEATURE_GETTER(XAttrCacheTimeout)
+FILESTORE_DURATION_FEATURES(FILESTORE_DURATION_FEATURE_GETTER)
 
-#undef DURATION_FEATURE_GETTER
+#undef FILESTORE_DURATION_FEATURE_GETTER
 
 TFileIOConfig TLocalFileStoreConfig::GetFileIOConfig() const
 {

--- a/cloud/filestore/libs/service_local/config.h
+++ b/cloud/filestore/libs/service_local/config.h
@@ -146,6 +146,10 @@ public:
         const TString& fsId) const;
 
     bool GetDirectoryHandlesStorageEnabled() const;
+    bool GetDirectoryHandlesStorageEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& fsId) const;
 
     ui64 GetDirectoryHandlesTableSize() const;
 

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -60,9 +60,11 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         features->SetXAttrCacheTimeout(
             Config->GetXAttrCacheTimeout(cloudId, folderId, fsId)
                 .MilliSeconds());
+        const bool directoryHandlesStorageEnabled =
+            Config->GetDirectoryHandlesStorageEnabled(cloudId, folderId, fsId);
         features->SetDirectoryHandlesStorageEnabled(
-            Config->GetDirectoryHandlesStorageEnabled());
-        if (Config->GetDirectoryHandlesStorageEnabled()) {
+            directoryHandlesStorageEnabled);
+        if (directoryHandlesStorageEnabled) {
             features->SetDirectoryHandlesTableSize(
                 Config->GetDirectoryHandlesTableSize());
         }


### PR DESCRIPTION
Use DirectoryHandles from feature config in vhost_local to allow more granular roll out

Issue: #2390