### PR TITLE
issue-4853: removed unused SessionRetryTimeout config parameter

### DIFF
--- a/cloud/filestore/config/client.proto
+++ b/cloud/filestore/config/client.proto
@@ -75,5 +75,4 @@ message TSessionConfig
     optional string ClientId = 2;
 
     optional uint32 SessionPingTimeout = 3;
-    optional uint32 SessionRetryTimeout = 4;
 }

--- a/cloud/filestore/config/nfs_gateway.proto
+++ b/cloud/filestore/config/nfs_gateway.proto
@@ -15,6 +15,5 @@ message TNfsGatewayConfig
     optional string FileSystemId = 2;
 
     // Session options.
-    optional uint32 SessionRetryTimeout = 100;
     optional uint32 SessionPingTimeout = 101;
 }

--- a/cloud/filestore/libs/client/config.cpp
+++ b/cloud/filestore/libs/client/config.cpp
@@ -64,7 +64,6 @@ FILESTORE_CLIENT_CONFIG(FILESTORE_CLIENT_DECLARE_CONFIG)
     xxx(FileSystemId,           TString,        {}                            )\
     xxx(ClientId,               TString,        {}                            )\
     xxx(SessionPingTimeout,     TDuration,      Seconds(1)                    )\
-    xxx(SessionRetryTimeout,    TDuration,      Seconds(1)                    )\
 // FILESTORE_SESSION_CONFIG
 
 #define FILESTORE_SESSION_DECLARE_CONFIG(name, type, value)                    \

--- a/cloud/filestore/libs/client/config.h
+++ b/cloud/filestore/libs/client/config.h
@@ -64,7 +64,6 @@ public:
     TString GetClientId() const;
 
     TDuration GetSessionPingTimeout() const;
-    TDuration GetSessionRetryTimeout() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/client/session_ut.cpp
+++ b/cloud/filestore/libs/client/session_ut.cpp
@@ -30,7 +30,6 @@ static const TString FileSystemId = "fs1";
 static const TString ClientId = "client1";
 static const TString SessionId = "session1";
 
-constexpr TDuration RetryTimeout = TDuration::MilliSeconds(100);
 constexpr TDuration PingTimeout = TDuration::Seconds(5);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -115,7 +114,6 @@ struct TBootstrap
         NProto::TSessionConfig proto;
         proto.SetFileSystemId(FileSystemId);
         proto.SetClientId(ClientId);
-        proto.SetSessionRetryTimeout(RetryTimeout.MilliSeconds());
         proto.SetSessionPingTimeout(PingTimeout.MilliSeconds());
 
         return std::make_shared<TSessionConfig>(proto);

