### PR TITLE
Revert contrib/libs/grpc back to using c-ares DNS resolver

### DIFF
--- a/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -811,7 +811,7 @@ class AresDNSResolver : public DNSResolver {
 };
 
 bool ShouldUseAres(y_absl::string_view resolver_env) {
-  return !resolver_env.empty() && y_absl::EqualsIgnoreCase(resolver_env, "ares");
+  return resolver_env.empty() || y_absl::EqualsIgnoreCase(resolver_env, "ares");
 }
 
 bool UseAresDnsResolver() {


### PR DESCRIPTION
[Patch](https://github.com/ydb-platform/ydb/commit/0a389f06b20b9bf1811bf0c3228fa32d0375a1c2.diff) form GRPC repository to fix ASAN leak in GRPC.

ya test -ttt cloud/filestore/tests/registration/ -F "test.py::test_server_registration[True-True-True]" --sanitize=address

ASAN leak log:
Warning parsing text-format NKikimrConfig.TStaticNameserviceConfig: 10:3: text format contains deprecated field "Body"Warning parsing text-format NKikimrConfig.TStaticNameserviceConfig: 11:1: text format contains deprecated field "WalleLocation"2025-11-28T07:15:55.780315Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:170: ProfileLog initialized
2025-11-28T07:15:55.780382Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:178: Metrics initialized
2025-11-28T07:15:55.780747Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:442: Trying to register with discovery service: U=0/
2025-11-28T07:15:55.830122Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:15:56.853577Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:15:57.875487Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:15:58.897148Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:15:59.932674Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:16:00.954662Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:16:01.977594Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:16:03.013157Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
2025-11-28T07:16:04.036268Z :NFS_SERVER WARN: cloud/storage/core/libs/kikimr/node.cpp:538: Failed to register dynamic node at "localhost:24708": [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]. Will retry after 1.000000s
main bootstrap start: (NCloud::TServiceError) cloud/storage/core/libs/kikimr/node.cpp:531: Cannot register dynamic node: [ { <main>: Error: GRpc error: (4): Deadline Exceeded } { <main>: Error: Grpc error response on endpoint localhost:24708 } ]
2025-11-28T07:16:05.058672Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:112: Stopped BackgroundScheduler
2025-11-28T07:16:05.058720Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:113: Stopped Scheduler
2025-11-28T07:16:05.058774Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:118: Stopped ProfileLog
2025-11-28T07:16:05.058845Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:119: Stopped BackgroundThreadPool
2025-11-28T07:16:05.058887Z :NFS_SERVER INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:123: Stopped Metrics
E1128 07:16:05.059298428  178130 ssl_transport_security.cc:804]        Could not set ephemeral ECDH key.
E1128 07:16:05.059448045  178130 ssl_security_connector.cc:129]        Handshaker factory creation failed with TSI_INTERNAL_ERROR.
E1128 07:16:05.059577939  178130 chttp2_connector.cc:269]              Failed to create channel args during subchannel creation: INTERNAL: Failed to create secure subchannel for secure name 'localhost:24708'; Got args: {grpc.client_channel_factory=0x6020001d6630, grpc.default_authority=localhost:24708, grpc.default_compression_algorithm=0, grpc.http2.max_pings_without_data=0, grpc.internal.channel_credentials=0x606000163880, grpc.internal.event_engine=0x602000212590, grpc.internal.subchannel_pool=0x604000366510, grpc.keepalive_permit_without_calls=0, grpc.keepalive_time_ms=1250, grpc.keepalive_timeout_ms=10000, grpc.max_receive_message_length=64000000, grpc.max_send_message_length=64000000, grpc.primary_user_agent=grpc-c++/1.54.2, grpc.resource_quota=0x604000366350, grpc.server_uri=dns:///localhost:24708}
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x60 has a premature terminator entry at offset 0x70
warning: address range table at offset 0x90 has a premature terminator entry at offset 0xa0
warning: address range table at offset 0xc0 has a premature terminator entry at offset 0xd0
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0x1000 has a premature terminator entry at offset 0x1010
warning: address range table at offset 0x1030 has a premature terminator entry at offset 0x1040
warning: address range table at offset 0x1060 has a premature terminator entry at offset 0x1070
warning: address range table at offset 0x1090 has a premature terminator entry at offset 0x10a0
warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
warning: address range table at offset 0x10f0 has a premature terminator entry at offset 0x1100
warning: address range table at offset 0x1120 has a premature terminator entry at offset 0x1130
warning: address range table at offset 0x1150 has a premature terminator entry at offset 0x1160
warning: address range table at offset 0x1180 has a premature terminator entry at offset 0x1190
warning: address range table at offset 0x11b0 has a premature terminator entry at offset 0x11c0
warning: address range table at offset 0x11e0 has a premature terminator entry at offset 0x11f0
warning: address range table at offset 0x1210 has a premature terminator entry at offset 0x1220
warning: address range table at offset 0x1240 has a premature terminator entry at offset 0x1250
warning: address range table at offset 0x1270 has a premature terminator entry at offset 0x1280
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
warning: address range table at offset 0x12d0 has a premature terminator entry at offset 0x12e0
warning: address range table at offset 0x13f0 has a premature terminator entry at offset 0x1400
warning: address range table at offset 0x1420 has a premature terminator entry at offset 0x1430
warning: address range table at offset 0x1450 has a premature terminator entry at offset 0x1460
warning: address range table at offset 0x1480 has a premature terminator entry at offset 0x1490
warning: address range table at offset 0x14b0 has a premature terminator entry at offset 0x14c0
warning: address range table at offset 0x1510 has a premature terminator entry at offset 0x1520
warning: address range table at offset 0x1540 has a premature terminator entry at offset 0x1550
warning: address range table at offset 0x1570 has a premature terminator entry at offset 0x1580

=================================================================
==175699==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 584 byte(s) in 1 object(s) allocated from:
    #0 0x15555f3e in __interceptor_malloc /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_malloc_linux.cpp:69:3
    #1 0x1722551d in CRYPTO_malloc /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/mem.c:222:11
    #2 0x1722551d in CRYPTO_zalloc /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/mem.c:230:17
    #3 0x17221ad2 in ERR_get_state /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/err/err.c:766:22
    #4 0x17224998 in ERR_set_mark /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/err/err.c:915:10
    #5 0x172fe2fb in pubkey_cb /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/x509/x_pubkey.c:45:9
    #6 0x1727d276 in asn1_item_embed_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:432:25
    #7 0x1727fdef in asn1_template_noexp_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:643:15
    #8 0x1727d84a in asn1_template_ex_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:518:16
    #9 0x1727cc57 in asn1_item_embed_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:382:19
    #10 0x1727fdef in asn1_template_noexp_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:643:15
    #11 0x1727d84a in asn1_template_ex_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:518:16
    #12 0x1727cc57 in asn1_item_embed_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:382:19
    #13 0x1727c0f1 in ASN1_item_ex_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:124:10
    #14 0x1727c0f1 in ASN1_item_d2i /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/asn1/tasn_dec.c:114:9
    #15 0x173bec7f in d2i_X509 /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/x509/x_x509.c:109:1
    #16 0x173bec7f in d2i_X509_AUX /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/x509/x_x509.c:141:11
    #17 0x1747903e in PEM_ASN1_read_bio /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/pem/pem_oth.c:31:11
    #18 0x1721a2ca in ssl_ctx_use_certificate_chain /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc:541:9
    #19 0x1721a2ca in populate_ssl_context(ssl_ctx_st*, tsi_ssl_pem_key_cert_pair const*, char const*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc:780:16
    #20 0x172194f9 in tsi_create_ssl_client_handshaker_factory_with_options(tsi_ssl_client_handshaker_options const*, tsi_ssl_client_handshaker_factory**) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc:2008:14
    #21 0x1767f85d in (anonymous namespace)::grpc_ssl_channel_security_connector::InitializeHandshakerFactory /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc:125:9
    #22 0x1767f85d in grpc_ssl_channel_security_connector_create(grpc_core::RefCountedPtr<grpc_channel_credentials>, grpc_core::RefCountedPtr<grpc_call_credentials>, grpc_ssl_config const*, char const*, char const*, tsi_ssl_session_cache*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc:440:42
    #23 0x1767c65c in grpc_ssl_credentials::create_security_connector(grpc_core::RefCountedPtr<grpc_call_credentials>, char const*, grpc_core::ChannelArgs*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/security/credentials/ssl/ssl_credentials.cc:70:7
    #24 0x170685bb in grpc_core::(anonymous namespace)::Chttp2SecureClientChannelFactory::GetSecureNamingChannelArgs /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/transport/chttp2/client/chttp2_connector.cc:302:34
    #25 0x170685bb in grpc_core::(anonymous namespace)::Chttp2SecureClientChannelFactory::CreateSubchannel(grpc_resolved_address const&, grpc_core::ChannelArgs const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/transport/chttp2/client/chttp2_connector.cc:267:46
    #26 0x16fd944d in grpc_core::ClientChannel::ClientChannelControlHelper::CreateSubchannel(grpc_core::ServerAddress, grpc_core::ChannelArgs const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:923:42
    #27 0x16f025ac in grpc_core::ChildPolicyHandler::Helper::CreateSubchannel(grpc_core::ServerAddress, grpc_core::ChannelArgs const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/child_policy_handler.cc:60:47
    #28 0x16f2a04b in grpc_core::SubchannelList<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList, grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelData>::SubchannelList /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h:382:17
    #29 0x16f2a04b in grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList::PickFirstSubchannelList /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:105:11
    #30 0x16f2a04b in grpc_core::MakeRefCounted<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList, grpc_core::(anonymous namespace)::PickFirst *, std::__y1::vector<grpc_core::ServerAddress, std::__y1::allocator<grpc_core::ServerAddress> >, grpc_core::ChannelArgs &> /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/ref_counted_ptr.h:323:31
    #31 0x16f2a04b in grpc_core::(anonymous namespace)::PickFirst::AttemptToConnectUsingLatestUpdateArgsLocked() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:223:37
    #32 0x16f28ce9 in grpc_core::(anonymous namespace)::PickFirst::UpdateLocked(grpc_core::LoadBalancingPolicy::UpdateArgs) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:289:5
    #33 0x16f00033 in grpc_core::ChildPolicyHandler::UpdateLocked(grpc_core::LoadBalancingPolicy::UpdateArgs) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/child_policy_handler.cc:262:28
    #34 0x16fac179 in grpc_core::ClientChannel::CreateOrUpdateLbPolicyLocked(grpc_core::RefCountedPtr<grpc_core::LoadBalancingPolicy::Config>, std::__y1::optional<TBasicString<char, std::__y1::char_traits<char>>> const&, grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:1412:22
    #35 0x16fa8877 in grpc_core::ClientChannel::OnResolverResultChangedLocked(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:1330:30
    #36 0x16fe2373 in grpc_core::ClientChannel::ResolverResultHandler::ReportResult(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:470:13
    #37 0x16ea3ef5 in grpc_core::PollingResolver::OnRequestCompleteLocked(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:183:22
    #38 0x16ea7041 in grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:34
    #39 0x16ea7041 in std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #40 0x16ea7041 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #41 0x16ea7041 in std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #42 0x16ea7041 in std::__y1::__function::__func<grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result)::$_0, std::__y1::allocator<grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result)::$_0>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12

Direct leak of 376 byte(s) in 1 object(s) allocated from:
    #0 0x15555f3e in __interceptor_malloc /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_malloc_linux.cpp:69:3
    #1 0x1722551d in CRYPTO_malloc /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/mem.c:222:11
    #2 0x1722551d in CRYPTO_zalloc /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/mem.c:230:17
    #3 0x17261a90 in rand_drbg_new /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/rand/drbg_lib.c:191:32
    #4 0x172648f5 in RAND_DRBG_secure_new /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/rand/drbg_lib.c:257:12
    #5 0x172648f5 in drbg_setup /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/rand/drbg_lib.c:863:12
    #6 0x17264d05 in RAND_DRBG_get0_public /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/rand/drbg_lib.c:1109:16
    #7 0x17264d05 in drbg_bytes /actions-runner/_work/nbs/nbs/contrib/libs/openssl/crypto/rand/drbg_lib.c:952:23
    #8 0x175b6999 in SSL_CTX_new /actions-runner/_work/nbs/nbs/contrib/libs/openssl/ssl/ssl_lib.c:3128:10
    #9 0x17219239 in tsi_create_ssl_client_handshaker_factory_with_options(tsi_ssl_client_handshaker_options const*, tsi_ssl_client_handshaker_factory**) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc:1962:17
    #10 0x1767f85d in (anonymous namespace)::grpc_ssl_channel_security_connector::InitializeHandshakerFactory /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc:125:9
    #11 0x1767f85d in grpc_ssl_channel_security_connector_create(grpc_core::RefCountedPtr<grpc_channel_credentials>, grpc_core::RefCountedPtr<grpc_call_credentials>, grpc_ssl_config const*, char const*, char const*, tsi_ssl_session_cache*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc:440:42
    #12 0x1767c65c in grpc_ssl_credentials::create_security_connector(grpc_core::RefCountedPtr<grpc_call_credentials>, char const*, grpc_core::ChannelArgs*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/security/credentials/ssl/ssl_credentials.cc:70:7
    #13 0x170685bb in grpc_core::(anonymous namespace)::Chttp2SecureClientChannelFactory::GetSecureNamingChannelArgs /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/transport/chttp2/client/chttp2_connector.cc:302:34
    #14 0x170685bb in grpc_core::(anonymous namespace)::Chttp2SecureClientChannelFactory::CreateSubchannel(grpc_resolved_address const&, grpc_core::ChannelArgs const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/transport/chttp2/client/chttp2_connector.cc:267:46
    #15 0x16fd944d in grpc_core::ClientChannel::ClientChannelControlHelper::CreateSubchannel(grpc_core::ServerAddress, grpc_core::ChannelArgs const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:923:42
    #16 0x16f025ac in grpc_core::ChildPolicyHandler::Helper::CreateSubchannel(grpc_core::ServerAddress, grpc_core::ChannelArgs const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/child_policy_handler.cc:60:47
    #17 0x16f2a04b in grpc_core::SubchannelList<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList, grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelData>::SubchannelList /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h:382:17
    #18 0x16f2a04b in grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList::PickFirstSubchannelList /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:105:11
    #19 0x16f2a04b in grpc_core::MakeRefCounted<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList, grpc_core::(anonymous namespace)::PickFirst *, std::__y1::vector<grpc_core::ServerAddress, std::__y1::allocator<grpc_core::ServerAddress> >, grpc_core::ChannelArgs &> /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/ref_counted_ptr.h:323:31
    #20 0x16f2a04b in grpc_core::(anonymous namespace)::PickFirst::AttemptToConnectUsingLatestUpdateArgsLocked() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:223:37
    #21 0x16f28ce9 in grpc_core::(anonymous namespace)::PickFirst::UpdateLocked(grpc_core::LoadBalancingPolicy::UpdateArgs) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:289:5
    #22 0x16f00033 in grpc_core::ChildPolicyHandler::UpdateLocked(grpc_core::LoadBalancingPolicy::UpdateArgs) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/lb_policy/child_policy_handler.cc:262:28
    #23 0x16fac179 in grpc_core::ClientChannel::CreateOrUpdateLbPolicyLocked(grpc_core::RefCountedPtr<grpc_core::LoadBalancingPolicy::Config>, std::__y1::optional<TBasicString<char, std::__y1::char_traits<char>>> const&, grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:1412:22
    #24 0x16fa8877 in grpc_core::ClientChannel::OnResolverResultChangedLocked(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:1330:30
    #25 0x16fe2373 in grpc_core::ClientChannel::ResolverResultHandler::ReportResult(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/client_channel.cc:470:13
    #26 0x16ea3ef5 in grpc_core::PollingResolver::OnRequestCompleteLocked(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:183:22
    #27 0x16ea7041 in grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:34
    #28 0x16ea7041 in std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #29 0x16ea7041 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #30 0x16ea7041 in std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:149:7)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #31 0x16ea7041 in std::__y1::__function::__func<grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result)::$_0, std::__y1::allocator<grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result)::$_0>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12
    #32 0x16d1b864 in std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16
    #33 0x16d1b864 in std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12
    #34 0x16d1b864 in grpc_core::WorkSerializer::WorkSerializerImpl::Run(std::__y1::function<void ()>, grpc_core::DebugLocation const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/work_serializer.cc:108:5
    #35 0x16d1c91b in grpc_core::WorkSerializer::Run(std::__y1::function<void ()>, grpc_core::DebugLocation const&) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/work_serializer.cc:237:10
    #36 0x16ea3233 in grpc_core::PollingResolver::OnRequestComplete(grpc_core::Resolver::Result) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/polling_resolver.cc:148:21
    #37 0x171452fd in grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::OnResolved(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address>>>) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc:144:3
    #38 0x17146493 in std::__y1::__invoke<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*&)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *&, y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:368:23
    #39 0x17146493 in std::__y1::invoke<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*&)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *&, y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > > > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:540:12
    #40 0x17146493 in std::__y1::__bind_front_op::operator()<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*&)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *&, y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > > > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/bind_front.h:33:27
    #41 0x17146493 in std::__y1::__perfect_forward_impl<std::__y1::__bind_front_op, std::__y1::integer_sequence<unsigned long, 0UL, 1UL>, void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *>::operator()<y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/perfect_forward.h:53:23
    #42 0x17146493 in std::__y1::__invoke<std::__y1::__bind_front_t<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *> &, y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > > > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:403:23
    #43 0x17146493 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<std::__y1::__bind_front_t<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *> &, y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > > > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h:488:9
    #44 0x17146493 in std::__y1::__function::__alloc_func<std::__y1::__bind_front_t<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *>, std::__y1::allocator<std::__y1::__bind_front_t<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver *> >, void (y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:185:16
    #45 0x17146493 in std::__y1::__function::__func<std::__y1::__bind_front_t<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address>>>), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver*>, std::__y1::allocator<std::__y1::__bind_front_t<void (grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver::*)(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address>>>), grpc_core::(anonymous namespace)::NativeClientChannelDNSResolver*>>, void (y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address>>>)>::operator()(y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address>>>&&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:359:12
    #46 0x16dd3327 in std::__y1::__function::__value_func<void (y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:512:16
    #47 0x16dd3327 in std::__y1::function<void (y_absl::lts_y_20230802::StatusOr<std::__y1::vector<grpc_resolved_address, std::__y1::allocator<grpc_resolved_address> > >)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1187:12
    #48 0x16dd3327 in grpc_core::(anonymous namespace)::NativeDNSRequest::DoRequestThread(void*, y_absl::lts_y_20230802::Status) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/iomgr/resolve_address_posix.cc:70:5
    #49 0x16b651d5 in grpc_core::Executor::RunClosures(char const*, grpc_closure_list) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/iomgr/executor.cc:138:5
    #50 0x16b65d4e in grpc_core::Executor::ThreadMain(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/iomgr/executor.cc:257:22
    #51 0x16b6a00e in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(const char *, void (*)(void *), void *, bool *, const grpc_core::Thread::Options &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:135:11
    #52 0x16b6a00e in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /actions-runner/_work/nbs/nbs/contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc:117:9
    #53 0x7ff2de094ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)