### PR TITLE
[Filestore] fix values interval for offset and blocks count in StressTestForWriteFlushCompactionCleanup

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -665,10 +665,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
 
         std::uniform_int_distribution<ui32> dist(0, EStepType::MAX - 1);
         std::uniform_int_distribution<ui64> opTypeDist(0, EStepType::MAX);
-        std::uniform_int_distribution<ui64> blockDist(
-            1,
-            maxNumBlocksInRequest + 1);
-        std::uniform_int_distribution<ui64> offsetDist(0, maxOffset + 1);
+        std::uniform_int_distribution<ui64> blockDist(1, maxNumBlocksInRequest);
+        std::uniform_int_distribution<ui64> offsetDist(0, maxOffset);
         std::uniform_int_distribution<ui64> seedDist(0, 1000000);
 
         const auto seedValue = time(0);


### PR DESCRIPTION
issue: #4695

remove +1 from values interval as the interval in std::uniform_int_distribution is closed