### PR TITLE
Probabilistic request reject

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1394,5 +1394,5 @@ message TStorageServiceConfig
     optional uint32 FreshChannelCountHDD = 473;
 
     // Reject request if GetRejectProbability()*100 is greater than this value
-    optional uint32 ProbabilisticRequestRejectionThreshold = 474; 
+    optional uint32 TabletExecutorRejectionThreshold = 474; 
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -653,7 +653,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(SendLocalTabletMetricsToHiveEnabled,  bool,        false              )\
                                                                                \
     xxx(EnableVhostDiscardForNewVolumes,      bool,        false              )\
-    xxx(ProbabilisticRequestRejectionThreshold,            ui32,     0        )\
+    xxx(TabletExecutorRejectionThreshold,     ui32,        0                  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -754,7 +754,7 @@ public:
 
     [[nodiscard]] bool GetEnableVhostDiscardForNewVolumes() const;
 
-    [[nodiscard]] ui32 GetProbabilisticRequestRejectionThreshold() const;
+    [[nodiscard]] ui32 GetTabletExecutorRejectionThreshold() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp
@@ -259,9 +259,9 @@ void TPartitionActor::WriteBlocks(
         return;
     }
 
-    if (Config->GetProbabilisticRequestRejectionThreshold() &&
+    if (Config->GetTabletExecutorRejectionThreshold() &&
         Executor()->GetRejectProbability() * 100 >
-            Config->GetProbabilisticRequestRejectionThreshold())
+            Config->GetTabletExecutorRejectionThreshold())
     {
         replyError(ctx, MakeError(E_REJECTED, "rejected by tablet executor"));
         return;

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblocks.cpp
@@ -225,9 +225,9 @@ void TPartitionActor::HandleWriteBlocksRequest(
         return;
     }
 
-    if (Config->GetProbabilisticRequestRejectionThreshold() &&
+    if (Config->GetTabletExecutorRejectionThreshold() &&
         Executor()->GetRejectProbability() * 100 >
-            Config->GetProbabilisticRequestRejectionThreshold())
+            Config->GetTabletExecutorRejectionThreshold())
     {
         replyError(MakeError(E_REJECTED, "rejected by tablet executor"));
         return;


### PR DESCRIPTION
Reject WriteBlocksRequest if `GetRejectProbability() * 100` is greater than `ProbabilisticRequestRejectionThreshold`. `ProbabilisticRequestRejectionThreshold` ranges from 0 (feature is disabled) to 100.