### PR TITLE
issue-4961: fix handling of TEvServerDisconnected in tablet

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -847,17 +847,17 @@ void TStorageServiceActor::HandleSessionCreated(
 
     auto* session = State->FindSession(msg->SessionId);
     if (SUCCEEDED(msg->GetStatus())) {
-        // in case of vhost restart we don't know session id
-        // so inevitably will create new actor
-        auto actorId = ev->Sender;
+        auto newSessionActor = ev->Sender;
         if (session &&
             session->SessionActor &&
-            session->SessionActor != ev->Sender)
+            session->SessionActor != newSessionActor)
         {
-            ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
-            actorId = session->SessionActor;
+            // killing old session actor
+            ctx.Send(session->SessionActor, new TEvents::TEvPoisonPill());
         }
 
+        // in case of vhost restart we don't know session id
+        // so inevitably will create new actor
         if (!session) {
             LOG_INFO(ctx, TFileStoreComponents::SERVICE,
                 "%s session created (%s), state(%lu)",
@@ -887,7 +887,7 @@ void TStorageServiceActor::HandleSessionCreated(
                 msg->ReadOnly,
                 mediaKind,
                 std::move(stats),
-                actorId,
+                newSessionActor,
                 msg->TabletId);
 
             Y_ABORT_UNLESS(session);
@@ -896,7 +896,7 @@ void TStorageServiceActor::HandleSessionCreated(
                 msg->SessionState,
                 msg->FileStore);
             session->AddSubSession(msg->SessionSeqNo, msg->ReadOnly);
-            session->SessionActor = actorId;
+            session->SessionActor = newSessionActor;
         }
     } else if (session) {
         // else it's an old notify from a dead actor

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -945,8 +945,6 @@ void TStorageServiceActor::HandleSessionCreated(
             }
         }
 
-        // in case of vhost restart we don't know session id
-        // so inevitably will create new actor
         if (!session) {
             LOG_INFO(ctx, TFileStoreComponents::SERVICE,
                 "%s session created (%s), state(%lu)",

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -945,6 +945,8 @@ void TStorageServiceActor::HandleSessionCreated(
             }
         }
 
+        // in case of vhost restart we don't know session id
+        // so inevitably will create new actor
         if (!session) {
             LOG_INFO(ctx, TFileStoreComponents::SERVICE,
                 "%s session created (%s), state(%lu)",

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -261,14 +261,8 @@ public:
         const NActors::TActorId& owner,
         const NActors::TActorId& pipeServer)
     {
-        auto result = SubSessions.UpdateSubSession(seqNo, readOnly, owner, pipeServer);
-        UpdateSeqNo();
-        return result;
-    }
-
-    ui32 DeleteSubSession(const NActors::TActorId& owner)
-    {
-        auto result = SubSessions.DeleteSubSession(owner);
+        auto result =
+            SubSessions.UpdateSubSession(seqNo, readOnly, owner, pipeServer);
         UpdateSeqNo();
         return result;
     }
@@ -280,7 +274,7 @@ public:
         return result;
     }
 
-    ui32 DeleteSubSession(ui64 sessionSeqNo)
+    std::optional<TSubSession> DeleteSubSession(ui64 sessionSeqNo)
     {
         auto result = SubSessions.DeleteSubSession(sessionSeqNo);
         UpdateSeqNo();
@@ -289,12 +283,22 @@ public:
 
     TVector<NActors::TActorId> GetSubSessions() const
     {
-        return SubSessions.GetSubSessions();
+        return SubSessions.GetSubSessionsOwner();
     }
 
     TVector<NActors::TActorId> GetSubSessionsPipeServer() const
     {
         return SubSessions.GetSubSessionsPipeServer();
+    }
+
+    std::optional<TSubSession> GetSubSessionBySeqNo(ui64 seqNo) const
+    {
+        return SubSessions.GetSubSessionBySeqNo(seqNo);
+    }
+
+    bool ReadyToDestroy(ui64 seqNo) const
+    {
+        return SubSessions.ReadyToDestroy(seqNo);
     }
 
     ui64 GenerateDupCacheEntryId()

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -440,6 +440,8 @@ struct TSessionHistoryEntry
 using TSessionList = TIntrusiveListWithAutoDelete<TSession, TDelete>;
 using TSessionMap = THashMap<TString, TSession*>;
 using TSessionOwnerMap = THashMap<NActors::TActorId, TSession*>;
+using TSessionOwnerByPipeServerMap =
+    THashMap<NActors::TActorId, NActors::TActorId>;
 using TSessionClientMap = THashMap<TString, TSession*>;
 using TSessionHistoryList = TDeque<TSessionHistoryEntry>;
 

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -255,7 +255,7 @@ public:
         SetMaxRwSeqNo(SubSessions.GetMaxSeenRwSeqNo());
     }
 
-    NActors::TActorId UpdateSubSession(
+    std::optional<TSessionPipeInfo> UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -258,9 +258,10 @@ public:
     NActors::TActorId UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
-        const NActors::TActorId& owner)
+        const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer)
     {
-        auto result = SubSessions.UpdateSubSession(seqNo, readOnly, owner);
+        auto result = SubSessions.UpdateSubSession(seqNo, readOnly, owner, pipeServer);
         UpdateSeqNo();
         return result;
     }
@@ -268,6 +269,13 @@ public:
     ui32 DeleteSubSession(const NActors::TActorId& owner)
     {
         auto result = SubSessions.DeleteSubSession(owner);
+        UpdateSeqNo();
+        return result;
+    }
+
+    ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
+    {
+        auto result = SubSessions.DeleteSubSessionByPipeServer(pipeServer);
         UpdateSeqNo();
         return result;
     }
@@ -282,6 +290,11 @@ public:
     TVector<NActors::TActorId> GetSubSessions() const
     {
         return SubSessions.GetSubSessions();
+    }
+
+    TVector<NActors::TActorId> GetSubSessionsPipeServer() const
+    {
+        return SubSessions.GetSubSessionsPipeServer();
     }
 
     ui64 GenerateDupCacheEntryId()

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -255,7 +255,7 @@ public:
         SetMaxRwSeqNo(SubSessions.GetMaxSeenRwSeqNo());
     }
 
-    std::optional<TSessionPipeInfo> UpdateSubSession(
+    TSubSessionUpdateResult UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -272,13 +272,6 @@ public:
         return result;
     }
 
-    ui32 DeleteSubSession(const NActors::TActorId& owner)
-    {
-        auto result = SubSessions.DeleteSubSession(owner);
-        UpdateSeqNo();
-        return result;
-    }
-
     ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
     {
         auto result = SubSessions.DeleteSubSessionByPipeServer(pipeServer);
@@ -286,7 +279,7 @@ public:
         return result;
     }
 
-    ui32 DeleteSubSession(ui64 sessionSeqNo)
+    std::optional<TSubSession> DeleteSubSession(ui64 sessionSeqNo)
     {
         auto result = SubSessions.DeleteSubSession(sessionSeqNo);
         UpdateSeqNo();
@@ -295,12 +288,22 @@ public:
 
     TVector<NActors::TActorId> GetSubSessions() const
     {
-        return SubSessions.GetSubSessions();
+        return SubSessions.GetSubSessionsOwner();
     }
 
     TVector<NActors::TActorId> GetSubSessionsPipeServer() const
     {
         return SubSessions.GetSubSessionsPipeServer();
+    }
+
+    std::optional<TSubSession> GetSubSessionBySeqNo(ui64 seqNo) const
+    {
+        return SubSessions.GetSubSessionBySeqNo(seqNo);
+    }
+
+    bool ReadyToDestroy(ui64 seqNo) const
+    {
+        return SubSessions.ReadyToDestroy(seqNo);
     }
 
     ui64 GenerateDupCacheEntryId()

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -259,12 +259,14 @@ public:
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         ui32 tabletGeneration)
     {
         auto result = SubSessions.UpdateSubSession(
             seqNo,
             readOnly,
             owner,
+            pipeServer,
             tabletGeneration);
         UpdateSeqNo();
         return result;
@@ -273,6 +275,13 @@ public:
     ui32 DeleteSubSession(const NActors::TActorId& owner)
     {
         auto result = SubSessions.DeleteSubSession(owner);
+        UpdateSeqNo();
+        return result;
+    }
+
+    ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
+    {
+        auto result = SubSessions.DeleteSubSessionByPipeServer(pipeServer);
         UpdateSeqNo();
         return result;
     }
@@ -287,6 +296,11 @@ public:
     TVector<NActors::TActorId> GetSubSessions() const
     {
         return SubSessions.GetSubSessions();
+    }
+
+    TVector<NActors::TActorId> GetSubSessionsPipeServer() const
+    {
+        return SubSessions.GetSubSessionsPipeServer();
     }
 
     ui64 GenerateDupCacheEntryId()

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -445,6 +445,8 @@ struct TSessionHistoryEntry
 using TSessionList = TIntrusiveListWithAutoDelete<TSession, TDelete>;
 using TSessionMap = THashMap<TString, TSession*>;
 using TSessionOwnerMap = THashMap<NActors::TActorId, TSession*>;
+using TSessionOwnerByPipeServerMap =
+    THashMap<NActors::TActorId, NActors::TActorId>;
 using TSessionClientMap = THashMap<TString, TSession*>;
 using TSessionHistoryList = TDeque<TSessionHistoryEntry>;
 

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -272,38 +272,34 @@ public:
         return result;
     }
 
-    ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
+    TDeleteSubSessionResult DeleteSubSessionByPipeServer(
+        const NActors::TActorId& pipeServer)
     {
         auto result = SubSessions.DeleteSubSessionByPipeServer(pipeServer);
         UpdateSeqNo();
         return result;
     }
 
-    std::optional<TSubSession> DeleteSubSession(ui64 sessionSeqNo)
+    TDeleteSubSessionResult DeleteSubSession(ui64 sessionSeqNo)
     {
         auto result = SubSessions.DeleteSubSession(sessionSeqNo);
         UpdateSeqNo();
         return result;
     }
 
-    TVector<NActors::TActorId> GetSubSessions() const
+    TVector<NActors::TActorId> GetSubSessionOwnerIds() const
     {
-        return SubSessions.GetSubSessionsOwner();
+        return SubSessions.GetSubSessionOwnerIds();
     }
 
-    TVector<NActors::TActorId> GetSubSessionsPipeServer() const
+    TVector<NActors::TActorId> GetSubSessionPipeServerIds() const
     {
-        return SubSessions.GetSubSessionsPipeServer();
+        return SubSessions.GetSubSessionPipeServerIds();
     }
 
     std::optional<TSubSession> GetSubSessionBySeqNo(ui64 seqNo) const
     {
         return SubSessions.GetSubSessionBySeqNo(seqNo);
-    }
-
-    bool ReadyToDestroy(ui64 seqNo) const
-    {
-        return SubSessions.ReadyToDestroy(seqNo);
     }
 
     ui64 GenerateDupCacheEntryId()

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -457,9 +457,7 @@ struct TSessionHistoryEntry
 
 using TSessionList = TIntrusiveListWithAutoDelete<TSession, TDelete>;
 using TSessionMap = THashMap<TString, TSession*>;
-using TSessionOwnerMap = THashMap<NActors::TActorId, TSession*>;
-using TSessionOwnerByPipeServerMap =
-    THashMap<NActors::TActorId, NActors::TActorId>;
+using TSessionByPipeServerMap = THashMap<NActors::TActorId, TSession*>;
 using TSessionClientMap = THashMap<TString, TSession*>;
 using TSessionHistoryList = TDeque<TSessionHistoryEntry>;
 

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -37,7 +37,7 @@ ui32 ExtractSubSessionOwnerGeneration(ui64 ownerGeneration)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::optional<TSessionPipeInfo> TSubSessions::AddSubSession(
+TSubSessionUpdateResult TSubSessions::AddSubSession(
     ui64 seqNo,
     bool readOnly,
     const NActors::TActorId& owner,
@@ -62,14 +62,18 @@ std::optional<TSessionPipeInfo> TSubSessions::AddSubSession(
             [] (const auto& a, const auto& b) {
                 return a.SeqNo < b.SeqNo;
             });
-        auto ans = loSeqNo->PipeInfo;
+        // The evicted subsession is a fully separate, older mount: both its
+        // pipe server binding and its owner actor are stale.
+        TSubSessionUpdateResult result;
+        result.StalePipeServer = loSeqNo->PipeInfo.PipeServer;
+        result.StaleOwner = loSeqNo->PipeInfo.Owner;
         SubSessions.erase(loSeqNo);
-        return ans;
+        return result;
     }
     return {};
 }
 
