### PR TITLE
Making `SamplingRate` configurable per test-suite and cleaning up some incorrect and confusing code

### DIFF
--- a/cloud/filestore/tests/client/ya.make
+++ b/cloud/filestore/tests/client/ya.make
@@ -21,6 +21,8 @@ SET(
     cloud/filestore/tests/client/nfs-storage.txt
 )
 
+SET(NFS_TRACE_SAMPLING_RATE 1)
+
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 
 END()

--- a/cloud/filestore/tests/python/lib/daemon_config.py
+++ b/cloud/filestore/tests/python/lib/daemon_config.py
@@ -62,6 +62,7 @@ class FilestoreDaemonConfigGenerator:
         secure=False,
         access_service_type=AccessService,
         ic_port=None,
+        trace_sampling_rate=None,
     ):
         self.__binary_path = binary_path
         self.__working_dir, self.__configs_dir = get_directories()
@@ -99,6 +100,8 @@ class FilestoreDaemonConfigGenerator:
                 config_file.flush()
         if self.__is_storage_kikimr():
             self.__storage_config.SchemeShardDir = "/Root/nfs"
+
+        self.__trace_sampling_rate = trace_sampling_rate
 
     @property
     def port(self):
@@ -235,7 +238,7 @@ class FilestoreDaemonConfigGenerator:
 
         config.ProfileLogTimeThreshold = 100
         config.DumpTracksInterval = 100
-        config.SamplingRate = 1
+        config.SamplingRate = self.__trace_sampling_rate or 10000
         config.SlowRequestSamplingRate = 1000
         config.HDDSlowRequestThreshold = 1000
         config.SSDSlowRequestThreshold = 1000
@@ -395,6 +398,7 @@ class FilestoreServerConfigGenerator(FilestoreDaemonConfigGenerator):
         secure=False,
         access_service_type=AccessService,
         ic_port=None,
+        trace_sampling_rate=None,
     ):
         super().__init__(
             binary_path,
@@ -413,7 +417,8 @@ class FilestoreServerConfigGenerator(FilestoreDaemonConfigGenerator):
             use_secure_registration=use_secure_registration,
             secure=secure,
             access_service_type=access_service_type,
-            ic_port=ic_port
+            ic_port=ic_port,
+            trace_sampling_rate=trace_sampling_rate,
         )
 
 
@@ -434,6 +439,7 @@ class FilestoreVhostConfigGenerator(FilestoreDaemonConfigGenerator):
         ic_port=None,
         access_service_type=AccessService,
         secure=False,
+        trace_sampling_rate=None,
     ):
         super().__init__(
             binary_path,
@@ -452,7 +458,8 @@ class FilestoreVhostConfigGenerator(FilestoreDaemonConfigGenerator):
             use_secure_registration=use_secure_registration,
             ic_port=ic_port,
             access_service_type=access_service_type,
-            secure=secure
+            secure=secure,
+            trace_sampling_rate=trace_sampling_rate,
         )
 
         self.__local_service_port = self._port_manager.get_port()

--- a/cloud/filestore/tests/recipes/service-kikimr.inc
+++ b/cloud/filestore/tests/recipes/service-kikimr.inc
@@ -37,6 +37,10 @@ IF (USE_UNIX_SOCKET)
     SET_APPEND(RECIPE_ARGS --use-unix-socket)
 ENDIF()
 
+IF (NFS_TRACE_SAMPLING_RATE)
+    SET_APPEND(RECIPE_ARGS --trace-sampling-rate $NFS_TRACE_SAMPLING_RATE)
+ENDIF()
+
 USE_RECIPE(
     cloud/filestore/tests/recipes/service-kikimr/service-kikimr-recipe
     ${RECIPE_ARGS}

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -45,6 +45,7 @@ def start(argv):
     parser.add_argument("--server-config-patch", action="store", default=None)
     parser.add_argument("--bs-cache-file-path", action="store", default=None)
     parser.add_argument("--use-unix-socket", action="store_true", default=False)
+    parser.add_argument("--trace-sampling-rate", action="store", default=None, type=int)
     args = parser.parse_args(argv)
 
     kikimr_binary_path = common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
@@ -139,6 +140,7 @@ def start(argv):
         storage_config=storage_config,
         secure=secure,
         access_service_type=access_service_type,
+        trace_sampling_rate=args.trace_sampling_rate,
     )
     filestore_configurator.generate_configs(kikimr_configurator.domains_txt, kikimr_configurator.names_txt)
 

--- a/cloud/filestore/tests/recipes/vhost-kikimr.inc
+++ b/cloud/filestore/tests/recipes/vhost-kikimr.inc
@@ -31,6 +31,10 @@ IF (USE_VHOST_UNIX_SOCKET)
     SET_APPEND(RECIPE_ARGS --use-unix-socket)
 ENDIF()
 
+IF (NFS_TRACE_SAMPLING_RATE)
+    SET_APPEND(RECIPE_ARGS --trace-sampling-rate $NFS_TRACE_SAMPLING_RATE)
+ENDIF()
+
 USE_RECIPE(
     cloud/filestore/tests/recipes/vhost/vhost-recipe
     ${RECIPE_ARGS}

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -45,6 +45,7 @@ def start(argv):
     parser.add_argument("--storage-config-patch", action="store", default=None)
     parser.add_argument("--direct-io", action="store_true", default=False)
     parser.add_argument("--use-unix-socket", action="store_true", default=False)
+    parser.add_argument("--trace-sampling-rate", action="store", default=None, type=int)
 
     args = parser.parse_args(argv)
 
@@ -156,6 +157,7 @@ def start(argv):
         restart_flag=restart_flag,
         storage_config=storage_config,
         access_service_type=access_service_type,
+        trace_sampling_rate=args.trace_sampling_rate,
     )
 
     filestore_vhost = FilestoreVhost(vhost_configurator)


### PR DESCRIPTION
### Notes
Making `SamplingRate` configurable per test-suite.

Needed to mostly revert incorrect code merged here https://github.com/ydb-platform/nbs/pull/2886 to be able to do that - done as a separate commit to make the whole thing easy to review. Reverting that code because:
* `diag_config_file` was never passed from the outside - the only way it was used was to pass it from `Filestore{Server,Vhost}ConfigGenerator` constructors to their parent's (`FilestoreDaemonConfigGenerator`) constructor
* the actual value used for `diag_config_file` was "diag.txt" which is the same value that's used internally by `FilestoreDaemonConfigGenerator`
* `--diag-file ...somepath.../diag.txt` was added twice to the commandline
* even though the contents of diag.txt were generated by `Filestore{Server,Vhost}ConfigGenerator` constructors, they were later overwritten by `FilestoreDaemonConfigGenerator::generate_configs()`