### PR TITLE
[Disk Manager] fix typo in task type

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/filesystem_snapshot/register.go
+++ b/cloud/disk_manager/internal/pkg/services/filesystem_snapshot/register.go
@@ -73,7 +73,7 @@ func RegisterForExecution(
 
 	taskScheduler.ScheduleRegularTasks(
 		ctx,
-		"snapfilesystem_snapshotshots.ClearDeletedFilesystemSnapshots",
+		"filesystem_snapshot.ClearDeletedFilesystemSnapshots",
 		tasks.TaskSchedule{
 			ScheduleInterval: clearDeletedTaskScheduleInterval,
 			MaxTasksInflight: 1,


### PR DESCRIPTION
Task is scheduled, but not executed due to a typo in task type name. Fix it.