### PR TITLE
issue-4853: ability to disable ReadBlob and WriteBlob at the tablet level to focus on vfs_fuse+service+tablet layer perf tests

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -696,4 +696,11 @@ message TStorageConfig
     // MaxShardCount used to be hardcoded and equal to 254.
     // Now it is configurable with the default == 254
     optional uint32 MaxShardCount = 473;
+
+    // These 2 parameters convert ReadBlob and WriteBlob ops to no-op. These
+    // parameters are supposed to be used only for testing purposes - to test
+    // fuse / service / tablet layer performance without direct blobstorage
+    // reads / writes. Tablet local DB still continues to use blobstorage.
+    optional bool ReadBlobDisabled = 474;
+    optional bool WriteBlobDisabled = 475;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -308,6 +308,9 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(BlockChecksumsInProfileLogEnabled, bool,      false                   )\
                                                                                \
     xxx(MaxShardCount,                     ui32,      254                     )\
+                                                                               \
+    xxx(ReadBlobDisabled,                  bool,      false                   )\
+    xxx(WriteBlobDisabled,                 bool,      false                   )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -360,6 +360,9 @@ public:
     [[nodiscard]] bool GetBlockChecksumsInProfileLogEnabled() const;
 
     ui32 GetMaxShardCount() const;
+
+    bool GetReadBlobDisabled() const;
+    bool GetWriteBlobDisabled() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -61,6 +61,7 @@ private:
     const TActorId Tablet;
     const TRequestInfoPtr RequestInfo;
     const TString FileSystemId;
+    const bool WriteBlobDisabled;
     const IProfileLogPtr ProfileLog;
 
     TVector<TWriteBlobRequest> Requests;
@@ -78,6 +79,7 @@ public:
         TActorId tablet,
         TRequestInfoPtr requestInfo,
         TString fileSystemId,
+        bool writeBlobDisabled,
         IProfileLogPtr profileLog,
         TVector<TWriteBlobRequest> requests,
         NProto::TProfileLogRequestInfo profileLogRequest);
@@ -113,6 +115,7 @@ TWriteBlobActor::TWriteBlobActor(
         TActorId tablet,
         TRequestInfoPtr requestInfo,
         TString fileSystemId,
+        bool writeBlobDisabled,
         IProfileLogPtr profileLog,
         TVector<TWriteBlobRequest> requests,
         NProto::TProfileLogRequestInfo profileLogRequest)
@@ -120,6 +123,7 @@ TWriteBlobActor::TWriteBlobActor(
     , Tablet(tablet)
     , RequestInfo(std::move(requestInfo))
     , FileSystemId(std::move(fileSystemId))
+    , WriteBlobDisabled(writeBlobDisabled)
     , ProfileLog(std::move(profileLog))
     , Requests(std::move(requests))
     , ProfileLogRequest(std::move(profileLogRequest))
@@ -131,6 +135,11 @@ void TWriteBlobActor::Bootstrap(const TActorContext& ctx)
         RequestReceived_TabletWorker,
         RequestInfo->CallContext,
         "WriteBlob");
+
+    if (WriteBlobDisabled) {
+        ReplyAndDie(ctx);
+        return;
+    }
 
     SendRequests(ctx);
     Become(&TThis::StateWork);
@@ -364,6 +373,7 @@ void TIndexTabletActor::HandleWriteBlob(
         ctx.SelfID,
         std::move(requestInfo),
         GetFileSystemId(),
+        Config->GetWriteBlobDisabled(),
         ProfileLog,
         std::move(requests),
         std::move(profileLogRequest));


### PR DESCRIPTION
### Notes
Added 2 simple StorageConfig flags - `ReadBlobDisabled` and `WriteBlobDisabled` - to avoid sending requests to blobstorage which lets us load our own components (vfs_fuse, storage service, tablet layers) better. Intended only for perftesting purposes.

Making the diff as simple as possible. If we ever need to introduce some artificial delay, I'll make a separate PR with the parameters that would specify the distribution of the delays.

### Issue
https://github.com/ydb-platform/nbs/issues/4853