### PR TITLE
Describe volume with exact-disk-id-match optional flag

### DIFF
--- a/cloud/blockstore/apps/client/lib/describe_volume.cpp
+++ b/cloud/blockstore/apps/client/lib/describe_volume.cpp
@@ -19,14 +19,21 @@ class TDescribeVolumeCommand final
 {
 private:
     TString DiskId;
+    bool ExactDiskIdMatch = false;
 
 public:
-    TDescribeVolumeCommand(IBlockStorePtr client)
+    explicit TDescribeVolumeCommand(IBlockStorePtr client)
         : TCommand(std::move(client))
     {
         Opts.AddLongOption("disk-id", "volume identifier")
             .RequiredArgument("STR")
             .StoreResult(&DiskId);
+
+        Opts.AddLongOption(
+                "exact-disk-id-match",
+                "Requires an exact match of the DiskId.  When set it does not "
+                "allow to find copied disk with mangled name.")
+            .StoreTrue(&ExactDiskIdMatch);
     }
 
 protected:
@@ -45,6 +52,7 @@ protected:
             ParseFromTextFormat(input, *request);
         } else {
             request->SetDiskId(DiskId);
+            request->MutableHeaders()->SetExactDiskIdMatch(ExactDiskIdMatch);
         }
 
         STORAGE_DEBUG("Sending DescribeVolume request");

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_describe.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_describe.cpp
@@ -31,6 +31,7 @@ private:
     const TString Input;
 
     TString DiskId;
+    bool ExactDiskIdMatch = false;
 
 public:
     TDescribeVolumeActionsActor(
@@ -73,6 +74,9 @@ void TDescribeVolumeActionsActor::Bootstrap(const TActorContext& ctx)
     if (input.Has("DiskId")) {
         DiskId = input["DiskId"].GetStringRobust();
     }
+    if (input.Has("ExactDiskIdMatch")) {
+        ExactDiskIdMatch = input["ExactDiskIdMatch"].GetBoolean();
+    }
 
     if (!DiskId) {
         HandleError(ctx, MakeError(E_ARGUMENT, "DiskId should be defined"));
@@ -87,7 +91,8 @@ void TDescribeVolumeActionsActor::DescribeVolume(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
         RequestInfo->CallContext,
-        DiskId);
+        DiskId,
+        ExactDiskIdMatch);
 
     NCloud::Send(ctx, MakeSSProxyServiceId(), std::move(request));
 }

--- a/cloud/blockstore/libs/storage/volume/actors/create_volume_link_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/create_volume_link_actor.cpp
@@ -43,13 +43,15 @@ void TCreateVolumeLinkActor::Bootstrap(const TActorContext& ctx)
         ctx,
         MakeSSProxyServiceId(),
         std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
-            Follower.Link.LeaderDiskId),
+            Follower.Link.LeaderDiskId,
+            true),
         DESCRIBE_KIND_LEADER);
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
         std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
-            Follower.Link.FollowerDiskId),
+            Follower.Link.FollowerDiskId,
+            true),
         DESCRIBE_KIND_FOLLOWER);
 }
 
@@ -69,8 +71,8 @@ void TCreateVolumeLinkActor::LinkVolumes(const TActorContext& ctx)
                             << "The size of the leader disk "
                             << Follower.Link.LeaderDiskIdForPrint().Quote()
                             << " is larger than the size of follower disk "
-                            << Follower.Link.FollowerDiskIdForPrint().Quote() << " "
-                            << sourceSize << " > " << targetSize;
+                            << Follower.Link.FollowerDiskIdForPrint().Quote()
+                            << " " << sourceSize << " > " << targetSize;
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::VOLUME,

--- a/example/8-backward.sh
+++ b/example/8-backward.sh
@@ -1,6 +1,0 @@
-./5-create_disk.sh -k nonreplicated -d nrd1
-#./blockstore-client.sh CreateVolume --disk-id=nrd1 --storage-media-kind nonreplicated --blocks-count=131072 --block-size=8192
-
-./blockstore-client.sh ExecuteAction --action=modifytags --input-bytes='{"DiskId":"nrd1","TagsToAdd":"source-disk-id=nrd1-copy","TagsToRemove":""}'
-
-./blockstore-client.sh createvolumelink --leader-disk-id=nrd1-copy --follower-disk-id=nrd1

