### PR TITLE
issue-4282: added filestore service layer probes

### DIFF
--- a/cloud/filestore/libs/storage/core/probes.h
+++ b/cloud/filestore/libs/storage/core/probes.h
@@ -69,6 +69,34 @@
             NCloud::NProbeParam::RequestType,                                  \
             NCloud::NProbeParam::RequestId)                                    \
     )                                                                          \
+    PROBE(RequestReceived_Service,                                             \
+        GROUPS("NFSRequest"),                                                  \
+        TYPES(TString, ui64),                                                  \
+        NAMES(                                                                 \
+            NCloud::NProbeParam::RequestType,                                  \
+            NCloud::NProbeParam::RequestId)                                    \
+    )                                                                          \
+    PROBE(ResponseSent_Service,                                                \
+        GROUPS("NFSRequest"),                                                  \
+        TYPES(TString, ui64),                                                  \
+        NAMES(                                                                 \
+            NCloud::NProbeParam::RequestType,                                  \
+            NCloud::NProbeParam::RequestId)                                    \
+    )                                                                          \
+    PROBE(RequestReceived_ServiceWorker,                                       \
+        GROUPS("NFSRequest"),                                                  \
+        TYPES(TString, ui64),                                                  \
+        NAMES(                                                                 \
+            NCloud::NProbeParam::RequestType,                                  \
+            NCloud::NProbeParam::RequestId)                                    \
+    )                                                                          \
+    PROBE(ResponseSent_ServiceWorker,                                          \
+        GROUPS("NFSRequest"),                                                  \
+        TYPES(TString, ui64),                                                  \
+        NAMES(                                                                 \
+            NCloud::NProbeParam::RequestType,                                  \
+            NCloud::NProbeParam::RequestId)                                    \
+    )                                                                          \
     PROBE(TxInit,                                                              \
         GROUPS("NFSRequest"),                                                  \
         TYPES(TString, ui64),                                                  \

--- a/cloud/filestore/libs/storage/service/service_actor_complete.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_complete.cpp
@@ -5,6 +5,7 @@
 #include <cloud/filestore/libs/diagnostics/trace_serializer.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/probes.h>
 
 #include <cloud/storage/core/libs/common/verify.h>
 
@@ -15,6 +16,8 @@ using namespace NActors;
 using namespace NKikimr;
 
 namespace {
+
+LWTRACE_USING(FILESTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -96,6 +99,11 @@ void TStorageServiceActor::CompleteRequest(
         request->Cookie,
         // undeliveredRequestActor
         nullptr);
+
+    FILESTORE_TRACK(
+        ResponseSent_Service,
+        request->CallContext,
+        TMethod::Name);
 
     const auto& error = msg->Record.GetError();
     request->Complete(ctx.Now(), error);


### PR DESCRIPTION
### Notes
Added probes at the storage service layer:
* in `TStorageServiceActor::CompleteRequest` - for all requests
* in `TStorageServiceActor::HandleXXX` and in the actors spawned by `TStorageServiceActor` - for read and write requests

Some examples of the resulting traces (the latencies are terrible - these traces were taken from my local setup):
one-stage-write:
```
2025-12-15T20:50:13.503266Z :NFS_TRACE WARN: [["RequestReceived",0,"WriteBuf","3780570","nfs","3","4096"],["RequestReceived_Service",27,"WriteData","3780570"],["RequestReceived_Tablet",226,"WriteData","3780570","","2"],["TxInit",232,"WriteData","3780570"],["Fork",233,"0"],["TxPrepare",240,"WriteData","3780570"],["TxExecute",247,"WriteData","3780570"],["TxExecuteDone",266,"WriteData","3780570"],["TxComplete",2495,"WriteData","3780570"],["Join",2496,"0","5"],["TransactionBegin",238,"1790614","72075186224037897","NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::TTransaction<NCloud::NFileStore::NStorage::TIndexTabletActor::TWriteData>"],["TransactionExecuteBegin",239,"1790614"],["TransactionExecuteEnd",267,"1790614","1"],["TransactionReadWriteCommit",282,"1790614","426"],["TransactionCompleteBegin",2494,"1790614"],["ResponseSent_Tablet",2497,"WriteData","3780570"],["ResponseSent_Service",2710,"WriteData","3780570"],["ResponseSent",2750,"Write","3780570"],["RequestCompleted",2770,"Write","3780570","2737","2737","0"],["SlowRequests"]]
```

three-stage-write:
```
2025-12-15T20:30:43.494164Z :NFS_TRACE WARN: [["RequestReceived",0,"WriteBuf","3780312","nfs","3","1048576"],["RequestReceived_Service",208,"WriteData","3780312"],["RequestReceived_ServiceWorker",222,"GenerateBlobIds","3780312"],["RequestReceived_ServiceWorker",612,"WriteBlobs","3780312"],["RequestReceived_ServiceWorker",4336,"AddData","3780312"],["ResponseSent_ServiceWorker",7668,"WriteData","3780312"],["ResponseSent_Service",7677,"WriteData","3780312"],["ResponseSent",7696,"Write","3780312"],["RequestCompleted",7716,"Write","3780312","7503","7503","0"],["SlowRequests"]]
```

one-stage-read:
```
2025-12-15T20:48:43.502413Z :NFS_TRACE WARN: [["RequestReceived",0,"Read","3780538","nfs","3","1048576"],["RequestReceived_Service",25,"ReadData","3780538"],["RequestReceived_ServiceWorker",44,"ReadData","3780538"],["ResponseSent_ServiceWorker",3290,"ReadData","3780538"],["ResponseSent_Service",3294,"ReadData","3780538"],["ResponseSent",3310,"Buf","3780538"],["RequestCompleted",3414,"Buf","3780538","3383","3383","0"],["SlowRequests"]]
```

two-stage-read
```
2025-12-15T20:55:03.794029Z :NFS_TRACE WARN: [["RequestReceived",0,"Read","3780982","nfs","3","1048576"],["RequestReceived_Service",35,"ReadData","3780982"],["RequestReceived_ServiceWorker",57,"DescribeData","3780982"],["RequestReceived_ServiceWorker",696,"ReadBlobs","3780982"],["ResponseSent_ServiceWorker",2297,"ReadData","3780982"],["ResponseSent_Service",2310,"ReadData","3780982"],["ResponseSent",2331,"Buf","3780982"],["RequestCompleted",2552,"Buf","3780982","2512","2512","0"],["SlowRequests"]]
``` 

### Issue
https://github.com/ydb-platform/nbs/issues/4282