### PR TITLE
Remove stats without meaning. Fix use-after-free.

### DIFF
--- a/cloud/blockstore/tools/analytics/dump-event-log/io_deps_stat_accumulator.cpp
+++ b/cloud/blockstore/tools/analytics/dump-event-log/io_deps_stat_accumulator.cpp
@@ -123,7 +123,8 @@ TIoDepsStatAccumulator::TIoDepsStatAccumulator(const TString& knownDisksFile)
 
 TIoDepsStatAccumulator::~TIoDepsStatAccumulator()
 {
-    ExtractRequests();
+    ProcessRequests();
+    FinishEventHandler();
 }
 
 void TIoDepsStatAccumulator::AddEventHandler(
@@ -177,7 +178,7 @@ TDiskInfo& TIoDepsStatAccumulator::GetDiskInfo(const TString& diskId)
     return it->second;
 }
 
-void TIoDepsStatAccumulator::ExtractRequests()
+void TIoDepsStatAccumulator::ProcessRequests()
 {
     Cerr << "Requests: " << Requests.size() << Endl;
     const auto now = TInstant::Now();
@@ -220,6 +221,13 @@ void TIoDepsStatAccumulator::ExtractRequests()
                 request->ReplicaChecksums,
                 request->InflightData);
         }
+    }
+}
+
+void TIoDepsStatAccumulator::FinishEventHandler()
+{
+    for (auto& handler: EventHandlers) {
+        handler->Finish();
     }
 }
 

--- a/cloud/blockstore/tools/analytics/dump-event-log/io_deps_stat_accumulator.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/io_deps_stat_accumulator.h
@@ -63,7 +63,8 @@ public:
 
 private:
     TDiskInfo& GetDiskInfo(const TString& diskId);
-    void ExtractRequests();
+    void ProcessRequests();
+    void FinishEventHandler();
 };
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/tools/analytics/dump-event-log/io_distribution.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/io_distribution.h
@@ -16,10 +16,12 @@ struct IDistributionCalculator
 {
     virtual ~IDistributionCalculator() = default;
 
+    [[nodiscard]] virtual bool HaveMeaning() const = 0;
     [[nodiscard]] virtual TString GetName() const = 0;
     virtual void Apply(ui32 requestType, TBlockRange64 blockRange) = 0;
     [[nodiscard]] virtual NJson::TJsonValue Dump() = 0;
 };
+
 using IDistributionCalculatorPtr = std::unique_ptr<IDistributionCalculator>;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,7 +53,6 @@ class TIODistributionStat: public IProfileLogEventHandler
 
 public:
     explicit TIODistributionStat(const TString& filename);
-    ~TIODistributionStat() override;
 
     void ProcessRequest(
         const TDiskInfo& diskInfo,
@@ -61,10 +62,10 @@ public:
         const TReplicaChecksums& replicaChecksums,
         const TInflightData& inflightData) override;
 
+    void Finish() override;
+
 private:
     TVolumeStat& GetVolumeStat(const TDiskInfo& diskInfo);
-
-    void Dump();
 };
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/tools/analytics/dump-event-log/profile_log_event_handler.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/profile_log_event_handler.h
@@ -86,6 +86,8 @@ struct IProfileLogEventHandler
         TBlockRange64 blockRange,
         const TReplicaChecksums& replicaChecksums,
         const TInflightData& inflightData) = 0;
+
+    virtual void Finish() = 0;
 };
 
 bool IsReadRequestType(ui32 requestType);

