### PR TITLE
Fix flapping of test TFileRingBufferTest.RandomizedPushPopRestore

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -92,7 +92,7 @@ struct TReferenceImplementation
         if (!Empty()) {
             if (ReadPos < WritePos) {
                 const auto avail = MaxWeight - WritePos;
-                if (avail <= sz) {
+                if (avail < sz) {
                     if (ReadPos <= sz) {
                         // out of space
                         return false;


### PR DESCRIPTION
Problem:
```
[[bad]]assertion failed at cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:366, void NCloud::NTestSuiteTFileRingBufferTest::DoRandomizedPushPopRestore(ui32, ui32, ui32, ui32): (pushed == rb->PushBack(data)) failed: (0 != 1) [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char> > const&, bool)+336 (0xE12770)
NCloud::NTestSuiteTFileRingBufferTest::DoRandomizedPushPopRestore(unsigned int, unsigned int, unsigned int, unsigned int)+2801 (0x797BA1)
std::__y1::__function::__func<NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+231 (0x7EC347)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char> > const&, char const*, bool)+412 (0xE18C8C)
NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()+1395 (0x7EB2A3)
NUnitTest::TTestFactory::Execute()+3329 (0xE1A541)
NUnitTest::RunMain(int, char**)+5957 (0xE3F325)
??+0 (0x7F1DBFC29D90)
__libc_start_main+128 (0x7F1DBFC29E40)
??+0 (0x5B21A9)
[[rst]]
```

Caused by different logic in available space utilization between actual and real implementation.