### PR TITLE
filestore: small cleanup

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-storage.txt
+++ b/cloud/filestore/bin/nfs/nfs-storage.txt
@@ -2,7 +2,7 @@ SchemeShardDir: "/Root/NFS"
 MultiTabletForwardingEnabled: true
 AllowFileStoreForceDestroy: true
 AutomaticShardCreationEnabled: true
-AutomaticallyCreatedShardSize: 1073741824
+StrictFileSystemSizeEnforcementEnabled: true
 ThreeStageWriteEnabled: true
 UnalignedThreeStageWriteEnabled: true
 DirectoryHandlesStorageEnabled: true


### PR DESCRIPTION
### Notes
* enabled `StrictFileSystemSizeEnforcementEnabled: true` instead of fixed shard size for local setup
* fixed typos and removed some minor code duplication from `TAlterFileStoreActor` (small side-effect - we'll print MainFileSystemId if for some reason we receive main filesystem cookie in shard event handlers instead of "UNKNOWN", which is good IMO)