### PR TITLE
Fix for long running TServiceVolumeStatsTest.ShouldRetryStatsUploadInCaseOfFailure

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,4 +1,3 @@
 cloud/filestore/tests/fio_index/mount-kikimr-test *
 cloud/filestore/tests/fio_index/mount-local-test *
 cloud/storage/core/libs/kikimr/ut TConfigInitializerTest.ShouldAdjustActorSystemThreadsAccordingToAvailableCpuCores
-cloud/blockstore/libs/storage/stats_service/ut TServiceVolumeStatsTest.ShouldRetryStatsUploadInCaseOfFailure

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -1252,7 +1252,7 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
 
         RegisterVolume(runtime, "disk1");
         RegisterVolume(runtime, "disk2-copy");
-        ForceYdbStatsUpdate(runtime, {"disk1", "disk2-copy"}, 3, 1);
+        ForceYdbStatsUpdate(runtime, {"disk1", "disk2-copy"}, 3, 2);
 
         UNIT_ASSERT_VALUES_EQUAL(3, attemptCount);
     }


### PR DESCRIPTION
The test took a long time to complete due to an incorrect final condition in the DispatchEvents call. This was fixed by sending another event with the statistics request. With this change, the test no longer waits for a scheduled event.