### PR TITLE
issue-4035, issue-4853: support for multiqueue in filestore tests, added a multiqueue fio test suite

### DIFF
--- a/cloud/filestore/libs/diagnostics/events/profile_events.ev
+++ b/cloud/filestore/libs/diagnostics/events/profile_events.ev
@@ -108,6 +108,8 @@ message TProfileLogRequestInfo {
     repeated TProfileLogCompactionRangeInfo CompactionRanges = 9;
 
     optional TProfileLogCollectGarbageInfo CollectGarbageInfo = 10;
+
+    optional uint64 LoopThreadId = 11;
 };
 
 message TProfileLogRecord {

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -22,6 +22,8 @@ public:
     ui64 RequestSize = 0;
     bool Unaligned = false;
 
+    ui64 LoopThreadId = 0;
+
     int CancellationCode = 0;
     std::atomic<bool> Cancelled = false;
 

--- a/cloud/filestore/libs/storage/service/service_actor.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor.cpp
@@ -121,6 +121,9 @@ std::pair<ui64, TInFlightRequest*> TStorageServiceActor::CreateInFlightRequest(
     Y_ABORT_UNLESS(inserted);
     it->second.Start(start);
 
+    it->second.ProfileLogRequest.SetLoopThreadId(
+        it->second.CallContext->LoopThreadId);
+
     return std::make_pair(cookie, &it->second);
 }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -754,6 +754,7 @@ void TFileSystem::Flush(
     NProto::TProfileLogRequestInfo requestInfo;
     InitProfileLogRequestInfo(requestInfo, EFileStoreFuseRequest::Flush, Now());
     InitNodeInfo(requestInfo, true, TNodeId{ino}, THandle{fi->fh});
+    requestInfo.SetLoopThreadId(callContext->LoopThreadId);
 
     auto callback = [=, ptr = weak_from_this(), requestInfo = std::move(requestInfo)]
         (const auto& future) mutable {
@@ -816,6 +817,7 @@ void TFileSystem::FSync(
         datasync,
         TNodeId{fi ? ino : InvalidNodeId},
         THandle{fi ? fi->fh : InvalidHandle});
+    requestInfo.SetLoopThreadId(callContext->LoopThreadId);
 
     std::function<void(const TFuture<NProto::TError>&)>
     callback = [=, ptr = weak_from_this(), requestInfo = std::move(requestInfo)]
@@ -940,6 +942,7 @@ void TFileSystem::FSyncDir(
         datasync,
         TNodeId{ino},
         THandle{fi->fh});
+    requestInfo.SetLoopThreadId(callContext->LoopThreadId);
 
     auto callback = [=, ptr = weak_from_this(), requestInfo = std::move(requestInfo)]
         (const auto& future) mutable {

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1356,6 +1356,7 @@ private:
             fuse_req_unique(req));
         callContext->RequestType = requestType;
         callContext->RequestSize = requestSize;
+        callContext->LoopThreadId = TThread::CurrentThreadId();
 
         if (auto cancelCode = pThis->CompletionQueue->Enqueue(req, callContext)) {
             STORAGE_DEBUG("driver is stopping, cancel request");

--- a/cloud/filestore/tests/fio/qemu-kikimr-mq-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-mq-test/nfs-patch.txt
@@ -1,0 +1,1 @@
+MaxFuseLoopThreads: 8

--- a/cloud/filestore/tests/fio/qemu-kikimr-mq-test/test.py
+++ b/cloud/filestore/tests/fio/qemu-kikimr-mq-test/test.py
@@ -1,0 +1,51 @@
+import pytest
+
+import cloud.filestore.tools.testing.profile_log.common as profile
+import cloud.storage.core.tools.testing.fio.lib as fio
+
+import yatest.common as common
+
+from cloud.filestore.tests.python.lib.common import get_filestore_mount_path
+
+import sys
+
+
+TESTS = fio.generate_tests(iodepths=[32], duration=30)
+
+
+@pytest.mark.parametrize("name", TESTS.keys())
+def test_fio(name):
+    mount_dir = get_filestore_mount_path()
+    file_name = fio.get_file_name(mount_dir, name)
+
+    fio.run_test(file_name, TESTS[name], fail_on_errors=True)
+
+    profile_tool_bin_path = common.binary_path(
+        "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")
+    fs_name = "nfs_test"
+    events = profile.get_profile_log_events(
+        profile_tool_bin_path,
+        common.output_path("vhost-profile.log"),
+        fs_name)
+
+    #
+    # Calculating the number of threads that were actually involved in request
+    # processing.
+    #
+
+    thread_ids = set()
+    for event in events:
+        loop_thread_id = event[1].get("loop_thread_id")
+        if loop_thread_id is not None:
+            thread_ids.add(loop_thread_id)
+
+    #
+    # Usually the number of threads involved is 7 or 8 but sometimes its less
+    # so let's use a coarse check (> 1) in order not to have an unstable test.
+    # The main thing that we want to verify is that multiqueue actually works
+    # which means that more than 1 thread should be involved in request
+    # processing.
+    #
+
+    print("loop_thread_count=%s" % len(thread_ids), file=sys.stderr)
+    assert len(thread_ids) > 1

--- a/cloud/filestore/tests/fio/qemu-kikimr-mq-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-mq-test/ya.make
@@ -1,0 +1,39 @@
+PY3TEST()
+
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+ENDIF()
+
+DEPENDS(
+    cloud/filestore/tools/analytics/profile_tool
+    cloud/storage/core/tools/testing/fio/bin
+    cloud/storage/core/tools/testing/qemu/image-noble
+)
+
+PEERDIR(
+    cloud/filestore/tests/python/lib
+    cloud/filestore/tools/testing/profile_log
+    cloud/storage/core/tools/testing/fio/lib
+)
+
+TEST_SRCS(
+    test.py
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/fio/qemu-kikimr-mq-test/nfs-patch.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_ROOTFS cloud/storage/core/tools/testing/qemu/image-plucky/rootfs.img)
+SET(QEMU_NUM_REQUEST_QUEUES 8)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/fio/ya.make
+++ b/cloud/filestore/tests/fio/ya.make
@@ -8,6 +8,7 @@ RECURSE_FOR_TESTS(
     qemu-kikimr-zero-copy-test
     qemu-kikimr-zero-copy-fallback-test
     qemu-local-noserver-direct-io-test
+    qemu-local-noserver-mq
     qemu-local-noserver-test
     qemu-local-test
 )

--- a/cloud/filestore/tests/recipes/vhost-endpoint/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost-endpoint/__main__.py
@@ -19,6 +19,11 @@ def env_with_index(env, index):
     return "{}__{}".format(env, index)
 
 
+# expected production setup settings
+DEFAULT_VHOST_FRONTEND_QUEUE_COUNT = 8
+VHOST_PRIORITY_QUEUE_COUNT = 1
+
+
 def start(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--filesystem", action="store", default="nfs_share")
@@ -29,7 +34,11 @@ def start(argv):
     parser.add_argument("--read-only", action="store_true", default=False)
     parser.add_argument("--verbose", action="store_true", default=False)
     parser.add_argument("--endpoint-count", action="store", default=1, type=int)
-    parser.add_argument("--vhost-queue-count", action="store", default=0, type=int)
+    parser.add_argument(
+        "--vhost-queue-count",
+        action="store",
+        default=DEFAULT_VHOST_FRONTEND_QUEUE_COUNT + VHOST_PRIORITY_QUEUE_COUNT,
+        type=int)
     args = parser.parse_args(argv)
 
     port = os.getenv("NFS_SERVER_PORT")

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
@@ -371,6 +371,11 @@ public:
             out << PrintBlobsInfo(request.GetBlobsInfo()) << "\t";
         }
 
+        if (request.GetLoopThreadId()) {
+            out << PrintValue("loop_thread_id", request.GetLoopThreadId())
+                << "\t";
+        }
+
         if (out.empty()) {
             out << "{no_info}";
         } else {

--- a/cloud/storage/core/tests/recipes/qemu.inc
+++ b/cloud/storage/core/tests/recipes/qemu.inc
@@ -49,6 +49,7 @@ USE_RECIPE(
     --instance-count $QEMU_INSTANCE_COUNT
     --invoke-test $QEMU_INVOKE_TEST
     --use-virtiofs-server $QEMU_USE_VIRTIOFS_SERVER
+    --num-request-queues $QEMU_NUM_REQUEST_QUEUES
 )
 
 REQUIREMENTS(kvm)

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -85,7 +85,8 @@ class Qemu:
                  backup_rootfs=False,
                  inst_index=0,
                  shared_nic_port=0,
-                 use_virtiofs_server=False):
+                 use_virtiofs_server=False,
+                 num_request_queues=1):
 
         self.ssh_port = 0
         self.qmp = None
@@ -103,6 +104,7 @@ class Qemu:
         self.proc = proc
         self.virtio = virtio
         self.qemu_options = qemu_options
+        self.num_request_queues = num_request_queues
         self.virtio_options = self._get_virtio_options(self.virtio, vhost_socket)
         self.enable_kvm = enable_kvm
         self.backup_rootfs = backup_rootfs
@@ -144,7 +146,8 @@ class Qemu:
         cmd = ["-chardev",
                "socket,id=vhost0,path={},reconnect=1".format(vhost_socket)]
         cmd += ["-device",
-                "vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,queue-size=512,migration=external"]
+                "vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,num-request-queues=%s,queue-size=512,migration=external"
+                % self.num_request_queues]
         return cmd
 
     def _get_virtioblk_options(self, vhost_socket):

--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -94,7 +94,8 @@ def start_instance(args, inst_index):
                 enable_kvm=_get_vm_enable_kvm(args),
                 inst_index=inst_index,
                 shared_nic_port=args.shared_nic_port,
-                use_virtiofs_server=use_virtiofs_server)
+                use_virtiofs_server=use_virtiofs_server,
+                num_request_queues=_get_num_request_queues(args))
 
     qemu.set_mount_paths(mount_paths)
     qemu.start()
