### PR TITLE
fixing 'ythrow TServiceError' pattern which breaks exception messages - introduced STORAGE_THROW_SERVICE_ERROR macro which builds much better messages

### DIFF
--- a/cloud/filestore/apps/client/lib/add_cluster_node.cpp
+++ b/cloud/filestore/apps/client/lib/add_cluster_node.cpp
@@ -35,7 +35,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/create.cpp
+++ b/cloud/filestore/apps/client/lib/create.cpp
@@ -115,7 +115,7 @@ public:
         }
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/describe.cpp
+++ b/cloud/filestore/apps/client/lib/describe.cpp
@@ -25,7 +25,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         if (JsonOutput) {

--- a/cloud/filestore/apps/client/lib/destroy.cpp
+++ b/cloud/filestore/apps/client/lib/destroy.cpp
@@ -32,7 +32,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/kick_endpoint.cpp
+++ b/cloud/filestore/apps/client/lib/kick_endpoint.cpp
@@ -34,7 +34,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/list_cluster_nodes.cpp
+++ b/cloud/filestore/apps/client/lib/list_cluster_nodes.cpp
@@ -23,7 +23,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         if (JsonOutput) {

--- a/cloud/filestore/apps/client/lib/list_endpoints.cpp
+++ b/cloud/filestore/apps/client/lib/list_endpoints.cpp
@@ -22,7 +22,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         if (JsonOutput) {

--- a/cloud/filestore/apps/client/lib/list_filestores.cpp
+++ b/cloud/filestore/apps/client/lib/list_filestores.cpp
@@ -21,7 +21,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         if (JsonOutput) {

--- a/cloud/filestore/apps/client/lib/mount.cpp
+++ b/cloud/filestore/apps/client/lib/mount.cpp
@@ -84,7 +84,7 @@ public:
             auto error = FileSystemLoop->StartAsync().GetValueSync();
             if (FAILED(error.GetCode())) {
                 STORAGE_ERROR("failed to start driver: " << FormatError(error))
-                ythrow TServiceError(error);
+                STORAGE_THROW_SERVICE_ERROR(error);
             }
         }
     }

--- a/cloud/filestore/apps/client/lib/remove_cluster_node.cpp
+++ b/cloud/filestore/apps/client/lib/remove_cluster_node.cpp
@@ -35,7 +35,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/resize.cpp
+++ b/cloud/filestore/apps/client/lib/resize.cpp
@@ -62,7 +62,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/start_endpoint.cpp
+++ b/cloud/filestore/apps/client/lib/start_endpoint.cpp
@@ -74,7 +74,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/stop_endpoint.cpp
+++ b/cloud/filestore/apps/client/lib/stop_endpoint.cpp
@@ -34,7 +34,7 @@ public:
                 std::move(request)));
 
         if (HasError(response)) {
-            ythrow TServiceError(response.GetError());
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
         }
 
         return true;

--- a/cloud/filestore/libs/client/client.cpp
+++ b/cloud/filestore/libs/client/client.cpp
@@ -705,7 +705,7 @@ protected:
             StartWithTcpSocket();
 
         if (!res) {
-            ythrow TServiceError(E_FAIL)
+            STORAGE_THROW_SERVICE_ERROR(E_FAIL)
                 << "could not start gRPC client";
         }
 
@@ -742,7 +742,7 @@ protected:
         auto& config = AppCtx.Config;
 
         if (config->GetSecurePort() == 0 && config->GetPort() == 0) {
-            ythrow TServiceError(E_ARGUMENT)
+            STORAGE_THROW_SERVICE_ERROR(E_ARGUMENT)
                 << "gRPC client ports are not set";
         }
 

--- a/cloud/filestore/libs/endpoint_vhost/listener.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/listener.cpp
@@ -101,7 +101,7 @@ public:
 
         auto filestore = FileStoreEndpoints->GetEndpoint(serviceEndpoint);
         if (!filestore) {
-            ythrow TServiceError(E_ARGUMENT)
+            STORAGE_THROW_SERVICE_ERROR(E_ARGUMENT)
                 << "invalid service endpoint " << serviceEndpoint.Quote();
         }
 