--- a/example/8-forward.sh
+++ b/example/8-forward.sh
@@ -1,6 +1,0 @@
-./5-create_disk.sh -k nonreplicated -d nrd1-copy
-#./blockstore-client.sh CreateVolume --disk-id=nrd1-copy --storage-media-kind nonreplicated --blocks-count=131072 --block-size=8192
-
-./blockstore-client.sh ExecuteAction --action=modifytags --input-bytes='{"DiskId":"nrd1-copy","TagsToAdd":"source-disk-id=nrd1","TagsToRemove":""}'
-
-./blockstore-client.sh createvolumelink --leader-disk-id=nrd1 --follower-disk-id=nrd1-copy

--- a/example/8-make-disks.sh
+++ b/example/8-make-disks.sh
@@ -1,0 +1,9 @@
+./blockstore-client.sh CreatePlacementGroup --group-id=pg-part --placement-strategy=partition --partition-count=4
+./blockstore-client.sh CreatePlacementGroup --group-id=pg-spread --placement-strategy=spread
+
+./blockstore-client.sh CreateVolume --disk-id=nrd1 --storage-media-kind nonreplicated --blocks-count=131072 --block-size=8192 --cloud-id=cloud --folder-id=folder --placement-group-id=pg-spread
+./blockstore-client.sh CreateVolume --disk-id=nrd2 --storage-media-kind nonreplicated --blocks-count=262144 --block-size=4096 --cloud-id=cloud --folder-id=folder --placement-group-id=pg-part --placement-partition-index=1
+./blockstore-client.sh CreateVolume --disk-id=mrr1 --verbose error --storage-media-kind mirror3 --blocks-count=262144 --cloud-id=cloud --folder-id=folder
+./blockstore-client.sh CreateVolume --disk-id=ssd1 --verbose error --storage-media-kind ssd --blocks-count=262144 --cloud-id=cloud --folder-id=folder
+./blockstore-client.sh CreateVolume --disk-id=ssd2 --verbose error --storage-media-kind ssd --blocks-count=262144 --partitions-count=2 --cloud-id=cloud --folder-id=folder
+./blockstore-client.sh CreateVolume --disk-id=hdd1 --verbose error --storage-media-kind hybrid --blocks-count=262144 --cloud-id=cloud --folder-id=folder

--- a/example/8-start.sh
+++ b/example/8-start.sh
@@ -1,2 +1,0 @@
-./5-create_disk.sh -k nonreplicated -d nrd1
-#./blockstore-client.sh CreateVolume --disk-id=nrd1 --storage-media-kind nonreplicated --blocks-count=131072 --block-size=8192

--- a/example/8-stop.sh
+++ b/example/8-stop.sh
@@ -1,3 +1,0 @@
-./blockstore-client.sh stopendpoint --socket /tmp/nrd1.sock
-./blockstore-client.sh destroyvolume --disk-id=nrd1
-./blockstore-client.sh destroyvolume --disk-id=nrd1-copy

