### PR TITLE
filestore service: logging client-id to profile log; added support for --client-id in most of the filestore-client commands

### DIFF
--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -371,14 +371,21 @@ void TFileStoreServiceCommand::Stop()
     TCommand::Stop();
 }
 
-TFileStoreCommand::TFileStoreCommand()
+TFileStoreCommand::TFileStoreCommand(bool isClientIdRequired)
 {
-    ClientId = CreateGuidAsString();
-
     Opts.AddLongOption("filesystem")
         .Required()
         .RequiredArgument("STR")
         .StoreResult(&FileSystemId);
+
+    auto& opt = Opts.AddLongOption("client-id")
+        .RequiredArgument("CLIENT_ID")
+        .StoreResult(&ClientId);
+    if (isClientIdRequired) {
+        opt.Required();
+    } else {
+        opt.DefaultValue(CreateGuidAsString());
+    }
 
     Opts.AddLongOption("disable-multitablet-forwarding")
         .NoArgument()

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -153,7 +153,7 @@ class TFileStoreCommand
     : public TFileStoreServiceCommand
 {
 public:
-    TFileStoreCommand();
+    TFileStoreCommand(bool isClientIdRequired = false);
 
     void Start() override;
     void Stop() override;

--- a/cloud/filestore/apps/client/lib/create_session.cpp
+++ b/cloud/filestore/apps/client/lib/create_session.cpp
@@ -28,14 +28,11 @@ private:
 
 public:
     TCreateSessionCommand()
+        : TFileStoreCommand(true /* isClientIdRequired */)
     {
         Opts.AddLongOption("session-id")
             .RequiredArgument("SESSION_ID")
             .StoreResult(&SessionId);
-
-        Opts.AddLongOption("client-id")
-            .RequiredArgument("CLIENT_ID")
-            .StoreResult(&ClientId);
 
         Opts.AddLongOption("seq-no")
             .RequiredArgument("SEQ_NO")

--- a/cloud/filestore/apps/client/lib/destroy_session.cpp
+++ b/cloud/filestore/apps/client/lib/destroy_session.cpp
@@ -28,14 +28,11 @@ private:
 
 public:
     TDestroySessionCommand()
+        : TFileStoreCommand(true /* isClientIdRequired */)
     {
         Opts.AddLongOption("session-id")
             .RequiredArgument("SESSION_ID")
             .StoreResult(&SessionId);
-
-        Opts.AddLongOption("client-id")
-            .RequiredArgument("CLIENT_ID")
-            .StoreResult(&ClientId);
 
         Opts.AddLongOption("seq-no")
             .RequiredArgument("SEQ_NO")

--- a/cloud/filestore/apps/client/lib/reset_session.cpp
+++ b/cloud/filestore/apps/client/lib/reset_session.cpp
@@ -20,16 +20,12 @@ private:
 
 public:
     TResetSessionCommand()
+        : TFileStoreCommand(true /* isClientIdRequired */)
     {
         Opts.AddLongOption("session-id")
             .RequiredArgument("SESSION_ID")
             .Required()
             .StoreResult(&SessionId);
-
-        Opts.AddLongOption("client-id")
-            .RequiredArgument("CLIENT_ID")
-            .Required()
-            .StoreResult(&ClientId);
 
         Opts.AddLongOption("seq-no")
             .RequiredArgument("SEQ_NO")

--- a/cloud/filestore/libs/diagnostics/events/profile_events.ev
+++ b/cloud/filestore/libs/diagnostics/events/profile_events.ev
@@ -110,6 +110,8 @@ message TProfileLogRequestInfo {
     optional TProfileLogCollectGarbageInfo CollectGarbageInfo = 10;
 
     optional uint64 LoopThreadId = 11;
+
+    optional string ClientId = 12;
 };
 
 message TProfileLogRecord {

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -28,7 +28,7 @@ public:
     std::atomic<bool> Cancelled = false;
 
     explicit TCallContext(ui64 requestId = 0);
-    TCallContext(TString fileSystemId, ui64 requestId = 0);
+    explicit TCallContext(TString fileSystemId, ui64 requestId = 0);
 
     TString LogString() const;
 };

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -327,6 +327,7 @@ void TStorageServiceActor::HandleCreateHandle(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -376,6 +376,7 @@ void TStorageServiceActor::HandleCreateNode(
                 ctx.Now());
 
             InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+            inflight->ProfileLogRequest.SetClientId(session->ClientId);
 
             auto requestInfo =
                 CreateRequestInfo(SelfId(), cookie, msg->CallContext);

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -695,6 +695,7 @@ void TStorageServiceActor::HandleCreateSession(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(clientId);
 
     auto sessionId = GetSessionId(msg->Record);
     auto seqNo = GetSessionSeqNo(msg->Record);

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -213,6 +213,7 @@ void TStorageServiceActor::HandleDestroySession(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(clientId);
 
     auto reply = [&, inflight = std::move(inflight)] (auto error) {
         auto response =

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -136,6 +136,7 @@ void TStorageServiceActor::ForwardRequest(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(session->ClientId);
     const bool blockChecksumsEnabled =
         filestore.GetFeatures().GetBlockChecksumsInProfileLogEnabled()
         || StorageConfig->GetBlockChecksumsInProfileLogEnabled();
@@ -217,6 +218,7 @@ void TStorageServiceActor::ForwardRequestToShard(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(session->ClientId);
     TraceSerializer->BuildTraceRequest(
         *msg->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
         msg->CallContext->LWOrbit);

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -286,6 +286,7 @@ void TStorageServiceActor::HandleGetNodeAttr(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -697,6 +697,7 @@ void TStorageServiceActor::HandleListNodes(
         ctx.Now());
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -883,6 +883,7 @@ void TStorageServiceActor::HandleReadData(
         startTime);
 
     InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    inflight->ProfileLogRequest.SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -818,6 +818,7 @@ void TStorageServiceActor::HandleWriteData(
             startTime);
 
         InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+        inflight->ProfileLogRequest.SetClientId(session->ClientId);
         if (blockChecksumsEnabled) {
             CalculateWriteDataRequestChecksums(
                 msg->Record,
@@ -844,7 +845,7 @@ void TStorageServiceActor::HandleWriteData(
             TFileStoreComponents::SERVICE,
             "Forwarding WriteData request to tablet");
         MoveIovecsToBuffer(msg->Record);
-        return ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
+        ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
     }
 }
 

--- a/cloud/filestore/tests/client/canondata/test.test_io_telemetry/results.txt
+++ b/cloud/filestore/tests/client/canondata/test.test_io_telemetry/results.txt
@@ -30,29 +30,29 @@ AddData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
 AddData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
 DescribeData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
 DescribeData	{'node_id': '4', 'offset': '0', 'bytes': '131072'}
-ReadData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'actual_bytes': '131072', 'actual_offset': '0', 'checksums': '650595490 1275610441 2531880895 2576766623 1131904105 699954562 4082720628 927336386 3987156276 2271749343 1569263145 1391867657 2283216383 3805811732 943275746 1862980489 3052140927 3743740052 96852578 180020034 3495676340 3130310751 1618340521 2758455839 2123077865 340037890 650595490 1275610441 2531880895 2576766623 1131904105 699954562'}
+ReadData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'actual_bytes': '131072', 'actual_offset': '0', 'checksums': '650595490 1275610441 2531880895 2576766623 1131904105 699954562 4082720628 927336386 3987156276 2271749343 1569263145 1391867657 2283216383 3805811732 943275746 1862980489 3052140927 3743740052 96852578 180020034 3495676340 3130310751 1618340521 2758455839 2123077865 340037890 650595490 1275610441 2531880895 2576766623 1131904105 699954562', 'client_id': 'client0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'actual_bytes': '131072', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0', 'checksums': '650595490 1275610441 2531880895 2576766623'}
+ReadData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0', 'checksums': '650595490 1275610441 2531880895 2576766623', 'client_id': 'client0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '0', 'bytes': '4096', 'actual_bytes': '9', 'actual_offset': '0', 'checksums': '2901820631'}
+ReadData	{'node_id': '0', 'offset': '0', 'bytes': '4096', 'actual_bytes': '9', 'actual_offset': '0', 'checksums': '2901820631', 'client_id': 'client0'}
 ReadData	{'node_id': '0', 'offset': '0', 'bytes': '4096', 'actual_bytes': '9', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0', 'checksums': '1131904105 699954562 4082720628 927336386'}
+ReadData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0', 'checksums': '1131904105 699954562 4082720628 927336386', 'client_id': 'client0'}
 ReadData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
-ReadData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0', 'checksums': '3987156276 2271749343 1569263145 1391867657'}
+ReadData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0', 'checksums': '3987156276 2271749343 1569263145 1391867657', 'client_id': 'client0'}
 ReadData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'actual_bytes': '16384', 'actual_offset': '0'}
 ReadData	{'node_id': '2', 'offset': '0', 'bytes': '4096', 'checksums': '2901820631'}
 ReadData	{'node_id': '3', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}
 ReadData	{'node_id': '3', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386'}
 ReadData	{'node_id': '3', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657'}
-WriteData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'checksums': '650595490 1275610441 2531880895 2576766623 1131904105 699954562 4082720628 927336386 3987156276 2271749343 1569263145 1391867657 2283216383 3805811732 943275746 1862980489 3052140927 3743740052 96852578 180020034 3495676340 3130310751 1618340521 2758455839 2123077865 340037890 650595490 1275610441 2531880895 2576766623 1131904105 699954562'}
+WriteData	{'node_id': '0', 'offset': '0', 'bytes': '131072', 'checksums': '650595490 1275610441 2531880895 2576766623 1131904105 699954562 4082720628 927336386 3987156276 2271749343 1569263145 1391867657 2283216383 3805811732 943275746 1862980489 3052140927 3743740052 96852578 180020034 3495676340 3130310751 1618340521 2758455839 2123077865 340037890 650595490 1275610441 2531880895 2576766623 1131904105 699954562', 'client_id': 'client0'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '131072'}
-WriteData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}
+WriteData	{'node_id': '0', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623', 'client_id': 'client0'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '16384'}
-WriteData	{'node_id': '0', 'offset': '0', 'bytes': '9', 'checksums': '2901820631'}
+WriteData	{'node_id': '0', 'offset': '0', 'bytes': '9', 'checksums': '2901820631', 'client_id': 'client0'}
 WriteData	{'node_id': '0', 'offset': '0', 'bytes': '9'}
-WriteData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386'}
+WriteData	{'node_id': '0', 'offset': '16384', 'bytes': '16384', 'checksums': '1131904105 699954562 4082720628 927336386', 'client_id': 'client0'}
 WriteData	{'node_id': '0', 'offset': '16384', 'bytes': '16384'}
-WriteData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657'}
+WriteData	{'node_id': '0', 'offset': '32768', 'bytes': '16384', 'checksums': '3987156276 2271749343 1569263145 1391867657', 'client_id': 'client0'}
 WriteData	{'node_id': '0', 'offset': '32768', 'bytes': '16384'}
 WriteData	{'node_id': '2', 'offset': '0', 'bytes': '9', 'checksums': '2901820631'}
 WriteData	{'node_id': '3', 'offset': '0', 'bytes': '16384', 'checksums': '650595490 1275610441 2531880895 2576766623'}

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
@@ -376,6 +376,11 @@ public:
                 << "\t";
         }
 
+        if (request.GetClientId()) {
+            out << PrintValue("client_id", request.GetClientId())
+                << "\t";
+        }
+
         if (out.empty()) {
             out << "{no_info}";
         } else {

--- a/cloud/filestore/tools/testing/profile_log/common.py
+++ b/cloud/filestore/tools/testing/profile_log/common.py
@@ -34,12 +34,13 @@ def get_profile_log_events(profile_tool_bin_path, profile_log_path, fs_name):
     for line in proc.stdout.decode("utf-8").splitlines():
         parts = line.rstrip().split("\t")
         request_type = parts[2]
-        body_str = re.sub(r"[{}\[\]]", "", parts[-1])
-        body_parts = body_str.split(", ")
         body_dict = {}
-        for body_part in body_parts:
-            kv = body_part.split("=", 2)
-            body_dict[kv[0]] = kv[1] if len(kv) == 2 else None
+        for i in range(5, len(parts)):
+            body_str = re.sub(r"[{}\[\]]", "", parts[i])
+            body_parts = body_str.split(", ")
+            for body_part in body_parts:
+                kv = body_part.split("=", 2)
+                body_dict[kv[0]] = kv[1] if len(kv) == 2 else None
 
         events.append((request_type, body_dict))
 


### PR DESCRIPTION
### Notes
* added ClientId to profile log messages
* support for ClientId in most of the filestore-client commands - required for stable client-ids in `test.py::test_io_telemetry` canondata
* small fix for profile log record parsing in our pytest profile_log lib