### PR TITLE
issue-2674, issue-4947: CommitRenameNodeInSource unit tests + CommitIdOverflow fix

### DIFF
--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -53,6 +53,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(SyncShardSessions,                      __VA_ARGS__)                   \
     xxx(LoadCompactionMapChunk,                 __VA_ARGS__)                   \
     xxx(PrepareRenameNodeInSource,              __VA_ARGS__)                   \
+    xxx(CommitRenameNodeInSource,               __VA_ARGS__)                   \
     xxx(DeleteOpLogEntry,                       __VA_ARGS__)                   \
     xxx(GetOpLogEntry,                          __VA_ARGS__)                   \
 // FILESTORE_TABLET_REQUESTS_PRIVATE
@@ -771,6 +772,33 @@ struct TEvIndexTabletPrivate
     struct TPrepareRenameNodeInSourceResponse
     {
         ui64 OpLogEntryId = 0;
+    };
+
+    //
+    // CommitRenameNodeInSource
+    //
+    // NOTE: This event is not supposed to be sent outside of unit tests.
+    //
+
+    struct TCommitRenameNodeInSourceRequest
+    {
+        NProto::TRenameNodeRequest Request;
+        NProtoPrivate::TRenameNodeInDestinationResponse Response;
+        const ui64 OpLogEntryId;
+
+        TCommitRenameNodeInSourceRequest(
+                NProto::TRenameNodeRequest request,
+                NProtoPrivate::TRenameNodeInDestinationResponse response,
+                ui64 opLogEntryId)
+            : Request(std::move(request))
+            , Response(std::move(response))
+            , OpLogEntryId(opLogEntryId)
+        {
+        }
+    };
+
+    struct TCommitRenameNodeInSourceResponse
+    {
     };
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1027,6 +1027,7 @@ struct TTxIndexTablet
         const NProto::TRenameNodeRequest Request;
         const NProtoPrivate::TRenameNodeInDestinationResponse Response;
         const ui64 OpLogEntryId;
+        const bool IsExplicitRequest;
 
         ui64 CommitId = InvalidCommitId;
         TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
@@ -1035,12 +1036,14 @@ struct TTxIndexTablet
                 TRequestInfoPtr requestInfo,
                 NProto::TRenameNodeRequest request,
                 NProtoPrivate::TRenameNodeInDestinationResponse response,
-                ui64 opLogEntryId)
+                ui64 opLogEntryId,
+                bool isExplicitRequest)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , Request(std::move(request))
             , Response(std::move(response))
             , OpLogEntryId(opLogEntryId)
+            , IsExplicitRequest(isExplicitRequest)
         {}
 
         void Clear() override

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -367,6 +367,15 @@ public:
         return request;
     }
 
+    auto CreateUnsafeGetNodeRefRequest(ui64 parentId, const TString& name)
+    {
+        using TRequestEvent = TEvIndexTablet::TEvUnsafeGetNodeRefRequest;
+        auto request = std::make_unique<TRequestEvent>();
+        request->Record.SetParentId(parentId);
+        request->Record.SetName(name);
+        return request;
+    }
+
     //
     // TEvIndexTabletPrivate
     //
@@ -475,6 +484,19 @@ public:
         return std::make_unique<TRequestEvent>(
             std::move(subRequest),
             newShardId);
+    }
+
+    auto CreateCommitRenameNodeInSourceRequest(
+        NProto::TRenameNodeRequest subRequest,
+        NProtoPrivate::TRenameNodeInDestinationResponse subResponse,
+        ui64 opLogEntryId)
+    {
+        using TRequestEvent =
+            TEvIndexTabletPrivate::TEvCommitRenameNodeInSourceRequest;
+        return std::make_unique<TRequestEvent>(
+            std::move(subRequest),
+            std::move(subResponse),
+            opLogEntryId);
     }
 
     auto CreateDeleteOpLogEntryRequest(ui64 entryId)


### PR DESCRIPTION
### Notes
* Fixed `CommitRenameNodeInSource` CommitId overflow handling
* Added a unit test for `CommitRenameNodeInSource` which tests its logic including the behaviour upon CommitId overflow

Related to https://github.com/ydb-platform/nbs/pull/5035

### Issue
https://github.com/ydb-platform/nbs/issues/2674
https://github.com/ydb-platform/nbs/issues/4947