### PR TITLE
issue-4853: cleanup - InFlightRequest Complete + Erase -> CompleteAndErase

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -72,7 +72,9 @@ void CompleteRequestImpl(
     const NActors::TActorContext& ctx,
     const ITraceSerializerPtr& traceSerializer,
     typename TMethod::TResponse::ProtoRecordType& record,
-    TInFlightRequest *request);
+    TInFlightRequest *request,
+    TInFlightRequestStorage& requestStorage,
+    ui64 requestCookie);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -457,9 +457,13 @@ void TStorageServiceActor::HandleCreateFileStore(
 
     auto error = ValidateCreateFileSystemRequest(msg->Record);
     if (HasError(error)) {
-        auto response = std::make_unique<TEvService::TEvCreateFileStoreResponse>(error);
-        inflight->Complete(ctx.Now(), error);
-        InFlightRequests->Erase(cookie);
+        auto response =
+            std::make_unique<TEvService::TEvCreateFileStoreResponse>(error);
+        InFlightRequests->CompleteAndErase(
+            ctx.Now(),
+            error,
+            *inflight,
+            cookie);
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -704,8 +704,11 @@ void TStorageServiceActor::HandleCreateSession(
         session->GetInfo(
             *response->Record.MutableSession(),
             GetSessionSeqNo(msg->Record));
-        inflight->Complete(ctx.Now(), std::move(error));
-        InFlightRequests->Erase(cookie);
+        InFlightRequests->CompleteAndErase(
+            ctx.Now(),
+            error,
+            *inflight,
+            cookie);
         NCloud::Reply(ctx, *ev, std::move(response));
     };
 
@@ -959,8 +962,12 @@ void TStorageServiceActor::HandleSessionCreated(
         }
 
         NCloud::Reply(ctx, *inflight, std::move(response));
-        inflight->Complete(ctx.Now(), msg->GetError());
-        InFlightRequests->Erase(msg->RequestInfo->Cookie);
+
+        InFlightRequests->CompleteAndErase(
+            ctx.Now(),
+            msg->GetError(),
+            *inflight,
+            msg->RequestInfo->Cookie);
     }
 }
 

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -837,8 +837,9 @@ void TReadDataActor::SendResponseAndDie(
         ctx,
         TraceSerializer,
         response->Record,
-        MainInFlightRequest);
-    InFlightRequests->Erase(RequestCookie);
+        MainInFlightRequest,
+        *InFlightRequests,
+        RequestCookie);
 
     ctx.Send(Sender, response.release(), 0 /* flags */, Cookie);
 

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -217,7 +217,11 @@ public:
 
     TLockedRequest FindAndLock(ui64 key);
 
-    void Erase(ui64 key);
+    void CompleteAndErase(
+        TInstant currentTs,
+        const NCloud::NProto::TError& error,
+        TInFlightRequest& request,
+        ui64 key);
 
     [[nodiscard]] TVector<ui64> GetKeys() const;
 };


### PR DESCRIPTION
### Notes
The most common request completion scenario consists of 2 steps:
* `TInFlightRequest::Complete()` - updates stats and profile-log, then marks the request as completed
* `TInFlightRequestStorage::Erase()` - removes this request from the set of in-flight requests because it's not needed anymore

Added a helper func `CompleteAndErase()` and replaced `Complete()` + `Erase()` calls with `CompleteAndErase()` to make it a bit harder to forget to call `Erase()`. Added an extra debug-mode safety check into `CompleteAndErase()` as well.

### Issue
follow-up for https://github.com/ydb-platform/nbs/issues/4853