### PR TITLE
issue-2674: filestore - implemented unsafe node-ref ops

### DIFF
--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -35,6 +35,10 @@ namespace NCloud::NFileStore::NStorage {
     xxx(UnsafeDeleteNode,           __VA_ARGS__)                               \
     xxx(UnsafeUpdateNode,           __VA_ARGS__)                               \
     xxx(UnsafeGetNode,              __VA_ARGS__)                               \
+    xxx(UnsafeCreateNodeRef,        __VA_ARGS__)                               \
+    xxx(UnsafeDeleteNodeRef,        __VA_ARGS__)                               \
+    xxx(UnsafeUpdateNodeRef,        __VA_ARGS__)                               \
+    xxx(UnsafeGetNodeRef,           __VA_ARGS__)                               \
     xxx(ForcedOperationStatus,      __VA_ARGS__)                               \
     xxx(GetFileSystemTopology,      __VA_ARGS__)                               \
     xxx(RestartTablet,              __VA_ARGS__)                               \
@@ -138,6 +142,18 @@ struct TEvIndexTablet
 
         EvMarkNodeRefsExhaustiveRequest = EvBegin + 53,
         EvMarkNodeRefsExhaustiveResponse,
+
+        EvUnsafeCreateNodeRefRequest = EvBegin + 55,
+        EvUnsafeCreateNodeRefResponse,
+
+        EvUnsafeDeleteNodeRefRequest = EvBegin + 57,
+        EvUnsafeDeleteNodeRefResponse,
+
+        EvUnsafeUpdateNodeRefRequest = EvBegin + 59,
+        EvUnsafeUpdateNodeRefResponse,
+
+        EvUnsafeGetNodeRefRequest = EvBegin + 61,
+        EvUnsafeGetNodeRefResponse,
 
         EvEnd
     };

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -301,6 +301,22 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateUnsafeCreateNodeRefActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateUnsafeDeleteNodeRefActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateUnsafeUpdateNodeRefActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateUnsafeGetNodeRefActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
     NActors::IActorPtr CreateGetStorageStatsActionActor(
         TRequestInfoPtr requestInfo,
         TString input);

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -89,6 +89,22 @@ void TStorageServiceActor::HandleExecuteAction(
             &TStorageServiceActor::CreateUnsafeGetNodeActionActor
         },
         {
+            "unsafecreatenoderef",
+            &TStorageServiceActor::CreateUnsafeCreateNodeRefActionActor
+        },
+        {
+            "unsafedeletenoderef",
+            &TStorageServiceActor::CreateUnsafeDeleteNodeRefActionActor
+        },
+        {
+            "unsafeupdatenoderef",
+            &TStorageServiceActor::CreateUnsafeUpdateNodeRefActionActor
+        },
+        {
+            "unsafegetnoderef",
+            &TStorageServiceActor::CreateUnsafeGetNodeRefActionActor
+        },
+        {
             "getstoragestats",
             &TStorageServiceActor::CreateGetStorageStatsActionActor
         },

