### PR TITLE
[Disk Manager] Delete disk form nbs even if the disk is absent in dm database

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
@@ -74,13 +74,15 @@ func (t *deleteDiskTask) deleteDisk(
 
 	zoneID := ""
 	if diskMeta != nil {
+		// Disk exists in the database.
 		zoneID = diskMeta.ZoneID
 	}
 	if len(zoneID) == 0 {
-		// Should proceed deleting even if the disk is absent it the storage.
+		// Disk does not exist in the database. Nevertheless, proceed deleting.
 		zoneID = t.request.Disk.ZoneId
 	}
 	if len(zoneID) == 0 {
+		// Zone was not specified in the request.
 		return t.storage.DiskDeleted(ctx, diskID, time.Now())
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task_test.go
@@ -248,7 +248,7 @@ func TestDeleteDiskTaskWithNonExistentDisk(t *testing.T) {
 	).Return((*resources.DiskMeta)(nil), nil)
 	storage.On("DiskDeleted", ctx, "disk", mock.Anything).Return(nil)
 
-	// Should proceed deleting even if the disk is absent it the storage.
+	// Should proceed deleting even if the disk is absent it the database.
 	nbsFactory.On("GetClient", ctx, "zone").Return(nbsClient, nil)
 	nbsClient.On("Delete", ctx, "disk").Return(nil)
 


### PR DESCRIPTION
The logic changed In https://github.com/ydb-platform/nbs/pull/4339: since then, we don't proceed deleting disk if it is absent in dm database.

But in fact, we should. In particular, the destroy volume request should be sent to NBS.