### PR TITLE
filestore tablet actor: {Add/Remove}Transaction -> {Add/Remove}InFlightRequest + some other related cleanup

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_accessnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_accessnode.cpp
@@ -39,7 +39,7 @@ void TIndexTabletActor::HandleAccessNode(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TAccessNodeMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TAccessNodeMethod>(*requestInfo);
 
     ExecuteTx<TAccessNode>(
         ctx,
@@ -104,7 +104,7 @@ void TIndexTabletActor::CompleteTx_AccessNode(
     const TActorContext& ctx,
     TTxIndexTablet::TAccessNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvAccessNodeResponse>(args.Error);
     CompleteResponse<TEvService::TAccessNodeMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_acquirelock.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_acquirelock.cpp
@@ -58,7 +58,7 @@ void TIndexTabletActor::HandleAcquireLock(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TAcquireLockMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TAcquireLockMethod>(*requestInfo);
 
     ExecuteTx<TAcquireLock>(
         ctx,
@@ -111,7 +111,7 @@ void TIndexTabletActor::CompleteTx_AcquireLock(
     const TActorContext& ctx,
     TTxIndexTablet::TAcquireLock& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvAcquireLockResponse>(args.Error);
     CompleteResponse<TEvService::TAcquireLockMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -134,7 +134,7 @@ void TIndexTabletActor::CompleteTx_AddData(
     const TActorContext& ctx,
     TTxIndexTablet::TAddData& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto reply = [&](const TActorContext& ctx, TTxIndexTablet::TAddData& args)
     {
@@ -521,7 +521,7 @@ void TIndexTabletActor::HandleAddData(
             approximateFreeSpaceShare);
     }
 
-    AddTransaction<TEvIndexTablet::TAddDataMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TAddDataMethod>(*requestInfo);
 
     ExecuteTx<TAddData>(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -89,7 +89,7 @@ void TIndexTabletActor::HandleAllocateData(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TAllocateDataMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TAllocateDataMethod>(*requestInfo);
 
     ExecuteTx<TAllocateData>(
         ctx,
@@ -243,7 +243,7 @@ void TIndexTabletActor::CompleteTx_AllocateData(
 {
     InvalidateNodeCaches(args.NodeId);
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvAllocateDataResponse>(args.Error);
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
@@ -43,7 +43,7 @@ void TIndexTabletActor::CompleteTx_ChangeStorageConfig(
     const TActorContext& ctx,
     TTxIndexTablet::TChangeStorageConfig& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvIndexTablet::TEvChangeStorageConfigResponse>();
@@ -65,7 +65,8 @@ void TIndexTabletActor::HandleChangeStorageConfig(
         MakeIntrusive<TCallContext>());
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TChangeStorageConfigMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TChangeStorageConfigMethod>(
+        *requestInfo);
 
     const auto* msg = ev->Get();
     ExecuteTx<TChangeStorageConfig>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
@@ -30,7 +30,7 @@ void TIndexTabletActor::HandleCreateCheckpoint(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TCreateCheckpointMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TCreateCheckpointMethod>(*requestInfo);
 
     ExecuteTx<TCreateCheckpoint>(
         ctx,
@@ -83,7 +83,7 @@ void TIndexTabletActor::CompleteTx_CreateCheckpoint(
     TTxIndexTablet::TCreateCheckpoint& args)
 {
     // TODO(#1146) checkpoint-related tables are not yet supported
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvCreateCheckpointResponse>(args.Error);
     CompleteResponse<TEvService::TCreateCheckpointMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -132,7 +132,7 @@ void TIndexTabletActor::HandleCreateHandle(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TCreateHandleMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TCreateHandleMethod>(*requestInfo);
 
     ExecuteTx<TCreateHandle>(
         ctx,
@@ -489,7 +489,7 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         return;
     }
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvService::TEvCreateHandleResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -530,7 +530,7 @@ void TIndexTabletActor::HandleCreateNode(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TCreateNodeMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TCreateNodeMethod>(*requestInfo);
 
     ExecuteTx<TCreateNode>(
         ctx,
@@ -869,7 +869,7 @@ void TIndexTabletActor::CompleteTx_CreateNode(
         return;
     }
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvService::TEvCreateNodeResponse>(args.Error);
@@ -928,7 +928,7 @@ void TIndexTabletActor::HandleNodeCreatedInShard(
     auto& res = msg->Result;
 
     if (msg->RequestInfo) {
-        RemoveTransaction(*msg->RequestInfo);
+        RemoveInFlightRequest(*msg->RequestInfo);
     }
 
     WorkerActors.erase(ev->Sender);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -225,7 +225,7 @@ void TIndexTabletActor::HandleCreateSession(
             message.c_str());
     }
 
-    AddTransaction<TEvIndexTablet::TCreateSessionMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TCreateSessionMethod>(*requestInfo);
 
     ExecuteTx<TCreateSession>(
         ctx,
@@ -366,7 +366,7 @@ void TIndexTabletActor::CompleteTx_CreateSession(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateSession& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     using TResponse = TEvIndexTablet::TEvCreateSessionResponse;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -42,7 +42,8 @@ void TIndexTabletActor::HandleDeleteCheckpoint(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTabletPrivate::TDeleteCheckpointMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTabletPrivate::TDeleteCheckpointMethod>(
+        *requestInfo);
 
     ExecuteTx<TDeleteCheckpoint>(
         ctx,
@@ -251,7 +252,7 @@ void TIndexTabletActor::CompleteTx_DeleteCheckpoint(
     TTxIndexTablet::TDeleteCheckpoint& args)
 {
     // TODO(#1146) checkpoint-related tables are not yet supported
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
         "%s DeleteCheckpoint completed (%s)",

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -44,7 +44,7 @@ void TIndexTabletActor::HandleDestroyHandle(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TDestroyHandleMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TDestroyHandleMethod>(*requestInfo);
 
     ExecuteTx<TDestroyHandle>(
         ctx,
@@ -125,7 +125,7 @@ void TIndexTabletActor::CompleteTx_DestroyHandle(
     const TActorContext& ctx,
     TTxIndexTablet::TDestroyHandle& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     if (!HasError(args.Error)) {
         Metrics.DestroyHandle.Update(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -71,7 +71,7 @@ void TIndexTabletActor::HandleDestroySession(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TDestroySessionMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TDestroySessionMethod>(*requestInfo);
 
     ExecuteTx<TDestroySession>(
         ctx,
@@ -182,7 +182,7 @@ void TIndexTabletActor::CompleteTx_DestroySession(
     const TActorContext& ctx,
     TTxIndexTablet::TDestroySession& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvIndexTablet::TEvDestroySessionResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -92,7 +92,7 @@ void TIndexTabletActor::HandleGetNodeAttr(
         }
     }
 
-    AddTransaction<TEvService::TGetNodeAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TGetNodeAttrMethod>(*requestInfo);
 
     ExecuteTx<TGetNodeAttr>(
         ctx,
@@ -194,7 +194,7 @@ void TIndexTabletActor::CompleteTx_GetNodeAttr(
     const TActorContext& ctx,
     TTxIndexTablet::TGetNodeAttr& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {
@@ -288,7 +288,7 @@ void TIndexTabletActor::HandleGetNodeAttrBatch(
         return;
     }
 
-    AddTransaction<TEvService::TGetNodeAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TGetNodeAttrBatchMethod>(*requestInfo);
 
     ExecuteTx<TGetNodeAttrBatch>(
         ctx,
@@ -428,7 +428,7 @@ void TIndexTabletActor::CompleteTx_GetNodeAttrBatch(
     const TActorContext& ctx,
     TTxIndexTablet::TGetNodeAttrBatch& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     using TResponse = TEvIndexTablet::TEvGetNodeAttrBatchResponse;
     auto response = std::make_unique<TResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
@@ -43,7 +43,7 @@ void TIndexTabletActor::HandleGetNodeXAttr(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TGetNodeXAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TGetNodeXAttrMethod>(*requestInfo);
 
     ExecuteTx<TGetNodeXAttr>(
         ctx,
@@ -116,7 +116,7 @@ void TIndexTabletActor::CompleteTx_GetNodeXAttr(
     const TActorContext& ctx,
     TTxIndexTablet::TGetNodeXAttr& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvGetNodeXAttrResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -63,7 +63,7 @@ void TIndexTabletActor::HandleListNodes(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TListNodesMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TListNodesMethod>(*requestInfo);
 
     auto maxBytes = Min(
         Config->GetMaxResponseEntries() * MaxName,
@@ -182,7 +182,7 @@ void TIndexTabletActor::CompleteTx_ListNodes(
     const TActorContext& ctx,
     TTxIndexTablet::TListNodes& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvListNodesResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
@@ -39,7 +39,7 @@ void TIndexTabletActor::HandleListNodeXAttr(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TListNodeXAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TListNodeXAttrMethod>(*requestInfo);
 
     ExecuteTx<TListNodeXAttr>(
         ctx,
@@ -106,7 +106,7 @@ void TIndexTabletActor::CompleteTx_ListNodeXAttr(
     const TActorContext& ctx,
     TTxIndexTablet::TListNodeXAttr& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvListNodeXAttrResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -148,7 +148,7 @@ void TIndexTabletActor::HandleDeleteOpLogEntry(
         ev->Cookie,
         msg->CallContext);
 
-    AddTransaction<TEvIndexTabletPrivate::TDeleteOpLogEntryMethod>(
+    AddInFlightRequest<TEvIndexTabletPrivate::TDeleteOpLogEntryMethod>(
         *requestInfo);
 
     ExecuteTx<TDeleteOpLogEntry>(
@@ -192,7 +192,7 @@ void TIndexTabletActor::CompleteTx_DeleteOpLogEntry(
         args.EntryId);
 
     if (args.RequestInfo) {
-        RemoveTransaction(*args.RequestInfo);
+        RemoveInFlightRequest(*args.RequestInfo);
         using TResponse = TEvIndexTabletPrivate::TEvDeleteOpLogEntryResponse;
         auto response = std::make_unique<TResponse>();
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
@@ -212,7 +212,8 @@ void TIndexTabletActor::HandleGetOpLogEntry(
         ev->Cookie,
         msg->CallContext);
 
-    AddTransaction<TEvIndexTabletPrivate::TGetOpLogEntryMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTabletPrivate::TGetOpLogEntryMethod>(
+        *requestInfo);
 
     ExecuteTx<TGetOpLogEntry>(
         ctx,
@@ -247,7 +248,7 @@ void TIndexTabletActor::CompleteTx_GetOpLogEntry(
     const TActorContext& ctx,
     TTxIndexTablet::TGetOpLogEntry& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
         "%s GetOpLogEntry completed (%lu): %s",
@@ -276,7 +277,8 @@ void TIndexTabletActor::HandleWriteOpLogEntry(
         ev->Cookie,
         msg->CallContext);
 
-    AddTransaction<TEvIndexTabletPrivate::TWriteOpLogEntryMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTabletPrivate::TWriteOpLogEntryMethod>(
+        *requestInfo);
 
     ExecuteTx<TWriteOpLogEntry>(
         ctx,
@@ -320,7 +322,7 @@ void TIndexTabletActor::CompleteTx_WriteOpLogEntry(
     const TActorContext& ctx,
     TTxIndexTablet::TWriteOpLogEntry& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     if (HasError(args.Error)) {
         LOG_ERROR(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -661,7 +661,7 @@ void TIndexTabletActor::HandleReadData(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TReadDataMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TReadDataMethod>(*requestInfo);
 
     TByteRange alignedByteRange = byteRange.AlignedSuperRange();
     auto blockBuffer = CreateBlockBuffer(alignedByteRange);
@@ -793,7 +793,7 @@ void TIndexTabletActor::HandleDescribeData(
         return;
     }
 
-    AddTransaction<TEvIndexTablet::TDescribeDataMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TDescribeDataMethod>(*requestInfo);
 
     TByteRange alignedByteRange = byteRange.AlignedSuperRange();
     auto blockBuffer = CreateLazyBlockBuffer(alignedByteRange);
@@ -981,7 +981,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
     const TActorContext& ctx,
     TTxIndexTablet::TReadData& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     Y_DEFER {
         ReleaseMixedBlocks(args.MixedBlocksRanges);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp
@@ -39,7 +39,7 @@ void TIndexTabletActor::HandleReadLink(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TReadLinkMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TReadLinkMethod>(*requestInfo);
 
     ExecuteTx<TReadLink>(
         ctx,
@@ -98,7 +98,7 @@ void TIndexTabletActor::CompleteTx_ReadLink(
     const TActorContext& ctx,
     TTxIndexTablet::TReadLink& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvReadLinkResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readnoderefs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readnoderefs.cpp
@@ -53,7 +53,7 @@ void TIndexTabletActor::CompleteTx_ReadNodeRefs(
     const TActorContext& ctx,
     TTxIndexTablet::TReadNodeRefs& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET,
@@ -89,7 +89,7 @@ void TIndexTabletActor::HandleReadNodeRefs(
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TReadNodeRefsMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TReadNodeRefsMethod>(*requestInfo);
 
     ExecuteTx<TReadNodeRefs>(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_releaselock.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_releaselock.cpp
@@ -24,7 +24,7 @@ void TIndexTabletActor::HandleReleaseLock(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TReleaseLockMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TReleaseLockMethod>(*requestInfo);
 
     ExecuteTx<TReleaseLock>(
         ctx,
@@ -92,7 +92,7 @@ void TIndexTabletActor::CompleteTx_ReleaseLock(
     const TActorContext& ctx,
     TTxIndexTablet::TReleaseLock& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvReleaseLockResponse>(args.Error);
     CompleteResponse<TEvService::TReleaseLockMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
@@ -32,7 +32,11 @@ void TIndexTabletActor::HandleRemoveNodeXAttr(
     const TEvService::TEvRemoveNodeXAttrRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    if (!AcceptRequest<TEvService::TRemoveNodeXAttrMethod>(ev, ctx, ValidateRequest)) {
+    const bool accepted = AcceptRequest<TEvService::TRemoveNodeXAttrMethod>(
+        ev,
+        ctx,
+        ValidateRequest);
+    if (!accepted) {
         return;
     }
 
@@ -43,7 +47,7 @@ void TIndexTabletActor::HandleRemoveNodeXAttr(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TRemoveNodeXAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TRemoveNodeXAttrMethod>(*requestInfo);
 
     ExecuteTx<TRemoveNodeXAttr>(
         ctx,
@@ -119,7 +123,7 @@ void TIndexTabletActor::CompleteTx_RemoveNodeXAttr(
     const TActorContext& ctx,
     TTxIndexTablet::TRemoveNodeXAttr& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvRemoveNodeXAttrResponse>(args.Error);
     CompleteResponse<TEvService::TRemoveNodeXAttrMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -79,7 +79,7 @@ void TIndexTabletActor::HandleRenameNode(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TRenameNodeMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TRenameNodeMethod>(*requestInfo);
 
     // we have separate logic for cross-shard move ops, see the following link
     // for more details:
@@ -560,7 +560,7 @@ void TIndexTabletActor::CompleteTx_RenameNode(
         NotifySessionEvent(ctx, sessionEvent);
     }
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     Metrics.RenameNode.Update(
         1,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -399,7 +399,7 @@ void TIndexTabletActor::HandleRenameNodeInDestination(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TMethod>(*requestInfo);
+    AddInFlightRequest<TMethod>(*requestInfo);
 
     ExecuteTx<TRenameNodeInDestination>(
         ctx,
@@ -760,7 +760,7 @@ void TIndexTabletActor::CompleteTx_RenameNodeInDestination(
         // TODO(#1350): support session events for external nodes
     }
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     Metrics.RenameNodeInDestination.Update(
         1,
@@ -800,7 +800,7 @@ void TIndexTabletActor::HandleUnlinkDirectoryNodeAbortedInShard(
         return;
     }
 
-    RemoveTransaction(*msg->RequestInfo);
+    RemoveInFlightRequest(*msg->RequestInfo);
 
     Metrics.RenameNodeInDestination.Update(
         1,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -445,7 +445,7 @@ void TIndexTabletActor::HandleCommitRenameNodeInSource(
         ev->Cookie,
         msg->CallContext);
 
-    AddTransaction<TEvIndexTabletPrivate::TCommitRenameNodeInSourceMethod>(
+    AddInFlightRequest<TEvIndexTabletPrivate::TCommitRenameNodeInSourceMethod>(
         *requestInfo);
 
     ExecuteTx<TCommitRenameNodeInSource>(
@@ -581,7 +581,7 @@ void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(
         return;
     }
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     if (args.IsExplicitRequest) {
         using TResponse =

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -55,7 +55,7 @@ void TIndexTabletActor::HandleResetSession(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TResetSessionMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TResetSessionMethod>(*requestInfo);
 
     ExecuteTx<TResetSession>(
         ctx,
@@ -181,7 +181,7 @@ void TIndexTabletActor::CompleteTx_ResetSession(
     const TActorContext& ctx,
     TTxIndexTablet::TResetSession& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvService::TEvResetSessionResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resolvepath.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resolvepath.cpp
@@ -44,7 +44,7 @@ void TIndexTabletActor::HandleResolvePath(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TResolvePathMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TResolvePathMethod>(*requestInfo);
 
     ExecuteTx<TResolvePath>(
         ctx,
@@ -80,7 +80,7 @@ void TIndexTabletActor::CompleteTx_ResolvePath(
     const TActorContext& ctx,
     TTxIndexTablet::TResolvePath& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvResolvePathResponse>(args.Error);
     CompleteResponse<TEvService::TResolvePathMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_set_has_xattrs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_set_has_xattrs.cpp
@@ -57,7 +57,7 @@ void TIndexTabletActor::CompleteTx_SetHasXAttrs(
     const TActorContext& ctx,
     TTxIndexTablet::TSetHasXAttrs& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvIndexTablet::TEvSetHasXAttrsResponse>();
 
@@ -88,7 +88,7 @@ void TIndexTabletActor::HandleSetHasXAttrs(
         MakeIntrusive<TCallContext>());
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TSetHasXAttrsMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TSetHasXAttrsMethod>(*requestInfo);
 
     const auto* msg = ev->Get();
     ExecuteTx<TSetHasXAttrs>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -74,7 +74,7 @@ void TIndexTabletActor::HandleSetNodeAttr(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TSetNodeAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TSetNodeAttrMethod>(*requestInfo);
 
     ExecuteTx<TSetNodeAttr>(
         ctx,
@@ -202,7 +202,7 @@ void TIndexTabletActor::CompleteTx_SetNodeAttr(
 {
     InvalidateNodeCaches(args.NodeId);
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvSetNodeAttrResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
@@ -38,7 +38,11 @@ void TIndexTabletActor::HandleSetNodeXAttr(
     const TEvService::TEvSetNodeXAttrRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    if (!AcceptRequest<TEvService::TSetNodeXAttrMethod>(ev, ctx, ValidateRequest)) {
+    const bool accepted = AcceptRequest<TEvService::TSetNodeXAttrMethod>(
+        ev,
+        ctx,
+        ValidateRequest);
+    if (!accepted) {
         return;
     }
 
@@ -49,7 +53,7 @@ void TIndexTabletActor::HandleSetNodeXAttr(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TSetNodeXAttrMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TSetNodeXAttrMethod>(*requestInfo);
 
     ExecuteTx<TSetNodeXAttr>(
         ctx,
@@ -141,7 +145,7 @@ void TIndexTabletActor::CompleteTx_SetNodeXAttr(
     const TActorContext& ctx,
     TTxIndexTablet::TSetNodeXAttr& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     if (SUCCEEDED(args.Error.GetCode())) {
         NProto::TSessionEvent sessionEvent;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_testlock.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_testlock.cpp
@@ -56,7 +56,7 @@ void TIndexTabletActor::HandleTestLock(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvService::TTestLockMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TTestLockMethod>(*requestInfo);
 
     ExecuteTx<TTestLock>(
         ctx,
@@ -114,7 +114,7 @@ void TIndexTabletActor::CompleteTx_TestLock(
     const TActorContext& ctx,
     TTxIndexTablet::TTestLock& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response = std::make_unique<TEvService::TEvTestLockResponse>(args.Error);
     if (args.Incompatible.has_value()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
@@ -176,7 +176,7 @@ void TIndexTabletActor::HandleAbortUnlinkDirectoryNodeInShard(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TAbortUnlinkDirectoryNodeInShardMethod>(
+    AddInFlightRequest<TEvIndexTablet::TAbortUnlinkDirectoryNodeInShardMethod>(
         *requestInfo);
 
     ExecuteTx<TAbortUnlinkDirectoryNode>(
@@ -298,7 +298,7 @@ void TIndexTabletActor::CompleteTx_AbortUnlinkDirectoryNode(
 
     InvalidateNodeCaches(args.Request.GetNodeId());
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
     EnqueueBlobIndexOpIfNeeded(ctx);
 
     if (!HasError(args.Error)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
@@ -24,8 +24,8 @@ void TIndexTabletActor::HandlePrepareUnlinkDirectoryNodeInShard(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TPrepareUnlinkDirectoryNodeInShardMethod>(
-        *requestInfo);
+    using TMethod = TEvIndexTablet::TPrepareUnlinkDirectoryNodeInShardMethod;
+    AddInFlightRequest<TMethod>(*requestInfo);
 
     ExecuteTx<TPrepareUnlinkDirectoryNode>(
         ctx,
@@ -132,7 +132,7 @@ void TIndexTabletActor::CompleteTx_PrepareUnlinkDirectoryNode(
 
     InvalidateNodeCaches(args.Request.GetNodeId());
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
     EnqueueBlobIndexOpIfNeeded(ctx);
 
     if (!HasError(args.Error)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
@@ -23,7 +23,7 @@ void TIndexTabletActor::HandleUnsafeDeleteNode(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeDeleteNodeMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeDeleteNodeMethod>(*requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeDeleteNode: %s",
@@ -78,7 +78,7 @@ void TIndexTabletActor::CompleteTx_UnsafeDeleteNode(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeDeleteNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeDeleteNode: %s, status: %s",
@@ -107,7 +107,7 @@ void TIndexTabletActor::HandleUnsafeUpdateNode(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeUpdateNodeMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeUpdateNodeMethod>(*requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeUpdateNode: %s",
@@ -182,7 +182,7 @@ void TIndexTabletActor::CompleteTx_UnsafeUpdateNode(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeUpdateNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     TString oldNode;
     if (args.Node) {
@@ -215,7 +215,7 @@ void TIndexTabletActor::HandleUnsafeGetNode(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeGetNodeMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeGetNodeMethod>(*requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeGetNode: %s",
@@ -258,7 +258,7 @@ void TIndexTabletActor::CompleteTx_UnsafeGetNode(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeGetNode& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvIndexTablet::TEvUnsafeGetNodeResponse>();
@@ -294,7 +294,8 @@ void TIndexTabletActor::HandleUnsafeCreateNodeRef(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeCreateNodeRefMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeCreateNodeRefMethod>(
+        *requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeCreateNodeRef: %s",
@@ -363,7 +364,7 @@ void TIndexTabletActor::CompleteTx_UnsafeCreateNodeRef(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeCreateNodeRef& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeCreateNodeRef: %s, status: %s",
@@ -392,7 +393,8 @@ void TIndexTabletActor::HandleUnsafeDeleteNodeRef(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeDeleteNodeRefMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeDeleteNodeRefMethod>(
+        *requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeDeleteNodeRef: %s",
@@ -464,7 +466,7 @@ void TIndexTabletActor::CompleteTx_UnsafeDeleteNodeRef(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeDeleteNodeRef& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeDeleteNodeRef: %s, status: %s",
@@ -493,7 +495,8 @@ void TIndexTabletActor::HandleUnsafeUpdateNodeRef(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeUpdateNodeRefMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeUpdateNodeRefMethod>(
+        *requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeUpdateNodeRef: %s",
@@ -574,7 +577,7 @@ void TIndexTabletActor::CompleteTx_UnsafeUpdateNodeRef(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeUpdateNodeRef& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeUpdateNodeRef: %s",
@@ -601,7 +604,7 @@ void TIndexTabletActor::HandleUnsafeGetNodeRef(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeGetNodeRefMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeGetNodeRefMethod>(*requestInfo);
 
     LOG_WARN(ctx, TFileStoreComponents::TABLET,
         "%s UnsafeGetNodeRef: %s",
@@ -645,7 +648,7 @@ void TIndexTabletActor::CompleteTx_UnsafeGetNodeRef(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeGetNodeRef& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvIndexTablet::TEvUnsafeGetNodeRefResponse>();
@@ -681,7 +684,7 @@ void TIndexTabletActor::HandleUnsafeCreateHandle(
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddTransaction<TEvIndexTablet::TUnsafeCreateHandleMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TUnsafeCreateHandleMethod>(*requestInfo);
 
     LOG_WARN(
         ctx,
@@ -749,7 +752,7 @@ void TIndexTabletActor::CompleteTx_UnsafeCreateHandle(
     const TActorContext& ctx,
     TTxIndexTablet::TUnsafeCreateHandle& args)
 {
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto response =
         std::make_unique<TEvIndexTablet::TEvUnsafeCreateHandleResponse>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writebatch.cpp
@@ -252,7 +252,9 @@ void TIndexTabletActor::HandleWriteBatch(
     }
 
     for (const auto& request: writeBatch) {
-        AddTransaction(*request.RequestInfo, request.RequestInfo->CancelRoutine);
+        AddInFlightRequest(
+            *request.RequestInfo,
+            request.RequestInfo->CancelRoutine);
     }
 
     auto batchInfo = GetBatchInfo(writeBatch);
@@ -495,7 +497,7 @@ void TIndexTabletActor::CompleteTx_WriteBatch(
     TTxIndexTablet::TWriteBatch& args)
 {
     for (const auto& request: args.WriteBatch) {
-        RemoveTransaction(*request.RequestInfo);
+        RemoveInFlightRequest(*request.RequestInfo);
     }
 
     auto reply = [] (

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -169,7 +169,7 @@ void TIndexTabletActor::HandleWriteData(
         return;
     }
 
-    AddTransaction<TEvService::TWriteDataMethod>(*requestInfo);
+    AddInFlightRequest<TEvService::TWriteDataMethod>(*requestInfo);
 
     ExecuteTx<TWriteData>(
         ctx,
@@ -392,7 +392,7 @@ void TIndexTabletActor::CompleteTx_WriteData(
 {
     InvalidateNodeCaches(args.NodeId);
 
-    RemoveTransaction(*args.RequestInfo);
+    RemoveInFlightRequest(*args.RequestInfo);
 
     auto reply = [&] (
         const TActorContext& ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
@@ -44,6 +44,8 @@ void TIndexTabletActor::HandleZeroRange(
         msg->CallContext,
         "ZeroRange");
 
+    AddInFlightRequest<TEvIndexTabletPrivate::TZeroRangeMethod>(*requestInfo);
+
     ExecuteTx<TZeroRange>(
         ctx,
         std::move(requestInfo),
@@ -93,6 +95,8 @@ void TIndexTabletActor::CompleteTx_ZeroRange(
     const TActorContext& ctx,
     TTxIndexTablet::TZeroRange& args)
 {
+    RemoveInFlightRequest(*args.RequestInfo);
+
     // log request
     FinalizeProfileLogRequestInfo(
         std::move(args.ProfileLogRequest),


### PR DESCRIPTION
### Notes
`{Add/Remove}Transaction` functions actually register/unregister inflight requests to be able to quickly reply with `E_REJECTED` to them upon tablet actor death. Renamed those functions and some other related ones ("Transaction" -> "InFlightRequest"). Also fixed the following issues:
* `GetNodeAttrBatch` used to register itself as `GetNodeAttr` so upon tablet death we used to reply with `TGetNodeAttrResponse` (which was wrong)
* inflight request registration was missing in the `ZeroRange` handler