### PR TITLE
issue-4853: filestore - fixed SessionPingTimeout

### DIFF
--- a/cloud/filestore/libs/endpoint_vhost/helpers.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/helpers.cpp
@@ -1,0 +1,30 @@
+#include "helpers.h"
+
+#include <cloud/filestore/config/client.pb.h>
+#include <cloud/filestore/public/api/protos/endpoint.pb.h>
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void EndpointConfigToSessionConfig(
+    const NProto::TEndpointConfig& endpointConfig,
+    NProto::TSessionConfig *sessionConfig)
+{
+    sessionConfig->SetFileSystemId(endpointConfig.GetFileSystemId());
+    sessionConfig->SetClientId(endpointConfig.GetClientId());
+
+    //
+    // TEndpointConfig is proto3 and has no notion of HasXXX for scalars so we
+    // need to check whether the value of the field is zero.
+    //
+    // See #4853
+    //
+
+    if (endpointConfig.GetSessionPingTimeout()) {
+        sessionConfig->SetSessionPingTimeout(
+            endpointConfig.GetSessionPingTimeout());
+    }
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/endpoint_vhost/helpers.h
+++ b/cloud/filestore/libs/endpoint_vhost/helpers.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace NCloud::NFileStore {
+
+namespace NProto {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TEndpointConfig;
+class TSessionConfig;
+
+}   // namespace NProto
+
+////////////////////////////////////////////////////////////////////////////////
+
+void EndpointConfigToSessionConfig(
+    const NProto::TEndpointConfig& endpointConfig,
+    NProto::TSessionConfig *sessionConfig);
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/endpoint_vhost/helpers_ut.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/helpers_ut.cpp
@@ -1,0 +1,58 @@
+#include "helpers.h"
+
+#include <cloud/filestore/config/client.pb.h>
+#include <cloud/filestore/public/api/protos/endpoint.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore::NServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TEndpointVhostHelpersTest)
+{
+    Y_UNIT_TEST(ShouldConvertEndpointConfigToSessionConfig)
+    {
+        {
+            NProto::TEndpointConfig endpointConfig;
+
+            NProto::TSessionConfig sessionConfig;
+            UNIT_ASSERT(!sessionConfig.HasFileSystemId());
+            UNIT_ASSERT(!sessionConfig.HasClientId());
+            UNIT_ASSERT(!sessionConfig.HasSessionPingTimeout());
+
+            EndpointConfigToSessionConfig(endpointConfig, &sessionConfig);
+            UNIT_ASSERT(sessionConfig.HasFileSystemId());
+            UNIT_ASSERT(sessionConfig.HasClientId());
+            UNIT_ASSERT(!sessionConfig.HasSessionPingTimeout());
+            UNIT_ASSERT_VALUES_EQUAL("", sessionConfig.GetFileSystemId());
+            UNIT_ASSERT_VALUES_EQUAL("", sessionConfig.GetClientId());
+        }
+
+        {
+            NProto::TEndpointConfig endpointConfig;
+            endpointConfig.SetFileSystemId("fs0");
+            endpointConfig.SetClientId("c0");
+
+            NProto::TSessionConfig sessionConfig;
+
+            EndpointConfigToSessionConfig(endpointConfig, &sessionConfig);
+            UNIT_ASSERT(sessionConfig.HasFileSystemId());
+            UNIT_ASSERT(sessionConfig.HasClientId());
+            UNIT_ASSERT(!sessionConfig.HasSessionPingTimeout());
+            UNIT_ASSERT_VALUES_EQUAL("fs0", sessionConfig.GetFileSystemId());
+            UNIT_ASSERT_VALUES_EQUAL("c0", sessionConfig.GetClientId());
+
+            endpointConfig.SetSessionPingTimeout(0);
+            EndpointConfigToSessionConfig(endpointConfig, &sessionConfig);
+            UNIT_ASSERT(!sessionConfig.HasSessionPingTimeout());
+
+            endpointConfig.SetSessionPingTimeout(5);
+            EndpointConfigToSessionConfig(endpointConfig, &sessionConfig);
+            UNIT_ASSERT(sessionConfig.HasSessionPingTimeout());
+            UNIT_ASSERT_VALUES_EQUAL(5, sessionConfig.GetSessionPingTimeout());
+        }
+    }
+}
+
+}   // namespace NCloud::NFileStore::NServer

--- a/cloud/filestore/libs/endpoint_vhost/listener.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/listener.cpp
@@ -1,5 +1,7 @@
 #include "listener.h"
 
+#include "helpers.h"
+
 #include <cloud/filestore/libs/client/config.h>
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/endpoint/listener.h>
@@ -104,9 +106,7 @@ public:
         }
 
         NProto::TSessionConfig sessionConfig;
-        sessionConfig.SetFileSystemId(config.GetFileSystemId());
-        sessionConfig.SetClientId(config.GetClientId());
-        sessionConfig.SetSessionPingTimeout(config.GetSessionPingTimeout());
+        EndpointConfigToSessionConfig(config, &sessionConfig);
 
         auto session = CreateSession(
             Logging,

--- a/cloud/filestore/libs/endpoint_vhost/ut/ya.make
+++ b/cloud/filestore/libs/endpoint_vhost/ut/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(cloud/filestore/libs/endpoint_vhost)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
+
+SRCS(
+    helpers_ut.cpp
+)
+
+END()

--- a/cloud/filestore/libs/endpoint_vhost/ya.make
+++ b/cloud/filestore/libs/endpoint_vhost/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     config.cpp
+    helpers.cpp
     listener.cpp
 )
 
@@ -17,3 +18,5 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(ut)


### PR DESCRIPTION
### Notes
If `TEndpointConfig::SessionPingTimeout` (proto3) is not set (which is always or almost always the case) we set `TSessionConfig::SessionPingTimeout` (proto2) to 0 which became a problem after https://github.com/ydb-platform/nbs/commit/3fbcdb934f3391faa0aca5919652afd0f94fba1f. Fixing this by checking whether this field is zero before copying it to `TSessionConfig`. 

### Issue
https://github.com/ydb-platform/nbs/issues/4853