### PR TITLE
Benchmark for TBlockRangeMap class

### DIFF
--- a/cloud/blockstore/libs/common/benchmark/ya.make
+++ b/cloud/blockstore/libs/common/benchmark/ya.make
@@ -11,6 +11,7 @@ ELSE()
 ENDIF()
 
 SRCS(
+    ../block_range_map_benchmark.cpp
     ../iovector_benchmark.cpp
 )
 

--- a/cloud/blockstore/libs/common/block_range_map_benchmark.cpp
+++ b/cloud/blockstore/libs/common/block_range_map_benchmark.cpp
@@ -1,0 +1,63 @@
+#include "block_range_map.h"
+
+#include <library/cpp/testing/gbenchmark/benchmark.h>
+
+#include <util/random/random.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+void BlockRangeMapBenchmark(
+    benchmark::State& state,
+    size_t ioDeps,
+    ui64 blockCount)
+{
+    const ui64 maxCount = 1024;
+    TBlockRangeMap<ui64, TString> map;
+    TVector<ui64> inflight;
+    ui64 keyGenerator = 0;
+
+    auto addRange = [&]() -> ui64
+    {
+        const ui64 key = keyGenerator++;
+        map.AddRange(
+            key,
+            TBlockRange64::WithLength(
+                RandomNumber<ui64>(blockCount),
+                RandomNumber<ui64>(maxCount) + 1));
+        return key;
+    };
+
+    for (size_t i = 0; i < ioDeps; ++i) {
+        inflight.push_back(addRange());
+    }
+
+    for (const auto _: state) {
+        const size_t indx = RandomNumber<size_t>(inflight.size());
+        auto val = map.ExtractRange(inflight[indx]);
+        Y_ABORT_UNLESS(val);
+        inflight[indx] = addRange();
+    }
+}
+
+}   // namespace
+
+///////////////////////////////////////////////////////////////////////////////
+
+#define DECLARE_BENCHMARK(ioDeps, blockCount)                           \
+    void BlockRangeMap_##ioDeps##_##blockCount(benchmark::State& state) \
+    {                                                                   \
+        BlockRangeMapBenchmark(state, ioDeps, blockCount);              \
+    }                                                                   \
+    BENCHMARK(BlockRangeMap_##ioDeps##_##blockCount);
+
+DECLARE_BENCHMARK(16, 100000);
+DECLARE_BENCHMARK(32, 100000);
+DECLARE_BENCHMARK(1024, 100000);
+DECLARE_BENCHMARK(1024, 1000000);
+DECLARE_BENCHMARK(1024, 10000000);
+
+}   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
```
BlockRangeMap_16_100000                            145 ns          145 ns      4725240
BlockRangeMap_32_100000                            148 ns          148 ns      4720900
BlockRangeMap_1024_100000                          197 ns          197 ns      3554158
BlockRangeMap_1024_1000000                         196 ns          196 ns      3559545
BlockRangeMap_1024_10000000                        197 ns          197 ns      3558830
```