### PR TITLE
issue-4853: changing MaxBackground default value from 128 to 16384

### DIFF
--- a/cloud/filestore/libs/vfs/config.cpp
+++ b/cloud/filestore/libs/vfs/config.cpp
@@ -21,7 +21,7 @@ namespace {
     xxx(Debug,                  bool,           false                         )\
                                                                                \
     xxx(MaxWritePages,          ui32,           256                           )\
-    xxx(MaxBackground,          ui32,           128                           )\
+    xxx(MaxBackground,          ui32,           16384                         )\
     xxx(MountSeqNumber,         ui64,           0                             )\
     xxx(VhostQueuesCount,       ui32,           0                             )\
                                                                                \


### PR DESCRIPTION
### Notes
After the optimizations that were done in https://github.com/ydb-platform/nbs/issues/4853 if we use our default settings we get bottlenecked by `MaxBackground: 128`. Since inflight request count is limited by the number of virtio queues X queue-size, we don't see any value in having a separate small inflight limiter so we decided to increase `MaxBackground` default value to `16384`. So this basically disables `MaxBackground`-based limiting by default.

### Issue
Related to https://github.com/ydb-platform/nbs/issues/4853