### PR TITLE
Print all checked paths when volume not found. Print in log as WARN instead of ERROR.

### DIFF
--- a/cloud/blockstore/libs/storage/api/ss_proxy.h
+++ b/cloud/blockstore/libs/storage/api/ss_proxy.h
@@ -187,6 +187,7 @@ struct TEvSSProxy
     {
         const TString Path;
         const NKikimrSchemeOp::TPathDescription PathDescription;
+        const TVector<TString> CheckedPaths;
 
         TDescribeVolumeResponse() = default;
 
@@ -197,8 +198,13 @@ struct TEvSSProxy
             , PathDescription(std::move(pathDescription))
         {}
 
+        TDescribeVolumeResponse(TString path, TVector<TString> checkedPaths)
+            : Path(std::move(path))
+            , CheckedPaths(std::move(checkedPaths))
+        {}
+
         TDescribeVolumeResponse(TString path)
-            : TDescribeVolumeResponse(std::move(path), {})
+            : Path(std::move(path))
         {}
     };
 

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
@@ -49,6 +49,7 @@ private:
     const bool ExactDiskIdMatch = false;
 
     EState State = EState::DescribePrimaryDeprecated;
+    TVector<TString> CheckedPaths;
 
 public:
     TDescribeVolumeActor(
@@ -148,6 +149,10 @@ void TDescribeVolumeActor::DescribeVolume(const TActorContext& ctx)
     auto request =
         std::make_unique<TEvSSProxy::TEvDescribeSchemeRequest>(GetFullPath());
 
+    if (CheckedPaths.empty() || CheckedPaths.back() != GetFullPath()) {
+        CheckedPaths.push_back(GetFullPath());
+    }
+
     NCloud::Send(ctx, MakeSSProxyServiceId(), std::move(request));
 }
 
@@ -207,7 +212,8 @@ void TDescribeVolumeActor::HandleDescribeSchemeResponse(
             ctx,
             std::make_unique<TEvSSProxy::TEvDescribeVolumeResponse>(
                 error,
-                GetFullPath()));
+                GetFullPath(),
+                std::move(CheckedPaths)));
         return;
     }
 


### PR DESCRIPTION
```
2026-01-12T09:16:34.811148Z :BLOCKSTORE_SERVICE WARN: Could not resolve paths ["/Root/NBS/fhm80voab8dcderaqpff", "/Root/NBS/_395/fhm80voab8dcderaqpff", "/Root/NBS/_3EF/fhm80voab8dcderaqpff-copy"] for volume "fhm80voab8dcderaqpff": SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path doesn't exist
```
<img width="1101" height="119" alt="image" src="https://github.com/user-attachments/assets/aec578b6-af60-4dab-bcab-715228f507f9" />
