### PR TITLE
issue-4938, issue-4949: fixed SetNodeAttr and AllocateData behaviour upon CommitIdOverflow

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -180,6 +180,8 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
 {
     FILESTORE_VALIDATE_TX_ERROR(AllocateData, args);
 
+    Y_UNUSED(ctx);
+
     const ui64 size = args.Offset + args.Length;
     const ui64 minBorder = Min(size, args.Node->Attrs.GetSize());
     const bool needExtend = args.Node->Attrs.GetSize() < size &&
@@ -198,7 +200,8 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
         // Here we should zero range in current file
         args.CommitId = GenerateCommitId();
         if (args.CommitId == InvalidCommitId) {
-            return ScheduleRebootTabletOnCommitIdOverflow(ctx, "AllocateData");
+            args.OnCommitIdOverflow();
+            return;
         }
         auto e = ZeroRange(
             db,
@@ -221,7 +224,8 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
     if (!shouldTruncateExistentRange) {
         args.CommitId = GenerateCommitId();
         if (args.CommitId == InvalidCommitId) {
-            return ScheduleRebootTabletOnCommitIdOverflow(ctx, "AllocateData");
+            args.OnCommitIdOverflow();
+            return;
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -133,7 +133,8 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
-        return ScheduleRebootTabletOnCommitIdOverflow(ctx, "SetAttr");
+        args.OnCommitIdOverflow();
+        return;
     }
 
     auto flags = args.Request.GetFlags();


### PR DESCRIPTION
### Notes
Similar to other CommitIdOverflow race fixes. If we fail to perform the operation because of CommitId overflow, we should return an error.

### Issue
https://github.com/ydb-platform/nbs/issues/4938
https://github.com/ydb-platform/nbs/issues/4949