-std::optional<TSessionPipeInfo> TSubSessions::UpdateSubSession(
+TSubSessionUpdateResult TSubSessions::UpdateSubSession(
     ui64 seqNo,
     bool readOnly,
     const NActors::TActorId& owner,
@@ -87,17 +91,30 @@ std::optional<TSessionPipeInfo> TSubSessions::UpdateSubSession(
         });
     if (subsession != SubSessions.end()) {
         subsession->ReadOnly = readOnly;
-        if (subsession->PipeInfo.Owner != owner) {
-            auto toKill = subsession->PipeInfo;
-            subsession->PipeInfo.Owner = owner;
-            subsession->PipeInfo.PipeServer = pipeServer;
+
+        // Owner and PipeServer change independently on reconnect.
+        const bool ownerChanged = subsession->PipeInfo.Owner != owner;
+        const bool pipeServerChanged =
+            subsession->PipeInfo.PipeServer != pipeServer;
+        if (!ownerChanged && !pipeServerChanged) {
+            return {};
+        }
+
+        TSubSessionUpdateResult result;
+        result.StalePipeServer = subsession->PipeInfo.PipeServer;
+        if (ownerChanged) {
+            result.StaleOwner = subsession->PipeInfo.Owner;
+        }
+
+        subsession->PipeInfo.Owner = owner;
+        subsession->PipeInfo.PipeServer = pipeServer;
+        if (ownerChanged) {
             subsession->OwnerGeneration = MakeSubSessionOwnerGeneration(
                 tabletGeneration,
                 ExtractSubSessionOwnerGeneration(
                     subsession->OwnerGeneration) + 1);
-            return toKill;
         }
-        return {};
+        return result;
     }
     return AddSubSession(seqNo, readOnly, owner, pipeServer, tabletGeneration);
 }

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -37,7 +37,7 @@ ui32 ExtractSubSessionOwnerGeneration(ui64 ownerGeneration)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NActors::TActorId TSubSessions::AddSubSession(
+std::optional<TSessionPipeInfo> TSubSessions::AddSubSession(
     ui64 seqNo,
     bool readOnly,
     const NActors::TActorId& owner,
@@ -51,8 +51,7 @@ NActors::TActorId TSubSessions::AddSubSession(
     SubSessions.push_back(
         {seqNo,
          readOnly,
-         owner,
-         pipeServer,
+         {owner, pipeServer},
          MakeSubSessionOwnerGeneration(
              tabletGeneration,
              1 /* ownerGeneration */)});
@@ -63,14 +62,14 @@ NActors::TActorId TSubSessions::AddSubSession(
             [] (const auto& a, const auto& b) {
                 return a.SeqNo < b.SeqNo;
             });
-        auto ans = loSeqNo->Owner;
+        auto ans = loSeqNo->PipeInfo;
         SubSessions.erase(loSeqNo);
         return ans;
     }
     return {};
 }
 
-NActors::TActorId TSubSessions::UpdateSubSession(
+std::optional<TSessionPipeInfo> TSubSessions::UpdateSubSession(
     ui64 seqNo,
     bool readOnly,
     const NActors::TActorId& owner,
@@ -88,10 +87,10 @@ NActors::TActorId TSubSessions::UpdateSubSession(
         });
     if (subsession != SubSessions.end()) {
         subsession->ReadOnly = readOnly;
-        if (subsession->Owner != owner) {
-            auto toKill = subsession->Owner;
-            subsession->Owner = owner;
-            subsession->PipeServer = pipeServer;
+        if (subsession->PipeInfo.Owner != owner) {
+            auto toKill = subsession->PipeInfo;
+            subsession->PipeInfo.Owner = owner;
+            subsession->PipeInfo.PipeServer = pipeServer;
             subsession->OwnerGeneration = MakeSubSessionOwnerGeneration(
                 tabletGeneration,
                 ExtractSubSessionOwnerGeneration(
@@ -108,7 +107,7 @@ ui32 TSubSessions::DeleteSubSession(const NActors::TActorId& owner)
     auto subsession = FindIf(
         SubSessions,
         [&] (const auto& subsession) {
-            return subsession.Owner == owner;
+            return subsession.PipeInfo.Owner == owner;
         });
     if (subsession == SubSessions.end()) {
         return true;
@@ -137,7 +136,7 @@ ui32 TSubSessions::DeleteSubSessionByPipeServer(const NActors::TActorId& pipeSer
     auto subsession = FindIf(
         SubSessions,
         [&] (const auto& subsession) {
-            return subsession.PipeServer == pipeServer;
+            return subsession.PipeInfo.PipeServer == pipeServer;
         });
     if (subsession == SubSessions.end()) {
         return true;
@@ -194,7 +193,7 @@ TVector<NActors::TActorId> TSubSessions::GetSubSessions() const
 {
     TVector<NActors::TActorId> ans;
     for (const auto& s: SubSessions) {
-        ans.push_back(s.Owner);
+        ans.push_back(s.PipeInfo.Owner);
     }
     return ans;
 }
@@ -203,7 +202,7 @@ TVector<NActors::TActorId> TSubSessions::GetSubSessionsPipeServer() const
 {
     TVector<NActors::TActorId> ans;
     for (const auto& s: SubSessions) {
-        ans.push_back(s.PipeServer);
+        ans.push_back(s.PipeInfo.PipeServer);
     }
     return ans;
 }
@@ -234,7 +233,7 @@ bool TSubSessions::IsValid() const
     return AllOf(
         SubSessions,
         [&] (const auto& subsession) {
-            return !!subsession.Owner;
+            return !!subsession.PipeInfo.Owner;
         });
 }
 

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -102,35 +102,6 @@ std::optional<TSessionPipeInfo> TSubSessions::UpdateSubSession(
     return AddSubSession(seqNo, readOnly, owner, pipeServer, tabletGeneration);
 }
 
-ui32 TSubSessions::DeleteSubSession(const NActors::TActorId& owner)
-{
-    auto subsession = FindIf(
-        SubSessions,
-        [&] (const auto& subsession) {
-            return subsession.PipeInfo.Owner == owner;
-        });
-    if (subsession == SubSessions.end()) {
-        return true;
-    }
-
-    auto sessionSeqNo = subsession->SeqNo;
-    SubSessions.erase(subsession);
-
-    auto alive = !ReadyToDestroy(sessionSeqNo);
-    if (!alive) {
-        return false;
-    }
-
-    if (sessionSeqNo == MaxSeenRwSeqNo) {
-        MaxSeenRwSeqNo = 0;
-    }
-    if (sessionSeqNo == MaxSeenSeqNo) {
-        MaxSeenSeqNo = MaxSeenRwSeqNo;
-    }
-
-    return true;
-}
-
 ui32 TSubSessions::DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
 {
     auto subsession = FindIf(
@@ -160,7 +131,7 @@ ui32 TSubSessions::DeleteSubSessionByPipeServer(const NActors::TActorId& pipeSer
     return true;
 }
 
-ui32 TSubSessions::DeleteSubSession(ui64 sessionSeqNo)
+std::optional<TSubSession> TSubSessions::DeleteSubSession(ui64 sessionSeqNo)
 {
     auto subsession = FindIf(
         SubSessions,
@@ -169,14 +140,7 @@ ui32 TSubSessions::DeleteSubSession(ui64 sessionSeqNo)
         });
 
     if (subsession == SubSessions.end()) {
-        return !ReadyToDestroy(sessionSeqNo);
-    }
-
-    SubSessions.erase(subsession);
-
-    auto alive = !ReadyToDestroy(sessionSeqNo);
-    if (!alive) {
-        return false;
+        return {};
     }
 
     if (sessionSeqNo == MaxSeenRwSeqNo) {
@@ -186,10 +150,12 @@ ui32 TSubSessions::DeleteSubSession(ui64 sessionSeqNo)
         MaxSeenSeqNo = MaxSeenRwSeqNo;
     }
 
-    return true;
+    auto result = *subsession;
+    SubSessions.erase(subsession);
+    return result;
 }
 
-TVector<NActors::TActorId> TSubSessions::GetSubSessions() const
+TVector<NActors::TActorId> TSubSessions::GetSubSessionsOwner() const
 {
     TVector<NActors::TActorId> ans;
     for (const auto& s: SubSessions) {

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -41,6 +41,7 @@ NActors::TActorId TSubSessions::AddSubSession(
     ui64 seqNo,
     bool readOnly,
     const NActors::TActorId& owner,
+    const NActors::TActorId& pipeServer,
     ui32 tabletGeneration)
 {
     MaxSeenSeqNo = std::max(MaxSeenSeqNo, seqNo);
@@ -51,6 +52,7 @@ NActors::TActorId TSubSessions::AddSubSession(
         {seqNo,
          readOnly,
          owner,
+         pipeServer,
          MakeSubSessionOwnerGeneration(
              tabletGeneration,
              1 /* ownerGeneration */)});
@@ -72,6 +74,7 @@ NActors::TActorId TSubSessions::UpdateSubSession(
     ui64 seqNo,
     bool readOnly,
     const NActors::TActorId& owner,
+    const NActors::TActorId& pipeServer,
     ui32 tabletGeneration)
 {
     MaxSeenSeqNo = std::max(MaxSeenSeqNo, seqNo);
@@ -88,6 +91,7 @@ NActors::TActorId TSubSessions::UpdateSubSession(
         if (subsession->Owner != owner) {
             auto toKill = subsession->Owner;
             subsession->Owner = owner;
+            subsession->PipeServer = pipeServer;
             subsession->OwnerGeneration = MakeSubSessionOwnerGeneration(
                 tabletGeneration,
                 ExtractSubSessionOwnerGeneration(
@@ -96,7 +100,7 @@ NActors::TActorId TSubSessions::UpdateSubSession(
         }
         return {};
     }
-    return AddSubSession(seqNo, readOnly, owner, tabletGeneration);
+    return AddSubSession(seqNo, readOnly, owner, pipeServer, tabletGeneration);
 }
 
 ui32 TSubSessions::DeleteSubSession(const NActors::TActorId& owner)
@@ -105,6 +109,35 @@ ui32 TSubSessions::DeleteSubSession(const NActors::TActorId& owner)
         SubSessions,
         [&] (const auto& subsession) {
             return subsession.Owner == owner;
+        });
+    if (subsession == SubSessions.end()) {
+        return true;
+    }
+
+    auto sessionSeqNo = subsession->SeqNo;
+    SubSessions.erase(subsession);
+
+    auto alive = !ReadyToDestroy(sessionSeqNo);
+    if (!alive) {
+        return false;
+    }
+
+    if (sessionSeqNo == MaxSeenRwSeqNo) {
+        MaxSeenRwSeqNo = 0;
+    }
+    if (sessionSeqNo == MaxSeenSeqNo) {
+        MaxSeenSeqNo = MaxSeenRwSeqNo;
+    }
+
+    return true;
+}
+
+ui32 TSubSessions::DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
+{
+    auto subsession = FindIf(
+        SubSessions,
+        [&] (const auto& subsession) {
+            return subsession.PipeServer == pipeServer;
         });
     if (subsession == SubSessions.end()) {
         return true;
@@ -162,6 +195,15 @@ TVector<NActors::TActorId> TSubSessions::GetSubSessions() const
     TVector<NActors::TActorId> ans;
     for (const auto& s: SubSessions) {
         ans.push_back(s.Owner);
+    }
+    return ans;
+}
+
+TVector<NActors::TActorId> TSubSessions::GetSubSessionsPipeServer() const
+{
+    TVector<NActors::TActorId> ans;
+    for (const auto& s: SubSessions) {
+        ans.push_back(s.PipeServer);
     }
     return ans;
 }

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -48,13 +48,17 @@ TSubSessionUpdateResult TSubSessions::AddSubSession(
     if (!readOnly) {
         MaxSeenRwSeqNo = std::max(MaxSeenRwSeqNo, seqNo);
     }
-    SubSessions.push_back(
-        {seqNo,
-         readOnly,
-         {owner, pipeServer},
-         MakeSubSessionOwnerGeneration(
-             tabletGeneration,
-             1 /* ownerGeneration */)});
+    SubSessions.push_back(TSubSession{
+        .SeqNo = seqNo,
+        .ReadOnly = readOnly,
+        .PipeInfo = TSessionPipeInfo{
+            .Owner = owner,
+            .PipeServer = pipeServer,
+        },
+        .OwnerGeneration = MakeSubSessionOwnerGeneration(
+            tabletGeneration,
+            1 /* ownerGeneration */),
+    });
     if (SubSessions.size() > MaxSubSessions) {
         auto loSeqNo = std::min_element(
             SubSessions.begin(),
@@ -92,7 +96,8 @@ TSubSessionUpdateResult TSubSessions::UpdateSubSession(
     if (subsession != SubSessions.end()) {
         subsession->ReadOnly = readOnly;
 
-        // Owner and PipeServer change independently on reconnect.
+        // Owner and PipeServer can change independently,
+        // track each fact on its own.
         const bool ownerChanged = subsession->PipeInfo.Owner != owner;
         const bool pipeServerChanged =
             subsession->PipeInfo.PipeServer != pipeServer;
@@ -101,7 +106,9 @@ TSubSessionUpdateResult TSubSessions::UpdateSubSession(
         }
 
         TSubSessionUpdateResult result;
-        result.StalePipeServer = subsession->PipeInfo.PipeServer;
+        if (pipeServerChanged) {
+            result.StalePipeServer = subsession->PipeInfo.PipeServer;
+        }
         if (ownerChanged) {
             result.StaleOwner = subsession->PipeInfo.Owner;
         }
@@ -119,60 +126,55 @@ TSubSessionUpdateResult TSubSessions::UpdateSubSession(
     return AddSubSession(seqNo, readOnly, owner, pipeServer, tabletGeneration);
 }
 
-ui32 TSubSessions::DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer)
+TDeleteSubSessionResult TSubSessions::DeleteSubSessionIf(
+    const std::function<bool(const TSubSession&)>& predicate)
 {
-    auto subsession = FindIf(
-        SubSessions,
-        [&] (const auto& subsession) {
-            return subsession.PipeInfo.PipeServer == pipeServer;
-        });
-    if (subsession == SubSessions.end()) {
-        return true;
-    }
-
-    auto sessionSeqNo = subsession->SeqNo;
-    SubSessions.erase(subsession);
-
-    auto alive = !ReadyToDestroy(sessionSeqNo);
-    if (!alive) {
-        return false;
-    }
-
-    if (sessionSeqNo == MaxSeenRwSeqNo) {
-        MaxSeenRwSeqNo = 0;
-    }
-    if (sessionSeqNo == MaxSeenSeqNo) {
-        MaxSeenSeqNo = MaxSeenRwSeqNo;
-    }
-
-    return true;
-}
-
-std::optional<TSubSession> TSubSessions::DeleteSubSession(ui64 sessionSeqNo)
-{
-    auto subsession = FindIf(
-        SubSessions,
-        [&] (const auto& subsession) {
-            return subsession.SeqNo == sessionSeqNo;
-        });
-
+    auto subsession = FindIf(SubSessions, predicate);
     if (subsession == SubSessions.end()) {
         return {};
     }
 
+    auto sessionSeqNo = subsession->SeqNo;
+    auto removed = *subsession;
+    SubSessions.erase(subsession);
+
+    if (ReadyToDestroy(sessionSeqNo)) {
+        return {.Removed = removed, .SessionCanBeDestroyed = true};
+    }
+
+    // MaxSeenRwSeqNo only tracks a single seqNo (the highest one ever
+    // passed with readOnly=false). If the removed one's seqNo equals it,
+    // it is reset to 0.
     if (sessionSeqNo == MaxSeenRwSeqNo) {
         MaxSeenRwSeqNo = 0;
     }
+    // With at most two subsessions, if the removed one's seqNo equals
+    // MaxSeenSeqNo, the only other seqNo we can fall back to is MaxSeenRwSeqNo.
     if (sessionSeqNo == MaxSeenSeqNo) {
         MaxSeenSeqNo = MaxSeenRwSeqNo;
     }
 
-    auto result = *subsession;
-    SubSessions.erase(subsession);
-    return result;
+    return {.Removed = removed, .SessionCanBeDestroyed = false};
 }
 
-TVector<NActors::TActorId> TSubSessions::GetSubSessionsOwner() const
+TDeleteSubSessionResult TSubSessions::DeleteSubSessionByPipeServer(
+    const NActors::TActorId& pipeServer)
+{
+    return DeleteSubSessionIf(
+        [&] (const TSubSession& subsession) {
+            return subsession.PipeInfo.PipeServer == pipeServer;
+        });
+}
+
+TDeleteSubSessionResult TSubSessions::DeleteSubSession(ui64 sessionSeqNo)
+{
+    return DeleteSubSessionIf(
+        [&] (const TSubSession& subsession) {
+            return subsession.SeqNo == sessionSeqNo;
+        });
+}
+
+TVector<NActors::TActorId> TSubSessions::GetSubSessionOwnerIds() const
 {
     TVector<NActors::TActorId> ans;
     for (const auto& s: SubSessions) {
@@ -181,7 +183,7 @@ TVector<NActors::TActorId> TSubSessions::GetSubSessionsOwner() const
     return ans;
 }
 
-TVector<NActors::TActorId> TSubSessions::GetSubSessionsPipeServer() const
+TVector<NActors::TActorId> TSubSessions::GetSubSessionPipeServerIds() const
 {
     TVector<NActors::TActorId> ans;
     for (const auto& s: SubSessions) {

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -52,11 +52,10 @@ public:
         const NActors::TActorId& owner,
         const NActors::TActorId& pipeServer);
 
-    ui32 DeleteSubSession(const NActors::TActorId& owner);
     ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer);
-    ui32 DeleteSubSession(ui64 sessionSeqNo);
+    std::optional<TSubSession> DeleteSubSession(ui64 sessionSeqNo);
 
-    TVector<NActors::TActorId> GetSubSessions() const;
+    TVector<NActors::TActorId> GetSubSessionsOwner() const;
     TVector<NActors::TActorId> GetSubSessionsPipeServer() const;
     TVector<TSubSession> GetAllSubSessions() const;
 

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -18,6 +18,7 @@ struct TSubSession
     ui64 SeqNo;
     bool ReadOnly;
     NActors::TActorId Owner;
+    NActors::TActorId PipeServer;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -37,17 +38,21 @@ public:
     NActors::TActorId AddSubSession(
         ui64 seqNo,
         bool readOnly,
-        const NActors::TActorId& owner);
+        const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer);
 
     NActors::TActorId UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
-        const NActors::TActorId& owner);
+        const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer);
 
     ui32 DeleteSubSession(const NActors::TActorId& owner);
+    ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer);
     ui32 DeleteSubSession(ui64 sessionSeqNo);
 
     TVector<NActors::TActorId> GetSubSessions() const;
+    TVector<NActors::TActorId> GetSubSessionsPipeServer() const;
     TVector<TSubSession> GetAllSubSessions() const;
 
     bool HasSeqNo(ui64 seqNo) const;

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -13,12 +13,17 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TSessionPipeInfo
+{
+    NActors::TActorId Owner;
+    NActors::TActorId PipeServer;
+};
+
 struct TSubSession
 {
     ui64 SeqNo;
     bool ReadOnly;
-    NActors::TActorId Owner;
-    NActors::TActorId PipeServer;
+    TSessionPipeInfo PipeInfo;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,13 +40,13 @@ public:
         , MaxSeenRwSeqNo(maxSeenRwSeqNo)
     {}
 
-    NActors::TActorId AddSubSession(
+    std::optional<TSessionPipeInfo> AddSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
         const NActors::TActorId& pipeServer);
 
-    NActors::TActorId UpdateSubSession(
+    std::optional<TSessionPipeInfo> UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -13,12 +13,17 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TSessionPipeInfo
+{
+    NActors::TActorId Owner;
+    NActors::TActorId PipeServer;
+};
+
 struct TSubSession
 {
     ui64 SeqNo;
     bool ReadOnly;
-    NActors::TActorId Owner;
-    NActors::TActorId PipeServer;
+    TSessionPipeInfo PipeInfo;
     ui64 OwnerGeneration = 0;
 };
 
@@ -45,14 +50,14 @@ public:
         , MaxSeenRwSeqNo(maxSeenRwSeqNo)
     {}
 
-    NActors::TActorId AddSubSession(
+    std::optional<TSessionPipeInfo> AddSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
         const NActors::TActorId& pipeServer,
         ui32 tabletGeneration);
 
-    NActors::TActorId UpdateSubSession(
+    std::optional<TSessionPipeInfo> UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -18,6 +18,7 @@ struct TSubSession
     ui64 SeqNo;
     bool ReadOnly;
     NActors::TActorId Owner;
+    NActors::TActorId PipeServer;
     ui64 OwnerGeneration = 0;
 };
 
@@ -48,18 +49,22 @@ public:
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         ui32 tabletGeneration);
 
     NActors::TActorId UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         ui32 tabletGeneration);
 
     ui32 DeleteSubSession(const NActors::TActorId& owner);
+    ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer);
     ui32 DeleteSubSession(ui64 sessionSeqNo);
 
     TVector<NActors::TActorId> GetSubSessions() const;
+    TVector<NActors::TActorId> GetSubSessionsPipeServer() const;
     TVector<TSubSession> GetAllSubSessions() const;
 
     bool HasSeqNo(ui64 seqNo) const;

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -64,11 +64,10 @@ public:
         const NActors::TActorId& pipeServer,
         ui32 tabletGeneration);
 
-    ui32 DeleteSubSession(const NActors::TActorId& owner);
     ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer);
-    ui32 DeleteSubSession(ui64 sessionSeqNo);
+    std::optional<TSubSession> DeleteSubSession(ui64 sessionSeqNo);
 
-    TVector<NActors::TActorId> GetSubSessions() const;
+    TVector<NActors::TActorId> GetSubSessionsOwner() const;
     TVector<NActors::TActorId> GetSubSessionsPipeServer() const;
     TVector<TSubSession> GetAllSubSessions() const;
 

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -29,6 +29,14 @@ struct TSubSession
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TSubSessionUpdateResult
+{
+    std::optional<NActors::TActorId> StalePipeServer;
+    std::optional<NActors::TActorId> StaleOwner;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 ui64 MakeSubSessionOwnerGeneration(
     ui32 tabletGeneration,
     ui32 ownerGeneration);
@@ -50,14 +58,14 @@ public:
         , MaxSeenRwSeqNo(maxSeenRwSeqNo)
     {}
 
-    std::optional<TSessionPipeInfo> AddSubSession(
+    TSubSessionUpdateResult AddSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
         const NActors::TActorId& pipeServer,
         ui32 tabletGeneration);
 
-    std::optional<TSessionPipeInfo> UpdateSubSession(
+    TSubSessionUpdateResult UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -6,6 +6,7 @@
 
 #include <util/datetime/base.h>
 
+#include <functional>
 #include <optional>
 
 
@@ -27,12 +28,21 @@ struct TSubSession
     ui64 OwnerGeneration = 0;
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
 struct TSubSessionUpdateResult
 {
     std::optional<NActors::TActorId> StalePipeServer;
     std::optional<NActors::TActorId> StaleOwner;
+};
+
+struct TDeleteSubSessionResult
+{
+    // The subsession that was removed, if any matched.
+    std::optional<TSubSession> Removed;
+
+    // True if nothing else holds the session after this removal - the
+    // caller should destroy the whole session instead of just this
+    // subsession.
+    bool SessionCanBeDestroyed = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,6 +61,9 @@ class TSubSessions
     TVector<TSubSession> SubSessions;
     ui64 MaxSeenSeqNo = 0;
     ui64 MaxSeenRwSeqNo = 0;
+
+    TDeleteSubSessionResult DeleteSubSessionIf(
+        const std::function<bool(const TSubSession&)>& predicate);
 
 public:
     explicit TSubSessions(ui64 maxSeenSeqNo, ui64 maxSeenRwSeqNo)
@@ -72,11 +85,12 @@ public:
         const NActors::TActorId& pipeServer,
         ui32 tabletGeneration);
 
-    ui32 DeleteSubSessionByPipeServer(const NActors::TActorId& pipeServer);
-    std::optional<TSubSession> DeleteSubSession(ui64 sessionSeqNo);
+    TDeleteSubSessionResult DeleteSubSessionByPipeServer(
+        const NActors::TActorId& pipeServer);
+    TDeleteSubSessionResult DeleteSubSession(ui64 sessionSeqNo);
 
-    TVector<NActors::TActorId> GetSubSessionsOwner() const;
-    TVector<NActors::TActorId> GetSubSessionsPipeServer() const;
+    TVector<NActors::TActorId> GetSubSessionOwnerIds() const;
+    TVector<NActors::TActorId> GetSubSessionPipeServerIds() const;
     TVector<TSubSession> GetAllSubSessions() const;
 
     bool HasSeqNo(ui64 seqNo) const;

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -14,7 +14,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     {
         TSubSessions subsessions(0, 0);
 
-        subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        subsessions.UpdateSubSession(1, true, TActorId(0, 1), TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
     }
 
@@ -22,12 +22,12 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     {
         TSubSessions subsessions(0, 0);
 
-        subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        subsessions.UpdateSubSession(1, true, TActorId(0, 1), TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
         UNIT_ASSERT_VALUES_EQUAL(0, subsessions.GetMaxSeenRwSeqNo());
 
-        subsessions.UpdateSubSession(1, false, TActorId(1, 1));
+        subsessions.UpdateSubSession(1, false, TActorId(1, 1), TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenRwSeqNo());
@@ -41,7 +41,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         }
 
         {
-            subsessions.UpdateSubSession(2, true, TActorId(2, 1));
+            subsessions.UpdateSubSession(2, true, TActorId(2, 1), TActorId(2, 1));
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
             auto subsession = subsessions.GetSubSessionBySeqNo(2);
             UNIT_ASSERT_VALUES_EQUAL(true, subsession.has_value());
@@ -58,15 +58,15 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TSubSessions subsessions(0, 0);
         TActorId ans;
 
-        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1) , TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1), TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(3, true, TActorId(2, 1));
+        ans = subsessions.UpdateSubSession(3, true, TActorId(2, 1), TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), ans);
 
@@ -80,11 +80,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1), TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1), TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -104,11 +104,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1), TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1), TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -123,11 +123,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1), TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1), TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -142,11 +142,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1), TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1), TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -42,7 +42,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         }
 
         {
-            subsessions.UpdateSubSession(2, true, TActorId(2, 1), TActorId(2, 2));
+            subsessions.UpdateSubSession(
+                2,
+                true,
+                TActorId(2, 1),
+                TActorId(2, 2));
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
             auto subsession = subsessions.GetSubSessionBySeqNo(2);
             UNIT_ASSERT_VALUES_EQUAL(true, subsession.has_value());
@@ -59,15 +63,27 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     {
         TSubSessions subsessions(0, 0);
 
-        auto ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1) , TActorId(2, 0));
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1), TActorId(2, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            false,
+            TActorId(1, 1),
+            TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        ans = subsessions.UpdateSubSession(3, true, TActorId(2, 1), TActorId(2, 2));
+        ans = subsessions.UpdateSubSession(
+            3,
+            true,
+            TActorId(2, 1),
+            TActorId(2, 2));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), ans->Owner);
         UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 0), ans->PipeServer);
@@ -81,19 +97,27 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TSubSessions subsessions(0, 0);
         ui32 size = 0;
 
-        auto ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1), TActorId(2, 0));
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1), TActorId(2, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            true,
+            TActorId(1, 1),
+            TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(0, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, size);
 
-        size = subsessions.DeleteSubSession(TActorId(1, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(0, size);
         UNIT_ASSERT_VALUES_EQUAL(false, subsessions.IsValid());
@@ -104,15 +128,23 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TSubSessions subsessions(0, 0);
         ui32 size = 0;
 
-        auto ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1), TActorId(2, 0));
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(0, 1),
+            TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1), TActorId(2, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            true,
+            TActorId(1, 1),
+            TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(1, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, size);
     }
