### PR TITLE
[Filestore] reduce number of iteration in ShouldEncodeRandomBlocks, ShouldEncodeRandomBlockGroups* test cases; make libs/storage/tablet/model/ut small

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/block_list_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/block_list_ut.cpp
@@ -403,14 +403,14 @@ Y_UNIT_TEST_SUITE(TBlockListTest)
 
     Y_UNIT_TEST(ShouldEncodeRandomBlocks)
     {
-        for (size_t i = 0; i < 50; i++) {
+        for (size_t i = 0; i < 30; i++) {
             TestEncodeBlocks(GenerateRandomBlocks(1000));
         }
     }
 
     Y_UNIT_TEST(ShouldEncodeRandomBlockGroupsWithoutDeletions)
     {
-        for (size_t i = 0; i < 50; i++) {
+        for (size_t i = 0; i < 30; i++) {
             TestEncodeBlocks(
                 GenerateRandomBlockGroups(
                     /* blockGroups = */ 50,
@@ -420,7 +420,7 @@ Y_UNIT_TEST_SUITE(TBlockListTest)
 
     Y_UNIT_TEST(ShouldEncodeRandomBlockGroupsWithDeletions)
     {
-        for (size_t i = 0; i < 50; i++) {
+        for (size_t i = 0; i < 30; i++) {
             TestEncodeBlocks(
                 GenerateRandomBlockGroups(
                     /* blockGroups = */ 20,

--- a/cloud/filestore/libs/storage/tablet/model/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ut/ya.make
@@ -1,6 +1,6 @@
 UNITTEST_FOR(cloud/filestore/libs/storage/tablet/model)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
 
 SRCS(
     block_list_ut.cpp


### PR DESCRIPTION
Follow up after https://github.com/ydb-platform/nbs/pull/4874