### PR TITLE
issue-4035: virtiofs - fixed incorrect queue naming: frontend <-> backend

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -246,7 +246,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static ui32 CalcBackendVhostQueuesCount(const TVFSConfig& vfsConfig)
+static ui32 CalcFrontendVhostQueueCount(const TVFSConfig& vfsConfig)
 {
     // HIPRIO + number of requests queues
     return Max(2u, vfsConfig.GetVhostQueuesCount());
@@ -272,9 +272,9 @@ public:
         }
 
         AddArg(
-            "--num-backend-queues=" +
-            ToString(CalcBackendVhostQueuesCount(config)));
-        AddArg("--num-frontend-queues=" + ToString(threadsCount));
+            "--num-frontend-queues=" +
+            ToString(CalcFrontendVhostQueueCount(config)));
+        AddArg("--num-backend-queues=" + ToString(threadsCount));
 #else
         Y_UNUSED(threadsCount);
         if (config.GetReadOnly()) {
@@ -473,7 +473,7 @@ class TFuseLoopThread final
 private:
     TSession& Session;
     const ui32 FuseLoopIndex = 0;
-    const ui32 FrontendQueueIndex = 0;
+    const ui32 BackendQueueIndex = 0;
     bool InterruptSignaled = false;
     TLog Log;
 
@@ -483,11 +483,11 @@ public:
     TFuseLoopThread(
             TSession& session,
             ui32 fuseLoopIndex,
-            ui32 frontendQueueIndex,
+            ui32 backendQueueIndex,
             TLog log)
         : Session(session)
         , FuseLoopIndex(fuseLoopIndex)
-        , FrontendQueueIndex(frontendQueueIndex)
+        , BackendQueueIndex(backendQueueIndex)
         , Log(std::move(log))
     {}
 
@@ -510,14 +510,14 @@ public:
     {
         STORAGE_INFO(
             "stopping FUSE loop thread " << FuseLoopIndex << "."
-                                         << FrontendQueueIndex);
+                                         << BackendQueueIndex);
 
         SignalInterrupt();
         Join();
 
         STORAGE_INFO(
             "stopped FUSE loop thread " << FuseLoopIndex << "."
-                                        << FrontendQueueIndex);
+                                        << BackendQueueIndex);
     }
 
 private:
