### PR TITLE
Fix build nbsd-lightweight

### DIFF
--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -2,8 +2,6 @@ PROGRAM(nbsd-lightweight)
 
 ALLOCATOR(TCMALLOC_TC)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
-
 SRCS(
     main.cpp
 )


### PR DESCRIPTION
Continue https://github.com/ydb-platform/nbs/pull/4923
There is no need to apply restrictions to nbsd-lightheight since it has an ALLOW_ONLY section defined.
```
Multiple CHECK_DEPENDENT_DIRS macro with different restriction types applied to the same module
```