### PR TITLE
Backport YDB PR 33006: [ICB] IsDefault() and GetDefault() methods for TControlWrapper

### DIFF
--- a/contrib/ydb/core/control/immediate_control_board_wrapper.h
+++ b/contrib/ydb/core/control/immediate_control_board_wrapper.h
@@ -21,6 +21,14 @@ public:
         return Control->Get();
     }
 
+    bool IsDefault() const {
+        return Control->IsDefault();
+    }
+
+    TAtomicBase GetDefault() const {
+        return Control->GetDefault();
+    }
+
     i64 operator=(i64 value) {
         Control->Set(value);
         return value;


### PR DESCRIPTION
#5106
Backport of https://github.com/ydb-platform/ydb/pull/33006
