### PR TITLE
Fix crash on double register same diskId in TStatsServiceActor

### DIFF
--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -274,22 +274,8 @@ void TStatsServiceActor::HandleRegisterVolume(
     Y_UNUSED(ctx);
     const auto* msg = ev->Get();
 
-    auto *volume = State.GetOrAddVolume(msg->DiskId, msg->Config);
+    auto* volume = State.GetOrAddVolume(msg->DiskId, msg->Config);
     volume->VolumeTabletId = msg->TabletId;
-
-    if (volume->IsDiskRegistryBased()) {
-        volume->PerfCounters = TDiskPerfData(
-            EPublishingPolicy::DiskRegistryBased,
-            DiagnosticsConfig->GetHistogramCounterOptions());
-    } else {
-        volume->PerfCounters = TDiskPerfData(
-            EPublishingPolicy::Repl,
-            DiagnosticsConfig->GetHistogramCounterOptions());
-    }
-
-    if (volume->ServiceVolumeCounters) {
-        volume->PerfCounters.Register(volume->ServiceVolumeCounters);
-    }
 }
 
 void TStatsServiceActor::HandleVolumeConfigUpdated(

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -145,10 +145,13 @@ struct TVolumeStatsInfo
     THashMap<ui64, TVector<NKikimr::TTabletChannelInfo>> ChannelInfos;
 
     TVolumeStatsInfo(
-            NProto::TVolume config,
-            EHistogramCounterOptions histCounterOptions)
+        NProto::TVolume config,
+        EHistogramCounterOptions histCounterOptions)
         : VolumeInfo(std::move(config))
-        , PerfCounters(EPublishingPolicy::All, histCounterOptions)
+        , PerfCounters(
+              IsDiskRegistryBased() ? EPublishingPolicy::DiskRegistryBased
+                                    : EPublishingPolicy::Repl,
+              histCounterOptions)
     {}
 
     bool IsDiskRegistryBased() const

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -1557,8 +1557,9 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             {0},
             EVolumeTestOptions::VOLUME_HASCLIENTS);
         UNIT_ASSERT(counters[0] == 1);
+
         RegisterVolume(runtime, DefaultDiskId);
-        BroadcastVolumeCounters(
+        counters = BroadcastVolumeCounters(
             runtime,
             {0},
             EVolumeTestOptions::VOLUME_HASCLIENTS);


### PR DESCRIPTION
continue https://github.com/ydb-platform/nbs/pull/4840
Do not reinitialize the PerfCounters field when re-registering a disk.