--- a/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
@@ -52,7 +52,7 @@ IActorPtr TStorageServiceActor::CreateGetStorageStatsActionActor(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// UnsafeNodeOps
+// UnsafeNodeOps / UnsafeNodeRefOps
 
 IActorPtr TStorageServiceActor::CreateUnsafeDeleteNodeActionActor(
     TRequestInfoPtr requestInfo,
@@ -86,6 +86,54 @@ IActorPtr TStorageServiceActor::CreateUnsafeGetNodeActionActor(
         TEvIndexTablet::TEvUnsafeGetNodeRequest,
         TEvIndexTablet::TEvUnsafeGetNodeResponse>;
     return std::make_unique<TUnsafeGetNodeActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateUnsafeCreateNodeRefActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TUnsafeCreateNodeRefActor = TTabletActionActor<
+        TEvIndexTablet::TEvUnsafeCreateNodeRefRequest,
+        TEvIndexTablet::TEvUnsafeCreateNodeRefResponse>;
+    return std::make_unique<TUnsafeCreateNodeRefActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateUnsafeDeleteNodeRefActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TUnsafeDeleteNodeRefActor = TTabletActionActor<
+        TEvIndexTablet::TEvUnsafeDeleteNodeRefRequest,
+        TEvIndexTablet::TEvUnsafeDeleteNodeRefResponse>;
+    return std::make_unique<TUnsafeDeleteNodeRefActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateUnsafeUpdateNodeRefActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TUnsafeUpdateNodeRefActor = TTabletActionActor<
+        TEvIndexTablet::TEvUnsafeUpdateNodeRefRequest,
+        TEvIndexTablet::TEvUnsafeUpdateNodeRefResponse>;
+    return std::make_unique<TUnsafeUpdateNodeRefActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateUnsafeGetNodeRefActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TUnsafeGetNodeRefActor = TTabletActionActor<
+        TEvIndexTablet::TEvUnsafeGetNodeRefRequest,
+        TEvIndexTablet::TEvUnsafeGetNodeRefResponse>;
+    return std::make_unique<TUnsafeGetNodeRefActor>(
         std::move(requestInfo),
         std::move(input));
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -77,6 +77,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
                                                                                \
     xxx(UnsafeGetNode,                      __VA_ARGS__)                       \
+    xxx(UnsafeGetNodeRef,                   __VA_ARGS__)                       \
                                                                                \
     xxx(LoadNodeRefs,                       __VA_ARGS__)                       \
     xxx(LoadNodes,                          __VA_ARGS__)                       \
@@ -147,6 +148,9 @@ namespace NCloud::NFileStore::NStorage {
                                                                                \
     xxx(UnsafeDeleteNode,                   __VA_ARGS__)                       \
     xxx(UnsafeUpdateNode,                   __VA_ARGS__)                       \
+    xxx(UnsafeCreateNodeRef,                __VA_ARGS__)                       \
+    xxx(UnsafeDeleteNodeRef,                __VA_ARGS__)                       \
+    xxx(UnsafeUpdateNodeRef,                __VA_ARGS__)                       \
 // FILESTORE_TABLET_RW_TRANSACTIONS
 
 #define FILESTORE_TABLET_TRANSACTIONS(xxx, ...)                                \
@@ -2367,7 +2371,7 @@ struct TTxIndexTablet
     };
 
     //
-    // UnsafeNodeOps
+    // UnsafeNodeOps / UnsafeNodeRefOps
     //
 
     struct TUnsafeDeleteNode
@@ -2438,6 +2442,110 @@ struct TTxIndexTablet
         {
             TIndexStateNodeUpdates::Clear();
             Node.Clear();
+        }
+    };
+
+    struct TUnsafeCreateNodeRef
+        : TTxIndexTabletBase
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const NProtoPrivate::TUnsafeCreateNodeRefRequest Request;
+
+        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        NProto::TError Error;
+        bool CommitIdOverflowDetected = false;
+
+        TUnsafeCreateNodeRef(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TUnsafeCreateNodeRefRequest request)
+            : RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
+        {}
+
+        void Clear() override
+        {
+            TIndexStateNodeUpdates::Clear();
+            NodeRef.Clear();
+            Error.Clear();
+            CommitIdOverflowDetected = false;
+        }
+    };
+
+    struct TUnsafeDeleteNodeRef
+        : TTxIndexTabletBase
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const NProtoPrivate::TUnsafeDeleteNodeRefRequest Request;
+
+        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        NProto::TError Error;
+        bool CommitIdOverflowDetected = false;
+
+        TUnsafeDeleteNodeRef(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TUnsafeDeleteNodeRefRequest request)
+            : RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
+        {}
+
+        void Clear() override
+        {
+            TIndexStateNodeUpdates::Clear();
+            NodeRef.Clear();
+            Error.Clear();
+            CommitIdOverflowDetected = false;
+        }
+    };
+
+    struct TUnsafeUpdateNodeRef
+        : TTxIndexTabletBase
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const NProtoPrivate::TUnsafeUpdateNodeRefRequest Request;
+
+        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        NProto::TError Error;
+        bool CommitIdOverflowDetected = false;
+
+        TUnsafeUpdateNodeRef(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TUnsafeUpdateNodeRefRequest request)
+            : RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
+        {}
+
+        void Clear() override
+        {
+            TIndexStateNodeUpdates::Clear();
+            NodeRef.Clear();
+            Error.Clear();
+            CommitIdOverflowDetected = false;
+        }
+    };
+
+    struct TUnsafeGetNodeRef
+        : TTxIndexTabletBase
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const NProtoPrivate::TUnsafeGetNodeRefRequest Request;
+
+        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+
+        TUnsafeGetNodeRef(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TUnsafeGetNodeRefRequest request)
+            : RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
+        {}
+
+        void Clear() override
+        {
+            TIndexStateNodeUpdates::Clear();
+            NodeRef.Clear();
         }
     };
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -710,7 +710,7 @@ message TWriteCompactionMapResponse
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Direct inode manipulation.
+// Direct inode and node ref manipulation.
 
 message TUnsafeDeleteNodeRequest
 {
@@ -747,6 +747,67 @@ message TUnsafeGetNodeResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
     NProto.TNodeAttr Node = 2;
+}
+
+message TUnsafeCreateNodeRefRequest
+{
+    string FileSystemId = 1;
+    uint64 ParentId = 2;
+    bytes Name = 3;
+    uint64 ChildId = 4;
+    string ShardId = 5;
+    string ShardNodeName = 6;
+}
+
+message TUnsafeCreateNodeRefResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}
+
+message TUnsafeDeleteNodeRefRequest
+{
+    string FileSystemId = 1;
+    uint64 ParentId = 2;
+    bytes Name = 3;
+}
+
+message TUnsafeDeleteNodeRefResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}
+
+message TUnsafeUpdateNodeRefRequest
+{
+    string FileSystemId = 1;
+    uint64 ParentId = 2;
+    bytes Name = 3;
+    uint64 ChildId = 4;
+    string ShardId = 5;
+    string ShardNodeName = 6;
+}
+
+message TUnsafeUpdateNodeRefResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}
+
+message TUnsafeGetNodeRefRequest
+{
+    string FileSystemId = 1;
+    uint64 ParentId = 2;
+    bytes Name = 3;
+}
+
+message TUnsafeGetNodeRefResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+    uint64 ChildId = 2;
+    string ShardId = 3;
+    string ShardNodeName = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
Implemented `Unsafe{Create,Delete,Update,Get}NodeRef` IndexTablet and private API methods. Needed for the following things:
* to be able to implement tests for parts of complex cross-shard transactions - I need to perform partial state modifications here which are not allowed (and should not be allowed) to perform via IndexTablet and Service public API
* to be able to investigate and fix metadata corruption issues on real clusters 
* changed `UnsafeGetNode` - now it returns `E_FS_NOENT` if the requested `NodeId` doesn't exist - this doesn't break any real-life use cases because these `UnsafeXXX` methods were supposed to be used after `DirectoryCreationInShardsEnabled: true` is deployed and it's not yet deployed anywhere

This PR contains service-level unit tests (for the private API methods). Tablet-level unit tests will be added together with `RenameNodeInDestination` unit tests.

### Issue
https://github.com/ydb-platform/nbs/issues/2674