### PR TITLE
issue-4853: profile log handling in storage service - cleanup and fixes

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor.cpp
@@ -75,6 +75,15 @@ void TStorageServiceActor::RegisterCounters(const NActors::TActorContext& ctx)
     TotalTabletCount = serviceCounters->GetCounter("TabletCount", false);
     InFlightRequestCount =
         serviceCounters->GetCounter("InFlightRequestCount", false);
+    CompletedRequestCountWithLogData = serviceCounters->GetCounter(
+        "CompletedRequestCountWithLogData",
+        true);
+    CompletedRequestCountWithError = serviceCounters->GetCounter(
+        "CompletedRequestCountWithError",
+        true);
+    CompletedRequestCountWithoutErrorOrLogData = serviceCounters->GetCounter(
+        "CompletedRequestCountWithoutErrorOrLogData",
+        true);
 
     auto hddCounters = serviceCounters->GetSubgroup("type", "hdd");
     HddFileSystemCount = hddCounters->GetCounter("FileSystemCount", false);

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -94,17 +94,22 @@ private:
     TInFlightRequestStoragePtr InFlightRequests;
     ui64 InFlightRequestCounter = 0;
 
-    NMonitoring::TDynamicCounters::TCounterPtr CpuWaitCounter;
+    using TCounterPtr = NMonitoring::TDynamicCounters::TCounterPtr;
 
-    NMonitoring::TDynamicCounters::TCounterPtr TotalFileSystemCount;
-    NMonitoring::TDynamicCounters::TCounterPtr TotalTabletCount;
-    NMonitoring::TDynamicCounters::TCounterPtr InFlightRequestCount;
+    TCounterPtr CpuWaitCounter;
 
-    NMonitoring::TDynamicCounters::TCounterPtr HddFileSystemCount;
-    NMonitoring::TDynamicCounters::TCounterPtr HddTabletCount;
+    TCounterPtr TotalFileSystemCount;
+    TCounterPtr TotalTabletCount;
+    TCounterPtr InFlightRequestCount;
+    TCounterPtr CompletedRequestCountWithLogData;
+    TCounterPtr CompletedRequestCountWithError;
+    TCounterPtr CompletedRequestCountWithoutErrorOrLogData;
 
