### PR TITLE
Fix asan build. Use after free in TMultiAgentWriteActor in test

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -3254,7 +3254,7 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionTest)
                     auto sendTo = event->Sender;
                     // Due to the specifics of the test actor system, calling
                     // runtime.Send() causes the actor message handler to be
-                    // called while it is handle another message.
+                    // called while it is handling another message.
                     runtime.Schedule(
                         new IEventHandle(
                             sendTo,


### PR DESCRIPTION
Fix test from https://github.com/ydb-platform/nbs/pull/4828

```
Test crashed (return code: 100)
==918286==ERROR: AddressSanitizer: heap-use-after-free on address 0x7cf4bea12f38 at pc 0x00001c6de9d4 bp 0x7ffec7c7b130 sp 0x7ffec7c7b128
READ of size 16 at 0x7cf4bea12f38 thread T0
    #0 0x00001c6de9d3 in TResponseEvent<NCloud::NBlockStore::NStorage::TEvNonreplPartitionPrivate::TGetDeviceForRangeRequest::EPurpose, void, const NCloud::NBlockStore::TBlockRange<unsigned long> &> /-S/cloud/blockstore/libs/kikimr/events.h:84:39
    #1 0x00001c6de9d3 in make_unique<NCloud::NBlockStore::TResponseEvent<NCloud::NBlockStore::NStorage::TEvNonreplPartitionPrivate::TGetDeviceForRangeRequest, 274859919U>, NCloud::NBlockStore::NStorage::TEvNonreplPartitionPrivate::TGetDeviceForRangeRequest::EPurpose, const NCloud::NBlockStore::TBlockRange<unsigned long> &> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:642:30
    #2 0x00001c6de9d3 in NCloud::NBlockStore::NStorage::TMultiAgentWriteActor<NCloud::NBlockStore::NStorage::TEvService::TWriteBlocksMethod>::SendDiscoveryRequests(NActors::TActorContext const&) /-S/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h:174:24
    #3 0x00001c6dd683 in NCloud::NBlockStore::NStorage::TMultiAgentWriteActor<NCloud::NBlockStore::NStorage::TEvService::TWriteBlocksMethod>::Bootstrap(NActors::TActorContext const&) /-S/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h:162:5
    #4 0x00001c6dc7fa in NActors::TActorBootstrapped<NCloud::NBlockStore::NStorage::TMultiAgentWriteActor<NCloud::NBlockStore::NStorage::TEvService::TWriteBlocksMethod>>::StateBootstrap(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/contrib/ydb/library/actors/core/actor_bootstrapped.h:22:22
    #5 0x0000136ee339 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/contrib/ydb/library/actors/core/actor.cpp:350:17
    #6 0x00002fe42229 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1718:33
    #7 0x00002fe3a752 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1307:45
    #8 0x00002fe45163 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1566:22
    #9 0x0000113d5810 in NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>* NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>>(TAutoPtr<NActors::IEventHandle, TDelete>&, std::__y1::function<bool (NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u> const&)>, TDuration) /-S/contrib/ydb/library/actors/testlib/test_runtime.h:474:13
    #10 0x0000113d512c in GrabEdgeEvent<NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954U> > /-S/contrib/ydb/library/actors/testlib/test_runtime.h:538:20
    #11 0x0000113d512c in NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>* NActors::TTestActorRuntimeBase::GrabEdgeEventRethrow<NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>>(TAutoPtr<NActors::IEventHandle, TDelete>&, TDuration) /-S/contrib/ydb/library/actors/testlib/test_runtime.h:587:24
    #12 0x0000113d2bff in std::__y1::unique_ptr<NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>, std::__y1::default_delete<NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>>> NCloud::NBlockStore::NStorage::TPartitionClient::RecvResponse<NCloud::NBlockStore::TProtoResponseEvent<NCloud::NBlockStore::NProto::TWriteBlocksResponse, 272760954u>>(unsigned long) /-S/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h:366:17
    #13 0x0000117d6c7a in RecvWriteBlocksResponse /-S/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h:558:5
    #14 0x0000117d6c7a in NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionTest::TTestCaseShouldFallbackFromMultiAgentWriteWhenDiscoveryRequestUndelivered::Execute_(NUnitTest::TTestContext&) /-S/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp:3281:32
    #15 0x00001180b621 in operator() /-S/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp:431:1
    #16 0x00001180b621 in __invoke<(lambda at /-S/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp:431:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:149:25
    #17 0x00001180b621 in __call<(lambda at /-S/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp:431:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:224:5
    #18 0x00001180b621 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:169:12
    #19 0x00001180b621 in std::__y1::__function::__func<NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:314:10
    #20 0x00001245e6db in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:431:12
    #21 0x00001245e6db in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:990:10
    #22 0x00001245e6db in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:526:20
    #23 0x0000124345d7 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:373:18
    #24 0x00001180a831 in NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionTest::TCurrentTest::Execute() /-S/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp:431:1
    #25 0x000012435ddf in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:494:19
    #26 0x000012457aec in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:875:44
    #27 0x7fa4bf41f082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/../csu/libc-start.c:308:16
    #28 0x00000ec08028 in _start (build-release/cloud/blockstore/libs/storage/partition_nonrepl/ut/blockstore-libs-storage-partition_nonrepl-ut+0xec08028) (BuildId: 991e2b0cfc63fba56157e810bd7d9000e18a2e92)
SUMMARY: AddressSanitizer: heap-use-after-free /-S/cloud/blockstore/libs/kikimr/events.h:84:39 in TResponseEvent<NCloud::NBlockStore::NStorage::TEvNonreplPartitionPrivate::TGetDeviceForRangeRequest::EPurpose, void, const NCloud::NBlockStore::TBlockRange<unsigned long> &>
S
```