@@ -122,15 +154,23 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TSubSessions subsessions(0, 0);
         ui32 size = 0;
 
-        auto ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1), TActorId(2, 0));
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(0, 1),
+            TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1), TActorId(2, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            true,
+            TActorId(1, 1),
+            TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(0, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, size);
     }
@@ -140,18 +180,25 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TSubSessions subsessions(0, 0);
         ui32 size = 0;
 
-        auto ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1), TActorId(2, 0));
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1), TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            false,
+            TActorId(1, 1),
+            TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(1, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, size);
     }
 }
 
 }   // namespace NCloud::NFileStore::NStorage
-

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -24,6 +24,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
     }
@@ -36,6 +37,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
@@ -44,6 +46,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         subsessions.UpdateSubSession(
             1,
             false,
+            TActorId(1, 1),
             TActorId(1, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -62,6 +65,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             subsessions.UpdateSubSession(
                 2,
                 true,
+                TActorId(2, 1),
                 TActorId(2, 1),
                 TabletGeneration);
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
@@ -140,6 +144,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
@@ -148,6 +153,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             2,
             false,
             TActorId(1, 1),
+            TActorId(1, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
@@ -155,6 +161,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         ans = subsessions.UpdateSubSession(
             3,
             true,
+            TActorId(2, 1),
             TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
@@ -174,6 +181,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
@@ -181,6 +189,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         ans = subsessions.UpdateSubSession(
             2,
             true,
+            TActorId(1, 1),
             TActorId(1, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
@@ -206,6 +215,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             false,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
@@ -213,6 +223,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         ans = subsessions.UpdateSubSession(
             2,
             true,
+            TActorId(1, 1),
             TActorId(1, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
@@ -233,6 +244,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             false,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
@@ -240,6 +252,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         ans = subsessions.UpdateSubSession(
             2,
             true,
+            TActorId(1, 1),
             TActorId(1, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
@@ -260,6 +273,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
+            TActorId(0, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
@@ -267,6 +281,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         ans = subsessions.UpdateSubSession(
             2,
             false,
+            TActorId(1, 1),
             TActorId(1, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -37,7 +37,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
-            TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
@@ -47,7 +47,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             false,
             TActorId(1, 1),
-            TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
@@ -58,7 +58,12 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             UNIT_ASSERT_VALUES_EQUAL(true, subsession.has_value());
             UNIT_ASSERT_VALUES_EQUAL(1, subsession->SeqNo);
             UNIT_ASSERT_VALUES_EQUAL(false, subsession->ReadOnly);
-            UNIT_ASSERT_VALUES_EQUAL(TActorId(1, 1), subsession->PipeInfo.Owner);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TActorId(1, 1),
+                subsession->PipeInfo.Owner);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TActorId(2, 1),
+                subsession->PipeInfo.PipeServer);
         }
 
         {
@@ -66,7 +71,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
                 2,
                 true,
                 TActorId(2, 1),
-                TActorId(2, 1),
+                TActorId(2, 2),
                 TabletGeneration);
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
             auto subsession = subsessions.GetSubSessionBySeqNo(2);
@@ -75,7 +80,12 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             UNIT_ASSERT_VALUES_EQUAL(true, subsession->ReadOnly);
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetMaxSeenSeqNo());
             UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenRwSeqNo());
-            UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 1), subsession->PipeInfo.Owner);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TActorId(2, 1),
+                subsession->PipeInfo.Owner);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TActorId(2, 2),
+                subsession->PipeInfo.PipeServer);
         }
     }
 
@@ -87,6 +97,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             true,
             TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         {
             auto subsession = subsessions.GetSubSessionBySeqNo(1);
@@ -104,6 +115,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             false,
             TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         {
             auto subsession = subsessions.GetSubSessionBySeqNo(1);
@@ -121,6 +133,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             1,
             false,
             TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         {
             auto subsession = subsessions.GetSubSessionBySeqNo(1);
@@ -138,34 +151,34 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     Y_UNIT_TEST(ShouldRemoveSubSessionWithLowestSeqNo)
     {
         TSubSessions subsessions(0, 0);
-        TActorId ans;
 
-        ans = subsessions.UpdateSubSession(
+        auto ans = subsessions.UpdateSubSession(
             1,
             true,
             TActorId(0, 1),
-            TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         ans = subsessions.UpdateSubSession(
             2,
             false,
             TActorId(1, 1),
-            TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         ans = subsessions.UpdateSubSession(
             3,
             true,
             TActorId(2, 1),
-            TActorId(2, 1),
+            TActorId(2, 2),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), ans);
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), ans->Owner);
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 0), ans->PipeServer);
 
         UNIT_ASSERT_VALUES_EQUAL(3, subsessions.GetMaxSeenSeqNo());
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetMaxSeenRwSeqNo());
@@ -174,26 +187,25 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     Y_UNIT_TEST(ShouldRemoveSubSession)
     {
         TSubSessions subsessions(0, 0);
-        TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(
+        auto ans = subsessions.UpdateSubSession(
             1,
             true,
             TActorId(0, 1),
-            TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         ans = subsessions.UpdateSubSession(
             2,
             true,
             TActorId(1, 1),
-            TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         size = subsessions.DeleteSubSession(TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -208,26 +220,25 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     Y_UNIT_TEST(ShouldNotRemoveSessionIfWriterIsStillAlive)
     {
         TSubSessions subsessions(0, 0);
-        TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(
+        auto ans = subsessions.UpdateSubSession(
             1,
             false,
             TActorId(0, 1),
-            TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         ans = subsessions.UpdateSubSession(
             2,
             true,
             TActorId(1, 1),
-            TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         size = subsessions.DeleteSubSession(TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -237,26 +248,25 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     Y_UNIT_TEST(ShouldNotRemoveSessionSeqNoIsLower)
     {
         TSubSessions subsessions(0, 0);
-        TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(
+        auto ans = subsessions.UpdateSubSession(
             1,
             false,
             TActorId(0, 1),
-            TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         ans = subsessions.UpdateSubSession(
             2,
             true,
             TActorId(1, 1),
-            TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         size = subsessions.DeleteSubSession(TActorId(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -266,26 +276,25 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     Y_UNIT_TEST(ShouldRemoveSubSessionIfRemovedWriterWithHighestSeqNo)
     {
         TSubSessions subsessions(0, 0);
-        TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(
+        auto ans = subsessions.UpdateSubSession(
             1,
             true,
             TActorId(0, 1),
-            TActorId(0, 1),
+            TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         ans = subsessions.UpdateSubSession(
             2,
             false,
             TActorId(1, 1),
-            TActorId(1, 1),
+            TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
+        UNIT_ASSERT(!ans.has_value());
 
         size = subsessions.DeleteSubSession(TActorId(1, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, size);

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -207,11 +207,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(0, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, size);
 
-        size = subsessions.DeleteSubSession(TActorId(1, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(0, size);
         UNIT_ASSERT_VALUES_EQUAL(false, subsessions.IsValid());
@@ -240,7 +240,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(1, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, size);
     }
@@ -268,7 +268,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(0, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, size);
     }
@@ -296,7 +296,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT(!ans.has_value());
 
-        size = subsessions.DeleteSubSession(TActorId(1, 1));
+        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, size);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             UNIT_ASSERT_VALUES_EQUAL(true, subsession.has_value());
             UNIT_ASSERT_VALUES_EQUAL(1, subsession->SeqNo);
             UNIT_ASSERT_VALUES_EQUAL(false, subsession->ReadOnly);
-            UNIT_ASSERT_VALUES_EQUAL(TActorId(1, 1), subsession->Owner);
+            UNIT_ASSERT_VALUES_EQUAL(TActorId(1, 1), subsession->PipeInfo.Owner);
         }
 
         {
@@ -75,7 +75,7 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             UNIT_ASSERT_VALUES_EQUAL(true, subsession->ReadOnly);
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetMaxSeenSeqNo());
             UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenRwSeqNo());
-            UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 1), subsession->Owner);
+            UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 1), subsession->PipeInfo.Owner);
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -89,6 +89,61 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         }
     }
 
+    Y_UNIT_TEST(ShouldUpdatePipeServerWhenOwnerUnchanged)
+    {
+        TSubSessions subsessions(0, 0);
+
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 0),
+            TabletGeneration);
+
+        // Client reconnects through a new pipe server, but the owner actor
+        // (the session actor on the client side) stays the same.
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 99),
+            TabletGeneration);
+
+        auto subsession = subsessions.GetSubSessionBySeqNo(1);
+        UNIT_ASSERT(subsession.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), subsession->PipeInfo.Owner);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TActorId(2, 99),
+            subsession->PipeInfo.PipeServer);
+    }
+
+    Y_UNIT_TEST(ShouldNotReportStaleOwnerWhenOnlyPipeServerChanges)
+    {
+        // The caller kills whatever UpdateSubSession reports as StaleOwner
+        // (see TIndexTabletState::RecoverSession). If a pipe-only reconnect
+        // reported the (unchanged) owner as stale, the tablet would send a
+        // PoisonPill to the very session actor that just reconnected.
+        TSubSessions subsessions(0, 0);
+
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 0),
+            TabletGeneration);
+
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),    // same owner
+            TActorId(2, 99),   // new pipe server
+            TabletGeneration);
+
+        UNIT_ASSERT(ans.StalePipeServer.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 0), *ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner.has_value());
+    }
+
     Y_UNIT_TEST(ShouldTrackOwnerGeneration)
     {
         TSubSessions subsessions(0, 0);
@@ -159,7 +214,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         ans = subsessions.UpdateSubSession(
             2,
@@ -168,7 +224,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         ans = subsessions.UpdateSubSession(
             3,
@@ -177,8 +234,10 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 2),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), ans->Owner);
-        UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 0), ans->PipeServer);
+        UNIT_ASSERT(ans.StalePipeServer.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(2, 0), *ans.StalePipeServer);
+        UNIT_ASSERT(ans.StaleOwner.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), *ans.StaleOwner);
 
         UNIT_ASSERT_VALUES_EQUAL(3, subsessions.GetMaxSeenSeqNo());
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetMaxSeenRwSeqNo());
@@ -196,7 +255,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         ans = subsessions.UpdateSubSession(
             2,
@@ -205,7 +265,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -229,7 +290,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         ans = subsessions.UpdateSubSession(
             2,
@@ -238,7 +300,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -257,7 +320,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         ans = subsessions.UpdateSubSession(
             2,
@@ -266,7 +330,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
@@ -285,7 +350,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 0),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         ans = subsessions.UpdateSubSession(
             2,
@@ -294,7 +360,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
             TActorId(2, 1),
             TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
-        UNIT_ASSERT(!ans.has_value());
+        UNIT_ASSERT(!ans.StalePipeServer);
+        UNIT_ASSERT(!ans.StaleOwner);
 
         size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, size);

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -144,6 +144,34 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT(!ans.StaleOwner.has_value());
     }
 
+    Y_UNIT_TEST(ShouldNotReportStalePipeServerWhenOnlyOwnerChanges)
+    {
+        // The caller unbinds whatever UpdateSubSession reports as
+        // StalePipeServer (see TIndexTabletState::RecoverSession). Reporting
+        // the current, unchanged pipe server as stale would erase and
+        // immediately re-add the same PipeServer -> TSession entry - harmless
+        // there, but the field would no longer mean "actually stale".
+        TSubSessions subsessions(0, 0);
+
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TActorId(2, 0),
+            TabletGeneration);
+
+        auto ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 99),   // new owner
+            TActorId(2, 0),    // same pipe server
+            TabletGeneration);
+
+        UNIT_ASSERT(!ans.StalePipeServer.has_value());
+        UNIT_ASSERT(ans.StaleOwner.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), *ans.StaleOwner);
+    }
+
     Y_UNIT_TEST(ShouldTrackOwnerGeneration)
     {
         TSubSessions subsessions(0, 0);
@@ -246,7 +274,6 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     Y_UNIT_TEST(ShouldRemoveSubSession)
     {
         TSubSessions subsessions(0, 0);
-        ui32 size = 0;
 
         auto ans = subsessions.UpdateSubSession(
             1,
@@ -268,20 +295,19 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT(!ans.StalePipeServer);
         UNIT_ASSERT(!ans.StaleOwner);
 
-        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
+        auto result = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(1, size);
+        UNIT_ASSERT(!result.SessionCanBeDestroyed);
 
-        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
+        result = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(0, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(0, size);
+        UNIT_ASSERT(result.SessionCanBeDestroyed);
         UNIT_ASSERT_VALUES_EQUAL(false, subsessions.IsValid());
     }
 
     Y_UNIT_TEST(ShouldNotRemoveSessionIfWriterIsStillAlive)
     {
         TSubSessions subsessions(0, 0);
-        ui32 size = 0;
 
         auto ans = subsessions.UpdateSubSession(
             1,
@@ -303,15 +329,14 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT(!ans.StalePipeServer);
         UNIT_ASSERT(!ans.StaleOwner);
 
-        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
+        auto result = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(1, size);
+        UNIT_ASSERT(!result.SessionCanBeDestroyed);
     }
 
     Y_UNIT_TEST(ShouldNotRemoveSessionSeqNoIsLower)
     {
         TSubSessions subsessions(0, 0);
-        ui32 size = 0;
 
         auto ans = subsessions.UpdateSubSession(
             1,
@@ -333,15 +358,14 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT(!ans.StalePipeServer);
         UNIT_ASSERT(!ans.StaleOwner);
 
-        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
+        auto result = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 0));
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
-        UNIT_ASSERT_VALUES_EQUAL(1, size);
+        UNIT_ASSERT(!result.SessionCanBeDestroyed);
     }
 
     Y_UNIT_TEST(ShouldRemoveSubSessionIfRemovedWriterWithHighestSeqNo)
     {
         TSubSessions subsessions(0, 0);
-        ui32 size = 0;
 
         auto ans = subsessions.UpdateSubSession(
             1,
@@ -363,8 +387,8 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         UNIT_ASSERT(!ans.StalePipeServer);
         UNIT_ASSERT(!ans.StaleOwner);
 
-        size = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
-        UNIT_ASSERT_VALUES_EQUAL(0, size);
+        auto result = subsessions.DeleteSubSessionByPipeServer(TActorId(2, 1));
+        UNIT_ASSERT(result.SessionCanBeDestroyed);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -749,18 +749,6 @@ void TIndexTabletActor::HandleSessionDisconnected(
     const TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
     const TActorContext& ctx)
 {
-    LOG_INFO(ctx, TFileStoreComponents::TABLET,
-        "%s Server disconnected, ev->Sender: %s",
-        LogTag.c_str(),
-        ev->Sender.ToString().c_str());
-
-    OrphanSession(ev->Sender, ctx.Now());
-}
-
-void TIndexTabletActor::HandleSessionDisconnectedInWork(
-    const TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
-    const TActorContext& ctx)
-{
     const auto& msg = *ev->Get();
 
     // TODO (#4962): once owner-to-session relation is tracked properly, use
@@ -796,6 +784,8 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
     // from this client connection. Unconfirmed data keeps this actor id from
     // GenerateBlobIds, so clean it up when the pipe disconnects.
     DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
+
+    OrphanSession(msg.ServerId, ctx.Now());
     RemoveSessionByPipeServer(msg.ServerId);
 }
 
@@ -1313,10 +1303,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
+        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleSessionDisconnected);
+
         IgnoreFunc(TEvTabletPipe::TEvServerConnected);
-        HFunc(
-            TEvTabletPipe::TEvServerDisconnected,
-            HandleSessionDisconnectedInWork);
 
         HFunc(TEvLocal::TEvTabletMetrics, HandleTabletMetrics);
         HFunc(TEvFileStore::TEvUpdateConfig, HandleUpdateConfig);
@@ -1402,9 +1391,7 @@ STFUNC(TIndexTabletActor::StateAdapter)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         IgnoreFunc(TEvTabletPipe::TEvServerConnected);
-        HFunc(
-            TEvTabletPipe::TEvServerDisconnected,
-            HandleSessionDisconnectedInWork);
+        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleSessionDisconnected);
 
         HFunc(TEvLocal::TEvTabletMetrics, HandleTabletMetrics);
         HFunc(TEvFileStore::TEvUpdateConfig, HandleUpdateConfig);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1056,33 +1056,35 @@ void TIndexTabletActor::HandleSessionDisconnected(
 {
     const auto& msg = *ev->Get();
 
-    // TODO (#4962): once owner-to-session relation is tracked properly, use
-    // the session id directly and simplify this split session/pipe cleanup.
-    const auto& sessionIds = FindSessionIdsByPipeServer(msg.ServerId);
+    // If msg.ServerId is a session's own control pipe, session is found
+    // here, and below we orphan that session and delete its unconfirmed
+    // data. If it is not (e.g. IndexTabletProxy's own pipe, used for
+    // AddData/GenerateBlobIds), session is null - but that pipe id can
+    // still have unconfirmed writes tracked under it, so
+    // DeleteUnconfirmedDataForPipeServer below cleans those up regardless
+    // of whether a session was found.
+    auto* session = FindSessionByPipeServer(msg.ServerId);
 
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,
         "%s Server disconnected, sender: %s, client: %s, server: %s, "
-        "matchedSessions: %zu",
+        "matchedSession: %s",
         LogTag.c_str(),
         ev->Sender.ToString().c_str(),
         msg.ClientId.ToString().c_str(),
         msg.ServerId.ToString().c_str(),
-        sessionIds.size());
+        session ? session->GetSessionId().c_str() : "<none>");
 
-    // The disconnected pipe may be the control pipe, while unconfirmed writes
-    // for the same logical session can be tracked with a separate data pipe
-    // server id. Delete by session too.
-    for (const auto& sessionId: sessionIds) {
+    if (session) {
         LOG_INFO(
             ctx,
             TFileStoreComponents::TABLET,
             "%s Deleting unconfirmed data for session: sessionId=%s",
             LogTag.c_str(),
-            sessionId.Quote().c_str());
+            session->GetSessionId().Quote().c_str());
 
-        DeleteUnconfirmedDataForSession(sessionId, ctx);
+        DeleteUnconfirmedDataForSession(session->GetSessionId(), ctx);
     }
 
     // msg.ServerId is the tablet-pipe server actor that received requests
@@ -1091,7 +1093,6 @@ void TIndexTabletActor::HandleSessionDisconnected(
     DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
 
     OrphanSession(msg.ServerId, ctx.Now());
-    RemoveSessionByPipeServer(msg.ServerId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1691,7 +1691,10 @@ STFUNC(TIndexTabletActor::StateZombie)
 
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);
-        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleSessionDisconnected);
+
+        // Tablet is rebooting - sessions get orphaned and unconfirmed data gets
+        // cleaned up on startup anyway, no need to do anything extra on stop.
+        IgnoreFunc(TEvTabletPipe::TEvServerDisconnected);
 
         // If compaction/cleanup/collectgarbage/flush started before the tablet
         // reload and completed during the zombie state, we should ignore it.

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1092,7 +1092,7 @@ void TIndexTabletActor::HandleSessionDisconnected(
     // GenerateBlobIds, so clean it up when the pipe disconnects.
     DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
 
-    OrphanSession(msg.ServerId, ctx.Now());
+    OrphanSession(msg.ServerId, ctx.Now() + Config->GetIdleSessionTimeout());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1054,18 +1054,6 @@ void TIndexTabletActor::HandleSessionDisconnected(
     const TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
     const TActorContext& ctx)
 {
-    LOG_INFO(ctx, TFileStoreComponents::TABLET,
-        "%s Server disconnected, ev->Sender: %s",
-        LogTag.c_str(),
-        ev->Sender.ToString().c_str());
-
-    OrphanSession(ev->Sender, ctx.Now());
-}
-
-void TIndexTabletActor::HandleSessionDisconnectedInWork(
-    const TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
-    const TActorContext& ctx)
-{
     const auto& msg = *ev->Get();
 
     // TODO (#4962): once owner-to-session relation is tracked properly, use
@@ -1101,6 +1089,8 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
     // from this client connection. Unconfirmed data keeps this actor id from
     // GenerateBlobIds, so clean it up when the pipe disconnects.
     DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
+
+    OrphanSession(msg.ServerId, ctx.Now());
     RemoveSessionByPipeServer(msg.ServerId);
 }
 
@@ -1587,10 +1577,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(TEvents::TEvWakeup, HandleWakeup);
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
+        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleSessionDisconnected);
+
         IgnoreFunc(TEvTabletPipe::TEvServerConnected);
-        HFunc(
-            TEvTabletPipe::TEvServerDisconnected,
-            HandleSessionDisconnectedInWork);
 
         HFunc(TEvLocal::TEvTabletMetrics, HandleTabletMetrics);
         HFunc(TEvFileStore::TEvUpdateConfig, HandleUpdateConfig);
@@ -1676,9 +1665,7 @@ STFUNC(TIndexTabletActor::StateAdapter)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         IgnoreFunc(TEvTabletPipe::TEvServerConnected);
-        HFunc(
-            TEvTabletPipe::TEvServerDisconnected,
-            HandleSessionDisconnectedInWork);
+        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleSessionDisconnected);
 
         HFunc(TEvLocal::TEvTabletMetrics, HandleTabletMetrics);
         HFunc(TEvFileStore::TEvUpdateConfig, HandleUpdateConfig);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1790,7 +1790,7 @@ STFUNC(TIndexTabletActor::StateBroken)
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);
 
         IgnoreFunc(TEvTabletPipe::TEvServerConnected);
-        HFunc(TEvTabletPipe::TEvServerDisconnected, HandleSessionDisconnected);
+        IgnoreFunc(TEvTabletPipe::TEvServerDisconnected);
 
         IgnoreFunc(TEvLocal::TEvTabletMetrics);
         IgnoreFunc(TEvFileStore::TEvUpdateConfig);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -639,9 +639,6 @@ private:
     void HandleSessionDisconnected(
         const NKikimr::TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
         const NActors::TActorContext& ctx);
-    void HandleSessionDisconnectedInWork(
-        const NKikimr::TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
-        const NActors::TActorContext& ctx);
 
     void HandleTabletMetrics(
         const NKikimr::TEvLocal::TEvTabletMetrics::TPtr& ev,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -734,9 +734,6 @@ private:
     void HandleSessionDisconnected(
         const NKikimr::TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
         const NActors::TActorContext& ctx);
-    void HandleSessionDisconnectedInWork(
-        const NKikimr::TEvTabletPipe::TEvServerDisconnected::TPtr& ev,
-        const NActors::TActorContext& ctx);
 
     void HandleTabletMetrics(
         const NKikimr::TEvLocal::TEvTabletMetrics::TPtr& ev,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -126,12 +126,13 @@ TActorId DoRecoverSession(
     ui64 sessionSeqNo,
     bool readOnly,
     const TActorId& owner,
+    const TActorId& pipeServer,
     const TActorContext& ctx)
 {
     auto oldSessionSeqNo = session->GetSessionSeqNo();
 
     auto oldOwner =
-        state.RecoverSession(session, sessionSeqNo, readOnly, owner);
+        state.RecoverSession(session, sessionSeqNo, readOnly, owner, pipeServer);
     if (oldOwner) {
         LOG_INFO(ctx, TFileStoreComponents::TABLET,
             "[s:%s][n:%lu] kill from tablet %s self %s",
@@ -273,6 +274,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
     const auto readOnly = args.Request.GetReadOnly();
 
     const auto owner = args.RequestInfo->Sender;
+    const auto pipeServer = args.PipeServerId;
 
     TIndexTabletDatabase db(tx.DB);
 
@@ -291,6 +293,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 seqNo,
                 readOnly,
                 owner,
+                pipeServer,
                 ctx);
             args.SessionInterrupted = true;
             if (toKill != owner) {
@@ -338,6 +341,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 seqNo,
                 readOnly,
                 owner,
+                pipeServer,
                 ctx);
             args.SessionInterrupted = true;
 
@@ -374,6 +378,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
         seqNo,
         readOnly,
         owner,
+        pipeServer,
         sessionOptions);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -523,9 +523,6 @@ void TIndexTabletActor::CompleteTx_CreateSession(
         return;
     }
 
-    UnregisterSessionByPipeServer(args.SessionId);
-    RegisterSessionByPipeServer(args.PipeServerId, args.SessionId);
-
     auto response = std::make_unique<TResponse>(args.Error);
     response->Record.SetSessionId(std::move(args.SessionId));
     response->Record.SetSessionState(session->GetSessionState());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -150,12 +150,13 @@ TActorId DoRecoverSession(
     ui64 sessionSeqNo,
     bool readOnly,
     const TActorId& owner,
+    const TActorId& pipeServer,
     const TActorContext& ctx)
 {
     auto oldSessionSeqNo = session->GetSessionSeqNo();
 
     auto oldOwner =
-        state.RecoverSession(session, sessionSeqNo, readOnly, owner);
+        state.RecoverSession(session, sessionSeqNo, readOnly, owner, pipeServer);
     if (oldOwner) {
         LOG_INFO(ctx, TFileStoreComponents::TABLET,
             "[s:%s][n:%lu] kill from tablet %s self %s",
@@ -337,6 +338,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
     const auto readOnly = args.Request.GetReadOnly();
 
     const auto owner = args.RequestInfo->Sender;
+    const auto pipeServer = args.PipeServerId;
 
     auto db = CreateIndexTabletDatabase(tx.DB);
 
@@ -355,6 +357,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 seqNo,
                 readOnly,
                 owner,
+                pipeServer,
                 ctx);
             args.SessionInterrupted = true;
             if (toKill != owner) {
@@ -415,6 +418,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 seqNo,
                 readOnly,
                 owner,
+                pipeServer,
                 ctx);
             const auto subSession =
                 session->SubSessions.GetSubSessionBySeqNo(seqNo);
@@ -464,6 +468,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
         seqNo,
         readOnly,
         owner,
+        pipeServer,
         sessionOptions);
     const auto subSession =
         newSession->SubSessions.GetSubSessionBySeqNo(seqNo);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -153,7 +153,12 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
             return;
         }
 
-        if (session->DeleteSubSession(args.SessionSeqNo)) {
+        if (!session->ReadyToDestroy(args.SessionSeqNo)) {
+            auto subsession = session->DeleteSubSession(args.SessionSeqNo);
+            if (subsession) {
+                RemovePipeServer(subsession->PipeInfo.PipeServer);
+            }
+
             db->WriteSession(*session);
             args.Completed = true;
             return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -222,7 +222,6 @@ void TIndexTabletActor::CompleteTx_DestroySession(
         return;
     }
 
-    UnregisterSessionByPipeServer(args.SessionId);
     DeleteUnconfirmedDataForSession(args.SessionId, ctx);
 
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -153,10 +153,10 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
             return;
         }
 
-        if (!session->ReadyToDestroy(args.SessionSeqNo)) {
-            auto subsession = session->DeleteSubSession(args.SessionSeqNo);
-            if (subsession) {
-                RemovePipeServer(subsession->PipeInfo.PipeServer);
+        auto result = session->DeleteSubSession(args.SessionSeqNo);
+        if (!result.SessionCanBeDestroyed) {
+            if (result.Removed) {
+                RemovePipeServer(result.Removed->PipeInfo.PipeServer);
             }
 
             db->WriteSession(*session);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -154,11 +154,11 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
         }
 
         auto result = session->DeleteSubSession(args.SessionSeqNo);
-        if (!result.SessionCanBeDestroyed) {
-            if (result.Removed) {
-                RemovePipeServer(result.Removed->PipeInfo.PipeServer);
-            }
+        if (result.Removed) {
+            RemovePipeServer(result.Removed->PipeInfo.PipeServer);
+        }
 
+        if (!result.SessionCanBeDestroyed) {
             db->WriteSession(*session);
             args.Completed = true;
             return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -750,7 +750,7 @@ void DumpSessions(
                         }
                         TABLED() { out << ss.SeqNo; }
                         TABLED() { out << (ss.ReadOnly ? "True" : "False"); }
-                        TABLED() { out << ToString(ss.Owner); }
+                        TABLED() { out << ToString(ss.PipeInfo.Owner); }
                         TABLED() { out << session.InactivityDeadline.ToString(); }
                     }
                 };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -752,7 +752,7 @@ void DumpSessions(
                         TABLED() { out << ss.SeqNo; }
                         TABLED() { out << (ss.ReadOnly ? "True" : "False"); }
                         TABLED() { out << ss.OwnerGeneration; }
-                        TABLED() { out << ToString(ss.Owner); }
+                        TABLED() { out << ToString(ss.PipeInfo.Owner); }
                         TABLED() { out << session.InactivityDeadline.ToString(); }
                     }
                 };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_subscribesession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_subscribesession.cpp
@@ -50,7 +50,7 @@ void TIndexTabletActor::NotifySessionEvent(
                 session->GetSessionId().c_str(),
                 seqNo);
 
-            for (const auto& s: session->GetSubSessions()) {
+            for (const auto& s: session->GetSubSessionOwnerIds()) {
                 auto response =
                     std::make_unique<TEvService::TEvGetSessionEventsResponse>();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -775,6 +775,7 @@ public:
     void RemoveSessionByPipeServer(const NActors::TActorId& pipeServer);
     void OrphanSession(const NActors::TActorId& owner, TInstant inactivityDeadline);
     void ResetSession(TIndexTabletDatabase& db, TSession* session, const TMaybe<TString>& state);
+    void RemovePipeServer(const NActors::TActorId& pipeServer);
 
     TVector<TSession*> GetTimedOutSessions(TInstant now) const;
     TVector<TSession*> GetSessionsToNotify(const NProto::TSessionEvent& event) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -745,6 +745,7 @@ public:
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         const NProto::TSessionOptions& sessionOptions);
 
     void RemoveSession(
@@ -762,7 +763,9 @@ public:
         TSession* session,
         ui64 sessionSeqNo,
         bool readOnly,
-        const NActors::TActorId& owner);
+        const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer);
+
     void RegisterSessionByPipeServer(
         const NActors::TActorId& pipeServer,
         const TString& sessionId);
@@ -801,6 +804,7 @@ private:
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         const NProto::TSessionOptions& sessionOptions);
 
     void RemoveSession(TSession* session);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -843,6 +843,8 @@ public:
         const TString& clientId,
         const TString& sessionId,
         ui64 SeqNo) const;
+    TSession* FindSessionByPipeServer(
+        const NActors::TActorId& pipeServer) const;
 
     NActors::TActorId RecoverSession(
         TSession* session,
@@ -851,13 +853,6 @@ public:
         const NActors::TActorId& owner,
         const NActors::TActorId& pipeServer);
 
-    void RegisterSessionByPipeServer(
-        const NActors::TActorId& pipeServer,
-        const TString& sessionId);
-    void UnregisterSessionByPipeServer(const TString& sessionId);
-    const TVector<TString>& FindSessionIdsByPipeServer(
-        const NActors::TActorId& pipeServer) const;
-    void RemoveSessionByPipeServer(const NActors::TActorId& pipeServer);
     void OrphanSession(const NActors::TActorId& owner, TInstant inactivityDeadline);
     void ResetSession(IIndexTabletDatabase& db, TSession* session, const TMaybe<TString>& state);
     void RemovePipeServer(const NActors::TActorId& pipeServer);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -860,6 +860,7 @@ public:
     void RemoveSessionByPipeServer(const NActors::TActorId& pipeServer);
     void OrphanSession(const NActors::TActorId& owner, TInstant inactivityDeadline);
     void ResetSession(IIndexTabletDatabase& db, TSession* session, const TMaybe<TString>& state);
+    void RemovePipeServer(const NActors::TActorId& pipeServer);
 
     TVector<TSession*> GetTimedOutSessions(TInstant now) const;
     TVector<TSession*> GetSessionsToNotify(const NProto::TSessionEvent& event) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -830,6 +830,7 @@ public:
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         const NProto::TSessionOptions& sessionOptions);
 
     void RemoveSession(
@@ -847,7 +848,9 @@ public:
         TSession* session,
         ui64 sessionSeqNo,
         bool readOnly,
-        const NActors::TActorId& owner);
+        const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer);
+
     void RegisterSessionByPipeServer(
         const NActors::TActorId& pipeServer,
         const TString& sessionId);
@@ -886,6 +889,7 @@ private:
         ui64 seqNo,
         bool readOnly,
         const NActors::TActorId& owner,
+        const NActors::TActorId& pipeServer,
         const NProto::TSessionOptions& sessionOptions);
 
     void RemoveSession(TSession* session);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -42,6 +42,7 @@ struct TIndexTabletState::TImpl
     TSessionList OrphanSessions;
     TSessionMap SessionById;
     TSessionOwnerMap SessionByOwner;
+    TSessionOwnerByPipeServerMap SessionOwnerByPipeServerId;
     TSessionClientMap SessionByClient;
     TSessionIdsByPipeServerMap SessionIdsByPipeServer;
     TSessionHistoryList SessionHistoryList;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -41,8 +41,7 @@ struct TIndexTabletState::TImpl
     TSessionList Sessions;
     TSessionList OrphanSessions;
     TSessionMap SessionById;
-    TSessionOwnerMap SessionByOwner;
-    TSessionOwnerByPipeServerMap SessionOwnerByPipeServerId;
+    TSessionOwnerMap SessionByPipeServer;
     TSessionClientMap SessionByClient;
     TSessionIdsByPipeServerMap SessionIdsByPipeServer;
     TSessionHistoryList SessionHistoryList;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -43,6 +43,7 @@ struct TIndexTabletState::TImpl
     TSessionList OrphanSessions;
     TSessionMap SessionById;
     TSessionOwnerMap SessionByOwner;
+    TSessionOwnerByPipeServerMap SessionOwnerByPipeServerId;
     TSessionClientMap SessionByClient;
     TSessionIdsByPipeServerMap SessionIdsByPipeServer;
     TSessionHistoryList SessionHistoryList;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -31,12 +31,6 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using TSessionIds = TVector<TString>;
-using TSessionIdsByPipeServerMap =
-    THashMap<NActors::TActorId, TSessionIds>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TIndexTabletState::TImpl
 {
     TSessionList Sessions;
@@ -44,7 +38,6 @@ struct TIndexTabletState::TImpl
     TSessionMap SessionById;
     TSessionOwnerMap SessionByPipeServer;
     TSessionClientMap SessionByClient;
-    TSessionIdsByPipeServerMap SessionIdsByPipeServer;
     TSessionHistoryList SessionHistoryList;
 
     TNodeRefsByHandle NodeRefsByHandle;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -42,8 +42,7 @@ struct TIndexTabletState::TImpl
     TSessionList Sessions;
     TSessionList OrphanSessions;
     TSessionMap SessionById;
-    TSessionOwnerMap SessionByOwner;
-    TSessionOwnerByPipeServerMap SessionOwnerByPipeServerId;
+    TSessionOwnerMap SessionByPipeServer;
     TSessionClientMap SessionByClient;
     TSessionIdsByPipeServerMap SessionIdsByPipeServer;
     TSessionHistoryList SessionHistoryList;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -36,7 +36,7 @@ struct TIndexTabletState::TImpl
     TSessionList Sessions;
     TSessionList OrphanSessions;
     TSessionMap SessionById;
-    TSessionOwnerMap SessionByPipeServer;
+    TSessionByPipeServerMap SessionByPipeServer;
     TSessionClientMap SessionByClient;
     TSessionHistoryList SessionHistoryList;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -197,13 +197,12 @@ TSession* TIndexTabletState::CreateSession(
     const NProto::TSessionOptions& sessionOptions)
 {
     auto session = std::make_unique<TSession>(proto, sessionOptions);
-    session->UpdateSubSession(seqNo, readOnly, owner);
+    session->UpdateSubSession(seqNo, readOnly, owner, pipeServer);
 
     Impl->Sessions.PushBack(session.get());
     Impl->SessionById.emplace(session->GetSessionId(), session.get());
-    Impl->SessionByOwner.emplace(owner, session.get());
+    Impl->SessionByPipeServer.emplace(pipeServer, session.get());
     Impl->SessionByClient.emplace(session->GetClientId(), session.get());
-    Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
         "%s created session c: %s, s: %s, owner: %s",
@@ -223,17 +222,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     const TActorId& pipeServer)
 {
     auto oldOwner =
-        session->UpdateSubSession(sessionSeqNo, readOnly, owner);
-    if (oldOwner) {
-        Impl->SessionByOwner.erase(oldOwner);
-
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed old owner for session c: %s, s: %s, owner: %s",
-            LogTag.c_str(),
-            session->GetClientId().c_str(),
-            session->GetSessionId().c_str(),
-            oldOwner.ToString().c_str());
-    }
+        session->UpdateSubSession(sessionSeqNo, readOnly, owner, pipeServer);
 
     if (oldOwner != owner) {
         session->InactivityDeadline = {};
@@ -241,8 +230,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         session->Unlink();
         Impl->Sessions.PushBack(session);
 
-        Impl->SessionByOwner.emplace(owner, session);
-        Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
+        Impl->SessionByPipeServer.emplace(pipeServer, session);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
             "%s added new owner for session c: %s, s: %s, owner: %s",
@@ -355,42 +343,34 @@ void TIndexTabletState::OrphanSession(
     const TActorId& pipeServer,
     TInstant deadline)
 {
-    auto it = Impl->SessionOwnerByPipeServerId.find(pipeServer);
-    if (it == Impl->SessionOwnerByPipeServerId.end()) {
+    auto it = Impl->SessionByPipeServer.find(pipeServer);
+    if (it == Impl->SessionByPipeServer.end()) {
         return; // not a session pipe
     }
 
-    const auto& owner = it->second;
-    auto sit = Impl->SessionByOwner.find(owner);
-    if (sit == Impl->SessionByOwner.end()) {
-        Impl->SessionOwnerByPipeServerId.erase(it);
-        return; // no session for this owner
-    }
-
-    auto* session = sit->second;
-
+    auto* session = it->second;
+    
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-        "%s orphaning session c: %s, s: %s, owner: %s",
+        "%s orphaning session c: %s, s: %s, pipeServer: %s",
         LogTag.c_str(),
         session->GetClientId().c_str(),
         session->GetSessionId().c_str(),
-        owner.ToString().c_str());
+        pipeServer.ToString().c_str());
 
-    if (!session->DeleteSubSession(owner)) {
+    if (!session->DeleteSubSessionByPipeServer(pipeServer)) {
         session->InactivityDeadline = deadline;
 
         session->Unlink();
         Impl->OrphanSessions.PushBack(session);
 
-        Impl->SessionByOwner.erase(sit);
-        Impl->SessionOwnerByPipeServerId.erase(it);
+        Impl->SessionByPipeServer.erase(it);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed last owner for session c: %s, s: %s, owner: %s",
+            "%s removed last owner for session c: %s, s: %s, pipeServer: %s",
             LogTag.c_str(),
             session->GetClientId().c_str(),
             session->GetSessionId().c_str(),
-            owner.ToString().c_str());
+            pipeServer.ToString().c_str());
     }
 }
 
@@ -466,8 +446,8 @@ void TIndexTabletState::RemoveSession(TSession* session)
         session->GetClientId().c_str(),
         session->GetSessionId().c_str());
 
