### PR TITLE
local filestore debug - impld ability to run multiple test VMs on the same host

### DIFF
--- a/cloud/filestore/README.md
+++ b/cloud/filestore/README.md
@@ -16,7 +16,11 @@ usermod -a -G kvm $USER
 To build run the following command from the repository root folder:
 
 ```bash
-./ya make -r -- cloud/filestore/buildall
+./ya make -r -- cloud/filestore/buildall -D CFLAGS="-fno-omit-frame-pointer"
+```
+or
+```bash
+./ya make --build=profile -- cloud/filestore/buildall
 ```
 
 ### 2. Configuring
@@ -61,6 +65,16 @@ qemu@test> sudo mount -t virtiofs fs0 mnt    # creates mount point for the files
 - or you can mount filestore localy
 ```bash
 ./initctl.sh mount
+```
+
+To run second (third, fourth, etc.) VM:
+```bash
+CLIENT_ID="local-qemu2" VHOST_SOCKET_PATH="/tmp/vhost2.sock" ./initctl.sh startendpoint
+QMP_PORT=4445 NET_PORT=3390 VHOST_SOCKET_PATH="/tmp/vhost2.sock" ./run_test_qemu.sh
+```
+```bash
+CLIENT_ID="local-qemu3" VHOST_SOCKET_PATH="/tmp/vhost3.sock" ./initctl.sh startendpoint
+QMP_PORT=4446 NET_PORT=3391 VHOST_SOCKET_PATH="/tmp/vhost3.sock" ./run_test_qemu.sh
 ```
 
 Thanks for flying NFS

--- a/cloud/filestore/bin/initctl.sh
+++ b/cloud/filestore/bin/initctl.sh
@@ -17,6 +17,7 @@ BLOCK_COUNT=${BLOCK_COUNT:-10485760} # 40GiB
 BLOCK_SIZE=${BLOCK_SIZE:-4096}
 SHARD_COUNT=${SHARD_COUNT:-8}
 MOUNT_POINT=${MOUNT_POINT:-"$HOME/filestore_mounts/$FS"}
+CLIENT_ID=${CLIENT_ID:-"local-qemu"}
 VHOST_SOCKET_PATH=${VHOST_SOCKET_PATH:-/tmp/vhost.sock}
 VHOST_QUEUE_COUNT=${VHOST_QUEUE_COUNT:-9}
 
@@ -163,7 +164,7 @@ if [[ "$1" == "startendpoint" ]]; then
         --server-port       "$VHOST_PORT"           \
         --filesystem        "$FS"                   \
         --socket-path       "$VHOST_SOCKET_PATH"    \
-        --client-id         "local-qemu"            \
+        --client-id         "$CLIENT_ID"            \
         --vhost-queue-count "$VHOST_QUEUE_COUNT"    \
         --persistent
     echo "started endpoint at $VHOST_SOCKET_PATH"

--- a/cloud/filestore/bin/run_test_qemu.sh
+++ b/cloud/filestore/bin/run_test_qemu.sh
@@ -25,6 +25,7 @@ QEMU_FIRMWARE_REL=/usr/share/qemu
       tar -xzf $QEMU_BIN_TAR -C $QEMU_BIN_DIR
 
 : ${QMP_PORT:=4444}
+: ${NET_PORT:=3389}
 : ${DISK_IMAGE:=$QEMU_DIR/image-plucky/rootfs.img}
 : ${VHOST_SOCKET_PATH:=/tmp/vhost.sock}
 
@@ -47,20 +48,20 @@ args=(
     -object memory-backend-memfd,id=mem,size=$MEM_SIZE,share=on
     -numa node,memdev=mem
 
-    -netdev user,id=netdev0,hostfwd=tcp::3389-:3389
+    -netdev user,id=netdev0,hostfwd=tcp::$NET_PORT-:$NET_PORT
     -device virtio-net-pci,netdev=netdev0,id=net0
 
     -drive format=qcow2,file="$DISK_IMAGE",id=hdd0,if=none,aio=native,cache=none,discard=unmap
     -device virtio-blk-pci,id=vblk0,drive=hdd0,num-queues=$NCORES,bootindex=1
 
     -chardev socket,path=$VHOST_SOCKET_PATH,id=vhost0,reconnect=1
-    -device vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,num-request-queues=8,queue-size=512
+    -device vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,num-request-queues=8,queue-size=1024
 
     -serial stdio
     -nographic
     ${KERNEL_IMAGE:+-kernel $KERNEL_IMAGE}
     ${KCMDLINE:+-append "$KCMDLINE"}
-    -s
+    # -s
 )
 
 # QEMU="ya tool gdb --args $QEMU"


### PR DESCRIPTION
### Notes 
Useful for stress-testing filestore-vhost and not getting bottlenecked by single VM client-side driver performance. See usage examples in README.md.

Changed default queue-size as well - using the maximum allowed value (1024).