### PR TITLE
issue-568: checksumming for profile log - ignoring buffer overflows for reads, not ignoring any kind of buffer overflows for writes, reporting debug-info in buffer overflow crit event

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -38,6 +38,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheCorruptionError)                                         \
     xxx(ErrorWasSentToTheGuest)                                                \
     xxx(DirectoryHandlesStorageError)                                          \
+    xxx(CalculateChecksumsBufferOverflow)                                      \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_IMPOSSIBLE_EVENTS(xxx)                                       \
@@ -60,7 +61,6 @@ namespace NCloud::NFileStore{
     xxx(FailedToLockNodeRef)                                                   \
     xxx(InvalidNodeRefUponCompleteUnlinkNode)                                  \
     xxx(UnknownOpLogEntry)                                                     \
-    xxx(CalculateChecksumsBufferOverflow)                                      \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/diagnostics/profile_log_events.h
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.h
@@ -91,9 +91,25 @@ void FinalizeProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
     const TProtoResponse& response);
 
-void CalculateChecksums(
+/**
+ * @brief Calculates buffer checksums corresponding to the ranges in the
+ * supplied profile-log-request.
+ *
+ * @param buffer - data buffer.
+ * @param blockSize - Filesystem block size.
+ * @param ignoreBufferOverflow - if true, buffer vs ranges inconsistencies will
+ *  be ignored, otherwise a crit event will be raised and calculation will be
+ *  aborted.
+ * @param fsId - this will be added to crit event message.
+ * @param profileLogRequest - Profile log request reference.
+ *
+ * @return false if the input is inconsistent, true - otherwise.
+ */
+bool CalculateChecksums(
     const TStringBuf buffer,
     ui32 blockSize,
+    bool ignoreBufferOverflow,
+    TStringBuf fsId,
     NProto::TProfileLogRequestInfo& profileLogRequest);
 
 /**
@@ -103,8 +119,10 @@ void CalculateChecksums(
  * @param request - Request proto.
  * @param blockSize - Filesystem block size.
  * @param profileLogRequest - Profile log request reference.
+ *
+ * @return false if the input is inconsistent, true - otherwise.
  */
-void CalculateWriteDataRequestChecksums(
+bool CalculateWriteDataRequestChecksums(
     const NProto::TWriteDataRequest& request,
     ui32 blockSize,
     NProto::TProfileLogRequestInfo& profileLogRequest);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -526,6 +526,8 @@ void TReadDataActor::ReplyAndDie(
                 CalculateChecksums(
                     response->Record.GetBuffer(),
                     BlockSize,
+                    true /* ignoreBufferOverflow */,
+                    FileSystemId,
                     ProfileLogRequest);
             }
         }
@@ -1069,6 +1071,8 @@ void TIndexTabletActor::CompleteTx_ReadData(
             CalculateChecksums(
                 response->Record.GetBuffer(),
                 GetBlockSize(),
+                true /* ignoreBufferOverflow */,
+                GetFileSystemId(),
                 args.ProfileLogRequest);
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -44,6 +44,8 @@ void TIndexTabletActor::HandleWriteData(
         CalculateChecksums(
             buffer,
             GetBlockSize(),
+            false /* ignoreBufferOverflow */,
+            GetFileSystemId(),
             profileLogRequest);
     }
 


### PR DESCRIPTION
### Notes
* ReadData: having a range which is either partially or completely beyond the end of the buffer is valid, the client can try to read beyond the end of the file, we shouldn't be reporting crit events in this case
* WriteData: any kind of buffer overflow - even partial - is not okay, we should report a crit event
* reporting debug info in the buffer-overflow crit event - fs-id, node-id, range, buffer-size 

### Issue
https://github.com/ydb-platform/nbs/issues/568