### PR TITLE
[Filestore] add write request timeout to prevent rare deadlock in TFuseVirtioClient during FUSE shutdown - this fixes flapping TFileSystemTest.ShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight

### DIFF
--- a/cloud/filestore/libs/vhost/client.h
+++ b/cloud/filestore/libs/vhost/client.h
@@ -32,7 +32,12 @@ public:
         : WaitTimeout(timeout)
         , ThreadPool(CreateThreadPool("reqs", 4))
     {
-        Client = std::make_unique<NVHost::TBufferedClient>(SocketPath);
+        NVHost::TBufferedClientParams clientParams = {
+            .WriteTimeout = WaitTimeout
+        };
+        Client = std::make_unique<NVHost::TBufferedClient>(
+            SocketPath,
+            std::move(clientParams));
         ThreadPool->Start();
     }
 

--- a/cloud/storage/core/libs/vhost-client/vhost-buffered-client.h
+++ b/cloud/storage/core/libs/vhost-client/vhost-buffered-client.h
@@ -3,6 +3,7 @@
 #include "chunked_allocator.h"
 #include "vhost-client.h"
 
+#include <util/datetime/base.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 #include <util/system/mutex.h>
@@ -22,12 +23,14 @@ struct TBufferedClientParams
     ui32 QueueCount = 2;
     ui32 QueueSize = 128;
     ui64 QueueBufferSize = 8192;
