### PR TITLE
Checking prohibited dependencies for binaries.

### DIFF
--- a/cloud/blockstore/apps/disk_agent/ya.make
+++ b/cloud/blockstore/apps/disk_agent/ya.make
@@ -2,6 +2,8 @@ PROGRAM(diskagentd)
 
 ALLOCATOR(TCMALLOC_TC)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 SRCS(
     main.cpp
 )

--- a/cloud/blockstore/apps/server/ya.make
+++ b/cloud/blockstore/apps/server/ya.make
@@ -2,6 +2,8 @@ PROGRAM(nbsd)
 
 ALLOCATOR(TCMALLOC_TC)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 SRCS(
     main.cpp
 )

--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -2,6 +2,8 @@ PROGRAM(nbsd-lightweight)
 
 ALLOCATOR(TCMALLOC_TC)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 SRCS(
     main.cpp
 )

--- a/cloud/blockstore/vhost-server/ya.make
+++ b/cloud/blockstore/vhost-server/ya.make
@@ -1,5 +1,7 @@
 PROGRAM(blockstore-vhost-server)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 SRCS(
     main.cpp
 

--- a/cloud/filestore/apps/client/ya.make
+++ b/cloud/filestore/apps/client/ya.make
@@ -2,6 +2,8 @@ PROGRAM(filestore-client)
 
 ALLOCATOR(TCMALLOC_TC)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 SPLIT_DWARF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/filestore/apps/server/ya.make
+++ b/cloud/filestore/apps/server/ya.make
@@ -2,6 +2,8 @@ PROGRAM(filestore-server)
 
 ALLOCATOR(TCMALLOC_TC)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
 ELSE()

--- a/cloud/filestore/apps/vhost/ya.make
+++ b/cloud/filestore/apps/vhost/ya.make
@@ -1,5 +1,7 @@
 PROGRAM(filestore-vhost)
 
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
+
 IF (PROFILE_MEMORY_ALLOCATIONS)
     ALLOCATOR(LF_DBG)
 ELSE()

--- a/cloud/storage/binaries_dependency.inc
+++ b/cloud/storage/binaries_dependency.inc
@@ -1,0 +1,8 @@
+# Executables should not depend on test definitions and YDB definitions, which
+# are redefined in NBS/NFS. To get an error at the build stage, and undefined
+# behavior due to ODR violations, such dependencies should be placed here.
+
+CHECK_DEPENDENT_DIRS(
+    DENY contrib/ydb/apps/version
+    DENY contrib/ydb/core/testlib/basics
+)


### PR DESCRIPTION
Executables should not depend on test definitions and YDB definitions, which are redefined in NBS/NFS. To get an error at the build stage, and undefined behavior due to ODR violations, such dependencies should be placed here.

Protects against this class of problems: https://github.com/ydb-platform/nbs/pull/3281