-    for (const auto& s: session->GetSubSessions()) {
-        Impl->SessionByOwner.erase(s);
+    for (const auto& s: session->GetSubSessionsPipeServer()) {
+        Impl->SessionByPipeServer.erase(s);
     }
 
     std::unique_ptr<TSession> holder(session);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -366,28 +366,29 @@ void TIndexTabletState::OrphanSession(
     }
 
     auto* session = it->second;
-    
+
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-        "%s orphaning session c: %s, s: %s, pipeServer: %s",
+        "%s remove subsession c: %s, s: %s, pipeServer: %s",
         LogTag.c_str(),
         session->GetClientId().c_str(),
         session->GetSessionId().c_str(),
         pipeServer.ToString().c_str());
+    Impl->SessionByPipeServer.erase(it);
 
     if (!session->DeleteSubSessionByPipeServer(pipeServer)) {
-        session->InactivityDeadline = deadline;
-
-        session->Unlink();
-        Impl->OrphanSessions.PushBack(session);
-
-        Impl->SessionByPipeServer.erase(it);
-
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed last owner for session c: %s, s: %s, pipeServer: %s",
+        LOG_INFO(
+            *TlsActivationContext,
+            TFileStoreComponents::TABLET,
+            "%s removed last owner for session, orphaning session c: %s, s: "
+            "%s, pipeServer: %s",
             LogTag.c_str(),
             session->GetClientId().c_str(),
             session->GetSessionId().c_str(),
             pipeServer.ToString().c_str());
+
+        session->InactivityDeadline = deadline;
+        session->Unlink();
+        Impl->OrphanSessions.PushBack(session);
     }
 }
 
