### PR TITLE
[NBS] Local NVMe service: reset NVMe to single namespace during release operation

### DIFF
--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -122,6 +122,13 @@ public:
         return TString();
     }
 
+    NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
 public:
     void WaitSanitizeRequested()
     {
@@ -905,6 +912,11 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         auto future = Service->ReleaseNVMeDevice(Devices[0].GetSerialNumber());
         NVMeManager->WaitSanitizeRequested();
+        NVMeManager->UpdateSanitizeStatus(
+            ctrlPath,
+            MakeError(E_TRY_AGAIN),
+            10.0);
+        Sleep(200ms);
         NVMeManager->UpdateSanitizeStatus(
             ctrlPath,
             MakeError(E_FAIL, "fail"),

--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -37,6 +37,8 @@ struct INvmeManager
     virtual TResultOrError<bool> IsSsd(const TString& path) = 0;
 
     virtual TResultOrError<TString> GetSerialNumber(const TString& path) = 0;
+
+    virtual NProto::TError ResetToSingleNamespace(const TString& ctrlPath) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nvme/nvme_stub.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_stub.cpp
@@ -75,6 +75,13 @@ public:
 
         return TSanitizeStatus{};
     }
+
+    NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
 };
 
 }   // namespace

--- a/cloud/blockstore/libs/nvme/spec.h
+++ b/cloud/blockstore/libs/nvme/spec.h
@@ -792,6 +792,13 @@ struct nvme_ns_data {
     uint8_t vendor_specific[3712];
 };
 
+struct nvme_ctrlr_list {
+    uint16_t num;
+    uint16_t identifiers[2047];
+};
+
+static_assert(sizeof(nvme_ctrlr_list) == 4096);
+
 enum nvme_secure_erase_setting {
     NVME_FMT_NVM_SES_NO_SECURE_ERASE = 0x0,
     NVME_FMT_NVM_SES_USER_DATA_ERASE = 0x1,

--- a/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
+++ b/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
@@ -86,6 +86,13 @@ struct TTestNvmeManager final: NNvme::INvmeManager
 
         return TSanitizeStatus{};
     }
+
+    NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -162,6 +162,13 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         return NNvme::TSanitizeStatus{};
     }
+
+    NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -109,6 +109,13 @@ struct TTestNvmeManager
 
         return NNvme::TSanitizeStatus{};
     }
+
+    NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -89,6 +89,13 @@ struct TTestNvmeManager
 
         return NNvme::TSanitizeStatus{};
     }
+
+    NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reset NVMe device to single namespace during ReleaseNVMeDevice operation

Detach and delete all existing namespaces, then create a single namespace spanning the entire device capacity.

#5250