### PR TITLE
building plucky instead of noble by default

### DIFF
--- a/cloud/storage/core/tools/testing/qemu/build-image/__main__.py
+++ b/cloud/storage/core/tools/testing/qemu/build-image/__main__.py
@@ -232,7 +232,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--out", help="output file path", default="rootfs.img")
     parser.add_argument("--release", help="Ubuntu release name",
-                        default="noble")
+                        default="plucky")
     parser.add_argument("--arch", help="Ubuntu architecture", default="amd64")
     parser.add_argument("--image", help="image file path to use instead of downloading", default=None)
     parser.add_argument("--cloud-images-mirror",


### PR DESCRIPTION
we use virtiofs multiqueue more and more and we need guest kernels which support it

the default kernel in ubuntu noble doesn't have virtiofs multiqueue support