### PR TITLE
Backport EnableNodeBrokerDeltaProtocol YDB feature flag

### DIFF
--- a/contrib/ydb/core/protos/feature_flags.proto
+++ b/contrib/ydb/core/protos/feature_flags.proto
@@ -130,4 +130,5 @@ message TFeatureFlags {
     optional bool EnableAddColumsWithDefaults = 115 [ default = false];
     optional bool EnableReplaceIfExistsForExternalEntities = 116 [ default = false];
     optional bool EnableStableNodeNames = 122 [default = false];
+    optional bool EnableNodeBrokerDeltaProtocol = 185 [default = false];
 }


### PR DESCRIPTION
From https://github.com/ydb-platform/ydb/pull/17616

Blockstore requires new YDB feature flag EnableNodeBrokerDeltaProtocol to be set from CMS at node registration.