### PR TITLE
[Filestore, Disk Agent] Apply allowed YDB feature flags, received from CMS on node registration

### DIFF
--- a/cloud/blockstore/libs/disk_agent/config_initializer.h
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.h
@@ -82,6 +82,10 @@ private:
     void ApplyDiskRegistryProxyConfig(const TString& text);
 
     void ApplySpdkEnvConfig(const NProto::TSpdkEnvConfig& config);
+
+    void ApplyNamedConfigs(const NKikimrConfig::TAppConfig& config);
+    void ApplyAllowedKikimrFeatureFlags(
+        const NKikimrConfig::TAppConfig& config);
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/filestore/libs/daemon/common/config_initializer.h
+++ b/cloud/filestore/libs/daemon/common/config_initializer.h
@@ -41,7 +41,8 @@ public:
     void InitStorageConfig();
     void InitFeaturesConfig();
 
-    void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config) final;
+    void ApplyCustomCMSConfigs(
+        const NKikimrConfig::TAppConfig& config) override;
 
     NCloud::NStorage::TNodeRegistrationSettings GetNodeRegistrationSettings();
 
@@ -51,6 +52,10 @@ private:
     void ApplyFeaturesConfig(const TString& text);
 
     void ApplyOptionsToStorageConfig(NProto::TStorageConfig& storageConfig);
+
+    void ApplyNamedConfigs(const NKikimrConfig::TAppConfig& config);
+    void ApplyAllowedKikimrFeatureFlags(
+        const NKikimrConfig::TAppConfig& config);
 };
 
 }   // namespace NCloud::NFileStore::NDaemon

--- a/cloud/filestore/libs/daemon/server/config_initializer_ut.cpp
+++ b/cloud/filestore/libs/daemon/server/config_initializer_ut.cpp
@@ -1,9 +1,12 @@
 #include "config_initializer.h"
+
 #include "options.h"
 
 #include <cloud/filestore/libs/diagnostics/config.h>
 #include <cloud/filestore/libs/server/config.h>
 #include <cloud/filestore/libs/storage/core/config.h>
+
+#include <contrib/ydb/core/protos/feature_flags.pb.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/protobuf/util/pb_io.h>
@@ -32,6 +35,107 @@ TOptionsServerPtr CreateOptions()
 {
     auto options = std::make_shared<TOptionsServer>();
     return options;
+}
+
+/**
+ * *LoadKikimrFeaturesFromCms implementation
+ */
+void ShouldLoadKikimrFeatureFromCms(
+    const std::string& featureName,
+    bool cmsEmpty,
+    bool valueEmpty,
+    bool shouldLoad)
+{
+    auto ci = TConfigInitializerServer(CreateOptions());
+    ci.InitKikimrConfig();
+
+    NKikimrConfig::TAppConfig appCfg;
+    auto* cmsFeatureFlags = appCfg.MutableFeatureFlags();
+    auto* featureFlags = ci.KikimrConfig->MutableFeatureFlags();
+
+    const auto* reflection = featureFlags->GetReflection();
+    const auto* descriptor = featureFlags->GetDescriptor();
+    const auto* field = descriptor->FindFieldByName(featureName.c_str());
+
+    UNIT_ASSERT(field);
+    UNIT_ASSERT(field->type() == google::protobuf::FieldDescriptor::TYPE_BOOL);
+
+    if (valueEmpty) {
+        reflection->ClearField(featureFlags, field);
+    } else {
+        // Use default value
+        reflection->SetBool(
+            featureFlags,
+            field,
+            reflection->GetBool(*featureFlags, field));
+    }
+    UNIT_ASSERT(reflection->HasField(*featureFlags, field) == !valueEmpty);
+
+    auto oldValue = reflection->GetBool(*featureFlags, field);
+
+    if (cmsEmpty) {
+        reflection->ClearField(cmsFeatureFlags, field);
+    } else {
+        reflection->SetBool(cmsFeatureFlags, field, !oldValue);
+    }
+
+    ci.ApplyCustomCMSConfigs(appCfg);
+
+    TStringStream testInfo;
+    testInfo << "featureName: " << featureName << ", cmsEmpty = " << cmsEmpty
+             << ", valueEmpty = " << valueEmpty << ", should = " << shouldLoad;
+    auto&& comment = testInfo.Str();
+
+    if (shouldLoad) {
+        if (cmsEmpty) {
+            if (valueEmpty) {
+                UNIT_ASSERT_C(
+                    !reflection->HasField(*featureFlags, field),
+                    comment);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    reflection->GetBool(*featureFlags, field),
+                    oldValue,
+                    comment);
+            }
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                reflection->GetBool(*featureFlags, field),
+                reflection->GetBool(*cmsFeatureFlags, field),
+                comment);
+        }
+    } else {
+        if (valueEmpty) {
+            UNIT_ASSERT_C(!reflection->HasField(*featureFlags, field), comment);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                reflection->GetBool(*featureFlags, field),
+                oldValue,
+                comment);
+        }
+    }
+}
+
+void ShouldLoadKikimrFeaturesFromCms(
+    const std::vector<std::string>& featureNames,
+    bool shouldLoad)
+{
+    for (auto&& featureName: featureNames) {
+        // CmsEmpty -> Empty = Empty
+        // CmsEmpty -> Value = Value
+        // CmsValue -> Empty = shouldLoad ? CmsValue : Empty
+        // CmsValue -> Value = shouldLoad ? CmsValue : Value
+
+        for (bool cmsEmpty: {true, false}) {
+            for (bool valueEmpty: {true, false}) {
+                ShouldLoadKikimrFeatureFromCms(
+                    featureName,
+                    cmsEmpty,
+                    valueEmpty,
+                    shouldLoad);
+            }
+        }
+    }
 }
 
 }   // namespace
@@ -172,6 +276,23 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(
             "abc",
             ci.ServerConfig->GetHost());
+    }
+
+    Y_UNIT_TEST(ShouldLoadAllowedKikimrFeaturesFromCms)
+    {
+        std::vector<std::string> featureNames = {
+            "EnableNodeBrokerDeltaProtocol"};
+
+        ShouldLoadKikimrFeaturesFromCms(featureNames, true);
+    }
+
+    Y_UNIT_TEST(ShouldNotLoadUnallowedKikimrFeaturesFromCms)
+    {
+        std::vector<std::string> featureNames = {
+            "EnableSchemeBoard",
+            "EnableGracefulShutdown"};
+
+        ShouldLoadKikimrFeaturesFromCms(featureNames, false);
     }
 }
 


### PR DESCRIPTION
Allowed YDB feature flags, received from CMS on node registration, now applied into KikimrConfig for Filestore and Disk Agent as for Blockstore (https://github.com/ydb-platform/nbs/pull/5096).

Allowed flags (TAppConfig::FeatureFlags):

  - EnableNodeBrokerDeltaProtocol (only YDB >= 25.1)