### PR TITLE
save the source address; resolves #5085

### DIFF
--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -1600,8 +1600,7 @@ void TServer::Listen(TServerEndpoint* endpoint)
         endpoint->Port,
         &hints);
 
-    RDMA_INFO("listen on "
-        << NAddr::PrintHostAndPort(NAddr::TOpaqueAddr(addrinfo->ai_src_addr)));
+    RDMA_INFO("listen on " << NVerbs::PrintAddressAndPort(addrinfo->ai_src_addr));
 
     Verbs->BindAddress(endpoint->Connection.get(), addrinfo->ai_src_addr);
     Verbs->Listen(endpoint->Connection.get(), Config->Backlog);


### PR DESCRIPTION
It's somewhat tricky to write a test for this, but asan/msan should catch such cases

Manually changing the family after the loop

```cpp
        NAddr::IRemoteAddrRef src;

        // find the first non local address of the specified interface
        for (auto& interface: NAddr::GetNetworkInterfaces()) {
            if (interface.Name == Config->SourceInterface &&
                GetScopeId(interface.Address->Addr()) == 0)
            {
                src = interface.Address;

                RDMA_INFO(endpoint->Log, "bind to " << interface.Name
                    << " address " << NAddr::PrintHost(*src));

                RDMA_INFO(endpoint->Log, "src.ref_count=" << src.RefCount());

                hints.ai_src_addr = const_cast<sockaddr*>(src->Addr());
                hints.ai_src_len = src->Len();
                break;
            }
        }

        RDMA_INFO(endpoint->Log, "src.ref_count=" << src.RefCount());
        const_cast<sockaddr*>(src->Addr())->sa_family = 0;
```

produces a crash similar to what we've seen in the wild
```
tpashkin@man0-1327:~$ ./rdma-test --test Initiator --storage Rdma --host node-1207.kubevirt-testing.ik8s.nebiuscloud.net --port 12345 --iodepth 1 --wait BusyWait --verbose --source-interface storage0
2026-01-27T18:00:55.073644Z :BLOCKSTORE_RDMA DEBUG: start client
2026-01-27T18:00:55.074219Z :BLOCKSTORE_RDMA INFO: [12288178989269772224] start endpoint node-1207.kubevirt-testing.ik8s.nebiuscloud.net [send_magic=AA8861AF recv_magic=67D7E7C0]
2026-01-27T18:00:55.096201Z :BLOCKSTORE_RDMA INFO: [12288178989269772224] bind to storage0 address 2a13:5945:38:2112:40db:c1ff:fef2:6620
2026-01-27T18:00:55.096213Z :BLOCKSTORE_RDMA INFO: [12288178989269772224] src.ref_count=2
2026-01-27T18:00:55.096218Z :BLOCKSTORE_RDMA INFO: [12288178989269772224] src.ref_count=1
2026-01-27T18:00:55.096223Z :BLOCKSTORE_RDMA DEBUG: [12288178989269772224] Disconnected -> ResolvingAddress
2026-01-27T18:00:55.096900Z :BLOCKSTORE_RDMA DEBUG: [12288178989269772224] resolve server address
uncaught exception:
    address -> 0x4513bf402210
    what() -> "util/network/address.cpp:208: unsupported address family: 0"
    type -> yexception
Aborted (core dumped)
```