### PR TITLE
fix data race in TDescribeVolumeTest::ShouldReplyRetriableErrorOnTimeout

### DIFF
--- a/cloud/blockstore/libs/cells/impl/describe_volume_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume_ut.cpp
@@ -145,6 +145,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -186,6 +187,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -244,6 +246,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -285,6 +288,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -343,6 +347,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -400,6 +405,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -456,6 +462,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,
@@ -519,6 +526,7 @@ Y_UNIT_TEST_SUITE(TDescribeVolumeTest)
         bootstrap.Logging = CreateLoggingService("console");
         bootstrap.Scheduler = CreateScheduler();
         bootstrap.Scheduler->Start();
+        Y_DEFER { bootstrap.Scheduler->Stop(); };
 
         auto response = DescribeVolume(
             config,


### PR DESCRIPTION
Fixes:
https://github-actions-s3.storage.eu-north1.nebius.cloud/ydb-platform/nbs/PR-check/21148543927/1/nebius-x86-64-tsan/logs/1/cloud/blockstore/libs/cells/impl/ut/test-results/unittest/chunk9/testing_out_stuff/TDescribeVolumeTest.ShouldReplyRetriableErrorOnTimeout.err

The problem is that scheduler in test is not stopped upon test completion (destructor is not called because there still active reference to it captured in currently executed lambda https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/cells/impl/describe_volume.cpp#L176). So lambda is executed and at the same time AtExit is called.

One way to fix this was to just insert Y_DEFER { Scheduler->Stop();} . But looking at the code, it seems like TMultiCellDescribeHandler does not need to hold Scheduler, so I made Scheduler parameter for Start method where it is needed.