### PR TITLE
Fix asan fail in test TFileRingBufferTest::ShouldResumeAbortedMetadataResize

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -792,7 +792,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             m.ResizeAndRemap(0, resized.length() + len);
             auto* data = static_cast<char*>(m.Ptr());
             MemCopy(data, initial.data(), initial.length());
-            MemCopy(data + resized.length(), initial.data() - len, 3);
+            const auto* entryData = initial.data() + initial.length() - len;
+            MemCopy(data + resized.length(), entryData, 3);
         }
         {
             TFileRingBuffer rb(f1.GetName(), len, 100);
@@ -812,8 +813,9 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             m.ResizeAndRemap(0, resized.length() + len);
             auto* data = static_cast<char*>(m.Ptr());
             MemCopy(data, initial.data(), initial.length());
-            MemCopy(data + resized.length(), initial.data() - len, len);
-            MemCopy(data + resized.length() - len, initial.data() - len, 3);
+            const auto* entryData = initial.data() + initial.length() - len;
+            MemCopy(data + resized.length(), entryData, len);
+            MemCopy(data + resized.length() - len, entryData, 3);
             *reinterpret_cast<ui64*>(data + 40) = resized.length();
         }
         {


### PR DESCRIPTION
```
=================================================================
==22643==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x612000002bb4 at pc 0x000000d89fcd bp 0x7ffdc5b60b90 sp 0x7ffdc5b60358
READ of size 3 at 0x612000002bb4 thread T0
    #0 0xd89fcc in __asan_memcpy /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3
    #1 0x9ea6dd in MemCopy<char> /actions-runner/_work/nbs/nbs/util/generic/mem_copy.h:18:9
    #2 0x9ea6dd in NCloud::NTestSuiteTFileRingBufferTest::TTestCaseShouldResumeAbortedMetadataResize::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:795:13
    #3 0x9f05e8 in NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1
    #4 0x9f05e8 in std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #5 0x9f05e8 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #6 0x9f05e8 in std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #7 0x9f05e8 in std::__y1::__function::__func<NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12
    #8 0x11c09da in std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16
    #9 0x11c09da in std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12
    #10 0x11c09da in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20
    #11 0x118fcb5 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18
    #12 0x9ef353 in NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1
    #13 0x1191a79 in NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19
    #14 0x11b8dfc in NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44
    #15 0x7fe546429d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #16 0x7fe546429e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #17 0x769d88 in _start (/home/github/.ya/build/build_root/l5cg/0012e9/cloud/storage/core/libs/common/ut/cloud-storage-core-libs-common-ut+0x769d88) (BuildId: a93909b0fcbc17331fc5bd2767230c2e7d76ae4b)
0x612000002bb4 is located 12 bytes before 288-byte region [0x612000002bc0,0x612000002ce0)
allocated by thread T0 here:
    #0 0xdbb9bd in operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_new_delete.cpp:95:3
    #1 0x9ea00d in std::__y1::__libcpp_operator_new<unsigned long> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/new:246:10
    #2 0x9ea00d in std::__y1::__libcpp_allocate /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/new:272:10
    #3 0x9ea00d in std::__y1::allocator<char>::allocate /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:112:38
    #4 0x9ea00d in std::__y1::__allocate_at_least<std::__y1::allocator<char> > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocate_at_least.h:54:19
    #5 0x9ea00d in std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> >::__init /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/string:2005:29
    #6 0x9ea00d in std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> >::basic_string /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/string:2033:5
    #7 0x9ea00d in TStdString<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >::TStdString<const char *&, unsigned long &> /actions-runner/_work/nbs/nbs/util/generic/string.h:74:11
    #8 0x9ea00d in TBasicString<char, std::__y1::char_traits<char> >::Construct<const char *&, unsigned long &> /actions-runner/_work/nbs/nbs/util/generic/string.h:206:21
    #9 0x9ea00d in TBasicString<char, std::__y1::char_traits<char> >::TBasicString /actions-runner/_work/nbs/nbs/util/generic/string.h:449:18
    #10 0x9ea00d in NCloud::NTestSuiteTFileRingBufferTest::TTestCaseShouldResumeAbortedMetadataResize::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:776:23
    #11 0x9f05e8 in NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1
    #12 0x9f05e8 in std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #13 0x9f05e8 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #14 0x9f05e8 in std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #15 0x9f05e8 in std::__y1::__function::__func<NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12
    #16 0x11c09da in std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16
    #17 0x11c09da in std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12
    #18 0x11c09da in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20
    #19 0x118fcb5 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18
    #20 0x9ef353 in NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:176:1
    #21 0x1191a79 in NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19
    #22 0x11b8dfc in NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44
    #23 0x7fe546429d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
SUMMARY: AddressSanitizer: heap-buffer-overflow /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3 in __asan_memcpy
Shadow bytes around the buggy address:
  0x612000002900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x612000002980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x612000002a00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x612000002a80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x612000002b00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x612000002b80: fa fa fa fa fa fa[fa]fa 00 00 00 00 00 00 00 00
  0x612000002c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x612000002c80: 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa
  0x612000002d00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x612000002d80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x612000002e00: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==22643==ABORTING
```