### PR TITLE
Tune clang-format. SeparateDefinitionBlocks=Always

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -297,7 +297,7 @@ RemoveBracesLLVM: false
 RemoveSemicolon: true
 RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Leave
+SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 1
 SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before


### PR DESCRIPTION
Specifies the use of empty lines to separate definition blocks, including classes, structs, enums, and functions.