### PR TITLE
[Disk Manager] fix snapshot creation for DiskRegistry-based disk with blocking checkpoints (when shadow disks feature is disabled)

### DIFF
--- a/cloud/blockstore/public/sdk/go/client/error.go
+++ b/cloud/blockstore/public/sdk/go/client/error.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -116,7 +118,9 @@ func GetClientCode(err error) uint32 {
 		return S_OK
 	}
 
-	if cerr, ok := err.(*ClientError); ok {
+	cerr := &ClientError{}
+
+	if errors.As(err, &cerr) {
 		return cerr.Code
 	}
 
@@ -128,7 +132,9 @@ func GetClientError(err error) ClientError {
 		return ClientError{S_OK, ""}
 	}
 
-	if cerr, ok := err.(*ClientError); ok {
+	cerr := &ClientError{}
+
+	if errors.As(err, &cerr) {
 		return *cerr
 	}
 

--- a/cloud/blockstore/public/sdk/go/client/error_test.go
+++ b/cloud/blockstore/public/sdk/go/client/error_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestGetClientError(t *testing.T) {
+	code := E_NOT_IMPLEMENTED
+	message := "Message"
+	clientErr := &ClientError{
+		Code:    code,
+		Message: message,
+	}
+
+	var err error
+	err = clientErr
+
+	require.Equal(t, code, GetClientCode(err))
+
+	e := GetClientError(err)
+	require.Equal(t, code, e.Code)
+	require.Equal(t, message, e.Message)
+
+	err = fmt.Errorf("wrapped error: %w", err)
+
+	require.Equal(t, code, GetClientCode(err))
+
+	e = GetClientError(err)
+	require.Equal(t, code, e.Code)
+	require.Equal(t, message, e.Message)
+}

--- a/cloud/blockstore/public/sdk/go/client/ya.make
+++ b/cloud/blockstore/public/sdk/go/client/ya.make
@@ -26,6 +26,7 @@ GO_TEST_SRCS(
     client_test.go
     discovery_test.go
     durable_test.go
+    error_test.go
     grpc_test.go
     log_test.go
     session_test.go

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -505,12 +505,9 @@ func IsNotFoundError(e error) bool {
 	return errors.As(e, &clientErr) && clientErr.Code == nbs_client.E_NOT_FOUND
 }
 
-func IsGetChangedBlocksNotSupportedError(e error) bool {
+func IsNotImplementedError(e error) bool {
 	clientErr := nbs_client.GetClientError(e)
-
-	// TODO: don't check E_ARGUMENT after https://github.com/ydb-platform/nbs/issues/1297#issuecomment-2149816298
-	return clientErr.Code == nbs_client.E_ARGUMENT && strings.Contains(clientErr.Error(), "Disk registry based disks can not handle GetChangedBlocks requests for normal checkpoints") ||
-		clientErr.Code == nbs_client.E_NOT_IMPLEMENTED
+	return clientErr.Code == nbs_client.E_NOT_IMPLEMENTED
 }
 
 func IsAlterPlacementGroupMembershipPublicError(e error) bool {
@@ -1837,7 +1834,7 @@ func (c *client) GetScanDiskStatus(
 		return ScanDiskStatus{}, err
 	}
 
-	return fromScanDiskProgress(response.Progress), err
+	return fromScanDiskProgress(response.Progress), nil
 }
 
 func (c *client) FinishFillDisk(
@@ -1891,7 +1888,7 @@ func (c *client) GetClusterCapacity(
 		infos = append(infos, info)
 	}
 
-	return infos, err
+	return infos, nil
 }
 
 func (c *client) ZoneID() string {
@@ -1959,7 +1956,7 @@ func (c *client) describeVolume(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return volume, err
+	return volume, nil
 }
 
 func (c *client) describePlacementGroup(
@@ -1982,7 +1979,7 @@ func (c *client) describePlacementGroup(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return group, err
+	return group, nil
 }
 
 func (c *client) ping(ctx context.Context) (err error) {
@@ -2187,7 +2184,7 @@ func (c *client) assignVolume(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return volume, err
+	return volume, nil
 }
 
 func (c *client) describeVolumeModel(
@@ -2225,7 +2222,7 @@ func (c *client) describeVolumeModel(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return model, err
+	return model, nil
 }
 
 func (c *client) createPlacementGroup(
@@ -2339,7 +2336,7 @@ func (c *client) listDiskStates(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return states, err
+	return states, nil
 }
 
 func (c *client) listPlacementGroups(
@@ -2358,7 +2355,7 @@ func (c *client) listPlacementGroups(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return groups, err
+	return groups, nil
 }
 
 func (c *client) getChangedBlocks(
@@ -2384,7 +2381,7 @@ func (c *client) getChangedBlocks(
 	if err != nil {
 		return nil, wrapError(err)
 	}
-	return blockMask, err
+	return blockMask, nil
 }
 
 func (c *client) statVolume(
@@ -2398,5 +2395,5 @@ func (c *client) statVolume(
 	if err != nil {
 		return nil, nil, wrapError(err)
 	}
-	return volume, stats, err
+	return volume, stats, nil
 }

--- a/cloud/disk_manager/internal/pkg/facade/without_shadow_disks_test/without_shadow_disks_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/without_shadow_disks_test/without_shadow_disks_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+	disk_manager "github.com/ydb-platform/nbs/cloud/disk_manager/api"
+	internal_client "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/client"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/facade/testcommon"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestCreateSnapshotFromSsdNonreplicatedDiskWithoutShadowDisks(
+	t *testing.T,
+) {
+
+	diskKind := disk_manager.DiskKind_DISK_KIND_SSD_NONREPLICATED
+	diskBlockSize := 4096
+	diskSize := 262144 * 4096
+	zoneID := "zone-a"
+	diskID := t.Name()
+
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: int64(diskSize),
+		Kind: diskKind,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		BlockSize: int64(diskBlockSize),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	// Disk cell is not determined, when creating in sharded zone.
+	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	require.NoError(t, err)
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
+	_, err = nbsClient.FillDisk(ctx, diskID, 64*4096)
+	require.NoError(t, err)
+
+	snapshotID := t.Name()
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
+		Src: &disk_manager.DiskId{
+			ZoneId: zoneID,
+			DiskId: diskID,
+		},
+		SnapshotId: snapshotID,
+		FolderId:   "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+
+	response := disk_manager.CreateSnapshotResponse{}
+	err = internal_client.WaitResponse(ctx, client, operation.Id, &response)
+	require.NoError(t, err)
+	require.Equal(t, int64(diskSize), response.Size)
+
+	meta := disk_manager.CreateSnapshotMetadata{}
+	err = internal_client.GetOperationMetadata(ctx, client, operation.Id, &meta)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), meta.Progress)
+
+	testcommon.RequireCheckpointsDoNotExist(t, ctx, diskID)
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.DeleteSnapshot(reqCtx, &disk_manager.DeleteSnapshotRequest{
+		SnapshotId: snapshotID,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	testcommon.CheckConsistency(t, ctx)
+}

--- a/cloud/disk_manager/internal/pkg/facade/without_shadow_disks_test/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/without_shadow_disks_test/ya.make
@@ -1,0 +1,10 @@
+GO_TEST_FOR(cloud/disk_manager/internal/pkg/facade)
+
+SET_APPEND(RECIPE_ARGS --without-shadow-disks)
+INCLUDE(${ARCADIA_ROOT}/cloud/disk_manager/internal/pkg/facade/testcommon/common.inc)
+
+GO_XTEST_SRCS(
+    without_shadow_disks_test.go
+)
+
+END()

--- a/cloud/disk_manager/internal/pkg/facade/ya.make
+++ b/cloud/disk_manager/internal/pkg/facade/ya.make
@@ -31,6 +31,7 @@ RECURSE_FOR_TESTS(
     private_service_test
     with_broken_checkpoints_test
     with_broken_checkpoints_nemesis_test
+    without_shadow_disks_test
     snapshot_service_nemesis_test
     snapshot_service_test
     testcommon

--- a/cloud/disk_manager/test/recipe/__main__.py
+++ b/cloud/disk_manager/test/recipe/__main__.py
@@ -67,6 +67,7 @@ def parse_args(args):
     parser.add_argument("--retry-broken-disk-registry-based-disk-checkpoint", action='store_true', default=False)
     parser.add_argument("--cell-selection-policy", type=str, default="FIRST_IN_CONFIG")
     parser.add_argument("--allow-filestore-force-destroy", action='store_true', default=False)
+    parser.add_argument("--without-shadow-disks", action='store_true', default=False)
     args, _ = parser.parse_known_args(args=args)
     return args
 
@@ -137,7 +138,9 @@ def start(argv):
         compute_port=compute_port,
         kms_port=kms_port,
         destruction_allowed_only_for_disks_with_id_prefixes=destruction_allowed_only_for_disks_with_id_prefixes,
-        disk_agent_count=args.disk_agent_count)
+        disk_agent_count=args.disk_agent_count,
+        without_shadow_disks=args.without_shadow_disks,
+    )
     nbs.start()
     set_env("DISK_MANAGER_RECIPE_NBS_PORT", str(nbs.port))
 
@@ -160,7 +163,9 @@ def start(argv):
             ydb_client=ydb2.client,
             compute_port=compute_port,
             kms_port=kms_port,
-            destruction_allowed_only_for_disks_with_id_prefixes=destruction_allowed_only_for_disks_with_id_prefixes)
+            destruction_allowed_only_for_disks_with_id_prefixes=destruction_allowed_only_for_disks_with_id_prefixes,
+            without_shadow_disks=args.without_shadow_disks,
+        )
         nbs2.start()
         append_recipe_err_files(ERR_LOG_FILE_NAMES_FILE, nbs2.nbs.stderr_file_name)
 
@@ -181,6 +186,7 @@ def start(argv):
             compute_port=compute_port,
             kms_port=kms_port,
             destruction_allowed_only_for_disks_with_id_prefixes=destruction_allowed_only_for_disks_with_id_prefixes,
+            without_shadow_disks=args.without_shadow_disks,
         )
         nbs3.start()
         append_recipe_err_files(ERR_LOG_FILE_NAMES_FILE, nbs3.nbs.stderr_file_name)
@@ -216,7 +222,8 @@ def start(argv):
             cell_id="zone-d",
             cells=[
                 {"cell_id": "zone-d-shard1", "hosts": [f"localhost:{nbs5_secure_port}"]},
-            ]
+            ],
+            without_shadow_disks=args.without_shadow_disks,
         )
         nbs4.start()
         append_recipe_err_files(ERR_LOG_FILE_NAMES_FILE, nbs4.nbs.stderr_file_name)
@@ -242,7 +249,8 @@ def start(argv):
             cell_id="zone-d-shard1",
             cells=[
                 {"cell_id": "zone-d", "hosts": [f"localhost:{nbs4_secure_port}"]},
-            ]
+            ],
+            without_shadow_disks=args.without_shadow_disks,
         )
         nbs5.start()
         append_recipe_err_files(ERR_LOG_FILE_NAMES_FILE, nbs5.nbs.stderr_file_name)

--- a/cloud/disk_manager/test/recipe/nbs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nbs_launcher.py
@@ -49,6 +49,7 @@ class NbsLauncher:
         nbs_secure_port=None,
         cell_id=None,
         cells=None,
+        without_shadow_disks=False,
     ):
         self.__ydb_port = ydb_port
         self.__domains_txt = domains_txt
@@ -105,7 +106,7 @@ class NbsLauncher:
         storage_config_patch.DisableLocalService = False
         storage_config_patch.InactiveClientsTimeout = 60000  # 1 min
         storage_config_patch.AgentRequestTimeout = 5000      # 5 sec
-        storage_config_patch.UseShadowDisksForNonreplDiskCheckpoints = True
+        storage_config_patch.UseShadowDisksForNonreplDiskCheckpoints = not without_shadow_disks
 
         # TODO: Actualize blockstore storage config.
         storage_config_patch.FreshChannelWriteRequestsEnabled = True
@@ -124,7 +125,7 @@ class NbsLauncher:
 
         devices = create_devices(
             use_memory_devices=True,
-            device_count=device_count_per_agent*self.__disk_agent_count,
+            device_count=device_count_per_agent * self.__disk_agent_count,
             block_size=DEFAULT_BLOCK_SIZE,
             block_count_per_device=DEFAULT_BLOCK_COUNT_PER_DEVICE,
             ram_drive_path=None


### PR DESCRIPTION
* Fixed error while calculating estimated bytes to read:
```
runtime/debug.Stack()
	/-S/contrib/go/_std_1.21/src/runtime/debug/stack.go:24 +0x5e
github.com/ydb-platform/nbs/cloud/tasks/errors.newNonRetriableError(...)
	/-S/cloud/tasks/errors/errors.go:123
github.com/ydb-platform/nbs/cloud/tasks/errors.NewNonRetriableError(...)
	/-S/cloud/tasks/errors/errors.go:100
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs.wrapErrorWithInternalFlag({0xa30840, 0xc00117d170}, 0x1)
	/-S/cloud/disk_manager/internal/pkg/clients/nbs/client.go:458 +0x36e
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs.wrapError(...)
	/-S/cloud/disk_manager/internal/pkg/clients/nbs/client.go:417
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs.(*client).getChangedBlocks(0xc000e92660, {0xa49290, 0xc00152a510}, {0xc0007abd80, 0x3c}, 0xc0007abd80?, 0x3c?, {0x0, 0x0}, {0xc0007abdc0, ...}, ...)
	/-S/cloud/disk_manager/internal/pkg/clients/nbs/client.go:2386 +0x11a
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs.(*client).GetChangedBlocks(0xc000e92660, {0xa49290, 0xc00152a510}, {0xc0007abd80, 0x3c}, 0x0?, 0x0?, {0x0, 0x0}, {0xc0007abdc0, ...}, ...)
	/-S/cloud/disk_manager/internal/pkg/clients/nbs/client.go:1498 +0x179
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs.(*client).GetChangedBytes(0xc000e92660, {0xa49290, 0xc000a81ad0}, {0xc0007abd80, 0x3c}, {0x0, 0x0}, {0xc0007abdc0, 0x3c}, 0x0)
	/-S/cloud/disk_manager/internal/pkg/clients/nbs/client.go:1635 +0xbee
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/nbs.(*diskSource).EstimatedBytesToRead(0xc000a81ad0?, {0xa49290?, 0xc000a81ad0?})
	/-S/cloud/disk_manager/internal/pkg/dataplane/nbs/source.go:238 +0x4c
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane.(*createSnapshotFromDiskTask).setEstimate(0xc001271c80, {0xa49290, 0xc000a81ad0}, {0xa535c8, 0xc000140d80}, {0xa4ecd0?, 0xc0004f54a0?})
	/-S/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go:424 +0x5b
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane.(*createSnapshotFromDiskTask).run(0xc001271c80, {0xa49290, 0xc000a81ad0}, {0xa535c8, 0xc000140d80})
	/-S/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go:301 +0x6c8
github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane.(*createSnapshotFromDiskTask).Run(0xc001271c80, {0xa49290, 0xc000a81ad0}, {0xa535c8?, 0xc000140d80?})
	/-S/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go:52 +0x30
github.com/ydb-platform/nbs/cloud/tasks.(*runnerForRun).run(0xa49290?, {0xa49290?, 0xc000a81320?}, 0x2d?, {0xa4de48, 0xc001271c80})
	/-S/cloud/tasks/runner.go:315 +0xdc
github.com/ydb-platform/nbs/cloud/tasks.(*runnerForRun).executeTask(0xc000bc9080, {0xa49290, 0xc000a81320}, 0xc000140d80, {0xa4de48, 0xc001271c80})
	/-S/cloud/tasks/runner.go:141 +0x145
github.com/ydb-platform/nbs/cloud/tasks.lockAndExecuteTask({0xa492c8, 0xc000ca9ae0}, {0xa5c4d0?, 0xc000c1c000}, 0x5a?, {0xa49760, 0xc000ca9bd0}, 0x3b9aca00, 0x12a05f200, {0xa49728, ...}, ...)
	/-S/cloud/tasks/runner.go:646 +0xd15
github.com/ydb-platform/nbs/cloud/tasks.(*runnerForRun).lockAndExecuteTask(0xa492c8?, {0xa492c8, 0xc000ca9ae0}, {{0xc000c9a420, 0x24}, 0x0, {0xc001180880, 0x20}})
	/-S/cloud/tasks/runner.go:329 +0x13d
github.com/ydb-platform/nbs/cloud/tasks.runnerLoop({0xa492c8, 0xc000ca9ae0}, 0x0?, {0xa49728, 0xc000bc9080})
	/-S/cloud/tasks/runner.go:667 +0x16f
created by github.com/ydb-platform/nbs/cloud/tasks.startRunner in goroutine 1
	/-S/cloud/tasks/runner.go:715 +0x309
```
* Correctly handle error wrapping in blockstore client
* Cleanup