### PR TITLE
issue-2674: filesystem resize uts with DirectoryCreationInShardsEnabled: true

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -584,7 +584,7 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
         }
 
         // The shards are resized only if
-        // StrictFileSystemSizeEnforcementEnabled, otherwise the shards doesn't
+        // StrictFileSystemSizeEnforcementEnabled, otherwise the shards don't
         // change their size.
         if (StrictFileSystemSizeEnforcementEnabled) {
             ShardsToDescribe = ExistingShardIds.size();


### PR DESCRIPTION
### Notes
There was a report that either main fs resize or shard resize doesn't work with `DirectoryCreationInShardsEnabled: true` (giving "Cannot decrease number of shards" error message), I added unit tests for both of these cases - seems to work.

### Issue
https://github.com/ydb-platform/nbs/issues/2674