### PR TITLE
filestore tablet_tx Error & CommitIdOverflow handling cleanup

### DIFF
--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -146,24 +146,6 @@ enum class EAddBlobMode
     Compaction,
 };
 
-inline TString GetAddBlobModeName(EAddBlobMode mode)
-{
-    switch (mode) {
-        case EAddBlobMode::Write:
-            return "AddBlobWrite";
-        case EAddBlobMode::WriteBatch:
-            return "AddBlobWriteBatch";
-        case EAddBlobMode::Flush:
-            return "AddBlobFlush";
-        case EAddBlobMode::FlushBytes:
-            return "AddBlobFlushBytes";
-        case EAddBlobMode::Compaction:
-            return "AddBlobCompaction";
-        default:
-            return "AddBlobUnknown";
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 enum class EDeleteCheckpointMode

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
@@ -66,7 +66,7 @@ void TIndexTabletActor::ExecuteTx_CreateCheckpoint(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -92,10 +92,6 @@ void TIndexTabletActor::CompleteTx_CreateCheckpoint(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitId == InvalidCommitId) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "CreateCheckpoint");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -291,8 +291,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
     // TODO: check if session is read only
     args.WriteCommitId = GenerateCommitId();
     if (args.WriteCommitId == InvalidCommitId) {
-        args.CommitIdOverflowDetected = true;
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -502,10 +501,6 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflowDetected) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "CreateHandle");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -96,8 +96,7 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
 
     auto commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
-        args.CommitIdOverflowDetected = true;
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -143,10 +142,6 @@ void TIndexTabletActor::CompleteTx_DestroyHandle(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflowDetected) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "DestroyHandle");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -151,8 +151,7 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
-        args.CommitIdOverflow = true;
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -190,11 +189,6 @@ void TIndexTabletActor::CompleteTx_DestroySession(
 
     if (HasError(args.Error)) {
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-        if (args.CommitIdOverflow) {
-            return ScheduleRebootTabletOnCommitIdOverflow(
-                ctx,
-                "DestroySession");
-        }
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
@@ -103,8 +103,7 @@ void TIndexTabletActor::ExecuteTx_RemoveNodeXAttr(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.CommitIdOverflow = true;
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -129,10 +128,6 @@ void TIndexTabletActor::CompleteTx_RemoveNodeXAttr(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflow) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "RemoveXAttr");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -348,7 +348,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -569,10 +569,6 @@ void TIndexTabletActor::CompleteTx_RenameNode(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitId == InvalidCommitId) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "RenameNode");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -189,7 +189,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -340,12 +340,6 @@ void TIndexTabletActor::CompleteTx_RenameNodeInDestination(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitId == InvalidCommitId) {
-        ScheduleRebootTabletOnCommitIdOverflow(
-            ctx,
-            "RenameNodeInDestination");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -289,7 +289,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -356,14 +356,6 @@ void TIndexTabletActor::CompleteTx_PrepareRenameNodeInSource(
             << "RenameNode: " << args.Request.ShortDebugString());
         args.Error = MakeError(E_INVALID_STATE, std::move(message));
     }
-
-    Y_DEFER {
-        if (args.CommitId == InvalidCommitId) {
-            ScheduleRebootTabletOnCommitIdOverflow(
-                ctx,
-                "PrepareRenameNodeInSource");
-        }
-    };
 
     if (args.IsExplicitRequest) {
         //
@@ -532,7 +524,7 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -584,14 +576,6 @@ void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(
 {
     InvalidateNodeCaches(args.Request.GetNodeId());
     CommitDupCacheEntry(args.SessionId, args.RequestId);
-
-    Y_DEFER {
-        if (args.CommitId == InvalidCommitId) {
-            ScheduleRebootTabletOnCommitIdOverflow(
-                ctx,
-                "CommitRenameNodeInSource");
-        }
-    };
 
     if (!args.RequestInfo) {
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -133,8 +133,7 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
 
     auto commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
-        args.CommitIdOverflow = true;
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -189,9 +188,6 @@ void TIndexTabletActor::CompleteTx_ResetSession(
 
     if (HasError(args.Error)) {
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-        if (args.CommitIdOverflow) {
-            return ScheduleRebootTabletOnCommitIdOverflow(ctx, "ResetSession");
-        }
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
@@ -115,8 +115,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeXAttr(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.CommitIdOverflow = true;
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -162,10 +161,6 @@ void TIndexTabletActor::CompleteTx_SetNodeXAttr(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflow) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "SetXAttr");
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
@@ -332,8 +332,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeCreateNodeRef(
 
     auto commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
-        args.CommitIdOverflowDetected = true;
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -373,10 +372,6 @@ void TIndexTabletActor::CompleteTx_UnsafeCreateNodeRef(
             std::move(args.Error));
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflowDetected) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "UnsafeCreateNodeRef");
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -435,7 +430,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeDeleteNodeRef(
 
     auto commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -478,10 +473,6 @@ void TIndexTabletActor::CompleteTx_UnsafeDeleteNodeRef(
             std::move(args.Error));
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflowDetected) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "UnsafeDeleteNodeRef");
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -540,8 +531,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeUpdateNodeRef(
 
     auto commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
-        args.CommitIdOverflowDetected = true;
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -591,10 +581,6 @@ void TIndexTabletActor::CompleteTx_UnsafeUpdateNodeRef(
         std::make_unique<TEvIndexTablet::TEvUnsafeUpdateNodeRefResponse>();
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitIdOverflowDetected) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "UnsafeUpdateNodeRef");
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -295,7 +295,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -416,9 +416,6 @@ void TIndexTabletActor::CompleteTx_WriteData(
 
     if (FAILED(args.Error.GetCode())) {
         reply(ctx, args);
-        if (args.CommitId == InvalidCommitId) {
-            ScheduleRebootTabletOnCommitIdOverflow(ctx, "WriteData");
-        }
         return;
     }
 
@@ -462,9 +459,9 @@ void TIndexTabletActor::CompleteTx_WriteData(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         reply(ctx, args);
-        return ScheduleRebootTabletOnCommitIdOverflow(ctx, "WriteData");
+        return;
     }
 
     ui32 blobIndex = 0;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
@@ -76,7 +76,7 @@ void TIndexTabletActor::ExecuteTx_ZeroRange(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        args.Error = ErrorCommitIdOverflow();
+        args.OnCommitIdOverflow();
         return;
     }
 
@@ -112,11 +112,6 @@ void TIndexTabletActor::CompleteTx_ZeroRange(
         std::make_unique<TEvIndexTabletPrivate::TEvZeroRangeResponse>(
             std::move(args.Error));
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
-
-    if (args.CommitId == InvalidCommitId) {
-        ScheduleRebootTabletOnCommitIdOverflow(ctx, "ZeroRange");
-        return;
-    }
 
     EnqueueCollectGarbageIfNeeded(ctx);
 }


### PR DESCRIPTION
### Notes
* `Error` & `CommitIdOverflow` flag moved to `TErrorAware`
* crash (debug) / `E_INVALID_STATE` (release) upon tx restart attempt with non-empty `Error` / `CommitIdOverflow`
* generic `CommitIdOverflow` handling upon tx completion

### Issue
https://github.com/ydb-platform/nbs/issues/4937 and related issues