### PR TITLE
local filestore setup: fixes and perf improvements

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-diag.txt
+++ b/cloud/filestore/bin/nfs/nfs-diag.txt
@@ -1,3 +1,3 @@
-SamplingRate: 1
-SlowRequestSamplingRate: 1
+SamplingRate: 100000
+SlowRequestSamplingRate: 1000
 

--- a/cloud/filestore/bin/nfs/nfs-log.txt
+++ b/cloud/filestore/bin/nfs/nfs-log.txt
@@ -1,18 +1,18 @@
 Entry {
   Component: "NFS_TABLET_WORKER"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_VHOST"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_SERVICE"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_TABLET"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_SERVICE_PROXY"
@@ -20,15 +20,15 @@ Entry {
 }
 Entry {
   Component: "NFS_FUSE"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_SERVICE_WORKER"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_TRACE"
-  Level: 7
+  Level: 6
 }
 Entry {
   Component: "NFS_SERVER"

--- a/cloud/filestore/bin/nfs/nfs-storage.txt
+++ b/cloud/filestore/bin/nfs/nfs-storage.txt
@@ -7,3 +7,5 @@ ThreeStageWriteEnabled: true
 UnalignedThreeStageWriteEnabled: true
 DirectoryHandlesStorageEnabled: true
 DirectoryHandlesTableSize: 10000
+TwoStageReadEnabled: true
+TwoStageReadThreshold: 65536

--- a/cloud/filestore/bin/nfs/nfs-sys.txt
+++ b/cloud/filestore/bin/nfs/nfs-sys.txt
@@ -1,12 +1,12 @@
 Executor {
   Type: BASIC
-  Threads: 3
+  Threads: 6
   SpinThreshold: 10
   Name: "System"
 }
 Executor {
   Type: BASIC
-  Threads: 3
+  Threads: 6
   SpinThreshold: 10
   Name: "User"
 }
@@ -23,7 +23,7 @@ Executor {
 }
 Executor {
   Type: BASIC
-  Threads: 3
+  Threads: 6
   SpinThreshold: 10
   Name: "IC"
   TimePerMailboxMicroSecs: 100

--- a/cloud/filestore/bin/setup.sh
+++ b/cloud/filestore/bin/setup.sh
@@ -62,3 +62,6 @@ done
 
 # Generate certs
 generate_cert "server" "$BIN_DIR/certs"
+
+# Allow filestore to access /run/qemu
+sudo chmod 777 /run/qemu


### PR DESCRIPTION
### Notes
* lots of changes and fixes to initctl.sh - bigger fs, shards by default, ssd media-kind, etc
* made tracing & logging parameters closer to what's actually usually used for real setups
* tweaked thread pool sizes
* enabled two-stage-read with proper settings