-    NMonitoring::TDynamicCounters::TCounterPtr SsdFileSystemCount;
-    NMonitoring::TDynamicCounters::TCounterPtr SsdTabletCount;
+    TCounterPtr HddFileSystemCount;
+    TCounterPtr HddTabletCount;
+
+    TCounterPtr SsdFileSystemCount;
+    TCounterPtr SsdTabletCount;
 
     NProto::EServiceState ServiceState = NProto::SERVICE_STATE_UNKNOWN;
 

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -973,7 +973,7 @@ void TStorageServiceActor::HandleAlterFileStore(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto requestInfo = CreateRequestInfo(
         SelfId(),
@@ -999,7 +999,7 @@ void TStorageServiceActor::HandleResizeFileStore(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto requestInfo = CreateRequestInfo(
         SelfId(),

--- a/cloud/filestore/libs/storage/service/service_actor_complete.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_complete.cpp
@@ -72,10 +72,10 @@ void CompleteRequestImpl(
             checksumCalcInfo.Iovecs,
             record,
             checksumCalcInfo.BlockSize,
-            request->ProfileLogRequest);
+            request->AccessProfileLogRequest());
     }
 
-    FinalizeProfileLogRequestInfo(request->ProfileLogRequest, record);
+    FinalizeProfileLogRequestInfo(request->AccessProfileLogRequest(), record);
     HandleServiceTraceInfo(
         TMethod::Name,
         ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -453,7 +453,7 @@ void TStorageServiceActor::HandleCreateFileStore(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto error = ValidateCreateFileSystemRequest(msg->Record);
     if (HasError(error)) {

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -328,8 +328,8 @@ void TStorageServiceActor::HandleCreateHandle(
         session->RequestStats,
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(session->ClientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -379,8 +379,10 @@ void TStorageServiceActor::HandleCreateNode(
                 session->RequestStats,
                 ctx.Now());
 
-            InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-            inflight->ProfileLogRequest.SetClientId(session->ClientId);
+            InitProfileLogRequestInfo(
+                inflight->AccessProfileLogRequest(),
+                msg->Record);
+            inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
 
             auto requestInfo =
                 CreateRequestInfo(SelfId(), cookie, msg->CallContext);

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -692,8 +692,8 @@ void TStorageServiceActor::HandleCreateSession(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(clientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(clientId);
 
     auto sessionId = GetSessionId(msg->Record);
     auto seqNo = GetSessionSeqNo(msg->Record);

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -333,7 +333,7 @@ void TStorageServiceActor::HandleDestroyFileStore(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto requestInfo = CreateRequestInfo(
         SelfId(),

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -212,8 +212,8 @@ void TStorageServiceActor::HandleDestroySession(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(clientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(clientId);
 
     auto reply = [&] (const auto& error) {
         auto response =

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -170,8 +170,8 @@ void TStorageServiceActor::ForwardRequest(
         session->RequestStats,
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(session->ClientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
     const bool blockChecksumsEnabled =
         filestore.GetFeatures().GetBlockChecksumsInProfileLogEnabled()
         || StorageConfig->GetBlockChecksumsInProfileLogEnabled();
@@ -179,7 +179,7 @@ void TStorageServiceActor::ForwardRequest(
         CalculateRequestChecksums(
             msg->Record,
             filestore.GetBlockSize(),
-            inflight->ProfileLogRequest);
+            inflight->AccessProfileLogRequest());
     }
     TraceSerializer->BuildTraceRequest(
         *msg->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
@@ -253,8 +253,8 @@ void TStorageServiceActor::ForwardRequestToShard(
         session->RequestStats,
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(session->ClientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
     TraceSerializer->BuildTraceRequest(
         *msg->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
         msg->CallContext->LWOrbit);

--- a/cloud/filestore/libs/storage/service/service_actor_getfsinfo.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getfsinfo.cpp
@@ -155,7 +155,7 @@ void TStorageServiceActor::HandleGetFileStoreInfo(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto requestInfo = CreateRequestInfo(
         SelfId(),

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -287,8 +287,8 @@ void TStorageServiceActor::HandleGetNodeAttr(
         session->RequestStats,
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(session->ClientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_list.cpp
@@ -152,7 +152,7 @@ void TStorageServiceActor::HandleListFileStores(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto requestInfo = CreateRequestInfo(
         SelfId(),

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -698,8 +698,8 @@ void TStorageServiceActor::HandleListNodes(
         session->RequestStats,
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-    inflight->ProfileLogRequest.SetClientId(session->ClientId);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -212,9 +212,10 @@ void TReadDataActor::Bootstrap(const TActorContext& ctx)
         RequestCookie);
 
     InitProfileLogRequestInfo(
-        MainInFlightRequest->ProfileLogRequest,
+        MainInFlightRequest->AccessProfileLogRequest(),
         ReadRequest);
-    MainInFlightRequest->ProfileLogRequest.SetClientId(std::move(ClientId));
+    MainInFlightRequest->AccessProfileLogRequest().SetClientId(
+        std::move(ClientId));
 
     if (UseTwoStageRead) {
         DescribeData(ctx);
@@ -266,7 +267,7 @@ void TReadDataActor::DescribeData(const TActorContext& ctx)
 
     InFlightRequest->Start(ctx.Now());
     InitProfileLogRequestInfo(
-        InFlightRequest->ProfileLogRequest,
+        InFlightRequest->AccessProfileLogRequest(),
         request->Record);
     TraceSerializer->BuildTraceRequest(
         *request->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
@@ -354,10 +355,10 @@ void TReadDataActor::HandleDescribeDataResponse(
 
     TABLET_VERIFY(InFlightRequest);
 
-    InFlightRequest->Complete(ctx.Now(), error);
     FinalizeProfileLogRequestInfo(
-        InFlightRequest->ProfileLogRequest,
+        InFlightRequest->AccessProfileLogRequest(),
         msg->Record);
+    InFlightRequest->Complete(ctx.Now(), error);
     HandleServiceTraceInfo(
         "DescribeData",
         ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
@@ -187,7 +187,7 @@ void TStorageServiceActor::HandleStatFileStore(
         StatsRegistry->GetRequestStats(),
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
 
     auto requestInfo = CreateRequestInfo(
         SelfId(),

--- a/cloud/filestore/libs/storage/service/service_actor_update_stats.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_update_stats.cpp
@@ -70,6 +70,16 @@ void TStorageServiceActor::HandleUpdateStats(
         }
     }
 
+    {
+        const auto stats = InFlightRequests->GetStats();
+        CompletedRequestCountWithLogData->Set(
+            stats.CompletedRequestCountWithLogData);
+        CompletedRequestCountWithError->Set(
+            stats.CompletedRequestCountWithError);
+        CompletedRequestCountWithoutErrorOrLogData->Set(
+            stats.CompletedRequestCountWithoutErrorOrLogData);
+    }
+
     if (StatsFetcher) {
         auto [cpuWait, error] = StatsFetcher->GetCpuWait();
         auto now = ctx.Monotonic();

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -252,7 +252,7 @@ public:
             RequestStats);
         InFlightRequest->Start(ctx.Now());
         InitProfileLogRequestInfo(
-            InFlightRequest->ProfileLogRequest,
+            InFlightRequest->AccessProfileLogRequest(),
             request->Record);
         auto* trace =
             request->Record.MutableHeaders()->MutableInternal()->MutableTrace();
@@ -310,10 +310,10 @@ private:
 
         TABLET_VERIFY(InFlightRequest);
 
-        InFlightRequest->Complete(ctx.Now(), error);
         FinalizeProfileLogRequestInfo(
-            InFlightRequest->ProfileLogRequest,
+            InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
+        InFlightRequest->Complete(ctx.Now(), error);
         HandleServiceTraceInfo(
             "GenerateBlobIds",
             ctx,
@@ -585,7 +585,7 @@ private:
             RequestStats);
         InFlightRequest->Start(ctx.Now());
         InitProfileLogRequestInfo(
-            InFlightRequest->ProfileLogRequest,
+            InFlightRequest->AccessProfileLogRequest(),
             request->Record);
         auto* trace =
             request->Record.MutableHeaders()->MutableInternal()->MutableTrace();
@@ -610,10 +610,10 @@ private:
         auto* msg = ev->Get();
 
         TABLET_VERIFY(InFlightRequest);
-        InFlightRequest->Complete(ctx.Now(), msg->GetError());
         FinalizeProfileLogRequestInfo(
-            InFlightRequest->ProfileLogRequest,
+            InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
+        InFlightRequest->Complete(ctx.Now(), msg->GetError());
         HandleServiceTraceInfo(
             "AddData",
             ctx,
@@ -834,13 +834,15 @@ void TStorageServiceActor::HandleWriteData(
             session->RequestStats,
             startTime);
 
-        InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
-        inflight->ProfileLogRequest.SetClientId(session->ClientId);
+        InitProfileLogRequestInfo(
+            inflight->AccessProfileLogRequest(),
+            msg->Record);
+        inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
         if (blockChecksumsEnabled) {
             CalculateWriteDataRequestChecksums(
                 msg->Record,
                 blockSize,
-                inflight->ProfileLogRequest);
+                inflight->AccessProfileLogRequest());
         }
 
         auto requestInfo =

--- a/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
@@ -182,7 +182,7 @@ void TStorageServiceActor::ForwardXAttrRequest(
         session->RequestStats,
         ctx.Now());
 
-    InitProfileLogRequestInfo(inflight->ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
     TraceSerializer->BuildTraceRequest(
         *msg->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
         msg->CallContext->LWOrbit);
@@ -227,11 +227,11 @@ void TStorageServiceActor::ReplyToXAttrRequest(
         session->MediaKind,
         session->RequestStats);
 
-    InitProfileLogRequestInfo(inflight.ProfileLogRequest, msg->Record);
+    InitProfileLogRequestInfo(inflight.AccessProfileLogRequest(), msg->Record);
     inflight.Start(ctx.Now());
 
     FinalizeProfileLogRequestInfo(
-        inflight.ProfileLogRequest,
+        inflight.AccessProfileLogRequest(),
         response->Record);
     inflight.Complete(ctx.Now(), response->GetError());
 

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -12,6 +12,7 @@
 #include <cloud/filestore/public/api/protos/session.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
 #include <contrib/ydb/library/actors/core/actorid.h>
@@ -49,15 +50,13 @@ struct TChecksumCalcInfo
 struct TInFlightRequest
     : public TRequestInfo
 {
-public:
-    NProto::TProfileLogRequestInfo ProfileLogRequest;
-
 private:
     const NCloud::NProto::EStorageMediaKind MediaKind;
     const TChecksumCalcInfo ChecksumCalcInfo;
     const IRequestStatsPtr RequestStats;
     const IProfileLogPtr ProfileLog;
 
+    NProto::TProfileLogRequestInfo ProfileLogRequest;
     std::atomic_bool Completed = false;
 
 public:
@@ -128,7 +127,26 @@ public:
 
     void Start(TInstant currentTs);
     void Complete(TInstant currentTs, const NCloud::NProto::TError& error);
+    bool HasLogData() const;
     bool IsCompleted() const;
+
+    const auto& GetProfileLogRequest() const
+    {
+        STORAGE_VERIFY_DEBUG(
+            !IsCompleted(),
+            CallContext->FileSystemId,
+            TWellKnownEntityTypes::FILESYSTEM);
+        return ProfileLogRequest;
+    }
+
+    auto& AccessProfileLogRequest()
+    {
+        STORAGE_VERIFY_DEBUG(
+            !IsCompleted(),
+            CallContext->FileSystemId,
+            TWellKnownEntityTypes::FILESYSTEM);
+        return ProfileLogRequest;
+    }
 
     const TChecksumCalcInfo& GetChecksumCalcInfo() const
     {
@@ -151,24 +169,18 @@ private:
     IProfileLogPtr ProfileLog;
     THashMap<ui64, TInFlightRequest> Requests;
     mutable TAdaptiveLock Lock;
+    std::atomic_uint64_t CompletedRequestCountWithLogData;
+    std::atomic_uint64_t CompletedRequestCountWithError;
+    std::atomic_uint64_t CompletedRequestCountWithoutErrorOrLogData;
+
+    static constexpr auto StatsMemOrder = std::memory_order_relaxed;
 
 public:
     explicit TInFlightRequestStorage(IProfileLogPtr profileLog);
 
 public:
-    TInFlightRequest* Register(
-        NActors::TActorId sender,
-        ui64 cookie,
-        TCallContextPtr callContext,
-        NProto::EStorageMediaKind mediaKind,
-        TChecksumCalcInfo checksumCalcInfo,
-        IRequestStatsPtr requestStats,
-        TInstant start,
-        ui64 key);
-
-    TInFlightRequest* Find(ui64 key);
-
-    class TLockedRequest {
+    class TLockedRequest
+    {
     private:
         TAdaptiveLock* Lock;
         TInFlightRequest* Request;
@@ -215,6 +227,26 @@ public:
         }
     };
 
+    struct TStats
+    {
+        ui64 CompletedRequestCountWithLogData = 0;
+        ui64 CompletedRequestCountWithError = 0;
+        ui64 CompletedRequestCountWithoutErrorOrLogData = 0;
+    };
+
+public:
+    TInFlightRequest* Register(
+        NActors::TActorId sender,
+        ui64 cookie,
+        TCallContextPtr callContext,
+        NProto::EStorageMediaKind mediaKind,
+        TChecksumCalcInfo checksumCalcInfo,
+        IRequestStatsPtr requestStats,
+        TInstant start,
+        ui64 key);
+
+    TInFlightRequest* Find(ui64 key);
+
     TLockedRequest FindAndLock(ui64 key);
 
     void CompleteAndErase(
@@ -224,6 +256,18 @@ public:
         ui64 key);
 
     [[nodiscard]] TVector<ui64> GetKeys() const;
+
+    TStats GetStats() const
+    {
+        return {
+            .CompletedRequestCountWithLogData =
+                CompletedRequestCountWithLogData.load(StatsMemOrder),
+            .CompletedRequestCountWithError =
+                CompletedRequestCountWithError.load(StatsMemOrder),
+            .CompletedRequestCountWithoutErrorOrLogData =
+                CompletedRequestCountWithoutErrorOrLogData.load(StatsMemOrder),
+        };
+    }
 };
 
 using TInFlightRequestStoragePtr = TIntrusivePtr<TInFlightRequestStorage>;
@@ -246,17 +290,17 @@ enum class ESessionCreateDestroyState
 class TShardState: public TAtomicRefCount<TShardState>
 {
 private:
-    TAtomic IsOverloaded = false;
+    std::atomic_bool IsOverloaded = false;
 
 public:
     void SetIsOverloaded(bool isOverloaded)
     {
-        AtomicSet(IsOverloaded, static_cast<TAtomicBase>(isOverloaded));
+        IsOverloaded.store(isOverloaded, std::memory_order_relaxed);
     }
 
     bool GetIsOverloaded() const
     {
-        return static_cast<bool>(AtomicGet(IsOverloaded));
+        return IsOverloaded.load(std::memory_order_relaxed);
     }
 };
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3923,6 +3923,21 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             ->FindSubgroup("component", "service")
             ->GetCounter("InFlightRequestCount", false);
 
+        auto requestCountWithLogDataCounter = counters
+            ->FindSubgroup("counters", "filestore")
+            ->FindSubgroup("component", "service")
+            ->GetCounter("CompletedRequestCountWithLogData", true);
+
+        auto requestCountWithErrorCounter = counters
+            ->FindSubgroup("counters", "filestore")
+            ->FindSubgroup("component", "service")
+            ->GetCounter("CompletedRequestCountWithError", true);
+
+        auto requestCountWithoutLogDataOrErrorCounter = counters
+            ->FindSubgroup("counters", "filestore")
+            ->FindSubgroup("component", "service")
+            ->GetCounter("CompletedRequestCountWithoutLogDataOrError", true);
+
         auto hddTabletCounter = counters
             ->FindSubgroup("counters", "filestore")
             ->FindSubgroup("component", "service")
@@ -3944,6 +3959,13 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         // smoke
         UNIT_ASSERT_VALUES_EQUAL(0, inFlightRequestCounter->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            requestCountWithLogDataCounter->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(0, requestCountWithErrorCounter->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            requestCountWithoutLogDataOrErrorCounter->GetAtomic());
 
         service.UnregisterLocalFileStore("test", 1);
 
@@ -3959,6 +3981,13 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         // smoke
         UNIT_ASSERT_VALUES_EQUAL(0, inFlightRequestCounter->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            requestCountWithLogDataCounter->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(0, requestCountWithErrorCounter->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            requestCountWithoutLogDataOrErrorCounter->GetAtomic());
     }
 
     Y_UNIT_TEST(ShouldUseThreeStageWriteAndTwoStageReadForHandlelessIO)


### PR DESCRIPTION
### Notes 
* `TInFlightRequest::ProfileLogRequest` made private + added accessor methods which contain debug-mode checks
* those checks detected some bugs in profile log request finalization/logging order - fixed those
* we have a weird condition which disables profile log request logging for some requests - I want to remove this constraint but first I would like to see how many requests we currently ignore - added relevant counters for this
* not tracking internal requests (e.g. AddData, GenerateBlobIds, etc) in those counters - not really interested in those here, decided not to make the code more complex to track those
* minor `TAtomic/std::atomic` cleanup in `service_state.h/cpp` - using `std::atomic` everywhere in this part of the code

### Issue
followup for https://github.com/ydb-platform/nbs/issues/4853