### PR TITLE
WriteBackCache: Remove Flushing state, renamed Cached to Unflushed, remove unneeded stats

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_write_back_cache_stats.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_write_back_cache_stats.cpp
@@ -18,8 +18,7 @@ void TTestWriteBackCacheStats::ResetNonDerivativeCounters()
     NodeCount = 0;
 
     PendingStats.ResetNonDerivativeCounters();
-    CachedStats.ResetNonDerivativeCounters();
-    FlushingStats.ResetNonDerivativeCounters();
+    UnflushedStats.ResetNonDerivativeCounters();
     FlushedStats.ResetNonDerivativeCounters();
 }
 
@@ -55,10 +54,8 @@ TTestWriteDataRequestStats& TTestWriteBackCacheStats::GetWriteStats(
     switch (status) {
         case EWriteDataRequestStatus::Pending:
             return PendingStats;
-        case EWriteDataRequestStatus::Cached:
-            return CachedStats;
-        case EWriteDataRequestStatus::Flushing:
-            return FlushingStats;
+        case EWriteDataRequestStatus::Unflushed:
+            return UnflushedStats;
         case EWriteDataRequestStatus::Flushed:
             return FlushedStats;
         default:
@@ -94,12 +91,8 @@ void TTestWriteBackCacheStats::WriteDataRequestUpdateMinTime(
 }
 
 void TTestWriteBackCacheStats::AddReadDataStats(
-    EReadDataRequestCacheStatus status,
-    TDuration pendingDuration)
+    EReadDataRequestCacheStatus status)
 {
-    if (ReadStats.Data.size() < MaxItems) {
-        ReadStats.Data.push_back(pendingDuration);
-    }
     switch (status) {
         case EReadDataRequestCacheStatus::Miss:
             ReadStats.CacheMissCount++;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_write_back_cache_stats.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_write_back_cache_stats.h
@@ -35,8 +35,7 @@ struct TTestWriteBackCacheStats: public IWriteBackCacheStats
     ui64 NodeCount = 0;
 
     TTestWriteDataRequestStats PendingStats;
-    TTestWriteDataRequestStats CachedStats;
-    TTestWriteDataRequestStats FlushingStats;
+    TTestWriteDataRequestStats UnflushedStats;
     TTestWriteDataRequestStats FlushedStats;
 
     TTestReadDataRequestStats ReadStats;
@@ -71,9 +70,7 @@ struct TTestWriteBackCacheStats: public IWriteBackCacheStats
         EWriteDataRequestStatus status,
         TInstant minTime) override;
 
-    void AddReadDataStats(
-        EReadDataRequestCacheStatus status,
-        TDuration pendingDuration) override;
+    void AddReadDataStats(EReadDataRequestCacheStatus status) override;
 
     void UpdatePersistentStorageStats(
         const TPersistentStorageStats& stats) override;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -158,11 +158,6 @@ public:
         return GetOffset() + ByteCount;
     }
 
-    bool IsCached() const
-    {
-        return Status == NWriteBackCache::EWriteDataRequestStatus::Cached;
-    }
-
     bool IsCorrupted() const
     {
         return Status == NWriteBackCache::EWriteDataRequestStatus::Corrupted;
@@ -184,8 +179,7 @@ public:
         TQueuedOperations& pendingOperations,
         TImpl* impl);
 
-    void StartFlush(TImpl* impl);
-    void FinishFlush(TImpl* impl);
+    void SetFlushed(TImpl* impl);
     void Complete(TImpl* impl);
 
     NThreading::TFuture<NProto::TWriteDataResponse> GetCachedFuture();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_stats.cpp
@@ -48,12 +48,9 @@ public:
         Y_UNUSED(minTime);
     }
 
-    void AddReadDataStats(
-        EReadDataRequestCacheStatus status,
-        TDuration duration) override
+    void AddReadDataStats(EReadDataRequestCacheStatus status) override
     {
         Y_UNUSED(status);
-        Y_UNUSED(duration);
     }
 
     void UpdatePersistentStorageStats(


### PR DESCRIPTION
Part of https://github.com/ydb-platform/nbs/pull/5064

Simplification of the reported stats:
* `Flushing` state is not needed - this is duplicated by existing `service_fs` request stats;
* Time stats for read requests are not needed - this is duplicated by existing `client_fs` request stats and will not be needed because read-write-lock is to be removed;
* `Cached` renamed to `Unflushed` — this better suits the internal WriteBackCache logic because `Flushed` requests are cached too.