+    TDuration WriteTimeout;
 };
 
 class TBufferedClient
 {
 private:
     const ui64 QueueBufferSize;
+    const TDuration WriteTimeout;
 
     std::optional<TChunkedAllocator> Allocator;
 


### PR DESCRIPTION
Add a timeout for write requests to avoid a deadlock in TFuseVirtioClient in a rare case where a request is not enqueued to the virtio queue by the time FUSE is stopped.
Deadlock stack trace:
```
Thread 3 (LWP 686756 "cloud-fi.reqs1"):
#0  0x00007ffff7cb0117 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff7cb2a41 in pthread_cond_wait () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x0000000002b3ab0d in TCondVar::TImpl::WaitD (this=0x792fef2fe20, lock=..., deadLine=...) at /home/svartmetal/nbs-github2/util/system/condvar.cpp:99
#3  0x0000000002b3aaa5 in TCondVar::WaitD (this=0x792fefd9668, mutex=..., deadLine=...) at /home/svartmetal/nbs-github2/util/system/condvar.cpp:144
#4  0x0000000002b3fad0 in TSystemEvent::TEvImpl::WaitD (this=0x792fefd9660, deadLine=...) at /home/svartmetal/nbs-github2/util/system/event.cpp:81
#5  0x0000000002b3fa1d in TSystemEvent::WaitD (this=0x792ffd4feb8, deadLine=...) at /home/svartmetal/nbs-github2/util/system/event.cpp:134
#6  0x0000000002964a9b in NThreading::NImpl::TFutureState<unsigned int>::Wait (this=0x792ffa52660, deadline=...) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:246
#7  0x0000000002964712 in NThreading::NImpl::TFutureState<unsigned int>::Wait (this=0x792ffa52660, timeout=...) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:227
#8  0x0000000002964266 in NThreading::NImpl::TFutureState<unsigned int>::AccessValue (this=0x792ffa52660, timeout=..., acquireState=4) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:56
#9  0x00000000029640be in NThreading::NImpl::TFutureState<unsigned int>::GetValue (this=0x792ffa52660, timeout=...) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:121
#10 0x00000000028858aa in NThreading::TFuture<unsigned int>::GetValue (this=0x7ffff72e1718, timeout=...) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:556
#11 0x00000000028ac32a in NThreading::TFuture<unsigned int>::GetValueSync (this=0x7ffff72e1718) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:567
#12 0x000000000445fc5a in NVHost::TBufferedClient::Write(TVector<TVector<char, std::__y1::allocator<char>>, std::__y1::allocator<TVector<char, std::__y1::allocator<char>>>> const&, TVector<TVector<char, std::__y1::allocator<char>>, std::__y1::allocator<TVector<char, std::__y1::allocator<char>>>>&) (this=0x792fef40000, inBuffers=TVector (length=1, capacity=1) = {...}, outBuffers=TVector (length=1, capacity=1) = {...}) at /home/svartmetal/nbs-github/cloud/storage/core/libs/vhost-client/vhost-buffered-client.cpp:98
#13 0x00000000029304b0 in NCloud::NFileStore::NVhost::TFuseVirtioClient::SendRequestImpl<NCloud::NFileStore::NVhost::TForgetRequest> (this=0x792ffa4e618, request=std::__y1::shared_ptr (count 2, weak 0) = 0x792fef2fe68) at /home/svartmetal/nbs-github/cloud/filestore/libs/vhost/client.h:102
#14 0x0000000002930021 in auto NCloud::NFileStore::NVhost::TFuseVirtioClient::SendRequest<NCloud::NFileStore::NVhost::TForgetRequest>(std::__y1::shared_ptr<NCloud::NFileStore::NVhost::TForgetRequest>)::'lambda'()::operator()() const (this=0x792fef2fec0) at /home/svartmetal/nbs-github/cloud/filestore/libs/vhost/client.h:56
#15 0x000000000292ff10 in void NThreading::NImpl::SetValue<auto NCloud::NFileStore::NVhost::TFuseVirtioClient::SendRequest<NCloud::NFileStore::NVhost::TForgetRequest>(std::__y1::shared_ptr<NCloud::NFileStore::NVhost::TForgetRequest>)::'lambda'()&>(NThreading::TPromise<void>&, NCloud::NFileStore::NVhost::TForgetRequest&&, std::__y1::enable_if<std::is_void<TCallableTraits<NCloud::NFileStore::NVhost::TForgetRequest>::TResult>::value, bool>::type) (promise=..., func=...) at /home/svartmetal/nbs-github/library/cpp/threading/future/core/future-inl.h:499
#16 0x000000000292fed2 in NCloud::TFutureTask<auto NCloud::NFileStore::NVhost::TFuseVirtioClient::SendRequest<NCloud::NFileStore::NVhost::TForgetRequest>(std::__y1::shared_ptr<NCloud::NFileStore::NVhost::TForgetRequest>)::'lambda'()>::Execute() (this=0x792fef2feb0) at /home/svartmetal/nbs-github/cloud/storage/core/libs/common/task_queue.h:41
#17 0x0000000003425fb8 in NCloud::(anonymous namespace)::TThreadPool::Run (this=0x792ffbc0040, worker=...) at /home/svartmetal/nbs-github/cloud/storage/core/libs/common/thread_pool.cpp:138
#18 0x0000000003425efd in NCloud::(anonymous namespace)::TThreadPool::TWorkerThread::ThreadProc (this=0x792ff3fd480) at /home/svartmetal/nbs-github/cloud/storage/core/libs/common/thread_pool.cpp:52
#19 0x0000000002b9e7d6 in (anonymous namespace)::ThreadProcWrapper<ISimpleThread> (param=0x792ff3fd480) at /home/svartmetal/nbs-github2/util/system/thread.cpp:383
#20 0x0000000002ba51cd in (anonymous namespace)::TPosixThread::ThreadProxy (arg=0x792fef0be80) at /home/svartmetal/nbs-github2/util/system/thread.cpp:244
#21 0x00007ffff7cb3ac3 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#22 0x00007ffff7d458c0 in ?? () from /lib/x86_64-linux-gnu/libc.so.6

Thread 1 (LWP 686744 "cloud-filestore"):
#0  0x00007ffff7cb0117 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff7cb5624 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x0000000002b9e1b8 in (anonymous namespace)::TPosixThread::Join (this=0x792ff3c0760) at /home/svartmetal/nbs-github2/util/system/thread.cpp:198
#3  0x0000000002b9d817 in TThread::Join (this=0x792ff3fd488) at /home/svartmetal/nbs-github2/util/system/thread.cpp:319
#4  0x0000000002b9d7b9 in TThread::~TThread (this=0x792ff3fd488) at /home/svartmetal/nbs-github2/util/system/thread.cpp:310
#5  0x0000000002b9fd79 in ISimpleThread::~ISimpleThread (this=0x792ff3fd480) at /home/svartmetal/nbs-github2/util/system/thread.h:165
#6  0x0000000003425ea5 in NCloud::(anonymous namespace)::TThreadPool::TWorkerThread::~TWorkerThread (this=0x792ff3fd480) at /home/svartmetal/nbs-github/cloud/storage/core/libs/common/thread_pool.cpp:40
#7  0x0000000003425ec9 in NCloud::(anonymous namespace)::TThreadPool::TWorkerThread::~TWorkerThread (this=0x792ff3fd480) at /home/svartmetal/nbs-github/cloud/storage/core/libs/common/thread_pool.cpp:40
#8  0x00000000034273bc in std::__y1::default_delete<ISimpleThread>::operator()[abi:v15000](ISimpleThread*) const (this=0x792ff8c0118, __ptr=0x792ff3fd480) at /home/svartmetal/nbs-github/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:49
#9  0x00000000034272bc in std::__y1::unique_ptr<ISimpleThread, std::__y1::default_delete<ISimpleThread>>::reset[abi:v15000](ISimpleThread*) (this=0x792ff8c0118, __p=0x0) at /home/svartmetal/nbs-github/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:306
#10 0x0000000003425358 in NCloud::(anonymous namespace)::TThreadPool::Stop (this=0x792ffbc0040) at /home/svartmetal/nbs-github/cloud/storage/core/libs/common/thread_pool.cpp:115
#11 0x000000000292f32b in NCloud::NFileStore::NVhost::TFuseVirtioClient::DeInit (this=0x792ffa4e618) at /home/svartmetal/nbs-github/cloud/filestore/libs/vhost/client.h:78
#12 0x00000000028a19f1 in NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrap::Stop (this=0x7fffffffcfd0) at /home/svartmetal/nbs-github/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:266
#13 0x00000000028de9fd in NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TTestCaseShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight::Execute_ (this=0x792ffa41f40, ut_context=...) at /home/svartmetal/nbs-github/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:2711
#14 0x00000000028f0df3 in NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()::operator()() const (this=0x7fffffffd768) at /home/svartmetal/nbs-github/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:308
#15 0x00000000028f0d65 in decltype(std::declval<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()&>()()) std::__y1::__invoke[abi:v15000]<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()&>(NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()&) (__f=...) at /home/svartmetal/nbs-github/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403
--Type <RET> for more, q to quit, c to continue without paging--
#16 0x00000000028f0d25 in void std::__y1::__invoke_void_return_wrapper<void, true>::__call<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()&>(NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()&) (__args=...) at /home/svartmetal/nbs-github/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488
#17 0x00000000028f0cfd in std::__y1::__function::__alloc_func<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()[abi:v15000]() (this=0x7fffffffd768) at /home/svartmetal/nbs-github/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185
#18 0x00000000028f00c9 in std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() (this=0x7fffffffd760) at /home/svartmetal/nbs-github/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359
#19 0x0000000002bab862 in std::__y1::__function::__value_func<void ()>::operator()[abi:v15000]() const (this=0x7fffffffd760) at /home/svartmetal/nbs-github2/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512
#20 0x0000000002b985d5 in std::__y1::function<void ()>::operator()() const (this=0x7fffffffd760) at /home/svartmetal/nbs-github2/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187
#21 0x0000000002c3ed0e in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) (this=0x7fffffffdcb8, f=..., suite=TFileSystemTest, name=0x1b8ec1b "ShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight", forceFork=false) at /home/svartmetal/nbs-github2/library/cpp/testing/unittest/utmain.cpp:525
#22 0x0000000002c152f6 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) (this=0x792ffdc2400, f=..., suite=TFileSystemTest, name=0x1b8ec1b "ShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight", forceFork=false) at /home/svartmetal/nbs-github2/library/cpp/testing/unittest/registar.cpp:374
#23 0x00000000028ee1c2 in NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute (this=0x792ffdc2400) at /home/svartmetal/nbs-github/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:308
#24 0x0000000002c15c37 in NUnitTest::TTestFactory::Execute (this=0x472a608 <NUnitTest::TTestFactory::Instance()::f>) at /home/svartmetal/nbs-github2/library/cpp/testing/unittest/registar.cpp:495
#25 0x0000000002c3c8b8 in NUnitTest::RunMain (argc=4, argv=0x7fffffffdf68) at /home/svartmetal/nbs-github2/library/cpp/testing/unittest/utmain.cpp:872
#26 0x0000000002c3b7e2 in main (argc=4, argv=0x7fffffffdf68) at /home/svartmetal/nbs-github2/library/cpp/testing/unittest_main/main.cpp:4
```