@@ -429,6 +430,11 @@ void TIndexTabletState::ResetSession(
                 TSessionHistoryEntry::RESET),
             SessionHistoryEntryCount);
     }
+}
+
+void TIndexTabletState::RemovePipeServer(const NActors::TActorId& pipeServer)
+{
+    Impl->SessionByPipeServer.erase(pipeServer);
 }
 
 void TIndexTabletState::RemoveSession(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -221,23 +221,40 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     const TActorId& owner,
     const TActorId& pipeServer)
 {
-    auto oldOwner =
+    auto oldPipe =
         session->UpdateSubSession(sessionSeqNo, readOnly, owner, pipeServer);
+
+    auto oldOwner = oldPipe ? oldPipe->Owner : TActorId();
+
+    if (oldOwner) {
+        Impl->SessionByPipeServer.erase(oldPipe->PipeServer);
+
+        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
+            "%s removed old pipe for session c: %s, s: %s, owner: %s, pipeServer: %s",
+            LogTag.c_str(),
+            session->GetClientId().c_str(),
+            session->GetSessionId().c_str(),
+            oldPipe->Owner.ToString().c_str(),
+            oldPipe->PipeServer.ToString().c_str());
+    }
 
     if (oldOwner != owner) {
         session->InactivityDeadline = {};
 
         session->Unlink();
         Impl->Sessions.PushBack(session);
-
         Impl->SessionByPipeServer.emplace(pipeServer, session);
 
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s added new owner for session c: %s, s: %s, owner: %s",
+        LOG_INFO(
+            *TlsActivationContext,
+            TFileStoreComponents::TABLET,
+            "%s added new owner for session c: %s, s: %s, owner: %s, "
+            "pipeServer: %s",
             LogTag.c_str(),
             session->GetClientId().c_str(),
             session->GetSessionId().c_str(),
-            owner.ToString().c_str());
+            owner.ToString().c_str(),
+            pipeServer.ToString().c_str());
     }
 
     session->SetRecoveryTimestampUs(Now().MicroSeconds());

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -132,6 +132,7 @@ TSession* TIndexTabletState::CreateSession(
     ui64 seqNo,
     bool readOnly,
     const TActorId& owner,
+    const TActorId& pipeServer,
     const NProto::TSessionOptions& sessionOptions)
 {
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
@@ -160,8 +161,13 @@ TSession* TIndexTabletState::CreateSession(
         SessionHistoryEntryCount);
     IncrementUsedSessionsCount(db);
 
-    auto* session =
-        CreateSession(proto, seqNo, readOnly, owner, sessionOptions);
+    auto* session = CreateSession(
+        proto,
+        seqNo,
+        readOnly,
+        owner,
+        pipeServer,
+        sessionOptions);
     TABLET_VERIFY(session);
 
     return session;
@@ -187,6 +193,7 @@ TSession* TIndexTabletState::CreateSession(
     ui64 seqNo,
     bool readOnly,
     const TActorId& owner,
+    const TActorId& pipeServer,
     const NProto::TSessionOptions& sessionOptions)
 {
     auto session = std::make_unique<TSession>(proto, sessionOptions);
@@ -196,6 +203,7 @@ TSession* TIndexTabletState::CreateSession(
     Impl->SessionById.emplace(session->GetSessionId(), session.get());
     Impl->SessionByOwner.emplace(owner, session.get());
     Impl->SessionByClient.emplace(session->GetClientId(), session.get());
+    Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
         "%s created session c: %s, s: %s, owner: %s",
@@ -211,7 +219,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     TSession* session,
     ui64 sessionSeqNo,
     bool readOnly,
-    const TActorId& owner)
+    const TActorId& owner,
+    const TActorId& pipeServer)
 {
     auto oldOwner =
         session->UpdateSubSession(sessionSeqNo, readOnly, owner);
@@ -233,6 +242,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         Impl->Sessions.PushBack(session);
 
         Impl->SessionByOwner.emplace(owner, session);
+        Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
             "%s added new owner for session c: %s, s: %s, owner: %s",
@@ -341,14 +351,23 @@ TSession* TIndexTabletState::FindSession(
     return nullptr;
 }
 
-void TIndexTabletState::OrphanSession(const TActorId& owner, TInstant deadline)
+void TIndexTabletState::OrphanSession(
+    const TActorId& pipeServer,
+    TInstant deadline)
 {
-    auto it = Impl->SessionByOwner.find(owner);
-    if (it == Impl->SessionByOwner.end()) {
+    auto it = Impl->SessionOwnerByPipeServerId.find(pipeServer);
+    if (it == Impl->SessionOwnerByPipeServerId.end()) {
         return; // not a session pipe
     }
 
-    auto* session = it->second;
+    const auto& owner = it->second;
+    auto sit = Impl->SessionByOwner.find(owner);
+    if (sit == Impl->SessionByOwner.end()) {
+        Impl->SessionOwnerByPipeServerId.erase(it);
+        return; // no session for this owner
+    }
+
+    auto* session = sit->second;
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
         "%s orphaning session c: %s, s: %s, owner: %s",
@@ -363,7 +382,8 @@ void TIndexTabletState::OrphanSession(const TActorId& owner, TInstant deadline)
         session->Unlink();
         Impl->OrphanSessions.PushBack(session);
 
-        Impl->SessionByOwner.erase(it);
+        Impl->SessionByOwner.erase(sit);
+        Impl->SessionOwnerByPipeServerId.erase(it);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
             "%s removed last owner for session c: %s, s: %s, owner: %s",

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -197,13 +197,17 @@ TSession* TIndexTabletState::CreateSession(
     const NProto::TSessionOptions& sessionOptions)
 {
     auto session = std::make_unique<TSession>(proto, sessionOptions);
-    session->UpdateSubSession(seqNo, readOnly, owner, GetGeneration());
+    session->UpdateSubSession(
+        seqNo,
+        readOnly,
+        owner,
+        pipeServer,
+        GetGeneration());
 
     Impl->Sessions.PushBack(session.get());
     Impl->SessionById.emplace(session->GetSessionId(), session.get());
-    Impl->SessionByOwner.emplace(owner, session.get());
+    Impl->SessionByPipeServer.emplace(pipeServer, session.get());
     Impl->SessionByClient.emplace(session->GetClientId(), session.get());
-    Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
         "%s created session c: %s, s: %s, owner: %s",
@@ -227,17 +231,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
             sessionSeqNo,
             readOnly,
             owner,
+            pipeServer,
             GetGeneration());
-    if (oldOwner) {
-        Impl->SessionByOwner.erase(oldOwner);
-
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed old owner for session c: %s, s: %s, owner: %s",
-            LogTag.c_str(),
-            session->GetClientId().c_str(),
-            session->GetSessionId().c_str(),
-            oldOwner.ToString().c_str());
-    }
 
     if (oldOwner != owner) {
         session->InactivityDeadline = {};
@@ -245,8 +240,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         session->Unlink();
         Impl->Sessions.PushBack(session);
 
-        Impl->SessionByOwner.emplace(owner, session);
-        Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
+        Impl->SessionByPipeServer.emplace(pipeServer, session);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
             "%s added new owner for session c: %s, s: %s, owner: %s",
@@ -359,42 +353,34 @@ void TIndexTabletState::OrphanSession(
     const TActorId& pipeServer,
     TInstant deadline)
 {
-    auto it = Impl->SessionOwnerByPipeServerId.find(pipeServer);
-    if (it == Impl->SessionOwnerByPipeServerId.end()) {
+    auto it = Impl->SessionByPipeServer.find(pipeServer);
+    if (it == Impl->SessionByPipeServer.end()) {
         return; // not a session pipe
     }
 
-    const auto& owner = it->second;
-    auto sit = Impl->SessionByOwner.find(owner);
-    if (sit == Impl->SessionByOwner.end()) {
-        Impl->SessionOwnerByPipeServerId.erase(it);
-        return; // no session for this owner
-    }
-
-    auto* session = sit->second;
+    auto* session = it->second;
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-        "%s orphaning session c: %s, s: %s, owner: %s",
+        "%s orphaning session c: %s, s: %s, pipeServer: %s",
         LogTag.c_str(),
         session->GetClientId().c_str(),
         session->GetSessionId().c_str(),
-        owner.ToString().c_str());
+        pipeServer.ToString().c_str());
 
-    if (!session->DeleteSubSession(owner)) {
+    if (!session->DeleteSubSessionByPipeServer(pipeServer)) {
         session->InactivityDeadline = deadline;
 
         session->Unlink();
         Impl->OrphanSessions.PushBack(session);
 
-        Impl->SessionByOwner.erase(sit);
-        Impl->SessionOwnerByPipeServerId.erase(it);
+        Impl->SessionByPipeServer.erase(it);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed last owner for session c: %s, s: %s, owner: %s",
+            "%s removed last owner for session c: %s, s: %s, pipeServer: %s",
             LogTag.c_str(),
             session->GetClientId().c_str(),
             session->GetSessionId().c_str(),
-            owner.ToString().c_str());
+            pipeServer.ToString().c_str());
     }
 }
 
@@ -470,8 +456,8 @@ void TIndexTabletState::RemoveSession(TSession* session)
         session->GetClientId().c_str(),
         session->GetSessionId().c_str());
 
-    for (const auto& s: session->GetSubSessions()) {
-        Impl->SessionByOwner.erase(s);
+    for (const auto& s: session->GetSubSessionsPipeServer()) {
+        Impl->SessionByPipeServer.erase(s);
     }
 
     std::unique_ptr<TSession> holder(session);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -226,7 +226,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     const TActorId& owner,
     const TActorId& pipeServer)
 {
-    auto oldPipe =
+    auto update =
         session->UpdateSubSession(
             sessionSeqNo,
             readOnly,
@@ -234,99 +234,31 @@ NActors::TActorId TIndexTabletState::RecoverSession(
             pipeServer,
             GetGeneration());
 
-    auto oldOwner = oldPipe ? oldPipe->Owner : TActorId();
-
-    if (oldOwner) {
-        Impl->SessionByPipeServer.erase(oldPipe->PipeServer);
-
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed old pipe for session c: %s, s: %s, owner: %s, pipeServer: %s",
-            LogTag.c_str(),
-            session->GetClientId().c_str(),
-            session->GetSessionId().c_str(),
-            oldPipe->Owner.ToString().c_str(),
-            oldPipe->PipeServer.ToString().c_str());
+    if (update.StalePipeServer) {
+        Impl->SessionByPipeServer.erase(*update.StalePipeServer);
     }
+    Impl->SessionByPipeServer[pipeServer] = session;
 
-    if (oldOwner != owner) {
-        session->InactivityDeadline = {};
+    session->InactivityDeadline = {};
+    session->Unlink();
+    Impl->Sessions.PushBack(session);
 
-        session->Unlink();
-        Impl->Sessions.PushBack(session);
-        Impl->SessionByPipeServer.emplace(pipeServer, session);
-
-        LOG_INFO(
-            *TlsActivationContext,
-            TFileStoreComponents::TABLET,
-            "%s added new owner for session c: %s, s: %s, owner: %s, "
-            "pipeServer: %s",
-            LogTag.c_str(),
-            session->GetClientId().c_str(),
-            session->GetSessionId().c_str(),
-            owner.ToString().c_str(),
-            pipeServer.ToString().c_str());
-    }
+    LOG_INFO(
+        *TlsActivationContext,
+        TFileStoreComponents::TABLET,
+        "%s recovered session c: %s, s: %s, owner: %s, pipeServer: %s, "
+        "stale pipeServer: %s, stale owner: %s",
+        LogTag.c_str(),
+        session->GetClientId().c_str(),
+        session->GetSessionId().c_str(),
+        owner.ToString().c_str(),
+        pipeServer.ToString().c_str(),
+        update.StalePipeServer.value_or(TActorId()).ToString().c_str(),
+        update.StaleOwner.value_or(TActorId()).ToString().c_str());
 
     session->SetRecoveryTimestampUs(Now().MicroSeconds());
 
-    return oldOwner;
-}
-
-void TIndexTabletState::RegisterSessionByPipeServer(
-    const TActorId& pipeServer,
-    const TString& sessionId)
-{
-    if (!pipeServer || sessionId.empty()) {
-        return;
-    }
-
-    auto& sessionIds = Impl->SessionIdsByPipeServer[pipeServer];
-    for (const auto& existingSessionId: sessionIds) {
-        if (existingSessionId == sessionId) {
-            return;
-        }
-    }
-
-    sessionIds.push_back(sessionId);
-}
-
-void TIndexTabletState::UnregisterSessionByPipeServer(const TString& sessionId)
-{
-    for (auto it = Impl->SessionIdsByPipeServer.begin();
-         it != Impl->SessionIdsByPipeServer.end();)
-    {
-        auto& sessionIds = it->second;
-        for (auto jt = sessionIds.begin(); jt != sessionIds.end();) {
-            if (*jt == sessionId) {
-                jt = sessionIds.erase(jt);
-            } else {
-                ++jt;
-            }
-        }
-
-        if (sessionIds.empty()) {
-            auto erased = it++;
-            Impl->SessionIdsByPipeServer.erase(erased);
-        } else {
-            ++it;
-        }
-    }
-}
-
-const TVector<TString>& TIndexTabletState::FindSessionIdsByPipeServer(
-    const TActorId& pipeServer) const
-{
-    auto it = Impl->SessionIdsByPipeServer.find(pipeServer);
-    if (it != Impl->SessionIdsByPipeServer.end()) {
-        return it->second;
-    }
-
-    return Default<TVector<TString>>();
-}
-
-void TIndexTabletState::RemoveSessionByPipeServer(const TActorId& pipeServer)
-{
-    Impl->SessionIdsByPipeServer.erase(pipeServer);
+    return update.StaleOwner.value_or(TActorId());
 }
 
 TSession* TIndexTabletState::FindSession(const TString& sessionId) const
@@ -343,6 +275,17 @@ TSession* TIndexTabletState::FindSessionByClientId(const TString& clientId) cons
 {
     auto it = Impl->SessionByClient.find(clientId);
     if (it != Impl->SessionByClient.end()) {
+        return it->second;
+    }
+
+    return nullptr;
+}
+
+TSession* TIndexTabletState::FindSessionByPipeServer(
+    const TActorId& pipeServer) const
+{
+    auto it = Impl->SessionByPipeServer.find(pipeServer);
+    if (it != Impl->SessionByPipeServer.end()) {
         return it->second;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -132,6 +132,7 @@ TSession* TIndexTabletState::CreateSession(
     ui64 seqNo,
     bool readOnly,
     const TActorId& owner,
+    const TActorId& pipeServer,
     const NProto::TSessionOptions& sessionOptions)
 {
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
@@ -160,8 +161,13 @@ TSession* TIndexTabletState::CreateSession(
         SessionHistoryEntryCount);
     IncrementUsedSessionsCount(db);
 
-    auto* session =
-        CreateSession(proto, seqNo, readOnly, owner, sessionOptions);
+    auto* session = CreateSession(
+        proto,
+        seqNo,
+        readOnly,
+        owner,
+        pipeServer,
+        sessionOptions);
     TABLET_VERIFY(session);
 
     return session;
@@ -187,6 +193,7 @@ TSession* TIndexTabletState::CreateSession(
     ui64 seqNo,
     bool readOnly,
     const TActorId& owner,
+    const TActorId& pipeServer,
     const NProto::TSessionOptions& sessionOptions)
 {
     auto session = std::make_unique<TSession>(proto, sessionOptions);
@@ -196,6 +203,7 @@ TSession* TIndexTabletState::CreateSession(
     Impl->SessionById.emplace(session->GetSessionId(), session.get());
     Impl->SessionByOwner.emplace(owner, session.get());
     Impl->SessionByClient.emplace(session->GetClientId(), session.get());
+    Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
         "%s created session c: %s, s: %s, owner: %s",
@@ -211,7 +219,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     TSession* session,
     ui64 sessionSeqNo,
     bool readOnly,
-    const TActorId& owner)
+    const TActorId& owner,
+    const TActorId& pipeServer)
 {
     auto oldOwner =
         session->UpdateSubSession(
@@ -237,6 +246,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         Impl->Sessions.PushBack(session);
 
         Impl->SessionByOwner.emplace(owner, session);
+        Impl->SessionOwnerByPipeServerId.emplace(pipeServer, owner);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
             "%s added new owner for session c: %s, s: %s, owner: %s",
@@ -345,14 +355,23 @@ TSession* TIndexTabletState::FindSession(
     return nullptr;
 }
 
-void TIndexTabletState::OrphanSession(const TActorId& owner, TInstant deadline)
+void TIndexTabletState::OrphanSession(
+    const TActorId& pipeServer,
+    TInstant deadline)
 {
-    auto it = Impl->SessionByOwner.find(owner);
-    if (it == Impl->SessionByOwner.end()) {
+    auto it = Impl->SessionOwnerByPipeServerId.find(pipeServer);
+    if (it == Impl->SessionOwnerByPipeServerId.end()) {
         return; // not a session pipe
     }
 
-    auto* session = it->second;
+    const auto& owner = it->second;
+    auto sit = Impl->SessionByOwner.find(owner);
+    if (sit == Impl->SessionByOwner.end()) {
+        Impl->SessionOwnerByPipeServerId.erase(it);
+        return; // no session for this owner
+    }
+
+    auto* session = sit->second;
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
         "%s orphaning session c: %s, s: %s, owner: %s",
@@ -367,7 +386,8 @@ void TIndexTabletState::OrphanSession(const TActorId& owner, TInstant deadline)
         session->Unlink();
         Impl->OrphanSessions.PushBack(session);
 
-        Impl->SessionByOwner.erase(it);
+        Impl->SessionByOwner.erase(sit);
+        Impl->SessionOwnerByPipeServerId.erase(it);
 
         LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
             "%s removed last owner for session c: %s, s: %s, owner: %s",

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -378,26 +378,27 @@ void TIndexTabletState::OrphanSession(
     auto* session = it->second;
 
     LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-        "%s orphaning session c: %s, s: %s, pipeServer: %s",
+        "%s remove subsession c: %s, s: %s, pipeServer: %s",
         LogTag.c_str(),
         session->GetClientId().c_str(),
         session->GetSessionId().c_str(),
         pipeServer.ToString().c_str());
+    Impl->SessionByPipeServer.erase(it);
 
     if (!session->DeleteSubSessionByPipeServer(pipeServer)) {
-        session->InactivityDeadline = deadline;
-
-        session->Unlink();
-        Impl->OrphanSessions.PushBack(session);
-
-        Impl->SessionByPipeServer.erase(it);
-
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s removed last owner for session c: %s, s: %s, pipeServer: %s",
+        LOG_INFO(
+            *TlsActivationContext,
+            TFileStoreComponents::TABLET,
+            "%s removed last owner for session, orphaning session c: %s, s: "
+            "%s, pipeServer: %s",
             LogTag.c_str(),
             session->GetClientId().c_str(),
             session->GetSessionId().c_str(),
             pipeServer.ToString().c_str());
+
+        session->InactivityDeadline = deadline;
+        session->Unlink();
+        Impl->OrphanSessions.PushBack(session);
     }
 }
 
@@ -439,6 +440,11 @@ void TIndexTabletState::ResetSession(
                 TSessionHistoryEntry::RESET),
             SessionHistoryEntryCount);
     }
+}
+
+void TIndexTabletState::RemovePipeServer(const NActors::TActorId& pipeServer)
+{
+    Impl->SessionByPipeServer.erase(pipeServer);
 }
 
 void TIndexTabletState::RemoveSession(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -226,7 +226,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     const TActorId& owner,
     const TActorId& pipeServer)
 {
-    auto oldOwner =
+    auto oldPipe =
         session->UpdateSubSession(
             sessionSeqNo,
             readOnly,
@@ -234,20 +234,37 @@ NActors::TActorId TIndexTabletState::RecoverSession(
             pipeServer,
             GetGeneration());
 
+    auto oldOwner = oldPipe ? oldPipe->Owner : TActorId();
+
+    if (oldOwner) {
+        Impl->SessionByPipeServer.erase(oldPipe->PipeServer);
+
+        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
+            "%s removed old pipe for session c: %s, s: %s, owner: %s, pipeServer: %s",
+            LogTag.c_str(),
+            session->GetClientId().c_str(),
+            session->GetSessionId().c_str(),
+            oldPipe->Owner.ToString().c_str(),
+            oldPipe->PipeServer.ToString().c_str());
+    }
+
     if (oldOwner != owner) {
         session->InactivityDeadline = {};
 
         session->Unlink();
         Impl->Sessions.PushBack(session);
-
         Impl->SessionByPipeServer.emplace(pipeServer, session);
 
-        LOG_INFO(*TlsActivationContext, TFileStoreComponents::TABLET,
-            "%s added new owner for session c: %s, s: %s, owner: %s",
+        LOG_INFO(
+            *TlsActivationContext,
+            TFileStoreComponents::TABLET,
+            "%s added new owner for session c: %s, s: %s, owner: %s, "
+            "pipeServer: %s",
             LogTag.c_str(),
             session->GetClientId().c_str(),
             session->GetSessionId().c_str(),
-            owner.ToString().c_str());
+            owner.ToString().c_str(),
+            pipeServer.ToString().c_str());
     }
 
     session->SetRecoveryTimestampUs(Now().MicroSeconds());

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -253,8 +253,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
         session->GetSessionId().c_str(),
         owner.ToString().c_str(),
         pipeServer.ToString().c_str(),
-        update.StalePipeServer.value_or(TActorId()).ToString().c_str(),
-        update.StaleOwner.value_or(TActorId()).ToString().c_str());
+        updateResult.StalePipeServer.value_or(TActorId()).ToString().c_str(),
+        updateResult.StaleOwner.value_or(TActorId()).ToString().c_str());
 
     session->SetRecoveryTimestampUs(Now().MicroSeconds());
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -226,7 +226,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     const TActorId& owner,
     const TActorId& pipeServer)
 {
-    auto update =
+    auto updateResult =
         session->UpdateSubSession(
             sessionSeqNo,
             readOnly,
@@ -234,8 +234,8 @@ NActors::TActorId TIndexTabletState::RecoverSession(
             pipeServer,
             GetGeneration());
 
-    if (update.StalePipeServer) {
-        Impl->SessionByPipeServer.erase(*update.StalePipeServer);
+    if (updateResult.StalePipeServer) {
+        Impl->SessionByPipeServer.erase(*updateResult.StalePipeServer);
     }
     Impl->SessionByPipeServer[pipeServer] = session;
 
@@ -258,7 +258,7 @@ NActors::TActorId TIndexTabletState::RecoverSession(
 
     session->SetRecoveryTimestampUs(Now().MicroSeconds());
 
-    return update.StaleOwner.value_or(TActorId());
+    return updateResult.StaleOwner.value_or(TActorId());
 }
 
 TSession* TIndexTabletState::FindSession(const TString& sessionId) const
@@ -328,7 +328,7 @@ void TIndexTabletState::OrphanSession(
         pipeServer.ToString().c_str());
     Impl->SessionByPipeServer.erase(it);
 
-    if (!session->DeleteSubSessionByPipeServer(pipeServer)) {
+    if (session->DeleteSubSessionByPipeServer(pipeServer).SessionCanBeDestroyed) {
         LOG_INFO(
             *TlsActivationContext,
             TFileStoreComponents::TABLET,
@@ -422,7 +422,7 @@ void TIndexTabletState::RemoveSession(TSession* session)
         session->GetClientId().c_str(),
         session->GetSessionId().c_str());
 
-    for (const auto& s: session->GetSubSessionsPipeServer()) {
+    for (const auto& s: session->GetSubSessionPipeServerIds()) {
         Impl->SessionByPipeServer.erase(s);
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -541,8 +541,8 @@ struct TTxIndexTablet
 
         TCreateSession(
                 TRequestInfoPtr requestInfo,
-                const NActors::TActorId& pipeServerId,
-                NProtoPrivate::TCreateSessionRequest request)
+                NActors::TActorId pipeServerId,
+                const NProtoPrivate::TCreateSessionRequest request)
             : RequestInfo(std::move(requestInfo))
             , PipeServerId(pipeServerId)
             , Request(std::move(request))

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -524,8 +524,8 @@ struct TTxIndexTablet
 
         TCreateSession(
                 TRequestInfoPtr requestInfo,
-                const NActors::TActorId& pipeServerId,
-                NProtoPrivate::TCreateSessionRequest request)
+                NActors::TActorId pipeServerId,
+                const NProtoPrivate::TCreateSessionRequest request)
             : RequestInfo(std::move(requestInfo))
             , PipeServerId(pipeServerId)
             , Request(std::move(request))

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -524,8 +524,8 @@ struct TTxIndexTablet
 
         TCreateSession(
                 TRequestInfoPtr requestInfo,
-                NActors::TActorId pipeServerId,
-                const NProtoPrivate::TCreateSessionRequest request)
+                const NActors::TActorId& pipeServerId,
+                NProtoPrivate::TCreateSessionRequest request)
             : RequestInfo(std::move(requestInfo))
             , PipeServerId(pipeServerId)
             , Request(std::move(request))

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1113,7 +1113,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
             UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
         }
+<<<<<<< HEAD
 
+=======
+>>>>>>> 94e93db539 (fix)
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1072,7 +1072,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         }
     }
 
-    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnetion)
+    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnect)
     {
         TTestEnv env;
 
@@ -1081,13 +1081,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
 
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
-        bool pipeDisconnectionObserved = false;
+        bool pipeDisconnectObserved = false;
         env.GetRuntime().SetEventFilter([&] (auto& runtime, auto& event) {
             Y_UNUSED(runtime);
 
             switch (event->GetTypeRewrite()) {
                 case NKikimr::TEvTabletPipe::EvServerDisconnected: {
-                    pipeDisconnectionObserved = true;
+                    pipeDisconnectObserved = true;
                 }
             }
 
@@ -1100,7 +1100,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
 
         // Check that pipe was disconnected
-        UNIT_ASSERT(pipeDisconnectionObserved);
+        UNIT_ASSERT(pipeDisconnectObserved);
 
         // Check that the tablet handles pipe disconnection
         // and marks the session as orphaned.

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1071,6 +1071,50 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             tablet.DestroySession();
         }
     }
+
+    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnetion)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        bool pipeDisconnectionObserved = false;
+        env.GetRuntime().SetEventFilter([&] (auto& runtime, auto& event) {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case NKikimr::TEvTabletPipe::EvServerDisconnected: {
+                    pipeDisconnectionObserved = true;
+                }
+            }
+
+            return false;
+        });
+
+        tablet.InitSession("client", "session");
+
+        tablet.DisconnectPipe();
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+        // Check that pipe was disconnected
+        UNIT_ASSERT(pipeDisconnectionObserved);
+
+        // Check that the tablet handles pipe disconnection
+        // and marks the session as orphaned.
+        {
+            tablet.ReconnectPipe();
+            auto sessions = tablet.DescribeSessions();
+            UNIT_ASSERT_VALUES_EQUAL(sessions->Record.SessionsSize(), 1);
+            const auto& session = sessions->Record.GetSessions(0);
+            UNIT_ASSERT_VALUES_EQUAL(session.GetClientId(), "client");
+            UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
+            UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
+        }
+
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1113,10 +1113,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
             UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
         }
