### PR TITLE
[Filestore local] Propagate error message for read/write

### DIFF
--- a/cloud/filestore/libs/service_local/fs_data.cpp
+++ b/cloud/filestore/libs/service_local/fs_data.cpp
@@ -118,8 +118,10 @@ TFuture<NProto::TReadDataLocalResponse> TLocalFileSystem::ReadDataLocalAsync(
                     auto bytesRead = f.GetValue();
                     response.BytesRead = bytesRead;
                 } catch (const TServiceError& e) {
-                    *response.MutableError() = MakeError(MAKE_FILESTORE_ERROR(
-                        ErrnoToFileStoreError(STATUS_FROM_CODE(e.GetCode()))));
+                    *response.MutableError() = MakeError(
+                        MAKE_FILESTORE_ERROR(ErrnoToFileStoreError(
+                            STATUS_FROM_CODE(e.GetCode()))),
+                        TString(e.GetMessage()));
                 } catch (...) {
                     *response.MutableError() =
                         MakeError(E_IO, CurrentExceptionMessage());
@@ -158,8 +160,10 @@ TFuture<NProto::TReadDataResponse> TLocalFileSystem::ReadDataAsync(
                 response.SetBufferOffset(b->AlignedDataOffset());
                 response.SetBuffer(b->TakeBuffer());
             } catch (const TServiceError& e) {
-                *response.MutableError() = MakeError(MAKE_FILESTORE_ERROR(
-                    ErrnoToFileStoreError(STATUS_FROM_CODE(e.GetCode()))));
+                *response.MutableError() = MakeError(
+                    MAKE_FILESTORE_ERROR(
+                        ErrnoToFileStoreError(STATUS_FROM_CODE(e.GetCode()))),
+                    TString(e.GetMessage()));
             } catch (...) {
                 *response.MutableError() =
                     MakeError(E_IO, CurrentExceptionMessage());
@@ -203,8 +207,10 @@ TFuture<NProto::TWriteDataLocalResponse> TLocalFileSystem::WriteDataLocalAsync(
                         *response.MutableError() = MakeError(E_REJECTED);
                     }
                 } catch (const TServiceError& e) {
-                    *response.MutableError() = MakeError(MAKE_FILESTORE_ERROR(
-                        ErrnoToFileStoreError(STATUS_FROM_CODE(e.GetCode()))));
+                    *response.MutableError() = MakeError(
+                        MAKE_FILESTORE_ERROR(ErrnoToFileStoreError(
+                            STATUS_FROM_CODE(e.GetCode()))),
+                        TString(e.GetMessage()));
                 } catch (...) {
                     *response.MutableError() =
                         MakeError(E_IO, CurrentExceptionMessage());
@@ -241,8 +247,10 @@ TFuture<NProto::TWriteDataResponse> TLocalFileSystem::WriteDataAsync(
                 try {
                     f.GetValue();
                 } catch (const TServiceError& e) {
-                    *response.MutableError() = MakeError(MAKE_FILESTORE_ERROR(
-                        ErrnoToFileStoreError(STATUS_FROM_CODE(e.GetCode()))));
+                    *response.MutableError() = MakeError(
+                        MAKE_FILESTORE_ERROR(ErrnoToFileStoreError(
+                            STATUS_FROM_CODE(e.GetCode()))),
+                        TString(e.GetMessage()));
                 } catch (...) {
                     *response.MutableError() =
                         MakeError(E_IO, CurrentExceptionMessage());


### PR DESCRIPTION
When error code is converted to EIO we will have the original error message
reported to log
