### PR TITLE
issue-4138: [Filestore] Allow to upsize small sharded filesystems

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -480,16 +480,16 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
     }
 
     if (FileStoreConfig.ShardConfigs.size() < ExistingShardIds.size()) {
-        if (!StrictFileSystemSizeEnforcementEnabled || ExplicitShardCount) {
+        if (ExplicitShardCount) {
             ReplyAndDie(
                 ctx,
                 MakeError(E_ARGUMENT, "Cannot decrease number of shards"));
             return;
         } else {
-            // We can't reduce shards count but in strict mode we should resize
-            // all the shards to have the same size as the main filesystem.
-            // So, FileStoreConfig.ShardConfigs should have the same size as
-            // ExistingShardIds.
+            // We can't reduce the shard count, but in strict mode we should
+            // resize all shards so that they have the same size as the main
+            // filesystem. In non-strict mode, we simply keep the number of
+            // shards the same and alter only the main filesystem.
             FileStoreConfig.ShardConfigs.clear();
             FileStoreConfig = SetupMultiShardFileStorePerformanceAndChannels(
                 *StorageConfig,

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -2804,6 +2804,57 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
+    SERVICE_TEST_SIMPLE(ShouldResizeOldSmallFileSystemWithLargeShards)
+    {
+        config.SetAutomaticShardCreationEnabled(true);
+
+        TStorageConfig storageConfig(config);
+        const ui64 blockSize = 4_KB;
+        const ui64 shardBlockCount =
+            storageConfig.GetAutomaticallyCreatedShardSize() / blockSize;
+
+        TTestEnv env({}, config);
+        env.CreateSubDomain("nfs");
+
+        ui32 nodeIdx = env.CreateNode("nfs");
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        // Create a small filesystem with two large shards
+        ui64 fsSize = 1000;
+        const ui64 shardsCount = 2;
+        service.CreateFileStore("test", fsSize);
+        service.ResizeFileStore("test", fsSize, false /* force */, shardsCount);
+
+        WaitForTabletStart(service);
+
+        // In spite new filesystem size is much smaller than the shards size
+        // it should be allowed to resize it.
+
+        fsSize *= 2;
+        service.ResizeFileStore("test", fsSize);
+
+        auto checkSizes = [&]()
+        {
+            const auto response = GetStorageStats(service, "test");
+            const auto& stats = response.GetStats();
+            UNIT_ASSERT_EQUAL(fsSize, stats.GetTotalBlocksCount());
+            UNIT_ASSERT_EQUAL(2, stats.GetShardStats().size());
+            for (const auto& stat: stats.GetShardStats()) {
+                UNIT_ASSERT_EQUAL(shardBlockCount, stat.GetTotalBlocksCount());
+            }
+        };
+        checkSizes();
+
+        config.SetStrictFileSystemSizeEnforcementEnabled(true);
+        env.UpdateStorageConfig(config);
+        env.CreateAndRegisterStorageService(nodeIdx);
+
+        fsSize *= 2;
+        service.ResizeFileStore("test", fsSize);
+        checkSizes();
+    }
+
     SERVICE_TEST_SIMPLE(ShouldAggregateFileSystemMetricsInBackground)
     {
         config.SetMultiTabletForwardingEnabled(true);


### PR DESCRIPTION
#4138
It is possible to create a filesystem that has shards but its size is less than the shard allocation unit.
Such filesystems are created for test purposes only.
If a filesystem did not have StrictFileSystemSizeEnforcementEnabled flag it was possible to upsize the filesystem only using filestore-client specifying a number of shards explicitly.
The PR makes it possible to upsize such a filesystem from the console.