-<<<<<<< HEAD
-
-=======
->>>>>>> 94e93db539 (fix)
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1849,7 +1849,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         }
     }
 
-    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnetion)
+    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnect)
     {
         TTestEnv env;
 
@@ -1858,13 +1858,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
 
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
-        bool pipeDisconnectionObserved = false;
+        bool pipeDisconnectObserved = false;
         env.GetRuntime().SetEventFilter([&] (auto& runtime, auto& event) {
             Y_UNUSED(runtime);
 
             switch (event->GetTypeRewrite()) {
                 case NKikimr::TEvTabletPipe::EvServerDisconnected: {
-                    pipeDisconnectionObserved = true;
+                    pipeDisconnectObserved = true;
                 }
             }
 
@@ -1877,7 +1877,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
 
         // Check that pipe was disconnected
-        UNIT_ASSERT(pipeDisconnectionObserved);
+        UNIT_ASSERT(pipeDisconnectObserved);
 
         // Check that the tablet handles pipe disconnection
         // and marks the session as orphaned.

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1848,6 +1848,50 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             tablet.DestroySession();
         }
     }
+
+    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnetion)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        bool pipeDisconnectionObserved = false;
+        env.GetRuntime().SetEventFilter([&] (auto& runtime, auto& event) {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case NKikimr::TEvTabletPipe::EvServerDisconnected: {
+                    pipeDisconnectionObserved = true;
+                }
+            }
+
+            return false;
+        });
+
+        tablet.InitSession("client", "session");
+
+        tablet.DisconnectPipe();
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+        // Check that pipe was disconnected
+        UNIT_ASSERT(pipeDisconnectionObserved);
+
+        // Check that the tablet handles pipe disconnection
+        // and marks the session as orphaned.
+        {
+            tablet.ReconnectPipe();
+            auto sessions = tablet.DescribeSessions();
+            UNIT_ASSERT_VALUES_EQUAL(sessions->Record.SessionsSize(), 1);
+            const auto& session = sessions->Record.GetSessions(0);
+            UNIT_ASSERT_VALUES_EQUAL(session.GetClientId(), "client");
+            UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
+            UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
+        }
+
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1890,7 +1890,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
             UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
         }
