### PR TITLE
Get rid writing used blocks map for encrypted NRD

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward_trackused.cpp
@@ -36,29 +36,18 @@ bool TVolumeActor::SendRequestToPartitionWithUsedBlockTracking(
         {
             auto requestInfo =
                 CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
-            // TODO(drbasic)
-            // For encrypted disk-registry based disks, we will continue to
-            // write a map of encrypted blocks for a while.
-            const bool encryptedDiskRegistryBasedDisk =
-                State->IsDiskRegistryMediaKind() &&
-                State->GetMeta()
-                        .GetVolumeConfig()
-                        .GetEncryptionDesc()
-                        .GetMode() != NProto::NO_ENCRYPTION;
 
             // For overlay disks we need to ensure that the only bits that are
             // set in the used block map are the bits that correspond to the
             // blocks that have been successfully written. Therefore we must
             // update the map only after the block has been successfully
             // written.
-            const bool needReliableUsedBlockTracking =
-                encryptedDiskRegistryBasedDisk || overlayDiskRegistryBasedDisk;
             NCloud::Register<TWriteAndMarkUsedActor<TMethod>>(
                 ctx,
                 std::move(requestInfo),
                 std::move(msg->Record),
                 State->GetBlockSize(),
-                needReliableUsedBlockTracking,
+                overlayDiskRegistryBasedDisk,
                 volumeRequestId,
                 partActorId,
                 TabletID(),


### PR DESCRIPTION
continue https://github.com/ydb-platform/nbs/pull/1771
No longer need to write a map of used blocks for encrypted NRD disks. We don't use it.