### PR TITLE
issue-4782: taking TIndexTabletActor's cpu usage into account for IsOverloaded flag calculation

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -726,4 +726,8 @@ message TStorageConfig
     // propagated to newly created files (including directories, symlinks, etc.)
     // inside that directory.
     optional bool GidPropagationEnabled = 481;
+
+    // If tablet actor CPU usage goes over this threshold, tablets will start
+    // setting the IsOverloaded flag in their responses.
+    optional uint32 TabletActorCpuUsageOverloadThreshold = 482;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -314,7 +314,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(ReadBlobDisabled,                  bool,      false                   )\
     xxx(WriteBlobDisabled,                 bool,      false                   )\
                                                                                \
-    xxx(CpuLackOverloadThreshold,          ui32,      101                     )\
+    xxx(CpuLackOverloadThreshold,               ui32,      101                )\
+    xxx(TabletActorCpuUsageOverloadThreshold,   ui32,      101                )\
                                                                                \
     xxx(MaxTabletStep,                     ui32,      Max<ui32>()             )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -378,6 +378,7 @@ public:
     bool GetWriteBlobDisabled() const;
 
     ui32 GetCpuLackOverloadThreshold() const;
+    ui32 GetTabletActorCpuUsageOverloadThreshold() const;
 
     ui32 GetMaxTabletStep() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -206,7 +206,11 @@ void TIndexTabletActor::CompleteTx_AddData(
     }
 
     NProto::TBackendInfo backendInfo;
-    BuildBackendInfo(*Config, *SystemCounters, &backendInfo);
+    BuildBackendInfo(
+        *Config,
+        *SystemCounters,
+        Metrics.CPUUsageRate,
+        &backendInfo);
 
     auto actor = std::make_unique<TAddDataActor>(
         TraceSerializer,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -1113,7 +1113,11 @@ void TIndexTabletActor::CompleteTx_ReadData(
     AcquireCollectBarrier(args.CommitId);
 
     NProto::TBackendInfo backendInfo;
-    BuildBackendInfo(*Config, *SystemCounters, &backendInfo);
+    BuildBackendInfo(
+        *Config,
+        *SystemCounters,
+        Metrics.CPUUsageRate,
+        &backendInfo);
 
     auto actor = std::make_unique<TReadDataActor>(
         TraceSerializer,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -109,7 +109,11 @@ void TIndexTabletActor::CompleteResponse(
         FormatError(response.GetError()).c_str(),
         builtTraceInfo);
     BuildThrottlerInfo(*callContext, response);
-    BuildBackendInfo(*Config, *SystemCounters, response);
+    BuildBackendInfo(
+        *Config,
+        *SystemCounters,
+        Metrics.CPUUsageRate,
+        response);
     if constexpr (HasResponseHeaders<decltype(response)>()) {
         const auto& responseHeaders = response.GetHeaders();
         if (responseHeaders.GetBackendInfo().GetIsOverloaded()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -485,7 +485,11 @@ void TIndexTabletActor::CompleteTx_WriteData(
     AcquireCollectBarrier(args.CommitId);
 
     NProto::TBackendInfo backendInfo;
-    BuildBackendInfo(*Config, *SystemCounters, &backendInfo);
+    BuildBackendInfo(
+        *Config,
+        *SystemCounters,
+        Metrics.CPUUsageRate,
+        &backendInfo);
 
     auto actor = std::make_unique<TWriteDataActor>(
         TraceSerializer,

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -76,7 +76,8 @@ TTestEnv::TTestEnv(
         NProto::TStorageConfig storageConfig,
         NKikimr::NFake::TCaches cachesConfig,
         IProfileLogPtr profileLog,
-        NProto::TDiagnosticsConfig diagConfig)
+        NProto::TDiagnosticsConfig diagConfig,
+        bool useRealThreads)
     : Config(std::move(config))
     , Logging(CreateLoggingService("console", { TLOG_DEBUG }))
     , ProfileLog(std::move(profileLog))
@@ -86,7 +87,7 @@ TTestEnv::TTestEnv(
             "NFS_TRACE",
             NLwTraceMonPage::TraceManager(false)))
     , SystemCounters(MakeIntrusive<TSystemCounters>())
-    , Runtime(Config.StaticNodes + Config.DynamicNodes, false)
+    , Runtime(Config.StaticNodes + Config.DynamicNodes, useRealThreads)
     , NextDynamicNode(Config.StaticNodes)
     , Counters(MakeIntrusive<NMonitoring::TDynamicCounters>())
 {

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -107,7 +107,8 @@ public:
         NProto::TStorageConfig storageConfig = {},
         NKikimr::NFake::TCaches cachesConfig = {},
         IProfileLogPtr profileLog = CreateProfileLogStub(),
-        NProto::TDiagnosticsConfig diagConfig = {});
+        NProto::TDiagnosticsConfig diagConfig = {},
+        bool useRealThreads = false);
 
     void UpdateStorageConfig(NProto::TStorageConfig storageConfig);
 


### PR DESCRIPTION
### Notes
We can get bottlenecked by `TIndexTabletActor` code so we need to take its cpu usage into account for `IsOverloaded` flag calculation - in order not to send `ReadData` requests to overloaded tablet actors (preferring cheaper `DescribeData` requests instead).

See https://github.com/ydb-platform/nbs/issues/4782#issuecomment-3800124941 for more details

### Issue
https://github.com/ydb-platform/nbs/issues/4782