### PR TITLE
issue-4649: do not keep file handle for shared memory region

### DIFF
--- a/cloud/filestore/libs/server/server_memory_state.cpp
+++ b/cloud/filestore/libs/server/server_memory_state.cpp
@@ -85,10 +85,7 @@ TResultOrError<TMmapRegionMetadata> TServerState::CreateMmapRegion(
     }
 
     ui64 mmapId = ClampVal(RandomNumber<ui64>(), 1ul, Max<ui64>());
-
-    // passing ownership of fd to the TMmapRegion struct
-    TMmapRegion
-        region(std::move(fullPath), addr, size, mmapId, std::move(file));
+    TMmapRegion region(std::move(fullPath), addr, size, mmapId);
 
     TLightWriteGuard guard(StateLock);
 

--- a/cloud/filestore/libs/server/server_memory_state.h
+++ b/cloud/filestore/libs/server/server_memory_state.h
@@ -43,8 +43,7 @@ public:
             TString filePath,
             void* address,
             size_t size,
-            ui64 id,
-            TFileHandle fd)
+            ui64 id)
         : Metadata{
             .FilePath = std::move(filePath),
             .Address = address,
@@ -52,7 +51,6 @@ public:
             .Id = id,
             .LatestActivityTimestamp = TInstant::Now()
         }
-        , Fd(std::move(fd))
     {}
 
     TMmapRegionMetadata ToMetadata() const
@@ -67,7 +65,6 @@ public:
 
 private:
     TMmapRegionMetadata Metadata;
-    TFileHandle Fd;
 };
 
 class TServerState


### PR DESCRIPTION
issue: #4649 

After the mmap() call has returned, the file descriptor, fd, can be closed immediately without invalidating the mapping.