### PR TITLE
issue-4853: logging all requests to profile log, not dropping those where HasData() == false

### DIFF
--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -32,12 +32,10 @@ void TInFlightRequest::Complete(
         currentTs.MicroSeconds() - ProfileLogRequest.GetTimestampMcs());
     ProfileLogRequest.SetErrorCode(error.GetCode());
 
-    if (HasLogData()) {
-        ProfileLog->Write({
-            CallContext->FileSystemId,
-            std::move(ProfileLogRequest)});
-        ProfileLogRequest.Clear();
-    }
+    ProfileLog->Write({
+        CallContext->FileSystemId,
+        std::move(ProfileLogRequest)});
+    ProfileLogRequest.Clear();
 
     //
     // Signalling request completion - after this line this request may be

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1095,43 +1095,43 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         profileLog->Start();
 
         service.CreateFileStore("test", 1'000);
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, profileLog->Requests.size());
 
         service.AlterFileStore("test", "yyyy", "zzzz");
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, profileLog->Requests.size());
 
         service.ResizeFileStore("test", 100'000'000);
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(3, profileLog->Requests.size());
 
-        service.DescribeFileStoreModel(1_GB/DefaultBlockSize);
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        service.DescribeFileStoreModel(1_GB / DefaultBlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(3, profileLog->Requests.size());
 
         service.ListFileStores();
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(4, profileLog->Requests.size());
 
         auto headers = service.InitSession("test", "client");
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(5, profileLog->Requests.size());
 
         service.PingSession(headers);
-        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(5, profileLog->Requests.size());
 
         service.CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"));
-        UNIT_ASSERT_VALUES_EQUAL(1, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(6, profileLog->Requests.size());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
             profileLog->Requests[static_cast<ui32>(EFileStoreRequest::CreateNode)].size());
 
         service.ListNodes(headers, 1);
-        UNIT_ASSERT_VALUES_EQUAL(2, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(7, profileLog->Requests.size());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
             profileLog->Requests[static_cast<ui32>(EFileStoreRequest::ListNodes)].size());
 
         service.DestroySession(headers);
-        UNIT_ASSERT_VALUES_EQUAL(2, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(8, profileLog->Requests.size());
 
         service.DestroyFileStore("test");
-        UNIT_ASSERT_VALUES_EQUAL(2, profileLog->Requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(9, profileLog->Requests.size());
 
         profileLog->Stop();
     }

--- a/cloud/filestore/tests/profile_log/qemu-kikimr-test/canondata/test.test_profile_log/results.txt
+++ b/cloud/filestore/tests/profile_log/qemu-kikimr-test/canondata/test.test_profile_log/results.txt
@@ -6,6 +6,7 @@ VHOST profile:
 AcquireLock
 CreateHandle
 CreateNode
+CreateSession
 DestroyHandle
 Flush
 GetNodeAttr
@@ -14,6 +15,8 @@ ListNodes
 ReadData
 ReadLink
 RenameNode
+ResetSession
 SetNodeAttr
+StatFileStore
 UnlinkNode
 WriteData


### PR DESCRIPTION
### Notes
There's a weird check that disables logging to profile log for some of the requests - we can drop important log records because of that check. Before removing that check I added counters to make sure that the amount of log records dropped by that check is not huge: https://github.com/ydb-platform/nbs/commit/c6faf93b5efcda8af4586d8678ff464d269c268a - turns out that it's rather small and we won't inflate our log size so it's safe to remove that check - removing it in this PR. 

### Issue
The commit where I added counters for requests w error / w logdata / w/o logdata was linked to https://github.com/ydb-platform/nbs/issues/4853 so linking this one to the same issue as well