### PR TITLE
issue-4664: disable zero-copy read when write-back cache is enabled

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -353,7 +353,7 @@ void TFileSystem::Read(
     request->SetOffset(offset);
     request->SetLength(size);
 
-    if (Config->GetZeroCopyReadEnabled()) {
+    if (!WriteBackCache && Config->GetZeroCopyReadEnabled()) {
         // TODO(issue-4800): Support ZeroCopyReadEnabled for local filestore
         struct iovec* iov = nullptr;
         int count = 0;


### PR DESCRIPTION
zero-copy read and write-back cache features are not compatible at this moment