--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -426,7 +426,7 @@ void TAppContext::ValidateRequest(
         bool result = TryParseSourceFd(peer, &fd);
 
         if (!result) {
-            ythrow TServiceError(E_FAIL)
+            STORAGE_THROW_SERVICE_ERROR(E_FAIL)
                 << "failed to parse request source fd: " << peer;
         }
 
@@ -434,7 +434,7 @@ void TAppContext::ValidateRequest(
         // so pretend they are coming from data channel.
         auto src = SessionStorage->FindSourceByFd(fd);
         if (!src) {
-            ythrow TServiceError(E_GRPC_UNAVAILABLE)
+            STORAGE_THROW_SERVICE_ERROR(E_GRPC_UNAVAILABLE)
                 << "endpoint has been stopped (fd = " << fd << ").";
         }
 
@@ -442,7 +442,7 @@ void TAppContext::ValidateRequest(
     }
 
     if (headers.HasInternal()) {
-        ythrow TServiceError(E_ARGUMENT)
+        STORAGE_THROW_SERVICE_ERROR(E_ARGUMENT)
             << "internal field should not be set by client";
     }
 
@@ -1656,7 +1656,7 @@ public:
 
         AppCtx.Server = builder.BuildAndStart();
         if (!AppCtx.Server) {
-            ythrow TServiceError(E_FAIL)
+            STORAGE_THROW_SERVICE_ERROR(E_FAIL)
                 << "could not start gRPC server";
         }
 

--- a/cloud/filestore/libs/service_local/fs.cpp
+++ b/cloud/filestore/libs/service_local/fs.cpp
@@ -110,7 +110,7 @@ void ConvertStats(const NLowLevel::TFileStatEx& stat, NProto::TNodeAttr& node)
      } else if (S_ISBLK(stat.Mode)) {
         node.SetType(NProto::E_BLOCKDEV_NODE);
      }  else {
-        ythrow TServiceError(E_IO) << "invalid stats";
+        STORAGE_THROW_SERVICE_ERROR(E_IO) << "invalid stats";
     }
 
     node.SetId(stat.INode);

--- a/cloud/filestore/libs/service_local/index.cpp
+++ b/cloud/filestore/libs/service_local/index.cpp
@@ -219,7 +219,7 @@ TNodeLoader::TNodeLoader(const TIndexNodePtr& rootNode)
     case NLowLevel::TFileId::EFileIdType::VastNfs:
         break;
     default:
-        ythrow TServiceError(E_FS_NOTSUPP)
+        STORAGE_THROW_SERVICE_ERROR(E_FS_NOTSUPP)
             << "Not supported hande type, RootFileId=" << RootFileId.ToString();
     }
 }
@@ -252,7 +252,7 @@ TIndexNodePtr TNodeLoader::LoadNode(ui64 nodeId) const
         fileId.VastNfsInodeId.FileType = S_IFREG;
         break;
     default:
-        ythrow TServiceError(E_FS_NOTSUPP);
+        STORAGE_THROW_SERVICE_ERROR(E_FS_NOTSUPP);
     }
 
     auto handle =  fileId.Open(RootHandle, O_PATH);

--- a/cloud/filestore/libs/service_local/lowlevel.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel.cpp
@@ -316,7 +316,7 @@ TListDirResult ListDirAt(
     auto* dir = fdopendir(fd);
     if (!dir) {
         close(fd);
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "failed to list dir: "
             << LastSystemErrorText();
     }
@@ -378,7 +378,7 @@ void Fsync(const TFileHandle& handle, bool datasync)
 {
     int res = datasync ? fdatasync(Fd(handle)) : fsync(Fd(handle));
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "failed to fsync, datasync=" << datasync << " "
             << LastSystemErrorText();
     }
@@ -393,7 +393,7 @@ void Access(const TFileHandle& handle, int mode)
 
     int res = access(path, mode);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "access failed: "
             << LastSystemErrorText();
     }
@@ -406,7 +406,7 @@ void Chmod(const TFileHandle& handle, int mode)
 
     int res = chmod(path, mode);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "chmod failed: "
             << LastSystemErrorText();
     }
@@ -419,7 +419,7 @@ void Chown(const TFileHandle& handle, uid_t uid, gid_t gid)
 
     int res = chown(path, uid, gid);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "chown failed: "
             << LastSystemErrorText();
     }
@@ -434,7 +434,7 @@ void Utimes(const TFileHandle& handle, TInstant atime, TInstant mtime)
 
     int res = utimensat(AT_FDCWD, path, tv, 0);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "utime failed: "
             << LastSystemErrorText();
     }
@@ -447,7 +447,7 @@ void Truncate(const TFileHandle& handle, size_t size)
 
     int res = truncate(path, size);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "truncate failed: "
             << LastSystemErrorText();
     }
@@ -467,13 +467,13 @@ TString ReadLink(const TFileHandle& handle)
 
     int res = readlinkat(Fd(handle), "", &link[0], link.size());
     if (res == -1) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "readlink failed: "
             << LastSystemErrorText();
     }
 
     if ((size_t)res == link.size()) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "readlink failed: name is too long";
     }
 