--- a/cloud/filestore/libs/endpoint/endpoint_manager.cpp
+++ b/cloud/filestore/libs/endpoint/endpoint_manager.cpp
@@ -35,7 +35,6 @@ bool CompareRequests(
     return left.GetFileSystemId() == right.GetFileSystemId()
         && left.GetClientId() == right.GetClientId()
         && left.GetSocketPath() == right.GetSocketPath()
-        && left.GetSessionRetryTimeout() == right.GetSessionRetryTimeout()
         && left.GetSessionPingTimeout() == right.GetSessionPingTimeout()
         && left.GetServiceEndpoint() == right.GetServiceEndpoint()
         && left.GetMountSeqNumber() == right.GetMountSeqNumber()

--- a/cloud/filestore/libs/endpoint_vhost/listener.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/listener.cpp
@@ -107,7 +107,6 @@ public:
         sessionConfig.SetFileSystemId(config.GetFileSystemId());
         sessionConfig.SetClientId(config.GetClientId());
         sessionConfig.SetSessionPingTimeout(config.GetSessionPingTimeout());
-        sessionConfig.SetSessionRetryTimeout(config.GetSessionRetryTimeout());
 
         auto session = CreateSession(
             Logging,

--- a/cloud/filestore/libs/storage/service/service_actor_pingsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_pingsession.cpp
@@ -18,6 +18,13 @@ void TStorageServiceActor::HandlePingSession(
     const auto seqNo = GetSessionSeqNo(msg->Record);
     const auto sessionId = GetSessionId(msg->Record);
 
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "HandlePingSession %s, %s",
+        clientId.Quote().c_str(),
+        sessionId.Quote().c_str());
+
     auto* session = State->FindSession(sessionId, seqNo);
     if (!session ||
         session->ClientId != clientId ||

--- a/cloud/filestore/public/api/protos/endpoint.proto
+++ b/cloud/filestore/public/api/protos/endpoint.proto
@@ -25,7 +25,7 @@ message TEndpointConfig
     bool ReadOnly = 4;
 
     // Session options.
-    uint32 SessionRetryTimeout = 5;
+    // uint32 SessionRetryTimeout = 5; // obsolete
     uint32 SessionPingTimeout = 6;
 
     // Service endpoint name.

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -431,8 +431,7 @@ type StartEndpointOpts struct {
 	SocketPath string
 	ReadOnly   bool
 
-	SessionRetryTimeout uint32
-	SessionPingTimeout  uint32
+	SessionPingTimeout uint32
 
 	ServiceEndpoint string
 }
@@ -458,8 +457,7 @@ func (client *EndpointClient) StartEndpoint(
 		SocketPath: opts.SocketPath,
 		ReadOnly:   opts.ReadOnly,
 
-		SessionRetryTimeout: opts.SessionRetryTimeout,
-		SessionPingTimeout:  opts.SessionPingTimeout,
+		SessionPingTimeout: opts.SessionPingTimeout,
 
 		ServiceEndpoint: opts.ServiceEndpoint,
 	}

--- a/cloud/filestore/public/sdk/python/client/endpoint.py
+++ b/cloud/filestore/public/sdk/python/client/endpoint.py
@@ -56,7 +56,6 @@ class EndpointClient(object):
             client_id,
             socket_path,
             read_only=False,
-            retry_timeout=0,
             ping_timeout=0,
             service_endpoint="",
             idempotence_id=None,
@@ -68,7 +67,6 @@ class EndpointClient(object):
             ClientId=client_id,
             SocketPath=socket_path,
             ReadOnly=read_only,
-            SessionRetryTimeout=retry_timeout,
             SessionPingTimeout=ping_timeout,
             ServiceEndpoint=service_endpoint
         )
@@ -91,7 +89,6 @@ class EndpointClient(object):
             client_id,
             socket_path,
             read_only=False,
-            retry_timeout=0,
             ping_timeout=0,
             service_endpoint="",
             idempotence_id=None,
@@ -104,7 +101,6 @@ class EndpointClient(object):
             ClientId=client_id,
             SocketPath=socket_path,
             ReadOnly=read_only,
-            SessionRetryTimeout=retry_timeout,
             SessionPingTimeout=ping_timeout,
             ServiceEndpoint=service_endpoint,
             Persistent=persistent,

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -559,7 +559,6 @@ private:
         proto.SetFileSystemId(FileSystemId);
         proto.SetClientId(ClientId);
         proto.SetSessionPingTimeout(Config.GetSessionPingTimeout());
-        proto.SetSessionRetryTimeout(Config.GetSessionRetryTimeout());
 
         Session = NClient::CreateSession(
             Logging,

--- a/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
@@ -148,7 +148,6 @@ message TLoadTest
     uint32 RequestsCount = 11;
     uint32 TestDuration = 12;
     uint32 SessionPingTimeout = 13;
-    uint32 SessionRetryTimeout = 14;
 
     TMigrationSpec MigrationSpec = 15;
 


### PR DESCRIPTION
### Notes
`SessionRetryTimeout` is not used and looks like it's never been used. Should be safe to delete from everywhere because it's not used in real configs:
```
$ grep -r SessionRetryTimeout *
YYY@XXX:~/nebo/nbs$
```  
and as for endpoint.proto:
* it's stored in binary format and any unknown fields should be ignored upon parsing
* it's proto3 and according to my knowledge we've never tried to override the value of `SessionRetryTimeout` so it should've never been set in those stored endpoints in the first place and any 0 scalar value in proto3 is equivalent to "no value" 

### Issue
https://github.com/ydb-platform/nbs/issues/4853