### PR TITLE
WriteBackCache: Put request to the Pending queue after obtaining region lock

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -515,23 +515,12 @@ public:
             return MakeFuture(std::move(response));
         }
 
-        auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
-
-        const auto nodeId = entry->GetNodeId();
-        const auto offset = entry->GetOffset();
-        const auto end = entry->GetEnd();
+        const auto nodeId = request->GetNodeId();
+        const auto offset = request->GetOffset();
+        const auto end = NStorage::CalculateByteCount(*request) -
+                         request->GetBufferOffset() + offset;
 
         Y_ABORT_UNLESS(offset < end);
-
-        const auto serializedSize = entry->GetSerializedSize();
-        const auto maxSerializedSize =
-            PersistentStorage->GetMaxSupportedAllocationByteCount();
-
-        Y_ABORT_UNLESS(
-            serializedSize <= maxSerializedSize,
-            "Serialized request size %lu is expected to be <= %lu",
-            serializedSize,
-            maxSerializedSize);
 
         auto unlocker =
             [ptr = weak_from_this(), nodeId, offset, end](const auto&)
@@ -545,33 +534,45 @@ public:
             }
         };
 
-        auto future = entry->GetCachedFuture();
+        auto promise = NewPromise<NProto::TWriteDataResponse>();
+        auto future = promise.GetFuture();
+
         future.Subscribe(std::move(unlocker));
 
-        auto* entryPtr = entry.release();
-
         auto locker =
-            [ptr = weak_from_this(), entry = entryPtr]() mutable
+            [ptr = weak_from_this(), request = std::move(request), promise = std::move(promise)]() mutable
         {
             auto self = ptr.lock();
             // Lock action is invoked immediately or from
             // UnlockRead/UnlockWrite calls that can be made only when
             // TImpl is alive
             Y_ABORT_UNLESS(self);
-            if (self) {
-                if (self->PendingEntries.empty()) {
-                    self->QueuedOperations.ShouldProcessPendingEntries = true;
-                }
-                self->PendingEntries.push_back(
-                    std::unique_ptr<TWriteDataEntry>(entry));
+
+            auto entry = std::make_unique<TWriteDataEntry>(
+                std::move(request),
+                std::move(promise));
+
+            const auto serializedSize = entry->GetSerializedSize();
+            const auto maxSerializedSize =
+                self->PersistentStorage->GetMaxSupportedAllocationByteCount();
+
+            Y_ABORT_UNLESS(
+                serializedSize <= maxSerializedSize,
+                "Serialized request size %lu is expected to be <= %lu",
+                serializedSize,
+                maxSerializedSize);
+
+            entry->SetPending(self.get());
+            self->RegisterWriteDataEntry(entry.get());
+            self->EmptyFlag = false;
+
+            if (self->PendingEntries.empty()) {
+                self->QueuedOperations.ShouldProcessPendingEntries = true;
             }
+            self->PendingEntries.push_back(std::move(entry));
         };
 
         auto guard = Guard(Lock);
-
-        entryPtr->SetPending(this);
-        RegisterWriteDataEntry(entryPtr);
-        EmptyFlag = false;
 
         auto* nodeState = GetOrCreateNodeState(nodeId);
         nodeState->RangeLock.LockWrite(offset, end, std::move(locker));
@@ -1447,12 +1448,13 @@ void TWriteBackCache::SetCachedNodeSize(ui64 nodeId, ui64 size)
 ////////////////////////////////////////////////////////////////////////////////
 
 TWriteBackCache::TWriteDataEntry::TWriteDataEntry(
-        std::shared_ptr<NProto::TWriteDataRequest> request)
+        std::shared_ptr<NProto::TWriteDataRequest> request,
+        NThreading::TPromise<NProto::TWriteDataResponse> cachedPromise)
     : PendingRequest(std::move(request))
     , ByteCount(
           NStorage::CalculateByteCount(*PendingRequest) -
           PendingRequest->GetBufferOffset())
-    , CachedPromise(NewPromise<NProto::TWriteDataResponse>())
+    , CachedPromise(std::move(cachedPromise))
 {
     Y_ABORT_UNLESS(ByteCount > 0);
 }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_impl.h
@@ -83,8 +83,9 @@ private:
     TInstant StatusChangeTime = TInstant::Zero();
 
 public:
-    explicit TWriteDataEntry(
-        std::shared_ptr<NProto::TWriteDataRequest> request);
+    TWriteDataEntry(
+        std::shared_ptr<NProto::TWriteDataRequest> request,
+        NThreading::TPromise<NProto::TWriteDataResponse> cachedPromise);
 
     TWriteDataEntry(
         TStringBuf serializedRequest,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_util_ut.cpp
@@ -322,7 +322,9 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
             request->SetOffset(e.Offset);
             request->SetBuffer(TString(e.Length, 'a')); // dummy buffer
 
-            auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
+            auto entry = std::make_unique<TWriteDataEntry>(
+                std::move(request),
+                NThreading::NewPromise<NProto::TWriteDataResponse>());
             entries.push_back(std::move(entry));
         }
 
@@ -375,7 +377,9 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
             request->SetOffset(e.Offset);
             request->SetBuffer(TString(e.Length, 'a')); // dummy buffer
 
-            auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
+            auto entry = std::make_unique<TWriteDataEntry>(
+                std::move(request),
+                NThreading::NewPromise<NProto::TWriteDataResponse>());
             entries.push_back(std::move(entry));
         }
 
@@ -481,7 +485,9 @@ Y_UNIT_TEST_SUITE(TCalculateDataPartsToReadTest)
             request->SetOffset(e.Offset);
             request->SetBuffer(TString(e.Length, 'a')); // dummy buffer
 
-            auto entry = std::make_unique<TWriteDataEntry>(std::move(request));
+            auto entry = std::make_unique<TWriteDataEntry>(
+                std::move(request),
+                NThreading::NewPromise<NProto::TWriteDataResponse>());
             entries.push_back(std::move(entry));
         }
 


### PR DESCRIPTION
Part of https://github.com/ydb-platform/nbs/pull/5064

Previous logic:
* WriteData request is assigned a sequence id
* ReadWrite lock is acquired
* WriteData is added to the pending queue.

New logic:
* ReadWrite lock is acquired
* WriteData request is assigned a sequence id
* WriteData is added to the pending queue.

In the previous logic, sequence id reordering could happen and it has to be handled additionally.
In the new logic, the requests in the pending queue will be strictly ordered.

The reason why the previous logic was used is to be able to flush pending requests that haven't acquired ReadWrite lock yet. In the future, the ReadWrite lock is to be removed, so this change will not affect the final logic and it will simplify future refactoring related PRs.