### PR TITLE
[Blockstore/Disk Agent] Local NVMe service basic implementation

### DIFF
--- a/cloud/blockstore/config/local_nvme.proto
+++ b/cloud/blockstore/config/local_nvme.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package NCloud.NBlockStore.NProto;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TLocalNVMeConfig {
+    // Source URI for retrieving the list of NVMe devices to use (e.g. file:///etc/nbs/devices.txt)
+    optional string DevicesSourceUri = 1;
+}

--- a/cloud/blockstore/config/ya.make
+++ b/cloud/blockstore/config/ya.make
@@ -11,6 +11,7 @@ SRCS(
     disk.proto
     grpc_client.proto
     http_proxy.proto
+    local_nvme.proto
     logbroker.proto
     notify.proto
     plugin.proto

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.h
@@ -85,8 +85,10 @@ struct TServerModuleFactories
         ILoggingServicePtr logging)>
         NotifyServiceFactory;
 
-    std::function<ILocalNVMeServicePtr(ILoggingServicePtr logging)>
-        LocalNVMeServiceFactory;
+    std::function<ILocalNVMeDeviceProviderPtr(
+        ILoggingServicePtr logging,
+        const TString& uri)>
+        LocalNVMeDeviceProviderFactory;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -174,6 +174,17 @@ void TConfigInitializerYdb::InitComputeClientConfig()
     ComputeClientConfig = std::move(config);
 }
 
