### PR TITLE
Fix arcadia build. Change test suite type

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ut/ya.make
@@ -1,8 +1,6 @@
 UNITTEST_FOR(cloud/filestore/libs/storage/tablet/model)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
-
-TIMEOUT(120)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
 
 SRCS(
     block_list_ut.cpp


### PR DESCRIPTION
```
Max allowed timeout for test size SMALL is 60 sec, suggested size: MEDIUM
```