### PR TITLE
DiskStateUpdate is only saved if the disk is in SupportedNotications

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_notification.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_notification.cpp
@@ -308,7 +308,7 @@ void TNotificationSystem::OnDiskStateChanged(
             auto notif = MakeBlankNotification(seqNo, timestamp);
             notif.MutableDiskError()->SetDiskId(diskId);
             AddUserNotification(db, std::move(notif));
-         }
+        }
     } else {
         if (oldState >= NProto::DISK_STATE_TEMPORARILY_UNAVAILABLE) {
             auto notif = MakeBlankNotification(seqNo, timestamp);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_updates.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_updates.cpp
@@ -220,47 +220,57 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateUpdatesTest)
         const auto deviceId = "uuid-1.1";
         const auto diskId = "disk-1";
 
-        const TVector agents {
-            AgentConfig(1, {
+        const TVector agents{AgentConfig(
+            1,
+            {
                 Device("dev-1", deviceId, "", DefaultBlockSize, 10000000000),
-            })
-        };
+            })};
 
         TTestExecutor executor;
-        executor.WriteTx([&] (TDiskRegistryDatabase db) {
-            db.InitSchema();
-        });
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
 
         auto statePtr = TDiskRegistryStateBuilder()
                             .WithKnownAgents(agents)
                             .WithDisks({Disk(diskId, {deviceId})})
                             .Build();
-        
+
         TVector<TDiskStateUpdate> dbUpdates;
-        executor.ReadTx([&](TDiskRegistryDatabase db) {
-            db.ReadDiskStateChanges(dbUpdates);
-        });
+        executor.ReadTx([&](TDiskRegistryDatabase db)
+                        { db.ReadDiskStateChanges(dbUpdates); });
 
         TVector<TDiskStateUpdate> updates = statePtr->GetDiskStateUpdates();
         UNIT_ASSERT(dbUpdates.size() == updates.size());
-        for(size_t i = 0; i < dbUpdates.size(); ++i) {
-            UNIT_ASSERT(google::protobuf::util::MessageDifferencer::Equals(dbUpdates[i].State, updates[i].State));
+        for (size_t i = 0; i < dbUpdates.size(); ++i) {
+            UNIT_ASSERT(
+                google::protobuf::util::MessageDifferencer::Equals(
+                    dbUpdates[i].State,
+                    updates[i].State));
         }
-        
+
         TString affectedDisk;
-        executor.WriteTx([&](TDiskRegistryDatabase db) {
-            statePtr->UpdateDeviceState(db, deviceId, NProto::DEVICE_STATE_WARNING, TInstant::Now(), "", affectedDisk);
-        });
-        
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                statePtr->UpdateDeviceState(
+                    db,
+                    deviceId,
+                    NProto::DEVICE_STATE_WARNING,
+                    TInstant::Now(),
+                    "",
+                    affectedDisk);
+            });
+
         updates = statePtr->GetDiskStateUpdates();
         dbUpdates.clear();
-        executor.ReadTx([&](TDiskRegistryDatabase db) {
-            db.ReadDiskStateChanges(dbUpdates);
-        });
+        executor.ReadTx([&](TDiskRegistryDatabase db)
+                        { db.ReadDiskStateChanges(dbUpdates); });
 
         UNIT_ASSERT(dbUpdates.size() == updates.size());
-        for(size_t i = 0; i < dbUpdates.size(); ++i) {
-            UNIT_ASSERT(google::protobuf::util::MessageDifferencer::Equals(dbUpdates[i].State, updates[i].State));
+        for (size_t i = 0; i < dbUpdates.size(); ++i) {
+            UNIT_ASSERT(
+                google::protobuf::util::MessageDifferencer::Equals(
+                    dbUpdates[i].State,
+                    updates[i].State));
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/ydb-platform/nbs/issues/4873

In some cases, for example, when a disk is deleted and its id is no longer present in SupportsNotifications, records of its updates appear in the database, but everything remains the same in DiskRegistryState.

To solve this problem DiskStateUpdate will be appeared in the database only if disk_id is specified in SupportsNotifications