+void TConfigInitializerYdb::InitLocalNVMeConfig()
+{
+    NProto::TLocalNVMeConfig config;
+
+    if (Options->LocalNVMeConfig) {
+        ParseProtoTextFromFile(Options->LocalNVMeConfig, config);
+    }
+
+    LocalNVMeConfig = std::move(config);
+}
+
 bool TConfigInitializerYdb::GetUseNonreplicatedRdmaActor() const
 {
     if (!StorageConfig) {
@@ -374,6 +385,14 @@ void TConfigInitializerYdb::ApplyComputeClientConfig(const TString& text)
     ComputeClientConfig = std::move(config);
 }
 
+void TConfigInitializerYdb::ApplyLocalNVMeConfig(const TString& text)
+{
+    NProto::TLocalNVMeConfig config;
+    ParseProtoTextFromString(text, config);
+
+    LocalNVMeConfig = std::move(config);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TConfigInitializerYdb::ApplyNamedConfigs(
@@ -415,6 +434,7 @@ void TConfigInitializerYdb::ApplyNamedConfigs(
         { "KmsClientConfig",         &TSelf::ApplyKmsClientConfig         },
         { "RootKmsConfig",           &TSelf::ApplyRootKmsConfig           },
         { "ComputeClientConfig",     &TSelf::ApplyComputeClientConfig     },
+        { "LocalNVMeConfig",         &TSelf::ApplyLocalNVMeConfig         },
     };
 
     for (const auto& handler: configHandlers) {

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/blockstore/config/grpc_client.pb.h>
+#include <cloud/blockstore/config/local_nvme.pb.h>
 #include <cloud/blockstore/config/root_kms.pb.h>
 
 #include <cloud/blockstore/libs/client/config.h>
@@ -63,6 +64,7 @@ struct TConfigInitializerYdb final
     NProto::TGrpcClientConfig KmsClientConfig;
     NProto::TGrpcClientConfig ComputeClientConfig;
     NProto::TRootKmsConfig RootKmsConfig;
+    NProto::TLocalNVMeConfig LocalNVMeConfig;
 
     TConfigInitializerYdb(TOptionsYdbPtr options);
 
@@ -75,7 +77,7 @@ struct TConfigInitializerYdb final
     void InitKmsClientConfig();
     void InitRootKmsConfig();
     void InitComputeClientConfig();
-    void InitTraceServiceClientConfig();
+    void InitLocalNVMeConfig();
 
     bool GetUseNonreplicatedRdmaActor() const override;
     TDuration GetInactiveClientsTimeout() const override;
@@ -100,6 +102,7 @@ private:
     void ApplyKmsClientConfig(const TString& text);
     void ApplyRootKmsConfig(const TString& text);
     void ApplyComputeClientConfig(const TString& text);
+    void ApplyLocalNVMeConfig(const TString& text);
 
     void ApplyNamedConfigs(const NKikimrConfig::TAppConfig& config);
     void ApplyBlockstoreConfig(const NKikimrConfig::TAppConfig& config);

--- a/cloud/blockstore/libs/daemon/ydb/options.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/options.cpp
@@ -44,6 +44,10 @@ TOptionsYdb::TOptionsYdb()
     Opts.AddLongOption("compute-file")
         .RequiredArgument("PATH")
         .StoreResult(&ComputeConfig);
+
+    Opts.AddLongOption("local-nvme-file")
+        .RequiredArgument("PATH")
+        .StoreResult(&LocalNVMeConfig);
 }
 
 void TOptionsYdb::Parse(int argc, char** argv)

--- a/cloud/blockstore/libs/daemon/ydb/options.h
+++ b/cloud/blockstore/libs/daemon/ydb/options.h
@@ -23,6 +23,7 @@ struct TOptionsYdb final
     TString KmsConfig;
     TString RootKmsConfig;
     TString ComputeConfig;
+    TString LocalNVMeConfig;
 
     TOptionsYdb();
 

--- a/cloud/blockstore/libs/kikimr/components.h
+++ b/cloud/blockstore/libs/kikimr/components.h
@@ -54,6 +54,7 @@ namespace NCloud::NBlockStore {
     xxx(RDMA)                                                                  \
     xxx(LOCAL_STORAGE)                                                         \
     xxx(EXTERNAL_ENDPOINT)                                                     \
+    xxx(LOCAL_NVME)                                                            \
     BLOCKSTORE_ACTORS(xxx)                                                     \
     xxx(USER_STATS)                                                            \
 // BLOCKSTORE_COMPONENTS

--- a/cloud/blockstore/libs/local_nvme/config.cpp
+++ b/cloud/blockstore/libs/local_nvme/config.cpp
@@ -1,0 +1,88 @@
+#include "config.h"
+
+#include <library/cpp/monlib/service/pages/templates.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define BLOCKSTORE_LOCAL_NVME_CONFIG(xxx)                                      \
+    xxx(DevicesSourceUri,                TString,          ""                 )\
+// BLOCKSTORE_LOCAL_NVME_CONFIG
+
+#define BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG(name, type, value)                \
+    Y_DECLARE_UNUSED static const type Default##name = value;                  \
+// BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG
+
+BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG)
+
+#undef BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TTarget, typename TSource>
+TTarget ConvertValue(const TSource& value)
+{
+    return TTarget(value);
+}
+
+}   //  namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLocalNVMeConfig::TLocalNVMeConfig(NProto::TLocalNVMeConfig proto)
+    : Proto(std::move(proto))
+{}
+
+TLocalNVMeConfig::~TLocalNVMeConfig() = default;
+
+#define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
+type TLocalNVMeConfig::Get##name() const                                       \
+{                                                                              \
+    const auto value = Proto.Get##name();                                      \
+    return !value ? Default##name : ConvertValue<type>(value);                 \
+}                                                                              \
+// BLOCKSTORE_CONFIG_GETTER
+
+BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_CONFIG_GETTER)
+
+#undef BLOCKSTORE_CONFIG_GETTER
+
+void TLocalNVMeConfig::Dump(IOutputStream& out) const
+{
+#define BLOCKSTORE_CONFIG_DUMP(name, ...)                                      \
+    out << #name << ": ";                                                      \
+    out << Get##name();                                                        \
+    out << Endl;                                                               \
+// BLOCKSTORE_CONFIG_DUMP
+
+    BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_CONFIG_DUMP);
+
+#undef BLOCKSTORE_CONFIG_DUMP
+}
+
+void TLocalNVMeConfig::DumpHtml(IOutputStream& out) const
+{
+#define BLOCKSTORE_CONFIG_DUMP(name, ...)                                      \
+    TABLER() {                                                                 \
+        TABLED() { out << #name; }                                             \
+        TABLED() { out << Get##name(); }                                       \
+    }                                                                          \
+// BLOCKSTORE_CONFIG_DUMP
+
+    HTML(out) {
+        TABLE_CLASS("table table-condensed") {
+            TABLEBODY() {
+                BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_CONFIG_DUMP);
+            }
+        }
+    }
+
+#undef BLOCKSTORE_CONFIG_DUMP
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/config.h
+++ b/cloud/blockstore/libs/local_nvme/config.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/config/local_nvme.pb.h>
+
+#include <util/generic/fwd.h>
+
+#include <variant>
+
+class IOutputStream;
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLocalNVMeConfig
+{
+private:
+    const NProto::TLocalNVMeConfig Proto;
+
+public:
+    explicit TLocalNVMeConfig(NProto::TLocalNVMeConfig proto);
+    ~TLocalNVMeConfig();
+
+    [[nodiscard]] TString GetDevicesSourceUri() const;
+
+    void Dump(IOutputStream& out) const;
+    void DumpHtml(IOutputStream& out) const;
+};
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/config_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/config_ut.cpp
@@ -1,0 +1,25 @@
+#include "config.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/stream/str.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLocalNVMeConfigTest)
+{
+    Y_UNIT_TEST(ShouldStoreConfig)
+    {
+        NProto::TLocalNVMeConfig proto;
+        proto.SetDevicesSourceUri("file:///etc/service/devices.txt");
+
+        TLocalNVMeConfigPtr config = std::make_shared<TLocalNVMeConfig>(proto);
+        UNIT_ASSERT_VALUES_EQUAL(
+            proto.GetDevicesSourceUri(),
+            config->GetDevicesSourceUri());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/local_nvme/device_provider.cpp
+++ b/cloud/blockstore/libs/local_nvme/device_provider.cpp
@@ -1,0 +1,65 @@
+#include "device_provider.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/proto_helpers.h>
+
+#include <library/cpp/threading/future/future.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileNVMeDeviceProvider final: public ILocalNVMeDeviceProvider
+{
+private:
+    const TString Path;
+
+public:
+    explicit TFileNVMeDeviceProvider(TString path)
+        : Path(std::move(path))
+    {}
+
+    [[nodiscard]] auto ListNVMeDevices() const
+        -> TFuture<TVector<NProto::TNVMeDevice>> final
+    {
+        NProto::TNVMeDeviceList list;
+        ParseProtoTextFromFile(Path, list);
+
+        return MakeFuture(
+            TVector<NProto::TNVMeDevice>{
+                std::make_move_iterator(list.MutableDevices()->begin()),
+                std::make_move_iterator(list.MutableDevices()->end())});
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLocalNVMeDeviceProviderStub final: public ILocalNVMeDeviceProvider
+{
+public:
+    [[nodiscard]] auto ListNVMeDevices() const
+        -> TFuture<TVector<NProto::TNVMeDevice>> final
+    {
+        return MakeFuture(TVector<NProto::TNVMeDevice>{});
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ILocalNVMeDeviceProviderPtr CreateFileNVMeDeviceProvider(const TString& path)
+{
+    return std::make_shared<TFileNVMeDeviceProvider>(path);
+}
+
+ILocalNVMeDeviceProviderPtr CreateLocalNVMeDeviceProviderStub()
+{
+    return std::make_shared<TLocalNVMeDeviceProviderStub>();
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/device_provider.h
+++ b/cloud/blockstore/libs/local_nvme/device_provider.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
+
+#include <library/cpp/threading/future/fwd.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ILocalNVMeDeviceProvider
+{
+    virtual ~ILocalNVMeDeviceProvider() = default;
+
+    [[nodiscard]] virtual auto ListNVMeDevices() const
+        -> NThreading::TFuture<TVector<NProto::TNVMeDevice>> = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Creates a provider that reads the NVMe device list from the specified file
+ILocalNVMeDeviceProviderPtr CreateFileNVMeDeviceProvider(const TString& path);
+
+ILocalNVMeDeviceProviderPtr CreateLocalNVMeDeviceProviderStub();
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/device_provider_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/device_provider_ut.cpp
@@ -1,0 +1,85 @@
+#include "device_provider.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/proto_helpers.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/future.h>
+
+#include <util/folder/tempdir.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<NProto::TNVMeDevice> PrepareDeviceFile(const TString& path)
+{
+    NProto::TNVMeDeviceList list;
+    ParseProtoTextFromString(
+        R"(
+        Devices {
+            SerialNumber: "NVME_0"
+            PCIAddress: "f1:00.0"
+            IOMMUGroup: 10
+            VendorId: 0x100
+            DeviceId: 0x200
+            Model: "Test NVMe 1"
+        }
+        Devices {
+            SerialNumber: "NVME_1"
+            PCIAddress: "31:00.0"
+            IOMMUGroup: 20
+            VendorId: 0x300
+            DeviceId: 0x400
+            Model: "Test NVMe 2"
+        }
+        Devices {
+            SerialNumber: "NVME_2"
+            PCIAddress: "33:00.0"
+            IOMMUGroup: 30
+            VendorId: 0x100
+            DeviceId: 0x200
+            Model: "Test NVMe 1"
+        }
+    )",
+        list);
+
+    UNIT_ASSERT_VALUES_EQUAL(3, list.DevicesSize());
+
+    SerializeToTextFormat(list, path);
+
+    return {
+        std::make_move_iterator(list.MutableDevices()->begin()),
+        std::make_move_iterator(list.MutableDevices()->end())};
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLocalNVMeDeviceProviderTest)
+{
+    Y_UNIT_TEST(ShouldListDevices)
+    {
+        TTempDir tempDir;
+        const TString path = tempDir.Path() / "devices.txt";
+        const auto expectedDevices = PrepareDeviceFile(path);
+
+        auto deviceProvider = CreateFileNVMeDeviceProvider(path);
+
+        auto future = deviceProvider->ListNVMeDevices();
+        const auto& devices = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL(expectedDevices.size(), devices.size());
+
+        for (size_t i = 0; i != devices.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedDevices[i].DebugString(),
+                devices[i].DebugString());
+        }
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/local_nvme/public.h
+++ b/cloud/blockstore/libs/local_nvme/public.h
@@ -6,7 +6,13 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TLocalNVMeConfig;
+using TLocalNVMeConfigPtr = std::shared_ptr<TLocalNVMeConfig>;
+
 struct ILocalNVMeService;
 using ILocalNVMeServicePtr = std::shared_ptr<ILocalNVMeService>;
+
+struct ILocalNVMeDeviceProvider;
+using ILocalNVMeDeviceProviderPtr = std::shared_ptr<ILocalNVMeDeviceProvider>;
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/service.cpp
+++ b/cloud/blockstore/libs/local_nvme/service.cpp
@@ -24,12 +24,13 @@ public:
     {}
 
     [[nodiscard]] auto ListNVMeDevices() const
-        -> TResultOrError<TVector<NProto::TNVMeDevice>> final
+        -> TFuture<TResultOrError<TVector<NProto::TNVMeDevice>>> final
     {
-        return TVector<NProto::TNVMeDevice>{};
+        return MakeFuture<TResultOrError<TVector<NProto::TNVMeDevice>>>(
+            TVector<NProto::TNVMeDevice>{});
     }
 
-    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber) const
+    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
         -> TFuture<NProto::TError> final
     {
         if (!serialNumber) {
@@ -42,7 +43,7 @@ public:
                 << "Device " << serialNumber.Quote() << " not found"));
     }
 
-    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber) const
+    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
         -> TFuture<NProto::TError> final
     {
         if (!serialNumber) {

--- a/cloud/blockstore/libs/local_nvme/service_generic.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_generic.cpp
@@ -1,0 +1,18 @@
+#include "service.h"
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+ILocalNVMeServicePtr CreateLocalNVMeService(
+    ILoggingServicePtr logging,
+    ILocalNVMeDeviceProviderPtr deviceProvider,
+    NNvme::INvmeManagerPtr nvmeManager,
+    TExecutorPtr executor)
+{
+    Y_UNUSED(logging, deviceProvider, nvmeManager, executor);
+
+    return CreateLocalNVMeServiceStub();
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -1,0 +1,280 @@
+#include "service.h"
+
+#include "device_provider.h"
+
+#include <cloud/storage/core/libs/coroutine/executor.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <util/generic/algorithm.h>
+#include <util/generic/hash_set.h>
+#include <util/stream/str.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const NProto::TError ServiceDestroyedError =
+    MakeError(E_REJECTED, "Local NVMe service is destroyed");
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename R>
+TString Join(TStringBuf delim, const R& range)
+{
+    TStringStream ss;
+    for (int i = 0; auto&& x: range) {
+        if (i++) {
+            ss << delim;
+        }
+        ss << x;
+    }
+
+    return ss.Str();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLocalNVMeService final
+    : public std::enable_shared_from_this<TLocalNVMeService>
+    , public ILocalNVMeService
+{
+    using TListDevicesResult = TResultOrError<TVector<NProto::TNVMeDevice>>;
+
+private:
+    const ILoggingServicePtr Logging;
+    const ILocalNVMeDeviceProviderPtr DeviceProvider;
+    const NNvme::INvmeManagerPtr NvmeManager;
+    const TExecutorPtr Executor;
+
+    TLog Log;
+    TFuture<NProto::TError> Ready;
+
+    THashMap<TString, NProto::TNVMeDevice> Devices;
+
+public:
+    TLocalNVMeService(
+        ILoggingServicePtr logging,
+        ILocalNVMeDeviceProviderPtr deviceProvider,
+        NNvme::INvmeManagerPtr nvmeManager,
+        TExecutorPtr executor);
+
+    // IStartable
+
+    void Start() final;
+    void Stop() final;
+
+    // ILocalNVMeService
+
+    [[nodiscard]] auto ListNVMeDevices() const
+        -> TFuture<TListDevicesResult> final;
+
+    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
+        -> TFuture<NProto::TError> final;
+
+    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
+        -> TFuture<NProto::TError> final;
+
+private:
+    auto AcquireDevice(const TString& serialNumber) -> NProto::TError;
+    auto ReleaseDevice(const TString& serialNumber) -> NProto::TError;
+    auto ListDevices() const -> TVector<NProto::TNVMeDevice>;
+    auto EnsureIsReady() const -> NProto::TError;
+    auto Initialize() -> NProto::TError;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLocalNVMeService::TLocalNVMeService(
+    ILoggingServicePtr logging,
+    ILocalNVMeDeviceProviderPtr deviceProvider,
+    NNvme::INvmeManagerPtr nvmeManager,
+    TExecutorPtr executor)
+    : Logging(std::move(logging))
+    , DeviceProvider(std::move(deviceProvider))
+    , NvmeManager(std::move(nvmeManager))
+    , Executor(std::move(executor))
+{
+    Y_UNUSED(NvmeManager);
+}
+
+void TLocalNVMeService::Start()
+{
+    Log = Logging->CreateLog("BLOCKSTORE_LOCAL_NVME");
+
+    Ready = Executor->Execute(
+        [weakSelf = weak_from_this()]() -> NProto::TError
+        {
+            if (auto self = weakSelf.lock()) {
+                return self->Initialize();
+            }
+
+            return ServiceDestroyedError;
+        });
+}
+
+void TLocalNVMeService::Stop()
+{}
+
+auto TLocalNVMeService::ListNVMeDevices() const -> TFuture<TListDevicesResult>
+{
+    STORAGE_INFO("List NVMe devices");
+
+    if (auto error = EnsureIsReady(); HasError(error)) {
+        return MakeFuture<TListDevicesResult>(error);
+    }
+
+    return Executor->Execute(
+        [weakSelf = weak_from_this()]() -> TListDevicesResult
+        {
+            if (auto self = weakSelf.lock()) {
+                return self->ListDevices();
+            }
+
+            return ServiceDestroyedError;
+        });
+}
+
+auto TLocalNVMeService::AcquireNVMeDevice(const TString& serialNumber)
+    -> TFuture<NProto::TError>
+{
+    STORAGE_INFO("Acquire NVMe device " << serialNumber.Quote());
+
+    if (auto error = EnsureIsReady(); HasError(error)) {
+        return MakeFuture(error);
+    }
+
+    return Executor->Execute(
+        [weakSelf = weak_from_this(), serialNumber]() -> NProto::TError
+        {
+            if (auto self = weakSelf.lock()) {
+                return self->AcquireDevice(serialNumber);
+            }
+            return ServiceDestroyedError;
+        });
+}
+
+auto TLocalNVMeService::ReleaseNVMeDevice(const TString& serialNumber)
+    -> TFuture<NProto::TError>
+{
+    STORAGE_INFO("Release NVMe device " << serialNumber.Quote());
+
+    if (auto error = EnsureIsReady(); HasError(error)) {
+        return MakeFuture(error);
+    }
+
+    return Executor->Execute(
+        [weakSelf = weak_from_this(), serialNumber]() -> NProto::TError
+        {
+            if (auto self = weakSelf.lock()) {
+                return self->ReleaseDevice(serialNumber);
+            }
+            return ServiceDestroyedError;
+        });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto TLocalNVMeService::EnsureIsReady() const -> NProto::TError
+{
+    if (Ready.HasValue()) {
+        return Ready.GetValue();
+    }
+
+    Y_DEBUG_ABORT_UNLESS(!Ready.HasException());
+
+    return MakeError(E_REJECTED, "not ready");
+}
+
+auto TLocalNVMeService::Initialize() -> NProto::TError
+{
+    auto future = DeviceProvider->ListNVMeDevices();
+
+    auto [devices, error] = Executor->ResultOrError(future);
+
+    if (HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to list NVMe devices from the provider: "
+            << FormatError(error));
+        return error;
+    }
+
+    STORAGE_INFO(
+        "Found NVMe devices (" << devices.size()
+                               << "): " << Join(", ", devices));
+
+    for (const auto& device: devices) {
+        Devices[device.GetSerialNumber()] = device;
+    }
+
+    return {};
+}
+
+auto TLocalNVMeService::AcquireDevice(const TString& serialNumber)
+    -> NProto::TError
+{
+    if (!Devices.contains(serialNumber)) {
+        return MakeError(
+            E_NOT_FOUND,
+            TStringBuilder()
+                << "Device " << serialNumber.Quote() << " not found");
+    }
+
+    // TODO
+
+    return {};
+}
+
+auto TLocalNVMeService::ReleaseDevice(const TString& serialNumber)
+    -> NProto::TError
+{
+    if (!Devices.contains(serialNumber)) {
+        return MakeError(
+            E_NOT_FOUND,
+            TStringBuilder()
+                << "Device " << serialNumber.Quote() << " not found");
+    }
+
+    // TODO
+
+    return {};
+}
+
+auto TLocalNVMeService::ListDevices() const -> TVector<NProto::TNVMeDevice>
+{
+    TVector<NProto::TNVMeDevice> devices;
+    devices.reserve(Devices.size());
+
+    for (auto& [_, device]: Devices) {
+        devices.push_back(device);
+    }
+
+    SortBy(devices, [](const auto& d) { return d.GetSerialNumber(); });
+
+    return devices;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ILocalNVMeServicePtr CreateLocalNVMeService(
+    ILoggingServicePtr logging,
+    ILocalNVMeDeviceProviderPtr deviceProvider,
+    NNvme::INvmeManagerPtr nvmeManager,
+    TExecutorPtr executor)
+{
+    return std::make_shared<TLocalNVMeService>(
+        std::move(logging),
+        std::move(deviceProvider),
+        std::move(nvmeManager),
+        std::move(executor));
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -1,0 +1,263 @@
+#include "service.h"
+
+#include "device_provider.h"
+
+#include <cloud/blockstore/libs/nvme/nvme_stub.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/proto_helpers.h>
+#include <cloud/storage/core/libs/coroutine/executor.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/future.h>
+
+#include <util/folder/tempdir.h>
+#include <util/stream/file.h>
+
+#include <chrono>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NThreading;
+using namespace std::chrono_literals;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestLocalNVMeDeviceProvider final: ILocalNVMeDeviceProvider
+{
+    TPromise<TVector<NProto::TNVMeDevice>> Promise =
+        NewPromise<TVector<NProto::TNVMeDevice>>();
+
+    [[nodiscard]] auto ListNVMeDevices() const
+        -> TFuture<TVector<NProto::TNVMeDevice>> final
+    {
+        return Promise;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    TVector<NProto::TNVMeDevice> Devices;
+
+    ILoggingServicePtr Logging;
+    std::shared_ptr<TTestLocalNVMeDeviceProvider> DeviceProvider;
+    NNvme::INvmeManagerPtr NVMeManager;
+    TExecutorPtr Executor;
+
+    ILocalNVMeServicePtr Service;
+
+    void SetUp(NUnitTest::TTestContext& /*testContext*/) final
+    {
+        PrepareDevices();
+
+        Logging =
+            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
+        Logging->Start();
+
+        DeviceProvider = std::make_shared<TTestLocalNVMeDeviceProvider>();
+
+        NVMeManager = NNvme::CreateNvmeManagerStub();
+
+        Executor = TExecutor::Create("TestExecutor");
+        Executor->Start();
+
+        Service = CreateLocalNVMeService(
+            Logging,
+            std::static_pointer_cast<ILocalNVMeDeviceProvider>(DeviceProvider),
+            NVMeManager,
+            Executor);
+        Service->Start();
+    }
+
+    void TearDown(NUnitTest::TTestContext& /* testContext */) final
+    {
+        Service->Stop();
+        Executor->Stop();
+        Logging->Stop();
+    }
+
+    void PrepareDevices()
+    {
+        NProto::TNVMeDeviceList list;
+        ParseProtoTextFromString(
+            R"(
+            Devices {
+                SerialNumber: "NVME_0"
+                PCIAddress: "f1:00.0"
+                IOMMUGroup: 10
+                VendorId: 0x100
+                DeviceId: 0x200
+                Model: "Test NVMe 1"
+            }
+            Devices {
+                SerialNumber: "NVME_1"
+                PCIAddress: "31:00.0"
+                IOMMUGroup: 20
+                VendorId: 0x300
+                DeviceId: 0x400
+                Model: "Test NVMe 2"
+            }
+            Devices {
+                SerialNumber: "NVME_2"
+                PCIAddress: "33:00.0"
+                IOMMUGroup: 30
+                VendorId: 0x100
+                DeviceId: 0x200
+                Model: "Test NVMe 1"
+            }
+        )",
+            list);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, list.DevicesSize());
+
+        Devices.assign(
+            std::make_move_iterator(list.MutableDevices()->begin()),
+            std::make_move_iterator(list.MutableDevices()->end()));
+    }
+
+    auto ListNVMeDevices()
+    {
+        for (;;) {
+            auto future = Service->ListNVMeDevices();
+            auto r = future.GetValueSync();
+            if (!HasError(r) || r.GetError().GetCode() != E_REJECTED) {
+                return r;
+            }
+            Sleep(100ms);
+        }
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
+{
+    Y_UNIT_TEST_F(ShouldListDevices, TFixture)
+    {
+        {
+            auto future = Service->ListNVMeDevices();
+            auto [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        DeviceProvider->Promise.SetValue(Devices);
+
+        {
+            auto [devices, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+
+            for (size_t i = 0; i != devices.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    Devices[i].DebugString(),
+                    devices[i].DebugString(),
+                    "#" << i);
+            }
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldAcquireAndReleaseDevice, TFixture)
+    {
+        for (TString sn: {"NVME_0", "UNK"}) {
+            {
+                auto future = Service->AcquireNVMeDevice(sn);
+                const auto& error = future.GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    E_REJECTED,
+                    error.GetCode(),
+                    FormatError(error));
+            }
+
+            {
+                auto future = Service->ReleaseNVMeDevice(sn);
+                const auto& error = future.GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    E_REJECTED,
+                    error.GetCode(),
+                    FormatError(error));
+            }
+        }
+
+        DeviceProvider->Promise.SetValue(Devices);
+
+        {
+            auto [_, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->AcquireNVMeDevice("UNK");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_NOT_FOUND,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->ReleaseNVMeDevice("UNK");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_NOT_FOUND,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->AcquireNVMeDevice("NVME_0");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->ReleaseNVMeDevice("NVME_0");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldHandleListDevicesError, TFixture)
+    {
+        DeviceProvider->Promise.SetException(
+            std::make_exception_ptr(std::runtime_error{"fail"}));
+
+        {
+            auto [_, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FAIL,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto [_, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FAIL,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/local_nvme/service_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_ut.cpp
@@ -5,13 +5,11 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/future.h>
 
-#include <util/folder/tempdir.h>
-
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
+Y_UNIT_TEST_SUITE(TLocalNVMeServiceStubTest)
 {
     Y_UNIT_TEST(ShouldStub)
     {
@@ -19,7 +17,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         service->Start();
 
         {
-            auto [list, error] = service->ListNVMeDevices();
+            auto future = service->ListNVMeDevices();
+            auto [list, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT_VALUES_EQUAL(0, list.size());
         }

--- a/cloud/blockstore/libs/local_nvme/ut/ya.make
+++ b/cloud/blockstore/libs/local_nvme/ut/ya.make
@@ -3,8 +3,16 @@ UNITTEST_FOR(cloud/blockstore/libs/local_nvme)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
+    config_ut.cpp
+    device_provider_ut.cpp
     service_ut.cpp
 )
+
+IF (OS_LINUX)
+    SRCS(
+        service_linux_ut.cpp
+    )
+ENDIF(OS_LINUX)
 
 PEERDIR(
     library/cpp/testing/unittest

--- a/cloud/blockstore/libs/local_nvme/ya.make
+++ b/cloud/blockstore/libs/local_nvme/ya.make
@@ -1,16 +1,31 @@
 LIBRARY()
 
 SRCS(
+    config.cpp
     service.cpp
+    device_provider.cpp
 )
 
 PEERDIR(
     cloud/blockstore/config
     cloud/blockstore/libs/common
+    cloud/blockstore/libs/nvme
     cloud/blockstore/libs/storage/protos
+    cloud/storage/core/libs/coroutine
+    cloud/storage/core/libs/diagnostics
 
     library/cpp/threading/future
 )
+
+IF (OS_LINUX)
+    SRCS(
+        service_linux.cpp
+    )
+ELSE(OS_LINUX)
+    SRCS(
+        service_generic.cpp
+    )
+ENDIF(OS_LINUX)
 
 END()
 

--- a/cloud/blockstore/libs/storage/testlib/local_nvme_mock.cpp
+++ b/cloud/blockstore/libs/storage/testlib/local_nvme_mock.cpp
@@ -13,8 +13,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TLocalNVMeServiceMock final
-    : public ILocalNVMeService
+class TLocalNVMeServiceMock final: public ILocalNVMeService
 {
 private:
     const TVector<NProto::TNVMeDevice> Devices;
@@ -31,12 +30,13 @@ public:
     {}
 
     [[nodiscard]] auto ListNVMeDevices() const
-        -> TResultOrError<TVector<NProto::TNVMeDevice>> final
+        -> TFuture<TResultOrError<TVector<NProto::TNVMeDevice>>> final
     {
-        return Devices;
+        return MakeFuture<TResultOrError<TVector<NProto::TNVMeDevice>>>(
+            Devices);
     }
 
-    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber) const
+    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
         -> TFuture<NProto::TError> final
     {
         const auto* disk = FindIfPtr(
@@ -54,7 +54,7 @@ public:
                 << "Disk " << serialNumber.Quote() << " not found"));
     }
 
-    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber) const
+    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
         -> TFuture<NProto::TError> final
     {
         const auto* disk = FindIfPtr(
@@ -73,7 +73,7 @@ public:
     }
 };
 
-}   //namespace
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -364,6 +364,7 @@ ui32 TTestEnv::CreateBlockStoreNode(
         google::protobuf::RepeatedPtrField<NProto::TDeviceConfig>(),
         TDiskAgentStatePtr(),
         CreateLocalNVMeServiceMock(std::move(NVMeDevices)));
+
     auto diskAgentId = Runtime.Register(
         diskAgent.release(),
         nodeIdx,

--- a/cloud/blockstore/tests/python/lib/config.py
+++ b/cloud/blockstore/tests/python/lib/config.py
@@ -259,6 +259,7 @@ def generate_log_txt():
         b"BLOCKSTORE_EXTERNAL_ENDPOINT",
         b"BLOCKSTORE_VHOST",
         b"BLOCKSTORE_RDMA",
+        b"BLOCKSTORE_LOCAL_NVME",
     ]
 
     log_config = TLogConfig()

--- a/cloud/blockstore/tests/ya.make
+++ b/cloud/blockstore/tests/ya.make
@@ -22,6 +22,7 @@ RECURSE(
     infra-cms
     loadtest
     loadtest/remote
+    local_nvme
     local_ssd
     monitoring
     mount


### PR DESCRIPTION
PR implements the basic infrastructure for the Local NVMe service. Service runs in the embedded Disk Agent.

Introduced `ILocalNVMeDeviceProvider` interface for obtaining NVMe device lists from different sources and its implementation for loading NVMe devices from a file.

Added `TLocalNVMeConfig` with `DevicesSourceUri` field to specify device list source (e.g., `file:///etc/nbs/devices.txt`).
Added `--local-nvme-file` CLI option for config loading.


#5250