### PR TITLE
[Blockstore] volume_proxy: add VolumeProxyPipeInactivityTimeout param into TStorageConfig

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1405,4 +1405,8 @@ message TStorageServiceConfig
     // When disabled, fast path waits for data and 2 checksums before replying
     // to the client.
     optional bool OptimizeFastPathReadsOnResync = 476;
+
+    // VolumeProxy to Volume inactive (with no requests from client) connection
+    // reset timeout (in milliseconds).
+    optional uint32 VolumeProxyPipeInactivityTimeout = 477;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -82,6 +82,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RO(xxx)                                      \
     xxx(SchemeShardDir,                TString,   "/Root"                     )\
     xxx(DisableLocalService,           bool,      false                       )\
@@ -166,8 +167,11 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
         TVector<NProto::TLinkedDiskFillBandwidth>,                             \
         {}                                                                    )\
     xxx(ComputeDigestForEveryBlockOnCompaction,     bool,            false    )\
-// BLOCKSTORE_STORAGE_CONFIG_RO
 
+// BLOCKSTORE_STORAGE_CONFIG_RO
+// clang-format on
+
+// clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \
     xxx(WriteBlobThreshold,            ui32,      1_MB                        )\
     xxx(WriteBlobThresholdSSD,         ui32,      128_KB                      )\
@@ -656,8 +660,11 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(EnableVhostDiscardForNewVolumes,      bool,        false              )\
     xxx(TabletExecutorRejectionThreshold,     ui32,        0                  )\
+                                                                               \
+    xxx(VolumeProxyPipeInactivityTimeout,     TDuration,   Minutes(1)         )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
+// clang-format on
 
 #define BLOCKSTORE_STORAGE_CONFIG(xxx)                                         \
     BLOCKSTORE_STORAGE_CONFIG_RO(xxx)                                          \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -757,6 +757,8 @@ public:
     [[nodiscard]] bool GetEnableVhostDiscardForNewVolumes() const;
 
     [[nodiscard]] ui32 GetTabletExecutorRejectionThreshold() const;
+
+    [[nodiscard]] TDuration GetVolumeProxyPipeInactivityTimeout() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
@@ -35,8 +35,6 @@ Y_HAS_MEMBER(GetThrottlerDelay);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr TDuration PipeInactivityTimeout = TDuration::Minutes(1);
-
 std::unique_ptr<NTabletPipe::IClientCache> CreateTabletPipeClientCache(
     const TStorageConfig& config)
 {
@@ -176,6 +174,7 @@ class TVolumeProxyActor final
 
 private:
     const TStorageConfigPtr Config;
+    const TDuration PipeInactivityTimeout;
     const ITraceSerializerPtr TraceSerializer;
     const bool TemporaryServer = false;
 
@@ -298,11 +297,12 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TVolumeProxyActor::TVolumeProxyActor(
-        TStorageConfigPtr config,
-        ITraceSerializerPtr traceSerializer,
-        bool temporaryServer)
+    TStorageConfigPtr config,
+    ITraceSerializerPtr traceSerializer,
+    bool temporaryServer)
     : TActor(&TThis::StateWork)
     , Config(std::move(config))
+    , PipeInactivityTimeout(Config->GetVolumeProxyPipeInactivityTimeout())
     , TraceSerializer(std::move(traceSerializer))
     , TemporaryServer(temporaryServer)
     , ClientCache(CreateTabletPipeClientCache(*Config))


### PR DESCRIPTION
VolumeProxyPipeInactivityTimeout is VolumeProxy to Volume inactive (with no requests from client) connection reset timeout, triggering new DescribeVolume request on next connection establish.
PipeInactivityTimeout made configurable via TStorageConfig to be able to decrease SchemeShard load (in case of lots snapshots taken simultaneously with lots volume_proxy running) via config.
Previously was hardcoded. Default value kept same (no logic changed by default).