### PR TITLE
issue-4853: TReadDataActor handles InFlightRequest registration and request completion by itself to decrease the load on TStorageServiceActor

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor.cpp
@@ -73,6 +73,8 @@ void TStorageServiceActor::RegisterCounters(const NActors::TActorContext& ctx)
     auto serviceCounters = rootGroup->GetSubgroup("component", "service");
     TotalFileSystemCount = serviceCounters->GetCounter("FileSystemCount", false);
     TotalTabletCount = serviceCounters->GetCounter("TabletCount", false);
+    InFlightRequestCount =
+        serviceCounters->GetCounter("InFlightRequestCount", false);
 
     auto hddCounters = serviceCounters->GetSubgroup("type", "hdd");
     HddFileSystemCount = hddCounters->GetCounter("FileSystemCount", false);

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -96,6 +96,7 @@ private:
 
     NMonitoring::TDynamicCounters::TCounterPtr TotalFileSystemCount;
     NMonitoring::TDynamicCounters::TCounterPtr TotalTabletCount;
+    NMonitoring::TDynamicCounters::TCounterPtr InFlightRequestCount;
 
     NMonitoring::TDynamicCounters::TCounterPtr HddFileSystemCount;
     NMonitoring::TDynamicCounters::TCounterPtr HddTabletCount;

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -459,6 +459,7 @@ void TStorageServiceActor::HandleCreateFileStore(
     if (HasError(error)) {
         auto response = std::make_unique<TEvService::TEvCreateFileStoreResponse>(error);
         inflight->Complete(ctx.Now(), error);
+        InFlightRequests->Erase(cookie);
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -219,6 +219,7 @@ void TStorageServiceActor::HandleDestroySession(
         auto response =
             std::make_unique<TEvService::TEvDestroySessionResponse>(error);
         inflight->Complete(ctx.Now(), std::move(error));
+        InFlightRequests->Erase(cookie);
         NCloud::Reply(ctx, *ev, std::move(response));
     };
 
@@ -340,6 +341,7 @@ void TStorageServiceActor::HandleSessionDestroyed(
     NCloud::Reply(ctx, *inflight, std::move(response));
 
     inflight->Complete(ctx.Now(), msg->GetError());
+    InFlightRequests->Erase(ev->Cookie);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -824,12 +824,9 @@ void TReadDataActor::SendResponseAndDie(
         TraceSerializer,
         response->Record,
         MainInFlightRequest);
+    InFlightRequests->Erase(RequestCookie);
 
-    ctx.Send(
-        MainInFlightRequest->Sender,
-        response.release(),
-        0,  // flags
-        MainInFlightRequest->Cookie);
+    ctx.Send(Sender, response.release(), 0 /* flags */, Cookie);
 
     Die(ctx);
 }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3844,6 +3844,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             ->FindSubgroup("component", "service")
             ->GetCounter("TabletCount", false);
 
+        auto inFlightRequestCounter = counters
+            ->FindSubgroup("counters", "filestore")
+            ->FindSubgroup("component", "service")
+            ->GetCounter("InFlightRequestCount", false);
+
         auto hddTabletCounter = counters
             ->FindSubgroup("counters", "filestore")
             ->FindSubgroup("component", "service")
@@ -3863,6 +3868,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, ssdFsCounter->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(0, ssdTabletCounter->GetAtomic());
 
+        // smoke
+        UNIT_ASSERT_VALUES_EQUAL(0, inFlightRequestCounter->GetAtomic());
+
         service.UnregisterLocalFileStore("test", 1);
 
         env.GetRuntime().AdvanceCurrentTime(TDuration::Seconds(15));
@@ -3874,6 +3882,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(0, hddTabletCounter->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(0, ssdFsCounter->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(0, ssdTabletCounter->GetAtomic());
+
+        // smoke
+        UNIT_ASSERT_VALUES_EQUAL(0, inFlightRequestCounter->GetAtomic());
     }
 
     Y_UNIT_TEST(ShouldUseThreeStageWriteAndTwoStageReadForHandlelessIO)


### PR DESCRIPTION
### Notes
`TStorageServiceActor` spends a lot of time doing these things:
* `TStorageServiceActor::CompleteRequest()` - responses are proxied to `TStorageServiceActor` so that it would find the corresponding `TInFlightRequest` in its state, call `Complete()` for it and then proxy the response back to `TRequestActor` - this is not actually needed to be done in `TStorageServiceActor` - getting rid of this proxying for `ReadData` requests
* `TStorageServiceActor::HandleReadData() -> CreateInFlightRequest()` - this thing can also be done by `TReadDataActor`

To do this I turned `InFlightRequests` into a thread-safe struct, a very simple one - just a `THashMap` + `TAdaptiveLock`. But even such a simple solution significantly improves performance: in my test with 3 VMs on the same host performing randread x 4KiB x iodepth=1 x numjobs=64 on top of the same filesystem I managed to increase read IOPS from 60k total (`main` branch version of filestore-vhost) to 132k total. 

I also got rid of `InFlightRequests` cleanup in `TStorageServiceActor::HandleUpdateStats()` - because of this `InFlightRequests` data structure becomes too big for no reason - it stores all the requests that we receive in a 1-second time window (which is 132k in my test). In this PR InFlightRequests are erased as soon as we complete the corresponding requests. This might actually improve performance of other requests - not just `ReadData`. I haven't measured the perf improvement for those other request types but it should be visible as well. `TStorageServiceActor::HandleUpdateStats()` used to be clearly visible on the flame graphs - most probably because it had to iterate over all those InFlightRequests (most of which were completed already).

Read IOPS (after vs before):
<img width="316" height="352" alt="Screenshot from 2026-01-07 20-56-31" src="https://github.com/user-attachments/assets/26f2fd48-e84f-41a3-aefa-0b5c0cae62d1" />

In the `main` branch version of filestore-vhost we were bottlenecked by `TStorageServiceActor` (ElapsedMicrosecByActivity being equal to 1M), now we are not bottlenecked by it (`TIndexTabletProxyActor` is our next bottleneck). A screenshot of ElapsedMicrosecByActivity normalized in such a way that 1M is shown as 100%:
<img width="1057" height="424" alt="Screenshot from 2026-01-07 20-56-47" src="https://github.com/user-attachments/assets/a57a2330-8287-4d8f-844c-d6e8c2d5cf97" />

There are still some old inefficiencies and just dirty code left in `TInFlightRequest` and `TReadDataActor ctor` - will make a separate cleanup PR for that. 

### Issue
https://github.com/ydb-platform/nbs/issues/4853

### Extra
fio config:
```
qemu@ubuntu:~/mnt$ cat fio_tests.txt 
[global]
filesize=2G
time_based=1
startdelay=5
exitall_on_error=1
create_serialize=0
filename_format=$filenum/$jobnum
group_reporting=1
clocksource=gettimeofday
ioengine=libaio
disk_util=0
direct=1

[init]
blocksize=1Mi
rw=write
size=100%
numjobs=64
time_based=0
description='pre-create files'

[read-4k]
stonewall
description='Read iops workload'
iodepth=1
bs=4k
rw=randread
numjobs=64
runtime=240
```

Test VMs were launched via https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/bin/run_test_qemu.sh with minor changes to be able to run 3 such VMs on the same host