@@ -498,7 +498,7 @@ TString GetXAttr(const TFileHandle& handle, const TString& name)
             0);
 
         if (res < 0) {
-            ythrow TServiceError(ErrorAttributeDoesNotExist(name));
+            STORAGE_THROW_SERVICE_ERROR(ErrorAttributeDoesNotExist(name));
         }
 
         buf.resize(res + 1);
@@ -514,7 +514,7 @@ TString GetXAttr(const TFileHandle& handle, const TString& name)
                 continue;
             }
 
-            ythrow TServiceError(E_IO)
+            STORAGE_THROW_SERVICE_ERROR(E_IO)
                 << "failed to get attribute (" << name.Quote() << "): "
                 << LastSystemErrorText();
         }
@@ -540,7 +540,7 @@ void SetXAttr(
         0 /*create or replace*/);
 
     if (res != 0) {
-        ythrow TServiceError(E_IO)
+        STORAGE_THROW_SERVICE_ERROR(E_IO)
             << "failed to set attribute (" << name.Quote() << ", " << value.Quote() << "): "
             << LastSystemErrorText();
     }
@@ -553,7 +553,7 @@ void RemoveXAttr(const TFileHandle& handle, const TString& name)
 
     int res = removexattr(path, name.c_str());
     if (res != 0) {
-        ythrow TServiceError(E_IO)
+        STORAGE_THROW_SERVICE_ERROR(E_IO)
             << "failed to remove attribute (" << name.Quote() << "): "
             << LastSystemErrorText();
     }
@@ -573,7 +573,7 @@ TVector<TString> ListXAttrs(const TFileHandle& handle)
             0);
 
         if (res < 0) {
-            ythrow TServiceError(E_IO)
+            STORAGE_THROW_SERVICE_ERROR(E_IO)
                 << "failed to list attributes: "
                 << LastSystemErrorText();
         }
@@ -590,7 +590,7 @@ TVector<TString> ListXAttrs(const TFileHandle& handle)
                 continue;
             }
 
-            ythrow TServiceError(E_IO)
+            STORAGE_THROW_SERVICE_ERROR(E_IO)
                 << "failed to list attributes: "
                 << LastSystemErrorText();
         }
@@ -621,7 +621,7 @@ bool AcquireLock(
     int res = fcntl(Fd(handle), F_OFD_SETLK, &lck);
     if (res != 0) {
         if (errno != EAGAIN) {
-            ythrow TServiceError(GetSystemErrorCode())
+            STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
                 << "lock failed at (" << offset << ", " << len << "): "
                 << LastSystemErrorText();
         }
@@ -642,7 +642,7 @@ bool TestLock(const TFileHandle& handle, off_t offset, off_t len, bool shared)
 
     int res = fcntl(Fd(handle), F_OFD_GETLK, &lck);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "test lock failed at (" << offset << ", " << len << "): "
             << LastSystemErrorText();
     }
@@ -660,7 +660,7 @@ void ReleaseLock(const TFileHandle& handle, off_t offset, off_t len)
 
     int res = fcntl(Fd(handle), F_OFD_SETLK, &lck);
     if (res != 0) {
-        ythrow TServiceError(GetSystemErrorCode())
+        STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
             << "unlock failed at (" << offset << ", " << len << "): "
             << LastSystemErrorText();
     }
@@ -671,7 +671,7 @@ bool Flock(const TFileHandle& handle, int operation)
     int res = flock(Fd(handle), operation);
     if (res != 0) {
         if (errno != EAGAIN) {
-            ythrow TServiceError(GetSystemErrorCode())
+            STORAGE_THROW_SERVICE_ERROR(GetSystemErrorCode())
                 << "flock failed: " << LastSystemErrorText();
         }
         return false;


### PR DESCRIPTION
### Notes
`ythrow TServiceError(...)` produces messages like this:
```
(NCloud::TServiceError) cloud/filestore/apps/client/lib/list_endpoints.cpp:25:
``` 
no error details by default, file:line gets misplaced as well in the cases when error message is not empty:
```
(NCloud::TServiceError) some messagecloud/filestore/apps/client/lib/list_endpoints.cpp:26:
```

adding `STORAGE_THROW_SERVICE_ERROR(...)` produces much better messages:
```
(NCloud::TServiceError) /home/astr/git/nbs/cloud/filestore/apps/client/lib/list_endpoints.cpp:25: E_GRPC_UNIMPLEMENTED | some details
```

updated filestore-client to use the new macro instead of the old approach