+<<<<<<< HEAD
 
+=======
+>>>>>>> 94e93db539 (fix)
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1890,10 +1890,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
             UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
         }
-<<<<<<< HEAD
-
-=======
->>>>>>> 94e93db539 (fix)
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1,4 +1,5 @@
 #include "tablet.h"
+#include "tablet_actor.h"
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
@@ -1849,27 +1850,50 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         }
     }
 
-    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnect)
+    Y_UNIT_TEST(ShouldMarkSessionAsOrphanAfterPipeDisconnectAndCleanUpAfterTimeout)
     {
-        TTestEnv env;
+        constexpr TDuration IdleSessionTimeout = TDuration::Seconds(5);
+
+        NProto::TStorageConfig config;
+        config.SetIdleSessionTimeout(IdleSessionTimeout.MilliSeconds());
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
+        env.GetRuntime().SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
         bool pipeDisconnectObserved = false;
-        env.GetRuntime().SetEventFilter([&] (auto& runtime, auto& event) {
-            Y_UNUSED(runtime);
-
-            switch (event->GetTypeRewrite()) {
-                case NKikimr::TEvTabletPipe::EvServerDisconnected: {
-                    pipeDisconnectObserved = true;
+        // The cleanup path destroys a timed-out session
+        // by sending TEvDestroySessionRequest.
+        TMaybe<TInstant> destroyedAt;
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<NActors::IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case NKikimr::TEvTabletPipe::EvServerDisconnected: {
+                        pipeDisconnectObserved = true;
+                        break;
+                    }
+                    case TEvIndexTablet::EvDestroySessionRequest: {
+                        const auto& record =
+                            event->Get<TEvIndexTablet::TEvDestroySessionRequest>()
+                                ->Record;
+                        if (record.GetHeaders().GetSessionId() == "session") {
+                            destroyedAt = env.GetRuntime().GetCurrentTime();
+                        }
+                        break;
+                    }
                 }
-            }
-
-            return false;
-        });
+                return NKikimr::TTestActorRuntime::DefaultObserverFunc(event);
+            });
 
         tablet.InitSession("client", "session");
 
