### PR TITLE
rename interface IIncompleteRequestProcessor  to IStatsHandler

### DIFF
--- a/cloud/blockstore/libs/diagnostics/incomplete_request_processor.cpp
+++ b/cloud/blockstore/libs/diagnostics/incomplete_request_processor.cpp
@@ -3,7 +3,7 @@
 #include "incomplete_requests.h"
 #include "server_stats.h"
 
-#include <cloud/storage/core/libs/diagnostics/incomplete_request_processor.h>
+#include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 
 namespace NCloud::NBlockStore {
 

--- a/cloud/blockstore/libs/diagnostics/public.h
+++ b/cloud/blockstore/libs/diagnostics/public.h
@@ -60,6 +60,9 @@ using IMetricConsumerPtr = std::shared_ptr<NMonitoring::IMetricConsumer>;
 struct IIncompleteRequestProvider;
 using IIncompleteRequestProviderPtr = std::shared_ptr<IIncompleteRequestProvider>;
 
+using IIncompleteRequestProcessor = NCloud::IStatsHandler;
+using IIncompleteRequestProcessorPtr = NCloud::IStatsHandlerPtr;
+
 struct IProfileLog;
 using IProfileLogPtr = std::shared_ptr<IProfileLog>;
 

--- a/cloud/filestore/libs/diagnostics/request_stats.h
+++ b/cloud/filestore/libs/diagnostics/request_stats.h
@@ -7,7 +7,7 @@
 #include <cloud/filestore/libs/service/public.h>
 #include <cloud/filestore/libs/service/request.h>
 
-#include <cloud/storage/core/libs/diagnostics/incomplete_request_processor.h>
+#include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
@@ -52,7 +52,7 @@ struct IRequestStats
 ////////////////////////////////////////////////////////////////////////////////
 
 struct IRequestStatsRegistry
-    : public IIncompleteRequestProcessor
+    : public IStatsHandler
 {
     virtual IRequestStatsPtr GetRequestStats() = 0;
 

--- a/cloud/storage/core/libs/diagnostics/public.h
+++ b/cloud/storage/core/libs/diagnostics/public.h
@@ -73,9 +73,8 @@ using IStatsPtr = std::shared_ptr<IStats>;
 struct IStatsUpdater;
 using IStatsUpdaterPtr = std::shared_ptr<IStatsUpdater>;
 
-struct IIncompleteRequestProcessor;
-using IIncompleteRequestProcessorPtr =
-    std::shared_ptr<IIncompleteRequestProcessor>;
+struct IStatsHandler;
+using IStatsHandlerPtr = std::shared_ptr<IStatsHandler>;
 
 struct IPostponeTimePredictor;
 using IPostponeTimePredictorPtr = std::shared_ptr<IPostponeTimePredictor>;

--- a/cloud/storage/core/libs/diagnostics/stats_handler.cpp
+++ b/cloud/storage/core/libs/diagnostics/stats_handler.cpp
@@ -1,4 +1,4 @@
-#include "incomplete_request_processor.h"
+#include "stats_handler.h"
 
 #include <memory>
 
@@ -8,8 +8,8 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TIncompleteRequestProcessorStub
-    : public IIncompleteRequestProcessor
+struct TStatsHandlerStub
+    : public IStatsHandler
 {
     void UpdateStats(bool updateIntervalFinished) override
     {
@@ -21,9 +21,9 @@ struct TIncompleteRequestProcessorStub
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IIncompleteRequestProcessorPtr CreateIncompleteRequestProcessorStub()
+IStatsHandlerPtr CreateStatsHandlerStub()
 {
-    return std::make_shared<TIncompleteRequestProcessorStub>();
+    return std::make_shared<TStatsHandlerStub>();
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/stats_handler.h
+++ b/cloud/storage/core/libs/diagnostics/stats_handler.h
@@ -6,15 +6,15 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IIncompleteRequestProcessor
+struct IStatsHandler
 {
-    virtual ~IIncompleteRequestProcessor() = default;
+    virtual ~IStatsHandler() = default;
 
     virtual void UpdateStats(bool updateIntervalFinished) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IIncompleteRequestProcessorPtr CreateInflightRequestCollectorStub();
+IStatsHandlerPtr CreateStatsHandlerStub();
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/stats_updater.cpp
+++ b/cloud/storage/core/libs/diagnostics/stats_updater.cpp
@@ -1,6 +1,6 @@
 #include "stats_updater.h"
 
-#include "incomplete_request_processor.h"
+#include "stats_handler.h"
 
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
@@ -22,7 +22,7 @@ struct TStatsUpdater
 protected:
     const ITimerPtr Timer;
     const ISchedulerPtr Scheduler;
-    const IIncompleteRequestProcessorPtr Collector;
+    const IStatsHandlerPtr StatsHandler;
 
     TAtomic ShouldStop = 0;
 
@@ -32,7 +32,7 @@ public:
     TStatsUpdater(
             ITimerPtr timer,
             ISchedulerPtr scheduler,
-            IIncompleteRequestProcessorPtr collector);
+            IStatsHandlerPtr statsHandler);
 
     void Start() override;
     void Stop() override;
@@ -47,10 +47,10 @@ private:
 TStatsUpdater::TStatsUpdater(
         ITimerPtr timer,
         ISchedulerPtr scheduler,
-        IIncompleteRequestProcessorPtr collector)
+        IStatsHandlerPtr statsHandler)
     : Timer(std::move(timer))
     , Scheduler(std::move(scheduler))
-    , Collector(std::move(collector))
+    , StatsHandler(std::move(statsHandler))
 {
 }
 
@@ -69,7 +69,7 @@ void TStatsUpdater::UpdateStats()
     bool updateIntervalFinished =
         (++UpdateStatsCounter % UpdateCountersInterval.Seconds() == 0);
 
-    Collector->UpdateStats(updateIntervalFinished);
+    StatsHandler->UpdateStats(updateIntervalFinished);
 }
 
 void TStatsUpdater::ScheduleUpdateStats()
@@ -97,12 +97,12 @@ void TStatsUpdater::ScheduleUpdateStats()
 IStatsUpdaterPtr CreateStatsUpdater(
     ITimerPtr timer,
     ISchedulerPtr scheduler,
-    IIncompleteRequestProcessorPtr collector)
+    IStatsHandlerPtr statsHandler)
 {
     return std::make_shared<TStatsUpdater>(
         std::move(timer),
         std::move(scheduler),
-        std::move(collector)
+        std::move(statsHandler)
     );
 }
 

--- a/cloud/storage/core/libs/diagnostics/stats_updater.h
+++ b/cloud/storage/core/libs/diagnostics/stats_updater.h
@@ -28,6 +28,6 @@ struct IStatsUpdater
 IStatsUpdaterPtr CreateStatsUpdater(
     ITimerPtr timer,
     ISchedulerPtr scheduler,
-    IIncompleteRequestProcessorPtr collector);
+    IStatsHandlerPtr statsHandler);
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/ya.make
+++ b/cloud/storage/core/libs/diagnostics/ya.make
@@ -8,7 +8,7 @@ SRCS(
     executor_counters.cpp
     histogram_types.cpp
     histogram.cpp
-    incomplete_request_processor.cpp
+    stats_handler.cpp
     logging.cpp
     max_calculator.cpp
     monitoring.cpp


### PR DESCRIPTION
I am planing to add new lightweight stats without dependency to requests stats and want to reuse some code related to update stats mechanic. 