@@ -525,12 +525,12 @@ private:
     {
         ::NCloud::SetCurrentThreadName(
             "FUSE" + ToString(FuseLoopIndex) + "." +
-                ToString(FrontendQueueIndex),
+                ToString(BackendQueueIndex),
             4);
 
         AtomicSet(ThreadId, pthread_self());
 #if defined(FUSE_VIRTIO)
-        fuse_session_loop(Session, FrontendQueueIndex);
+        fuse_session_loop(Session, BackendQueueIndex);
 #else
         fuse_session_loop(Session);
 #endif
@@ -545,7 +545,7 @@ private:
     TLog Log;
     TSession Session;
 
-    TVector<std::unique_ptr<TFuseLoopThread>> FrontendQueueThreads;
+    TVector<std::unique_ptr<TFuseLoopThread>> BackendQueueThreads;
 
 public:
     TFuseLoop(
@@ -557,13 +557,13 @@ public:
             void* context)
         : Log(std::move(log))
         , Session(config, threadsCount, ops, state, context)
-        , FrontendQueueThreads(threadsCount)
+        , BackendQueueThreads(threadsCount)
     {
         static std::atomic<ui64> NextFuseLoopIndex = 0;
         ui64 fuseLoopIndex = NextFuseLoopIndex++;
 
-        for (ui32 queueIndex = 0; queueIndex < FrontendQueueThreads.size(); queueIndex++) {
-            FrontendQueueThreads[queueIndex] = std::make_unique<TFuseLoopThread>(
+        for (ui32 queueIndex = 0; queueIndex < BackendQueueThreads.size(); queueIndex++) {
+            BackendQueueThreads[queueIndex] = std::make_unique<TFuseLoopThread>(
                 Session,
                 fuseLoopIndex,
                 queueIndex,
@@ -573,7 +573,7 @@ public:
 
     void Start()
     {
-        for (auto& thread: FrontendQueueThreads) {
+        for (auto& thread: BackendQueueThreads) {
             thread->Start();
         }
     }
@@ -584,11 +584,11 @@ public:
 
         Session.Exit();
 
-        for (auto& thread: FrontendQueueThreads) {
+        for (auto& thread: BackendQueueThreads) {
             thread->SignalInterrupt();
         }
 
-        for (auto& thread: FrontendQueueThreads) {
+        for (auto& thread: BackendQueueThreads) {
             thread->Stop();
         }
 
@@ -1024,7 +1024,7 @@ private:
 
             ui32 fuseLoopThreadCount =
                 Min(FileSystemConfig->GetMaxFuseLoopThreads(),
-                    CalcBackendVhostQueuesCount(*Config));
+                    CalcFrontendVhostQueueCount(*Config));
             if (fuseLoopThreadCount == 0) {
                 fuseLoopThreadCount = 1;
             }

--- a/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
+++ b/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
@@ -430,15 +430,15 @@ int virtio_session_mount(struct fuse_session* se)
 
     // no need to supply tag here - it will be handled by the QEMU
     dev->fsdev.socket_path = se->vu_socket_path;
-    dev->fsdev.num_queues = se->num_backend_queues;
+    dev->fsdev.num_queues = se->num_frontend_queues;
 
     VHD_LOG_INFO(
-        "starting device %s, num_backend_queues=%d, num_frontend_queues=%d",
+        "starting device %s, num_frontend_queues=%d, num_backend_queues=%d",
         dev->fsdev.socket_path,
-        se->num_backend_queues,
-        se->num_frontend_queues);
+        se->num_frontend_queues,
+        se->num_backend_queues);
 
-    dev->rq_count = se->num_frontend_queues;
+    dev->rq_count = se->num_backend_queues;
     dev->rqs = vhd_zalloc(sizeof(dev->rqs[0]) * dev->rq_count);
 
     for (queue_index = 0; queue_index < dev->rq_count; queue_index++) {

--- a/contrib/libs/virtiofsd/fuse_i.h
+++ b/contrib/libs/virtiofsd/fuse_i.h
@@ -72,10 +72,10 @@ struct fuse_session {
     int   vu_listen_fd;
     int   vu_socketfd;
     struct fuse_virtio_dev *virtio_dev;
-    /* number of queues on backend device (qemu) */
-    int num_backend_queues;
-    /* number of queues used to submit requests to backend device (vhd_request_queue) */
+    /* number of qemu device queues */
     int num_frontend_queues;
+    /* number of queues used to submit requests to backend device (vhd_request_queue) */
+    int num_backend_queues;
 };
 
 struct fuse_chan {

--- a/contrib/libs/virtiofsd/fuse_lowlevel.c
+++ b/contrib/libs/virtiofsd/fuse_lowlevel.c
@@ -26,8 +26,8 @@
 #include <sys/file.h>
 #include <unistd.h>
 
-#define NUM_BACKEND_QUEUES 64
-#define NUM_FRONTEND_QUEUES 1
+#define DEFAULT_NUM_FRONTEND_QUEUES 64
+#define DEFAULT_NUM_BACKEND_QUEUES 1
 
 #define OFFSET_MAX 0x7fffffffffffffffLL
 
@@ -2536,8 +2536,8 @@ static const struct fuse_opt fuse_ll_opts[] = {
     LL_OPTION("--socket-path=%s", vu_socket_path, 0),
     LL_OPTION("--socket-group=%s", vu_socket_group, 0),
     LL_OPTION("--fd=%d", vu_listen_fd, 0),
-    LL_OPTION("--num-backend-queues=%d", num_backend_queues, 0),
     LL_OPTION("--num-frontend-queues=%d", num_frontend_queues, 0),
+    LL_OPTION("--num-backend-queues=%d", num_backend_queues, 0),
     FUSE_OPT_END
 };
 
@@ -2557,10 +2557,10 @@ void fuse_lowlevel_help(void)
         "    -o allow_root              allow access by root\n"
         "    --socket-path=PATH         path for the vhost-user socket\n"
         "    --fd=FDNUM                 fd number of vhost-user socket\n"
-        "    --num-backend-queues=NUM   backend queues limit (default %d)\n"
-        "    --num-frontend-queues=NUM  frontend queues limit (default %d)\n",
-        NUM_BACKEND_QUEUES,
-        NUM_FRONTEND_QUEUES);
+        "    --num-frontend-queues=NUM  frontend queues limit (default %d)\n"
+        "    --num-backend-queues=NUM   backend queues limit (default %d)\n",
+        DEFAULT_NUM_FRONTEND_QUEUES,
+        DEFAULT_NUM_BACKEND_QUEUES);
 }
 
 void fuse_session_destroy(struct fuse_session *se)
@@ -2632,8 +2632,8 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
     }
     se->fd = -1;
     se->vu_listen_fd = -1;
-    se->num_backend_queues = NUM_BACKEND_QUEUES;
-    se->num_frontend_queues = NUM_FRONTEND_QUEUES;
+    se->num_frontend_queues = DEFAULT_NUM_FRONTEND_QUEUES;
+    se->num_backend_queues = DEFAULT_NUM_BACKEND_QUEUES;
     se->conn.max_write = UINT_MAX;
     se->conn.max_readahead = UINT_MAX;
 


### PR DESCRIPTION
### Notes
Fixing incorrect queue naming. Guest device queues should be called "frontend" queues and libvhost queues should be called "backend" queues.

### Issue
https://github.com/ydb-platform/nbs/issues/4035