@@ -1878,6 +1902,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
 
         // Check that pipe was disconnected
         UNIT_ASSERT(pipeDisconnectObserved);
+
+        TInstant disconnectedAt = env.GetRuntime().GetCurrentTime();
 
         // Check that the tablet handles pipe disconnection
         // and marks the session as orphaned.
@@ -1890,6 +1916,155 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             UNIT_ASSERT_VALUES_EQUAL(session.GetSessionId(), "session");
             UNIT_ASSERT_VALUES_EQUAL(session.GetIsOrphan(), true);
         }
+
+        // Cleanup runs periodically every IdleSessionTimeout since boot,
+        // independent of when this session was disconnected. In the worst
+        // case, disconnect happens right after a cleanup run, so that same
+        // run is already too early for the deadline and the session
+        // survives it - only the next run is guaranteed to be late enough.
+        // So we need to wait for at least 2 cleanup runs.
+        env.GetRuntime().DispatchEvents(
+            {},
+            2 * IdleSessionTimeout + TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(destroyedAt.Defined(), "session was never auto-destroyed");
+        UNIT_ASSERT_C(
+            *destroyedAt >= disconnectedAt + IdleSessionTimeout,
+            "session destroyed before its inactivity deadline");
+
+        auto sessions = tablet.DescribeSessions();
+        UNIT_ASSERT_VALUES_EQUAL(sessions->Record.SessionsSize(), 0);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyUpdateSessionByPipeServerMap)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        // BootIndexTablet doesn't expose the actor's TActorId - catch it.
+        NActors::TActorId tabletActorId;
+        env.GetRuntime().SetRegistrationObserverFunc(
+            [&](auto& runtime,
+                const NActors::TActorId& parentId,
+                const NActors::TActorId& actorId)
+            {
+                Y_UNUSED(parentId);
+                if (dynamic_cast<TIndexTabletActor*>(
+                        runtime.FindActor(actorId))) {
+                    tabletActorId = actorId;
+                }
+            });
+
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        // ev->Recipient is the pipe server's TActorId, the SessionByPipeServer
+        // key. We need to know which pipe server corresponds to which
+        // subsession.
+        THashMap<ui64, NActors::TActorId> pipeServerBySeqNo;
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<NActors::IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvIndexTablet::EvCreateSessionRequest)
+                {
+                    const auto& record =
+                        event->Get<TEvIndexTablet::TEvCreateSessionRequest>()
+                            ->Record;
+                    pipeServerBySeqNo[record.GetMountSeqNumber()] =
+                        event->Recipient;
+                }
+                return NKikimr::TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        // Both read-only, so GetSessionRwSeqNo() stays 0 and DestroySession
+        // always goes through DeleteSubSession.
+        TIndexTabletClient tablet1(env.GetRuntime(), nodeIdx, tabletId);
+        tablet1.InitSession("client", "session", {}, 1, true /* readOnly */);
+
+        TIndexTabletClient tablet2(env.GetRuntime(), nodeIdx, tabletId);
+        tablet2.InitSession("client", "session", {}, 2, true /* readOnly */);
+
+        // A second, independent session: D is a writer with the highest
+        // seqNo, so destroying it makes CheckSessionForDestroy match
+        // exactly - DeleteSubSession is never called, cleanup goes through
+        // RemoveSession's own loop over GetSubSessionPipeServerIds() instead.
+        TIndexTabletClient tablet3(env.GetRuntime(), nodeIdx, tabletId);
+        tablet3.InitSession("client2", "session2", {}, 3, true /* readOnly */);
+
+        TIndexTabletClient tablet4(env.GetRuntime(), nodeIdx, tabletId);
+        tablet4.InitSession("client2", "session2", {}, 4, false /* readOnly */);
+
+        env.GetRuntime().SetObserverFunc(
+            NKikimr::TTestActorRuntime::DefaultObserverFunc);
+
+        UNIT_ASSERT_C(
+            pipeServerBySeqNo.contains(1),
+            "CreateSessionRequest for seqNo=1 not observed");
+        UNIT_ASSERT_C(
+            pipeServerBySeqNo.contains(2),
+            "CreateSessionRequest for seqNo=2 not observed");
+        UNIT_ASSERT_C(
+            pipeServerBySeqNo.contains(3),
+            "CreateSessionRequest for seqNo=3 not observed");
+        UNIT_ASSERT_C(
+            pipeServerBySeqNo.contains(4),
+            "CreateSessionRequest for seqNo=4 not observed");
+        auto pipeServerA = pipeServerBySeqNo[1];
+        auto pipeServerB = pipeServerBySeqNo[2];
+        auto pipeServerC = pipeServerBySeqNo[3];
+        auto pipeServerD = pipeServerBySeqNo[4];
+
+        auto* actor = dynamic_cast<TIndexTabletActor*>(
+            env.GetRuntime().FindActor(tabletActorId));
+        UNIT_ASSERT_C(actor, "tablet actor not found");
+
+        // Sanity check, otherwise the destroy checks below would pass
+        // trivially.
+        auto* sessionA = actor->FindSessionByPipeServer(pipeServerA);
+        UNIT_ASSERT_C(sessionA, "pipeServerA not tracked right after creation");
+        UNIT_ASSERT_VALUES_EQUAL("session", sessionA->GetSessionId());
+        auto* sessionB = actor->FindSessionByPipeServer(pipeServerB);
+        UNIT_ASSERT_C(sessionB, "pipeServerB not tracked right after creation");
+        UNIT_ASSERT_VALUES_EQUAL("session", sessionB->GetSessionId());
+        auto* sessionC = actor->FindSessionByPipeServer(pipeServerC);
+        UNIT_ASSERT_C(sessionC, "pipeServerC not tracked right after creation");
+        UNIT_ASSERT_VALUES_EQUAL("session2", sessionC->GetSessionId());
+        auto* sessionD = actor->FindSessionByPipeServer(pipeServerD);
+        UNIT_ASSERT_C(sessionD, "pipeServerD not tracked right after creation");
+        UNIT_ASSERT_VALUES_EQUAL("session2", sessionD->GetSessionId());
+
+        // Scenario 1: DeleteSubSession returns SessionCanBeDestroyed=false
+        // (another subsession is still mounted) - the session survives,
+        // only its own entry is removed. Already worked before the fix.
+        tablet1.DestroySession();
+        UNIT_ASSERT_C(
+            actor->FindSessionByPipeServer(pipeServerA) == nullptr,
+            "pipeServerA entry not removed");
+        UNIT_ASSERT_C(
+            actor->FindSessionByPipeServer(pipeServerB) != nullptr,
+            "pipeServerB entry wrongly removed");
+
+        // Scenario 2: DeleteSubSession returns SessionCanBeDestroyed=true
+        // (last subsession) - the whole session is destroyed. The buggy
+        // path: its own entry must still be removed.
+        tablet2.DestroySession();
+        UNIT_ASSERT_C(
+            actor->FindSessionByPipeServer(pipeServerB) == nullptr,
+            "stale entry left in SessionByPipeServer after destroying the "
+            "last subsession of a session that never had a writer");
+
+        // Scenario 3: CheckSessionForDestroy matches exactly for D, so
+        // ExecuteTx_DestroySession skips DeleteSubSession entirely and goes
+        // straight to RemoveSession, which must clean up both D's own
+        // entry and C's (never individually destroyed) via its own loop.
+        tablet4.DestroySession();
+        UNIT_ASSERT_C(
+            actor->FindSessionByPipeServer(pipeServerC) == nullptr,
+            "pipeServerC entry left dangling by RemoveSession's own cleanup");
+        UNIT_ASSERT_C(
+            actor->FindSessionByPipeServer(pipeServerD) == nullptr,
+            "pipeServerD entry left dangling by RemoveSession's own cleanup");
     }
 }
 

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -496,6 +496,11 @@ public:
         return request;
     }
 
+    auto CreateDescribeSessionsRequest()
+    {
+        return std::make_unique<TEvIndexTablet::TEvDescribeSessionsRequest>();
+    }
+
     //
     // TEvIndexTabletPrivate
     //

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -529,6 +529,11 @@ public:
         return request;
     }
 
+    auto CreateDescribeSessionsRequest()
+    {
+        return std::make_unique<TEvIndexTablet::TEvDescribeSessionsRequest>();
+    }
+
     //
     // TEvIndexTabletPrivate
     //

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -344,7 +344,7 @@ public:
             return;
         }
         if (!ShouldStop()) {
-            STORAGE_INFO("%s establishing session %lu",
+            STORAGE_INFO("%s establishing session with seqNo %lu",
                 MakeTestTag().c_str(), cmd.SessionSeqNo);
 
             TFuture<NProto::TCreateSessionResponse> result;

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -354,7 +354,7 @@ public:
             return;
         }
         if (!ShouldStop()) {
-            STORAGE_INFO("%s establishing session %lu",
+            STORAGE_INFO("%s establishing session with seqNo %lu",
                 MakeTestTag().c_str(), cmd.SessionSeqNo);
 
             TFuture<NProto::TCreateSessionResponse> result;


### PR DESCRIPTION
#4961

In the EvServerDisconnected event, the Sender is not the id of the session owner that we stored in SessionByOwner during session creation. That is why I introduced a new TSessionOwnerByPipeServerMap to keep the PipeServerId -> Owner mapping.

We need to store PipeServerId during session creation. The initial recipient of messages sent through the pipe is the pipe client. The client rewrites the recipient to the pipe server and sends the message via the actor system. The pipe server then forwards the message to the tablet using RecipientRewrite. As a result, the pipe server is the Recipient, while the tablet is specified in RecipientRewrite. That’s why I stored ev->Recipient as the ID of the pipe server.

This is described in the documentation:
https://github.com/ydb-platform/ydb-rfc/blob/main/ydb_book/05-Tablet-infrastructure/05.02-Tablet-Pipe.md