### PR TITLE
Fix multi-agent writes discovery  requests undelivery handling

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
@@ -462,7 +462,7 @@ void TMultiAgentWriteActor<TMethod>::HandleDiscoveryUndelivery(
     LOG_WARN(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] TEvGetDeviceForRangeRequest request undelivered to nonrepl "
+        "[%s] TEvGetDeviceForRangeRequest undelivered to nonrepl "
         "partition #%lu",
         DiskId.c_str(),
         ev->Cookie);
@@ -486,12 +486,12 @@ void TMultiAgentWriteActor<TMethod>::HandleMultiAgentWriteUndelivery(
     LOG_WARN(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] TMultiAgentWriteRequest request undelivered to nonrepl partition",
+        "[%s] TMultiAgentWriteRequest undelivered to nonrepl partition",
         DiskId.c_str());
 
     UpdateResponse(MakeError(
         E_REJECTED,
-        "TMultiAgentWriteRequestrequest undelivered to nonrepl partition"));
+        "TMultiAgentWriteRequest undelivered to nonrepl partition"));
 
     --RemainResponseCount;
     if (!RemainResponseCount) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -3425,7 +3425,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
         UNIT_ASSERT_EQUAL(writtenDevices, expectedDevices);
     }
 
-    Y_UNIT_TEST(ShouldHandleUndelveryForMultiAgentWriteRequests)
+    Y_UNIT_TEST(ShouldHandleUndeliveryForMultiAgentWriteRequests)
     {
         TTestRuntime runtime;
 
@@ -3442,6 +3442,8 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                     }
 
                     if (!record.GetReplicationTargets().empty()) {
+                        // Bounce request back to the sender with
+                        // ForwardOnNondelivery semantics, simulating undelivery.
                         auto sendTo = event->Sender;
                         runtime.Send(
                             new IEventHandle(


### PR DESCRIPTION
1. TMirrorPartitionActor sends a write request to TMultiAgentWriteActor.
2. A replica partition (TNonreplicatedPartitionActor) restarts.
3. TMultiAgentWriteActor sends TEvGetDeviceForRangeRequest to the dead replica partition actor.
4. TMultiAgentWriteActor never receives a response.
5. The write request remains frozen until the volume is restarted.
