### PR TITLE
Try to fix flaky test_switch_multiple_endpoints

### DIFF
--- a/cloud/blockstore/tests/external_endpoint/multiple_endpoints.py
+++ b/cloud/blockstore/tests/external_endpoint/multiple_endpoints.py
@@ -225,7 +225,7 @@ def test_switch_multiple_endpoints(nbs):
             storage_media_kind=STORAGE_MEDIA_SSD_LOCAL,
             storage_pool_name="1Mb")
 
-    @retry(max_times=10, exception=requests.ConnectionError)
+    @retry(max_times=20, exception=requests.ConnectionError)
     def wait_for_vhost_servers(nbs, expected_count):
         count = 0
         for process in psutil.process_iter():


### PR DESCRIPTION
The retry decorator had 10 retries with ~1 second delay (with 1.2x backoff), giving roughly 30 seconds total. With a heavily loaded CI this can be too small of a wait. This PR attempts to fix test by increasing retry count.