### PR TITLE
Return disk agent to online from "back from unavailable"

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1474,4 +1474,11 @@ message TStorageServiceConfig
     // Maximum number of inflight attach/detach path requests.
     // VolumeBalancerMaxInProgress == 0 means no limit
     optional uint64 VolumeBalancerMaxInProgress = 488;
+
+    // Delay before changing Disk Agent from "back from unavailable" to online
+    // (time that must pass since the last status change).
+    optional uint64 AgentBackFromUnavailableToOnlineDelay = 489;
+
+    // Interval for checking disk agents with status "back from unavailable".
+    optional uint64 AgentBackFromUnavailableCheckInterval = 490;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -683,6 +683,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
         NProto::EOverlappingRequestsPolicy,                                    \
         NProto::EOverlappingRequestsPolicy::ORP_ENABLE                        )\
     xxx(VolumeBalancerMaxInProgress,          ui64,        0                  )\
+    xxx(AgentBackFromUnavailableToOnlineDelay,     TDuration,   Days(30)      )\
+    xxx(AgentBackFromUnavailableCheckInterval,     TDuration,   Days(0)       )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -786,6 +786,9 @@ public:
     GetPoolKindToMediaKindMapping() const;
 
     [[nodiscard]] ui64 GetVolumeBalancerMaxInProgress() const;
+
+    [[nodiscard]] TDuration GetAgentBackFromUnavailableToOnlineDelay() const;
+    [[nodiscard]] TDuration GetAgentBackFromUnavailableCheckInterval() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.cpp
@@ -316,6 +316,21 @@ void TDiskRegistryActor::ScheduleEnsureDiskRegistryStateIntegrity(
             new TEvDiskRegistry::TEvEnsureDiskRegistryStateIntegrityRequest()));
 }
 
+void TDiskRegistryActor::ScheduleRestoreAgentsToOnline(
+    const NActors::TActorContext& ctx)
+{
+    if (!Config->GetAgentBackFromUnavailableCheckInterval()) {
+        return;
+    }
+
+    ctx.Schedule(
+        Config->GetAgentBackFromUnavailableCheckInterval(),
+        std::make_unique<IEventHandle>(
+            SelfId(),
+            SelfId(),
+            new TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest()));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TDiskRegistryActor::HandlePoisonPill(
@@ -753,8 +768,14 @@ STFUNC(TDiskRegistryActor::StateWork)
 
         HFunc(
             TEvDiskRegistry::TEvEnsureDiskRegistryStateIntegrityResponse,
-            HandleEnsureDiskRegistryStateIntegrityResponse
-        )
+            HandleEnsureDiskRegistryStateIntegrityResponse);
+
+        HFunc(TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest,
+            HandleRestoreAgentsToOnline);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineResponse,
+            HandleRestoreAgentsToOnlineResponse);
 
         default:
             if (!HandleRequests(ev) && !HandleDefaultEvents(ev, SelfId())) {
@@ -811,8 +832,15 @@ STFUNC(TDiskRegistryActor::StateRestore)
 
         HFunc(
             TEvDiskRegistry::TEvEnsureDiskRegistryStateIntegrityResponse,
-            HandleEnsureDiskRegistryStateIntegrityResponse
-        )
+            HandleEnsureDiskRegistryStateIntegrityResponse);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest,
+            HandleRestoreAgentsToOnlineReadOnly);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineResponse,
+            HandleRestoreAgentsToOnlineResponse);
 
         IgnoreFunc(TEvDiskRegistryPrivate::TEvSwitchAgentDisksToReadOnlyResponse);
 
@@ -891,8 +919,15 @@ STFUNC(TDiskRegistryActor::StateReadOnly)
 
         HFunc(
             TEvDiskRegistry::TEvEnsureDiskRegistryStateIntegrityResponse,
-            HandleEnsureDiskRegistryStateIntegrityResponse
-        )
+            HandleEnsureDiskRegistryStateIntegrityResponse);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest,
+            HandleRestoreAgentsToOnlineReadOnly);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineResponse,
+            HandleRestoreAgentsToOnlineResponse);
 
         IgnoreFunc(
             TEvDiskRegistryPrivate::TEvSwitchAgentDisksToReadOnlyResponse);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -341,6 +341,8 @@ private:
     void ScheduleEnsureDiskRegistryStateIntegrity(
         const NActors::TActorContext& ctx);
 
