### PR TITLE
issue-4649: replace E_NOT_FOUND with E_TRANSPORT_ERROR in mmap region error handling

### DIFF
--- a/cloud/filestore/libs/server/server_memory_state.cpp
+++ b/cloud/filestore/libs/server/server_memory_state.cpp
@@ -107,7 +107,7 @@ NProto::TError TServerState::DestroyMmapRegion(ui64 mmapId)
     auto it = MmapRegions.find(mmapId);
     if (it == MmapRegions.end()) {
         return MakeError(
-            E_NOT_FOUND,
+            E_TRANSPORT_ERROR,
             Sprintf("Mmap region not found: %lu", mmapId));
     }
     auto metadata = it->second.ToMetadata();
@@ -142,7 +142,7 @@ TResultOrError<TMmapRegionMetadata> TServerState::GetMmapRegion(ui64 mmapId)
     auto it = MmapRegions.find(mmapId);
     if (it == MmapRegions.end()) {
         return MakeError(
-            E_NOT_FOUND,
+            E_TRANSPORT_ERROR,
             Sprintf("Mmap region not found: %lu", mmapId));
     }
     return it->second.ToMetadata();
@@ -154,7 +154,7 @@ NProto::TError TServerState::PingMmapRegion(ui64 mmapId)
     auto it = MmapRegions.find(mmapId);
     if (it == MmapRegions.end()) {
         return MakeError(
-            E_NOT_FOUND,
+            E_TRANSPORT_ERROR,
             Sprintf("Mmap region not found: %lu", mmapId));
     }
 

--- a/cloud/filestore/libs/server/server_memory_state_ut.cpp
+++ b/cloud/filestore/libs/server/server_memory_state_ut.cpp
@@ -164,7 +164,7 @@ Y_UNIT_TEST_SUITE(TServerStateTest)
         const auto result = state.DestroyMmapRegion(999999);
 
         UNIT_ASSERT(HasError(result));
-        UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, result.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(E_TRANSPORT_ERROR, result.GetCode());
     }
 
     Y_UNIT_TEST(ShouldListMmapRegions)
@@ -223,8 +223,11 @@ Y_UNIT_TEST_SUITE(TServerStateTest)
         UNIT_ASSERT_VALUES_EQUAL(mmapInfo.Size, result.GetResult().Size);
         UNIT_ASSERT_VALUES_EQUAL(mmapInfo.Id, result.GetResult().Id);
 
-        result = state.GetMmapRegion(999999);
+        result = state.GetMmapRegion(mmapInfo.Id + 1);
         UNIT_ASSERT(HasError(result));
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_TRANSPORT_ERROR,
+            result.GetError().GetCode());
     }
 
     Y_UNIT_TEST(ShouldPingMmapRegion)

--- a/cloud/storage/core/libs/common/error.h
+++ b/cloud/storage/core/libs/common/error.h
@@ -118,6 +118,7 @@ enum EWellKnownResultCodes: ui32
     E_IO_SILENT                  = MAKE_ERROR(13),  // A legacy code for input/output errors. Unlike E_IO, it does not increment the fatal error counter in monitoring
     E_RETRY_TIMEOUT              = MAKE_ERROR(14),  // The total time limit (24 hours) for executing the request has expired
     E_PRECONDITION_FAILED        = MAKE_ERROR(15),  // Transition to the requested state would violate object's preconditions (e.g. unexpected order of operations, write request in read-only state...). This error is not retryable
+    E_TRANSPORT_ERROR            = MAKE_ERROR(16),
 
     E_GRPC_CANCELLED             = MAKE_GRPC_ERROR(1),
     E_GRPC_UNKNOWN               = MAKE_GRPC_ERROR(2),


### PR DESCRIPTION
#4649