### PR TITLE
Backport new Hive API from 25-3; Handle TEvDrainNodeAck from Hive

### DIFF
--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
@@ -46,7 +46,7 @@ private:
         const TActorContext& ctx);
 
     void HandleDrainNodeResult(
-        const NKikimr::TEvHive::TEvDrainNodeResult::TPtr& ev,
+        const TEvHive::TEvDrainNodeResult::TPtr& ev,
         const TActorContext& ctx);
 
     STFUNC(StateWork);
@@ -57,7 +57,7 @@ private:
 void TDrainNodeRequestActor::Bootstrap(const TActorContext& ctx)
 {
 
-    auto ev = std::make_unique<NKikimr::TEvHive::TEvDrainNode>(Owner.NodeId());
+    auto ev = std::make_unique<TEvHive::TEvDrainNode>(Owner.NodeId());
     ev->Record.SetKeepDown(KeepDown);
     NKikimr::NTabletPipe::SendData(
         ctx,
@@ -90,7 +90,7 @@ void TDrainNodeRequestActor::HandleChangeTabletClient(
 }
 
 void TDrainNodeRequestActor::HandleDrainNodeResult(
-    const NKikimr::TEvHive::TEvDrainNodeResult::TPtr& ev,
+    const TEvHive::TEvDrainNodeResult::TPtr& ev,
     const TActorContext& ctx)
 {
     NProto::TError error;
@@ -110,7 +110,8 @@ STFUNC(TDrainNodeRequestActor::StateWork)
 {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvHiveProxyPrivate::TEvChangeTabletClient, HandleChangeTabletClient);
-        HFunc(NKikimr::TEvHive::TEvDrainNodeResult, HandleDrainNodeResult);
+        HFunc(TEvHive::TEvDrainNodeResult, HandleDrainNodeResult);
+        IgnoreFunc(TEvHive::TEvDrainNodeAck);
 
         default:
             HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -368,6 +368,8 @@ private:
         const TEvHive::TEvDrainNode::TPtr& ev,
         const TActorContext& ctx)
     {
+        ctx.Send(ev->Sender, new TEvHive::TEvDrainNodeAck());
+
         const auto& msg = ev->Get();
 
         NKikimrProto::EReplyStatus replyStatus = NKikimrProto::OK;

--- a/contrib/ydb/core/base/hive.h
+++ b/contrib/ydb/core/base/hive.h
@@ -82,6 +82,12 @@ namespace NKikimr {
             EvReassignOnDecommitGroupReply,
             EvUpdateTabletsObjectReply,
             EvUpdateDomainReply,
+            EvResponseTabletDistribution,
+            EvResponseScaleRecommendation,
+            EvConfigureScaleRecommenderReply,
+            EvDrainNodeAck,
+            EvResponseDrainInfo,
+            EvSetDownReply,
 
             EvEnd
         };
@@ -868,6 +874,11 @@ namespace NKikimr {
         struct TEvUpdateDomain : TEventPB<TEvUpdateDomain, NKikimrHive::TEvUpdateDomain, EvUpdateDomain> {};
 
         struct TEvUpdateDomainReply : TEventPB<TEvUpdateDomainReply, NKikimrHive::TEvUpdateDomainReply, EvUpdateDomainReply> {};
+
+        struct TEvDrainNodeAck: TEventLocal<TEvDrainNodeAck, EvDrainNodeAck>
+        {
+            TEvDrainNodeAck() = default;
+        };
     };
 
     IActor* CreateDefaultHive(const TActorId &tablet, TTabletStorageInfo *info);


### PR DESCRIPTION
In 25-3 the Hive responds with TEvHive::TEvDrainNodeAck after receiving drain task. Added it to ignore list to no trigger the UnexpectedEvent alert.

PRs to YDB:
https://github.com/ydb-platform/ydb/pull/31764
https://github.com/ydb-platform/ydb/pull/31765
https://github.com/ydb-platform/ydb/pull/31772
https://github.com/ydb-platform/ydb/pull/31773