### PR TITLE
[Disk Manager] fix idempotence of sync deletion of non-existent disk

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go
@@ -208,7 +208,7 @@ func (t *deleteDiskTask) setEstimate(
 		return err
 	}
 
-	if diskMeta == nil {
+	if diskMeta == nil || len(diskMeta.ZoneID) == 0 {
 		// Should be idempotent.
 		return nil
 	}


### PR DESCRIPTION
If we delete non-existent disk twice using `sync` flag, then the second deletions ends with an error:

```
    disk_service_test.go:1275: 
                Error Trace:    /-S/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go:1275
                                                        /-S/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go:1285
                Error:          Received unexpected error:
                                rpc error: code = Unknown desc = Non retriable error, Silent=false: unknown zone "", available zones: ["zone-a" "zone-b" "zone-c" "no_dataplane" "zone-d" "zone-d-shard1"]
```

Errors occures here, in `setEstimate`: https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go#L216

- After the first deletion tombstone is insterted into the database
- On the second deletion, we call GetDiskMeta here https://github.com/ydb-platform/nbs/blob/main/cloud/disk_manager/internal/pkg/services/disks/delete_disk_task.go#L206 and get a tombstone.
- The tombstone has empty zone id, so we can't create a Blockstore client with empty zone.
