### PR TITLE
issue-2566: fix crash on the shardName extraction in TStorageServiceActor::SelectShard

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -53,22 +53,22 @@ TResultOrError<TString> TStorageServiceActor::SelectShard(
         StorageConfig->GetMultiTabletForwardingEnabled()
         && !disableMultiTabletForwarding;
 
+    // It is now possible to have more than 255 shards, with the maximum
+    // number specified by TStorageConfig::MaxShardCount. The current code
+    // reserves the two most significant bytes for shardNo, but handles
+    // created by the old code, which used only the 8th byte for shardNo,
+    // may still exist. To allow for a shard count higher than 255, we first
+    // need to wait until the SevenBytesHandlesCount counter is zero, and
+    // only then increase MaxShardCount. The following 'if' reconciles old
+    // handles with the new code.
+    // TODO(#2566): Remove this code when there are no filesystems with
+    // shardIds.size() <= 255 and handles that use 7th byte.
+    if (shardNo && filestore.GetShardFileSystemIds().size() <= 255) {
+        shardNo &= 0xff;
+    }
+
     if (multiTabletForwardingEnabled && shardNo) {
         const auto& shardIds = filestore.GetShardFileSystemIds();
-
-        // It is now possible to have more than 255 shards, with the maximum
-        // number specified by TStorageConfig::MaxShardCount. The current code
-        // reserves the two most significant bytes for shardNo, but handles
-        // created by the old code, which used only the 8th byte for shardNo,
-        // may still exist. To allow for a shard count higher than 255, we first
-        // need to wait until the SevenBytesHandlesCount counter is zero, and
-        // only then increase MaxShardCount. The following 'if' reconciles old
-        // handles with the new code.
-        // TODO(#2566): Remove this code when there are no filesystems with
-        // shardIds.size() <= 255 and handles that use 7th byte.
-        if (shardNo && shardIds.size() <= 255) {
-            shardNo &= 0xff;
-        }
 
         if (shardIds.size() < static_cast<int>(shardNo)) {
             LOG_DEBUG(ctx, TFileStoreComponents::SERVICE,

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -6280,6 +6280,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                 return false;
             });
 
+        // Test handle that contains non-zero shard
         service.AssertReadDataFailed(
             headers,
             fsId,
@@ -6289,6 +6290,17 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             1);
 
         UNIT_ASSERT_EQUAL(fsId + "_s1", fsIdFromRequest);
+
+        // Test handle that contains zero shard
+        service.AssertReadDataFailed(
+            headers,
+            fsId,
+            nodeId,
+            0x0001000000000001,
+            0,
+            1);
+
+        UNIT_ASSERT_EQUAL(fsId, fsIdFromRequest);
     }
 }
 


### PR DESCRIPTION
#2566

If a real shardNo was zero,  the following 'shardIds[shardNo - 1]' generated SIGSEGV