### PR TITLE
issue-4782: added tablet-level OverloadedCount metric that tracks the number of requests with IsOverloaded=true in the response

### DIFF
--- a/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_adddata.cpp
@@ -114,7 +114,8 @@ void TAddDataActor::ReplyAndDie(
             1,
             BlobsSize,
             ctx.Now() - RequestInfo->StartedTs,
-            CommitId);
+            CommitId,
+            BackendInfo.GetIsOverloaded());
         NCloud::Send(ctx, Tablet, std::move(response));
     }
 

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -139,7 +139,8 @@ void TWriteDataActor::ReplyAndDie(
             CommitId,
             1,
             BlobsSize,
-            ctx.Now() - RequestInfo->StartedTs);
+            ctx.Now() - RequestInfo->StartedTs,
+            BackendInfo.GetIsOverloaded());
         NCloud::Send(ctx, Tablet, std::move(response));
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -374,6 +374,7 @@ private:
         // performance evaluation
         std::atomic<i64> CurrentLoad{0};
         std::atomic<i64> Suffer{0};
+        std::atomic<i64> OverloadedCount{0};
 
         const NMetrics::IMetricsRegistryPtr StorageRegistry;
         const NMetrics::IMetricsRegistryPtr StorageFsRegistry;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -549,6 +549,9 @@ void TIndexTabletActor::HandleAddDataCompleted(
             FormatError(msg->Error).Quote().c_str());
     } else {
         Metrics.AddData.Update(msg->Count, msg->Size, msg->Time);
+        if (msg->IsOverloaded) {
+            Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+        }
     }
 
     // We try to release commit barrier twice: once for the lock

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -551,6 +551,7 @@ void TIndexTabletActor::TMetrics::Register(
 
     REGISTER_LOCAL(CurrentLoad, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(Suffer, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(OverloadedCount, EMetricType::MT_DERIVATIVE);
 
 #undef REGISTER_REQUEST
 #undef REGISTER_LOCAL

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -504,7 +504,8 @@ void TReadDataActor::ReplyAndDie(
             CommitId,
             1,
             OriginByteRange.Length,
-            ctx.Now() - RequestInfo->StartedTs);
+            ctx.Now() - RequestInfo->StartedTs,
+            BackendInfo.GetIsOverloaded());
 
         NCloud::Send(ctx, Tablet, std::move(response));
     }
@@ -684,6 +685,9 @@ void TIndexTabletActor::HandleReadDataCompleted(
     WorkerActors.erase(ev->Sender);
 
     Metrics.ReadData.Update(msg->Count, msg->Size, msg->Time);
+    if (msg->IsOverloaded) {
+        Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -110,6 +110,12 @@ void TIndexTabletActor::CompleteResponse(
         builtTraceInfo);
     BuildThrottlerInfo(*callContext, response);
     BuildBackendInfo(*Config, *SystemCounters, response);
+    if constexpr (HasResponseHeaders<decltype(response)>()) {
+        const auto& responseHeaders = response.GetHeaders();
+        if (responseHeaders.GetBackendInfo().GetIsOverloaded()) {
+            Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
 
     Metrics.BusyIdleCalc.OnRequestCompleted();
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -193,6 +193,9 @@ void TIndexTabletActor::HandleWriteDataCompleted(
     EnqueueBlobIndexOpIfNeeded(ctx);
 
     Metrics.WriteData.Update(msg->Count, msg->Size, msg->Time);
+    if (msg->IsOverloaded) {
+        Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_private.h
@@ -343,7 +343,27 @@ struct TEvIndexTabletPrivate
     // ReadWrite completion
     //
 
-    using TReadWriteCompleted = TOperationCompleted;
+    struct TReadWriteCompleted: TOperationCompleted
+    {
+        const bool IsOverloaded;
+
+        TReadWriteCompleted(
+                TSet<ui32> mixedBlocksRanges,
+                ui64 commitId,
+                ui32 requestCount,
+                ui32 requestBytes,
+                TDuration d,
+                bool isOverloaded)
+            : TOperationCompleted(
+                std::move(mixedBlocksRanges),
+                commitId,
+                requestCount,
+                requestBytes,
+                d)
+            , IsOverloaded(isOverloaded)
+        {
+        }
+    };
 
     //
     // AddData completion
@@ -352,14 +372,17 @@ struct TEvIndexTabletPrivate
     struct TAddDataCompleted: TDataOperationCompleted
     {
         const ui64 CommitId;
+        const bool IsOverloaded;
 
         TAddDataCompleted(
                 ui32 requestCount,
                 ui32 requestBytes,
                 TDuration d,
-                ui64 commitId)
+                ui64 commitId,
+                bool isOverloaded)
             : TDataOperationCompleted(requestCount, requestBytes, d)
             , CommitId(commitId)
+            , IsOverloaded(isOverloaded)
         {
         }
     };


### PR DESCRIPTION
### Notes
Tracking the number of external requests for which the tablet returned `TBackendInfo::IsOverloaded=true` in the response headers.

It's needed for https://github.com/ydb-platform/nbs/issues/4782 to track how often the service layer gets a signal that it shouldn't issue direct ReadData requests to the tablet (that it should use two-stage-read even for small requests).

### Issue
https://github.com/ydb-platform/nbs/issues/4782