--- a/example/copy_volume.py
+++ b/example/copy_volume.py
@@ -1,0 +1,149 @@
+import json
+import subprocess as sp
+import optparse
+
+
+def parse_args():
+    parser = optparse.OptionParser()
+    parser.add_option('--disk-id')
+    parser.add_option('--new-type')
+    parser.add_option('--apply', default=False, action='store_true')
+    return parser.parse_args()
+
+
+def exec(cmd):
+    p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.STDOUT)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        s = 'Failed to run {} {} return code: {}'.format(
+            stdout, stderr, p.returncode)
+        raise Exception(s)
+
+    return stdout.decode('utf-8')
+
+
+def translate_media_kind(media_kind):
+    if media_kind == 1:
+        return 'ssd'
+    elif media_kind == 2:
+        return 'hybrid'
+    elif media_kind == 3:
+        return 'hdd'
+    elif media_kind == 4:
+        return 'nonreplicated'
+    elif media_kind == 5:
+        return 'mirror2'
+    elif media_kind == 7:
+        return 'mirror3'
+    elif media_kind == 8:
+        return 'hdd_nonrepl'
+    else:
+        raise Exception('Unknown media kind {}'.format(media_kind))
+
+
+def describe_disk(opts):
+    input = {"DiskId": opts.disk_id, "ExactDiskIdMatch": False}
+    cmd = [
+        './blockstore-client.sh', 'executeaction',
+        '--action=describevolume',
+        '--input-bytes={}'.format(json.dumps(input))
+    ]
+    print(cmd)
+    allLines = exec(cmd)
+    for line in allLines.split('\n'):
+        try:
+            return json.loads(line)
+        except Exception as e:
+            continue
+    raise Exception('Failed to find disk ' + opts.disk_id)
+
+
+def get_disk_info(described_disk):
+    volume_config = described_disk['VolumeConfig']
+    diskId = volume_config['DiskId']
+    cloudId = volume_config['CloudId']
+    folderId = volume_config['FolderId']
+    blockSize = int(volume_config['BlockSize'])
+    storageMediaKind = translate_media_kind(volume_config['StorageMediaKind'])
+    placementGroupId = volume_config['PlacementGroupId']
+    placementPartitionIndex = volume_config['PlacementPartitionIndex']
+
+    blockCount = 0
+    for partition in volume_config['Partitions']:
+        blockCount += int(partition['BlockCount'])
+
+    r = dict()
+    r["diskId"] = diskId
+    r["cloudId"] = cloudId
+    r["folderId"] = folderId
+    r["blockSize"] = blockSize
+    r["blockCount"] = blockCount
+    r["storageMediaKind"] = storageMediaKind
+    r["placementGroupId"] = placementGroupId
+    r["placementPartitionIndex"] = placementPartitionIndex
+    return r
+
+
+def make_copy_info(volume, opts):
+    copy = volume.copy()
+
+    diskId = volume["diskId"]
+    if diskId.endswith("-copy"):
+        diskId = volume["diskId"][:-5]
+    else:
+        diskId += "-copy"
+    copy["diskId"] = diskId
+
+    if opts.new_type is not None:
+        copy["storageMediaKind"] = opts.new_type
+
+    if copy["storageMediaKind"] != "nonreplicated":
+        copy["placementGroupId"] = ""
+        copy["placementPartitionIndex"] = ""
+
+    return copy
+
+
+def copy_disk(src, dst):
+    tags = "source-disk-id={}".format(src["diskId"])
+    create_cmd = [
+        './blockstore-client.sh',
+        'CreateVolume',
+        '--disk-id={}'.format(dst["diskId"]),
+        '--storage-media-kind={}'.format(dst["storageMediaKind"]),
+        '--blocks-count={}'.format(dst["blockCount"]),
+        '--block-size={}'.format(dst["blockSize"]),
+        '--folder-id={}'.format(dst["folderId"]),
+        '--cloud-id={}'.format(dst["cloudId"]),
+        '--placement-group-id={}'.format(dst["placementGroupId"]),
+        '--placement-partition-index={}'.format(
+            dst["placementPartitionIndex"]),
+        '--tags={}'.format(tags)
+    ]
+    print(create_cmd)
+    exec(create_cmd)
+
+    link_cmd = [
+        './blockstore-client.sh',
+        'CreateVolumeLink',
+        '--leader-disk-id={}'.format(src["diskId"]),
+        '--follower-disk-id={}'.format(dst["diskId"])
+    ]
+    print(link_cmd)
+    exec(link_cmd)
+
+
+def main(opts):
+    described_disk = describe_disk(opts)
+    # print(json.dumps(described_disk, indent=4))
+    src = get_disk_info(described_disk)
+    dst = make_copy_info(src, opts)
+    print(src)
+    print(dst)
+    if opts.apply:
+        copy_disk(src, dst)
+
+
+if __name__ == '__main__':
+    opts, args = parse_args()
+    main(opts)


### PR DESCRIPTION
continue https://github.com/ydb-platform/nbs/issues/2999

1. Describe volume blockstore-client with ExactDiskIdMatch optional flag
2. Use ExactDiskIdMatch when linking two volumes
3. Make test volumes in examples
4. Copy volume script in examples 