+    void ScheduleRestoreAgentsToOnline(const NActors::TActorContext& ctx);
+
     void ProcessPathsToAttachOnAgent(
         const NActors::TActorContext& ctx,
         const NProto::TAgentConfig& agent,
@@ -547,6 +549,14 @@ private:
 
     void HandleEnsureDiskRegistryStateIntegrityResponse(
         const TEvDiskRegistry::TEvEnsureDiskRegistryStateIntegrityResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleRestoreAgentsToOnlineReadOnly(
+        const TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleRestoreAgentsToOnlineResponse(
+        const TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     BLOCKSTORE_DISK_REGISTRY_REQUESTS(BLOCKSTORE_IMPLEMENT_REQUEST, TEvDiskRegistry)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_loadstate.cpp
@@ -215,6 +215,8 @@ void TDiskRegistryActor::CompleteLoadState(
 
     ProcessPathsToAttach(ctx);
 
+    ScheduleRestoreAgentsToOnline(ctx);
+
     if (auto orphanDevices = State->FindOrphanDevices()) {
         LOG_INFO(
             ctx,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_restore_agents_to_online.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_restore_agents_to_online.cpp
@@ -1,0 +1,285 @@
+#include "disk_registry_actor.h"
+
+#include <cloud/storage/core/libs/common/format.h>
+
+#include <util/string/join.h>
+
+using namespace NActors;
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRestoreAgentsActor final: public TActorBootstrapped<TRestoreAgentsActor>
+{
+private:
+    const TActorId DiskRegistryActorId;
+    const TRequestInfoPtr RequestInfo;
+    const TDuration RestoreAgentsDelay;
+
+    NProto::TError LastError;
+    size_t ResponsesCount = 0;
+    size_t RequestsSent = 0;
+    TVector<NProto::TAgentInfo> Agents;
+    TVector<TString> AffectedAgents;
+
+public:
+    TRestoreAgentsActor(
+        const TActorId& diskRegistryActorId,
+        TRequestInfoPtr requestInfo,
+        TDuration restoreAgentsDelay);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void QueryAgentsList(const TActorContext& ctx);
+    void ReplyAndDie(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleQueryAgentsInfoResponse(
+        const TEvService::TEvQueryAgentsInfoResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleQueryAgentsInfoUndelivery(
+        const TEvService::TEvQueryAgentsInfoRequest::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleChangeAgentStateResponse(
+        const TEvDiskRegistry::TEvChangeAgentStateResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleChangeAgentStateUndelivery(
+        const TEvDiskRegistry::TEvChangeAgentStateRequest::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TRestoreAgentsActor::TRestoreAgentsActor(
+    const TActorId& diskRegistryActorId,
+    TRequestInfoPtr requestInfo,
+    TDuration restoreAgentsDelay)
+    : DiskRegistryActorId(diskRegistryActorId)
+    , RequestInfo(std::move(requestInfo))
+    , RestoreAgentsDelay(restoreAgentsDelay)
+{}
+
+void TRestoreAgentsActor::Bootstrap(const TActorContext& ctx)
+{
+    Become(&TThis::StateWork);
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "Restoring agents with status \"back from unavailable\" and last state "
+        "change more than %s ago",
+        FormatDuration(RestoreAgentsDelay).c_str());
+
+    QueryAgentsList(ctx);
+}
+
+void TRestoreAgentsActor::QueryAgentsList(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvService::TEvQueryAgentsInfoRequest>();
+    request->Record.MutableFilter()->AddStates(
+        NProto::EAgentState::AGENT_STATE_WARNING);
+
+    NCloud::SendWithUndeliveryTracking(
+        ctx,
+        DiskRegistryActorId,
+        std::move(request));
+}
+
+void TRestoreAgentsActor::ReplyAndDie(const TActorContext& ctx)
+{
+    auto response = std::make_unique<
+        TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineResponse>(LastError);
+    response->AffectedAgents = AffectedAgents;
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TRestoreAgentsActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    Die(ctx);
+}
+
+void TRestoreAgentsActor::HandleQueryAgentsInfoResponse(
+    const TEvService::TEvQueryAgentsInfoResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    Agents = {msg->Record.GetAgents().begin(), msg->Record.GetAgents().end()};
+
+    for (size_t agentIdx = 0; agentIdx < Agents.size(); agentIdx++) {
+        const auto& agentInfo = Agents[agentIdx];
+        TDuration timeSinceLastChange =
+            ctx.Now() - TInstant::MicroSeconds(agentInfo.GetStateTs());
+
+        if (agentInfo.GetStateMessage() == BackFromUnavailableStateMessage &&
+            timeSinceLastChange > RestoreAgentsDelay)
+        {
+            auto request =
+                std::make_unique<TEvDiskRegistry::TEvChangeAgentStateRequest>();
+
+            request->Record.SetAgentId(agentInfo.GetAgentId());
+            request->Record.SetAgentState(NProto::AGENT_STATE_ONLINE);
+            request->Record.SetReason(
+                TString(AutomaticallyRestoredStateMessage));
+
+            ++RequestsSent;
+
+            NCloud::SendWithUndeliveryTracking(
+                ctx,
+                DiskRegistryActorId,
+                std::move(request),
+                agentIdx);
+        }
+    }
+
+    if (RequestsSent == 0) {
+        ReplyAndDie(ctx);
+    }
+}
+
+void TRestoreAgentsActor::HandleQueryAgentsInfoUndelivery(
+    const TEvService::TEvQueryAgentsInfoRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    LastError = MakeError(E_REJECTED, "Failed to fetch agents");
+
+    ReplyAndDie(ctx);
+}
+
+void TRestoreAgentsActor::HandleChangeAgentStateResponse(
+    const TEvDiskRegistry::TEvChangeAgentStateResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        LastError = msg->GetError();
+    } else {
+        AffectedAgents.emplace_back(Agents[ev->Cookie].GetAgentId());
+    }
+
+    ++ResponsesCount;
+    if (ResponsesCount == RequestsSent) {
+        ReplyAndDie(ctx);
+    }
+}
+
+void TRestoreAgentsActor::HandleChangeAgentStateUndelivery(
+    const TEvDiskRegistry::TEvChangeAgentStateRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LastError = MakeError(
+        E_REJECTED,
+        TStringBuilder() << "ChangeAgentStateRequest to agent "
+                         << msg->Record.GetAgentId() << " undelivered");
+
+    ++ResponsesCount;
+    if (ResponsesCount == RequestsSent) {
+        ReplyAndDie(ctx);
+    }
+}
+
+STFUNC(TRestoreAgentsActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(
+            TEvService::TEvQueryAgentsInfoResponse,
+            HandleQueryAgentsInfoResponse);
+        HFunc(
+            TEvService::TEvQueryAgentsInfoRequest,
+            HandleQueryAgentsInfoUndelivery);
+        HFunc(
+            TEvDiskRegistry::TEvChangeAgentStateResponse,
+            HandleChangeAgentStateResponse);
+        HFunc(
+            TEvDiskRegistry::TEvChangeAgentStateRequest,
+            HandleChangeAgentStateUndelivery);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::HandleRestoreAgentsToOnline(
+    const TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    TActorId actorId = NCloud::Register<TRestoreAgentsActor>(
+        ctx,
+        ctx.SelfID,
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        Config->GetAgentBackFromUnavailableToOnlineDelay());
+    Actors.insert(actorId);
+}
+
+void TDiskRegistryActor::HandleRestoreAgentsToOnlineReadOnly(
+    const TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    ScheduleRestoreAgentsToOnline(ctx);
+}
+
+void TDiskRegistryActor::HandleRestoreAgentsToOnlineResponse(
+    const TEvDiskRegistryPrivate::TEvRestoreAgentsToOnlineResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (msg->AffectedAgents) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "Restored agents to online state: %s",
+            JoinSeq(", ", msg->AffectedAgents).c_str());
+    }
+
+    Actors.erase(ev->Sender);
+    if (HasError(msg->GetError())) {
+        LOG_ERROR(
+            ctx,
+            TBlockStoreComponents::DISK_REGISTRY,
+            "Restoring agents from \"back from unavailable\" failed: %s",
+            FormatError(msg->GetError()).c_str());
+    }
+
+    ScheduleRestoreAgentsToOnline(ctx);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -212,6 +212,7 @@ using TVolumeConfig = NKikimrBlockStore::TVolumeConfig;
     xxx(SwitchAgentDisksToReadOnly,                 __VA_ARGS__)               \
     xxx(PurgeHostCms,                               __VA_ARGS__)               \
     xxx(UpdatePathAttachState,                      __VA_ARGS__)               \
+    xxx(RestoreAgentsToOnline,                      __VA_ARGS__)               \
 // BLOCKSTORE_DISK_REGISTRY_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -810,6 +811,19 @@ struct TEvDiskRegistryPrivate
     };
 
     //
+    // RestoreAgentsToOnline
+    //
+
+    struct TRestoreAgentsToOnlineRequest
+    {
+    };
+
+    struct TRestoreAgentsToOnlineResponse
+    {
+        TVector<TString> AffectedAgents;
+    };
+
+    //
     // Events declaration
     //
 
@@ -828,6 +842,8 @@ struct TEvDiskRegistryPrivate
         EvDiskRegistryAgentListExpiredParamsCleanup,
 
         EvAttachDetachPathsOperationCompleted,
+
+        EvRestoreAgentsToOnline,
 
         EvEnd
     };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1134,7 +1134,7 @@ auto TDiskRegistryState::RegisterAgent(
                 agent,
                 NProto::AGENT_STATE_WARNING,
                 timestamp,
-                "back from unavailable");
+                TString(BackFromUnavailableStateMessage));
 
             ApplyAgentStateChange(db, agent, timestamp, affectedDisks);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -3276,6 +3276,99 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         UNIT_ASSERT_VALUES_EQUAL(stateMismatchLocalDbError->Val(), 1);
     }
+
+    Y_UNIT_TEST(ShouldRestoreAgentsToOnline)
+    {
+        TVector agents{
+            CreateAgentConfig(
+                "agent-1",
+                {
+                    Device("dev-1", "uuid-1.1", "rack-1", 10_GB),
+                    Device("dev-2", "uuid-1.2", "rack-1", 10_GB),
+                }),
+            CreateAgentConfig(
+                "agent-2",
+                {
+                    Device("dev-10", "uuid-10.1", "rack-10", 10_GB),
+                    Device("dev-20", "uuid-10.2", "rack-10", 10_GB),
+                }),
+            CreateAgentConfig(
+                "agent-3",
+                {
+                    Device("dev-11", "uuid-11.1", "rack-11", 10_GB),
+                    Device("dev-21", "uuid-11.2", "rack-11", 10_GB),
+                })};
+
+        NProto::TStorageServiceConfig config;
+
+        config.SetAgentBackFromUnavailableToOnlineDelay(
+            TDuration::Minutes(12).MilliSeconds());
+        config.SetAgentBackFromUnavailableCheckInterval(
+            TDuration::Minutes(1).MilliSeconds());
+        config.SetNonReplicatedDiskRecyclingPeriod(Max<ui32>());
+        config.SetAllocationUnitNonReplicatedSSD(10);
+
+        auto runtime =
+            TTestRuntimeBuilder().With(config).WithAgents(agents).Build();
+
+        TDiskRegistryClient diskRegistry(*runtime);
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+
+        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+
+        auto countSpecificAgentStatus = [&](NProto::EAgentState expectedState,
+                                            const TString& expectedMessage)
+        {
+            size_t count = 0;
+
+            NProto::TQueryAgentsInfoRequest::TAgentFilter filter;
+            filter.AddStates(expectedState);
+            auto response = diskRegistry.QueryAgentsInfo(filter);
+            for (auto& agentInfo: response->Record.GetAgents()) {
+                if (agentInfo.GetStateMessage() == expectedMessage) {
+                    count += 1;
+                }
+            }
+            return count;
+        };
+
+        RegisterAndWaitForAgents(*runtime, agents);
+
+        for (size_t i = 0; i < agents.size(); i++) {
+            auto& agent = agents[i];
+            diskRegistry.ChangeAgentState(
+                agent.agentid(),
+                NProto::EAgentState::AGENT_STATE_UNAVAILABLE);
+
+            agent.SetNodeId(i + 1);
+            diskRegistry.RegisterAgent(agent);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            countSpecificAgentStatus(
+                NProto::EAgentState::AGENT_STATE_WARNING,
+                "back from unavailable"));
+
+        runtime->AdvanceCurrentTime(6min);
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            countSpecificAgentStatus(
+                NProto::EAgentState::AGENT_STATE_WARNING,
+                "back from unavailable"));
+
+        runtime->AdvanceCurrentTime(7min);
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            countSpecificAgentStatus(
+                NProto::EAgentState::AGENT_STATE_ONLINE,
+                "automatically restored"));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/model/public.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/public.h
@@ -1,1 +1,12 @@
 #pragma once
+
+#include <util/generic/fwd.h>
+#include <util/generic/strbuf.h>
+
+namespace NCloud::NBlockStore {
+
+constexpr TStringBuf BackFromUnavailableStateMessage = "back from unavailable";
+constexpr TStringBuf AutomaticallyRestoredStateMessage =
+    "automatically restored";
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -45,6 +45,7 @@ SRCS(
     disk_registry_actor_replace_devices.cpp
     disk_registry_actor_replace.cpp
     disk_registry_actor_restore_state.cpp
+    disk_registry_actor_restore_agents_to_online.cpp
     disk_registry_actor_resume_device.cpp
     disk_registry_actor_secure_erase.cpp
     disk_registry_actor_set_user_id.cpp


### PR DESCRIPTION
Issue: https://github.com/ydb-platform/nbs/issues/1845

Restores agents with the status "back from unavailable" and a time elapsed since the last change greater than `RestoreAgentsToOnlineInterval`. The check for the presence of such agents is performed with the period set in the `CheckAgentsToRestoreToOnlineInterval` parameter.