### PR TITLE
deserialization error should not trigger user error

### DIFF
--- a/cloud/blockstore/libs/rdma/iface/protobuf.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf.cpp
@@ -16,7 +16,7 @@ namespace NCloud::NBlockStore::NRdma {
 
 #define Y_ENSURE_RETURN(expr, message)                                         \
     if (Y_UNLIKELY(!(expr))) {                                                 \
-        return MakeError(E_ARGUMENT, TStringBuilder() << message);             \
+        return MakeError(E_REJECTED, TStringBuilder() << message);             \
     }                                                                          \
 // Y_ENSURE_RETURN
 


### PR DESCRIPTION
During RDMA failure we observed the following:

CRITICAL_EVENT:AppCriticalEvents/ErrorWasSentToTheGuestForReliableDisk:disk: "a7lm6b3djo0jcn18pt63", op: Read, range: [909261..909262], error: E_ARGUMENT invalid buffer length: 8 (expected: 1919278565)

Even if source of the problem could be in NBS code, it is bad idea to throw non-retrible error to user.