### PR TITLE
[Blockstore] Apply allowed YDB feature flags, received from CMS on node registration

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.h
@@ -103,6 +103,8 @@ private:
 
     void ApplyNamedConfigs(const NKikimrConfig::TAppConfig& config);
     void ApplyBlockstoreConfig(const NKikimrConfig::TAppConfig& config);
+    void ApplyAllowedKikimrFeatureFlags(
+        const NKikimrConfig::TAppConfig& config);
 };
 
 }   // namespace NCloud::NBlockStore::NServer


### PR DESCRIPTION
Allowed YDB feature flags, received from CMS on node registration, now applied into KikimrConfig.

Allowed flags (TAppConfig::FeatureFlags):
- EnableNodeBrokerDeltaProtocol