### PR TITLE
Fix arcadia sync: Go linter issue at filesystem_service_test.go

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go
@@ -104,7 +104,7 @@ func TestCreateFilesystemInCells(t *testing.T) {
 	require.NoError(t, err)
 	defer zoneNfsClient.Close()
 
-	session, err = zoneNfsClient.CreateSession(
+	_, err = zoneNfsClient.CreateSession(
 		ctx,
 		filesystemID,
 		"",


### PR DESCRIPTION
fixing linter error from arcdia sync:
```
$S/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go:107:2: "SA4006: this value of session is never used"
$S/cloud/disk_manager/internal/pkg/facade/filesystem_service_test/filesystem_service_test.go:107:2: "SA4006: if you believe this report is false positive, please silence it with //nolint:sa4006 comment"
```