### PR TITLE
Increment throttler percentiles with zeros

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -118,7 +118,7 @@ void TVolumeActor::UpdateDelayCounter(
     TVolumeThrottlingPolicy::EOpType opType,
     TDuration time)
 {
-    if (!VolumeSelfCounters || time == TDuration::Zero()) {
+    if (!VolumeSelfCounters) {
         return;
     }
     switch (opType) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -93,9 +93,6 @@ void TIndexTabletActor::UpdateDelayCounter(
     TThrottlingPolicy::EOpType opType,
     TDuration time)
 {
-    if (time == TDuration::Zero()) {
-        return;
-    }
     switch (opType) {
         case TThrottlingPolicy::EOpType::Read: {
             Metrics.ReadDataPostponed.Record(time.MicroSeconds());


### PR DESCRIPTION
#5095
This is partial revert of https://github.com/ydb-platform/nbs/pull/4814
This solution has one big downside: it is hard to judge how requests are throttled on average, because we only see the throttled ones.
The better solution here would be to introduce a zero bucket for all histograms.