--- a/cloud/blockstore/tools/analytics/dump-event-log/read_write_requests_with_inflight.cpp
+++ b/cloud/blockstore/tools/analytics/dump-event-log/read_write_requests_with_inflight.cpp
@@ -14,11 +14,6 @@ TReadWriteRequestsWithInflight::TReadWriteRequestsWithInflight(
     : Output(filename)
 {}
 
-TReadWriteRequestsWithInflight::~TReadWriteRequestsWithInflight()
-{
-    Output.Flush();
-}
-
 void TReadWriteRequestsWithInflight::ProcessRequest(
     const TDiskInfo& diskInfo,
     const TTimeData& timeData,
@@ -55,6 +50,11 @@ void TReadWriteRequestsWithInflight::ProcessRequest(
     printInflight(sb, inflightData.HostDiskRegistryBased);
     sb << "]\n";
     Output.Write(sb);
+}
+
+void TReadWriteRequestsWithInflight::Finish()
+{
+    Output.Flush();
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/tools/analytics/dump-event-log/read_write_requests_with_inflight.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/read_write_requests_with_inflight.h
@@ -14,7 +14,6 @@ class TReadWriteRequestsWithInflight: public IProfileLogEventHandler
 
 public:
     explicit TReadWriteRequestsWithInflight(const TString& filename);
-    ~TReadWriteRequestsWithInflight() override;
 
     void ProcessRequest(
         const TDiskInfo& diskInfo,
@@ -23,6 +22,8 @@ public:
         TBlockRange64 blockRange,
         const TReplicaChecksums& replicaChecksums,
         const TInflightData& inflightData) override;
+
+    void Finish() override;
 };
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/tools/analytics/dump-event-log/sqlite_output.cpp
+++ b/cloud/blockstore/tools/analytics/dump-event-log/sqlite_output.cpp
@@ -171,9 +171,6 @@ TSqliteOutput::TSqliteOutput(const TString& filename)
 
 TSqliteOutput::~TSqliteOutput()
 {
-    Transaction.reset();
-    Cout << "Total row count: " << TotalRowCount << Endl;
-
     if (Db) {
         sqlite3_finalize(AddDiskStmt);
         sqlite3_finalize(AddRequestStmt);
@@ -201,6 +198,12 @@ void TSqliteOutput::ProcessRequest(
     AddChecksums(requestId, blockRange, replicaChecksums);
 
     AdvanceTransaction();
+}
+
+void TSqliteOutput::Finish()
+{
+    Transaction.reset();
+    Cout << "Total row count: " << TotalRowCount << Endl;
 }
 
 void TSqliteOutput::CreateTables()

--- a/cloud/blockstore/tools/analytics/dump-event-log/sqlite_output.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/sqlite_output.h
@@ -43,6 +43,8 @@ public:
         const TReplicaChecksums& replicaChecksums,
         const TInflightData& inflightData) override;
 
+    void Finish() override;
+
 private:
     void CreateTables();
     void ReadDisks();

--- a/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.cpp
+++ b/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.cpp
@@ -88,11 +88,6 @@ TZeroRangesStat::TZeroRangesStat(const TString& filename)
     , ZeroChecksum(CalcZeroChecksum())
 {}
 
-TZeroRangesStat::~TZeroRangesStat()
-{
-    Dump();
-}
-
 void TZeroRangesStat::ProcessRequest(
     const TDiskInfo& diskInfo,
     const TTimeData& timeData,
@@ -120,7 +115,7 @@ void TZeroRangesStat::ProcessRequest(
     volume.Set(rangeIndex4MiB, isZeroRange);
 }
 
-void TZeroRangesStat::Dump()
+void TZeroRangesStat::Finish()
 {
     TFileOutput out(Filename);
 

--- a/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.h
@@ -44,7 +44,6 @@ class TZeroRangesStat: public IProfileLogEventHandler
 
 public:
     explicit TZeroRangesStat(const TString& filename);
-    ~TZeroRangesStat() override;
 
     void ProcessRequest(
         const TDiskInfo& diskInfo,
@@ -54,8 +53,7 @@ public:
         const TReplicaChecksums& replicaChecksums,
         const TInflightData& inflightData) override;
 
-private:
-    void Dump();
+    void Finish() override;
 };
 
 }   // namespace NCloud::NBlockStore


### PR DESCRIPTION
1. We do not count statics for configurations when the disk size is less than the slice size.
2. Fixed use-after-free