### PR TITLE
Fix open_close_bench build

### DIFF
--- a/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp
+++ b/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
                 return;
             }
 
-            auto threads = std::min<int>(parallel, total);
+            size_t threads = std::min<size_t>(parallel, total);
             std::vector<std::future<void>> futures;
             futures.reserve(threads);
 
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
 
                 futures.emplace_back(std::async(
                     std::launch::async,
-                    [chunkStart, chunkEnd, &func, currentNumber, &container]() {
+                    [chunkStart, chunkEnd, &func, currentNumber]() {
                         size_t thread = 0;
                         for (auto it = chunkStart; it != chunkEnd;
                              ++it, ++thread) {
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
 
         if (!keepOpen) {
             bench("Open", [&]() {
-                forEach(fds, [&fds, verbose](const auto i, auto &fd) {
+                forEach(fds, [verbose](const auto i, auto &fd) {
                     const auto filename = makeFilename(i);
                     fd = open(filename.c_str(), O_RDONLY);
                     if (verbose) {


### PR DESCRIPTION
```
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:121:67: error: lambda capture 'container' is not used [-Werror,-Wunused-lambda-capture]
  121 |                     [chunkStart, chunkEnd, &func, currentNumber, &container]() {
      |                                                                   ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:154:20: note: in instantiation of function template specialization 'main(int, char **)::(anonymous class)::operator()<std::vector<int>, (lambda at $(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:154:26)>' requested here
  154 |             forEach(fds, [&writeBytes, &verbose, &fallocateBytes, &keepOpen](
      |                    ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:113:44: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
  113 |             for (size_t thread = 0; thread < threads; ++thread) {
      |                                     ~~~~~~ ^ ~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:116:47: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'typename iterator_traits<const int *>::difference_type' (aka 'long') [-Werror,-Wsign-compare]
  116 |                     total / threads + (thread < (total % threads) ? 1 : 0);
      |                                        ~~~~~~ ^  ~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:207:32: error: lambda capture 'fds' is not used [-Werror,-Wunused-lambda-capture]
  207 |                 forEach(fds, [&fds, verbose](const auto i, auto &fd) {
      |                               ~^~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:121:67: error: lambda capture 'container' is not used [-Werror,-Wunused-lambda-capture]
  121 |                     [chunkStart, chunkEnd, &func, currentNumber, &container]() {
      |                                                                   ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:207:24: note: in instantiation of function template specialization 'main(int, char **)::(anonymous class)::operator()<std::vector<int>, (lambda at $(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:207:30)>' requested here
  207 |                 forEach(fds, [&fds, verbose](const auto i, auto &fd) {
      |                        ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:113:44: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
  113 |             for (size_t thread = 0; thread < threads; ++thread) {
      |                                     ~~~~~~ ^ ~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:116:47: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'typename iterator_traits<const int *>::difference_type' (aka 'long') [-Werror,-Wsign-compare]
  116 |                     total / threads + (thread < (total % threads) ? 1 : 0);
      |                                        ~~~~~~ ^  ~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:121:67: error: lambda capture 'container' is not used [-Werror,-Wunused-lambda-capture]
  121 |                     [chunkStart, chunkEnd, &func, currentNumber, &container]() {
      |                                                                   ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:230:20: note: in instantiation of function template specialization 'main(int, char **)::(anonymous class)::operator()<std::vector<int>, (lambda at $(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:230:26)>' requested here
  230 |             forEach(fds, [](const auto i, auto &fd) {
      |                    ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:113:44: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
  113 |             for (size_t thread = 0; thread < threads; ++thread) {
      |                                     ~~~~~~ ^ ~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:116:47: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'typename iterator_traits<const int *>::difference_type' (aka 'long') [-Werror,-Wsign-compare]
  116 |                     total / threads + (thread < (total % threads) ? 1 : 0);
      |                                        ~~~~~~ ^  ~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:121:67: error: lambda capture 'container' is not used [-Werror,-Wunused-lambda-capture]
  121 |                     [chunkStart, chunkEnd, &func, currentNumber, &container]() {
      |                                                                   ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:243:24: note: in instantiation of function template specialization 'main(int, char **)::(anonymous class)::operator()<std::vector<int>, (lambda at $(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:243:30)>' requested here
  243 |                 forEach(fds, [](const auto i, auto &fd) {
      |                        ^
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:113:44: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
  113 |             for (size_t thread = 0; thread < threads; ++thread) {
      |                                     ~~~~~~ ^ ~~~~~~~
$(SOURCE_ROOT)/cloud/filestore/tools/testing/open_close_bench/open_close_bench.cpp:116:47: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'typename iterator_traits<const int *>::difference_type' (aka 'long') [-Werror,-Wsign-compare]
  116 |                     total / threads + (thread < (total % threads) ? 1 : 0);
      |                                        ~~~~~~ ^  ~~~~~~~~~~~~~~~
13 errors generated.
```
