### PR TITLE
Fix ShouldPassTraceIdToBlobstorage under asan

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13474,7 +13474,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             SUCCEEDED(response->GetStatus()),
             response->GetErrorReason());
 
-        const auto& stats = partition.StatPartition()->Record.GetStats();
+        NProto::TVolumeStats stats =
+            partition.StatPartition()->Record.GetStats();
         UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
 
         UNIT_ASSERT(traceId.has_value());

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -7798,7 +7798,8 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
             SUCCEEDED(response->GetStatus()),
             response->GetErrorReason());
 
-        const auto& stats = partition.StatPartition()->Record.GetStats();
+        NProto::TVolumeStats stats =
+            partition.StatPartition()->Record.GetStats();
         UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
 
         UNIT_ASSERT(traceId.has_value());


### PR DESCRIPTION
`StatPartition()` returns an unique_ptr that holds the memory for `TVolumeStats`