### PR TITLE
[NBS] Local NVMe service: sanitize NVMe during release opereation

### DIFF
--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
@@ -63,6 +63,22 @@ public:
             WriteFile(basePath / "drivers" / driverName / "bind", pciAddr);
         }
     }
+
+    auto GetNVMeCtrlNameFromPCIAddr(const TString& pciAddr) -> TString final
+    {
+        const TFsPath path = SysFsRoot / "bus/pci/devices" / pciAddr / "nvme";
+
+        if (path.Exists()) {
+            TVector<TString> children;
+            path.ListNames(children);
+
+            if (children) {
+                return children[0];
+            }
+        }
+
+        return {};
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.h
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.h
@@ -24,6 +24,9 @@ struct ISysFs
     virtual void BindPCIDeviceToDriver(
         const TString& pciAddr,
         const TString& driverName) = 0;
+
+    virtual auto GetNVMeCtrlNameFromPCIAddr(const TString& pciAddr)
+        -> TString = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
@@ -240,6 +240,23 @@ Y_UNIT_TEST_SUITE(TSysFsHelpersTest)
                 ReadFile(VFIODriverPath / "bind"));
         }
     }
+
+    Y_UNIT_TEST_F(ShouldGetNVMeCtrlNameFromPCIAddr, TFixture)
+    {
+        for (size_t i = 0; i != Devices.size(); ++i) {
+            const auto& device = Devices[i];
+            const auto& pciAddr = device.GetPCIAddress();
+
+            if (i == 0) {
+                auto ctrlName = SysFs->GetNVMeCtrlNameFromPCIAddr(pciAddr);
+                UNIT_ASSERT_VALUES_EQUAL("nvme0", ctrlName);
+                continue;
+            }
+
+            auto ctrlName = SysFs->GetNVMeCtrlNameFromPCIAddr(pciAddr);
+            UNIT_ASSERT_VALUES_EQUAL("", ctrlName);
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -10,6 +10,12 @@ namespace NCloud::NBlockStore::NNvme {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TSanitizeStatus
+{
+    NProto::TError Status;
+    double Progress = 0;
+};
+
 struct INvmeManager
 {
     virtual ~INvmeManager() = default;
@@ -22,6 +28,11 @@ struct INvmeManager
         const TString& path,
         ui64 offsetBytes,
         ui64 sizeBytes) = 0;
+
+    virtual NProto::TError Sanitize(const TString& ctrlPath) = 0;
+
+    virtual TResultOrError<TSanitizeStatus> GetSanitizeStatus(
+        const TString& ctrlPath) = 0;
 
     virtual TResultOrError<bool> IsSsd(const TString& path) = 0;
 

--- a/cloud/blockstore/libs/nvme/nvme_stub.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_stub.cpp
@@ -60,6 +60,21 @@ public:
 
         return IsDeviceSsd;
     }
+
+    NProto::TError Sanitize(const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
+    TResultOrError<TSanitizeStatus> GetSanitizeStatus(
+        const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TSanitizeStatus{};
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/nvme/spec.h
+++ b/cloud/blockstore/libs/nvme/spec.h
@@ -807,4 +807,19 @@ struct nvme_format {
     uint32_t reserved : 20;
 };
 
+enum nvme_sanitize_action
+{
+    NVME_SANITIZE_ACT_BLOCK_ERASE = 0x2,
+    NVME_SANITIZE_ACT_CRYPTO_ERASE = 0x4,
+};
+
+enum nvme_sanitize_status
+{
+    NVME_SANITIZE_SSTAT_STATUS_MASK = 0x07,
+    NVME_SANITIZE_SSTAT_NEVER = 0x00,
+    NVME_SANITIZE_SSTAT_COMPLETED = 0x01,
+    NVME_SANITIZE_SSTAT_IN_PROGRESS = 0x02,
+    NVME_SANITIZE_SSTAT_FAILED = 0x03,
+};
+
 }   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
+++ b/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
@@ -71,6 +71,21 @@ struct TTestNvmeManager final: NNvme::INvmeManager
         Y_UNUSED(path);
         return TString("serial");
     }
+
+    NProto::TError Sanitize(const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
+    TResultOrError<TSanitizeStatus> GetSanitizeStatus(
+        const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TSanitizeStatus{};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -147,6 +147,21 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         return true;
     }
+
+    NProto::TError Sanitize(const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
+    TResultOrError<NNvme::TSanitizeStatus> GetSanitizeStatus(
+        const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return NNvme::TSanitizeStatus{};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -94,6 +94,21 @@ struct TTestNvmeManager
 
         return true;
     }
+
+    NProto::TError Sanitize(const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
+    TResultOrError<NNvme::TSanitizeStatus> GetSanitizeStatus(
+        const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return NNvme::TSanitizeStatus{};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -74,6 +74,21 @@ struct TTestNvmeManager
 
         return true;
     }
+
+    NProto::TError Sanitize(const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
+    TResultOrError<NNvme::TSanitizeStatus> GetSanitizeStatus(
+        const TString& ctrlPath) override
+    {
+        Y_UNUSED(ctrlPath);
+
+        return NNvme::TSanitizeStatus{};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add Sanitize and GetSanitizeStatus methods to INvmeManager interface.

Sanitize NVMe devices during release operation: bind device to nvme driver, invoke Sanitize, and poll GetSanitizeStatus until completion.

Refactor ListNVMeDevices, AcquireNVMeDevice, and ReleaseNVMeDevice to run as separate coroutines using ExecuteAsync helper.

#5250