### PR TITLE
issue 1751: [Filestore] WriteBackCache refactoring - extract WriteBackCacheStats + update TPersistentStorageStats

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/write_back_cache_stats_test.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/write_back_cache_stats_test.cpp
@@ -1,0 +1,124 @@
+#include "write_back_cache_stats_test.h"
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTestWriteDataRequestStats::ResetNonDerivativeCounters()
+{
+    InProgressCount = 0;
+    MinTime = TInstant::Zero();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTestWriteBackCacheStats::ResetNonDerivativeCounters()
+{
+    InProgressFlushCount = 0;
+    NodeCount = 0;
+
+    PendingStats.ResetNonDerivativeCounters();
+    CachedStats.ResetNonDerivativeCounters();
+    FlushingStats.ResetNonDerivativeCounters();
+    FlushedStats.ResetNonDerivativeCounters();
+}
+
+void TTestWriteBackCacheStats::FlushStarted()
+{
+    InProgressFlushCount++;
+}
+
+void TTestWriteBackCacheStats::FlushCompleted()
+{
+    InProgressFlushCount--;
+    CompletedFlushCount++;
+}
+
+void TTestWriteBackCacheStats::FlushFailed()
+{
+    FailedFlushCount++;
+}
+
+void TTestWriteBackCacheStats::IncrementNodeCount()
+{
+    NodeCount++;
+}
+
+void TTestWriteBackCacheStats::DecrementNodeCount()
+{
+    NodeCount--;
+}
+
+TTestWriteDataRequestStats& TTestWriteBackCacheStats::GetWriteStats(
+    EWriteDataRequestStatus status)
+{
+    switch (status) {
+        case EWriteDataRequestStatus::Pending:
+            return PendingStats;
+        case EWriteDataRequestStatus::Cached:
+            return CachedStats;
+        case EWriteDataRequestStatus::Flushing:
+            return FlushingStats;
+        case EWriteDataRequestStatus::Flushed:
+            return FlushedStats;
+        default:
+            Y_ABORT("Unknown EWriteDataRequestStatus value");
+    }
+}
+
+void TTestWriteBackCacheStats::WriteDataRequestEnteredStatus(
+    EWriteDataRequestStatus status)
+{
+    auto& stats = GetWriteStats(status);
+    stats.InProgressCount++;
+}
+
+void TTestWriteBackCacheStats::WriteDataRequestExitedStatus(
+    EWriteDataRequestStatus status,
+    TDuration duration)
+{
+    auto& stats = GetWriteStats(status);
+    stats.Count++;
+    stats.InProgressCount--;
+    if (stats.Data.size() < MaxItems) {
+        stats.Data.push_back(duration);
+    }
+}
+
+void TTestWriteBackCacheStats::WriteDataRequestUpdateMinTime(
+    EWriteDataRequestStatus status,
+    TInstant minTime)
+{
+    auto& stats = GetWriteStats(status);
+    stats.MinTime = minTime;
+}
+
+void TTestWriteBackCacheStats::AddReadDataStats(
+    EReadDataRequestCacheStatus status,
+    TDuration pendingDuration)
+{
+    if (ReadStats.Data.size() < MaxItems) {
+        ReadStats.Data.push_back(pendingDuration);
+    }
+    switch (status) {
+        case EReadDataRequestCacheStatus::Miss:
+            ReadStats.CacheMissCount++;
+            break;
+        case EReadDataRequestCacheStatus::PartialHit:
+            ReadStats.CachePartialHitCount++;
+            break;
+        case EReadDataRequestCacheStatus::FullHit:
+            ReadStats.CacheFullHitCount++;
+            break;
+        default:
+            Y_ABORT("Unknown EReadDataRequestCacheState value");
+    }
+}
+
+void TTestWriteBackCacheStats::UpdatePersistentStorageStats(
+    const TPersistentStorageStats& stats)
+{
+    StorageStats = stats;
+}
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/write_back_cache_stats_test.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/write_back_cache_stats_test.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.h>
+
+#include <util/generic/vector.h>
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestWriteDataRequestStats
+{
+    ui64 InProgressCount = 0;
+    TInstant MinTime = TInstant::Zero();
+    TVector<TDuration> Data;
+    ui64 Count = 0;
+
+    void ResetNonDerivativeCounters();
+};
+
+struct TTestReadDataRequestStats
+{
+    TVector<TDuration> Data;
+    ui64 CacheMissCount = 0;
+    ui64 CachePartialHitCount = 0;
+    ui64 CacheFullHitCount = 0;
+};
+
+struct TTestWriteBackCacheStats: public IWriteBackCacheStats
+{
+    ui64 InProgressFlushCount = 0;
+    ui64 CompletedFlushCount = 0;
+    ui64 FailedFlushCount = 0;
+
+    ui64 NodeCount = 0;
+
+    TTestWriteDataRequestStats PendingStats;
+    TTestWriteDataRequestStats CachedStats;
+    TTestWriteDataRequestStats FlushingStats;
+    TTestWriteDataRequestStats FlushedStats;
+
+    TTestReadDataRequestStats ReadStats;
+
+    TPersistentStorageStats StorageStats;
+
+    // Do not store more than the specified amount of elements in the following
+    // vectors in order to prevent OOM for large tests
+    ui64 MaxItems = 1000000;
+
+    void ResetNonDerivativeCounters() override;
+
+    void FlushStarted() override;
+
+    void FlushCompleted() override;
+
+    void FlushFailed() override;
+
+    void IncrementNodeCount() override;
+
+    void DecrementNodeCount() override;
+
+    TTestWriteDataRequestStats& GetWriteStats(EWriteDataRequestStatus status);
+
+    void WriteDataRequestEnteredStatus(EWriteDataRequestStatus status) override;
+
+    void WriteDataRequestExitedStatus(
+        EWriteDataRequestStatus status,
+        TDuration duration) override;
+
+    void WriteDataRequestUpdateMinTime(
+        EWriteDataRequestStatus status,
+        TInstant minTime) override;
+
+    void AddReadDataStats(
+        EReadDataRequestCacheStatus status,
+        TDuration pendingDuration) override;
+
+    void UpdatePersistentStorageStats(
+        const TPersistentStorageStats& stats) override;
+};
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/ut/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/ut/ya.make
@@ -7,6 +7,7 @@ SRCDIR(cloud/filestore/libs/vfs_fuse/write_back_cache)
 SRCS(
     overlapping_interval_set_ut.cpp
     read_write_range_lock_ut.cpp
+    test/write_back_cache_stats_test.cpp
     write_back_cache_ut.cpp
     write_back_cache_util_ut.cpp
 )

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -23,9 +23,7 @@ namespace NCloud::NFileStore::NFuse {
 
 using namespace NCloud::NFileStore::NVFS;
 using namespace NThreading;
-
-using EReadDataRequestCacheStatus =
-    IWriteBackCacheStats::EReadDataRequestCacheStatus;
+using namespace NWriteBackCache;
 
 namespace {
 
@@ -1554,12 +1552,12 @@ private:
 
     void UpdatePersistentQueueStats()
     {
-        Stats->UpdatePersistentQueueStats(
-            {.RawCapacity = CachedEntriesPersistentQueue.GetRawCapacity(),
-             .RawUsedBytesCount =
+        Stats->UpdatePersistentStorageStats(
+            {.RawCapacityByteCount =
+                 CachedEntriesPersistentQueue.GetRawCapacity(),
+             .RawUsedByteCount =
                  CachedEntriesPersistentQueue.GetRawUsedBytesCount(),
-             .MaxAllocationBytesCount =
-                 CachedEntriesPersistentQueue.GetMaxAllocationBytesCount(),
+             .EntryCount = CachedEntriesPersistentQueue.Size(),
              .IsCorrupted = CachedEntriesPersistentQueue.IsCorrupted()});
     }
 
@@ -1901,78 +1899,6 @@ void TWriteBackCache::TWriteDataEntryIntervalMap::Remove(TWriteDataEntry* entry)
                 TBase::Remove(it);
             }
         });
-}
-
-namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-class TDummyWriteBackCacheStats
-    : public IWriteBackCacheStats
-{
-public:
-    void ResetNonDerivativeCounters() override
-    {}
-
-    void FlushStarted() override
-    {}
-
-    void FlushCompleted() override
-    {}
-
-    void FlushFailed() override
-    {}
-
-    void IncrementNodeCount() override
-    {}
-
-    void DecrementNodeCount() override
-    {}
-
-    void WriteDataRequestEnteredStatus(
-        TWriteBackCache::EWriteDataRequestStatus status) override
-    {
-        Y_UNUSED(status);
-    }
-
-    void WriteDataRequestExitedStatus(
-        TWriteBackCache::EWriteDataRequestStatus status,
-        TDuration duration) override
-    {
-        Y_UNUSED(status);
-        Y_UNUSED(duration);
-    }
-
-    void WriteDataRequestUpdateMinTime(
-        TWriteBackCache::EWriteDataRequestStatus status,
-        TInstant minTime) override
-    {
-        Y_UNUSED(status);
-        Y_UNUSED(minTime);
-    }
-
-    void AddReadDataStats(
-        IWriteBackCacheStats::EReadDataRequestCacheStatus status,
-        TDuration duraton) override
-    {
-        Y_UNUSED(status);
-        Y_UNUSED(duraton);
-    }
-
-    void UpdatePersistentQueueStats(
-        const TWriteBackCache::TPersistentQueueStats& stats) override
-    {
-        Y_UNUSED(stats);
-    }
-};
-
-}   // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
-IWriteBackCacheStatsPtr CreateDummyWriteBackCacheStats()
-{
-    return std::make_shared<TDummyWriteBackCacheStats>();
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -13,11 +13,17 @@
 
 namespace NCloud::NFileStore::NFuse {
 
+namespace NWriteBackCache {
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct IWriteBackCacheStats;
 using IWriteBackCacheStatsPtr =
     std::shared_ptr<IWriteBackCacheStats>;
+
+}   // namespace NWriteBackCache
+
+////////////////////////////////////////////////////////////////////////////////
 
 class TWriteBackCache final
 {
@@ -33,7 +39,7 @@ public:
         IFileStorePtr session,
         ISchedulerPtr scheduler,
         ITimerPtr timer,
-        IWriteBackCacheStatsPtr stats,
+        NWriteBackCache::IWriteBackCacheStatsPtr stats,
         TLog log,
         const TString& fileSystemId,
         const TString& clientId,
@@ -74,7 +80,6 @@ public:
     ui64 GetCachedNodeSize(ui64 nodeId) const;
     void SetCachedNodeSize(ui64 nodeId, ui64 size);
 
-    enum class EWriteDataRequestStatus;
     struct TPersistentQueueStats;
 
 private:
@@ -94,103 +99,5 @@ private:
     class TContiguousWriteDataEntryPartsReader;
     class TWriteDataEntryIntervalMap;
 };
-
-////////////////////////////////////////////////////////////////////////////////
-
-/**
- * WriteData request life cycle:
- * Initial -> Pending -> Cached -> (FlushRequested) -> Flushing -> Flushed
- *
- * Status FlushRequested may be skipped — Flush takes as much WriteData requests
- * as possible from |TWriteBackCache::TNodeState::CachedEntries|.
- *
- * For each NodeId it is guaranteed that there are no requests with out-of-order
- * statuses: if two requests A and B have the same NodeId, and the request A was
- * added to the queue later than B, then A.Status <= B.Status.
- */
-
-enum class TWriteBackCache::EWriteDataRequestStatus
-{
-    // The object has just been created and does not hold a request.
-    Initial,
-
-    // Restoration from the persisent buffer was failed.
-    // The request will not be processed further.
-    Corrupted,
-
-    // Write request is waiting for the conditions:
-    // - enough space in the persistent buffer to store the request;
-    // - no overlapping read requests in progress.
-    Pending,
-
-    // Write request has been stored in the persistent buffer
-    // The caller code observes the request as completed
-    Cached,
-
-    // Write request is being flushed
-    Flushing,
-
-    // Write request has been written to the session and can be removed from
-    // the persistent buffer
-    Flushed
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TWriteBackCache::TPersistentQueueStats
-{
-    ui64 RawCapacity = 0;
-    ui64 RawUsedBytesCount = 0;
-    ui64 MaxAllocationBytesCount = 0;
-    bool IsCorrupted = false;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct IWriteBackCacheStats
-{
-    enum class EReadDataRequestCacheStatus
-    {
-        // A request wasn't served from the cache
-        Miss,
-
-        // A request was partially served from the cache
-        PartialHit,
-
-        // A request was fully served from the cache
-        FullHit
-    };
-
-    virtual ~IWriteBackCacheStats() = default;
-
-    virtual void ResetNonDerivativeCounters() = 0;
-
-    virtual void FlushStarted() = 0;
-    virtual void FlushCompleted() = 0;
-    virtual void FlushFailed() = 0;
-
-    virtual void IncrementNodeCount() = 0;
-    virtual void DecrementNodeCount() = 0;
-
-    virtual void WriteDataRequestEnteredStatus(
-        TWriteBackCache::EWriteDataRequestStatus status) = 0;
-
-    virtual void WriteDataRequestExitedStatus(
-        TWriteBackCache::EWriteDataRequestStatus status,
-        TDuration duration) = 0;
-
-    virtual void WriteDataRequestUpdateMinTime(
-        TWriteBackCache::EWriteDataRequestStatus status,
-        TInstant minTime) = 0;
-
-    virtual void AddReadDataStats(
-        IWriteBackCacheStats::EReadDataRequestCacheStatus status,
-        TDuration pendingDuration) = 0;
-
-    virtual void UpdatePersistentQueueStats(
-        const TWriteBackCache::TPersistentQueueStats& stats) = 0;
-};
-
-IWriteBackCacheStatsPtr CreateDummyWriteBackCacheStats();
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "write_back_cache.h"
+#include "write_back_cache_stats.h"
 
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/core/helpers.h>
@@ -77,7 +78,9 @@ private:
 
     NThreading::TPromise<NProto::TWriteDataResponse> CachedPromise;
 
-    EWriteDataRequestStatus Status = EWriteDataRequestStatus::Initial;
+    NWriteBackCache::EWriteDataRequestStatus Status =
+        NWriteBackCache::EWriteDataRequestStatus::Initial;
+
     TInstant StatusChangeTime = TInstant::Zero();
 
 public:
@@ -154,17 +157,17 @@ public:
 
     bool IsCached() const
     {
-        return Status == EWriteDataRequestStatus::Cached;
+        return Status == NWriteBackCache::EWriteDataRequestStatus::Cached;
     }
 
     bool IsCorrupted() const
     {
-        return Status == EWriteDataRequestStatus::Corrupted;
+        return Status == NWriteBackCache::EWriteDataRequestStatus::Corrupted;
     }
 
     bool IsFlushed() const
     {
-        return Status == EWriteDataRequestStatus::Flushed;
+        return Status == NWriteBackCache::EWriteDataRequestStatus::Flushed;
     }
 
     size_t GetSerializedSize() const;
@@ -183,7 +186,9 @@ public:
     NThreading::TFuture<NProto::TWriteDataResponse> GetCachedFuture();
 
 private:
-    void SetStatus(EWriteDataRequestStatus status, TImpl* impl);
+    void SetStatus(
+        NWriteBackCache::EWriteDataRequestStatus status,
+        TImpl* impl);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.cpp
@@ -1,0 +1,75 @@
+#include "write_back_cache_stats.h"
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDummyWriteBackCacheStats: public IWriteBackCacheStats
+{
+public:
+    void ResetNonDerivativeCounters() override
+    {}
+
+    void FlushStarted() override
+    {}
+
+    void FlushCompleted() override
+    {}
+
+    void FlushFailed() override
+    {}
+
+    void IncrementNodeCount() override
+    {}
+
+    void DecrementNodeCount() override
+    {}
+
+    void WriteDataRequestEnteredStatus(EWriteDataRequestStatus status) override
+    {
+        Y_UNUSED(status);
+    }
+
+    void WriteDataRequestExitedStatus(
+        EWriteDataRequestStatus status,
+        TDuration duration) override
+    {
+        Y_UNUSED(status);
+        Y_UNUSED(duration);
+    }
+
+    void WriteDataRequestUpdateMinTime(
+        EWriteDataRequestStatus status,
+        TInstant minTime) override
+    {
+        Y_UNUSED(status);
+        Y_UNUSED(minTime);
+    }
+
+    void AddReadDataStats(
+        EReadDataRequestCacheStatus status,
+        TDuration duration) override
+    {
+        Y_UNUSED(status);
+        Y_UNUSED(duration);
+    }
+
+    void UpdatePersistentStorageStats(
+        const TPersistentStorageStats& stats) override
+    {
+        Y_UNUSED(stats);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IWriteBackCacheStatsPtr CreateDummyWriteBackCacheStats()
+{
+    return std::make_shared<TDummyWriteBackCacheStats>();
+}
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <util/system/types.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * WriteData request life cycle:
+ * Initial -> Pending -> Cached -> (FlushRequested) -> Flushing -> Flushed
+ *
+ * Status FlushRequested may be skipped — Flush takes as much WriteData requests
+ * as possible from |TWriteBackCache::TNodeState::CachedEntries|.
+ *
+ * For each NodeId it is guaranteed that there are no requests with out-of-order
+ * statuses: if two requests A and B have the same NodeId, and the request A was
+ * added to the queue later than B, then A.Status <= B.Status.
+ */
+
+enum class EWriteDataRequestStatus
+{
+    // The object has just been created and does not hold a request.
+    Initial,
+
+    // Restoration from the persistent buffer was failed.
+    // The request will not be processed further.
+    Corrupted,
+
+    // Write request is waiting for the conditions:
+    // - enough space in the persistent buffer to store the request;
+    // - no overlapping read requests in progress.
+    Pending,
+
+    // Write request has been stored in the persistent buffer
+    // The caller code observes the request as completed
+    Cached,
+
+    // Write request is being flushed
+    Flushing,
+
+    // Write request has been written to the session and can be removed from
+    // the persistent buffer
+    Flushed
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EReadDataRequestCacheStatus
+{
+    // A request wasn't served from the cache
+    Miss,
+
+    // A request was partially served from the cache
+    PartialHit,
+
+    // A request was fully served from the cache
+    FullHit
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TPersistentStorageStats
+{
+    ui64 RawCapacityByteCount = 0;
+    ui64 RawUsedByteCount = 0;
+    ui64 EntryCount = 0;
+    bool IsCorrupted = false;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IWriteBackCacheStats
+{
+    virtual ~IWriteBackCacheStats() = default;
+
+    virtual void ResetNonDerivativeCounters() = 0;
+
+    virtual void FlushStarted() = 0;
+    virtual void FlushCompleted() = 0;
+    virtual void FlushFailed() = 0;
+
+    virtual void IncrementNodeCount() = 0;
+    virtual void DecrementNodeCount() = 0;
+
+    virtual void WriteDataRequestEnteredStatus(
+        EWriteDataRequestStatus status) = 0;
+
+    virtual void WriteDataRequestExitedStatus(
+        EWriteDataRequestStatus status,
+        TDuration duration) = 0;
+
+    virtual void WriteDataRequestUpdateMinTime(
+        EWriteDataRequestStatus status,
+        TInstant minTime) = 0;
+
+    virtual void AddReadDataStats(
+        EReadDataRequestCacheStatus status,
+        TDuration pendingDuration) = 0;
+
+    virtual void UpdatePersistentStorageStats(
+        const TPersistentStorageStats& stats) = 0;
+};
+
+using IWriteBackCacheStatsPtr = std::shared_ptr<IWriteBackCacheStats>;
+
+IWriteBackCacheStatsPtr CreateDummyWriteBackCacheStats();
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util_ut.cpp
@@ -898,7 +898,7 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
         constexpr ui64 MaxLength = 10;
         constexpr size_t MaxIntervalCount = 10;
 
-        auto stats = CreateDummyWriteBackCacheStats();
+        auto stats = NWriteBackCache::CreateDummyWriteBackCacheStats();
 
         for (size_t iter = 0; iter < IterationCount; iter++) {
             size_t intervalCount = RandomNumber(MaxIntervalCount) + 1;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/ya.make
@@ -4,6 +4,7 @@ SRCS(
     overlapping_interval_set.cpp
     read_write_range_lock.cpp
     write_back_cache.cpp
+    write_back_cache_stats.cpp
     write_back_cache_util.cpp
 )
 


### PR DESCRIPTION
Part of https://github.com/ydb-platform/nbs/pull/5064

Extract WriteBackCacheStats related code to a separate file.

Change storage stats to:
```
struct TPersistentStorageStats
{
    ui64 RawCapacityByteCount = 0;
    ui64 RawUsedByteCount = 0;
    ui64 EntryCount = 0;
    bool IsCorrupted = false;
};
```
Remove `MaxAllocationBytesCount` (it will not be used in future), add `EntryCount`.