@@ -189,6 +190,10 @@ def _parse_args(argv):
         "--instance-count", help="Number of qemu instances to start")
     parser.add_argument("--invoke-test", default="Invoke test from qemu after starting")
     parser.add_argument("--use-virtiofs-server", default="False")
+    parser.add_argument(
+        "--num-request-queues",
+        default=1,
+        help="Number of request queues for virtiofs")
 
     args = parser.parse_args(argv)
     if args.instance_count == "$QEMU_INSTANCE_COUNT":
@@ -366,6 +371,12 @@ def _get_vm_use_virtiofs_server(args):
     if args.use_virtiofs_server == "$QEMU_USE_VIRTIOFS_SERVER":
         return False
     return _str_to_bool(args.use_virtiofs_server)
+
+
+def _get_num_request_queues(args):
+    if args.num_request_queues == "$QEMU_NUM_REQUEST_QUEUES":
+        return 1
+    return int(args.num_request_queues)
 
 
 def _prepare_test_environment(ssh, virtio):


### PR DESCRIPTION
### Notes
* using 8+1 vhost queues per endpoint by default in all tests - the same default as on real clusters
* added support for num-request-queues virtiofs chardev tuning (default is still 1)
* added a test suite which uses num-request-queues=8, uses ubuntu-plucky (kernel 6.14 - with mq support) and checks that more than 1 queue is actually used for each test
* added loop_thread_id to each profile log request

### Issue
https://github.com/ydb-platform/nbs/issues/4853
https://github.com/ydb-platform/nbs/issues/4035