### PR TITLE
issue-568: writing resolved NodeIds into tablet profile log for ReadData and WriteData requests

### DIFF
--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -534,6 +534,17 @@ void InitProfileLogRequestInfo(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void UpdateRangeNodeIds(
+    NProto::TProfileLogRequestInfo& profileLogRequest,
+    ui64 nodeId)
+{
+    for (auto& range: *profileLogRequest.MutableRanges()) {
+        range.SetNodeId(nodeId);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 #define IMPLEMENT_DEFAULT_METHOD(name, ns)                                     \
     template <>                                                                \
     void FinalizeProfileLogRequestInfo(                                        \

--- a/cloud/filestore/libs/diagnostics/profile_log_events.h
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.h
@@ -73,6 +73,10 @@ void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
     const TProtoRequest& request);
 
+void UpdateRangeNodeIds(
+    NProto::TProfileLogRequestInfo& profileLogRequest,
+    ui64 nodeId);
+
 template <typename TProtoResponse>
 void FinalizeProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -908,6 +908,14 @@ bool TIndexTabletActor::PrepareTx_ReadData(
         return false;
     }
 
+    //
+    // NodeId might be missing in the original request but at this stage we
+    // have already read the Node and we can properly set NodeId in all request
+    // ranges.
+    //
+
+    UpdateRangeNodeIds(args.ProfileLogRequest, args.Node->NodeId);
+
     TReadDataVisitor visitor(LogTag, args);
 
     FindFreshBlocks(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -255,6 +255,15 @@ bool TIndexTabletActor::PrepareTx_WriteData(
         args.Error = ErrorInvalidTarget(args.NodeId);
         return true;
     }
+
+    //
+    // NodeId might be missing in the original request but at this stage we
+    // have already read the Node and we can properly set NodeId in all request
+    // ranges.
+    //
+
+    UpdateRangeNodeIds(args.ProfileLogRequest, args.Node->NodeId);
+
     // TODO: access check
     if (!HasSpaceLeft(args.Node->Attrs.GetSize(), args.ByteRange.End())) {
         args.Error = ErrorNoSpaceLeft();

--- a/cloud/filestore/tests/client/canondata/test.test_profile_log_io_requests/results.txt
+++ b/cloud/filestore/tests/client/canondata/test.test_profile_log_io_requests/results.txt
@@ -29,32 +29,32 @@ read_size=131072
 AddData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
 AddData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
 DescribeData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
-DescribeData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
+DescribeData	{'node_id': '4', 'offset': '0', 'bytes': '131072'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'actual_bytes': '131072', 'actual_offset': '0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'actual_bytes': '131072', 'actual_offset': '0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '4096', 'actual_bytes': '9', 'actual_offset': '0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '4096', 'actual_bytes': '9', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '0', 'bytes': '4096', 'checksums': '2901820631'}
 ReadData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
 ReadData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386'}
 ReadData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
 ReadData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657'}
+ReadData	{'node_id': '2', 'offset': '0', 'bytes': '4096', 'checksums': '2901820631'}
+ReadData	{'node_id': '3', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}
+ReadData	{'node_id': '3', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386'}
+ReadData	{'node_id': '3', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
-WriteData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '16384'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '16384'}
-WriteData	{'node_id': '0', 'offset': '0', 'bytes': '9', 'checksums': '2901820631'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '9'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '9'}
-WriteData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386'}
 WriteData	{'node_id': '0', 'offset': '16384', 'bytes': '16384'}
 WriteData	{'node_id': '0', 'offset': '16384', 'bytes': '16384'}
-WriteData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657'}
 WriteData	{'node_id': '0', 'offset': '32768', 'bytes': '16384'}
 WriteData	{'node_id': '0', 'offset': '32768', 'bytes': '16384'}
+WriteData	{'node_id': '2', 'offset': '0', 'bytes': '9', 'checksums': '2901820631'}
+WriteData	{'node_id': '3', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}
+WriteData	{'node_id': '3', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386'}
+WriteData	{'node_id': '3', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657'}


### PR DESCRIPTION
### Notes
Currently NodeIds are 0 in tablet profile log for ReadData and WriteData requests which don't have explicit NodeIds in the request body. Fixing this - updating NodeIds after the Nodes get resolved.

### Issue
https://github.com/ydb-platform/nbs/issues/568