### PR TITLE
Force-disable EnableListBasedRetryRules in blockstore-client

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -674,6 +674,10 @@ void TCommand::InitClientConfig()
         clientConfig.SetClientId(CreateGuidAsString());
     }
 
+    // This retry mode is not expected in blockstore-client
+    // as it can break some scripts (including release pipelines)
+    clientConfig.SetEnableListBasedRetryRules(false);
+
     ClientConfig = std::make_shared<TClientAppConfig>(appConfig);
 }
 


### PR DESCRIPTION
Force-disable EnableListBasedRetryRules for blockstore-client as more broad retriable errors subset breaks release scenarios
This feature is intended for customer experience and disabling it in blockstore-client doesn't pose a risk